### PR TITLE
docs(previews): seed data into a preview via port-forward + seed CLI

### DIFF
--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -6,8 +6,10 @@ description: >
   Use when spinning up or using a PR preview, logging into one, working out why
   a preview did not come up (built but the URL 404s, ImagePullBackOff, pods
   stuck Pending), reading web / worker / ClickHouse logs or otherwise debugging
-  a preview with kubectl, waking a preview that went to sleep off-hours, or
-  getting preview deploy or cluster access. Synthetic data only.
+  a preview with kubectl, waking a preview that went to sleep off-hours,
+  seeding or adding more test data to a preview (deep traces, big sessions,
+  bulk traces, v4 events) with the seed CLI over a port-forward, or getting
+  preview deploy or cluster access. Synthetic data only.
 ---
 
 # Langfuse PR Previews
@@ -62,6 +64,51 @@ Pushing updates it; closing the PR tears it down.
 - **Disposable data.** Closing a PR destroys its database; reopening gives a
   **fresh** environment, not the old one.
 - **Forks can't preview.** External / fork PRs never build or deploy.
+
+## Add or improve data in a preview
+
+Previews start pre-seeded with the demo project and some synthetic traces. To
+add the specific shape you're testing — a very deep trace, a huge session, bulk
+traces for list performance, v4 events, malformed payloads — run the
+deterministic **seed CLI from your local checkout**, pointed at the preview's
+datastores over a `port-forward`. The CLI has no LLM/agent loop; you (or your
+coding agent) pick the scenario — the **`seed-test-data` skill** maps "what I
+need" → the exact command and flags.
+
+Needs cluster access (see [Getting access](#getting-access)) and a working
+local `.env` (your normal local-dev setup — it supplies everything except the
+DB connection, which the commands below override).
+
+```bash
+NS=langfuse-pr-<N>              # e.g. langfuse-pr-42
+
+# 1. tunnel Postgres + ClickHouse to localhost (leave these running)
+kubectl -n $NS port-forward svc/$NS-postgresql 5432:5432 &
+CH=$(kubectl -n $NS get svc -o name | grep clickhouse | head -1)
+kubectl -n $NS port-forward "$CH" 8123:8123 &
+
+# 2. per-preview generated passwords (synthetic, disposable)
+PGPW=$(kubectl -n $NS get secret langfuse-secrets -o jsonpath='{.data.postgres-password}' | base64 -d)
+CHPW=$(kubectl -n $NS get secret langfuse-secrets -o jsonpath='{.data.clickhouse-password}' | base64 -d)
+
+# 3. seed — overrides only the DB connection (your .env supplies the rest);
+#    NEXTAUTH_URL makes the CLI's printed deep links point at the preview UI
+cd packages/shared
+DATABASE_URL="postgresql://postgres:$PGPW@localhost:5432/postgres_langfuse" \
+CLICKHOUSE_URL="http://localhost:8123" CLICKHOUSE_PASSWORD="$CHPW" \
+NEXTAUTH_URL="https://pr-<N>.preview.langfuse.com" \
+pnpm run seed:scenario -- deep-chain --v4
+```
+
+- `pnpm run seed:scenario -- list` shows every scenario and flag; add
+  `--dry-run` to predict counts and write nothing. Full catalog: the
+  `seed-test-data` skill.
+- The last stdout line is a JSON summary with `verified` and clickable `links`
+  straight into the preview UI.
+- Run from a checkout whose **migrations match the PR** — scenario code and the
+  preview DB must agree, so seed from the PR's branch (usually already checked
+  out), not a stale `main`.
+- **Synthetic data only** — same rule as everywhere else in a preview.
 
 ## Debug a preview
 


### PR DESCRIPTION
## What

Adds an **"Add or improve data in a preview"** section to the `langfuse-previews` skill: the simplest way to seed a PR preview with specific data shapes.

## Why

Improving preview data doesn't need an in-cluster agent or a bespoke LLM loop. The seed CLI is a **deterministic generator** with no agent inside — the "agent" is you (or your coding agent) picking a scenario via the existing `seed-test-data` skill. The only missing link was a documented network path from a local checkout to the preview's datastores.

## The flow it documents

`kubectl port-forward` the preview's Postgres + ClickHouse → run `pnpm run seed:scenario` from your local checkout with the DB connection overridden → clickable deep links into the preview UI. Your coding agent maps intent ("seed a deep trace into pr-1234") to the right scenario/flags.

## Public-safety

This is the public repo, so the addition uses **only** what the skill already exposes — the `$NS` / `<namespace>-<component>` conventions, per-namespace service/secret names, and synthetic disposable passwords. No account id, SSO URL, cluster name, or region (those remain in the internal doc referenced by *Getting access*).

Docs-only; one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
