### PR TITLE
test(events): approx-count behavioral test + documented tuple constant (LFE-11057 follow-up)

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
@@ -16,6 +16,9 @@ export const EVENTS_FILTER_OPTION_TOP_N = 1000;
 // Sentinel "column" carrying the approx total observation count in the facet result.
 export const EVENTS_APPROX_TOTAL_COUNT_MARKER = "__approxTotalCount__";
 
+// Facet tuple format: (option name, option value, value-occurrence count, sort order).
+const EVENTS_APPROX_TOTAL_COUNT_TUPLE = `tuple('${EVENTS_APPROX_TOTAL_COUNT_MARKER}', '', toUInt64(approx_total_count), toInt64(0))`;
+
 const EVENTS_FILTER_OPTION_TOP_K_MAX_N = 65_536;
 
 type EventFilterOptionSort = "countDesc" | "alpha" | "booleanAsc";
@@ -395,7 +398,7 @@ export const buildEventsFilterOptionsForColumnsQuery = (params: {
 
   // Approx total rides one extra sentinel row so the result shape stays {column, value, count}.
   const approxTotalCountRow = includeApproxTotal
-    ? `,\n      [tuple('${EVENTS_APPROX_TOTAL_COUNT_MARKER}', '', toUInt64(approx_total_count), toInt64(0))]`
+    ? `,\n      [${EVENTS_APPROX_TOTAL_COUNT_TUPLE}]`
     : "";
 
   const query = `

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -30,6 +30,7 @@ import { env } from "@/src/env.mjs";
 import {
   type EventsTableFilterState,
   type FilterCondition,
+  type TimeFilter,
 } from "@langfuse/shared";
 import waitForExpect from "wait-for-expect";
 
@@ -1035,6 +1036,117 @@ describe("Clickhouse Events Repository Test", () => {
           { value: "ERROR" },
           { value: "WARNING" },
         ]);
+      });
+    });
+
+    it("returns the approximate total observation count only when requested, filter-aware and flagged when partial", async () => {
+      const uniqueProjectId = randomUUID();
+      const now = Date.now();
+      const alphaName = "approx-count-alpha";
+      const betaName = "approx-count-beta";
+      const nameFilter: FilterCondition = {
+        type: "stringOptions",
+        column: "name",
+        operator: "any of",
+        value: [alphaName],
+      };
+      const startTimeFilter: TimeFilter[] = [
+        {
+          column: "startTime",
+          type: "datetime",
+          operator: ">=",
+          value: new Date(now - 60_000),
+        },
+      ];
+
+      // Two distinct observations named alpha, one named beta => 3 distinct span_ids.
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: randomUUID(),
+          type: "SPAN",
+          name: alphaName,
+          level: "WARNING",
+          start_time: now * 1000,
+          event_ts: now * 1000,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: randomUUID(),
+          type: "SPAN",
+          name: alphaName,
+          level: "ERROR",
+          start_time: (now + 1) * 1000,
+          event_ts: (now + 1) * 1000,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: randomUUID(),
+          type: "SPAN",
+          name: betaName,
+          level: "DEFAULT",
+          start_time: (now + 2) * 1000,
+          event_ts: (now + 2) * 1000,
+        }),
+      ]);
+
+      await waitForExpect(async () => {
+        // Eager/bulk request: count present and equal to the distinct observations.
+        const eager = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+          startTimeFilter,
+          columns: ["name", "level"],
+          includeApproxCount: true,
+        });
+        expect(eager.approxTotalCount).toBe(3);
+        expect(eager.approxTotalCountIsPartial).toBe(false);
+
+        // Lazy per-column request never asks for the count, so the keys stay absent.
+        const lazy = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+          startTimeFilter,
+          columns: ["level"],
+        });
+        expect(lazy).not.toHaveProperty("approxTotalCount");
+        expect(lazy).not.toHaveProperty("approxTotalCountIsPartial");
+
+        // Filter-aware: an applied native (name) filter narrows the count to alpha.
+        const filtered = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+          startTimeFilter,
+          columns: ["name", "level"],
+          filter: [nameFilter],
+          includeApproxCount: true,
+        });
+        expect(filtered.approxTotalCount).toBe(2);
+        expect(filtered.approxTotalCountIsPartial).toBe(false);
+
+        // A non-participating (input) filter is dropped from the facet scan, so the
+        // count over-counts vs the visible rows (still 2, ignoring input) and is
+        // flagged partial.
+        const partial = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+          startTimeFilter,
+          columns: ["name", "level"],
+          filter: [
+            nameFilter,
+            {
+              type: "string",
+              column: "input",
+              operator: "contains",
+              value: "expensive",
+            },
+          ],
+          includeApproxCount: true,
+        });
+        expect(partial.approxTotalCount).toBe(2);
+        expect(partial.approxTotalCountIsPartial).toBe(true);
       });
     });
 


### PR DESCRIPTION
## TL;DR
Addresses the two post-merge review nits on #15517 (approximate row count in the traces table): a behavioral approx-count test in the existing repository suite, and the sentinel tuple extracted into a documented named constant.

## What
- **Test (behavioral, not query-shape):** extend the existing `getEventFilterOptions` repository servertest (CH+PG tier) to assert the actual returned `approxTotalCount` for seeded data — present + correct on the eager bulk request, absent on the lazy per-column request, filter-aware over an applied native filter, and flagged partial when a non-participating filter is dropped from the scan.
- **Readability:** extract the approx-count sentinel row's inline tuple literal into a named `EVENTS_APPROX_TOTAL_COUNT_TUPLE` constant next to the other module constants, with a one-line comment documenting the 4-field facet tuple format `(option name, option value, value-occurrence count, sort order)`.

## Result
No behavior change — a test-coverage + readability follow-up. The former standalone SQL-shape test file was already removed on the feature branch before merge.

<details>
<summary>Verification</summary>

- Typecheck: `shared` + `web` clean.
- Lint: both changed files clean.
- Servertest: `getEventFilterOptions` describe block green (6 passed) against the CH+PG tier.
</details>

Follow-up to #15517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
