### PR TITLE
docs(agent): tighten skill descriptions

### DIFF
--- a/.agents/skills/backend-dev-guidelines/SKILL.md
+++ b/.agents/skills/backend-dev-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-dev-guidelines
-description: Shared backend guide for Langfuse's Next.js, tRPC, BullMQ, and TypeScript monorepo. Use when creating or reviewing tRPC routers, public REST endpoints, BullMQ queue processors, backend services, middleware, Prisma or ClickHouse data access, OpenTelemetry instrumentation, Zod validation, env configuration, or backend tests across web, worker, or packages/shared.
+description: Build or review Langfuse backend code. Use for tRPC routers, public REST APIs, BullMQ processors, services, middleware, Prisma or ClickHouse access, OpenTelemetry, Zod, environment configuration, or backend tests.
 ---
 
 # Backend Development Guidelines

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: code-review
-description: |
-  Shared code review workflow for Langfuse. Use when reviewing a PR, branch, diff,
-  or local changes for correctness, regressions, risk, and missing tests.
-  Start with references/review-checklist.md for repo-specific review rules and
-  use package AGENTS.md files plus any matching shared skills when the change
-  touches those areas.
+description: Review Langfuse code changes for correctness, regressions, and best practices.
 ---
 
 # Code Review

--- a/.agents/skills/create-repo-agent/SKILL.md
+++ b/.agents/skills/create-repo-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-repo-agent
-description: Use when designing, implementing, reviewing, or hardening Langfuse repo-owned autonomous agents, especially GitHub Actions that invoke Claude, Codex, or another LLM agent on a schedule or workflow_dispatch, create pull requests, update workflow prompts or allowlists, handle GitHub tokens/secrets, use untrusted web content, or self-improve repo agent instructions.
+description: Design, implement, review, or harden Langfuse repo-owned autonomous agents. Use for LLM-powered GitHub Actions, scheduled or dispatched agents, agent-created PRs, prompts, allowlists, tokens, untrusted content, or self-updating instructions.
 ---
 
 # Create Repo Agent

--- a/.agents/skills/datadog-query-recipes/SKILL.md
+++ b/.agents/skills/datadog-query-recipes/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: datadog-query-recipes
 description: |
-  Langfuse-specific Datadog query recipes for production telemetry research.
-  Use when asked to investigate tenant or project activity, public API endpoint
-  usage, queue consumer behavior, spans, logs, metrics, or ad hoc production
-  questions across prod-us, prod-eu, prod-hipaa, and prod-jp. This skill is for
-  reusable query shapes and measured research; pair it with
-  debug-issue-with-datadog when the task is an incident or root-cause analysis.
+  Research Langfuse production telemetry with reusable Datadog queries. Use for
+  tenant or project activity, API usage, queue behavior, spans, logs, metrics,
+  or ad hoc measurements across production regions; pair with
+  debug-issue-with-datadog for root-cause analysis.
 ---
 
 # Datadog Query Recipes

--- a/.agents/skills/debug-issue-with-datadog/SKILL.md
+++ b/.agents/skills/debug-issue-with-datadog/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: debug-issue-with-datadog
 description: |
-  Debug a user-reported issue, Linear ticket, or incident report by combining
-  Datadog (APM, logs, metrics) with the Langfuse repo to establish a
-  root cause. Use when given a Linear issue URL/ID (e.g. LFE-XXXX), a GitHub
-  issue, or a pasted error/report and asked to investigate, root-cause, or
-  triage. Produces a structured analysis — error breakdown, hypothesis-by-class,
-  suggested patches with code references.
+  Establish root cause by combining Datadog telemetry with the Langfuse repo.
+  Use when investigating or triaging a user report, Linear or GitHub issue,
+  incident, or pasted production error.
 ---
 
 # Debug Issue with Datadog

--- a/.agents/skills/frontend-large-feature-architecture/SKILL.md
+++ b/.agents/skills/frontend-large-feature-architecture/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: frontend-large-feature-architecture
 description: |
-  Use when building, changing, or refactoring large Langfuse frontend features,
-  virtualized lists, large tables, controller components, local feature state,
-  Zustand stores, row selection, high-frequency UI state, or
-  rendering-performance issues. Also read BEFORE writing any useEffect
-  (especially one that syncs fetched data into state), wiring form
-  initialValues/defaultValues from loaded data, or adding useCallback/useMemo.
+  Architect large or state-heavy Langfuse frontend features. Use for virtualized
+  lists, large tables, controllers, Zustand stores, row selection, high-frequency
+  state, rendering performance, or before adding useEffect, useMemo, useCallback,
+  or form defaults derived from loaded data.
 ---
 
 # Frontend Large Feature Architecture

--- a/.agents/skills/housekeeping/SKILL.md
+++ b/.agents/skills/housekeeping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: housekeeping
-description: Review an engineer's recurring work queue across Linear, Pylon, and GitHub. Use when asked to triage assigned issues, waiting or urgent work, customer-support follow-ups, stale tickets, or pull requests where the engineer is a direct or team reviewer; return concrete action recommendations and gate all writes on explicit human approval.
+description: Triage an engineer's work queue across Linear, Pylon, and GitHub. Use for assigned, urgent, waiting, or stale issues, support follow-ups, and PR reviews.
 ---
 
 # Housekeeping

--- a/.agents/skills/incident-alert-tickets/SKILL.md
+++ b/.agents/skills/incident-alert-tickets/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: incident-alert-tickets
 description: |
-  Look up, compare against, and (after human approval) update the Linear
-  incident-alert knowledge base: one ticket per production alert/monitor,
-  labeled `incident-alert`, with one dated cause section per distinct root
-  cause. Use whenever an investigation is anchored to a named alert identity —
-  a Datadog monitor ID or title, an incident.io alert/INC reference, or an
-  on-call page — both before debugging from scratch (a documented cause may
-  already answer it) and after establishing a new root cause (record it).
+  Read and, after human approval, update the Linear `incident-alert` knowledge
+  base. Use before and after investigating a named Datadog monitor, incident.io
+  alert or incident, or on-call page to find or record root causes.
 ---
 
 # Incident Alert Tickets

--- a/.agents/skills/infra-scaling/SKILL.md
+++ b/.agents/skills/infra-scaling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: infra-scaling
-description: Tune Langfuse infrastructure autoscaling safely across web, web-iso, and web-ingestion. Use when Codex needs to review or change Terraform scale settings, RPM targets, scale-up/scale-down boundaries, min/max task counts, cost/performance tradeoffs, dashboard scaling markers, Datadog event-loop metrics, trace/span evidence, GitHub pull requests, or Linear follow-up tickets for `web`, `web-iso`, or `web-ingestion` containers in the langfuse/infrastructure repository.
+description: Tune and review Langfuse autoscaling for web, web-iso, and web-ingestion. Use for Terraform scale settings, RPM targets, scaling bounds, task counts, cost/performance tradeoffs, or Datadog evidence in the infrastructure repo.
 ---
 
 # Langfuse Infra Scaling

--- a/.agents/skills/langfuse-codebase-navigator/SKILL.md
+++ b/.agents/skills/langfuse-codebase-navigator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: langfuse-codebase-navigator
-description: Navigate Langfuse repositories, code areas, and agent skills. Use when a user or agent asks where Langfuse code lives, which Langfuse repo to inspect, which Langfuse skill applies, how to search across Langfuse repositories, or how to orient in the Langfuse org before implementing, debugging, documenting, supporting, or operating Langfuse.
+description: Navigate Langfuse repositories, code areas, and agent skills. Use to locate code, choose the right repo or skill, search across the Langfuse organization, or orient before implementation, debugging, documentation, support, or operations.
 ---
 
 # Langfuse Codebase Navigator

--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: langfuse-previews
 description: >
-  Disposable per-PR preview environments for langfuse/langfuse. A same-repo PR
-  auto-builds a full Langfuse stack reachable at pr-N.preview.langfuse.com.
-  Use when spinning up or using a PR preview, logging into one, working out why
-  a preview did not come up (built but the URL 404s, ImagePullBackOff, pods
-  stuck Pending), reading web / worker / ClickHouse logs or otherwise debugging
-  a preview with kubectl, waking a preview that went to sleep off-hours,
-  seeding or adding more test data to a preview (deep traces, big sessions,
-  bulk traces, v4 events) with the seed CLI over a port-forward, or getting
-  preview deploy or cluster access. Synthetic data only.
+  Use Langfuse's disposable per-PR previews at pr-N.preview.langfuse.com
+  (synthetic data only). Use for preview access, failed deployments, test-data
+  seeding, kubectl debugging, or waking sleeping previews.
 ---
 
 # Langfuse PR Previews

--- a/.agents/skills/linear-bug-triage/SKILL.md
+++ b/.agents/skills/linear-bug-triage/SKILL.md
@@ -1,13 +1,8 @@
 ---
 name: linear-bug-triage
 description: |
-  Deduplicate measured bug or regression evidence against Linear, then either
-  add evidence comments to related existing issues or create concise Linear bug
-  issues in Triage. Use when Codex has confirmed evidence from Datadog,
-  benchmarks, traces, timings, flamegraphs, logs, or production measurements and
-  needs Linear search, comments, labels, Datadog links, or bug ticket creation
-  without fix suggestions, but only after a human has approved sharing the
-  findings in Linear.
+  Use this skill after a bug or regression candidate has measured evidence to document
+  them within linear.
 ---
 
 # Linear Bug Triage

--- a/.agents/skills/posthog-instrumentation/SKILL.md
+++ b/.agents/skills/posthog-instrumentation/SKILL.md
@@ -1,14 +1,9 @@
 ---
 name: posthog-instrumentation
 description: |
-  Instrument Langfuse with PostHog product analytics, and decide whether new
-  frontend work should be instrumented. Use when (1) adding a meaningful user
-  action to the frontend — a button, onClick/onSubmit handler, form, dialog,
-  toggle, tRPC mutation call, or a new feature surface in `web/**` — pause and
-  propose instrumentation before finishing; (2) asked to instrument a feature,
-  add analytics or usage tracking, or answer "how do people use X"; (3) adding
-  or reviewing `capture()` events, `usePostHogClientCapture`, or any code that
-  touches `posthog`.
+  Product analytics with posthog.
+  Use when adding a meaningful user action or feature in `web/**`, touching PostHog capture code,
+  or answering product-usage questions.
 ---
 
 # PostHog Instrumentation

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-review
-description: Security review patterns for Langfuse. Use during code review, design, or planning whenever a change accepts user-supplied URLs, host/endpoint/baseURL fields, secrets, cross-tenant data, new outbound HTTP requests, new integrations (webhooks, blob storage, LLM connections, image proxies), redirect-following behavior, or new auth/permission scopes. Covers SSRF/outbound URL validation today and is intentionally extensible to other recurring security findings (tenant isolation, secret handling, redirect mishandling, file upload, RBAC scope drift).
+description: Review Langfuse changes for SSRF, tenant isolation, secret handling, unsafe redirects or uploads, and RBAC drift. Use when a design or change accepts URLs or host fields, handles secrets or cross-tenant data, makes outbound requests, adds an integration, follows redirects, or widens permissions.
 ---
 
 # Security Review

--- a/.agents/skills/seed-test-data/SKILL.md
+++ b/.agents/skills/seed-test-data/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: seed-test-data
 description: |
-  Seed local Langfuse test data with one command: large/branching observation
-  trees (v3 and v4 events), long sessions, bulk traces for list performance.
-  Use whenever a task needs ClickHouse/Postgres test data — e.g. "seed a
-  complex trace", "make a tough session", "fill the trace list", "test v4
-  events UI", or when debugging trace/session/list rendering or performance.
-  Never write ad-hoc seed scripts or raw ClickHouse inserts.
+  Seed reproducible local Langfuse data in ClickHouse and Postgres. Use for
+  complex traces, long sessions, v3/v4 events, bulk list data, or frontend
+  rendering and performance tests; never use ad hoc scripts or raw inserts.
 ---
 
 # Seed Test Data

--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -1,16 +1,8 @@
 ---
 name: sentry-instrumentation
 description: |
-  Capture errors in Langfuse with Sentry deliberately, and decide whether a new
-  error path should report at all. Use when (1) adding or touching any
-  `captureException`, `console.error`, error boundary, `catch` block, Worker
-  `onerror`, or tRPC/REST error handler in `web/**` — pause and decide capture
-  before finishing; (2) adding or reviewing a Sentry `beforeSend` filter,
-  denylist rule, `ignoreErrors`, `denyUrls`, or any noise-suppression change
-  (MANDATORY here — the review question is "does this rule hide a real
-  error?"); (3) asked to reduce Sentry noise, triage a Sentry issue, or answer
-  "why is X / isn't X in Sentry"; (4) rendering user-supplied content (URLs,
-  hrefs) through a framework primitive that may reject it and log an error.
+  Decide whether and how errors report to Sentry. Use when touching capture or
+  error-handling paths in `web/**`, triaging Sentry noise, or changing Sentry settings.
 ---
 
 # Sentry Instrumentation

--- a/.agents/skills/turborepo/SKILL.md
+++ b/.agents/skills/turborepo/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: turborepo
 description: |
-  Turborepo monorepo build system guidance. Triggers on: turbo.json, task pipelines,
-  dependsOn, caching, remote cache, the "turbo" CLI, --filter, --affected, CI optimization, environment
-  variables, internal packages, monorepo structure/best practices, and boundaries.
-
-  Use when user: configures tasks/workflows/pipelines, creates packages, sets up
-  monorepo, shares code between apps, runs changed/affected packages, debugs cache,
-  or has apps/packages directories.
+  Configure and troubleshoot Turborepo monorepos. Use for turbo.json, task
+  pipelines, dependsOn, caching, filters, affected packages, CI optimization,
+  environment variables, package boundaries, or shared internal packages.
 metadata:
   version: 2.8.21-canary.9
 ---

--- a/.agents/skills/weekly-production-review/SKILL.md
+++ b/.agents/skills/weekly-production-review/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: weekly-production-review
 description: |
-  Prepare Langfuse weekly production reviews that audit what broke, what was
-  fixed, what remains open, and where Datadog, incident.io, or Linear tracking
-  needs cleanup. Use when asked for a production review, "what broke last week",
-  fixed/open production bugs, Datadog alerted monitors/pages, Datadog error log
-  patterns, incident.io incidents, incident.io alert load, pager load by
-  engineer or time of day, or a source-table engineering review across
-  incident.io, Linear bugs, Datadog alerts, and Datadog logs.
+  Prepare Langfuse weekly production reviews covering failures, fixes, open
+  issues, and tracking gaps. Use for "what broke last week," production bugs,
+  Datadog alerts or error patterns, incident.io activity, or pager load.
 ---
 
 # Weekly Production Review


### PR DESCRIPTION
## Summary

- Tighten 18 repo-owned skill descriptions so always-loaded metadata focuses on selecting the right skill while procedural detail stays in each skill body.
- Reduce the changed descriptions from 8,363 to 3,701 characters: 4,662 fewer characters (55.7%), or approximately 1,166 input tokens saved per agent turn using the standard four-characters-per-token estimate.
- This is a meaningful fixed-context reduction because skill metadata is present on every turn. Across 100 turns, it avoids roughly 116,600 input tokens; prompt caching may reduce the billing impact, but not the context-window savings.

## Linear

- None

## Major Decisions

- Keep already-concise descriptions unchanged and retain only reductions that materially lower context usage.
- Keep workflow procedures and safety gates in skill bodies unless they are necessary to decide whether a skill should trigger.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Tightens the frontmatter descriptions of 18 repository-owned agent skills while retaining their detailed procedures, safeguards, and reference material in the skill bodies.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the shortened descriptions retain sufficiently clear selection cues and leave all procedural guidance intact.

The changes are limited to frontmatter descriptions, and no concrete routing regression, broken contract, or security-boundary failure is established by the revised metadata.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agent): tighten skill descriptions"](https://github.com/langfuse/langfuse/commit/873af14e9406b6964a2d493613b8a1e53bbc9a14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48241478)</sub>

<!-- /greptile_comment -->