### PR TITLE
fix: prevent blob storage log queries from timing out

### DIFF
--- a/packages/shared/src/server/repositories/blobStorageLog.ts
+++ b/packages/shared/src/server/repositories/blobStorageLog.ts
@@ -40,6 +40,11 @@ export const getBlobStorageByProjectId = (
     params: {
       projectId,
     },
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        max_execution_time: 0,
+      },
+    },
     tags: { projectId },
   });
 };


### PR DESCRIPTION
## Summary

- Disable the ClickHouse execution-time limit for blob storage log queries.
- Prevent worker query timeouts when retrieving blob storage records by project.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes blob-storage-log retrieval timeout handling.
- Disables ClickHouse's server-side execution-time limit for full-project blob-storage-log queries.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR is not safe to merge until the client request timeout is extended or otherwise aligned with the newly unlimited server query.

Long-running full-project queries still hit the ClickHouse client's 30-second request timeout, causing worker cleanup to fail while the server query may continue after disconnection.

**Files Needing Attention:** packages/shared/src/server/repositories/blobStorageLog.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/repositories/blobStorageLog.ts:44-48
**Client timeout remains active**

When a full-project blob-log query exceeds 30 seconds, `max_execution_time: 0` removes only the server-side limit while the client's default `request_timeout` aborts the stream, causing cleanup to fail before all blob references are processed and leaving the ClickHouse query able to continue after disconnection.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Disable execution timeout for blob stora..."](https://github.com/langfuse/langfuse/commit/fd0bfb7d85ea9b126cb7e55d13e46fca29da5607) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48254660)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->