### PR TITLE
[Umbrella/reference - do not merge] feat(agent): background execution endpoints and drawer cutover (LFE-14373)

### DIFF
--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -282,9 +282,12 @@ model InAppAgentRun {
   errorCode         String?                @map("error_code")
   errorMessage      String?                @map("error_message")
   finishedAt        DateTime?              @map("finished_at")
-  // Nullable until the first status reader ships (see RFC-background-execution
-  // PR 4), whose migration backfills NULLs and sets DEFAULT/NOT NULL.
-  // NULL means "row written by code that predates the status column".
+  // Nullable, and deliberately without a default: every writer sets the status
+  // explicitly (foreground inserts RUNNING, background inserts QUEUED), so a
+  // default would be a lie for whichever path forgot. NULL means "row written
+  // by code that predates the status column"; readers treat it as legacy and
+  // derive from finished_at/error_code. Tightening to NOT NULL is a separate
+  // data migration, deliberately not bundled with a feature change.
   status            String?
   request           Json?
   claimedAt         DateTime?              @map("claimed_at")

--- a/packages/shared/scripts/seeder/utils/in-app-agent-seed.ts
+++ b/packages/shared/scripts/seeder/utils/in-app-agent-seed.ts
@@ -1,4 +1,5 @@
 import {
+  InAppAgentRunStatus,
   type Prisma,
   type PrismaClient,
   type Prompt,
@@ -328,6 +329,7 @@ export async function seedInAppAgentDemoConversation({
           conversationId,
           triggeredByUserId: userId,
           model: "claude-haiku-4-5",
+          status: InAppAgentRunStatus.SUCCEEDED,
           finishedAt: firstRunFinishedAt,
           createdAt: firstRunCreatedAt,
           updatedAt: firstRunFinishedAt,
@@ -338,6 +340,7 @@ export async function seedInAppAgentDemoConversation({
           conversationId,
           triggeredByUserId: userId,
           model: "claude-haiku-4-5",
+          status: InAppAgentRunStatus.SUCCEEDED,
           finishedAt: secondRunFinishedAt,
           createdAt: secondRunCreatedAt,
           updatedAt: secondRunFinishedAt,

--- a/packages/shared/src/features/inAppAgent/types.ts
+++ b/packages/shared/src/features/inAppAgent/types.ts
@@ -6,8 +6,8 @@ import { AgUiContextSchema } from "../../in-app-agent/schema";
  *
  * Stored as a plain string column (not a PG enum) so states can be added
  * without `ALTER TYPE`, following BatchExportStatus/BatchActionStatus.
- * The column is nullable until the first status reader ships: NULL means
- * the row was written by code that predates the column.
+ * The column is NOT NULL as of the background-execution read path: every
+ * writer sets it explicitly, so there is deliberately no column default.
  */
 export enum InAppAgentRunStatus {
   QUEUED = "QUEUED",
@@ -44,6 +44,43 @@ export enum InAppAgentRunErrorCode {
    * turn must verify whether the effect landed before proposing again.
    */
   OUTCOME_UNKNOWN = "outcome_unknown",
+  /** Run committed as QUEUED but the BullMQ enqueue failed right after. */
+  ENQUEUE_FAILED = "enqueue_failed",
+  /** QUEUED past `QUEUE_TIMEOUT`: no worker ever picked the run up. */
+  QUEUE_TIMEOUT = "queue_timeout",
+  /** RUNNING with a heartbeat older than `HEARTBEAT_STALE`: worker died. */
+  WORKER_LOST = "worker_lost",
+  /**
+   * RUNNING for longer than `RUN_MAX_DURATION` since claim — the backstop
+   * against a hung tool renewing an otherwise healthy heartbeat forever.
+   */
+  RUN_TIMEOUT = "run_timeout",
+  /** Approval parked longer than `APPROVAL_TTL` without a decision. */
+  APPROVAL_EXPIRED = "approval_expired",
+  /** Pending approval replaced by a newer user message (recorded on CANCELLED). */
+  APPROVAL_SUPERSEDED = "approval_superseded",
+  /** Pending approval cancelled by the user (recorded on CANCELLED). */
+  APPROVAL_CANCELLED = "approval_cancelled",
+}
+
+/**
+ * Whether a terminal run is a candidate for the UI's pre-filled retry
+ * gesture. Unknown codes are retryable: a new failure mode should degrade to
+ * "offer retry" rather than silently stranding the turn.
+ */
+export function isRetryableInAppAgentRunErrorCode(
+  errorCode: string | null,
+): boolean {
+  if (errorCode === null) return false;
+
+  return ![
+    // The approved tool may already have run; the next turn verifies first.
+    InAppAgentRunErrorCode.OUTCOME_UNKNOWN,
+    // The approval is gone — the user continues with a new message instead.
+    InAppAgentRunErrorCode.APPROVAL_EXPIRED,
+    InAppAgentRunErrorCode.APPROVAL_SUPERSEDED,
+    InAppAgentRunErrorCode.APPROVAL_CANCELLED,
+  ].includes(errorCode as InAppAgentRunErrorCode);
 }
 
 /**

--- a/packages/shared/src/in-app-agent/backgroundWatch.ts
+++ b/packages/shared/src/in-app-agent/backgroundWatch.ts
@@ -1,0 +1,193 @@
+// Client-safe contracts for background execution: the approval-decision
+// transcript event and the watch stream's browser wire format. Shared by the
+// tRPC mutations, the watch route, and the drawer's stream client, so the
+// three cannot drift.
+
+import { EventType } from "@ag-ui/core";
+import { z } from "zod";
+
+import {
+  InAppAgentRunErrorCode,
+  InAppAgentRunStatus,
+  InAppAgentRunStatusSchema,
+} from "../features/inAppAgent/types";
+import type { AgUiCustomEvent, AgUiEvent } from "./schema";
+
+/**
+ * A human decision on a pending tool approval, recorded in the append-only
+ * event stream rather than a side channel.
+ *
+ * Card state derives entirely from events plus run status: pending = parent
+ * run `AWAITING_APPROVAL`, decided = a matching decision event, superseded or
+ * expired = parent status plus error code. Without this event the decision and
+ * the decider would live only in the continuation run's request payload,
+ * invisible to the render stream, and the decide→claim gap would show a stale
+ * pending card.
+ *
+ * Render-only by contract, like reasoning events: it rides as a `CUSTOM`
+ * event, which `toPersistableAgentEvent` drops and the message accumulators
+ * skip, so the model never sees it. The agent learns the outcome from the tool
+ * result the continuation synthesizes.
+ */
+export const IN_APP_AGENT_APPROVAL_DECISION_EVENT_NAME =
+  "langfuse_approval_decision";
+
+export const InAppAgentApprovalDecisionSchema = z.object({
+  toolCallId: z.string().min(1),
+  approved: z.boolean(),
+  /**
+   * Always the conversation owner in v1, and kept anyway: events are
+   * immutable history, so omitting it now would leave every decision recorded
+   * before multi-viewer attribution arrives with an unknowable decider.
+   */
+  decidedByUserId: z.string().min(1),
+});
+
+export type InAppAgentApprovalDecision = z.infer<
+  typeof InAppAgentApprovalDecisionSchema
+>;
+
+export function buildInAppAgentApprovalDecisionEvent(
+  decision: InAppAgentApprovalDecision,
+): AgUiCustomEvent {
+  return {
+    type: EventType.CUSTOM,
+    name: IN_APP_AGENT_APPROVAL_DECISION_EVENT_NAME,
+    value: decision,
+  };
+}
+
+export function parseInAppAgentApprovalDecisionEvent(
+  event: AgUiEvent,
+): InAppAgentApprovalDecision | undefined {
+  if (
+    event.type !== EventType.CUSTOM ||
+    event.name !== IN_APP_AGENT_APPROVAL_DECISION_EVENT_NAME
+  ) {
+    return undefined;
+  }
+
+  const parsed = InAppAgentApprovalDecisionSchema.safeParse(event.value);
+
+  return parsed.success ? parsed.data : undefined;
+}
+
+/**
+ * Watch stream wire format.
+ *
+ * Scope is the conversation, not the run: the cursor is the conversation-wide
+ * `sequenceNumber`, so one stream spans approval continuations and supersedes
+ * without the client rediscovering run IDs. The stream carries the *current*
+ * run's status; the client never tracks "which run am I watching".
+ */
+export const InAppAgentWatchStatusFrameSchema = z.object({
+  type: z.literal("status"),
+  runId: z.string(),
+  status: InAppAgentRunStatusSchema,
+  errorCode: z.string().nullable().optional(),
+  errorMessage: z.string().nullable().optional(),
+  /**
+   * A cancel has been requested but the run has not stopped yet. Cancellation
+   * of a RUNNING run is cooperative — the worker observes the flag on its next
+   * heartbeat and aborts at the following step boundary — so this is the only
+   * thing that distinguishes "still working" from "winding down", and without
+   * it the UI looks unchanged for seconds after the user hits stop.
+   */
+  cancelRequested: z.boolean().optional(),
+});
+
+export const InAppAgentWatchEventFrameSchema = z.object({
+  type: z.literal("event"),
+  sequenceNumber: z.number().int(),
+  /** The persisted AG-UI event verbatim. */
+  event: z.record(z.string(), z.unknown()),
+});
+
+export const InAppAgentWatchErrorFrameSchema = z.object({
+  type: z.literal("error"),
+  code: z.string(),
+  message: z.string(),
+});
+
+/**
+ * The client's stop-reconnecting signal. Any *other* close — the keep-alive
+ * window elapsing, a deploy, a network blip — means reconnect with the cursor.
+ */
+export const InAppAgentWatchDoneFrameSchema = z.object({
+  type: z.literal("done"),
+});
+
+export const InAppAgentWatchFrameSchema = z.discriminatedUnion("type", [
+  InAppAgentWatchStatusFrameSchema,
+  InAppAgentWatchEventFrameSchema,
+  InAppAgentWatchErrorFrameSchema,
+  InAppAgentWatchDoneFrameSchema,
+]);
+
+export type InAppAgentWatchFrame = z.infer<typeof InAppAgentWatchFrameSchema>;
+
+/**
+ * Statuses that mean "the conversation is still busy". `AWAITING_APPROVAL` is
+ * deliberately absent: parking sets `finished_at`, freeing both the worker and
+ * the conversation slot while the approval waits.
+ */
+export const IN_APP_AGENT_ACTIVE_RUN_STATUSES: readonly InAppAgentRunStatus[] =
+  [InAppAgentRunStatus.QUEUED, InAppAgentRunStatus.RUNNING];
+
+export function isActiveInAppAgentRunStatus(
+  status: InAppAgentRunStatus,
+): boolean {
+  return IN_APP_AGENT_ACTIVE_RUN_STATUSES.includes(status);
+}
+
+/**
+ * Statuses a user can still stop. Deliberately wider than "active": a parked
+ * run occupies no worker and no conversation slot, but its decision is still
+ * outstanding, and discarding it is a real action (`approval_cancelled`) rather
+ * than a no-op. Conflating the two makes the stop control silently do nothing
+ * on exactly the state where the user is most likely to press it.
+ */
+export function isCancellableInAppAgentRunStatus(
+  status: InAppAgentRunStatus,
+): boolean {
+  return (
+    isActiveInAppAgentRunStatus(status) ||
+    status === InAppAgentRunStatus.AWAITING_APPROVAL
+  );
+}
+
+/**
+ * `FAILED` is never one thing: the code decides what the user is told. An
+ * unknown code falls back to the generic message rather than leaking a raw
+ * enum value — historical rows may carry codes this build has never heard of.
+ */
+export function getInAppAgentRunFailureMessage(
+  errorCode: string | null,
+): string {
+  switch (errorCode) {
+    case InAppAgentRunErrorCode.ENQUEUE_FAILED:
+      return "Couldn't start the run. Try again.";
+    case InAppAgentRunErrorCode.QUEUE_TIMEOUT:
+      return "No worker picked this up. Try again.";
+    case InAppAgentRunErrorCode.WORKER_LOST:
+      return "The run was interrupted. Try again.";
+    case InAppAgentRunErrorCode.RUN_TIMEOUT:
+      return "The run exceeded the maximum duration.";
+    case InAppAgentRunErrorCode.WORKER_SHUTDOWN:
+      return "The run was interrupted by a deploy. Try again.";
+    case InAppAgentRunErrorCode.OUTCOME_UNKNOWN:
+      return "The approved action may have completed. Verify before retrying.";
+    case InAppAgentRunErrorCode.APPROVAL_EXPIRED:
+      return "The approval request expired.";
+    case InAppAgentRunErrorCode.APPROVAL_SUPERSEDED:
+      return "Replaced by a newer message.";
+    case InAppAgentRunErrorCode.APPROVAL_CANCELLED:
+      return "Approval cancelled.";
+    case InAppAgentRunErrorCode.CANCELLED:
+      return "You stopped this run.";
+    case InAppAgentRunErrorCode.STALE:
+      return "The run was interrupted. Try again.";
+    default:
+      return "The run failed. Try again.";
+  }
+}

--- a/packages/shared/src/in-app-agent/index.ts
+++ b/packages/shared/src/in-app-agent/index.ts
@@ -2,5 +2,6 @@
 // re-exported here — this barrel is imported by web client components and is
 // covered by the client-bundle scan.
 export * from "./schema";
+export * from "./backgroundWatch";
 export * from "./constants";
 export * from "./ids";

--- a/packages/shared/src/in-app-agent/server/access.ts
+++ b/packages/shared/src/in-app-agent/server/access.ts
@@ -1,0 +1,42 @@
+import { LangfuseNotFoundError } from "../../index";
+import type { InAppAgentConversation } from "../../db";
+
+/**
+ * The single authorization seam for in-app agent conversations.
+ *
+ * v1 is owner-only for every action — watch (history + live tail), submit,
+ * cancel and decide all require `conversation.createdByUserId === userId`,
+ * exactly the rule the foreground path already enforced. Background
+ * execution must not silently widen the sharing surface, so the actions are
+ * spelled out here rather than collapsed into one boolean: enabling
+ * `visibilityScope: PROJECT` later is a change in this module only.
+ *
+ * The pre-decided direction for that future (do not relitigate it there):
+ * watch = any project member, submit = creator, cancel = creator + project
+ * admin, decide = creator only — the approved mutation executes on behalf of
+ * whoever triggered the run, and a colleague approving someone else's pending
+ * write is a confused-deputy shape to open only deliberately.
+ */
+export type InAppAgentConversationAction =
+  | "watch"
+  | "submit"
+  | "cancel"
+  | "decide";
+
+export function assertConversationAccess(params: {
+  action: InAppAgentConversationAction;
+  conversation: Pick<InAppAgentConversation, "createdByUserId" | "deletedAt">;
+  userId: string;
+}): void {
+  const { conversation } = params;
+
+  // Deliberately the same error for "does not exist", "deleted" and "not
+  // yours": a conversation the caller cannot access must not be
+  // distinguishable from one that is not there.
+  if (
+    conversation.deletedAt ||
+    conversation.createdByUserId !== params.userId
+  ) {
+    throw new LangfuseNotFoundError("Agent conversation not found");
+  }
+}

--- a/packages/shared/src/in-app-agent/server/index.ts
+++ b/packages/shared/src/in-app-agent/server/index.ts
@@ -1,6 +1,7 @@
 // Server entry of the in-app-agent runtime, consumed by web's foreground
 // adapter (handler/router) and, once background execution ships, the worker
 // queue processor.
+export * from "./access";
 export * from "./agent";
 export * from "./tools";
 export * from "./human-in-the-loop";
@@ -9,6 +10,7 @@ export * from "./eventCompaction";
 export * from "./persistence";
 export * from "./runLifecycle";
 export * from "./tunables";
+export * from "./watch";
 export * from "./promptClient";
 export * from "./skills";
 export * from "./sandbox";

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -30,6 +30,10 @@ import {
   type AgUiEvent,
   type AgUiMessage,
 } from "../schema";
+import {
+  assertConversationAccess,
+  type InAppAgentConversationAction,
+} from "./access";
 import { compactPersistedEventDeltas } from "./eventCompaction";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import { safeJsonParse } from "../../utils/json";
@@ -38,7 +42,7 @@ import { IN_APP_AGENT_SANDBOX_TOOL_NAMES } from "./tools";
 // Keep this close to the route maxDuration (120s) so a killed foreground stream
 // does not block the conversation long after the route can no longer respond.
 const ACTIVE_RUN_STALE_AFTER_MS = 150 * 1000;
-const ACTIVE_RUN_CONFLICT_MESSAGE =
+export const ACTIVE_RUN_CONFLICT_MESSAGE =
   "Assistant is already responding in this conversation";
 const STALE_RUN_ERROR_MESSAGE =
   "Run was marked stale before starting a new run";
@@ -56,6 +60,13 @@ export type PersistedConversationEvent = {
   event: AgUiEvent;
   runId: string;
   createdAt: Date;
+  /**
+   * Per-conversation monotonic position. This is the watch cursor: the
+   * hydration snapshot's high-water mark is definitionally the maximum over
+   * the events it returned, so attaching the tail with `> cursor` is
+   * gap-free and duplicate-free by construction.
+   */
+  sequenceNumber: number;
 };
 
 export function serializeConversation(
@@ -76,7 +87,7 @@ export function serializeConversation(
 
 export function isInAppAgentConversationWriteLocked(params: {
   conversation: Pick<InAppAgentConversation, "createdAt">;
-  events: readonly PersistedConversationEvent[];
+  events: readonly Pick<PersistedConversationEvent, "event">[];
   now?: Date;
 }) {
   const now = params.now ?? new Date();
@@ -105,19 +116,24 @@ export async function getOwnedConversationOrThrow(params: {
   projectId: string;
   conversationId: string;
   userId: string;
+  action?: InAppAgentConversationAction;
 }): Promise<InAppAgentConversation> {
   const conversation = await params.prisma.inAppAgentConversation.findFirst({
     where: {
       id: params.conversationId,
       projectId: params.projectId,
-      createdByUserId: params.userId,
-      deletedAt: null,
     },
   });
 
   if (!conversation) {
     throw new LangfuseNotFoundError("Agent conversation not found");
   }
+
+  assertConversationAccess({
+    action: params.action ?? "watch",
+    conversation,
+    userId: params.userId,
+  });
 
   return conversation;
 }
@@ -138,9 +154,11 @@ export async function ensureOwnedConversation(params: {
   });
 
   if (existing) {
-    if (existing.createdByUserId !== params.userId || existing.deletedAt) {
-      throw new LangfuseNotFoundError("Agent conversation not found");
-    }
+    assertConversationAccess({
+      action: "submit",
+      conversation: existing,
+      userId: params.userId,
+    });
 
     return existing;
   }
@@ -170,14 +188,24 @@ export async function createRun(params: {
   return params.prisma.$transaction(async (tx) => {
     await lockConversation(tx, params.projectId, params.conversationId);
 
-    // The v1 agent is foreground-only. If a stream dies before finishRun runs,
-    // lazily mark the old run stale so it does not block the conversation forever.
+    // If a foreground stream dies before finishRun runs, lazily mark the old
+    // run stale so it does not block the conversation forever.
+    //
+    // `claimedAt`/`heartbeatAt` must stay NULL here: only the background
+    // worker sets them, and a background run legitimately runs for up to
+    // RUN_MAX_DURATION. Without this guard a foreground submit (flag off)
+    // would stale-close a healthy background run at 150s and fence its
+    // worker — execution mode is not sticky per conversation, so that mix is
+    // a normal state. An unclaimed QUEUED run stays sweepable, which is what
+    // we want: it unblocks the conversation and reconcile-on-read agrees.
     await tx.inAppAgentRun.updateMany({
       where: {
         projectId: params.projectId,
         conversationId: params.conversationId,
         finishedAt: null,
         createdAt: { lt: staleBefore },
+        claimedAt: null,
+        heartbeatAt: null,
       },
       data: {
         status: InAppAgentRunStatus.FAILED,
@@ -344,13 +372,19 @@ export async function getConversationEvents(params: {
       conversationId: params.conversationId,
     },
     orderBy: { sequenceNumber: "asc" },
-    select: { event: true, runId: true, createdAt: true },
+    select: {
+      event: true,
+      runId: true,
+      createdAt: true,
+      sequenceNumber: true,
+    },
   });
 
-  return events.map(({ event, runId, createdAt }) => ({
+  return events.map(({ event, runId, createdAt, sequenceNumber }) => ({
     event: event as unknown as AgUiEvent,
     runId,
     createdAt,
+    sequenceNumber,
   }));
 }
 
@@ -359,7 +393,7 @@ export async function getConversationEvents(params: {
  * calls so each sandbox session can mount the same context.
  */
 export function getSandboxToolCallFiles(
-  events: readonly PersistedConversationEvent[],
+  events: readonly Omit<PersistedConversationEvent, "sequenceNumber">[],
 ) {
   const drafts = new Map<
     string,
@@ -1272,9 +1306,14 @@ function stripAssistantRunIds(messages: readonly AgUiMessage[]) {
   return changed ? sanitizedMessages : messages;
 }
 
-type InAppAgentTx = Prisma.TransactionClient;
+export type InAppAgentTx = Prisma.TransactionClient;
 
-async function lockConversation(
+/**
+ * Serializes every run-creating and approval-consuming mutation on one row.
+ * The partial unique index on active runs is only the backstop; this lock is
+ * what turns a race into a clean conflict error instead of a 500.
+ */
+export async function lockConversation(
   tx: InAppAgentTx,
   projectId: string,
   conversationId: string,

--- a/packages/shared/src/in-app-agent/server/runLifecycle.ts
+++ b/packages/shared/src/in-app-agent/server/runLifecycle.ts
@@ -1,5 +1,25 @@
-import { InAppAgentRunErrorCode, InAppAgentRunStatus } from "../../index";
+import {
+  InAppAgentRunErrorCode,
+  InAppAgentRunStatus,
+  LangfuseConflictError,
+} from "../../index";
+import { Prisma } from "../../db";
 import type { InAppAgentRun, PrismaClient } from "../../db";
+import { logger } from "../../server";
+import { buildInAppAgentApprovalDecisionEvent } from "../backgroundWatch";
+import type { AgUiEvent } from "../schema";
+import type { InAppAgentRunRequest } from "../../features/inAppAgent/types";
+import {
+  ACTIVE_RUN_CONFLICT_MESSAGE,
+  lockConversation,
+  type InAppAgentTx,
+} from "./persistence";
+import {
+  IN_APP_AGENT_APPROVAL_TTL_MS,
+  IN_APP_AGENT_HEARTBEAT_STALE_MS,
+  IN_APP_AGENT_QUEUE_TIMEOUT_MS,
+  IN_APP_AGENT_RUN_MAX_DURATION_MS,
+} from "./tunables";
 
 /**
  * Compare-and-swap transitions for background in-app agent runs.
@@ -111,4 +131,577 @@ export async function clearRunMcpApiKeyPointer(params: {
     where: { id: params.runId, projectId: params.projectId },
     data: { mcpApiKeyId: null },
   });
+}
+
+/**
+ * Submit a background run.
+ *
+ * One transaction does everything that must not interleave with another
+ * submit or an approval decision: take the conversation row lock, reconcile
+ * runs that are already dead, supersede a pending approval, enforce the
+ * single-active-run rule, insert the run as `QUEUED`, and append the
+ * `RUN_STARTED` event carrying the turn's input.
+ *
+ * The event row is inserted directly rather than through `appendRunEvents`,
+ * whose fence requires `status = RUNNING` — this run is `QUEUED` and not yet
+ * claimable. That is deliberate: the events table is the single render source
+ * from the instant of submit, so there is no optimistic UI state to survive a
+ * refresh, and the worker's replay reads its input from this row (it never
+ * writes `RUN_STARTED` itself).
+ *
+ * Idempotency for a lost response: if this commits but the client never sees
+ * the run ID, the client's retry hits the single-active-run conflict, and that
+ * clean conflict *is* the idempotency signal — the client rehydrates and finds
+ * the committed run plus its user message. No duplicate run, no duplicate
+ * message.
+ */
+export async function createQueuedRun(params: {
+  prisma: PrismaClient;
+  runId: string;
+  projectId: string;
+  conversationId: string;
+  triggeredByUserId: string;
+  model?: string;
+  request: InAppAgentRunRequest;
+  runStartedEvent: AgUiEvent;
+}): Promise<InAppAgentRun> {
+  return params.prisma.$transaction(async (tx) => {
+    await lockConversation(tx, params.projectId, params.conversationId);
+
+    await reconcileConversationRunsInTransaction({
+      tx,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+    });
+
+    // Supersede a pending approval rather than blocking input, which would
+    // hold the conversation hostage for up to APPROVAL_TTL.
+    await tx.inAppAgentRun.updateMany({
+      where: {
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        status: InAppAgentRunStatus.AWAITING_APPROVAL,
+      },
+      data: {
+        status: InAppAgentRunStatus.CANCELLED,
+        errorCode: InAppAgentRunErrorCode.APPROVAL_SUPERSEDED,
+        errorMessage: "Replaced by a newer message",
+      },
+    });
+
+    const activeRun = await tx.inAppAgentRun.findFirst({
+      where: {
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        finishedAt: null,
+      },
+      select: { id: true },
+    });
+
+    if (activeRun) {
+      throw new LangfuseConflictError(ACTIVE_RUN_CONFLICT_MESSAGE);
+    }
+
+    const run = await createRunRow(tx, {
+      runId: params.runId,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      triggeredByUserId: params.triggeredByUserId,
+      model: params.model,
+      request: params.request,
+    });
+
+    await appendConversationEventInTransaction({
+      tx,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      runId: params.runId,
+      event: params.runStartedEvent,
+    });
+
+    return run;
+  });
+}
+
+/**
+ * Record a human decision on a pending approval and queue the continuation.
+ *
+ * The CAS on the parent run's status is the exactly-once guarantee: zero rows
+ * updated means the approval was already decided or superseded, which surfaces
+ * as a clean conflict instead of a second continuation. Expiry is checked
+ * inline against the parking `finished_at`, so the TTL does not depend on
+ * anyone having polled.
+ *
+ * Only IDs and a boolean cross the wire; the tool name and arguments are read
+ * server-side from the persisted interrupt event, so there is nothing to
+ * tamper with and no fingerprint to maintain.
+ */
+export async function decideToolApproval(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  parentRunId: string;
+  continuationRunId: string;
+  toolCallId: string;
+  approved: boolean;
+  decidedByUserId: string;
+  model?: string;
+}): Promise<InAppAgentRun> {
+  return params.prisma.$transaction(async (tx) => {
+    // Serializes with createQueuedRun, so the loser of a decide/submit race
+    // gets a clean conflict rather than the unique-index violation.
+    await lockConversation(tx, params.projectId, params.conversationId);
+
+    const parentRun = await tx.inAppAgentRun.findFirst({
+      where: {
+        id: params.parentRunId,
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+      },
+      select: { status: true, finishedAt: true },
+    });
+
+    if (
+      !parentRun ||
+      parentRun.status !== InAppAgentRunStatus.AWAITING_APPROVAL
+    ) {
+      throw new LangfuseConflictError(
+        "This approval is no longer pending. Reload the conversation.",
+      );
+    }
+
+    const parkedAt = parentRun.finishedAt;
+    if (
+      parkedAt &&
+      Date.now() - parkedAt.getTime() > IN_APP_AGENT_APPROVAL_TTL_MS
+    ) {
+      await tx.inAppAgentRun.updateMany({
+        where: {
+          id: params.parentRunId,
+          projectId: params.projectId,
+          status: InAppAgentRunStatus.AWAITING_APPROVAL,
+        },
+        data: {
+          status: InAppAgentRunStatus.FAILED,
+          errorCode: InAppAgentRunErrorCode.APPROVAL_EXPIRED,
+          errorMessage: "The approval request expired",
+        },
+      });
+
+      throw new LangfuseConflictError("The approval request expired.");
+    }
+
+    // A parent that parked for approval and was decided completed its job;
+    // the handoff is the success. Zero rows = already decided or superseded.
+    const { count } = await tx.inAppAgentRun.updateMany({
+      where: {
+        id: params.parentRunId,
+        projectId: params.projectId,
+        status: InAppAgentRunStatus.AWAITING_APPROVAL,
+      },
+      data: { status: InAppAgentRunStatus.SUCCEEDED },
+    });
+
+    if (count === 0) {
+      throw new LangfuseConflictError(
+        "This approval was already decided. Reload the conversation.",
+      );
+    }
+
+    await appendConversationEventInTransaction({
+      tx,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      runId: params.parentRunId,
+      event: buildInAppAgentApprovalDecisionEvent({
+        toolCallId: params.toolCallId,
+        approved: params.approved,
+        decidedByUserId: params.decidedByUserId,
+      }),
+    });
+
+    // A rejection also spawns a continuation, so the agent can react to it.
+    return createRunRow(tx, {
+      runId: params.continuationRunId,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      triggeredByUserId: params.decidedByUserId,
+      model: params.model,
+      request: {
+        kind: "approvalDecision",
+        parentRunId: params.parentRunId,
+        toolCallId: params.toolCallId,
+        approved: params.approved,
+      },
+    });
+  });
+}
+
+export type CancelRunResult = {
+  /** Set when this mutation itself finished the run; null when the worker will. */
+  cancelledImmediately: boolean;
+  status: InAppAgentRunStatus | null;
+};
+
+/**
+ * Request cancellation of a run.
+ *
+ * Nothing is executing for a `QUEUED` or `AWAITING_APPROVAL` run, so cancel is
+ * immediate. A `RUNNING` run is cooperative: the flag is picked up by the next
+ * heartbeat (within one HEARTBEAT_INTERVAL) and the loop aborts at the next
+ * step boundary. `cancel_requested_at` is always set, so a run that is claimed
+ * between this read and the worker's next heartbeat still sees it.
+ */
+export async function requestRunCancellation(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  runId: string;
+}): Promise<CancelRunResult> {
+  return params.prisma.$transaction(async (tx) => {
+    await lockConversation(tx, params.projectId, params.conversationId);
+
+    const run = await tx.inAppAgentRun.findFirst({
+      where: {
+        id: params.runId,
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+      },
+      select: { status: true },
+    });
+
+    if (!run?.status) {
+      return { cancelledImmediately: false, status: null };
+    }
+
+    await tx.inAppAgentRun.updateMany({
+      where: { id: params.runId, projectId: params.projectId },
+      data: { cancelRequestedAt: new Date() },
+    });
+
+    const immediateCancel =
+      run.status === InAppAgentRunStatus.QUEUED
+        ? {
+            errorCode: InAppAgentRunErrorCode.CANCELLED,
+            errorMessage: "Cancelled before a worker picked the run up",
+          }
+        : run.status === InAppAgentRunStatus.AWAITING_APPROVAL
+          ? {
+              errorCode: InAppAgentRunErrorCode.APPROVAL_CANCELLED,
+              errorMessage: "Approval cancelled",
+            }
+          : null;
+
+    if (!immediateCancel) {
+      return {
+        cancelledImmediately: false,
+        status: run.status as InAppAgentRunStatus,
+      };
+    }
+
+    const { count } = await tx.inAppAgentRun.updateMany({
+      where: {
+        id: params.runId,
+        projectId: params.projectId,
+        status: run.status,
+      },
+      data: {
+        status: InAppAgentRunStatus.CANCELLED,
+        finishedAt: new Date(),
+        ...immediateCancel,
+      },
+    });
+
+    return {
+      cancelledImmediately: count > 0,
+      status: count > 0 ? InAppAgentRunStatus.CANCELLED : null,
+    };
+  });
+}
+
+export type ReconciledRun = {
+  runId: string;
+  errorCode: InAppAgentRunErrorCode;
+};
+
+/**
+ * Reconciliation-on-read: there is no scanner job, so every read of a
+ * conversation is the moment its dead runs become visibly dead.
+ *
+ * Four transitions, each anchored on a timestamp the writer already
+ * maintains, plus MCP-key cleanup retries for runs whose key delete failed.
+ * Since reads are what drive this, a badge or transcript can never show
+ * "Working" for a worker that is gone.
+ *
+ * A stale `QUEUED` run is failed rather than re-enqueued (dispatch option C).
+ * Re-enqueue-on-read is the pre-agreed follow-up and is purely additive here:
+ * one extra branch and one tunable.
+ */
+export async function reconcileConversationRuns(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+}): Promise<ReconciledRun[]> {
+  const reconciled = await params.prisma.$transaction((tx) =>
+    reconcileConversationRunsInTransaction({
+      tx,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+    }),
+  );
+
+  return reconciled;
+}
+
+async function reconcileConversationRunsInTransaction(params: {
+  tx: InAppAgentTx;
+  projectId: string;
+  conversationId: string;
+}): Promise<ReconciledRun[]> {
+  const { tx, projectId, conversationId } = params;
+  const now = Date.now();
+
+  const candidates = await tx.inAppAgentRun.findMany({
+    where: {
+      projectId,
+      conversationId,
+      status: {
+        in: [
+          InAppAgentRunStatus.QUEUED,
+          InAppAgentRunStatus.RUNNING,
+          InAppAgentRunStatus.AWAITING_APPROVAL,
+        ],
+      },
+    },
+    select: {
+      id: true,
+      status: true,
+      createdAt: true,
+      claimedAt: true,
+      heartbeatAt: true,
+      finishedAt: true,
+    },
+  });
+
+  const reconciled: ReconciledRun[] = [];
+
+  for (const run of candidates) {
+    const failure = classifyStaleRun(run, now);
+    if (!failure) continue;
+
+    const { count } = await tx.inAppAgentRun.updateMany({
+      where: { id: run.id, projectId, status: run.status },
+      data: {
+        status: InAppAgentRunStatus.FAILED,
+        finishedAt: new Date(),
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+      },
+    });
+
+    if (count > 0) {
+      reconciled.push({ runId: run.id, errorCode: failure.errorCode });
+    }
+  }
+
+  return reconciled;
+}
+
+function classifyStaleRun(
+  run: {
+    status: string | null;
+    createdAt: Date;
+    claimedAt: Date | null;
+    heartbeatAt: Date | null;
+    finishedAt: Date | null;
+  },
+  now: number,
+): { errorCode: InAppAgentRunErrorCode; errorMessage: string } | null {
+  if (run.status === InAppAgentRunStatus.QUEUED) {
+    return now - run.createdAt.getTime() > IN_APP_AGENT_QUEUE_TIMEOUT_MS
+      ? {
+          errorCode: InAppAgentRunErrorCode.QUEUE_TIMEOUT,
+          errorMessage: "No worker picked this run up",
+        }
+      : null;
+  }
+
+  if (run.status === InAppAgentRunStatus.RUNNING) {
+    // Ordered deliberately: the duration backstop wins over the heartbeat
+    // check, because a hung tool renews a healthy heartbeat forever and
+    // run_timeout is the honest description of that failure.
+    if (
+      run.claimedAt &&
+      now - run.claimedAt.getTime() > IN_APP_AGENT_RUN_MAX_DURATION_MS
+    ) {
+      return {
+        errorCode: InAppAgentRunErrorCode.RUN_TIMEOUT,
+        errorMessage: "The run exceeded the maximum duration",
+      };
+    }
+
+    const lastSign = run.heartbeatAt ?? run.claimedAt;
+    return lastSign &&
+      now - lastSign.getTime() > IN_APP_AGENT_HEARTBEAT_STALE_MS
+      ? {
+          errorCode: InAppAgentRunErrorCode.WORKER_LOST,
+          errorMessage: "The run was interrupted",
+        }
+      : null;
+  }
+
+  if (run.status === InAppAgentRunStatus.AWAITING_APPROVAL) {
+    // Anchored on the parking finished_at; no extra column.
+    const parkedAt = run.finishedAt;
+    return parkedAt && now - parkedAt.getTime() > IN_APP_AGENT_APPROVAL_TTL_MS
+      ? {
+          errorCode: InAppAgentRunErrorCode.APPROVAL_EXPIRED,
+          errorMessage: "The approval request expired",
+        }
+      : null;
+  }
+
+  return null;
+}
+
+/**
+ * Retry MCP-key cleanup for runs that are terminal with the pointer still set
+ * — the discoverable owners of a key whose delete failed. Runs outside the
+ * conversation transaction because deleting the key is not a Postgres-only
+ * operation and must never roll back a reconciliation that already committed.
+ */
+export async function cleanupTerminalRunMcpApiKeys(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  deleteApiKey: (apiKeyId: string) => Promise<void>;
+}): Promise<number> {
+  const staleKeyRuns = await params.prisma.inAppAgentRun.findMany({
+    where: {
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      finishedAt: { not: null },
+      mcpApiKeyId: { not: null },
+    },
+    select: { id: true, mcpApiKeyId: true },
+  });
+
+  let cleaned = 0;
+
+  for (const run of staleKeyRuns) {
+    if (!run.mcpApiKeyId) continue;
+
+    try {
+      await params.deleteApiKey(run.mcpApiKeyId);
+      await clearRunMcpApiKeyPointer({
+        prisma: params.prisma,
+        projectId: params.projectId,
+        runId: run.id,
+      });
+      cleaned += 1;
+    } catch (error) {
+      // Leave the pointer set so the next read retries. A nonzero steady-state
+      // count here means a cleanup path is broken, not that this is normal.
+      logger.error("Failed to clean up in-app agent MCP key on reconcile", {
+        projectId: params.projectId,
+        runId: run.id,
+        error,
+      });
+    }
+  }
+
+  return cleaned;
+}
+
+async function createRunRow(
+  tx: InAppAgentTx,
+  params: {
+    runId: string;
+    projectId: string;
+    conversationId: string;
+    triggeredByUserId: string;
+    model?: string;
+    request: InAppAgentRunRequest;
+  },
+): Promise<InAppAgentRun> {
+  try {
+    return await tx.inAppAgentRun.create({
+      data: {
+        id: params.runId,
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        triggeredByUserId: params.triggeredByUserId,
+        model: params.model,
+        status: InAppAgentRunStatus.QUEUED,
+        request: params.request,
+      },
+    });
+  } catch (error) {
+    // Backstop: the partial unique index on active runs. The conversation lock
+    // makes this unreachable; surface it as the same conflict as the primary
+    // check instead of a 500. Only map that index — the insert can also
+    // violate the (id, project_id) primary key on a replayed run ID.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002" &&
+      Array.isArray(error.meta?.target) &&
+      error.meta.target.includes("conversation_id")
+    ) {
+      throw new LangfuseConflictError(ACTIVE_RUN_CONFLICT_MESSAGE);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Append one web-authored event inside a mutation that already holds the
+ * conversation lock.
+ *
+ * Two writers share the events table but are never concurrent: web appends
+ * user-authored happenings (the submitted message, an approval decision)
+ * before the run is claimable, and the worker is the only writer while a run
+ * is `RUNNING`. `appendRunEvents` is the worker's door and fences on
+ * `status = RUNNING`; this is web's, and the conversation lock is what makes
+ * the sequence assignment safe.
+ */
+async function appendConversationEventInTransaction(params: {
+  tx: InAppAgentTx;
+  projectId: string;
+  conversationId: string;
+  runId: string;
+  event: AgUiEvent;
+}): Promise<number> {
+  const latestEvent = await params.tx.inAppAgentEvent.findFirst({
+    where: {
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+    },
+    orderBy: { sequenceNumber: "desc" },
+    select: { sequenceNumber: true },
+  });
+
+  const sequenceNumber = (latestEvent?.sequenceNumber ?? -1) + 1;
+
+  await params.tx.inAppAgentEvent.create({
+    data: {
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      runId: params.runId,
+      sequenceNumber,
+      type: String(params.event.type),
+      event: params.event as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  await params.tx.inAppAgentConversation.update({
+    where: {
+      id_projectId: {
+        id: params.conversationId,
+        projectId: params.projectId,
+      },
+    },
+    data: { updatedAt: new Date() },
+  });
+
+  return sequenceNumber;
 }

--- a/packages/shared/src/in-app-agent/server/tunables.ts
+++ b/packages/shared/src/in-app-agent/server/tunables.ts
@@ -44,3 +44,25 @@ export const IN_APP_AGENT_APPROVAL_TTL_MS = envMs(
   "LANGFUSE_IN_APP_AGENT_APPROVAL_TTL_MS",
   24 * 60 * 60_000,
 );
+
+/** Interval at which the watch stream re-reads run status + new events. */
+export const IN_APP_AGENT_WATCH_TAIL_POLL_MS = envMs(
+  "LANGFUSE_IN_APP_AGENT_WATCH_TAIL_POLL_MS",
+  1_000,
+);
+
+/** SSE comment interval, so load-balancer idle timeouts never fire. */
+export const IN_APP_AGENT_WATCH_KEEPALIVE_MS = envMs(
+  "LANGFUSE_IN_APP_AGENT_WATCH_KEEPALIVE_MS",
+  15_000,
+);
+
+/**
+ * Deliberate stream end; the client reconnects with its cursor through the
+ * same path as a fresh page load, so route/LB duration limits are never hit
+ * unpredictably. Kept well inside the watch route's 120s `maxDuration`.
+ */
+export const IN_APP_AGENT_WATCH_MAX_CONNECTION_MS = envMs(
+  "LANGFUSE_IN_APP_AGENT_WATCH_MAX_CONNECTION_MS",
+  90_000,
+);

--- a/packages/shared/src/in-app-agent/server/watch.test.ts
+++ b/packages/shared/src/in-app-agent/server/watch.test.ts
@@ -1,0 +1,333 @@
+import { EventType } from "@ag-ui/core";
+import { describe, expect, it } from "vitest";
+
+import { InAppAgentRunStatus } from "../../index";
+import type { PrismaClient } from "../../db";
+import type { InAppAgentWatchFrame } from "../backgroundWatch";
+import { watchConversationFrames } from "./watch";
+
+/**
+ * The framing rules are what these tests protect, so the data source is a
+ * fake: `@ag-ui/client` rejects a stream whose first event is not
+ * `RUN_STARTED` and rejects events after `RUN_FINISHED`, and getting that
+ * wrong is a runtime throw in the drawer that no type check can catch.
+ */
+type EventRow = {
+  sequenceNumber: number;
+  runId: string;
+  event: Record<string, unknown>;
+};
+
+type RunRow = {
+  id: string;
+  status: InAppAgentRunStatus;
+  errorCode: string | null;
+  errorMessage: string | null;
+  cancelRequestedAt?: Date | null;
+};
+
+function fakePrisma(polls: Array<{ events: EventRow[]; run: RunRow | null }>) {
+  let pollIndex = 0;
+
+  return {
+    // reconcileConversationRuns runs first in every poll; it must find nothing
+    // to do so it does not interfere with the framing under test.
+    $transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        inAppAgentRun: {
+          findMany: async () => [],
+          updateMany: async () => ({ count: 0 }),
+        },
+      }),
+    inAppAgentRun: {
+      findFirst: async () =>
+        polls[Math.min(pollIndex, polls.length - 1)]?.run ?? null,
+    },
+    inAppAgentEvent: {
+      findMany: async ({
+        where,
+      }: {
+        where: { sequenceNumber: { gt: number } };
+      }) => {
+        const poll = polls[Math.min(pollIndex, polls.length - 1)];
+        pollIndex += 1;
+
+        return (poll?.events ?? []).filter(
+          (row) => row.sequenceNumber > where.sequenceNumber.gt,
+        );
+      },
+    },
+  } as unknown as PrismaClient;
+}
+
+async function collect(
+  prisma: PrismaClient,
+  cursor: number,
+): Promise<InAppAgentWatchFrame[]> {
+  const frames: InAppAgentWatchFrame[] = [];
+
+  for await (const frame of watchConversationFrames({
+    prisma,
+    projectId: "project-1",
+    conversationId: "conversation-1",
+    cursor,
+    now: () => 0,
+    sleep: async () => undefined,
+  })) {
+    if (frame !== null) {
+      frames.push(frame);
+    }
+  }
+
+  return frames;
+}
+
+const eventFrames = (frames: InAppAgentWatchFrame[]) =>
+  frames.filter(
+    (frame): frame is Extract<InAppAgentWatchFrame, { type: "event" }> =>
+      frame.type === "event",
+  );
+
+const eventTypes = (frames: InAppAgentWatchFrame[]) =>
+  eventFrames(frames).map((frame) => frame.event.type);
+
+describe("watchConversationFrames", () => {
+  const runStarted = (runId: string, sequenceNumber: number): EventRow => ({
+    sequenceNumber,
+    runId,
+    event: {
+      type: EventType.RUN_STARTED,
+      runId,
+      threadId: "conversation-1",
+      // The persisted row carries the turn's input; the worker's replay reads
+      // the user message out of it.
+      input: {
+        runId,
+        messages: [{ id: "server-minted-id", role: "user", content: "hi" }],
+      },
+    },
+  });
+
+  const textMessage = (runId: string, sequenceNumber: number): EventRow => ({
+    sequenceNumber,
+    runId,
+    event: {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: `m-${sequenceNumber}`,
+    },
+  });
+
+  const runFinished = (runId: string, sequenceNumber: number): EventRow => ({
+    sequenceNumber,
+    runId,
+    event: { type: EventType.RUN_FINISHED, runId, threadId: "conversation-1" },
+  });
+
+  const succeeded: RunRow = {
+    id: "run-1",
+    status: InAppAgentRunStatus.SUCCEEDED,
+    errorCode: null,
+    errorMessage: null,
+    cancelRequestedAt: null,
+  };
+
+  it("relays a finished run verbatim and closes with a done frame", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [
+            runStarted("run-1", 0),
+            textMessage("run-1", 1),
+            runFinished("run-1", 2),
+          ],
+          run: succeeded,
+        },
+      ]),
+      -1,
+    );
+
+    // No synthetic twin for the boundaries the worker already persisted.
+    expect(eventTypes(frames)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.RUN_FINISHED,
+    ]);
+    expect(frames.at(-1)).toEqual({ type: "done" });
+    expect(frames.filter((frame) => frame.type === "status")).toEqual([
+      {
+        type: "status",
+        runId: "run-1",
+        status: InAppAgentRunStatus.SUCCEEDED,
+        errorCode: null,
+        errorMessage: null,
+        cancelRequested: false,
+      },
+    ]);
+  });
+
+  it("opens the run synthetically when attaching mid-run, without skipping the event it frames", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [textMessage("run-1", 1), runFinished("run-1", 2)],
+          run: succeeded,
+        },
+      ]),
+      // The client hydrated through the persisted RUN_STARTED at 0.
+      0,
+    );
+
+    expect(eventTypes(frames)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.RUN_FINISHED,
+    ]);
+
+    // A drop right after the synthetic frame must re-read event 1, not skip it.
+    expect(eventFrames(frames)[0]?.sequenceNumber).toBe(0);
+  });
+
+  it("hands off from cursor to tail with no duplicated and no missed event", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [textMessage("run-1", 1)],
+          run: { ...succeeded, status: InAppAgentRunStatus.RUNNING },
+        },
+        {
+          events: [
+            textMessage("run-1", 1),
+            textMessage("run-1", 2),
+            runFinished("run-1", 3),
+          ],
+          run: succeeded,
+        },
+      ]),
+      0,
+    );
+
+    const sequences = eventFrames(frames).map((frame) => frame.sequenceNumber);
+
+    // 0 is the synthetic open; 1, 2, 3 are each relayed exactly once even
+    // though poll two re-reported event 1 as still present.
+    expect(sequences).toEqual([0, 1, 2, 3]);
+  });
+
+  it("closes a terminal run whose stream never persisted its own RUN_FINISHED", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [runStarted("run-1", 0), textMessage("run-1", 1)],
+          run: {
+            id: "run-1",
+            status: InAppAgentRunStatus.FAILED,
+            errorCode: "worker_lost",
+            errorMessage: "The run was interrupted",
+          },
+        },
+      ]),
+      -1,
+    );
+
+    // Without the synthetic close, the client's verifier would reject the next
+    // run's RUN_STARTED on this stream.
+    expect(eventTypes(frames)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.RUN_FINISHED,
+    ]);
+    expect(frames.at(-1)).toEqual({ type: "done" });
+  });
+
+  it("re-emits status when a cancel is requested while the run is still RUNNING", async () => {
+    const running: RunRow = {
+      ...succeeded,
+      status: InAppAgentRunStatus.RUNNING,
+    };
+
+    const frames = await collect(
+      fakePrisma([
+        { events: [runStarted("run-1", 0)], run: running },
+        {
+          events: [],
+          run: { ...running, cancelRequestedAt: new Date(1) },
+        },
+        { events: [runFinished("run-1", 1)], run: { ...succeeded } },
+      ]),
+      -1,
+    );
+
+    const statuses = frames.filter((frame) => frame.type === "status");
+
+    // Status is deduplicated by key, so the cancel flag has to be part of that
+    // key: it flips while the status is still RUNNING, and if that frame is
+    // swallowed the drawer shows no sign that a stop is in flight.
+    expect(statuses).toMatchObject([
+      { status: InAppAgentRunStatus.RUNNING, cancelRequested: false },
+      { status: InAppAgentRunStatus.RUNNING, cancelRequested: true },
+      { status: InAppAgentRunStatus.SUCCEEDED, cancelRequested: false },
+    ]);
+  });
+
+  it("strips RUN_STARTED input so the submitted message is not rendered twice", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [runStarted("run-1", 0), runFinished("run-1", 1)],
+          run: succeeded,
+        },
+      ]),
+      -1,
+    );
+
+    // @ag-ui/client seeds agent.messages from RUN_STARTED.input.messages and
+    // dedupes by id only. The submitting client already added the message under
+    // its own id, so relaying the server's id renders the turn twice.
+    const relayedRunStarted = eventFrames(frames).find(
+      (frame) => frame.event.type === EventType.RUN_STARTED,
+    );
+
+    expect(relayedRunStarted?.event).not.toHaveProperty("input");
+    expect(relayedRunStarted?.event).toMatchObject({
+      type: EventType.RUN_STARTED,
+      runId: "run-1",
+    });
+  });
+
+  it("closes immediately when the conversation has no run with a readable status", async () => {
+    // Legacy rows predate the status column, and the column is deliberately
+    // still nullable. Polling such a conversation forever would reconnect in a
+    // loop for a run that is not executing.
+    const frames = await collect(fakePrisma([{ events: [], run: null }]), -1);
+
+    expect(frames).toEqual([{ type: "done" }]);
+  });
+
+  it("closes one run and opens the next when a continuation follows", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [
+            runStarted("run-1", 0),
+            textMessage("run-1", 1),
+            // The parked parent never wrote RUN_FINISHED; the continuation's
+            // first row is a plain event, not a RUN_STARTED.
+            textMessage("run-2", 2),
+            runFinished("run-2", 3),
+          ],
+          run: { ...succeeded, id: "run-2" },
+        },
+      ]),
+      -1,
+    );
+
+    expect(eventTypes(frames)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.RUN_FINISHED,
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.RUN_FINISHED,
+    ]);
+  });
+});

--- a/packages/shared/src/in-app-agent/server/watch.ts
+++ b/packages/shared/src/in-app-agent/server/watch.ts
@@ -1,0 +1,246 @@
+import { EventType } from "@ag-ui/core";
+
+import { InAppAgentRunStatus } from "../../index";
+import type { PrismaClient } from "../../db";
+import {
+  isActiveInAppAgentRunStatus,
+  type InAppAgentWatchFrame,
+} from "../backgroundWatch";
+import type { AgUiEvent } from "../schema";
+import { reconcileConversationRuns } from "./runLifecycle";
+import {
+  IN_APP_AGENT_WATCH_KEEPALIVE_MS,
+  IN_APP_AGENT_WATCH_MAX_CONNECTION_MS,
+  IN_APP_AGENT_WATCH_TAIL_POLL_MS,
+} from "./tunables";
+
+/**
+ * The watch stream's frame source, kept out of the HTTP route so it is
+ * testable without a server.
+ *
+ * Yields `null` where the transport should send a keep-alive comment: drops
+ * are normal and the cursor makes them free, but an idle load balancer must
+ * not decide the point for us during a long model call.
+ *
+ * ## Run framing is this generator's job
+ *
+ * `@ag-ui/client` verifies event ordering on the way in: the first event of a
+ * stream must be `RUN_STARTED`, nothing may follow `RUN_FINISHED` without a
+ * new `RUN_STARTED`, and `RUN_STARTED` may not arrive while a run is still
+ * open. Raw persisted rows satisfy none of that after a mid-run reconnect —
+ * the cursor is past the run's `RUN_STARTED` row, so the first tail event
+ * would be a bare `TEXT_MESSAGE_START`.
+ *
+ * So the generator tracks the open run and synthesizes the boundaries the
+ * client's verifier requires: it opens a run before relaying that run's first
+ * event and closes it when the events give way to another run's or the run
+ * reaches a terminal status. Persisted boundary events pass through and
+ * suppress their synthetic twin, so a cold attach at cursor 0 is byte-faithful
+ * to what the worker wrote.
+ *
+ * What makes this safe rather than clever: the worker appends *compacted
+ * units* (a whole message, a whole tool call), so every sequence boundary
+ * falls between units and the first event after any cursor is always a
+ * `*_START`. There is no partial unit to stitch.
+ *
+ * ## `sequenceNumber` on a frame means "cursor value valid after this frame"
+ *
+ * For persisted events that is the row's own number. Synthetic frames carry
+ * the cursor of the event they precede *minus one*, so a client that drops
+ * right after a synthetic frame re-reads the real event it was framing rather
+ * than skipping it. The value is therefore monotonic and never advances past
+ * an unreplayed row.
+ */
+export async function* watchConversationFrames(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  cursor: number;
+  signal?: AbortSignal;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}): AsyncGenerator<InAppAgentWatchFrame | null> {
+  const now = params.now ?? (() => Date.now());
+  const sleep =
+    params.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  const startedAt = now();
+  let cursor = params.cursor;
+  let lastKeepaliveAt = startedAt;
+  let openRunId: string | null = null;
+  let lastStatusKey: string | null = null;
+
+  while (!params.signal?.aborted) {
+    // Reads are what make dead runs visibly dead; this is the only reconciler.
+    await reconcileConversationRuns({
+      prisma: params.prisma,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+    });
+
+    // Status first, events second, deliberately. The worker appends a run's
+    // events *before* its terminal CAS, so reading the status first means a
+    // terminal status observed here is always followed by an event read that
+    // already contains everything that run wrote. The other order can observe
+    // "terminal" and miss the final events.
+    const latestRun = await params.prisma.inAppAgentRun.findFirst({
+      where: {
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+      },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        status: true,
+        errorCode: true,
+        errorMessage: true,
+        cancelRequestedAt: true,
+      },
+    });
+
+    const events = await params.prisma.inAppAgentEvent.findMany({
+      where: {
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        sequenceNumber: { gt: cursor },
+      },
+      orderBy: { sequenceNumber: "asc" },
+      select: { sequenceNumber: true, runId: true, event: true },
+    });
+
+    for (const row of events) {
+      const event = row.event as unknown as AgUiEvent;
+
+      if (openRunId !== row.runId) {
+        if (openRunId) {
+          yield syntheticFrame(row.sequenceNumber - 1, {
+            type: EventType.RUN_FINISHED,
+            threadId: params.conversationId,
+            runId: openRunId,
+          });
+        }
+
+        if (event.type !== EventType.RUN_STARTED) {
+          yield syntheticFrame(row.sequenceNumber - 1, {
+            type: EventType.RUN_STARTED,
+            threadId: params.conversationId,
+            runId: row.runId,
+          });
+        }
+
+        openRunId = row.runId;
+      }
+
+      yield {
+        type: "event",
+        sequenceNumber: row.sequenceNumber,
+        event: toPublicEvent(event) as unknown as Record<string, unknown>,
+      };
+
+      if (
+        event.type === EventType.RUN_FINISHED ||
+        event.type === EventType.RUN_ERROR
+      ) {
+        openRunId = null;
+      }
+
+      cursor = row.sequenceNumber;
+    }
+
+    // No run, or a legacy row written before the status column existed: there
+    // is nothing executing, so close rather than poll forever.
+    if (!latestRun?.status) {
+      yield { type: "done" };
+      return;
+    }
+
+    const status = latestRun.status as InAppAgentRunStatus;
+    const cancelRequested = Boolean(latestRun.cancelRequestedAt);
+    // Part of the key: a cancel request is observable while the status is still
+    // RUNNING, and that transition has to reach the client.
+    const statusKey = `${latestRun.id}:${status}:${cancelRequested}`;
+
+    if (statusKey !== lastStatusKey) {
+      lastStatusKey = statusKey;
+      yield {
+        type: "status",
+        runId: latestRun.id,
+        status,
+        errorCode: latestRun.errorCode,
+        errorMessage: latestRun.errorMessage,
+        cancelRequested,
+      };
+    }
+
+    if (!isActiveInAppAgentRunStatus(status)) {
+      // A terminal run whose stream never wrote its own RUN_FINISHED (the
+      // worker died, or the run parked for approval) still has to close, or
+      // the client's verifier rejects the next run's RUN_STARTED.
+      if (openRunId) {
+        yield syntheticFrame(cursor, {
+          type: EventType.RUN_FINISHED,
+          threadId: params.conversationId,
+          runId: openRunId,
+        });
+        openRunId = null;
+      }
+
+      // The done frame — not the close itself — is the client's
+      // stop-reconnecting signal.
+      yield { type: "done" };
+      return;
+    }
+
+    if (now() - startedAt >= IN_APP_AGENT_WATCH_MAX_CONNECTION_MS) {
+      // Deliberate end well inside the route's duration limit. The client
+      // reconnects with its cursor through the same path as a fresh page
+      // load, so this is not an error and emits no done frame.
+      return;
+    }
+
+    if (now() - lastKeepaliveAt >= IN_APP_AGENT_WATCH_KEEPALIVE_MS) {
+      lastKeepaliveAt = now();
+      yield null;
+    }
+
+    await sleep(IN_APP_AGENT_WATCH_TAIL_POLL_MS);
+  }
+}
+
+/**
+ * Strip `RUN_STARTED.input` before the event reaches a browser.
+ *
+ * The persisted row has to carry the turn's input — it is the only place the
+ * user message is stored, and the worker's replay rebuilds model context from
+ * it. But `@ag-ui/client` seeds `agent.messages` from a received
+ * `RUN_STARTED.input.messages`, deduplicating **by message id only**. The
+ * submitting client already added that message under its own locally-minted
+ * id, so relaying the server's id would render the same turn twice until the
+ * next `getConversation` refetch replaced local state.
+ *
+ * The foreground stream solves this the same way (`normalizeAdapterEvent` in
+ * `agent.ts` deletes `input` on the way out); the tail has to match it, since
+ * both feed the identical client pipeline.
+ */
+function toPublicEvent(event: AgUiEvent): AgUiEvent {
+  if (event.type !== EventType.RUN_STARTED || event.input === undefined) {
+    return event;
+  }
+
+  const publicEvent = { ...event };
+  delete publicEvent.input;
+
+  return publicEvent;
+}
+
+function syntheticFrame(
+  cursor: number,
+  event: AgUiEvent,
+): InAppAgentWatchFrame {
+  return {
+    type: "event",
+    sequenceNumber: cursor,
+    event: event as unknown as Record<string, unknown>,
+  };
+}

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -92,6 +92,7 @@ export * from "./redis/cloudFreeTierUsageThresholdQueue";
 export * from "./redis/getQueue";
 export * from "./redis/webhookQueue";
 export * from "./redis/monitorQueue";
+export * from "./redis/inAppAgentRunQueue";
 export * from "./redis/traceDelete";
 export * from "./redis/projectDelete";
 export * from "./redis/scoreDelete";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/web/package.json
+++ b/web/package.json
@@ -156,6 +156,7 @@
     "react18-json-view": "^0.2.8-canary.6",
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",
+    "rxjs": "7.8.1",
     "sonner": "^2.0.7",
     "streamdown": "^2.5.0",
     "stripe": "^18.5.0",

--- a/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
@@ -1,0 +1,644 @@
+/**
+ * Behavioral coverage for the background execution surface: submit, cancel,
+ * decide, and reconcile-on-read. These go through the tRPC callers rather than
+ * the lifecycle helpers directly, because the contracts worth protecting are
+ * the ones a browser can actually reach.
+ */
+import type { Session } from "next-auth";
+import type { Flags } from "@/src/features/feature-flags/types";
+import { EventType } from "@ag-ui/core";
+import { randomUUID } from "crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  InAppAgentRunErrorCode,
+  InAppAgentRunStatus,
+  type Plan,
+} from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import {
+  createInAppAgentConversationId,
+  createInAppAgentRunId,
+  IN_APP_AGENT_APPROVAL_DECISION_EVENT_NAME,
+} from "@langfuse/shared/in-app-agent";
+import { ensureOwnedConversation } from "@langfuse/shared/in-app-agent/server/persistence";
+import { env } from "@/src/env.mjs";
+import { inAppAgentRouter } from "@/src/features/in-app-agent/server/router";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+
+import type * as SharedServerModule from "@langfuse/shared/src/server";
+
+const enqueuedJobs: Array<{ name: string; payload: unknown; jobId?: string }> =
+  [];
+let enqueueShouldFail = false;
+
+vi.mock("@langfuse/shared/src/server", async () => {
+  const actual = await vi.importActual<typeof SharedServerModule>(
+    "@langfuse/shared/src/server",
+  );
+
+  return {
+    ...actual,
+    InAppAgentRunQueue: {
+      getInstance: () => ({
+        add: (name: string, payload: unknown, options?: { jobId?: string }) => {
+          if (enqueueShouldFail) {
+            throw new Error("queue unavailable");
+          }
+          enqueuedJobs.push({ name, payload, jobId: options?.jobId });
+          return Promise.resolve();
+        },
+        remove: () => Promise.resolve(),
+      }),
+    },
+  };
+});
+
+vi.mock("@/src/server/auth", () => ({
+  getServerAuthSession: vi.fn(),
+}));
+
+describe("in-app agent background runs", () => {
+  const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+  const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
+
+  beforeEach(() => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
+    (env as any).LANGFUSE_AWS_BEDROCK_MODEL = "test-model";
+    enqueuedJobs.length = 0;
+    enqueueShouldFail = false;
+  });
+
+  afterEach(() => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
+  });
+
+  const createCaller = async (
+    userId = `user-${randomUUID()}`,
+    plan: Plan = "cloud:hobby",
+  ) => {
+    const setup = await createOrgProjectAndApiKey();
+
+    await prisma.organization.update({
+      where: { id: setup.orgId },
+      data: { aiFeaturesEnabled: true },
+    });
+
+    await prisma.user.create({
+      data: { id: userId, email: `${userId}@example.com` },
+    });
+
+    const session: Session = {
+      expires: "1",
+      user: {
+        id: userId,
+        name: "Agent User",
+        canCreateOrganizations: true,
+        organizations: [
+          {
+            id: setup.orgId,
+            role: "OWNER",
+            plan,
+            cloudConfig: undefined,
+            name: "Test Organization",
+            metadata: {},
+            aiFeaturesEnabled: true,
+            aiTelemetryEnabled: false,
+            projects: [
+              {
+                id: setup.projectId,
+                role: "ADMIN",
+                name: "Test Project",
+                deletedAt: null,
+                retentionDays: null,
+                hasTraces: false,
+                metadata: {},
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          },
+        ],
+        featureFlags: {} as Flags,
+        admin: false,
+      },
+      environment: {} as any,
+    };
+
+    const ctx = createInnerTRPCContext({ session, headers: {} });
+
+    return {
+      ...setup,
+      userId,
+      caller: inAppAgentRouter.createCaller({ ...ctx, prisma }),
+    };
+  };
+
+  const createConversation = async (params: {
+    projectId: string;
+    userId: string;
+  }) =>
+    ensureOwnedConversation({
+      prisma,
+      projectId: params.projectId,
+      conversationId: createInAppAgentConversationId(),
+      userId: params.userId,
+    });
+
+  /** Park a run for approval the way the worker does: interrupt event, then CAS. */
+  const parkRunForApproval = async (params: {
+    projectId: string;
+    conversationId: string;
+    userId: string;
+    toolCallId: string;
+    parkedAt?: Date;
+  }) => {
+    const runId = createInAppAgentRunId();
+
+    await prisma.inAppAgentRun.create({
+      data: {
+        id: runId,
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        triggeredByUserId: params.userId,
+        status: InAppAgentRunStatus.AWAITING_APPROVAL,
+        finishedAt: params.parkedAt ?? new Date(),
+        request: { kind: "userMessage", context: [] },
+      },
+    });
+
+    await prisma.inAppAgentEvent.create({
+      data: {
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        runId,
+        sequenceNumber: 0,
+        type: EventType.CUSTOM,
+        event: {
+          type: EventType.CUSTOM,
+          name: "on_interrupt",
+          value: {
+            type: "mastra_suspend",
+            toolCallId: params.toolCallId,
+            toolName: "langfuse_createTextPrompt",
+            args: { name: "from-persisted-event" },
+            runId,
+          },
+        },
+      },
+    });
+
+    return runId;
+  };
+
+  it("commits a queued run with its user message and enqueues it by run id", async () => {
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+
+    const { runId } = await caller.startRun({
+      projectId,
+      conversationId: conversation.id,
+      message: "why did these traces fail?",
+      context: [{ description: "current_url", value: "/project/x/traces" }],
+    });
+
+    const run = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: runId, projectId },
+    });
+
+    expect(run.status).toBe(InAppAgentRunStatus.QUEUED);
+    expect(run.finishedAt).toBeNull();
+    expect(run.request).toMatchObject({ kind: "userMessage" });
+
+    // The worker never writes RUN_STARTED and reads the turn's input from it,
+    // so a missing or misshaped row silently yields an empty replay history.
+    const events = await prisma.inAppAgentEvent.findMany({
+      where: { projectId, conversationId: conversation.id },
+      orderBy: { sequenceNumber: "asc" },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      runId,
+      sequenceNumber: 0,
+      type: EventType.RUN_STARTED,
+    });
+    expect(events[0]?.event).toMatchObject({
+      type: EventType.RUN_STARTED,
+      runId,
+      input: {
+        messages: [{ role: "user", content: "why did these traces fail?" }],
+      },
+    });
+
+    expect(enqueuedJobs).toEqual([
+      expect.objectContaining({
+        jobId: runId,
+        payload: expect.objectContaining({
+          payload: { projectId, runId },
+        }),
+      }),
+    ]);
+  });
+
+  it("rejects a second submit while a run is active without duplicating anything", async () => {
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+
+    await caller.startRun({
+      projectId,
+      conversationId: conversation.id,
+      message: "first",
+    });
+
+    // The lost-response idempotency contract: a retry hits this clean conflict,
+    // then the client rehydrates and finds the committed run plus its message.
+    await expect(
+      caller.startRun({
+        projectId,
+        conversationId: conversation.id,
+        message: "first",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    expect(
+      await prisma.inAppAgentRun.count({
+        where: { projectId, conversationId: conversation.id },
+      }),
+    ).toBe(1);
+    expect(
+      await prisma.inAppAgentEvent.count({
+        where: { projectId, conversationId: conversation.id },
+      }),
+    ).toBe(1);
+  });
+
+  it("supersedes a pending approval when a new message is submitted", async () => {
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+    const parkedRunId = await parkRunForApproval({
+      projectId,
+      conversationId: conversation.id,
+      userId,
+      toolCallId: "tool-call-1",
+    });
+
+    const { runId } = await caller.startRun({
+      projectId,
+      conversationId: conversation.id,
+      message: "never mind, do this instead",
+    });
+
+    const parkedRun = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: parkedRunId, projectId },
+    });
+
+    expect(parkedRun.status).toBe(InAppAgentRunStatus.CANCELLED);
+    expect(parkedRun.errorCode).toBe(
+      InAppAgentRunErrorCode.APPROVAL_SUPERSEDED,
+    );
+    expect(runId).not.toBe(parkedRunId);
+  });
+
+  it("decides an approval exactly once and reads the tool args server-side", async () => {
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+    const parkedRunId = await parkRunForApproval({
+      projectId,
+      conversationId: conversation.id,
+      userId,
+      toolCallId: "tool-call-1",
+    });
+
+    const { runId: continuationRunId } = await caller.decideToolApproval({
+      projectId,
+      conversationId: conversation.id,
+      runId: parkedRunId,
+      toolCallId: "tool-call-1",
+      approved: true,
+    });
+
+    const parkedRun = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: parkedRunId, projectId },
+    });
+    // A parent that parked and was decided completed its job; the handoff is
+    // the success.
+    expect(parkedRun.status).toBe(InAppAgentRunStatus.SUCCEEDED);
+
+    const continuation = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: continuationRunId, projectId },
+    });
+    expect(continuation.status).toBe(InAppAgentRunStatus.QUEUED);
+    expect(continuation.request).toMatchObject({
+      kind: "approvalDecision",
+      parentRunId: parkedRunId,
+      toolCallId: "tool-call-1",
+      approved: true,
+    });
+
+    const decisionEvent = await prisma.inAppAgentEvent.findFirstOrThrow({
+      where: { projectId, conversationId: conversation.id, runId: parkedRunId },
+      orderBy: { sequenceNumber: "desc" },
+    });
+    expect(decisionEvent.event).toMatchObject({
+      name: IN_APP_AGENT_APPROVAL_DECISION_EVENT_NAME,
+      value: {
+        toolCallId: "tool-call-1",
+        approved: true,
+        decidedByUserId: userId,
+      },
+    });
+
+    await expect(
+      caller.decideToolApproval({
+        projectId,
+        conversationId: conversation.id,
+        runId: parkedRunId,
+        toolCallId: "tool-call-1",
+        approved: true,
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    expect(
+      await prisma.inAppAgentRun.count({
+        where: {
+          projectId,
+          conversationId: conversation.id,
+          status: InAppAgentRunStatus.QUEUED,
+        },
+      }),
+    ).toBe(1);
+  });
+
+  it("cancels a queued run immediately and a pending approval directly", async () => {
+    const { caller, projectId, userId } = await createCaller();
+
+    const queuedConversation = await createConversation({ projectId, userId });
+    const { runId: queuedRunId } = await caller.startRun({
+      projectId,
+      conversationId: queuedConversation.id,
+      message: "stop me",
+    });
+
+    const queuedResult = await caller.cancelRun({
+      projectId,
+      conversationId: queuedConversation.id,
+      runId: queuedRunId,
+    });
+
+    expect(queuedResult.cancelledImmediately).toBe(true);
+    const cancelledQueuedRun = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: queuedRunId, projectId },
+    });
+    expect(cancelledQueuedRun.status).toBe(InAppAgentRunStatus.CANCELLED);
+    expect(cancelledQueuedRun.errorCode).toBe(InAppAgentRunErrorCode.CANCELLED);
+    expect(cancelledQueuedRun.cancelRequestedAt).not.toBeNull();
+
+    const parkedConversation = await createConversation({ projectId, userId });
+    const parkedRunId = await parkRunForApproval({
+      projectId,
+      conversationId: parkedConversation.id,
+      userId,
+      toolCallId: "tool-call-2",
+    });
+
+    await caller.cancelRun({
+      projectId,
+      conversationId: parkedConversation.id,
+      runId: parkedRunId,
+    });
+
+    const cancelledParkedRun = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: parkedRunId, projectId },
+    });
+    expect(cancelledParkedRun.status).toBe(InAppAgentRunStatus.CANCELLED);
+    expect(cancelledParkedRun.errorCode).toBe(
+      InAppAgentRunErrorCode.APPROVAL_CANCELLED,
+    );
+
+    // Cancel writes no decision event, so the card can only stop being
+    // actionable by deriving from the parked run's status.
+    const afterCancel = await caller.getConversation({
+      projectId,
+      conversationId: parkedConversation.id,
+    });
+    expect(afterCancel.pendingToolApprovals).toEqual([]);
+  });
+
+  it("stops surfacing an approval that a newer message superseded", async () => {
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+    await parkRunForApproval({
+      projectId,
+      conversationId: conversation.id,
+      userId,
+      toolCallId: "tool-call-3",
+    });
+
+    const beforeSupersede = await caller.getConversation({
+      projectId,
+      conversationId: conversation.id,
+    });
+    expect(beforeSupersede.pendingToolApprovals).toHaveLength(1);
+
+    await caller.startRun({
+      projectId,
+      conversationId: conversation.id,
+      message: "never mind",
+    });
+
+    // Supersede also writes no decision event; the interrupt event is still
+    // there, so only the parent's status can retire the card.
+    const afterSupersede = await caller.getConversation({
+      projectId,
+      conversationId: conversation.id,
+    });
+    expect(afterSupersede.pendingToolApprovals).toEqual([]);
+  });
+
+  it("reconciles dead runs on read with the right typed error code", async () => {
+    const { caller, projectId, userId } = await createCaller();
+
+    const cases = [
+      {
+        name: "worker_lost",
+        expected: InAppAgentRunErrorCode.WORKER_LOST,
+        data: {
+          status: InAppAgentRunStatus.RUNNING,
+          claimedAt: new Date(Date.now() - 120_000),
+          heartbeatAt: new Date(Date.now() - 90_000),
+        },
+      },
+      {
+        name: "run_timeout",
+        expected: InAppAgentRunErrorCode.RUN_TIMEOUT,
+        data: {
+          status: InAppAgentRunStatus.RUNNING,
+          claimedAt: new Date(Date.now() - 16 * 60_000),
+          // A hung tool keeps the heartbeat healthy; the duration backstop is
+          // what has to fire here.
+          heartbeatAt: new Date(),
+        },
+      },
+      {
+        name: "queue_timeout",
+        expected: InAppAgentRunErrorCode.QUEUE_TIMEOUT,
+        data: { status: InAppAgentRunStatus.QUEUED },
+        createdAt: new Date(Date.now() - 6 * 60_000),
+      },
+      {
+        name: "approval_expired",
+        expected: InAppAgentRunErrorCode.APPROVAL_EXPIRED,
+        data: {
+          status: InAppAgentRunStatus.AWAITING_APPROVAL,
+          finishedAt: new Date(Date.now() - 25 * 60 * 60_000),
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const conversation = await createConversation({ projectId, userId });
+      const runId = createInAppAgentRunId();
+
+      await prisma.inAppAgentRun.create({
+        data: {
+          id: runId,
+          projectId,
+          conversationId: conversation.id,
+          triggeredByUserId: userId,
+          request: { kind: "userMessage", context: [] },
+          ...testCase.data,
+        },
+      });
+
+      if (testCase.createdAt) {
+        await prisma.inAppAgentRun.update({
+          where: { id_projectId: { id: runId, projectId } },
+          data: { createdAt: testCase.createdAt },
+        });
+      }
+
+      const result = await caller.getConversation({
+        projectId,
+        conversationId: conversation.id,
+      });
+
+      expect(result.latestRun, testCase.name).toMatchObject({
+        id: runId,
+        status: InAppAgentRunStatus.FAILED,
+        errorCode: testCase.expected,
+      });
+    }
+  });
+
+  it("fails the committed run when the enqueue fails", async () => {
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+
+    enqueueShouldFail = true;
+
+    await expect(
+      caller.startRun({
+        projectId,
+        conversationId: conversation.id,
+        message: "will not reach a worker",
+      }),
+    ).rejects.toThrow();
+
+    const run = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { projectId, conversationId: conversation.id },
+    });
+
+    // Never leave a committed QUEUED run that nobody will execute.
+    expect(run.status).toBe(InAppAgentRunStatus.FAILED);
+    expect(run.errorCode).toBe(InAppAgentRunErrorCode.ENQUEUE_FAILED);
+    expect(run.finishedAt).not.toBeNull();
+  });
+
+  it("denies every background mutation to a non-owner", async () => {
+    const owner = await createCaller();
+    const conversation = await createConversation({
+      projectId: owner.projectId,
+      userId: owner.userId,
+    });
+    const { runId } = await owner.caller.startRun({
+      projectId: owner.projectId,
+      conversationId: conversation.id,
+      message: "mine",
+    });
+
+    const intruderId = `user-${randomUUID()}`;
+    await prisma.user.create({
+      data: { id: intruderId, email: `${intruderId}@example.com` },
+    });
+
+    const intruderSession: Session = {
+      expires: "1",
+      user: {
+        id: intruderId,
+        name: "Intruder",
+        canCreateOrganizations: true,
+        organizations: [
+          {
+            id: owner.orgId,
+            role: "OWNER",
+            plan: "cloud:hobby",
+            cloudConfig: undefined,
+            name: "Test Organization",
+            metadata: {},
+            aiFeaturesEnabled: true,
+            aiTelemetryEnabled: false,
+            projects: [
+              {
+                id: owner.projectId,
+                role: "ADMIN",
+                name: "Test Project",
+                deletedAt: null,
+                retentionDays: null,
+                hasTraces: false,
+                metadata: {},
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          },
+        ],
+        featureFlags: {} as Flags,
+        admin: false,
+      },
+      environment: {} as any,
+    };
+
+    const intruder = inAppAgentRouter.createCaller({
+      ...createInnerTRPCContext({ session: intruderSession, headers: {} }),
+      prisma,
+    });
+
+    // Project membership is not enough: conversations are owner-only in v1.
+    await expect(
+      intruder.startRun({
+        projectId: owner.projectId,
+        conversationId: conversation.id,
+        message: "not mine",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    await expect(
+      intruder.cancelRun({
+        projectId: owner.projectId,
+        conversationId: conversation.id,
+        runId,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    await expect(
+      intruder.decideToolApproval({
+        projectId: owner.projectId,
+        conversationId: conversation.id,
+        runId,
+        toolCallId: "tool-call-1",
+        approved: true,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
@@ -12,7 +12,11 @@ import { EventType } from "@ag-ui/core";
 import { randomUUID } from "crypto";
 import { vi } from "vitest";
 
-import { InAppAgentRunErrorCode, type Plan } from "@langfuse/shared";
+import {
+  InAppAgentRunErrorCode,
+  InAppAgentRunStatus,
+  type Plan,
+} from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import type { Prisma } from "@langfuse/shared/src/db";
 import {
@@ -2047,6 +2051,50 @@ describe("in-app agent persistence", () => {
     expect(newRun.finishedAt).toBeNull();
   });
 
+  it("leaves a claimed background run alone when a foreground run starts", async () => {
+    const { projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+    const backgroundRun = await createConversationRun({
+      projectId,
+      conversationId: conversation.id,
+      userId,
+    });
+
+    // A background run legitimately runs for up to RUN_MAX_DURATION, far past
+    // the 150s foreground staleness window. Execution mode is not sticky per
+    // conversation, so a foreground submit landing here is a normal state — and
+    // it must not fence a healthy worker, which stale-closing would (both
+    // finishRun and the event append guard on the run still being open).
+    await prisma.inAppAgentRun.update({
+      where: { id_projectId: { id: backgroundRun.id, projectId } },
+      data: {
+        createdAt: new Date("2026-05-20T10:00:00.000Z"),
+        claimedAt: new Date("2026-05-20T10:00:01.000Z"),
+        heartbeatAt: new Date(),
+      },
+    });
+
+    await expect(
+      createConversationRun({
+        projectId,
+        conversationId: conversation.id,
+        userId,
+      }),
+    ).rejects.toMatchObject({
+      message: "Assistant is already responding in this conversation",
+    });
+
+    await expect(
+      prisma.inAppAgentRun.findUniqueOrThrow({
+        where: { id_projectId: { id: backgroundRun.id, projectId } },
+      }),
+    ).resolves.toMatchObject({
+      status: "RUNNING",
+      finishedAt: null,
+      errorCode: null,
+    });
+  });
+
   it("writes run lifecycle status on the foreground path", async () => {
     const { projectId, userId } = await createCaller();
     const conversation = await createConversation({ projectId, userId });
@@ -2119,6 +2167,7 @@ describe("in-app agent persistence", () => {
           id: createInAppAgentRunId(),
           projectId,
           conversationId: conversation.id,
+          status: InAppAgentRunStatus.RUNNING,
         },
       }),
     ).rejects.toMatchObject({

--- a/web/src/app/api/in-app-agent/watch/route.ts
+++ b/web/src/app/api/in-app-agent/watch/route.ts
@@ -1,0 +1,9 @@
+import watchHandler from "@/src/features/in-app-agent/server/watchHandler";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+// The generator ends every stream at WATCH_MAX_CONNECTION (90s), well inside
+// this limit, so the client's reconnect is always the deliberate path.
+export const maxDuration = 120;
+
+export const GET = watchHandler;

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -6,7 +6,7 @@ import { InAppAgentWindow } from "./InAppAgentWindow";
 import type { InAppAgentWindowConversation } from "./InAppAgentWindow";
 import { useInAppAiAgent } from "./InAppAiAgentProvider";
 import { useSmoothStreamingMessages } from "./useSmoothStreamingMessages";
-import { getDrawerMessages } from "./utils/utils";
+import { getDrawerMessages, withInterruptedRunNotices } from "./utils/utils";
 import { getInAppAgentScreenContextDescription } from "@/src/features/in-app-agent/context";
 import {
   getInAppAgentFocusedQuickActions,
@@ -46,6 +46,10 @@ export function ControlledInAppAgentWindow(
     isLoadingMoreConversations,
     isRunning,
     isSelectedConversationHydrating,
+    backgroundRunNotice,
+    cancelRun,
+    isCancellingRun,
+    interruptedRuns,
     isSubmitting,
     invalidateConversations,
     loadMoreConversations,
@@ -69,7 +73,12 @@ export function ControlledInAppAgentWindow(
     messages,
     liveMessageVersion,
     pendingToolApprovals,
-    shouldFlush: error !== null,
+    // Stop pacing the reveal once the user has asked the run to stop. The
+    // background path delivers whole compacted blocks, so a backlog can easily
+    // outlive the run itself — and watching buffered text keep typing out after
+    // pressing stop reads as "cancel did nothing", even though the run is
+    // already CANCELLED server-side.
+    shouldFlush: error !== null || isCancellingRun,
   });
   const isInputDisabled =
     isRunning ||
@@ -98,17 +107,21 @@ export function ControlledInAppAgentWindow(
 
   const drawerMessages = useMemo(
     () =>
-      getDrawerMessages({
-        error,
-        isRunning: isRunning || isAnimating,
-        messages: displayedMessages,
-        pendingToolApprovals: displayedPendingToolApprovals,
-        runningToolCallIds,
-      }),
+      withInterruptedRunNotices(
+        getDrawerMessages({
+          error,
+          isRunning: isRunning || isAnimating,
+          messages: displayedMessages,
+          pendingToolApprovals: displayedPendingToolApprovals,
+          runningToolCallIds,
+        }),
+        interruptedRuns,
+      ),
     [
       displayedMessages,
       displayedPendingToolApprovals,
       error,
+      interruptedRuns,
       isAnimating,
       isRunning,
       runningToolCallIds,
@@ -148,6 +161,9 @@ export function ControlledInAppAgentWindow(
       }}
       onExpandedChange={props.onExpandedChange}
       onSubmit={submit}
+      backgroundRunNotice={backgroundRunNotice}
+      isCancellingRun={isCancellingRun}
+      onCancelRun={cancelRun}
       onApproveToolCall={approveToolCall}
       onRejectToolCall={rejectToolCall}
       onSubmitFeedback={submitFeedback}

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -61,6 +61,12 @@ type InAppAgentRedirectActionContent = {
 
 export type InAppAgentMessageContent =
   | { type: "loading"; label?: string }
+  /**
+   * A run boundary: this turn ended without finishing. Rendered inline rather
+   * than as a banner because it belongs to a specific point in the transcript —
+   * the partial work above it really happened, and the next turn continues below.
+   */
+  | { type: "runNotice"; text: string }
   | { type: "reasoning"; text: string; isStreaming: boolean }
   | {
       type: "text";
@@ -180,6 +186,23 @@ export function InAppAgentMessage({
     return <InAppAgentReasoningBlock content={content} isCompact={isCompact} />;
   }
 
+  if (content.type === "runNotice") {
+    return (
+      <div className="flex items-center gap-2 py-1" role="note">
+        <span className="bg-border h-px flex-1" />
+        <span
+          className={cn(
+            "text-foreground-tertiary shrink-0",
+            isCompact ? "text-xs" : "text-xs",
+          )}
+        >
+          {content.text}
+        </span>
+        <span className="bg-border h-px flex-1" />
+      </div>
+    );
+  }
+
   if (content.type === "text" && role === "assistant") {
     return (
       <AssistantMessageWithFeedback
@@ -200,7 +223,7 @@ const MessageCard = forwardRef<
     role: InAppAgentMessageRole;
     content: Exclude<
       InAppAgentMessageContent,
-      { type: "toolGroup" | "redirectAction" | "reasoning" }
+      { type: "toolGroup" | "redirectAction" | "reasoning" | "runNotice" }
     >;
     isCompact: boolean;
   }

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -17,6 +17,7 @@ import {
   Minus,
   Plus,
   SendHorizontal,
+  Square,
   Trash2,
 } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
@@ -274,6 +275,16 @@ export type InAppAgentWindowProps = {
   onRejectToolCall: (approvalId: string) => Promise<void>;
   onOpenConversationHistory: () => void;
   onSelectConversation: (conversationId: string) => void;
+  /**
+   * Lifecycle copy for a worker-executed run: that the user may close the
+   * drawer while it works, or why the last run ended badly. Null on the
+   * foreground path, where a run cannot outlive the tab.
+   */
+  backgroundRunNotice?: string | null;
+  /** Present only when a run can outlive the browser and so needs stopping. */
+  onCancelRun?: () => void;
+  /** A stop is already in flight; the run is winding down cooperatively. */
+  isCancellingRun?: boolean;
   onSubmit: (
     input: string,
     options?: InAppAgentSubmitOptions,
@@ -376,6 +387,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onOpenConversationHistory,
     onSelectConversation,
     onSubmit,
+    backgroundRunNotice,
+    onCancelRun,
+    isCancellingRun = false,
     onSubmitFeedback,
     focusedQuickActions,
     quickActionContext,
@@ -391,6 +405,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const isMobile = useIsMobile();
   const isRateLimited = isInAppAgentRateLimited(error);
   const isInputDisabled = baseIsInputDisabled || isRateLimited;
+  // Stopping only makes sense while something is actually executing, and only
+  // where a run outlives the tab — otherwise closing the drawer is the stop.
+  const canStopRun = Boolean(onCancelRun) && isAssistantTurnInProgress;
   const viewportRef = useRef<HTMLDivElement>(null);
   const isAutoScrollAttachedRef = useRef(true);
   const previousScrollTopRef = useRef(0);
@@ -854,6 +871,19 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   {screenContextNotice}
                 </span>
               </p>
+              {backgroundRunNotice && (
+                <p
+                  className={cn(
+                    "border-border bg-muted/60 text-foreground-secondary flex w-full items-center gap-1 rounded-lg border px-2 py-1",
+                    isExpanded ? "text-sm" : "text-xs",
+                  )}
+                >
+                  <Info aria-hidden="true" className="size-3 shrink-0" />
+                  <span className="min-w-0" title={backgroundRunNotice}>
+                    {backgroundRunNotice}
+                  </span>
+                </p>
+              )}
             </div>
           </div>
         </div>
@@ -946,32 +976,64 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   : "border-input max-h-40 min-h-8 px-3 py-1",
               )}
             />
-            {!isExpanded && (
-              <Button
-                type="submit"
-                size="icon"
-                className="h-8 w-8 rounded-md border"
-                aria-label="Send message"
-                variant="outline"
-                disabled={isInputDisabled || !input.trim()}
-              >
-                <SendHorizontal className="h-4 w-4" />
-              </Button>
-            )}
+            {!isExpanded &&
+              (canStopRun ? (
+                <Button
+                  type="button"
+                  size="icon"
+                  className="h-8 w-8 rounded-md border"
+                  aria-label={isCancellingRun ? "Stopping run" : "Stop run"}
+                  variant="outline"
+                  disabled={isCancellingRun}
+                  onClick={() => {
+                    onCancelRun?.();
+                  }}
+                >
+                  <Square className="h-3 w-3" />
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  size="icon"
+                  className="h-8 w-8 rounded-md border"
+                  aria-label="Send message"
+                  variant="outline"
+                  disabled={isInputDisabled || !input.trim()}
+                >
+                  <SendHorizontal className="h-4 w-4" />
+                </Button>
+              ))}
 
             {isExpanded && (
               <div className="flex w-full justify-end p-1">
-                <Button
-                  type="submit"
-                  className="h-8 w-fit rounded-md px-3"
-                  aria-label="Send message"
-                  disabled={isInputDisabled || !input.trim()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                >
-                  Send <SendHorizontal className="ml-2 h-4 w-4" />
-                </Button>
+                {canStopRun ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-8 w-fit rounded-md px-3"
+                    aria-label={isCancellingRun ? "Stopping run" : "Stop run"}
+                    disabled={isCancellingRun}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCancelRun?.();
+                    }}
+                  >
+                    {isCancellingRun ? "Stopping" : "Stop"}
+                    <Square className="ml-2 h-3 w-3" />
+                  </Button>
+                ) : (
+                  <Button
+                    type="submit"
+                    className="h-8 w-fit rounded-md px-3"
+                    aria-label="Send message"
+                    disabled={isInputDisabled || !input.trim()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                  >
+                    Send <SendHorizontal className="ml-2 h-4 w-4" />
+                  </Button>
+                )}
               </div>
             )}
           </form>

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -10,7 +10,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-import { EventType, HttpAgent } from "@ag-ui/client";
+import { EventType, HttpAgent, type AbstractAgent } from "@ag-ui/client";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { z } from "zod";
@@ -25,12 +25,21 @@ import {
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@langfuse/shared/in-app-agent";
 import {
   AgUiMessageSchema,
+  getInAppAgentRunFailureMessage,
+  isActiveInAppAgentRunStatus,
+  isCancellableInAppAgentRunStatus,
   type AgUiMessage,
   type InAppAgentMessageFeedback,
   type InAppAgentMessageFeedbackValue,
   type InAppAgentRuntimeState,
   type InAppAgentToolApprovalRequest,
 } from "@langfuse/shared/in-app-agent";
+import { InAppAgentRunStatus } from "@langfuse/shared";
+import {
+  InAppAgentBackgroundClient,
+  type InAppAgentRunStatusUpdate,
+} from "@/src/features/in-app-agent/lib/backgroundAgentClient";
+import { useInAppAgentBackgroundExecutionEnabled } from "@/src/features/in-app-agent/lib/backgroundExecutionFlag";
 import type { InAppAgentError } from "@/src/features/in-app-agent/components/utils/utils";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
@@ -52,6 +61,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import {
   getInAppAgentError,
   isInAppAgentRateLimited,
+  type InAppAgentInterruptedRun,
   type InAppAiAgentMessage,
 } from "@/src/features/in-app-agent/components/utils/utils";
 import { evaluateSetStateAction } from "@/src/utils/evaluate-set-state-action";
@@ -98,6 +108,10 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   isSubmitting: false,
   pendingToolApprovals: [],
   isSelectedConversationHydrating: false,
+  backgroundExecutionEnabled: false,
+  backgroundRunNotice: null,
+  isCancellingRun: false,
+  interruptedRuns: [],
   error: null,
   messages: [],
   liveMessageVersion: 0,
@@ -152,6 +166,12 @@ export type InAppAgentPendingToolApproval = {
   id: string;
   approvalRequest: InAppAgentToolApprovalRequest;
   status: "pending" | "submitting";
+  /**
+   * The parked run this approval belongs to, as recorded on the persisted
+   * interrupt event. Present for approvals hydrated from history (background
+   * execution); the live stream carries it inside `approvalRequest` instead.
+   */
+  runId?: string;
 };
 
 export type InAppAiAgentConversation = {
@@ -175,6 +195,23 @@ type InAppAiAgentContextType = {
   isSubmitting: boolean;
   pendingToolApprovals: InAppAgentPendingToolApproval[];
   isSelectedConversationHydrating: boolean;
+  /** True when this browser is opted into worker-executed runs. */
+  backgroundExecutionEnabled: boolean;
+  /**
+   * Copy about the current background run's lifecycle: that the user may
+   * close the drawer while it works, or why the last one ended badly.
+   */
+  backgroundRunNotice: string | null;
+  /** A stop has been requested and the run has not wound down yet. */
+  isCancellingRun: boolean;
+  /**
+   * Turns that ended without finishing, so the transcript can mark the
+   * boundary. Their partial events are kept, not hidden: the tool calls really
+   * ran, and the event stream is the only record of them.
+   */
+  interruptedRuns: InAppAgentInterruptedRun[];
+  /** Present only on the background path, where a run outlives the browser. */
+  cancelRun?: () => void;
   error: InAppAgentError | null;
   messages: InAppAiAgentMessage[];
   liveMessageVersion: number;
@@ -301,12 +338,21 @@ function InAppAiAgentProviderInner({
     () => new Set(),
   );
   const [error, setError] = useState<InAppAgentError | null>(null);
-  const agentRef = useRef<HttpAgent | null>(null);
+  const agentRef = useRef<AbstractAgent | null>(null);
   const activeRunIdRef = useRef<string | null>(null);
+  const backgroundExecutionEnabled = useInAppAgentBackgroundExecutionEnabled();
+  const [backgroundRunStatus, setBackgroundRunStatus] =
+    useState<InAppAgentRunStatusUpdate | null>(null);
+  // Read once, when a background transport is constructed; never rendered, so
+  // mirroring it into state would re-render the drawer for nothing.
+  const conversationCursorRef = useRef(-1);
+  // Attaching is async (it fetches the persisted snapshot first), so the guard
+  // has to be set synchronously or a re-render can start a second attach.
+  const attachInFlightRef = useRef(false);
   const intentionalAbortRef = useRef(false);
   const submitInFlightRef = useRef(false);
   const runInFlightRef = useRef(false);
-  const subscriptionRef = useRef<ReturnType<HttpAgent["subscribe"]> | null>(
+  const subscriptionRef = useRef<ReturnType<AbstractAgent["subscribe"]> | null>(
     null,
   );
 
@@ -330,6 +376,10 @@ function InAppAiAgentProviderInner({
   const deleteConversationMutation =
     api.inAppAgent.deleteConversation.useMutation();
   const feedbackMutation = api.inAppAgent.submitFeedback.useMutation();
+  const startRunMutation = api.inAppAgent.startRun.useMutation();
+  const cancelRunMutation = api.inAppAgent.cancelRun.useMutation();
+  const decideToolApprovalMutation =
+    api.inAppAgent.decideToolApproval.useMutation();
   const isSelectedConversationNotFound =
     conversationQuery.error?.data?.code === "NOT_FOUND";
   const selectedConversationId = isSelectedConversationNotFound
@@ -346,6 +396,67 @@ function InAppAiAgentProviderInner({
   const isLoadingMoreConversations = conversationListQuery.isFetchingNextPage;
   const selectedConversationIsWriteLocked =
     conversationQuery.data?.conversation.isWriteLocked ?? false;
+
+  // Written during render on purpose: neither value is rendered, both are read
+  // when a background transport is constructed. Mirroring them into state
+  // would re-render the drawer on every hydration for no visible reason.
+  if (conversationQuery.data?.conversation.id === selectedConversationId) {
+    conversationCursorRef.current = conversationQuery.data.eventCursor;
+  }
+
+  const persistedToolApprovals = useMemo(
+    () =>
+      conversationQuery.data?.conversation.id === selectedConversationId
+        ? conversationQuery.data.pendingToolApprovals
+        : [],
+    [
+      conversationQuery.data?.conversation.id,
+      conversationQuery.data?.pendingToolApprovals,
+      selectedConversationId,
+    ],
+  );
+
+  /**
+   * Approval cards visible to the drawer.
+   *
+   * The foreground path only ever learns about an approval from the live
+   * stream, so a refresh loses the card. Background execution persists the
+   * interrupt event, so history is the source of truth — but a card that has
+   * just arrived over the tail is not in the last hydration yet, and one the
+   * user is currently deciding carries local "submitting" state. Union both,
+   * letting local status win.
+   */
+  const effectivePendingToolApprovals = useMemo(() => {
+    if (!backgroundExecutionEnabled) {
+      return pendingToolApprovals;
+    }
+
+    const localById = new Map(
+      pendingToolApprovals.map((approval) => [approval.id, approval]),
+    );
+
+    const hydrated = persistedToolApprovals.map(
+      ({ runId, approvalRequest }): InAppAgentPendingToolApproval => ({
+        id: approvalRequest.toolCallId,
+        approvalRequest,
+        status: localById.get(approvalRequest.toolCallId)?.status ?? "pending",
+        runId,
+      }),
+    );
+
+    const hydratedIds = new Set(hydrated.map((approval) => approval.id));
+
+    return [
+      ...hydrated,
+      ...pendingToolApprovals.filter(
+        (approval) => !hydratedIds.has(approval.id),
+      ),
+    ];
+  }, [
+    backgroundExecutionEnabled,
+    pendingToolApprovals,
+    persistedToolApprovals,
+  ]);
   const currentMessages = useMemo(() => {
     if (isSelectedConversationNotFound) {
       return EMPTY_MESSAGES;
@@ -516,6 +627,7 @@ function InAppAiAgentProviderInner({
     agentRef.current?.abortRun();
     agentRef.current = null;
     activeRunIdRef.current = null;
+    setBackgroundRunStatus(null);
     setDisplayState(createInAppAgentDisplayState());
     pendingToolApprovalsRef.current = [];
     setPendingToolApprovals([]);
@@ -557,7 +669,7 @@ function InAppAiAgentProviderInner({
   }, [rateLimitRetryAt]);
 
   const ensureSubscription = useCallback(
-    (agent: HttpAgent) => {
+    (agent: AbstractAgent) => {
       if (subscriptionRef.current) {
         return;
       }
@@ -701,22 +813,46 @@ function InAppAiAgentProviderInner({
 
       resetAgent();
 
-      const agent = new HttpAgent({
-        url: getInAppAgentUrl(),
-        threadId: conversationId,
-        initialMessages,
-        initialState: getConversationAgentState(
-          projectId,
-          conversationId,
-          isNewConversation,
-        ),
-      });
+      const initialState = getConversationAgentState(
+        projectId,
+        conversationId,
+        isNewConversation,
+      );
+
+      const agent = backgroundExecutionEnabled
+        ? new InAppAgentBackgroundClient({
+            projectId,
+            conversationId,
+            threadId: conversationId,
+            initialMessages,
+            initialState,
+            // The hydration snapshot's high-water mark. Attaching the tail
+            // above it is gap-free and duplicate-free by construction.
+            cursor: conversationCursorRef.current,
+            startRun: (params) =>
+              startRunMutation.mutateAsync({
+                projectId,
+                conversationId,
+                message: params.message,
+                context: [...params.context],
+              }),
+            onStatus: (status) => {
+              activeRunIdRef.current = status.runId;
+              setBackgroundRunStatus(status);
+            },
+          })
+        : new HttpAgent({
+            url: getInAppAgentUrl(),
+            threadId: conversationId,
+            initialMessages,
+            initialState,
+          });
 
       agentRef.current = agent;
 
       return agent;
     },
-    [projectId, resetAgent],
+    [backgroundExecutionEnabled, projectId, resetAgent, startRunMutation],
   );
 
   const releaseSubmitLock = useCallback(() => {
@@ -726,9 +862,9 @@ function InAppAiAgentProviderInner({
 
   const runAgent = useCallback(
     (
-      agent: HttpAgent,
+      agent: AbstractAgent,
       conversationId: string,
-      runParameters?: Parameters<HttpAgent["runAgent"]>[0],
+      runParameters?: Parameters<AbstractAgent["runAgent"]>[0],
       quickActionAttribution?: InAppAgentQuickActionAttribution,
       messageEntryPoint?: InAppAgentMessageEntryPoint,
     ) => {
@@ -928,9 +1064,14 @@ function InAppAiAgentProviderInner({
           conversationQuery.data?.conversation.id === conversationId
             ? conversationQuery.data.messages
             : undefined;
-        const initialMessages = !isNewConversation
-          ? getHydratedMessages(messages, storedMessages)
-          : [];
+        const initialMessages = isNewConversation
+          ? []
+          : backgroundExecutionEnabled
+            ? // Persisted state is the render source on the background path, so
+              // prefer it over the in-memory transcript.
+              (storedMessages?.filter(isAgentConversationMessage) ??
+              getHydratedMessages(messages, storedMessages))
+            : getHydratedMessages(messages, storedMessages);
         // TODO: Avoid hydrating the full history once the agent client can send
         // only the latest user turn; the server rebuilds history from persistence.
         const agent = getOrCreateAgent(
@@ -941,6 +1082,18 @@ function InAppAiAgentProviderInner({
 
         if (agent.isRunning) {
           return false;
+        }
+
+        // Submitting is an attach boundary too: a reused transport still holds
+        // AG-UI's in-memory transcript from the previous turn, while the
+        // smoother's baseline came from the server's projection after that
+        // turn's refetch. Re-seed both from persistence so the new turn is the
+        // only thing that animates. Foreground keeps its existing behaviour,
+        // where the transport is the sole source for a turn.
+        if (agent instanceof InAppAgentBackgroundClient && !isNewConversation) {
+          agent.setMessages(initialMessages);
+          agent.setCursor(conversationCursorRef.current);
+          setMessages(initialMessages);
         }
 
         ensureSubscription(agent);
@@ -978,6 +1131,7 @@ function InAppAiAgentProviderInner({
       }
     },
     [
+      backgroundExecutionEnabled,
       conversationQuery.data,
       capture,
       ensureSubscription,
@@ -1050,6 +1204,134 @@ function InAppAiAgentProviderInner({
     ],
   );
 
+  /**
+   * Background path only. Re-seed the transport from persisted state, then tail
+   * onward from that snapshot's cursor.
+   *
+   * The invariant this enforces: **the in-memory AG-UI transcript never crosses
+   * an attach boundary.** Whenever the user (re)opens the drawer, reselects a
+   * conversation, or decides an approval, what they see is what is in Postgres,
+   * and the stream continues from exactly there.
+   *
+   * Why it has to be re-seeded rather than resumed: the smoother decides what
+   * to animate by diffing the incoming message list against the one it last
+   * held, per message id. After a turn ends, that held list came from the
+   * server's display projection (the `getConversation` refetch), while a
+   * carried-over agent's list is AG-UI's in-memory reduction. The two disagree,
+   * so republishing the in-memory one reads as "the model just produced all of
+   * this" and re-reveals the whole transcript from the first divergence. Seeding
+   * both sides from the same persisted array makes that diff empty.
+   */
+  const attachToConversation = useCallback(
+    async (conversationId: string) => {
+      if (!backgroundExecutionEnabled || attachInFlightRef.current) {
+        return;
+      }
+
+      attachInFlightRef.current = true;
+
+      try {
+        // Authoritative read rather than whatever the query cache holds: the
+        // cursor and the transcript must come from one snapshot, or the tail
+        // can replay events the transcript already contains.
+        const snapshot = await utils.inAppAgent.getConversation.fetch({
+          projectId,
+          conversationId,
+        });
+
+        if (
+          !snapshot.latestRun ||
+          !isActiveInAppAgentRunStatus(snapshot.latestRun.status) ||
+          runInFlightRef.current
+        ) {
+          return;
+        }
+
+        const persistedMessages = snapshot.messages.filter(
+          isAgentConversationMessage,
+        );
+        const agent = getOrCreateAgent(
+          conversationId,
+          persistedMessages,
+          false,
+        );
+
+        if (!(agent instanceof InAppAgentBackgroundClient)) {
+          return;
+        }
+
+        agent.setMessages(persistedMessages);
+        agent.setCursor(snapshot.eventCursor);
+        // Deliberately not publishLiveMessages: hydration must not bump
+        // liveMessageVersion, or the smoother animates history.
+        setMessages(persistedMessages);
+
+        ensureSubscription(agent);
+        runInFlightRef.current = true;
+        setIsRunning(true);
+
+        agent
+          .connectAgent()
+          .finally(() => {
+            clearLoadingEvents();
+            setIsRunning(false);
+            runInFlightRef.current = false;
+            utils.inAppAgent.getConversation.invalidate({
+              projectId,
+              conversationId,
+            });
+            utils.inAppAgent.listConversations.invalidate({ projectId });
+          })
+          .catch((error: unknown) => {
+            setError(getInAppAgentError(error));
+            console.error(
+              "Failed to attach to background assistant run",
+              error,
+            );
+          });
+      } finally {
+        attachInFlightRef.current = false;
+      }
+    },
+    [
+      backgroundExecutionEnabled,
+      clearLoadingEvents,
+      ensureSubscription,
+      getOrCreateAgent,
+      projectId,
+      utils.inAppAgent.getConversation,
+      utils.inAppAgent.listConversations,
+    ],
+  );
+
+  const hydratedActiveRunId =
+    backgroundExecutionEnabled &&
+    conversationQuery.data?.conversation.id === selectedConversationId &&
+    conversationQuery.data.latestRun &&
+    isActiveInAppAgentRunStatus(conversationQuery.data.latestRun.status)
+      ? conversationQuery.data.latestRun.id
+      : null;
+
+  /**
+   * External system: the watch SSE connection to a run executing on a worker.
+   * Setup attaches the stream; the teardown effect below detaches it.
+   *
+   * An effect rather than an event handler because there is genuinely no
+   * initiating gesture — after a refresh the drawer restores itself from
+   * session storage and the conversation query resolves on its own, so "a run
+   * is executing and nobody is watching it" is a state we discover.
+   */
+  useEffect(() => {
+    if (!hydratedActiveRunId || !selectedConversationId) {
+      return;
+    }
+
+    attachToConversation(selectedConversationId).catch((error: unknown) => {
+      setError(getInAppAgentError(error));
+      console.error("Failed to attach to background assistant run", error);
+    });
+  }, [attachToConversation, hydratedActiveRunId, selectedConversationId]);
+
   const setAgentOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
     (action) => {
       const nextOpen = evaluateSetStateAction(action, open);
@@ -1057,11 +1339,32 @@ function InAppAiAgentProviderInner({
       if (!nextOpen) {
         // Collapse the drawer when closing
         setIsExpanded(false);
+
+        // A hidden drawer should not hold a watch connection open. Detaching is
+        // not cancelling: the run keeps executing on the worker.
+        if (backgroundExecutionEnabled) {
+          agentRef.current?.abortRun();
+        }
+      }
+
+      if (nextOpen && backgroundExecutionEnabled && selectedConversationId) {
+        // Reopening is an attach boundary: show what is persisted now, then
+        // stream onward from there.
+        attachToConversation(selectedConversationId).catch((error: unknown) => {
+          setError(getInAppAgentError(error));
+          console.error("Failed to attach to background assistant run", error);
+        });
       }
 
       setOpen(nextOpen);
     },
-    [open, setOpen],
+    [
+      attachToConversation,
+      backgroundExecutionEnabled,
+      open,
+      selectedConversationId,
+      setOpen,
+    ],
   );
 
   const openAssistant = useCallback(
@@ -1079,6 +1382,158 @@ function InAppAiAgentProviderInner({
     [capture, organization, setAgentOpen],
   );
 
+  /**
+   * Freshest view of the conversation's current run: the tail's status frame
+   * while attached, the hydration snapshot otherwise. One source for the
+   * notice, the stop control, and the cancel mutation, so they cannot disagree.
+   */
+  const currentBackgroundRun = useMemo(() => {
+    if (!backgroundExecutionEnabled) {
+      return null;
+    }
+
+    if (backgroundRunStatus) {
+      return {
+        id: backgroundRunStatus.runId,
+        status: backgroundRunStatus.status,
+        errorCode: backgroundRunStatus.errorCode ?? null,
+        cancelRequested: backgroundRunStatus.cancelRequested === true,
+      };
+    }
+
+    const hydrated = conversationQuery.data?.latestRun;
+
+    return hydrated
+      ? {
+          id: hydrated.id,
+          status: hydrated.status,
+          errorCode: hydrated.errorCode,
+          cancelRequested: hydrated.cancelRequested,
+        }
+      : null;
+  }, [
+    backgroundExecutionEnabled,
+    backgroundRunStatus,
+    conversationQuery.data?.latestRun,
+  ]);
+
+  const interruptedRuns = useMemo(
+    () =>
+      backgroundExecutionEnabled &&
+      conversationQuery.data?.conversation.id === selectedConversationId
+        ? conversationQuery.data.interruptedRuns
+        : [],
+    [
+      backgroundExecutionEnabled,
+      conversationQuery.data?.conversation.id,
+      conversationQuery.data?.interruptedRuns,
+      selectedConversationId,
+    ],
+  );
+
+  const isCancellingRun = Boolean(
+    currentBackgroundRun &&
+    isActiveInAppAgentRunStatus(currentBackgroundRun.status) &&
+    currentBackgroundRun.cancelRequested,
+  );
+
+  /**
+   * Background runs outlive the browser, so the drawer has to say so — and has
+   * to explain a failure the user did not witness.
+   */
+
+  /**
+   * Cancel the run itself, server-side. Aborting the local stream would only
+   * stop watching — the worker would keep going, which is the whole feature.
+   */
+  const cancelRun = useCallback(() => {
+    const run = currentBackgroundRun;
+
+    if (
+      !selectedConversationId ||
+      !run ||
+      !isCancellableInAppAgentRunStatus(run.status) ||
+      run.cancelRequested
+    ) {
+      return;
+    }
+
+    intentionalAbortRef.current = true;
+    cancelRunMutation
+      .mutateAsync({
+        projectId,
+        conversationId: selectedConversationId,
+        runId: run.id,
+      })
+      .catch((error: unknown) => {
+        intentionalAbortRef.current = false;
+        showErrorToast("Failed to stop the run", getAgentErrorMessage(error));
+      });
+  }, [
+    cancelRunMutation,
+    currentBackgroundRun,
+    projectId,
+    selectedConversationId,
+  ]);
+
+  const decideBackgroundToolApproval = useCallback(
+    async (params: {
+      approval: InAppAgentPendingToolApproval;
+      approved: boolean;
+      conversationId: string;
+    }) => {
+      const runId =
+        params.approval.runId ?? params.approval.approvalRequest.runId;
+
+      updatePendingToolApprovals((currentApprovals) =>
+        currentApprovals.map((currentApproval) =>
+          currentApproval.id === params.approval.id
+            ? { ...currentApproval, status: "submitting" }
+            : currentApproval,
+        ),
+      );
+      setError(null);
+
+      try {
+        await decideToolApprovalMutation.mutateAsync({
+          projectId,
+          conversationId: params.conversationId,
+          runId,
+          toolCallId: params.approval.approvalRequest.toolCallId,
+          approved: params.approved,
+        });
+
+        updatePendingToolApprovals((currentApprovals) =>
+          currentApprovals.filter(
+            (currentApproval) => currentApproval.id !== params.approval.id,
+          ),
+        );
+
+        // The decision queued a continuation run. Go through the same attach
+        // path as reopening the drawer: re-seed from persisted state, then tail
+        // onward. Resuming the in-memory transcript here is what made the whole
+        // conversation appear to re-stream.
+        await attachToConversation(params.conversationId);
+      } catch (error) {
+        updatePendingToolApprovals((currentApprovals) =>
+          currentApprovals.map((currentApproval) =>
+            currentApproval.id === params.approval.id
+              ? { ...currentApproval, status: "pending" }
+              : currentApproval,
+          ),
+        );
+        setError(getInAppAgentError(error));
+        console.error("Failed to decide in-app agent tool approval", error);
+      }
+    },
+    [
+      attachToConversation,
+      decideToolApprovalMutation,
+      projectId,
+      updatePendingToolApprovals,
+    ],
+  );
+
   const resumeToolApproval = useCallback(
     async (approvalId: string, approved: boolean) => {
       if (selectedConversationIsWriteLocked) {
@@ -1089,7 +1544,7 @@ function InAppAiAgentProviderInner({
         return;
       }
 
-      const approval = pendingToolApprovals.find(
+      const approval = effectivePendingToolApprovals.find(
         (approval) => approval.id === approvalId,
       );
 
@@ -1100,6 +1555,15 @@ function InAppAiAgentProviderInner({
         runInFlightRef.current ||
         isInAppAgentRateLimited(error)
       ) {
+        return;
+      }
+
+      if (backgroundExecutionEnabled) {
+        await decideBackgroundToolApproval({
+          approval,
+          approved,
+          conversationId: selectedConversationId,
+        });
         return;
       }
 
@@ -1179,16 +1643,47 @@ function InAppAiAgentProviderInner({
       }
     },
     [
+      backgroundExecutionEnabled,
+      decideBackgroundToolApproval,
+      effectivePendingToolApprovals,
       ensureSubscription,
       error,
       isRunning,
-      pendingToolApprovals,
       runAgent,
       selectedConversationId,
       selectedConversationIsWriteLocked,
       updatePendingToolApprovals,
     ],
   );
+
+  const backgroundRunNotice = useMemo(() => {
+    const run = currentBackgroundRun;
+
+    if (!run) {
+      return null;
+    }
+
+    if (isActiveInAppAgentRunStatus(run.status) && run.cancelRequested) {
+      // Cancelling a RUNNING run is cooperative: the worker sees the flag on its
+      // next heartbeat and stops at the following step boundary. Saying so is
+      // what makes those seconds read as progress rather than a dead UI.
+      return "Stopping the run…";
+    }
+
+    if (run.status === InAppAgentRunStatus.QUEUED) {
+      return "Waiting for a worker to pick this up. You can close this; the run continues in the background.";
+    }
+
+    if (run.status === InAppAgentRunStatus.RUNNING) {
+      return "You can close this; the run continues in the background.";
+    }
+
+    if (run.status === InAppAgentRunStatus.FAILED) {
+      return getInAppAgentRunFailureMessage(run.errorCode ?? null);
+    }
+
+    return null;
+  }, [currentBackgroundRun]);
 
   const approveToolCall = useCallback(
     (approvalId: string) => resumeToolApproval(approvalId, true),
@@ -1212,8 +1707,13 @@ function InAppAiAgentProviderInner({
       isSubmitting,
       pendingToolApprovals: isSelectedConversationNotFound
         ? []
-        : pendingToolApprovals,
+        : effectivePendingToolApprovals,
       isSelectedConversationHydrating,
+      backgroundExecutionEnabled,
+      backgroundRunNotice,
+      isCancellingRun,
+      interruptedRuns,
+      cancelRun: backgroundExecutionEnabled ? cancelRun : undefined,
       error,
       messages: messagesWithUiState,
       liveMessageVersion,
@@ -1249,7 +1749,12 @@ function InAppAiAgentProviderInner({
       messagesWithUiState,
       open,
       openAssistant,
-      pendingToolApprovals,
+      backgroundExecutionEnabled,
+      backgroundRunNotice,
+      cancelRun,
+      isCancellingRun,
+      interruptedRuns,
+      effectivePendingToolApprovals,
       rejectToolCall,
       setAgentOpen,
       invalidateConversations,

--- a/web/src/features/in-app-agent/components/useSmoothStreamingMessages.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/useSmoothStreamingMessages.clienttest.tsx
@@ -276,39 +276,21 @@ describe("useSmoothStreamingMessages", () => {
     expect(screen.getByTestId("animating")).toHaveTextContent("false");
   });
 
-  it("matches the observed generation rate for the next text chunk", () => {
-    const { rerender } = render(
-      <TestConsumer liveMessageVersion={0} messages={[userMessage]} />,
-    );
-    const emptyAssistantMessage = assistantMessage("");
-
-    rerender(
-      <TestConsumer
-        liveMessageVersion={1}
-        messages={[userMessage, emptyAssistantMessage]}
-      />,
-    );
-    act(() => {
-      vi.advanceTimersByTime(2_000);
-    });
-
-    const generatedContent = "x".repeat(200);
-    rerender(
-      <TestConsumer
-        liveMessageVersion={2}
-        messages={[userMessage, assistantMessage(generatedContent)]}
-      />,
-    );
-    advanceAnimationFrames(25);
-
-    const displayedLength =
-      screen.getByTestId("content-assistant").textContent?.length ?? 0;
-    expect(displayedLength).toBeGreaterThanOrEqual(75);
-    expect(displayedLength).toBeLessThanOrEqual(85);
-    runAllAnimationFrames();
-  });
-
-  it("keeps pacing headroom when the next chunk arrives late", () => {
+  /**
+   * Replaces three earlier cases that pinned the EMA-only ceiling (observed
+   * rate, late-chunk headroom, single-fast-chunk clamp). Those bounds were
+   * derived from a *generation* rate, which is meaningless once text arrives in
+   * whole compacted blocks: the backlog-aware floor dominates there, so
+   * re-asserting the old ceilings would only restate the implementation.
+   *
+   * What is worth protecting is the user-visible regression the floor fixes. A
+   * ~800-grapheme block at the 40 graphemes/second default crawled for ~20s,
+   * which is what the background path publishes on every flush. The floor
+   * recomputes from the remaining backlog each frame, so it eases out rather
+   * than finishing on a hard deadline — hence a generous bound here. It is
+   * still an order of magnitude away from the old behavior, which is the point.
+   */
+  it("reveals a whole compacted block progressively, not at the default crawl", () => {
     const { rerender } = render(
       <TestConsumer liveMessageVersion={0} messages={[userMessage]} />,
     );
@@ -323,65 +305,37 @@ describe("useSmoothStreamingMessages", () => {
       vi.advanceTimersByTime(2_000);
     });
 
-    const generatedContent = "x".repeat(200);
+    const generatedContent = "x".repeat(800);
     rerender(
       <TestConsumer
         liveMessageVersion={2}
         messages={[userMessage, assistantMessage(generatedContent)]}
       />,
     );
-    advanceAnimationFrames(50);
 
-    const displayedLength =
+    advanceAnimationFrames(1);
+    const afterFirstFrame =
       screen.getByTestId("content-assistant").textContent?.length ?? 0;
-    expect(displayedLength).toBeGreaterThanOrEqual(155);
-    expect(displayedLength).toBeLessThanOrEqual(165);
-    expect(screen.getByTestId("animating")).toHaveTextContent("true");
-    runAllAnimationFrames();
-  });
+    // Smoothed, not dumped.
+    expect(afterFirstFrame).toBeGreaterThan(0);
+    expect(afterFirstFrame).toBeLessThan(generatedContent.length);
 
-  it("limits acceleration from one unusually fast chunk", () => {
-    const { rerender } = render(
-      <TestConsumer liveMessageVersion={0} messages={[userMessage]} />,
-    );
+    let frames = 1;
+    const maxFrames = Math.ceil(5_000 / 40);
+    while (
+      frames < maxFrames &&
+      (screen.getByTestId("content-assistant").textContent?.length ?? 0) <
+        generatedContent.length
+    ) {
+      advanceAnimationFrames(1);
+      frames += 1;
+    }
 
-    rerender(
-      <TestConsumer
-        liveMessageVersion={1}
-        messages={[userMessage, assistantMessage("")]}
-      />,
+    expect(screen.getByTestId("content-assistant")).toHaveTextContent(
+      generatedContent,
     );
-    act(() => {
-      vi.advanceTimersByTime(2_000);
-    });
-    rerender(
-      <TestConsumer
-        liveMessageVersion={2}
-        messages={[userMessage, assistantMessage("x".repeat(100))]}
-      />,
-    );
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-
-    rerender(
-      <TestConsumer
-        liveMessageVersion={3}
-        messages={[userMessage, assistantMessage("x".repeat(200))]}
-      />,
-    );
-    const displayedBeforeFastChunk =
-      screen.getByTestId("content-assistant").textContent?.length ?? 0;
-    advanceAnimationFrames(25);
-
-    const displayedAfterOneSecond =
-      screen.getByTestId("content-assistant").textContent?.length ?? 0;
-    expect(
-      displayedAfterOneSecond - displayedBeforeFastChunk,
-    ).toBeGreaterThanOrEqual(45);
-    expect(
-      displayedAfterOneSecond - displayedBeforeFastChunk,
-    ).toBeLessThanOrEqual(51);
+    // 800 graphemes at the 40/s default would have needed ~500 frames (~20s).
+    expect(frames).toBeLessThan(maxFrames);
     runAllAnimationFrames();
   });
 
@@ -683,6 +637,36 @@ describe("useSmoothStreamingMessages", () => {
     expect(screen.getByTestId("approval-ids")).toHaveTextContent(
       "approval-1,approval-2",
     );
+  });
+
+  it("shows an approval restored from history without pacing the restored tools", () => {
+    // A pending approval survives a refresh, so hydration delivers it with no
+    // live publication. Pacing that schedules an appearance transition for every
+    // tool call in the restored history at 2/second, and the approval card sorts
+    // last — so it waited behind the whole backlog while `isAnimating` kept the
+    // drawer looking like the run was still executing.
+    const { rerender } = render(
+      <TestConsumer liveMessageVersion={0} messages={[userMessage]} />,
+    );
+
+    rerender(
+      <TestConsumer
+        liveMessageVersion={0}
+        messages={[
+          userMessage,
+          assistantToolMessage(["tool-1", "tool-2", "tool-3"], true),
+        ]}
+        pendingToolApprovals={[pendingToolApproval("approval-1", "pending")]}
+      />,
+    );
+
+    // Hydration is applied whole: the restored tools and the approval are all
+    // visible on the first render, with nothing left animating.
+    expect(screen.getByTestId("tool-call-ids")).toHaveTextContent(
+      "tool-1,tool-2,tool-3",
+    );
+    expect(screen.getByTestId("approval-ids")).toHaveTextContent("approval-1");
+    expect(screen.getByTestId("animating")).toHaveTextContent("false");
   });
 
   it("does not animate for reduced-motion users", () => {

--- a/web/src/features/in-app-agent/components/useSmoothStreamingMessages.ts
+++ b/web/src/features/in-app-agent/components/useSmoothStreamingMessages.ts
@@ -13,6 +13,7 @@ const PACING_EMA_WEIGHT = 0.35;
 const PACING_TARGET_UTILIZATION = 0.8;
 const MAX_PACING_INCREASE_FACTOR = 1.2;
 const MIN_SMOOTHED_GRAPHEMES = 16;
+const CATCH_UP_TARGET_MS = 1_500;
 const TOOL_TRANSITION_INTERVAL_MS = 500;
 const MIN_TOOL_RUNNING_DURATION_MS = 750;
 
@@ -248,10 +249,18 @@ function enqueueStreamingUpdate(
     publishedTexts,
     action.canAnimate,
   );
-  const approvalsChanged = !areToolApprovalsEqual(
-    state.targetToolApprovals,
-    action.pendingToolApprovals,
-  );
+  // Only a *live* approval change is worth pacing. Hydration delivers approvals
+  // too — a pending approval survives a refresh by design — and pacing those
+  // schedules an "appearance" transition for every tool call in the restored
+  // history at 2/second. The approval card sorts last, so it waits behind the
+  // entire backlog while `isAnimating` keeps the drawer looking busy: the run
+  // reads as still executing and the card never arrives.
+  const approvalsChanged =
+    isLivePublication &&
+    !areToolApprovalsEqual(
+      state.targetToolApprovals,
+      action.pendingToolApprovals,
+    );
 
   if (
     !action.canAnimate ||
@@ -326,11 +335,23 @@ function advanceStreamingFrame(state: SmoothStreamingState) {
   const remainingGraphemes = splitGraphemes(
     pendingText.targetText.slice(pendingText.displayedText.length),
   );
+  const pacedRate =
+    state.textPacingByMessageId[pendingText.targetMessage.id]
+      ?.graphemesPerSecond ?? DEFAULT_GRAPHEMES_PER_SECOND;
+  // Backlog-aware catch-up floor. The EMA estimates a *generation* rate from
+  // observed appends, which is meaningless when text arrives in whole
+  // compacted blocks: a single ~800-grapheme publication would crawl for ~20s
+  // at the default rate. Guaranteeing the backlog drains within
+  // CATCH_UP_TARGET_MS keeps the reveal smooth without pretending to pace
+  // something that already finished. It eases out naturally as the backlog
+  // shrinks, and it never fires on token-level streams, where the backlog is
+  // a few graphemes at a time.
+  const rate = Math.max(
+    pacedRate,
+    remainingGraphemes.length / (CATCH_UP_TARGET_MS / 1_000),
+  );
   const graphemeBudget =
-    state.animation.graphemeBudget +
-    (state.textPacingByMessageId[pendingText.targetMessage.id]
-      ?.graphemesPerSecond ?? DEFAULT_GRAPHEMES_PER_SECOND) *
-      (FRAME_DURATION_MS / 1_000);
+    state.animation.graphemeBudget + rate * (FRAME_DURATION_MS / 1_000);
   const graphemesThisFrame = Math.floor(graphemeBudget);
   const nextText =
     pendingText.displayedText +

--- a/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -4,8 +4,10 @@ import {
   getDrawerMessages,
   getInAppAgentError,
   isInAppAgentRateLimited,
+  withInterruptedRunNotices,
   type InAppAiAgentMessage,
 } from "./utils";
+import type { InAppAgentWindowMessage } from "../InAppAgentWindow";
 
 describe("getInAppAgentError", () => {
   const now = new Date("2026-07-08T20:00:54.997Z").getTime();
@@ -1114,5 +1116,98 @@ describe("getDrawerMessages", () => {
     if (toolGroup?.content.type === "toolGroup") {
       expect(toolGroup.content.tools[0]).not.toHaveProperty("approval");
     }
+  });
+});
+
+describe("withInterruptedRunNotices", () => {
+  const message = (id: string, runId?: string) => ({
+    id,
+    role: "assistant" as const,
+    content: { type: "text" as const, text: id },
+    ...(runId ? { runId } : {}),
+  });
+
+  const unattributed = (id: string) => ({
+    id,
+    role: "assistant" as const,
+    content: { type: "reasoning" as const, text: id, isStreaming: false },
+  });
+
+  const userMessage = (id: string) => ({
+    id,
+    role: "user" as const,
+    content: { type: "text" as const, text: id },
+  });
+
+  const label = (m: InAppAgentWindowMessage) =>
+    m.content.type === "runNotice" ? `notice:${m.content.text}` : m.id;
+
+  it("renders exactly one notice per interrupted run, at the end of its work", () => {
+    // The shape a real cancelled turn produces: only the assistant messages
+    // carry a runId, while the reasoning blocks and tool groups between and
+    // after them do not. Keying off "next message has a different runId" fires
+    // at every assistant message and scatters duplicate notices mid-transcript.
+    const result = withInterruptedRunNotices(
+      [
+        unattributed("thought-1"),
+        message("assistant-1", "run-1"),
+        unattributed("tools-1"),
+        message("assistant-2", "run-1"),
+        unattributed("thought-2"),
+      ],
+      [{ id: "run-1", message: "You stopped this run." }],
+    );
+
+    expect(result.map(label)).toEqual([
+      "thought-1",
+      "assistant-1",
+      "tools-1",
+      "assistant-2",
+      "thought-2",
+      "notice:You stopped this run.",
+    ]);
+  });
+
+  it("does not push a notice past the next user message", () => {
+    // A user message always starts a new turn, so attribution resets there;
+    // otherwise the interrupted run's notice lands below the next question.
+    const result = withInterruptedRunNotices(
+      [
+        message("assistant-1", "run-1"),
+        unattributed("thought-1"),
+        userMessage("user-2"),
+        message("assistant-2", "run-2"),
+      ],
+      [{ id: "run-1", message: "You stopped this run." }],
+    );
+
+    expect(result.map(label)).toEqual([
+      "assistant-1",
+      "thought-1",
+      "notice:You stopped this run.",
+      "user-2",
+      "assistant-2",
+    ]);
+  });
+
+  it("still marks a run that never produced a message", () => {
+    // Cancelling while the run is queued leaves nothing to anchor to; dropping
+    // the notice would make the cancel leave no trace at all.
+    const result = withInterruptedRunNotices(
+      [message("a1", "run-1")],
+      [{ id: "run-2", message: "You stopped this run." }],
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[1]?.content).toEqual({
+      type: "runNotice",
+      text: "You stopped this run.",
+    });
+  });
+
+  it("leaves the transcript untouched when nothing was interrupted", () => {
+    const messages = [message("a1", "run-1")];
+
+    expect(withInterruptedRunNotices(messages, [])).toBe(messages);
   });
 });

--- a/web/src/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.ts
@@ -697,3 +697,92 @@ function mergeSources(
 ): InAppAgentMessageSource[] {
   return deduplicateBy([...existing, ...next], (source) => source.url);
 }
+
+export type InAppAgentInterruptedRun = {
+  id: string;
+  /** User-facing reason, already mapped from the run's typed error code. */
+  message: string;
+};
+
+/**
+ * Mark turns that ended without finishing.
+ *
+ * A cancelled or failed run keeps its partial work in the transcript — the tool
+ * calls really ran, and the events are the only record of them, so they are
+ * neither deleted nor hidden. Without a boundary, though, the turn just appears
+ * to trail off mid-sentence, which is indistinguishable from the agent giving up
+ * on its own.
+ *
+ * The notice is anchored after the run's last message. A run that produced no
+ * message at all (cancelled while still queued) has nothing to anchor to, so its
+ * notice goes at the end — otherwise the cancel would leave no trace whatsoever.
+ */
+export function withInterruptedRunNotices(
+  messages: InAppAgentWindowMessage[],
+  interruptedRuns: readonly InAppAgentInterruptedRun[],
+): InAppAgentWindowMessage[] {
+  if (interruptedRuns.length === 0) {
+    return messages;
+  }
+
+  const messageByRunId = new Map(
+    interruptedRuns.map((run) => [run.id, run.message]),
+  );
+
+  // Only assistant messages carry a runId; reasoning blocks and tool groups do
+  // not. So attribution carries forward from the last assistant message, and
+  // resets at a user message — which always starts a new turn, and would
+  // otherwise inherit the previous run and push its notice below the user's
+  // next question. Without this, "is the next message a different run?" is true
+  // at *every* assistant message and one interrupted run renders several
+  // notices scattered mid-transcript.
+  const lastIndexByRunId = new Map<string, number>();
+  let attributedRunId: string | undefined;
+
+  messages.forEach((message, index) => {
+    if (message.role === "user") {
+      attributedRunId = undefined;
+      return;
+    }
+
+    if (message.runId) {
+      attributedRunId = message.runId;
+    }
+
+    if (attributedRunId) {
+      lastIndexByRunId.set(attributedRunId, index);
+    }
+  });
+
+  const anchored = new Set<string>();
+  const withNotices: InAppAgentWindowMessage[] = [];
+
+  messages.forEach((message, index) => {
+    withNotices.push(message);
+
+    for (const [runId, lastIndex] of lastIndexByRunId) {
+      if (lastIndex !== index || !messageByRunId.has(runId)) {
+        continue;
+      }
+
+      anchored.add(runId);
+      withNotices.push(createRunNotice(runId, messageByRunId.get(runId) ?? ""));
+    }
+  });
+
+  for (const run of interruptedRuns) {
+    if (!anchored.has(run.id)) {
+      withNotices.push(createRunNotice(run.id, run.message));
+    }
+  }
+
+  return withNotices;
+}
+
+function createRunNotice(runId: string, text: string): InAppAgentWindowMessage {
+  return {
+    id: `in-app-agent-run-notice-${runId}`,
+    role: "assistant",
+    content: { type: "runNotice", text },
+  };
+}

--- a/web/src/features/in-app-agent/lib/backgroundAgentClient.ts
+++ b/web/src/features/in-app-agent/lib/backgroundAgentClient.ts
@@ -1,0 +1,332 @@
+import { AbstractAgent, type RunAgentInput } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/core";
+import { Observable } from "rxjs";
+
+import {
+  InAppAgentWatchFrameSchema,
+  type AgUiMessage,
+  type AgUiRunAgentInput,
+  type InAppAgentWatchFrame,
+} from "@langfuse/shared/in-app-agent";
+
+import { env } from "@/src/env.mjs";
+import { parseSSEBuffer } from "@/src/hooks/useSSEDashboardQuery";
+
+export type InAppAgentRunStatusUpdate = Extract<
+  InAppAgentWatchFrame,
+  { type: "status" }
+>;
+
+const WATCH_RECONNECT_ATTEMPTS = 5;
+const WATCH_RECONNECT_BASE_DELAY_MS = 500;
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+type StartRunFn = (params: {
+  message: string;
+  context: AgUiRunAgentInput["context"];
+}) => Promise<{ runId: string }>;
+
+// @ag-ui/client publishes Zod v3-shaped declarations while this repo is on Zod
+// v4, so its RunAgentInput members resolve as unknown. Read the run input
+// through the locally-mirrored schema types instead (same reason
+// packages/shared/src/in-app-agent/schema.ts duplicates them).
+function asAgUiRunAgentInput(input: RunAgentInput): AgUiRunAgentInput {
+  return input as unknown as AgUiRunAgentInput;
+}
+
+/**
+ * AG-UI transport for background-executed runs.
+ *
+ * The whole point of subclassing `AbstractAgent` here is that nothing
+ * downstream has to change: `runAgent()` still pipes through
+ * `transformChunks`, `verifyEvents`, `apply` and the drawer's subscribers, so
+ * message reduction, smooth streaming and the tool cards are shared with the
+ * foreground path byte for byte. Only the transport differs — instead of
+ * POSTing and reading the response stream, we submit through a tRPC mutation
+ * and read the conversation's persisted event tail.
+ *
+ * - `run()` submits the turn, then tails from the pre-submit cursor.
+ * - `connect()` only tails. This is AG-UI's own seam for re-attaching to an
+ *   in-flight run, which is exactly what a page refresh mid-turn needs.
+ *
+ * Reconnects are the designed path, not an error path: the server ends every
+ * stream deliberately well inside the route's duration limit, and any close
+ * that was not preceded by a `done` frame is retried with the cursor. Cold
+ * start, refresh and reconnect are one code path.
+ */
+export class InAppAgentBackgroundClient extends AbstractAgent {
+  private readonly projectId: string;
+  private readonly conversationId: string;
+  private readonly startRun: StartRunFn;
+  private readonly onStatus?: (status: InAppAgentRunStatusUpdate) => void;
+  private cursor: number;
+  private abortController = new AbortController();
+
+  constructor(config: {
+    projectId: string;
+    conversationId: string;
+    /** High-water `sequenceNumber` of the hydrated history. */
+    cursor: number;
+    startRun: StartRunFn;
+    onStatus?: (status: InAppAgentRunStatusUpdate) => void;
+    threadId?: string;
+    initialMessages?: AgUiMessage[];
+    initialState?: unknown;
+  }) {
+    super({
+      threadId: config.threadId,
+      initialMessages: config.initialMessages as never,
+      initialState: config.initialState as never,
+    });
+
+    this.projectId = config.projectId;
+    this.conversationId = config.conversationId;
+    this.cursor = config.cursor;
+    this.startRun = config.startRun;
+    this.onStatus = config.onStatus;
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    return new Observable<BaseEvent>((subscriber) => {
+      const controller = this.resetAbortController();
+
+      const runInput = asAgUiRunAgentInput(input);
+      const message = getLastUserMessageContent(runInput.messages);
+
+      if (!message) {
+        subscriber.error(new Error("A user message is required"));
+        return;
+      }
+
+      this.startRun({ message, context: runInput.context })
+        .then(() => this.streamWithReconnects(subscriber, controller.signal))
+        .catch((error: unknown) => {
+          if (controller.signal.aborted) {
+            subscriber.complete();
+            return;
+          }
+          subscriber.error(error);
+        });
+
+      return () => {
+        controller.abort();
+      };
+    });
+  }
+
+  connect(): Observable<BaseEvent> {
+    return new Observable<BaseEvent>((subscriber) => {
+      const controller = this.resetAbortController();
+
+      this.streamWithReconnects(subscriber, controller.signal).catch(
+        (error: unknown) => {
+          if (controller.signal.aborted) {
+            subscriber.complete();
+            return;
+          }
+          subscriber.error(error);
+        },
+      );
+
+      return () => {
+        controller.abort();
+      };
+    });
+  }
+
+  /**
+   * Stop watching. Cancelling the *run* is a separate server-side mutation:
+   * a background run keeps going whether or not a browser is attached, which
+   * is the whole feature.
+   */
+  abortRun(): void {
+    this.abortController.abort();
+    super.abortRun();
+  }
+
+  /**
+   * Re-point the tail at a persisted high-water mark.
+   *
+   * Called at every attach boundary (drawer opened, conversation re-selected,
+   * approval decided) together with `setMessages`, so the transcript the client
+   * renders and the cursor it tails from always come from the same persisted
+   * snapshot. Letting those two drift is what makes an attach look like the
+   * model re-generating history.
+   */
+  setCursor(cursor: number): void {
+    this.cursor = cursor;
+  }
+
+  private resetAbortController(): AbortController {
+    this.abortController.abort();
+    this.abortController = new AbortController();
+    return this.abortController;
+  }
+
+  private async streamWithReconnects(
+    subscriber: {
+      next: (event: BaseEvent) => void;
+      complete: () => void;
+    },
+    signal: AbortSignal,
+  ): Promise<void> {
+    let consecutiveFailures = 0;
+
+    while (!signal.aborted) {
+      try {
+        const sawDoneFrame = await this.streamOnce(subscriber, signal);
+
+        if (sawDoneFrame) {
+          subscriber.complete();
+          return;
+        }
+
+        // A clean close without a done frame is the deliberate
+        // max-connection end: reconnect immediately, nothing went wrong.
+        consecutiveFailures = 0;
+      } catch (error) {
+        if (signal.aborted) {
+          break;
+        }
+
+        consecutiveFailures += 1;
+
+        // Give up only once retrying has stopped looking like a blip;
+        // the run itself keeps executing regardless of the browser.
+        if (consecutiveFailures > WATCH_RECONNECT_ATTEMPTS) {
+          throw error;
+        }
+
+        await sleep(
+          WATCH_RECONNECT_BASE_DELAY_MS * consecutiveFailures,
+          signal,
+        );
+      }
+    }
+
+    subscriber.complete();
+  }
+
+  /** Returns whether the server signalled that there is nothing left to watch. */
+  private async streamOnce(
+    subscriber: { next: (event: BaseEvent) => void },
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    const basePath = env.NEXT_PUBLIC_BASE_PATH ?? "";
+    const url = new URL(
+      `${basePath}/api/in-app-agent/watch`,
+      window.location.origin,
+    );
+    url.searchParams.set("projectId", this.projectId);
+    url.searchParams.set("conversationId", this.conversationId);
+    url.searchParams.set("cursor", String(this.cursor));
+
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+      signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(await readErrorMessage(response));
+    }
+
+    const reader = response.body?.getReader();
+
+    if (!reader) {
+      throw new Error("The assistant stream is unavailable");
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (!signal.aborted) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        return false;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const { events, remaining } = parseSSEBuffer(buffer);
+      buffer = remaining;
+
+      for (const sseEvent of events) {
+        const payload: unknown = JSON.parse(sseEvent.data);
+        const frame = InAppAgentWatchFrameSchema.safeParse(payload);
+
+        if (!frame.success) {
+          continue;
+        }
+
+        if (frame.data.type === "done") {
+          return true;
+        }
+
+        if (frame.data.type === "status") {
+          // Run status is not an AG-UI event; it drives the drawer's own
+          // "working" / failure rendering.
+          this.onStatus?.(frame.data);
+          continue;
+        }
+
+        if (frame.data.type === "error") {
+          // A server-side tail failure, not a run failure. Reconnecting with
+          // the cursor is the correct response.
+          throw new Error(frame.data.message);
+        }
+
+        this.cursor = frame.data.sequenceNumber;
+        subscriber.next(frame.data.event as unknown as BaseEvent);
+      }
+    }
+
+    return false;
+  }
+}
+
+function getLastUserMessageContent(
+  messages: AgUiRunAgentInput["messages"],
+): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+
+    if (message?.role === "user" && typeof message.content === "string") {
+      return message.content;
+    }
+  }
+
+  return undefined;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body: unknown = await response.json();
+
+    if (
+      body &&
+      typeof body === "object" &&
+      "error" in body &&
+      typeof body.error === "string"
+    ) {
+      return body.error;
+    }
+  } catch {
+    // Fall through to the generic message below.
+  }
+
+  return "The assistant is unavailable right now";
+}

--- a/web/src/features/in-app-agent/lib/backgroundExecutionFlag.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionFlag.ts
@@ -1,0 +1,31 @@
+import { useBrowserStorageValue } from "@/src/features/events/lib/appRootDefaultStorage";
+
+/**
+ * Opt-in flag for running the assistant on the background execution path
+ * (worker-executed runs, cursor-based streaming, refresh-survivable turns).
+ *
+ * Deliberately a client-only localStorage flag, not a server feature flag:
+ * the endpoints behind it ship live and are protected by the ordinary auth
+ * chain (owner-only, `in-app-agent` entitlement, `aiFeaturesEnabled`, cloud
+ * region, rate limit), so exposure is a stability question, not a security
+ * one. Canary is therefore a binary opt-in followed by a default flip at GA.
+ *
+ * Set it from devtools:
+ *   localStorage.setItem("langfuse-in-app-agent-background-execution", "true")
+ *
+ * Read through `useBrowserStorageValue` rather than `useLocalStorage`: it is
+ * effect-free, its server snapshot is `null` so SSR always renders flag-off,
+ * and it re-renders on same-tab writes — which is what makes toggling the key
+ * in devtools take effect without a reload.
+ */
+export const IN_APP_AGENT_BACKGROUND_EXECUTION_STORAGE_KEY =
+  "langfuse-in-app-agent-background-execution";
+
+export function useInAppAgentBackgroundExecutionEnabled(): boolean {
+  return (
+    useBrowserStorageValue(
+      "localStorage",
+      IN_APP_AGENT_BACKGROUND_EXECUTION_STORAGE_KEY,
+    ) === "true"
+  );
+}

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -10,8 +10,12 @@ import {
 import {
   getInAppAgentMessageEntryPointTraceMetadata,
   getInAppAgentQuickActionTraceMetadata,
-  sanitizeInAppAgentContext,
 } from "@/src/features/in-app-agent/context";
+import { resolveInAppAgentRunContext } from "@/src/features/in-app-agent/server/runContext";
+import {
+  checkInAppAgentRateLimit,
+  getInAppAgentApiAccessScope,
+} from "@/src/features/in-app-agent/server/rateLimit";
 import { getInAppAgentInstrumentationTraceId } from "@langfuse/shared/in-app-agent";
 import {
   AgUiRunAgentInputSchema,
@@ -58,18 +62,13 @@ import {
 import { getLangfuseClient } from "@/src/features/natural-language-filters/server/utils";
 import { getAuthOptions } from "@/src/server/auth";
 import { hasEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
-import { getOrganizationPlanServerSide } from "@/src/features/entitlements/server/getPlan";
-import {
-  createHttpHeaderFromRateLimit,
-  RateLimitService,
-} from "@/src/features/public-api/server/RateLimitService";
+import { createHttpHeaderFromRateLimit } from "@/src/features/public-api/server/RateLimitService";
+import type { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import {
   getLangfuseAITraceSinkParams,
-  parseSavedViewFromURL,
   addUserToSpan,
   logger,
   redis,
-  TableViewService,
   type ApiAccessScope,
 } from "@langfuse/shared/src/server";
 import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
@@ -78,14 +77,10 @@ import { assertUnreachable } from "@/src/utils/types";
 import {
   BaseError,
   ForbiddenError,
-  type FilterState,
   InAppAgentRunErrorCode,
   InvalidRequestError,
-  LangfuseNotFoundError,
   type RateLimitResult,
-  TableViewPresetTableName,
   UnauthorizedError,
-  CloudConfigSchema,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -690,65 +685,15 @@ function getInAppAgentUserAccess(
   };
 }
 
-function getInAppAgentApiAccessScope(
-  user: SessionUser,
-  projectId: string,
-  projectOrganization: {
-    id: string;
-    cloudConfig: unknown;
-  },
-): ApiAccessScope {
-  const organization = user.organizations.find((org) =>
-    org.projects.some((project) => project.id === projectId),
-  );
-
-  if (!organization) {
-    if (user.admin === true) {
-      const cloudConfig = projectOrganization.cloudConfig
-        ? CloudConfigSchema.parse(projectOrganization.cloudConfig)
-        : undefined;
-
-      return {
-        orgId: projectOrganization.id,
-        plan: getOrganizationPlanServerSide(cloudConfig),
-        projectId,
-        accessLevel: "project",
-        rateLimitOverrides: cloudConfig?.rateLimitOverrides ?? [],
-        apiKeyId: "in-app-agent-session",
-        publicKey: "in-app-agent-session",
-        isIngestionSuspended: false,
-      };
-    }
-
-    throw new ForbiddenError("User is not a member of this project");
-  }
-
-  return {
-    orgId: organization.id,
-    plan: organization.plan,
-    projectId,
-    accessLevel: "project",
-    rateLimitOverrides: organization.cloudConfig?.rateLimitOverrides ?? [],
-    apiKeyId: "in-app-agent-session",
-    publicKey: "in-app-agent-session",
-    isIngestionSuspended: false,
-  };
-}
-
 async function rateLimitInAppAgentRequest(
   scope: ApiAccessScope,
   resource: Parameters<RateLimitService["rateLimitRequest"]>[1],
 ): Promise<Response | undefined> {
-  const rateLimit = await RateLimitService.getInstance().rateLimitRequest(
-    scope,
-    resource,
-  );
+  const rateLimitRes = await checkInAppAgentRateLimit(scope, resource);
 
-  if (!rateLimit.isRateLimited() || !rateLimit.res) {
-    return undefined;
-  }
-
-  return createInAppAgentRateLimitResponse(rateLimit.res);
+  return rateLimitRes
+    ? createInAppAgentRateLimitResponse(rateLimitRes)
+    : undefined;
 }
 
 function createInAppAgentRateLimitResponse(rateLimitRes: RateLimitResult) {
@@ -910,47 +855,11 @@ async function prepareAgentInput(
     throw new InvalidRequestError("Invalid forwarded props");
   }
 
-  const currentUrlContext = input.context.find(
-    (item) => item.description === "current_url",
-  );
-  const selectedSavedView = currentUrlContext
-    ? parseSavedViewFromURL(currentUrlContext.value, isV4Enabled)
-    : undefined;
-  let viewFilters: FilterState | undefined;
-
-  if (selectedSavedView) {
-    try {
-      const { filters, tableName } =
-        await TableViewService.getTableViewPresetsById(
-          selectedSavedView.viewId,
-          projectId,
-        );
-
-      if (
-        tableName === selectedSavedView.tableName ||
-        (selectedSavedView.tableName ===
-          TableViewPresetTableName.ObservationsEvents &&
-          tableName === TableViewPresetTableName.Observations)
-      ) {
-        viewFilters = filters;
-      }
-    } catch (error) {
-      // Saved views can be deleted while their URLs remain open or shared.
-      if (!(error instanceof LangfuseNotFoundError)) {
-        logger.warn("Failed to resolve saved view for in-app agent context", {
-          error,
-          projectId,
-          savedViewId: selectedSavedView.viewId,
-        });
-      }
-    }
-  }
-
-  const context = sanitizeInAppAgentContext(
-    input.context,
+  const context = await resolveInAppAgentRunContext({
+    context: input.context,
     projectId,
-    viewFilters,
-  );
+    isV4Enabled,
+  });
 
   if (forwardedProps && "command" in forwardedProps) {
     const resumeForwardedProps =

--- a/web/src/features/in-app-agent/server/rateLimit.ts
+++ b/web/src/features/in-app-agent/server/rateLimit.ts
@@ -1,0 +1,100 @@
+import { type Session } from "next-auth";
+
+import {
+  BaseError,
+  CloudConfigSchema,
+  ForbiddenError,
+  type RateLimitResult,
+} from "@langfuse/shared";
+import type { ApiAccessScope } from "@langfuse/shared/src/server";
+
+import { getOrganizationPlanServerSide } from "@/src/features/entitlements/server/getPlan";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+
+type SessionUser = NonNullable<Session["user"]>;
+
+/**
+ * Build the org-scoped rate-limit scope for an in-app agent request.
+ *
+ * Shared by the foreground route and the background `startRun` mutation so a
+ * user cannot bypass the cap by submitting through the other path.
+ *
+ * TODO: this is org-scoped only; there is no per-user cap yet.
+ */
+export function getInAppAgentApiAccessScope(
+  user: SessionUser,
+  projectId: string,
+  projectOrganization: {
+    id: string;
+    cloudConfig: unknown;
+  },
+): ApiAccessScope {
+  const organization = user.organizations.find((org) =>
+    org.projects.some((project) => project.id === projectId),
+  );
+
+  if (!organization) {
+    if (user.admin === true) {
+      const cloudConfig = projectOrganization.cloudConfig
+        ? CloudConfigSchema.parse(projectOrganization.cloudConfig)
+        : undefined;
+
+      return {
+        orgId: projectOrganization.id,
+        plan: getOrganizationPlanServerSide(cloudConfig),
+        projectId,
+        accessLevel: "project",
+        rateLimitOverrides: cloudConfig?.rateLimitOverrides ?? [],
+        apiKeyId: "in-app-agent-session",
+        publicKey: "in-app-agent-session",
+        isIngestionSuspended: false,
+      };
+    }
+
+    throw new ForbiddenError("User is not a member of this project");
+  }
+
+  return {
+    orgId: organization.id,
+    plan: organization.plan,
+    projectId,
+    accessLevel: "project",
+    rateLimitOverrides: organization.cloudConfig?.rateLimitOverrides ?? [],
+    apiKeyId: "in-app-agent-session",
+    publicKey: "in-app-agent-session",
+    isIngestionSuspended: false,
+  };
+}
+
+export async function checkInAppAgentRateLimit(
+  scope: ApiAccessScope,
+  resource: Parameters<RateLimitService["rateLimitRequest"]>[1],
+): Promise<RateLimitResult | undefined> {
+  const rateLimit = await RateLimitService.getInstance().rateLimitRequest(
+    scope,
+    resource,
+  );
+
+  return rateLimit.isRateLimited() ? (rateLimit.res ?? undefined) : undefined;
+}
+
+/** tRPC-shaped variant; BaseErrors bubble to the tRPC error middleware. */
+export async function assertInAppAgentRateLimit(
+  scope: ApiAccessScope,
+  resource: Parameters<RateLimitService["rateLimitRequest"]>[1],
+): Promise<void> {
+  const rateLimitRes = await checkInAppAgentRateLimit(scope, resource);
+
+  if (!rateLimitRes) {
+    return;
+  }
+
+  throw new BaseError(
+    "TooManyRequestsError",
+    429,
+    `Too many assistant requests. Please retry in ${Math.ceil(
+      rateLimitRes.msBeforeNext / 1_000,
+    )} seconds.`,
+    true,
+  );
+}

--- a/web/src/features/in-app-agent/server/router.ts
+++ b/web/src/features/in-app-agent/server/router.ts
@@ -1,10 +1,16 @@
+import { EventType } from "@ag-ui/core";
+import { randomUUID } from "crypto";
 import { z } from "zod";
 import type { Session } from "next-auth";
 
 import {
   BaseError,
   ForbiddenError,
+  InAppAgentRunErrorCode,
+  InAppAgentRunStatus,
   InvalidRequestError,
+  isRetryableInAppAgentRunErrorCode,
+  LangfuseNotFoundError,
   ScoreDataTypeEnum,
   ScoreSourceEnum,
   TEXT_SCORE_MAX_LENGTH,
@@ -12,12 +18,22 @@ import {
 import type { PrismaClient } from "@langfuse/shared/src/db";
 import {
   convertDateToClickhouseDateTime,
+  InAppAgentRunQueue,
+  logger,
+  QueueJobs,
+  redis,
   upsertScore,
 } from "@langfuse/shared/src/server";
+import { deleteApiKeyFromDb } from "@langfuse/shared/src/server/auth/apiKeys";
 import { env } from "@/src/env.mjs";
 import {
+  AgUiContextSchema,
+  createInAppAgentMessageId,
+  createInAppAgentRunId,
   getInAppAgentInstrumentationObservationId,
   getInAppAgentInstrumentationTraceId,
+  getInAppAgentRunFailureMessage,
+  parseInAppAgentApprovalDecisionEvent,
 } from "@langfuse/shared/in-app-agent";
 import { InAppAgentMessageFeedbackValueSchema } from "@langfuse/shared/in-app-agent";
 import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
@@ -27,15 +43,34 @@ import {
   protectedProjectProcedureWithoutTracing,
 } from "@/src/server/api/trpc";
 import {
+  ensureOwnedConversation,
   getConversationEvents,
   getConversationMessagesForDisplay,
   getConversationMessages,
   getOwnedConversationOrThrow,
   isInAppAgentConversationWriteLocked,
+  maybeInferAndPersistConversationTitle,
   serializeConversation,
+  type PersistedConversationEvent,
 } from "@langfuse/shared/in-app-agent/server/persistence";
+import { parseInAppAgentInterruptEvent } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
+import {
+  cleanupTerminalRunMcpApiKeys,
+  createQueuedRun,
+  decideToolApproval,
+  reconcileConversationRuns,
+  requestRunCancellation,
+} from "@langfuse/shared/in-app-agent/server/runLifecycle";
+import { resolveInAppAgentRunContext } from "@/src/features/in-app-agent/server/runContext";
+import {
+  assertInAppAgentRateLimit,
+  getInAppAgentApiAccessScope,
+} from "@/src/features/in-app-agent/server/rateLimit";
 
 const CONVERSATION_LIST_LIMIT = 50;
+const MAX_IN_APP_AGENT_MESSAGE_LENGTH = 32_000;
+const SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE =
+  "Sandbox-enabled conversations become read-only after 8 hours. Start a new conversation to continue.";
 
 const ConversationListCursorSchema = z.object({
   updatedAt: z.date(),
@@ -49,6 +84,26 @@ const ConversationIdInput = z.object({
 
 const RenameConversationInput = ConversationIdInput.extend({
   title: z.string().trim().min(1).max(80),
+});
+
+const StartRunInput = ConversationIdInput.extend({
+  message: z.string().trim().min(1).max(MAX_IN_APP_AGENT_MESSAGE_LENGTH),
+  /**
+   * The same AG-UI context array the foreground path sends (current page, the
+   * quick action and entry point that triggered the turn); resolved and
+   * sanitized server-side, then stored on the run for the worker to replay.
+   */
+  context: z.array(AgUiContextSchema).default([]),
+});
+
+const CancelRunInput = ConversationIdInput.extend({
+  runId: z.string(),
+});
+
+const DecideToolApprovalInput = ConversationIdInput.extend({
+  runId: z.string(),
+  toolCallId: z.string(),
+  approved: z.boolean(),
 });
 
 const SubmitFeedbackInput = ConversationIdInput.extend({
@@ -123,7 +178,34 @@ export const inAppAgentRouter = createTRPCRouter({
         userId: ctx.session.user.id,
       });
 
-      const [messages, events] = await Promise.all([
+      // Reconcile before reading: this snapshot is also the background path's
+      // hydration source, and it must never show "Working" for a dead worker.
+      await reconcileConversationRuns({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+      });
+
+      // A run that is terminal with its MCP-key pointer still set is the
+      // discoverable owner of a key whose delete failed on the worker. Reads
+      // own the retry; the RFC's TTL sweep is the backstop for the case where
+      // even the pointer update was lost.
+      await cleanupTerminalRunMcpApiKeys({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        deleteApiKey: async (apiKeyId) => {
+          await deleteApiKeyFromDb({
+            prisma: ctx.prisma,
+            id: apiKeyId,
+            entityId: input.projectId,
+            scope: "PROJECT",
+            redis,
+          });
+        },
+      });
+
+      const [messages, events, runs] = await Promise.all([
         getConversationMessagesForDisplay({
           prisma: ctx.prisma,
           projectId: input.projectId,
@@ -134,7 +216,27 @@ export const inAppAgentRouter = createTRPCRouter({
           projectId: input.projectId,
           conversationId: input.conversationId,
         }),
+        // All runs, not just the newest: a turn that was cancelled or failed
+        // mid-conversation has to be markable in the transcript, and today it is
+        // completely invisible. Conversations have one run per turn, so this
+        // stays small.
+        ctx.prisma.inAppAgentRun.findMany({
+          where: {
+            projectId: input.projectId,
+            conversationId: input.conversationId,
+          },
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            status: true,
+            errorCode: true,
+            errorMessage: true,
+            cancelRequestedAt: true,
+          },
+        }),
       ]);
+
+      const latestRun = runs.at(-1) ?? null;
 
       return {
         conversation: serializeConversation(conversation, {
@@ -144,12 +246,282 @@ export const inAppAgentRouter = createTRPCRouter({
           }),
         }),
         messages,
+        /**
+         * The watch cursor. Definitionally the high-water mark of the events
+         * this very snapshot was built from, so attaching the tail with
+         * `> cursor` is gap-free and duplicate-free by construction — there is
+         * no separate cursor read to race against.
+         */
+        eventCursor: events.reduce(
+          (max, event) => Math.max(max, event.sequenceNumber),
+          -1,
+        ),
+        latestRun:
+          latestRun && latestRun.status
+            ? {
+                id: latestRun.id,
+                status: latestRun.status as InAppAgentRunStatus,
+                errorCode: latestRun.errorCode,
+                errorMessage: latestRun.errorMessage,
+                cancelRequested: Boolean(latestRun.cancelRequestedAt),
+                isRetryable: isRetryableInAppAgentRunErrorCode(
+                  latestRun.errorCode,
+                ),
+              }
+            : null,
+        /**
+         * Approvals rendered from persistence rather than from a live stream
+         * event, so a pending card survives a refresh. Undecided = an
+         * interrupt event with no matching decision event.
+         */
+        pendingToolApprovals: getPendingToolApprovals(
+          events,
+          new Set(
+            runs
+              .filter(
+                (run) => run.status === InAppAgentRunStatus.AWAITING_APPROVAL,
+              )
+              .map((run) => run.id),
+          ),
+        ),
+        /**
+         * Turns that ended without finishing. Their partial events stay in the
+         * transcript — the tool calls really ran and the events are the only
+         * record — so the UI marks the boundary instead of hiding them.
+         */
+        interruptedRuns: runs.flatMap((run) =>
+          run.status === InAppAgentRunStatus.CANCELLED ||
+          run.status === InAppAgentRunStatus.FAILED
+            ? [
+                {
+                  id: run.id,
+                  message: getInAppAgentRunFailureMessage(run.errorCode),
+                },
+              ]
+            : [],
+        ),
         state: {
           type: "existingConversation" as const,
           projectId: input.projectId,
           conversationId: input.conversationId,
         },
       };
+    }),
+
+  /**
+   * Submit a turn for background execution.
+   *
+   * Runs the same validation chain as the foreground route, then commits the
+   * run as QUEUED with its user message already appended — the events table is
+   * the render source from the instant of submit, so there is no optimistic UI
+   * state to survive a refresh. The BullMQ enqueue happens after commit; a
+   * failure there marks the run FAILED immediately rather than leaving a
+   * committed run nobody will execute.
+   */
+  startRun: protectedProjectProcedureWithoutTracing
+    .input(StartRunInput)
+    .mutation(async ({ ctx, input }) => {
+      const projectAvailability = await assertInAppAgentAvailable({
+        ctx,
+        projectId: input.projectId,
+      });
+
+      const project = await ctx.prisma.project.findUnique({
+        where: { id: input.projectId },
+        select: { organization: { select: { id: true, cloudConfig: true } } },
+      });
+
+      if (!project) {
+        throw new LangfuseNotFoundError("Project not found");
+      }
+
+      await assertInAppAgentRateLimit(
+        getInAppAgentApiAccessScope(
+          ctx.session.user,
+          input.projectId,
+          project.organization,
+        ),
+        "in-app-agent-run",
+      );
+
+      const conversation = await ensureOwnedConversation({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        userId: ctx.session.user.id,
+      });
+
+      const events = await getConversationEvents({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+      });
+
+      if (isInAppAgentConversationWriteLocked({ conversation, events })) {
+        throw new BaseError(
+          "PreconditionFailedError",
+          412,
+          SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+          true,
+        );
+      }
+
+      const bedrockModelId = env.LANGFUSE_AWS_BEDROCK_MODEL;
+      if (!bedrockModelId) {
+        throw new BaseError(
+          "PreconditionFailedError",
+          412,
+          "Assistant model is not configured.",
+          true,
+        );
+      }
+
+      const context = await resolveInAppAgentRunContext({
+        context: input.context,
+        projectId: input.projectId,
+        isV4Enabled: ctx.session.user.v4BetaEnabled === true,
+      });
+
+      const runId = createInAppAgentRunId();
+      const userMessage = {
+        id: createInAppAgentMessageId(),
+        role: "user" as const,
+        content: input.message,
+      };
+
+      const run = await createQueuedRun({
+        prisma: ctx.prisma,
+        runId,
+        projectId: input.projectId,
+        conversationId: conversation.id,
+        triggeredByUserId: ctx.session.user.id,
+        model: bedrockModelId,
+        request: { kind: "userMessage", context },
+        // Shaped exactly like the foreground handler's seeded RUN_STARTED:
+        // the worker reads the turn's input from `input.messages` here and
+        // never writes this event itself.
+        runStartedEvent: {
+          type: EventType.RUN_STARTED,
+          threadId: conversation.id,
+          runId,
+          input: {
+            threadId: conversation.id,
+            runId,
+            state: null,
+            messages: [userMessage],
+            tools: [],
+            context,
+            forwardedProps: {},
+          },
+        },
+      });
+
+      await enqueueInAppAgentRun({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        runId: run.id,
+      });
+
+      // Fire and forget, exactly as the foreground path does: a title is nice
+      // to have and must never delay or fail the turn. Without this call every
+      // background conversation would keep its default timestamp title, since
+      // the worker does not infer one.
+      maybeInferAndPersistConversationTitle({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: conversation.id,
+        userId: ctx.session.user.id,
+        aiTelemetryEnabled: projectAvailability.aiTelemetryEnabled,
+      });
+
+      return { runId: run.id };
+    }),
+
+  cancelRun: protectedProjectProcedureWithoutTracing
+    .input(CancelRunInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertInAppAgentAvailable({ ctx, projectId: input.projectId });
+
+      await getOwnedConversationOrThrow({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        userId: ctx.session.user.id,
+        action: "cancel",
+      });
+
+      const result = await requestRunCancellation({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        runId: input.runId,
+      });
+
+      if (result.cancelledImmediately) {
+        // Best effort: the claim CAS already makes a duplicate delivery a
+        // no-op, so a job left in the queue is harmless, just wasteful.
+        await removeInAppAgentRunJob(input.runId);
+      }
+
+      return result;
+    }),
+
+  /**
+   * Decide a pending tool approval.
+   *
+   * The client sends only IDs and a boolean. The tool name and arguments are
+   * read server-side from the persisted interrupt event, so there is nothing
+   * to tamper with on the way back and no fingerprint to keep in sync.
+   */
+  decideToolApproval: protectedProjectProcedureWithoutTracing
+    .input(DecideToolApprovalInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertInAppAgentAvailable({ ctx, projectId: input.projectId });
+
+      await getOwnedConversationOrThrow({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        userId: ctx.session.user.id,
+        action: "decide",
+      });
+
+      const events = await getConversationEvents({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+      });
+
+      const approvalRequest = events.find(
+        (persisted) =>
+          persisted.runId === input.runId &&
+          parseInAppAgentInterruptEvent(persisted.event)?.toolCallId ===
+            input.toolCallId,
+      );
+
+      if (!approvalRequest) {
+        throw new LangfuseNotFoundError("Approval request not found");
+      }
+
+      const continuationRun = await decideToolApproval({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        parentRunId: input.runId,
+        continuationRunId: createInAppAgentRunId(),
+        toolCallId: input.toolCallId,
+        approved: input.approved,
+        decidedByUserId: ctx.session.user.id,
+        model: env.LANGFUSE_AWS_BEDROCK_MODEL,
+      });
+
+      await enqueueInAppAgentRun({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        runId: continuationRun.id,
+      });
+
+      return { runId: continuationRun.id };
     }),
 
   deleteConversation: protectedProjectProcedureWithoutTracing
@@ -292,6 +664,115 @@ export const inAppAgentRouter = createTRPCRouter({
       return { feedback: { value: input.value, comment } };
     }),
 });
+
+/**
+ * Approval requests from the persisted event stream that nobody has decided.
+ *
+ * The parent run's `AWAITING_APPROVAL` status is what makes an approval
+ * actionable, but the request payload itself lives in the interrupt event —
+ * which is also why the foreground side table can eventually go.
+ */
+function getPendingToolApprovals(
+  events: readonly PersistedConversationEvent[],
+  parkedRunIds: ReadonlySet<string>,
+) {
+  const decidedToolCallIds = new Set(
+    events.flatMap((persisted) => {
+      const decision = parseInAppAgentApprovalDecisionEvent(persisted.event);
+      return decision ? [decision.toolCallId] : [];
+    }),
+  );
+
+  return events.flatMap((persisted) => {
+    const approvalRequest = parseInAppAgentInterruptEvent(persisted.event);
+
+    // Actionable only while its run is still parked. Three paths end an
+    // approval without writing a decision event — cancel
+    // (`approval_cancelled`), a newer message (`approval_superseded`) and the
+    // TTL (`approval_expired`) — so keying on events alone would leave a card
+    // the user can click but nothing can consume.
+    return approvalRequest &&
+      parkedRunIds.has(persisted.runId) &&
+      !decidedToolCallIds.has(approvalRequest.toolCallId)
+      ? [{ runId: persisted.runId, approvalRequest }]
+      : [];
+  });
+}
+
+/**
+ * Postgres and BullMQ are a dual write: the run is already committed as
+ * QUEUED, so an enqueue failure must not leave a run nobody will ever
+ * execute. Fail it right here with a typed, retryable code.
+ *
+ * A process death *between* the commit and this call is the one remaining
+ * dispatch gap; reconciliation fails such a run at `QUEUE_TIMEOUT`
+ * (dispatch option C). Re-enqueue-on-read is the pre-agreed follow-up.
+ */
+async function enqueueInAppAgentRun(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  runId: string;
+}) {
+  try {
+    const queue = InAppAgentRunQueue.getInstance();
+
+    if (!queue) {
+      throw new Error("In-app agent run queue is unavailable");
+    }
+
+    await queue.add(
+      QueueJobs.InAppAgentRunJob,
+      {
+        timestamp: new Date(),
+        id: randomUUID(),
+        name: QueueJobs.InAppAgentRunJob,
+        payload: { projectId: params.projectId, runId: params.runId },
+      },
+      // Dedup lever: a duplicate enqueue is dropped by BullMQ, and a duplicate
+      // delivery is a claim-CAS no-op anyway.
+      { jobId: params.runId },
+    );
+  } catch (error) {
+    logger.error("Failed to enqueue in-app agent run", {
+      error,
+      projectId: params.projectId,
+      runId: params.runId,
+    });
+
+    await params.prisma.inAppAgentRun.updateMany({
+      where: {
+        id: params.runId,
+        projectId: params.projectId,
+        status: InAppAgentRunStatus.QUEUED,
+      },
+      data: {
+        status: InAppAgentRunStatus.FAILED,
+        finishedAt: new Date(),
+        errorCode: InAppAgentRunErrorCode.ENQUEUE_FAILED,
+        errorMessage: "Couldn't start the run",
+      },
+    });
+
+    throw new BaseError(
+      "InternalServerError",
+      500,
+      "Couldn't start the run. Try again.",
+      true,
+    );
+  }
+}
+
+async function removeInAppAgentRunJob(runId: string) {
+  try {
+    await InAppAgentRunQueue.getInstance()?.remove(runId);
+  } catch (error) {
+    // Harmless: the claim CAS rejects a cancelled run anyway.
+    logger.info("Failed to remove cancelled in-app agent run job", {
+      error,
+      runId,
+    });
+  }
+}
 
 async function assertInAppAgentAvailable({
   ctx,

--- a/web/src/features/in-app-agent/server/runContext.ts
+++ b/web/src/features/in-app-agent/server/runContext.ts
@@ -1,0 +1,73 @@
+import {
+  type FilterState,
+  LangfuseNotFoundError,
+  TableViewPresetTableName,
+} from "@langfuse/shared";
+import type { AgUiRunAgentInput } from "@langfuse/shared/in-app-agent";
+
+type InAppAgentContext = AgUiRunAgentInput["context"];
+import {
+  logger,
+  parseSavedViewFromURL,
+  TableViewService,
+} from "@langfuse/shared/src/server";
+
+import { sanitizeInAppAgentContext } from "@/src/features/in-app-agent/context";
+
+/**
+ * Resolve and sanitize the AG-UI context items for a turn.
+ *
+ * Shared by the two submit paths: the foreground handler resolves at request
+ * time, and `startRun` resolves at submit time and stores the result in the
+ * run's request payload — so the worker replays a context that was resolved
+ * against the state the user actually saw, and never has to reach for a saved
+ * view that may since have been deleted.
+ */
+export async function resolveInAppAgentRunContext(params: {
+  context: InAppAgentContext;
+  projectId: string;
+  isV4Enabled: boolean;
+}): Promise<InAppAgentContext> {
+  const currentUrlContext = params.context.find(
+    (item) => item.description === "current_url",
+  );
+  const selectedSavedView = currentUrlContext
+    ? parseSavedViewFromURL(currentUrlContext.value, params.isV4Enabled)
+    : undefined;
+
+  let viewFilters: FilterState | undefined;
+
+  if (selectedSavedView) {
+    try {
+      const { filters, tableName } =
+        await TableViewService.getTableViewPresetsById(
+          selectedSavedView.viewId,
+          params.projectId,
+        );
+
+      if (
+        tableName === selectedSavedView.tableName ||
+        (selectedSavedView.tableName ===
+          TableViewPresetTableName.ObservationsEvents &&
+          tableName === TableViewPresetTableName.Observations)
+      ) {
+        viewFilters = filters;
+      }
+    } catch (error) {
+      // Saved views can be deleted while their URLs remain open or shared.
+      if (!(error instanceof LangfuseNotFoundError)) {
+        logger.warn("Failed to resolve saved view for in-app agent context", {
+          error,
+          projectId: params.projectId,
+          savedViewId: selectedSavedView.viewId,
+        });
+      }
+    }
+  }
+
+  return sanitizeInAppAgentContext(
+    params.context,
+    params.projectId,
+    viewFilters,
+  );
+}

--- a/web/src/features/in-app-agent/server/watchHandler.ts
+++ b/web/src/features/in-app-agent/server/watchHandler.ts
@@ -1,0 +1,212 @@
+import { getServerSession } from "next-auth";
+
+import {
+  BaseError,
+  ForbiddenError,
+  InvalidRequestError,
+  UnauthorizedError,
+} from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { addUserToSpan, logger } from "@langfuse/shared/src/server";
+import type { InAppAgentWatchFrame } from "@langfuse/shared/in-app-agent";
+import { assertConversationAccess } from "@langfuse/shared/in-app-agent/server/access";
+import { watchConversationFrames } from "@langfuse/shared/in-app-agent/server/watch";
+
+import { env } from "@/src/env.mjs";
+import { hasEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
+import { getAuthOptions } from "@/src/server/auth";
+import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
+
+/**
+ * Live tail of a conversation's persisted event stream.
+ *
+ * Scope is the conversation, not the run: one stream spans approval
+ * continuations and supersedes, so the client never has to rediscover run IDs.
+ * The cursor is the conversation-wide `sequenceNumber` that `getConversation`
+ * already returns, which makes the hydration→tail handoff gap-free and
+ * duplicate-free by construction.
+ *
+ * Drops are normal and the cursor makes them free. This endpoint therefore
+ * ends every stream deliberately after `WATCH_MAX_CONNECTION` rather than
+ * waiting to be cut off unpredictably by a route or load-balancer limit; the
+ * client reconnects with its cursor through the exact same path as a fresh
+ * page load. One code path for cold start, refresh and reconnect.
+ */
+export default async function watchHandler(request: Request) {
+  try {
+    const authOptions = await getAuthOptions();
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user) {
+      throw new UnauthorizedError("Unauthenticated");
+    }
+
+    const user = session.user;
+
+    addUserToSpan({ userId: user.id, email: user.email ?? undefined });
+
+    if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+      throw new BaseError(
+        "PreconditionFailedError",
+        412,
+        "Assistant is not available in self-hosted deployments.",
+        true,
+      );
+    }
+
+    const url = new URL(request.url);
+    const projectId = url.searchParams.get("projectId");
+    const conversationId = url.searchParams.get("conversationId");
+
+    if (!projectId || !conversationId) {
+      throw new InvalidRequestError(
+        "projectId and conversationId are required",
+      );
+    }
+
+    // Query param wins over Last-Event-ID: the cursor is a domain sequence the
+    // hydration call also produces, not stream-private state. The header is
+    // only the free fallback for browser-native reconnects.
+    const cursor = parseCursor(
+      url.searchParams.get("cursor") ?? request.headers.get("last-event-id"),
+    );
+
+    if (!isProjectMemberOrAdmin(user, projectId)) {
+      throw new ForbiddenError("User is not a member of this project");
+    }
+
+    if (
+      !hasEntitlement({
+        entitlement: "in-app-agent",
+        sessionUser: user,
+        projectId,
+      })
+    ) {
+      throw new ForbiddenError("Assistant is not enabled for this plan");
+    }
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { organization: { select: { aiFeaturesEnabled: true } } },
+    });
+
+    if (!project?.organization.aiFeaturesEnabled) {
+      throw new ForbiddenError(
+        "Assistant is not enabled for this organization",
+      );
+    }
+
+    const conversation = await prisma.inAppAgentConversation.findUnique({
+      where: { id_projectId: { id: conversationId, projectId } },
+      select: { createdByUserId: true, deletedAt: true },
+    });
+
+    if (!conversation) {
+      throw new BaseError("NotFoundError", 404, "Conversation not found", true);
+    }
+
+    assertConversationAccess({
+      action: "watch",
+      conversation,
+      userId: user.id,
+    });
+
+    // Everything fallible is done; from here on the response is a stream and
+    // failures can only be reported inside it.
+    const stream = createWatchStream({
+      projectId,
+      conversationId,
+      cursor,
+      signal: request.signal,
+    });
+
+    return new Response(stream as unknown as BodyInit, {
+      headers: {
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Content-Encoding": "none",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  } catch (error) {
+    if (error instanceof BaseError) {
+      return Response.json(
+        { error: error.message },
+        { status: error.httpCode },
+      );
+    }
+
+    throw error;
+  }
+}
+
+function parseCursor(raw: string | null): number {
+  const parsed = Number(raw);
+
+  // Sequence numbers start at 0, so -1 is "send me everything".
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : -1;
+}
+
+function createWatchStream(params: {
+  projectId: string;
+  conversationId: string;
+  cursor: number;
+  signal: AbortSignal;
+}): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const frames = watchConversationFrames({
+        prisma,
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        cursor: params.cursor,
+        signal: params.signal,
+      });
+
+      try {
+        for await (const frame of frames) {
+          if (params.signal.aborted) {
+            break;
+          }
+
+          controller.enqueue(
+            encoder.encode(
+              frame === null ? ": keepalive\n\n" : encodeFrame(frame),
+            ),
+          );
+        }
+      } catch (error) {
+        logger.error("In-app agent watch stream failed", {
+          error,
+          projectId: params.projectId,
+          conversationId: params.conversationId,
+        });
+
+        if (!params.signal.aborted) {
+          controller.enqueue(
+            encoder.encode(
+              encodeFrame({
+                type: "error",
+                code: "watch_failed",
+                message: "The connection to the run was interrupted.",
+              }),
+            ),
+          );
+        }
+      } finally {
+        await frames.return(undefined);
+        controller.close();
+      }
+    },
+  });
+}
+
+function encodeFrame(frame: InAppAgentWatchFrame): string {
+  // The SSE id is the cursor, so Last-Event-ID works as a free fallback.
+  const id = frame.type === "event" ? `id: ${frame.sequenceNumber}\n` : "";
+
+  return `${id}event: ${frame.type}\ndata: ${JSON.stringify(frame)}\n\n`;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Umbrella/reference only — do not merge.** The complete implementation and existing review context remain here for comparison while the change ships through two replacement drafts.

Replacement drafts:

- Backend lifecycle/watch: #15594
- Drawer cutover (stacked on backend): #15595

Close this umbrella after both replacement PRs are complete or merged.

---

Closes [LFE-14373](https://linear.app/clickhouse/issue/LFE-14373/flagged-background-apis-startrun-watch-sse-cancel-decide).

Fourth PR of [the background-execution RFC](https://linear.app/clickhouse/document/wip-rfc-background-execution-663f475912b3), stacked on #15525 (dark worker path). It makes the worker path reachable end to end.

## What this gives you

Set one key in devtools and the assistant drawer runs on the background path:

```js
localStorage.setItem("langfuse-in-app-agent-background-execution", "true")
```

Then: submit, block-granular streaming from the persisted event tail, refresh mid-turn and the turn keeps going, approve/reject a mutating tool from a card that survives that refresh, stop a run (with a "Stopping…" state while it winds down), and see a boundary marker where a turn was cancelled or failed. Flag absent or `"false"` → today's foreground SSE path, untouched.

**Scope note vs. the ticket.** LFE-14373 says the endpoints ship inert until PR 5. We deliberately merged the UI cutover in so the flag actually flips something — and that decision paid for itself: **nine of the twelve bugs below were only findable by using it.** Retry, conversation-list badges, the per-org active-run ceiling and dispatch option A remain follow-ups on [LFE-14374](https://linear.app/clickhouse/issue/LFE-14374/drawer-cutover-to-background-execution-same-flag-stacked-on).

**No data migration.** The ticket asked for the legacy `status IS NULL` sweep + `NOT NULL` here. It is deliberately *not* included: every new reader already tolerates NULL (reconcile filters on status, `getConversation` maps NULL → `null`, the watch stream closes on an unreadable status), so nothing in this feature needs it. Tightening the column is an unscoped `UPDATE` plus an `ACCESS EXCLUSIVE` lock that deserves its own review.

**Foreground is untouched.** It is still the prod default, so every change is gated on `backgroundExecutionEnabled` or on `agent instanceof InAppAgentBackgroundClient`. `getOrCreateAgent`'s reuse semantics, `getHydratedMessages`' local-preferred behaviour and the `HttpAgent` construction are unchanged. The only genuinely shared change is the streaming catch-up floor.

## Two design decisions worth reviewing first

**1. `verifyEvents` shapes the wire contract.** `@ag-ui/client` verifies ordering on the way in: a stream's first event must be `RUN_STARTED`, nothing may follow `RUN_FINISHED` without a new `RUN_STARTED`. A mid-run cursor attach satisfies neither, so `watchConversationFrames` owns run framing — synthesizing the boundaries the verifier needs and suppressing them where the worker already persisted its own. That is why the generator lives in shared rather than in the route: it is the riskiest logic here and had to be testable without HTTP.

It works because of append-only compaction: the worker appends whole units, so every sequence boundary falls between units and the first event after any cursor is always a `*_START`.

**2. The in-memory AG-UI transcript never crosses an attach boundary.** Every attach — reopen, conversation switch, approval continuation, submit — re-seeds both the transport and local state from one authoritative persisted snapshot and tails from that snapshot's cursor. Violating this is what made an approval continuation re-stream the entire conversation.

## Bugs found, and their root causes

Nine from dogfooding:

| symptom | cause |
| --- | --- |
| user message rendered twice | AG-UI seeds `agent.messages` from a relayed `RUN_STARTED.input.messages`, deduping **by id only**; the client minted one id and `startRun` another. Foreground already strips this (`normalizeAdapterEvent`, `agent.ts:1097`); the tail relayed the row verbatim and reintroduced it |
| approving re-streamed the whole conversation | the smoother diffs per message id and animates the first divergence, holding everything after. At approve time its baseline was the server's projection while the republished list was AG-UI's in-memory one |
| cancel "did nothing" | it worked in **2.8s** (measured in Postgres). `shouldFlush` was `error !== null` only, so the smoother kept revealing its backlog and `isAssistantTurnInProgress` stayed true. Block delivery decouples animation time from run time in a way token streaming never did |
| no feedback at all after pressing stop | `cancel_requested_at` existed on the row but was never exposed. It now rides the `status` frame — and had to join the frame's dedup key, since it flips *while the status stays `RUNNING`* and would otherwise be swallowed |
| second cancel press silently ignored | `cancelRun` read `activeRunIdRef`, which the turn's `finally` nulls; it now cancels the run the server says is current |
| cancelled turn invisible in transcript | nothing rendered a run boundary, and `getConversation` returned only the *latest* run — so a failure mid-conversation was equally invisible |
| two "You stopped this run." markers for one run | `runId` is set only on assistant messages, so "is the next message a different run?" fired at every one of them. Attribution now carries forward and resets at a user message |
| a restored approval never appeared after reload, and the drawer looked busy | hydration delivers approvals, and pacing them schedules an appearance transition for **every tool call in the restored history** at 2/second. The card sorts last, so it waited behind the whole backlog while `isAnimating` kept the run looking live |
| stop did nothing on a pending approval, and the card outlived cancel/supersede/expiry | the guard used `isActive`, which deliberately excludes `AWAITING_APPROVAL` (parking frees the worker). And card actionability was derived from events alone, while three paths end an approval *without* writing a decision event |

Three more found by reading rather than testing:

- The foreground 150s stale-close would have fenced healthy background runs — a background run legitimately runs to `RUN_MAX_DURATION`, and execution mode is not sticky per conversation. Now guarded on `claimedAt`/`heartbeatAt` being NULL. Pinned by a regression test.
- Nothing inferred conversation titles on the background path; every background conversation would have kept its default timestamp title.
- `backgroundRunStatus` was never cleared on conversation switch, so the notice would have shown the *previous* conversation's failure.

**Pattern worth noting for review:** most of these are a guard or derivation borrowed from an adjacent concept — active vs cancellable, live vs hydrated, attributed vs unattributed messages, `runId` vs `id`, `!== null` vs falsy. The background path keeps introducing a second case where the foreground only ever had one, and the existing code silently assumed the one.

Events are never deleted or hidden for a cancelled run — append-only is what makes the cursor safe, and the tool calls really ran. The model-facing half (telling replay the turn was interrupted) is [LFE-14590](https://linear.app/clickhouse/issue/LFE-14590/agent-tell-the-model-when-a-turn-was-interrupted-by-the-user).

## Reviewing this: where the code is

33 files, +4427/−273. Roughly **+3.2k prod / +1.2k test**, and **29% of the added prod lines are comments**. Seven files are ~80% of the prod diff, each one cohesive thing:

| lines | file | what |
| --- | --- | --- |
| 594 | `runLifecycle.ts` | four lifecycle mutations + reconciler; the CAS invariants are the part worth reading |
| 530 | `InAppAiAgentProvider.tsx` | flag-conditional branches in an existing 1.7k-line provider: transport choice, attach path, decide, cancel |
| 482 | `router.ts` | three mutations + `getConversation` additions; mostly the validation chain reused from the foreground handler |
| 332 | `backgroundAgentClient.ts` | the AG-UI transport: submit, tail, reconnect-with-cursor |
| 246 | `watch.ts` | the frame generator described above |
| 212 | `watchHandler.ts` | auth chain (copied from `handler.ts`) + SSE encoding |
| 193 | `backgroundWatch.ts` | client-safe contracts: watch frames, the approval-decision event, error-code → copy |

Plus ~170 lines of pure extraction — `rateLimit.ts` and `runContext.ts` lift shared helpers out of `handler.ts`, which is **−121**.

Natural two-sitting split: **shared lifecycle + watch** (correctness-critical, where most tests are), then **web router + provider + client** (plumbing).

Effect count in the provider went 3 → 4. The one added is the discovered-run attach: its trigger is "a run is executing and nobody is watching it", a state with no initiating gesture, since a refresh restores the drawer from sessionStorage on its own. Open/close were initially effects too and moved into `setAgentOpen`, which is the real handler — the repo's own `react-you-might-not-need-an-effect` rule caught that, and it was taken rather than suppressed.

## Also lands

`rxjs@7.8.1` becomes a direct `web` dependency — pinned to exactly what `@ag-ui/client` already resolves, so no new version enters the tree. It replaces a phantom dependency for code that constructs an `Observable` directly.

## Verification

- `pnpm --filter web run test in-app-agent` — `Tests 115 passed (115)` (includes the 22 foreground auth/route and 14 stream tests)
- `pnpm --filter web run test-client in-app-agent` — `Tests 77 passed (77)`
- `pnpm --filter @langfuse/shared run test in-app-agent` — `Tests 8 passed (8)`
- typecheck clean; `eslint src/features/in-app-agent --max-warnings 0` clean; shared/worker lint clean
- CI green, including `lint` under the ESLint 10 upgrade, `knip`, `prettier-check`, both image builds (where the client-bundle scan runs), and e2e
- Live against real Bedrock + MCP: submit, refresh mid-turn, approve, cancel (2.8s / 3.1s measured), worker-loss reconcile

**Before this leaves draft:** the repo's `security-review` skill over the new endpoint and the MCP-key cleanup path, plus a browser pass on the final round of fixes.

## Tests added: 24 (net +21)

- **`in-app-agent-background-run.servertest.ts` (9)** — one per contract a browser can break: queued-run + `RUN_STARTED` shape (the worker reads its replay input from that row and fails *silently* if it is missing); single-active-run conflict as the lost-response idempotency signal; supersede; decide-CAS exactly-once with args read server-side; immediate cancel of `QUEUED` and `AWAITING_APPROVAL` **plus the card being retired**; supersede retiring the card; reconcile across all four error codes; enqueue failure; non-owner denial on all three mutations.
- **`watch.test.ts` (8)** — the `verifyEvents` contract, a runtime throw in the drawer that no type check catches: verbatim relay, synthetic open on mid-run attach (and that its cursor does not skip the event it frames), gap-free/duplicate-free handoff, synthetic close for a terminal run that never wrote `RUN_FINISHED`, close-then-open across a continuation, immediate close on an unreadable status, `RUN_STARTED.input` stripped, and status re-emitted when a cancel is requested while still `RUNNING`.
- **`utils.clienttest.ts` (4)** — interrupted-run notice placement: one notice per run at the end of its work, not pushed past the next user message, a run that produced no message at all (cancelled while queued), and identity-return when nothing was interrupted.
- **`in-app-agent-persistence.servertest.ts` (1)** — the stale-close regression.
- **`useSmoothStreamingMessages.clienttest.tsx` (+2, −3)** — added the catch-up floor and the hydrated-approval case; removed three cases that pinned the EMA-only ceiling. Those bounds derived from a *generation* rate, which is meaningless once text arrives in whole blocks; re-asserting them would only restate the new floor. `MAX_PACING_INCREASE_FACTOR` loses its dedicated test as a result — it still applies where the floor does not bind, but asserting that is implementation detail.

Each fix's test was checked to fail without the fix, after one early attempt passed vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)