### PR TITLE
fix(dev): pin turbopack.root so nested-worktree dev servers resolve @langfuse/shared

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -3,6 +3,7 @@
  * for Docker builds.
  */
 await import("./src/env.mjs");
+import { fileURLToPath } from "node:url";
 import { withSentryConfig } from "@sentry/nextjs";
 import { env } from "./src/env.mjs";
 
@@ -105,8 +106,9 @@ const nextConfig = {
   turbopack: {
     // Pin the workspace root: in a nested git worktree Next.js infers the
     // OUTER checkout's root (outermost lockfile wins), which breaks the
-    // relative resolveAlias below.
-    root: new URL("..", import.meta.url).pathname,
+    // relative resolveAlias below. fileURLToPath, not URL.pathname — the
+    // latter percent-encodes spaces and breaks on Windows drive letters.
+    root: fileURLToPath(new URL("..", import.meta.url)),
     resolveAlias: {
       "@langfuse/shared": "./packages/shared/src",
     },

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -103,6 +103,10 @@ const nextConfig = {
     },
   },
   turbopack: {
+    // Pin the workspace root: in a nested git worktree Next.js infers the
+    // OUTER checkout's root (outermost lockfile wins), which breaks the
+    // relative resolveAlias below.
+    root: new URL("..", import.meta.url).pathname,
     resolveAlias: {
       "@langfuse/shared": "./packages/shared/src",
     },


### PR DESCRIPTION
## Summary

Dev-only fix, split out of #15540 per review feedback (it had ridden along there).

Running `next dev` from a git worktree nested inside the main checkout (e.g. `.claude/worktrees/<name>/`) fails with `Module not found: Can't resolve '@langfuse/shared'`: Next.js infers the workspace root by walking up to the **outermost** lockfile, so the relative `turbopack.resolveAlias` target `./packages/shared/src` resolves against the wrong root.

Pin `turbopack.root` to the monorepo root next to this config file. `fileURLToPath` rather than `URL.pathname` — the latter percent-encodes spaces and mangles Windows drive letters (matches the existing `web/.storybook/main.ts` convention).

No behavior change for plain checkouts: the pinned root is exactly what inference already picked there.

## Testing

- Reproduced the failure in a nested worktree, verified the pinned root fixes alias resolution and the dev server serves the app (this is how #15540 was reviewed locally).
- `pnpm run lint`: `Tasks: 7 successful, 7 total` (pre-commit on the original commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)