### PR TITLE
refactor(annotation-queues): remove custom cell rendering for description in AnnotationQueuesTable

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -78,19 +78,6 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
       id: "description",
       enableHiding: true,
       size: 200,
-      cell: ({ row }) => {
-        const description: RowData["description"] = row.getValue("description");
-        return (
-          <span
-            className={cn(
-              "grid h-full items-center overflow-auto",
-              rowHeight === "s" && "leading-3",
-            )}
-          >
-            {description}
-          </span>
-        );
-      },
     },
     {
       accessorKey: "countCompletedItems",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the annotation queue description column’s custom cell renderer so descriptions use the shared table’s standard string-cell rendering.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The shared table’s default renderer handles description strings and empty values, while the removed renderer leaves no unused symbols or broken configuration.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(annotation-queues): remove cust..."](https://github.com/langfuse/langfuse/commit/072cc661274ecabfced20573dd18c10fb7ae5112) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48247374)</sub>

<!-- /greptile_comment -->