### PR TITLE
fix(traces): push score names into the traces table scores CTE

### DIFF
--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -8,6 +8,9 @@ import {
   StringFilter,
   StringOptionsFilter,
   DateTimeFilter,
+  NumberObjectFilter,
+  CategoryOptionsFilter,
+  BooleanObjectFilter,
 } from "../queries/clickhouse-sql/clickhouse-filter";
 import {
   getProjectIdDefaultFilter,
@@ -274,10 +277,57 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       f.field === "timestamp" && (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
-  const requiresScoresJoin =
-    tracesFilter.find((f) => f.clickhouseTable === "scores") !== undefined ||
+  const ordersByScores =
     findUiColumnMapping(tracesTableUiColumnDefinitions, orderBy?.column)
       ?.clickhouseTableName === "scores";
+
+  const requiresScoresJoin =
+    tracesFilter.find((f) => f.clickhouseTable === "scores") !== undefined ||
+    ordersByScores;
+
+  // Restrict the scores CTE to the score names the filters actually reference.
+  //
+  // `scores` is ORDER BY (project_id, toDate(timestamp), name, id), so a `name`
+  // predicate is a primary key range scan. Without it the CTE aggregates every
+  // score name in the project from `traceTimestamp - 1 hour` onwards — there is
+  // no upper bound, because scores may be attached long after their trace — and
+  // the outer query then discards all but the filtered names. On projects with
+  // high score volume that CTE is the dominant cost of the whole statement, both
+  // as GROUP BY state and as the right side of the LEFT JOIN.
+  //
+  // Only sound when the CTE is not projected and not ordered on: `metrics`
+  // selects s.scores_avg / s.score_categories / s.score_booleans, and ordering by
+  // a score column needs the full per-trace aggregate. Score filters that do not
+  // name a score (e.g. a NullFilter on the column) disable the pushdown, since
+  // they can match a trace through any name.
+  //
+  // Equivalence holds for negated operators too ("!=", "none of", "<>"): each of
+  // these filters only ever inspects array entries carrying its own key, so
+  // entries for other names cannot change the outcome. Traces left without a CTE
+  // row are filled by the LEFT JOIN with empty arrays — the same value they would
+  // have had from an unfiltered CTE that matched none of their scores.
+  const scoreFilterNames: string[] = [];
+  let everyScoreFilterNamesAScore = true;
+  tracesFilter.forEach((f) => {
+    if (f.clickhouseTable !== "scores") return;
+    if (
+      f instanceof NumberObjectFilter ||
+      f instanceof CategoryOptionsFilter ||
+      f instanceof BooleanObjectFilter
+    ) {
+      scoreFilterNames.push(f.key);
+    } else {
+      everyScoreFilterNamesAScore = false;
+    }
+  });
+
+  const pushedDownScoreNames =
+    select !== "metrics" &&
+    !ordersByScores &&
+    everyScoreFilterNamesAScore &&
+    scoreFilterNames.length > 0
+      ? Array.from(new Set(scoreFilterNames))
+      : null;
 
   const requiresObservationsJoin =
     tracesFilter.find((f) => f.clickhouseTable === "observations") !==
@@ -342,6 +392,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
                   WHERE
                     project_id = {projectId: String}
                     ${timeStampFilter ? `AND s.timestamp >= {traceTimestamp: DateTime64(3)} - ${SCORE_TO_TRACE_OBSERVATIONS_INTERVAL}` : ""}
+                    ${pushedDownScoreNames ? `AND s.name IN {scoreNames: Array(String)}` : ""}
                     ${scoresFilterRes ? `AND ${scoresFilterRes.query}` : ""}
                   GROUP BY
                     project_id,
@@ -506,6 +557,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       limit: limit,
       offset: limit && page ? limit * page : 0,
       traceTimestamp: timeStampFilter?.value.getTime(),
+      ...(pushedDownScoreNames ? { scoreNames: pushedDownScoreNames } : {}),
       ...(traceDeleteCursor
         ? {
             cursorTimestamp: convertDateToClickhouseDateTime(

--- a/web/src/__tests__/server/traces-ui-table.servertest.ts
+++ b/web/src/__tests__/server/traces-ui-table.servertest.ts
@@ -5,7 +5,10 @@ import {
 } from "@langfuse/shared/src/server";
 import { createObservation, createTrace } from "@langfuse/shared/src/server";
 import {
+  createScoresCh,
+  createTraceScore,
   getTracesTable,
+  getTracesTableCount,
   type TracesTableUiReturnType,
   type ObservationRecordInsertType,
   type TraceRecordInsertType,
@@ -246,6 +249,149 @@ describe("Traces table API test", () => {
           expect(tableRows[index].public).toEqual(expectedTrace.public);
         }
       });
+    });
+  });
+
+  // The scores CTE is restricted to the score names referenced by the filters.
+  // These cover the cases where that restriction could change results: scores
+  // under other names must not affect matching, and negated operators must still
+  // see traces that carry no score of the filtered name at all.
+  describe("score name pushdown", () => {
+    const seedProject = async () => {
+      const project_id = v4();
+      const matching = v4();
+      const wrongValue = v4();
+      const otherNameOnly = v4();
+      const noScores = v4();
+      const timestamp = new Date().getTime();
+
+      await createTracesCh(
+        [matching, wrongValue, otherNameOnly, noScores].map((id) =>
+          createTrace({ id, project_id, timestamp }),
+        ),
+      );
+
+      await createScoresCh([
+        // Target name, passes `< 0`. Also carries an unrelated score so the CTE
+        // has a name to drop for a trace that must still match.
+        createTraceScore({
+          project_id,
+          trace_id: matching,
+          name: "target",
+          value: -5,
+          timestamp,
+        }),
+        createTraceScore({
+          project_id,
+          trace_id: matching,
+          name: "unrelated",
+          value: 100,
+          timestamp,
+        }),
+        // Target name, fails `< 0`.
+        createTraceScore({
+          project_id,
+          trace_id: wrongValue,
+          name: "target",
+          value: 7,
+          timestamp,
+        }),
+        // Only an unrelated name: must not match a positive filter on "target".
+        createTraceScore({
+          project_id,
+          trace_id: otherNameOnly,
+          name: "unrelated",
+          value: -42,
+          timestamp,
+        }),
+        // Boolean scores for the negated-operator case. `matching` carries
+        // flag:true, `wrongValue` carries flag:false, and the remaining two
+        // traces carry no "flag" score at all.
+        createTraceScore({
+          project_id,
+          trace_id: matching,
+          name: "flag",
+          value: 1,
+          string_value: "true",
+          data_type: "BOOLEAN",
+          timestamp,
+        }),
+        createTraceScore({
+          project_id,
+          trace_id: wrongValue,
+          name: "flag",
+          value: 0,
+          string_value: "false",
+          data_type: "BOOLEAN",
+          timestamp,
+        }),
+      ]);
+
+      return { project_id, matching, wrongValue, otherNameOnly, noScores };
+    };
+
+    it("matches only traces whose named score satisfies the filter", async () => {
+      const { project_id, matching } = await seedProject();
+
+      const filter: FilterState = [
+        {
+          column: "scores_avg",
+          type: "numberObject",
+          key: "target",
+          operator: "<",
+          value: 0,
+        },
+      ];
+
+      const rows = await getTracesTable({
+        projectId: project_id,
+        filter,
+        searchQuery: undefined,
+        orderBy: undefined,
+        limit: 50,
+        page: 0,
+      });
+
+      expect(rows.map((r) => r.id)).toEqual([matching]);
+
+      // countAll takes the same CTE path and must agree with the row query.
+      const count = await getTracesTableCount({
+        projectId: project_id,
+        filter,
+        searchType: [],
+      });
+      expect(count).toEqual(1);
+    });
+
+    it("keeps negated operators consistent for traces without the named score", async () => {
+      const { project_id, matching, wrongValue, otherNameOnly, noScores } =
+        await seedProject();
+
+      // NOT has(score_booleans, 'flag:true'). The pushdown restricts the CTE to
+      // name = 'flag', which leaves traces that never had a "flag" score without
+      // a CTE row at all. The LEFT JOIN fills those with an empty array, so they
+      // must still satisfy the negation — exactly as they would have with the
+      // unrestricted CTE.
+      const rows = await getTracesTable({
+        projectId: project_id,
+        filter: [
+          {
+            column: "score_booleans",
+            type: "booleanObject",
+            key: "flag",
+            operator: "<>",
+            value: true,
+          },
+        ],
+        searchQuery: undefined,
+        orderBy: undefined,
+        limit: 50,
+        page: 0,
+      });
+
+      const ids = rows.map((r) => r.id).sort();
+      expect(ids).toEqual([wrongValue, otherNameOnly, noScores].sort());
+      expect(ids).not.toContain(matching);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Restricts the `scores_avg` CTE in `getTracesTableGeneric` to the score names the filters actually reference.

Filtering the Traces table by a score value currently makes that CTE aggregate **every score name in the project**, and the outer `WHERE` then discards all but the filtered name. The CTE is bounded only from below:

```sql
FROM scores s FINAL
WHERE project_id = {projectId: String}
  AND s.timestamp >= {traceTimestamp: DateTime64(3)} - INTERVAL 1 HOUR   -- no upper bound
GROUP BY project_id, trace_id, name, data_type, string_value
```

The absent upper bound looks deliberate — scores can be attached long after their trace, so bounding at `toTimestamp` would drop late annotations and eval scores. A consequence is that narrowing the UI date range barely helps: the scan is anchored at the window start and always runs to "now", so an *older* 24 h window costs more than a recent one.

`name` is never filtered, even though it is the third column of the sort key:

```sql
ORDER BY (project_id, toDate(timestamp), name, id)
```

so a `name` predicate is a primary key range scan. No new index is required.

Fixes #15553

## Production measurements

Self-hosted, ClickHouse 25.2, 3 replicas, 25 GiB container limit (`max_server_memory_usage` 22.5 GiB). One project, `scores` 92 GB / `observations` 480 GB. Project has **69 distinct score names**; the three largest account for ~72% of score volume, and the name being filtered is **0.04%** of it.

For one real Traces-table query (single score filter, 2-day trace window, user filter), measured against the live dataset:

| Stage | Before | After | Factor |
|---|---:|---:|---:|
| Scores scanned | 65,412,538 | 25,265 | **2,589×** |
| Join build rows (`FillingRightJoinSide`) | 28,587,067 | 3,436 | **8,320×** |
| Inner GROUP BY groups (`AggregatingTransform`) | 60,332,535 | 3,436 | **17,558×** |

**With the pushdown, the same query completes and returns rows:**

| | |
|---|---:|
| Peak memory | **51.14 MiB** |
| Rows read | 598.9 K |
| Bytes read | 88.2 MiB |
| Duration | **336 ms** |


## Why this is sound

The pushdown is applied only where the CTE is not projected:

| `select` | route | uses `s.scores_avg` |
|---|---|---|
| `count` | `traces.countAll` | filter only |
| `rows` | `traces.all` | filter only |
| `identifiers` | — | filter only |
| `metrics` | `traces.metrics` | **projects** `scores_avg` / `score_categories` / `score_booleans` |

It is additionally skipped when ordering by a score column (the full per-trace aggregate is needed) and when any score filter does not name a score (e.g. a `NullFilter`, which can match through any name).

Every score filter — `NumberObjectFilter`, `CategoryOptionsFilter`, `BooleanObjectFilter` — carries a `key` holding the score name, and each only ever inspects array entries carrying that key. Entries under other names cannot change the outcome. This holds for negated operators too (`none of`, `<>`): traces left without a CTE row are filled by the `LEFT JOIN` with empty arrays, which is exactly the value an unrestricted CTE produces for a trace matching none of the filtered names. `join_use_nulls` is not set anywhere in the repo, so the default of filling type defaults applies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- `packages/shared` build (`tsc`) — clean
- `web` typecheck — clean
- `eslint` on both changed files — clean
- `prettier` — clean
- Repo-wide `format:check` + `lint` (pre-commit hook) — 7/7 tasks pass
- `traces-ui-table.servertest.ts` against live ClickHouse + Postgres — **9 passed** (7 pre-existing + 2 new)

Two tests added: one asserting that only the correctly-scored trace matches, with the `rows` and `count` paths agreeing; one covering the negated `<>` operator on `score_booleans`, which is the case where the pushdown could plausibly change results.

Confirmed via `system.query_log` that the pushdown fires only when intended — the new tests emit `s.name IN (...)`, the pre-existing tests (no score filters) do not.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Narrows the Traces table score aggregation to score names referenced by typed filters when full score data is not otherwise required.
- Collects and deduplicates names from numeric, categorical, and boolean score filters.
- Skips pushdown for metrics queries, score-based ordering, and filters without a specific score name.
- Adds server tests covering positive numeric filtering, count/row consistency, and negated boolean filtering for traces without the named score.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The pushdown is limited to non-projecting, non-score-ordered query modes, includes every referenced typed score key, and is disabled when a score filter cannot supply a name; the affected filter predicates only depend on entries for their own keys.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): push score names into the t..."](https://github.com/langfuse/langfuse/commit/956015412f44285411916ee2dc88ef5028bac281) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48257770)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->