### PR TITLE
fix(mcp): honor X-Forwarded-Host behind trusted proxies (opt-in)

### DIFF
--- a/web/src/__tests__/server/unit/mcp-security.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-security.servertest.ts
@@ -1,6 +1,7 @@
 const mockEnv = vi.hoisted(() => ({
   env: {
     LANGFUSE_MCP_ALLOWED_HOSTS: [] as string[],
+    LANGFUSE_MCP_TRUST_FORWARDED_HEADERS: undefined as string | undefined,
     NEXTAUTH_URL: "https://langfuse.example.com",
     NODE_ENV: "production",
   },
@@ -19,6 +20,7 @@ describe("MCP request security", () => {
     mockEnv.env.NEXTAUTH_URL = "https://langfuse.example.com";
     mockEnv.env.NODE_ENV = "production";
     mockEnv.env.LANGFUSE_MCP_ALLOWED_HOSTS = [];
+    mockEnv.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS = undefined;
   });
 
   it("allows an exact additional host from LANGFUSE_MCP_ALLOWED_HOSTS", () => {
@@ -43,5 +45,94 @@ describe("MCP request security", () => {
     expect(() =>
       validateMcpRequestSecurity(mockRequest({ host: "evil.example.com" })),
     ).toThrow("Invalid Host header: evil.example.com");
+  });
+
+  describe("X-Forwarded-Host handling", () => {
+    it("honors X-Forwarded-Host when LANGFUSE_MCP_TRUST_FORWARDED_HEADERS is enabled", () => {
+      mockEnv.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS = "true";
+
+      expect(
+        validateMcpRequestSecurity(
+          mockRequest({
+            host: "langfuse-web-internal:3000",
+            "x-forwarded-host": "langfuse.example.com",
+          }),
+        ),
+      ).toBe(null);
+    });
+
+    it("validates the Origin header against the forwarded host's allowlist entry", () => {
+      mockEnv.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS = "true";
+
+      expect(
+        validateMcpRequestSecurity(
+          mockRequest({
+            host: "langfuse-web-internal:3000",
+            "x-forwarded-host": "langfuse.example.com",
+            origin: "https://langfuse.example.com",
+          }),
+        ),
+      ).toBe("https://langfuse.example.com");
+    });
+
+    it("uses the first entry of a comma-separated X-Forwarded-Host list", () => {
+      mockEnv.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS = "true";
+
+      expect(
+        validateMcpRequestSecurity(
+          mockRequest({
+            host: "langfuse-web-internal:3000",
+            "x-forwarded-host": "langfuse.example.com, proxy.internal",
+          }),
+        ),
+      ).toBe(null);
+    });
+
+    it("rejects a forwarded host that is not in the allowlist", () => {
+      mockEnv.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS = "true";
+
+      expect(() =>
+        validateMcpRequestSecurity(
+          mockRequest({
+            host: "langfuse.example.com",
+            "x-forwarded-host": "evil.example.com",
+          }),
+        ),
+      ).toThrow("Invalid X-Forwarded-Host header: evil.example.com");
+    });
+
+    it("falls back to the Host header when X-Forwarded-Host is absent", () => {
+      mockEnv.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS = "true";
+
+      expect(
+        validateMcpRequestSecurity(
+          mockRequest({ host: "langfuse.example.com" }),
+        ),
+      ).toBe(null);
+    });
+
+    it("ignores X-Forwarded-Host by default (flag unset)", () => {
+      expect(() =>
+        validateMcpRequestSecurity(
+          mockRequest({
+            host: "langfuse-web-internal:3000",
+            "x-forwarded-host": "langfuse.example.com",
+          }),
+        ),
+      ).toThrow("Invalid Host header: langfuse-web-internal:3000");
+    });
+
+    it("ignores X-Forwarded-Host when the flag is explicitly disabled", () => {
+      mockEnv.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS = "false";
+
+      expect(() =>
+        validateMcpRequestSecurity(
+          mockRequest({
+            host: "langfuse-web-internal:3000",
+            "x-forwarded-host": "langfuse.example.com",
+          }),
+        ),
+      ).toThrow("Invalid Host header: langfuse-web-internal:3000");
+    });
   });
 });

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -72,6 +72,10 @@ export const env = createEnv({
               .filter(Boolean)
           : [],
       ),
+    // Only enable when Langfuse runs behind a trusted reverse proxy that
+    // overwrites the X-Forwarded-Host header; otherwise clients can spoof it
+    // and bypass the MCP Host allowlist (DNS-rebinding protection).
+    LANGFUSE_MCP_TRUST_FORWARDED_HEADERS: z.enum(["true", "false"]).optional(),
     NEXTAUTH_COOKIE_DOMAIN: z.string().optional(),
     // Optional suffix appended to the auth cookie NAMES (e.g. ".pr-1234" ->
     // "__Secure-next-auth.session-token.pr-1234"). Lets multiple Langfuse
@@ -566,6 +570,8 @@ export const env = createEnv({
     NEXTAUTH_COOKIE_NAME_SUFFIX: process.env.NEXTAUTH_COOKIE_NAME_SUFFIX,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     LANGFUSE_MCP_ALLOWED_HOSTS: process.env.LANGFUSE_MCP_ALLOWED_HOSTS,
+    LANGFUSE_MCP_TRUST_FORWARDED_HEADERS:
+      process.env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS,
     NEXT_PUBLIC_LANGFUSE_CLOUD_REGION:
       process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF:

--- a/web/src/features/mcp/server/security.ts
+++ b/web/src/features/mcp/server/security.ts
@@ -67,13 +67,44 @@ function getAllowedMcpOriginsAndHostnames() {
   return { allowedHostnames, allowedOrigins };
 }
 
+/**
+ * Resolves the host header to validate against the allowlist.
+ *
+ * Reverse proxies (ALB, Cloudflare, Traefik, nginx, k8s ingresses) commonly
+ * rewrite `Host` to the internal upstream name and relay the original client
+ * host in `X-Forwarded-Host`. We only honor `X-Forwarded-Host` when the
+ * operator has opted in via LANGFUSE_MCP_TRUST_FORWARDED_HEADERS, because the
+ * header is client-settable and blindly trusting it would let attackers
+ * bypass the Host allowlist (DNS-rebinding protection). Mirrors the
+ * first-comma-value convention of getRequestOrigin in server/utils/cookies.
+ */
+function getEffectiveHostHeader(req: NextApiRequest): {
+  headerName: "Host" | "X-Forwarded-Host";
+  value: string | undefined;
+} {
+  if (env.LANGFUSE_MCP_TRUST_FORWARDED_HEADERS === "true") {
+    const rawForwardedHost = Array.isArray(req.headers["x-forwarded-host"])
+      ? req.headers["x-forwarded-host"][0]
+      : req.headers["x-forwarded-host"];
+    const forwardedHost = rawForwardedHost?.split(",")[0]?.trim();
+    if (forwardedHost) {
+      return { headerName: "X-Forwarded-Host", value: forwardedHost };
+    }
+  }
+
+  return {
+    headerName: "Host",
+    value: Array.isArray(req.headers.host)
+      ? req.headers.host[0]
+      : req.headers.host,
+  };
+}
+
 export function validateMcpRequestSecurity(req: NextApiRequest): string | null {
   const { allowedHostnames, allowedOrigins } =
     getAllowedMcpOriginsAndHostnames();
 
-  const hostHeader = Array.isArray(req.headers.host)
-    ? req.headers.host[0]
-    : req.headers.host;
+  const { headerName, value: hostHeader } = getEffectiveHostHeader(req);
   if (!hostHeader) {
     throw new ForbiddenError("Missing Host header");
   }
@@ -82,11 +113,11 @@ export function validateMcpRequestSecurity(req: NextApiRequest): string | null {
   try {
     hostname = new URL(`http://${hostHeader}`).hostname.toLowerCase();
   } catch {
-    throw new ForbiddenError(`Invalid Host header: ${hostHeader}`);
+    throw new ForbiddenError(`Invalid ${headerName} header: ${hostHeader}`);
   }
 
   if (!allowedHostnames.has(hostname)) {
-    throw new ForbiddenError(`Invalid Host header: ${hostHeader}`);
+    throw new ForbiddenError(`Invalid ${headerName} header: ${hostHeader}`);
   }
 
   const originHeader = Array.isArray(req.headers.origin)


### PR DESCRIPTION
Fixes #15534, reported by @thepabloaguilar. @bezbac I see you were assigned recently, happy to close this if you already have a fix in flight.

The MCP server validates requests against a Host allowlist for DNS-rebinding protection. Reverse proxies and ingresses (ALB, Cloudflare, Traefik, nginx) rewrite Host to the internal upstream name and carry the original host in X-Forwarded-Host, so requests through standard proxy setups fail host verification.

This honors X-Forwarded-Host (first comma-separated value, mirroring the existing x-forwarded-proto handling in getRequestOrigin), falling back to Host when absent.

Since X-Forwarded-Host is client-settable, trusting it unconditionally would defeat the DNS-rebinding protection. It is therefore only honored behind an explicit opt-in, a new `LANGFUSE_MCP_TRUST_FORWARDED_HEADERS` env var (default off), meant for deployments behind a trusted proxy that overwrites the header. X-Forwarded-Proto is intentionally not consumed since host validation here is scheme-agnostic.

Tests cover the forwarded path (incl. Origin and comma-separated lists), Host fallback, rejection of non-allowlisted forwarded hosts, and the header being ignored when the flag is off.
