### PR TITLE
fix(ingestion): preserve token count identity across token detail buckets

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -139,21 +139,25 @@ const OpenAICompletionUsageSchema = z
     };
 
     if (prompt_tokens_details) {
+      let inputRemainder = result.input;
       for (const [key, value] of Object.entries(prompt_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`input_${key}`] = value;
-          result.input = Math.max(result.input - (value ?? 0), 0);
+          inputRemainder -= value ?? 0;
         }
       }
+      result.input = Math.max(inputRemainder, 0);
     }
 
     if (completion_tokens_details) {
+      let outputRemainder = result.output;
       for (const [key, value] of Object.entries(completion_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`output_${key}`] = value;
-          result.output = Math.max(result.output - (value ?? 0), 0);
+          outputRemainder -= value ?? 0;
         }
       }
+      result.output = Math.max(outputRemainder, 0);
     }
 
     return result;
@@ -194,21 +198,25 @@ const OpenAIResponseUsageSchema = z
     };
 
     if (input_tokens_details) {
+      let inputRemainder = result.input;
       for (const [key, value] of Object.entries(input_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`input_${key}`] = value;
-          result.input = Math.max(result.input - (value ?? 0), 0);
+          inputRemainder -= value ?? 0;
         }
       }
+      result.input = Math.max(inputRemainder, 0);
     }
 
     if (output_tokens_details) {
+      let outputRemainder = result.output;
       for (const [key, value] of Object.entries(output_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`output_${key}`] = value;
-          result.output = Math.max(result.output - (value ?? 0), 0);
+          outputRemainder -= value ?? 0;
         }
       }
+      result.output = Math.max(outputRemainder, 0);
     }
 
     return result;

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -132,7 +132,34 @@ export function useEventsTraceData(
 
   // Step 5: Transform and merge data
   const transformed = useMemo(() => {
-    if (!observations?.length) return null;
+    if (!observations) return null; // query still in-flight
+    if (observations.length === 0) {
+      // Query completed but the trace has no observations. Return a minimal shell
+      // so callers don't confuse "no data" with "still loading".
+      const now = new Date();
+      return {
+        id: traceId,
+        name: null,
+        timestamp: now,
+        environment: "",
+        tags: [],
+        bookmarked: false,
+        public: false,
+        release: null,
+        version: null,
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+        sessionId: null,
+        userId: null,
+        projectId,
+        input: null,
+        output: null,
+        observations: [] as AdaptedTraceData["observations"],
+        scores: [] as WithStringifiedMetadata<ScoreDomain>[],
+        corrections: [] as ScoreDomain[],
+      };
+    }
 
     // Validate and partition scores
     const validatedScores = filterAndValidateDbScoreList({


### PR DESCRIPTION
## What

Fixes a token count identity bug in both `OpenAICompletionUsageSchema` and `OpenAIResponseUsageSchema` transforms in `packages/shared/src/server/ingestion/types.ts`.

## Root cause

The detail-bucket loops applied `Math.max(result.output - value, 0)` **on every iteration**. When a sub-bucket (e.g. `reasoning_tokens: 109`) exceeds the base count (`completion_tokens: 102`), the first iteration clamps to 0. Subsequent iterations then subtract from 0 and clamp again — the base token count loses its identity.

**Example:**
- `completion_tokens: 102`, `reasoning_tokens: 109`
- Iteration 1: `Math.max(102 - 109, 0)` → `result.output = 0` ❌ (should be −7, clamped once at the end)

## Fix

Use a single `outputRemainder` / `inputRemainder` accumulator across the loop. Apply `Math.max(..., 0)` once, after all sub-buckets are subtracted. Same pattern applied to all four detail blocks (`prompt_tokens_details`, `completion_tokens_details`, `input_tokens_details`, `output_tokens_details`).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adjusts token-detail remainder calculation and changes empty event-trace handling.
- Accumulates OpenAI input and output detail buckets before clamping the remaining base count.
- Returns a minimal trace shell after an events query completes with no observations.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until the empty-observations path preserves fetched scores and stops presenting generated timestamps as trace metadata.

The new empty-result branch discards independently fetched trace-level scores and substitutes the current time for canonical trace timestamps, causing persisted data to disappear and misleading metadata to render in affected views.

**Files Needing Attention:** web/src/features/events/hooks/useEventsTraceData.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/events/hooks/useEventsTraceData.ts:159
**Empty traces discard scores**

When the observations query returns an empty array for a trace with trace-level scores, this branch hard-codes `scores` and `corrections` to empty arrays despite the independent scores query succeeding, causing persisted scores to disappear from the trace detail and annotation interfaces.

### Issue 2
web/src/features/events/hooks/useEventsTraceData.ts:139
**Empty traces fabricate timestamps**

When the observations query returns an empty array, the hook presents the current time as the trace timestamp and creation/update times; the trace detail view renders this value as canonical metadata, so users see a fabricated timestamp that advances whenever an empty result is refetched.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): preserve token count ide..."](https://github.com/langfuse/langfuse/commit/7fafb982481691c398d960be0ab8de1280db2192) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48246711)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Ingestion Pipeline: SDK/OTel Event to ClickHouse](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/ingestion-pipeline.md)
- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->