### PR TITLE
feat(events): Follow-up UX adjustments to the Pulse outlier strip 

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -3,7 +3,6 @@
  * for Docker builds.
  */
 await import("./src/env.mjs");
-import { fileURLToPath } from "node:url";
 import { withSentryConfig } from "@sentry/nextjs";
 import { env } from "./src/env.mjs";
 
@@ -104,11 +103,6 @@ const nextConfig = {
     },
   },
   turbopack: {
-    // Pin the workspace root: in a nested git worktree Next.js infers the
-    // OUTER checkout's root (outermost lockfile wins), which breaks the
-    // relative resolveAlias below. fileURLToPath, not URL.pathname — the
-    // latter percent-encodes spaces and breaks on Windows drive letters.
-    root: fileURLToPath(new URL("..", import.meta.url)),
     resolveAlias: {
       "@langfuse/shared": "./packages/shared/src",
     },

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -3,6 +3,7 @@
  * for Docker builds.
  */
 await import("./src/env.mjs");
+import { fileURLToPath } from "node:url";
 import { withSentryConfig } from "@sentry/nextjs";
 import { env } from "./src/env.mjs";
 
@@ -105,8 +106,9 @@ const nextConfig = {
   turbopack: {
     // Pin the workspace root: in a nested git worktree Next.js infers the
     // OUTER checkout's root (outermost lockfile wins), which breaks the
-    // relative resolveAlias below.
-    root: new URL("..", import.meta.url).pathname,
+    // relative resolveAlias below. fileURLToPath, not URL.pathname — the
+    // latter percent-encodes spaces and breaks on Windows drive letters.
+    root: fileURLToPath(new URL("..", import.meta.url)),
     resolveAlias: {
       "@langfuse/shared": "./packages/shared/src",
     },

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -103,6 +103,10 @@ const nextConfig = {
     },
   },
   turbopack: {
+    // Pin the workspace root: in a nested git worktree Next.js infers the
+    // OUTER checkout's root (outermost lockfile wins), which breaks the
+    // relative resolveAlias below.
+    root: new URL("..", import.meta.url).pathname,
     resolveAlias: {
       "@langfuse/shared": "./packages/shared/src",
     },

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -125,9 +125,6 @@ interface DataTableToolbarProps<TData, TValue> {
    * query — not the toolbar's stale local mirror — is captured. */
   currentSearchQuery?: string;
   actionButtons?: React.ReactNode;
-  /** Rendered at the start of the right-aligned control cluster (left of the
-   *  Columns toggle) — e.g. the events table's "Pulse" reopen button. */
-  preColumnsSlot?: React.ReactNode;
   filterState?: FilterState;
   setFilterState?:
     | Dispatch<SetStateAction<FilterState>>
@@ -209,7 +206,6 @@ export function DataTableToolbar<TData, TValue>({
   searchConfig,
   currentSearchQuery,
   actionButtons,
-  preColumnsSlot,
   filterState,
   setFilterState,
   columnVisibility,
@@ -495,7 +491,6 @@ export function DataTableToolbar<TData, TValue>({
         )}
 
         <div className="flex flex-row flex-wrap gap-2 pr-0.5 @3xl:ml-auto">
-          {preColumnsSlot}
           {!!columnVisibility && !!setColumnVisibility && (
             <DataTableColumnVisibilityFilter
               columns={columns}

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -65,7 +65,7 @@ import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTabl
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 import { BreakdownTooltip } from "@/src/components/trace/components/_shared/BreakdownToolTip";
-import { ChartNoAxesColumn, InfoIcon, LightbulbIcon } from "lucide-react";
+import { InfoIcon, LightbulbIcon } from "lucide-react";
 import { ProvidedModelNameCell } from "@/src/features/models/components/ProvidedModelNameCell";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { Badge } from "@/src/components/ui/badge";
@@ -131,8 +131,6 @@ import { EventsChartView } from "@/src/features/chart-view/EventsChartView";
 import { ViewModeToggle } from "@/src/features/chart-view/components/ViewModeToggle";
 import { useChartViewState } from "@/src/features/chart-view/lib/useChartViewState";
 import { EventsOutlierStrip } from "@/src/features/events/components/outlier-strip/EventsOutlierStrip";
-import useLocalStorage from "@/src/components/useLocalStorage";
-import { Button } from "@/src/components/ui/button";
 import {
   chartFilterExclusionReason,
   chartSearchFieldReason,
@@ -482,13 +480,6 @@ export default function ObservationsEventsTable({
     [dateRange],
   );
 
-  // Pulse strip open/closed — per-user persisted; null = no explicit choice
-  // yet (open on desktop, closed on mobile — resolved below once isMobile is
-  // known).
-  const [pulseClosedStored, setPulseClosed] = useLocalStorage<boolean | null>(
-    "events-outlier-strip-closed",
-    null,
-  );
   // Drill-in writes the clicked bucket as an absolute range. URL-only
   // (pushIn → browser Back restores the outer window) and deliberately NOT
   // persisted as the project's default range — a transient zoom must not
@@ -1092,22 +1083,6 @@ export default function ObservationsEventsTable({
   // checkboxes would do nothing. Omit the select column on mobile until a
   // dedicated mobile action affordance exists.
   const isMobile = useIsMobile();
-  const pulseClosed = pulseClosedStored ?? isMobile;
-  // One reopen affordance for both surfaces: the desktop toolbar slot (left of
-  // Columns) and the mobile header band — mobile defaults to closed, so
-  // without this the strip would be unreachable there.
-  const pulseReopenButton =
-    outlierStripEnabled && chartViewMode !== "chart" && pulseClosed ? (
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => setPulseClosed(false)}
-        className="h-8 gap-1.5 text-xs"
-      >
-        <ChartNoAxesColumn className="h-3.5 w-3.5" />
-        Pulse
-      </Button>
-    ) : null;
   const enableSorting = !hideControls;
 
   const columns: LangfuseColumnDef<EventsTableRow>[] = [
@@ -2011,7 +1986,6 @@ export default function ObservationsEventsTable({
                 onModeChange={setChartViewMode}
               />
             )}
-            {pulseReopenButton}
           </div>
         )}
         {!hideControls && !isMobile && (
@@ -2094,7 +2068,6 @@ export default function ObservationsEventsTable({
               setRowHeight={setRowHeight}
               timeRange={showControlsInPageHeader ? undefined : timeRange}
               setTimeRange={showControlsInPageHeader ? undefined : setTimeRange}
-              preColumnsSlot={pulseReopenButton ?? undefined}
               viewModeToggle={
                 chartEnabled ? (
                   <ViewModeToggle
@@ -2228,19 +2201,16 @@ export default function ObservationsEventsTable({
           <div className="flex flex-1 flex-col overflow-hidden">
             {/* Pulse strip (LFE-14451): table-width, so the facet sidebar keeps
                 its full height (design feedback); hidden in full chart mode. */}
-            {outlierStripEnabled &&
-              chartViewMode !== "chart" &&
-              !pulseClosed && (
-                <EventsOutlierStrip
-                  projectId={projectId}
-                  filterState={filterState}
-                  fromTimestamp={chartTimeWindow.from}
-                  toTimestamp={chartTimeWindow.to}
-                  searchIgnored={Boolean(searchQuery)}
-                  onSelectRange={setTimeRangeTransient}
-                  onClose={() => setPulseClosed(true)}
-                />
-              )}
+            {outlierStripEnabled && chartViewMode !== "chart" && (
+              <EventsOutlierStrip
+                projectId={projectId}
+                filterState={filterState}
+                fromTimestamp={chartTimeWindow.from}
+                toTimestamp={chartTimeWindow.to}
+                searchIgnored={Boolean(searchQuery)}
+                onSelectRange={setTimeRangeTransient}
+              />
+            )}
             {chartEnabled && chartViewMode === "chart" ? (
               <EventsChartView
                 projectId={projectId}

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -93,13 +93,10 @@ const AggDropdown = ({
   const focusGuard = usePointerSelectionFocusGuard();
   return (
     <span className="flex items-baseline gap-1">
-      {/* The separator dot stays outside the trigger so hover styling
-          (underline) applies to the value only. */}
-      <span className="text-muted-foreground text-[11px] leading-none">·</span>
       <DropdownMenu>
         <DropdownMenuTrigger
           aria-label={`${metricLabel} aggregation: ${value}`}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-[11px] leading-none underline-offset-2 hover:underline"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-[13px] leading-none underline-offset-2 hover:underline"
         >
           {value}
           <ChevronDown className="h-2.5 w-2.5" />
@@ -140,7 +137,7 @@ const ModeDropdown = ({
     <DropdownMenu>
       <DropdownMenuTrigger
         aria-label={`Chart mode: ${modeLabel(value)}`}
-        className="text-foreground hover:text-muted-foreground flex items-center gap-0.5 text-[11px] leading-none font-bold"
+        className="text-foreground hover:text-muted-foreground flex items-center gap-0.5 text-[13px] leading-none font-bold"
       >
         {modeLabel(value)}
         <ChevronDown className="h-2.5 w-2.5" />
@@ -387,7 +384,7 @@ export function EventsOutlierStrip({
                 )}
               </div>
               <OutlierBarStrip
-                className="mt-1"
+                className="mt-2"
                 dense={series.dense}
                 maxValue={series.maxValue}
                 ticks={series.ticks}

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { ChevronDown, X } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { type FilterState, type QueryType } from "@langfuse/shared";
 import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
@@ -10,7 +10,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import { Button } from "@/src/components/ui/button";
 import {
   chartFilterExclusionReason,
   toChartFilters,
@@ -33,8 +32,7 @@ import {
 
 /**
  * Production container for the outlier strip ("Pulse") above the events table
- * (LFE-14451). Open by default; the X hands control back to the caller, which
- * re-opens it via a toolbar "Pulse" button. One `dashboard.executeQuery` call
+ * (LFE-14451). Always visible. One `dashboard.executeQuery` call
  * fetches count + every registered aggregate per time bucket (see the metric
  * registry in lib/binning.ts), so switching metrics, aggregations, or the
  * multi-chart layout never refetches. Bucket width adapts to the measured
@@ -50,11 +48,11 @@ import {
 
 /** Target horizontal pixels per bar for granularity picking. */
 const BAR_SLOT_TARGET_PX = 5;
-/** Each chart needs this much width for Split (all three) to be offered. */
+/** Each chart needs this much width for Split (both charts) to be offered. */
 const CHART_MIN_WIDTH_PX = 400;
 const CHART_GAP_PX = 24;
 
-const SPLIT_METRICS: OutlierStripMetricKey[] = ["cost", "latency", "tokens"];
+const SPLIT_METRICS: OutlierStripMetricKey[] = ["cost", "latency"];
 
 type StripMode = OutlierStripSettings["mode"];
 
@@ -100,13 +98,11 @@ const AggDropdown = ({
     <span className="flex items-baseline gap-1">
       {/* The separator dot stays outside the trigger so hover styling
           (underline) applies to the value only. */}
-      <span className="text-muted-foreground font-mono text-[11px] leading-none">
-        ·
-      </span>
+      <span className="text-muted-foreground text-[11px] leading-none">·</span>
       <DropdownMenu>
         <DropdownMenuTrigger
           aria-label={`${metricLabel} aggregation: ${value}`}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 font-mono text-[11px] leading-none underline-offset-2 hover:underline"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-[11px] leading-none underline-offset-2 hover:underline"
         >
           {value}
           <ChevronDown className="h-2.5 w-2.5" />
@@ -122,7 +118,7 @@ const AggDropdown = ({
                 focusGuard.markPointerSelection(event);
                 onChange(agg);
               }}
-              className="font-mono text-xs"
+              className="text-xs"
             >
               {agg}
             </DropdownMenuItem>
@@ -147,7 +143,7 @@ const ModeDropdown = ({
     <DropdownMenu>
       <DropdownMenuTrigger
         aria-label={`Chart mode: ${modeLabel(value)}`}
-        className="text-foreground hover:text-muted-foreground flex items-center gap-0.5 font-mono text-[11px] leading-none font-bold"
+        className="text-foreground hover:text-muted-foreground flex items-center gap-0.5 text-[11px] leading-none font-bold"
       >
         {modeLabel(value)}
         <ChevronDown className="h-2.5 w-2.5" />
@@ -163,7 +159,7 @@ const ModeDropdown = ({
               focusGuard.markPointerSelection(event);
               onChange(mode);
             }}
-            className="font-mono text-xs"
+            className="text-xs"
           >
             {modeLabel(mode)}
           </DropdownMenuItem>
@@ -194,7 +190,6 @@ export function EventsOutlierStrip({
   toTimestamp,
   searchIgnored = false,
   onSelectRange,
-  onClose,
 }: {
   projectId: string;
   filterState: FilterState;
@@ -203,7 +198,6 @@ export function EventsOutlierStrip({
   /** The table has an active free-text search the strip cannot apply. */
   searchIgnored?: boolean;
   onSelectRange: (range: { from: Date; to: Date }) => void;
-  onClose: () => void;
 }) {
   const [wrapperRef, size] = useElementSize<HTMLDivElement>();
   // Transient drag selection, shared across the sibling charts so a drag on
@@ -223,9 +217,9 @@ export function EventsOutlierStrip({
   // getBoundingClientRect includes the wrapper's px-2 padding (border-box).
   const width = Math.max((size?.width ?? 0) - 16, 0);
 
-  // Split adapts: 3 charts when they fit, 2 (Cost + Latency) on smaller
-  // widths, and only below the 2-chart threshold does Split leave the menu.
-  // A stored Split preference degrades to Cost WITHOUT being overwritten.
+  // Split renders Cost + Latency side by side when both fit; below the
+  // 2-chart threshold Split leaves the menu. A stored Split preference
+  // degrades to Cost WITHOUT being overwritten.
   const splitChartCount = Math.min(
     SPLIT_METRICS.length,
     Math.floor((width + CHART_GAP_PX) / (CHART_MIN_WIDTH_PX + CHART_GAP_PX)),
@@ -292,11 +286,7 @@ export function EventsOutlierStrip({
   );
 
   const aggregationFor = (metric: OutlierStripMetricKey): OutlierStripAggKey =>
-    metric === "latency"
-      ? settings.latencyAgg
-      : metric === "cost"
-        ? settings.costAgg
-        : "max";
+    metric === "latency" ? settings.latencyAgg : settings.costAgg;
 
   const series = useMemo(
     () =>
@@ -306,11 +296,7 @@ export function EventsOutlierStrip({
             bins,
             metric,
             aggregation:
-              metric === "latency"
-                ? settings.latencyAgg
-                : metric === "cost"
-                  ? settings.costAgg
-                  : "max",
+              metric === "latency" ? settings.latencyAgg : settings.costAgg,
             fromMs,
             toMs,
             stepSeconds: granularity.stepSeconds,
@@ -376,20 +362,11 @@ export function EventsOutlierStrip({
     <div ref={wrapperRef} className="shrink-0 border-b">
       {size === undefined ? null : (
         <div className="relative px-2 pt-1 pb-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Close Pulse chart"
-            onClick={onClose}
-            className="text-muted-foreground absolute top-0.5 right-1 z-[1] h-6 w-6"
-          >
-            <X className="h-3.5 w-3.5" />
-          </Button>
           {isLoading || width === 0 ? (
             <div className="bg-muted h-[76px] animate-pulse rounded" />
           ) : queryResult.isError ? (
             <div className="text-muted-foreground flex h-[76px] items-center justify-center text-[11px]">
-              Could not load the outlier chart for the current view.
+              No Data
             </div>
           ) : (
             <div
@@ -417,36 +394,33 @@ export function EventsOutlierStrip({
                             onChange={(next) => update({ mode: next })}
                           />
                           {mode === "split" && (
-                            <span className="text-muted-foreground font-mono text-[11px] leading-none">
+                            <span className="text-muted-foreground text-[11px] leading-none">
                               {def.shortLabel}
                             </span>
                           )}
                         </>
                       ) : (
-                        <span className="text-muted-foreground font-mono text-[11px] leading-none">
+                        <span className="text-muted-foreground text-[11px] leading-none">
                           {def.shortLabel}
                         </span>
                       )}
-                      {/* The bar's aggregate must be legible (max vs p95, …);
-                          single-option metrics render it statically. */}
-                      {aggOptions.length > 1 ? (
+                      {/* The bar's aggregate must be legible where there is a
+                          choice (p95 vs avg); single-option metrics are
+                          unambiguous and render no aggregation label. */}
+                      {aggOptions.length > 1 && (
                         <AggDropdown
                           metricLabel={def.shortLabel}
                           value={aggregationFor(metric)}
                           options={aggOptions}
                           onChange={(agg) => setAggregation(metric, agg)}
                         />
-                      ) : (
-                        <span className="text-muted-foreground/70 font-mono text-[11px] leading-none">
-                          · {aggOptions[0]}
-                        </span>
                       )}
                       {/* Unlike full chart mode (which dims sidebar facets),
                           the TABLE still honors these filters — only the strip
                           can't express them, so the disclosure lives here. */}
                       {slot === 0 && ignoredFilterCount > 0 && (
                         <span
-                          className="text-muted-foreground/70 font-mono text-[11px] leading-none"
+                          className="text-muted-foreground/70 text-[11px] leading-none"
                           title="Some active filters (measures, scores, comments, metadata, free-text search) cannot be applied to this chart's aggregate query. The table still honors them; the chart shows the unfiltered distribution for those."
                         >
                           · {ignoredFilterCount} filter

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -34,8 +34,8 @@ import {
  * Production container for the outlier strip ("Pulse") above the events table
  * (LFE-14451). Always visible. One `dashboard.executeQuery` call
  * fetches count + every registered aggregate per time bucket (see the metric
- * registry in lib/binning.ts), so switching metrics, aggregations, or the
- * multi-chart layout never refetches. Bucket width adapts to the measured
+ * registry in lib/binning.ts), so switching metrics or aggregations never
+ * refetches. Bucket width adapts to the measured
  * width (space calculator → granularity preset). Clicking a bar narrows the
  * table's time range to that bucket; the browser Back button restores the
  * outer view.
@@ -48,16 +48,13 @@ import {
 
 /** Target horizontal pixels per bar for granularity picking. */
 const BAR_SLOT_TARGET_PX = 5;
-/** Each chart needs this much width for Split (both charts) to be offered. */
-const CHART_MIN_WIDTH_PX = 400;
-const CHART_GAP_PX = 24;
-
-const SPLIT_METRICS: OutlierStripMetricKey[] = ["cost", "latency"];
 
 type StripMode = OutlierStripSettings["mode"];
 
+const MODE_OPTIONS: StripMode[] = ["cost", "latency"];
+
 const modeLabel = (mode: StripMode): string =>
-  mode === "split" ? "Split" : OUTLIER_STRIP_METRICS[mode].shortLabel;
+  OUTLIER_STRIP_METRICS[mode].shortLabel;
 
 /**
  * Prevent Radix's close-refocus ONLY after a pointer-driven selection — the
@@ -200,10 +197,9 @@ export function EventsOutlierStrip({
   onSelectRange: (range: { from: Date; to: Date }) => void;
 }) {
   const [wrapperRef, size] = useElementSize<HTMLDivElement>();
-  // Transient drag selection, shared across the sibling charts so a drag on
-  // one strip highlights the same time span on all (LFE-14532, Grafana-style).
-  // Window-keyed: a range/granularity change (drill, browser back/forward)
-  // invalidates a lingering band by derivation.
+  // Transient drag selection (LFE-14532, Grafana-style). Window-keyed: a
+  // range/granularity change (drill, browser back/forward) invalidates a
+  // lingering band by derivation.
   const [dragSelection, setDragSelection] = useState<{
     fromMs: number;
     toMs: number;
@@ -217,24 +213,10 @@ export function EventsOutlierStrip({
   // getBoundingClientRect includes the wrapper's px-2 padding (border-box).
   const width = Math.max((size?.width ?? 0) - 16, 0);
 
-  // Split renders Cost + Latency side by side when both fit; below the
-  // 2-chart threshold Split leaves the menu. A stored Split preference
-  // degrades to Cost WITHOUT being overwritten.
-  const splitChartCount = Math.min(
-    SPLIT_METRICS.length,
-    Math.floor((width + CHART_GAP_PX) / (CHART_MIN_WIDTH_PX + CHART_GAP_PX)),
-  );
-  const splitFits = splitChartCount >= 2;
-  const mode: StripMode =
-    settings.mode === "split" && !splitFits ? "cost" : settings.mode;
-  const modeOptions: StripMode[] = splitFits
-    ? [...SPLIT_METRICS, "split"]
-    : [...SPLIT_METRICS];
-
-  const visibleMetrics: OutlierStripMetricKey[] =
-    mode === "split" ? SPLIT_METRICS.slice(0, splitChartCount) : [mode];
-  const chartCount = visibleMetrics.length;
-  const chartWidth = (width - CHART_GAP_PX * (chartCount - 1)) / chartCount;
+  const mode: StripMode = settings.mode;
+  const chartWidth = width;
+  const def = OUTLIER_STRIP_METRICS[mode];
+  const aggOptions = def.aggregations.map((agg) => agg.key);
 
   const granularity = pickChartGranularity({
     rangeMs: toMs - fromMs,
@@ -290,26 +272,22 @@ export function EventsOutlierStrip({
 
   const series = useMemo(
     () =>
-      (mode === "split" ? SPLIT_METRICS.slice(0, splitChartCount) : [mode]).map(
-        (metric) =>
-          prepareOutlierSeries({
-            bins,
-            metric,
-            aggregation:
-              metric === "latency" ? settings.latencyAgg : settings.costAgg,
-            fromMs,
-            toMs,
-            stepSeconds: granularity.stepSeconds,
-            widthPx: chartWidth,
-          }),
-      ),
+      prepareOutlierSeries({
+        bins,
+        metric: mode,
+        aggregation:
+          mode === "latency" ? settings.latencyAgg : settings.costAgg,
+        fromMs,
+        toMs,
+        stepSeconds: granularity.stepSeconds,
+        widthPx: chartWidth,
+      }),
     [
       bins,
       fromMs,
       toMs,
       granularity.stepSeconds,
       mode,
-      splitChartCount,
       settings.latencyAgg,
       settings.costAgg,
       chartWidth,
@@ -347,9 +325,8 @@ export function EventsOutlierStrip({
   // that must render as "loading", never as a false "No events in range".
   const placeholderMissesGrid =
     queryResult.isPlaceholderData &&
-    series.every(
-      (s) => s.maxValue === 0 && s.dense.every((bin) => bin.count === 0),
-    );
+    series.maxValue === 0 &&
+    series.dense.every((bin) => bin.count === 0);
   const isLoading =
     validRange &&
     width > 0 &&
@@ -373,76 +350,54 @@ export function EventsOutlierStrip({
               // Dim held-over bins during a refetch (filter change, saved-view
               // switch, drill-in) — stale data must not read as current.
               className={cn(
-                "flex transition-opacity",
+                "min-w-0 transition-opacity",
                 queryResult.isPlaceholderData &&
                   queryResult.isFetching &&
                   "opacity-60",
               )}
-              style={{ gap: CHART_GAP_PX }}
             >
-              {visibleMetrics.map((metric, slot) => {
-                const def = OUTLIER_STRIP_METRICS[metric];
-                const aggOptions = def.aggregations.map((agg) => agg.key);
-                return (
-                  <div key={slot} className="min-w-0">
-                    <div className="flex items-baseline gap-1.5">
-                      {slot === 0 ? (
-                        <>
-                          <ModeDropdown
-                            value={mode}
-                            options={modeOptions}
-                            onChange={(next) => update({ mode: next })}
-                          />
-                          {mode === "split" && (
-                            <span className="text-muted-foreground text-[11px] leading-none">
-                              {def.shortLabel}
-                            </span>
-                          )}
-                        </>
-                      ) : (
-                        <span className="text-muted-foreground text-[11px] leading-none">
-                          {def.shortLabel}
-                        </span>
-                      )}
-                      {/* The bar's aggregate must be legible where there is a
-                          choice (p95 vs avg); single-option metrics are
-                          unambiguous and render no aggregation label. */}
-                      {aggOptions.length > 1 && (
-                        <AggDropdown
-                          metricLabel={def.shortLabel}
-                          value={aggregationFor(metric)}
-                          options={aggOptions}
-                          onChange={(agg) => setAggregation(metric, agg)}
-                        />
-                      )}
-                      {/* Unlike full chart mode (which dims sidebar facets),
-                          the TABLE still honors these filters — only the strip
-                          can't express them, so the disclosure lives here. */}
-                      {slot === 0 && ignoredFilterCount > 0 && (
-                        <span
-                          className="text-muted-foreground/70 text-[11px] leading-none"
-                          title="Some active filters (measures, scores, comments, metadata, free-text search) cannot be applied to this chart's aggregate query. The table still honors them; the chart shows the unfiltered distribution for those."
-                        >
-                          · {ignoredFilterCount} filter
-                          {ignoredFilterCount > 1 ? "s" : ""} not applied
-                        </span>
-                      )}
-                    </div>
-                    <OutlierBarStrip
-                      className="mt-1"
-                      dense={series[slot].dense}
-                      maxValue={series[slot].maxValue}
-                      ticks={series[slot].ticks}
-                      stepMs={stepMs}
-                      metric={metric}
-                      widthPx={chartWidth}
-                      onSelectBucket={handleSelectBucket}
-                      selection={activeSelection}
-                      onSelectionChange={handleSelectionChange}
-                    />
-                  </div>
-                );
-              })}
+              <div className="flex items-baseline gap-1.5">
+                <ModeDropdown
+                  value={mode}
+                  options={MODE_OPTIONS}
+                  onChange={(next) => update({ mode: next })}
+                />
+                {/* The bar's aggregate must be legible where there is a
+                    choice (p95 vs avg); single-option metrics are
+                    unambiguous and render no aggregation label. */}
+                {aggOptions.length > 1 && (
+                  <AggDropdown
+                    metricLabel={def.shortLabel}
+                    value={aggregationFor(mode)}
+                    options={aggOptions}
+                    onChange={(agg) => setAggregation(mode, agg)}
+                  />
+                )}
+                {/* Unlike full chart mode (which dims sidebar facets),
+                    the TABLE still honors these filters — only the strip
+                    can't express them, so the disclosure lives here. */}
+                {ignoredFilterCount > 0 && (
+                  <span
+                    className="text-muted-foreground/70 text-[11px] leading-none"
+                    title="Some active filters (measures, scores, comments, metadata, free-text search) cannot be applied to this chart's aggregate query. The table still honors them; the chart shows the unfiltered distribution for those."
+                  >
+                    · {ignoredFilterCount} filter
+                    {ignoredFilterCount > 1 ? "s" : ""} not applied
+                  </span>
+                )}
+              </div>
+              <OutlierBarStrip
+                className="mt-1"
+                dense={series.dense}
+                maxValue={series.maxValue}
+                ticks={series.ticks}
+                stepMs={stepMs}
+                metric={mode}
+                widthPx={chartWidth}
+                onSelectBucket={handleSelectBucket}
+                selection={activeSelection}
+                onSelectionChange={handleSelectionChange}
+              />
             </div>
           )}
         </div>

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
@@ -69,26 +69,6 @@ export const HeightMatrix = meta.story({
   ),
 });
 
-/** The wide split layout: two 400px charts side by side. */
-export const SplitPair = meta.story({
-  render: () => {
-    const fixture = (metric: "cost" | "latency") =>
-      makeFixtureSeries({
-        rangeMs: 24 * 3600 * 1000,
-        stepSeconds: 1800,
-        profile: "spiky",
-        metric,
-        widthPx: 400,
-      });
-    return (
-      <div className="flex gap-6 p-2">
-        <OutlierBarStrip {...fixture("cost")} metric="cost" />
-        <OutlierBarStrip {...fixture("latency")} metric="latency" />
-      </div>
-    );
-  },
-});
-
 export const BurstyWeek = meta.story({
   args: {
     ...makeFixtureSeries({

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
@@ -5,8 +5,8 @@ import { makeFixtureSeries } from "./lib/fixtures";
 
 /**
  * Design surface for the outlier strip above the trace table (LFE-14451).
- * Every bar is the WORST single event in its time bucket (max cost / latency
- * / tokens) — the strip exists to click into spikes, so the visual must read
+ * Each bar aggregates its time bucket (summed cost, p95/avg latency, event
+ * count) — the strip exists to click into spikes, so the visual must read
  * at a glance: compact, Firefox-devtools-inspired, values on hover only,
  * sparse gridline ticks, a baseline that keeps the plot boundary visible
  * where data is absent.
@@ -69,10 +69,10 @@ export const HeightMatrix = meta.story({
   ),
 });
 
-/** The ≥1200px layout: three 400px charts side by side. */
-export const ThreeUp = meta.story({
+/** The wide split layout: two 400px charts side by side. */
+export const SplitPair = meta.story({
   render: () => {
-    const fixture = (metric: "cost" | "latency" | "tokens") =>
+    const fixture = (metric: "cost" | "latency") =>
       makeFixtureSeries({
         rangeMs: 24 * 3600 * 1000,
         stepSeconds: 1800,
@@ -84,7 +84,6 @@ export const ThreeUp = meta.story({
       <div className="flex gap-6 p-2">
         <OutlierBarStrip {...fixture("cost")} metric="cost" />
         <OutlierBarStrip {...fixture("latency")} metric="latency" />
-        <OutlierBarStrip {...fixture("tokens")} metric="tokens" />
       </div>
     );
   },
@@ -109,10 +108,10 @@ export const SparseData = meta.story({
       rangeMs: 24 * 3600 * 1000,
       stepSeconds: 600,
       profile: "sparse",
-      metric: "tokens",
+      metric: "latency",
       widthPx: 720,
     }),
-    metric: "tokens",
+    metric: "latency",
   },
 });
 

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -381,15 +381,37 @@ export function OutlierBarStrip({
             const x = Math.max(startX, 0);
             const w = Math.min(endX, widthPx) - x;
             if (w <= 0) return null;
+            // Fill alone reads faint over sparse bars; crisp 1px edge lines
+            // carry most of the band's perceived contrast (Grafana-style).
             return (
-              <rect
-                x={x}
-                y={0}
-                width={w}
-                height={plotHeight}
-                className="fill-foreground"
-                opacity={0.12}
-              />
+              <g>
+                <rect
+                  x={x}
+                  y={0}
+                  width={w}
+                  height={plotHeight}
+                  className="fill-foreground"
+                  opacity={0.18}
+                />
+                <line
+                  x1={x + 0.5}
+                  y1={0}
+                  x2={x + 0.5}
+                  y2={plotHeight}
+                  className="stroke-foreground"
+                  strokeWidth={1}
+                  opacity={0.55}
+                />
+                <line
+                  x1={x + w - 0.5}
+                  y1={0}
+                  x2={x + w - 0.5}
+                  y2={plotHeight}
+                  className="stroke-foreground"
+                  strokeWidth={1}
+                  opacity={0.55}
+                />
+              </g>
             );
           })()}
 

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -442,7 +442,7 @@ export function OutlierBarStrip({
       {hovered && mouse && !activePreview && (
         <Layer name="tooltip">
           <div
-            className="bg-popover text-popover-foreground pointer-events-none fixed rounded border px-1.5 py-1 font-mono text-[11px] leading-tight whitespace-nowrap shadow-sm"
+            className="bg-popover text-popover-foreground pointer-events-none fixed rounded border px-1.5 py-1 text-[11px] leading-tight whitespace-nowrap shadow-sm"
             style={
               // Top-right of the cursor; flips to top-left near the viewport's
               // right edge so it never runs off screen.
@@ -482,7 +482,7 @@ export function OutlierBarStrip({
       {activePreview && previewStats && (
         <Layer name="tooltip">
           <div
-            className="bg-popover text-popover-foreground fixed rounded border px-2 py-1.5 font-mono text-[11px] leading-tight whitespace-nowrap shadow-md"
+            className="bg-popover text-popover-foreground fixed rounded border px-2 py-1.5 text-[11px] leading-tight whitespace-nowrap shadow-md"
             style={{
               left: Math.min(
                 Math.max(activePreview.anchorX, 90),

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -26,7 +26,6 @@ import {
 const METRIC_COLOR: Record<OutlierStripMetricKey, string> = {
   cost: "hsl(var(--chart-1))",
   latency: "hsl(var(--chart-2))",
-  tokens: "hsl(var(--chart-4))",
 };
 
 /** Pointer travel before a press becomes a range-drag instead of a click. */
@@ -266,7 +265,7 @@ export function OutlierBarStrip({
         width={widthPx}
         height={heightPx + labelHeight}
         role="img"
-        aria-label={`${metricSpec.shortLabel} (max / bucket)`}
+        aria-label={`${metricSpec.shortLabel} per bucket`}
         className={cn(
           // pan-y: horizontal touch drags select a range; vertical stays with
           // the page scroll (LF-34 mobile gesture requirement). select-none +

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -231,8 +231,6 @@ export function OutlierBarStrip({
   // ?? null: a stale hoverIndex can outlive a shrinking dense array (data or
   // granularity change mid-hover), and undefined slips past a !== null check.
   const hovered = hoverIndex !== null ? (dense[hoverIndex] ?? null) : null;
-  const hoveredHasData =
-    hovered !== null && (hovered.count > 0 || hovered.value !== null);
   const windowKey = `${stepMs}:${dense[0]?.bucketStartMs ?? 0}:${dense.length}`;
   const activePreview =
     touchPreview && touchPreview.windowKey === windowKey ? touchPreview : null;
@@ -266,14 +264,14 @@ export function OutlierBarStrip({
         height={heightPx + labelHeight}
         role="img"
         aria-label={`${metricSpec.shortLabel} per bucket`}
-        className={cn(
-          // pan-y: horizontal touch drags select a range; vertical stays with
-          // the page scroll (LF-34 mobile gesture requirement). select-none +
-          // the pointerdown preventDefault keep a range-drag from ALSO
-          // starting a native text selection over the tick labels.
-          "block touch-pan-y select-none",
-          hoveredHasData || selection ? "cursor-pointer" : "cursor-default",
-        )}
+        // pan-y: horizontal touch drags select a range; vertical stays with
+        // the page scroll (LF-34 mobile gesture requirement). select-none +
+        // the pointerdown preventDefault keep a range-drag from ALSO
+        // starting a native text selection over the tick labels.
+        // Crosshair over the whole plot: the standard "this surface supports
+        // range selection" affordance (Grafana/Datadog) — it makes the
+        // drag-to-zoom brush discoverable where a pointer only said "click".
+        className="block cursor-crosshair touch-pan-y select-none"
         onPointerLeave={(event) => {
           if (event.pointerType !== "mouse") return;
           setHoverIndex(null);

--- a/web/src/features/events/components/outlier-strip/lib/binning.clienttest.ts
+++ b/web/src/features/events/components/outlier-strip/lib/binning.clienttest.ts
@@ -67,8 +67,8 @@ describe("metric registry", () => {
         });
       }
     }
-    // count + 2 cost + 3 latency + 1 tokens
-    expect(metrics).toHaveLength(7);
+    // count + 1 cost + 2 latency
+    expect(metrics).toHaveLength(4);
   });
 });
 
@@ -78,33 +78,26 @@ describe("rowsToOutlierBins", () => {
       {
         time_dimension: "2025-03-10 10:00:00",
         count_count: "2",
-        max_totalCost: "0.5",
         sum_totalCost: "2.5",
-        max_latency: "1500",
         p95_latency: "1000",
         avg_latency: "800",
-        max_totalTokens: "300",
       },
-      // ClickHouse WITH FILL filler: count 0, nullable measures null, but the
-      // non-nullable tokens measure fills with its type default 0.
+      // ClickHouse WITH FILL filler: count 0, nullable measures null, and the
+      // non-nullable count fills with its type default 0.
       {
         time_dimension: "2025-03-10 10:01:00",
         count_count: "0",
-        max_totalCost: null,
-        max_latency: null,
-        max_totalTokens: "0",
+        sum_totalCost: null,
+        p95_latency: null,
       },
     ]);
 
     expect(bins).toHaveLength(1);
     expect(bins[0].count).toBe(2);
     expect(bins[0].values).toEqual({
-      max_totalCost: 0.5,
       sum_totalCost: 2.5,
-      max_latency: 1500,
       p95_latency: 1000,
       avg_latency: 800,
-      max_totalTokens: 300,
     });
   });
 });
@@ -118,12 +111,9 @@ describe("prepareOutlierSeries", () => {
     bucketStart: new Date(bucketStartMs),
     count: value === null ? 0 : 1,
     values: {
-      max_totalCost: value,
-      sum_totalCost: value === null ? null : value * 10,
-      max_latency: value === null ? null : value * 1000,
+      sum_totalCost: value,
       p95_latency: value === null ? null : value * 500,
       avg_latency: value === null ? null : value * 250,
-      max_totalTokens: value,
     },
   });
 
@@ -191,14 +181,13 @@ describe("prepareOutlierSeries", () => {
         stepSeconds: step,
       }).dense[0].value;
 
-    expect(run("latency", "max")).toBe(8); // 8000ms → 8s
     expect(run("latency", "p95")).toBe(4); // 4000ms → 4s
     expect(run("latency", "avg")).toBe(2); // 2000ms → 2s
-    expect(run("cost", "max")).toBe(8);
-    expect(run("cost", "sum")).toBe(80); // sum = 10 × max in the helper
-    // Unknown option falls back to the metric's default (max) — a stored
-    // legacy value can never plot the wrong column.
+    expect(run("cost", "sum")).toBe(8);
+    // Unknown/legacy options fall back to the metric's default (first
+    // registry entry) — a stored legacy value can never plot the wrong column.
     expect(run("cost", "median")).toBe(8);
+    expect(run("latency", "max")).toBe(4); // legacy "max" → default p95
   });
 
   it("places phase-aware ticks with presentation-ready labels", () => {

--- a/web/src/features/events/components/outlier-strip/lib/binning.clienttest.ts
+++ b/web/src/features/events/components/outlier-strip/lib/binning.clienttest.ts
@@ -80,7 +80,7 @@ describe("rowsToOutlierBins", () => {
         count_count: "2",
         sum_totalCost: "2.5",
         p95_latency: "1000",
-        avg_latency: "800",
+        p50_latency: "800",
       },
       // ClickHouse WITH FILL filler: count 0, nullable measures null, and the
       // non-nullable count fills with its type default 0.
@@ -97,7 +97,7 @@ describe("rowsToOutlierBins", () => {
     expect(bins[0].values).toEqual({
       sum_totalCost: 2.5,
       p95_latency: 1000,
-      avg_latency: 800,
+      p50_latency: 800,
     });
   });
 });
@@ -113,7 +113,7 @@ describe("prepareOutlierSeries", () => {
     values: {
       sum_totalCost: value,
       p95_latency: value === null ? null : value * 500,
-      avg_latency: value === null ? null : value * 250,
+      p50_latency: value === null ? null : value * 250,
     },
   });
 
@@ -182,7 +182,7 @@ describe("prepareOutlierSeries", () => {
       }).dense[0].value;
 
     expect(run("latency", "p95")).toBe(4); // 4000ms → 4s
-    expect(run("latency", "avg")).toBe(2); // 2000ms → 2s
+    expect(run("latency", "p50")).toBe(2); // 2000ms → 2s
     expect(run("cost", "sum")).toBe(8);
     // Unknown/legacy options fall back to the metric's default (first
     // registry entry) — a stored legacy value can never plot the wrong column.

--- a/web/src/features/events/components/outlier-strip/lib/binning.ts
+++ b/web/src/features/events/components/outlier-strip/lib/binning.ts
@@ -1,9 +1,5 @@
 import { format } from "date-fns";
-import {
-  compactNumberFormatter,
-  latencyFormatter,
-  usdFormatter,
-} from "@/src/utils/numbers";
+import { latencyFormatter, usdFormatter } from "@/src/utils/numbers";
 import { parseChartTimestamp } from "@/src/features/widgets/chart-library/prepareTimeAxis";
 
 /**
@@ -108,21 +104,21 @@ export function pickChartGranularity(params: {
 // Metric registry
 // ---------------------------------------------------------------------------
 
-export type OutlierStripMetricKey = "cost" | "latency" | "tokens";
-export type OutlierStripLatencyAgg = "max" | "p95" | "avg";
-export type OutlierStripCostAgg = "max" | "sum";
+export type OutlierStripMetricKey = "cost" | "latency";
+export type OutlierStripLatencyAgg = "p95" | "avg";
+export type OutlierStripCostAgg = "sum";
 export type OutlierStripAggKey = OutlierStripLatencyAgg | OutlierStripCostAgg;
 
 type AggregationDef = {
   /** The user-facing option key (currently 1:1 with the query aggregation). */
   key: OutlierStripAggKey;
   /** The executeQuery aggregation this option lowers to. */
-  queryAggregation: "max" | "sum" | "p95" | "avg";
+  queryAggregation: "sum" | "p95" | "avg";
 };
 
 export type OutlierStripMetricDef = {
   shortLabel: string;
-  /** First entry is the default (the outlier semantics: max). */
+  /** First entry is the default. */
   aggregations: readonly AggregationDef[];
   /** The executeQuery measure name on the v2 observations view. */
   measure: string;
@@ -138,10 +134,7 @@ export const OUTLIER_STRIP_METRICS: Record<
   cost: {
     shortLabel: "Cost",
     measure: "totalCost",
-    aggregations: [
-      { key: "max", queryAggregation: "max" },
-      { key: "sum", queryAggregation: "sum" },
-    ],
+    aggregations: [{ key: "sum", queryAggregation: "sum" }],
     fromRaw: (raw) => raw,
     format: (value) =>
       usdFormatter(value, 2, value < 0.001 ? 6 : value < 0.1 ? 4 : 2),
@@ -150,19 +143,11 @@ export const OUTLIER_STRIP_METRICS: Record<
     shortLabel: "Latency",
     measure: "latency",
     aggregations: [
-      { key: "max", queryAggregation: "max" },
       { key: "p95", queryAggregation: "p95" },
       { key: "avg", queryAggregation: "avg" },
     ],
     fromRaw: (raw) => raw / 1000, // executeQuery latency is in ms
     format: (value) => latencyFormatter(value * 1000),
-  },
-  tokens: {
-    shortLabel: "Tokens",
-    measure: "totalTokens",
-    aggregations: [{ key: "max", queryAggregation: "max" }],
-    fromRaw: (raw) => raw,
-    format: (value) => compactNumberFormatter(value),
   },
 };
 

--- a/web/src/features/events/components/outlier-strip/lib/binning.ts
+++ b/web/src/features/events/components/outlier-strip/lib/binning.ts
@@ -105,7 +105,7 @@ export function pickChartGranularity(params: {
 // ---------------------------------------------------------------------------
 
 export type OutlierStripMetricKey = "cost" | "latency";
-export type OutlierStripLatencyAgg = "p95" | "avg";
+export type OutlierStripLatencyAgg = "p95" | "p50";
 export type OutlierStripCostAgg = "sum";
 export type OutlierStripAggKey = OutlierStripLatencyAgg | OutlierStripCostAgg;
 
@@ -113,7 +113,7 @@ type AggregationDef = {
   /** The user-facing option key (currently 1:1 with the query aggregation). */
   key: OutlierStripAggKey;
   /** The executeQuery aggregation this option lowers to. */
-  queryAggregation: "sum" | "p95" | "avg";
+  queryAggregation: "sum" | "p95" | "p50";
 };
 
 export type OutlierStripMetricDef = {
@@ -144,7 +144,7 @@ export const OUTLIER_STRIP_METRICS: Record<
     measure: "latency",
     aggregations: [
       { key: "p95", queryAggregation: "p95" },
-      { key: "avg", queryAggregation: "avg" },
+      { key: "p50", queryAggregation: "p50" },
     ],
     fromRaw: (raw) => raw / 1000, // executeQuery latency is in ms
     format: (value) => latencyFormatter(value * 1000),

--- a/web/src/features/events/components/outlier-strip/lib/fixtures.ts
+++ b/web/src/features/events/components/outlier-strip/lib/fixtures.ts
@@ -69,12 +69,9 @@ export function makeFixtureBins(params: {
       bucketStart: new Date(t),
       count,
       values: {
-        max_totalCost: noData ? null : 0.02 * base * outlier,
         sum_totalCost: noData ? null : 0.02 * base * outlier * 5,
-        max_latency: noData ? null : 2000 * base * outlier,
         p95_latency: noData ? null : 2000 * base * outlier * 0.6,
         avg_latency: noData ? null : 2000 * base * outlier * 0.35,
-        max_totalTokens: noData ? null : Math.round(1500 * base * outlier),
       },
     });
   }

--- a/web/src/features/events/components/outlier-strip/lib/fixtures.ts
+++ b/web/src/features/events/components/outlier-strip/lib/fixtures.ts
@@ -71,7 +71,7 @@ export function makeFixtureBins(params: {
       values: {
         sum_totalCost: noData ? null : 0.02 * base * outlier * 5,
         p95_latency: noData ? null : 2000 * base * outlier * 0.6,
-        avg_latency: noData ? null : 2000 * base * outlier * 0.35,
+        p50_latency: noData ? null : 2000 * base * outlier * 0.35,
       },
     });
   }

--- a/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
+++ b/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
@@ -12,7 +12,7 @@ import useLocalStorage from "@/src/components/useLocalStorage";
 const outlierStripSettingsSchema = z
   .object({
     mode: z.enum(["cost", "latency"]).catch("cost"),
-    latencyAgg: z.enum(["p95", "avg"]).catch("p95"),
+    latencyAgg: z.enum(["p95", "p50"]).catch("p95"),
     costAgg: z.enum(["sum"]).catch("sum"),
   })
   .catch({ mode: "cost", latencyAgg: "p95", costAgg: "sum" });

--- a/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
+++ b/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
@@ -11,7 +11,7 @@ import useLocalStorage from "@/src/components/useLocalStorage";
  */
 const outlierStripSettingsSchema = z
   .object({
-    mode: z.enum(["cost", "latency", "split"]).catch("cost"),
+    mode: z.enum(["cost", "latency"]).catch("cost"),
     latencyAgg: z.enum(["p95", "avg"]).catch("p95"),
     costAgg: z.enum(["sum"]).catch("sum"),
   })

--- a/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
+++ b/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
@@ -11,11 +11,11 @@ import useLocalStorage from "@/src/components/useLocalStorage";
  */
 const outlierStripSettingsSchema = z
   .object({
-    mode: z.enum(["cost", "latency", "tokens", "split"]).catch("cost"),
-    latencyAgg: z.enum(["max", "p95", "avg"]).catch("max"),
-    costAgg: z.enum(["max", "sum"]).catch("max"),
+    mode: z.enum(["cost", "latency", "split"]).catch("cost"),
+    latencyAgg: z.enum(["p95", "avg"]).catch("p95"),
+    costAgg: z.enum(["sum"]).catch("sum"),
   })
-  .catch({ mode: "cost", latencyAgg: "max", costAgg: "max" });
+  .catch({ mode: "cost", latencyAgg: "p95", costAgg: "sum" });
 
 export type OutlierStripSettings = z.infer<typeof outlierStripSettingsSchema>;
 


### PR DESCRIPTION
## Summary

UX adjustments to the Pulse outlier strip above the trace table (#15486):

**Always visible**
- The X close button, the toolbar "Pulse" reopen button, and the open/closed localStorage state are removed — the strip simply always shows (also on mobile, which previously defaulted to closed). The toolbar's `preColumnsSlot` prop existed only for the reopen button and is removed with it.
- The associated `pulse:closed` / `pulse:reopened` analytics events drop with the buttons; `pulse:drill_in`, `pulse:mode_switch`, `pulse:aggregation_switch`, and `pulse:preview_pinned` (from #15535) are kept with payloads adapted to the simplified shape.

**Simplified metrics**
- **Cost** plots `sum` only (was max/sum); single-option metrics render no aggregation label.
- **Latency** offers **p95 (default)** and **p50** — the old `avg` was replaced by a *true* `p50` executeQuery aggregation, not renamed.
- **Tokens** metric and the **Split** view are removed; the mode dropdown is just Cost / Latency. Stored legacy preferences (`split`, `tokens`, `max`, `avg`) degrade safely via the zod settings schema + registry fallback.

**Brush discoverability & visual polish**
- Crosshair cursor over the plot (the Grafana/Datadog "this surface supports range selection" affordance).
- Drag-selection band: stronger fill (0.12 → 0.18) plus crisp 1px edge lines — the flat faint fill was easy to miss over sparse bars.
- Sans-serif for the title/aggregation dropdowns and tooltips (one-off ahead of a design-system pass); triggers 11px → 13px; separator dot dropped; more headroom between label row and plot (mt-1 → mt-2).
- Query error state reads "No Data".

## Testing

- `binning.clienttest.ts`: `Tests  13 passed (13)` — registry derivation, WITH FILL handling, aggregation-column selection, and legacy-aggregation fallback updated for the new registry
- `pnpm run lint`: `Tasks: 7 successful, 7 total` (pre-commit on every commit)
- Browser-reviewed on local dev against seeded data (90-day window): strip render, mode/agg dropdowns, drag-selection band, drill-in, crosshair
- One review round applied; the unrelated dev-environment turbopack.root fix moved to #15541 per review feedback. No other findings (tenant isolation unchanged, no CH/PG/API/seeder surface)

## Screenshots

1280x720, seeded demo data, 90-day window. Before = main (`187686a1e`), after = this branch.

| | Before | After |
|---|---|---|
| **Strip** (mono "Cost · max" + X close → sans "Cost", no X) | ![strip before](https://raw.githubusercontent.com/langfuse/langfuse/pr-15540-assets/screenshots/1-strip-overview-before.png) | ![strip after](https://raw.githubusercontent.com/langfuse/langfuse/pr-15540-assets/screenshots/2-strip-overview-after.png) |
| **Drag-selection band** (0.12 flat fill → 0.18 fill + 1px edges) | ![drag band before](https://raw.githubusercontent.com/langfuse/langfuse/pr-15540-assets/screenshots/3-drag-band-before.png) | ![drag band after](https://raw.githubusercontent.com/langfuse/langfuse/pr-15540-assets/screenshots/4-drag-band-after.png) |
| **Tooltip** (mono → sans; same bucket also shows cost max → sum: $0.003 → $23.77) | ![tooltip before](https://raw.githubusercontent.com/langfuse/langfuse/pr-15540-assets/screenshots/5-tooltip-before.png) | ![tooltip after](https://raw.githubusercontent.com/langfuse/langfuse/pr-15540-assets/screenshots/6-tooltip-after.png) |

_Asset branch `pr-15540-assets` — delete after merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

