### PR TITLE
fix(worker): retry ClickHouse client request timeouts in ClickhouseWriter

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -190,6 +190,27 @@ describe("ClickhouseWriter", () => {
     );
   });
 
+  it("should retry client request timeouts within the same flush", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValueOnce(new Error("Timeout error."))
+      .mockResolvedValueOnce();
+
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+
+    await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    // let the backOff retry delay elapse
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+    expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+    expect(serverExports.recordIncrement).not.toHaveBeenCalledWith(
+      "langfuse.queue.clickhouse_writer.rows_dropped",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("should shutdown gracefully", async () => {
     writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
     const mockInsert = vi

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -138,8 +138,13 @@ export class ClickhouseWriter {
 
     const errorMessage = (error as Error).message?.toLowerCase() || "";
 
-    // Check for socket hang up and other network-related errors
-    return errorMessage.includes("socket hang up");
+    // Socket hang up and client-side request timeouts ("Timeout error." from
+    // @clickhouse/client when request_timeout elapses) are transient: a retry
+    // opens a fresh connection that can land on a healthy replica.
+    return (
+      errorMessage.includes("socket hang up") ||
+      errorMessage.includes("timeout error")
+    );
   }
 
   private isSizeError(error: unknown): boolean {


### PR DESCRIPTION
## Problem

`@clickhouse/client` throws `Timeout error.` when `request_timeout` (default 30s) elapses — e.g. while a ClickHouse replica's local disk is briefly saturated and `wait_for_async_insert=1` holds the insert connection until the part flush completes.

`ClickhouseWriter.isRetryableError` only matched `socket hang up`, so a client request timeout failed the whole flush immediately (no in-flush retry). With the 1s flush interval, all `maxAttempts` requeue cycles burned inside the same multi-minute replica stall and the batch was **dropped**.

Production impact (prod-eu, 2026-07-29 ~08:53–09:03 UTC, single-replica disk-IO stall on the main ClickHouse service): 141 `Timeout error.` flush failures → **3,683 observations + 472 events_full rows dropped** in the 09:00 UTC hour. Same-signature bursts occur on most days of the past week in both regions.

## Fix

Classify client-side request timeouts (`Timeout error.`) as retryable, like socket hang-ups. A retried attempt opens a fresh connection that can land on a healthy replica. Attempt bounds are unchanged (`LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS` per flush, same requeue behavior after exhaustion).

Note: this reduces but does not eliminate drops during very long single-replica stalls — the durable fix is the existing TODO to dead-letter exhausted batches instead of dropping them (follow-up).

## Impacted packages

- `worker`

## Verification

- `pnpm --filter worker run test src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts` → `Tests  43 passed (43)` (new test `should retry client request timeouts within the same flush` fails against the previous behavior: insert called once, batch requeued)
- `pnpm run lint` → `Tasks: 7 successful, 7 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes ClickHouse client request timeouts retryable within the current flush and adds a unit test confirming that a timed-out insert is retried without dropping the queued batch.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new classification targets the documented ClickHouse client timeout message and uses the writer's existing bounded retry and requeue behavior, with focused test coverage for successful recovery.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): retry ClickHouse client req..."](https://github.com/langfuse/langfuse/commit/b6bd553c3eb6de7c356bae0b36653785b5d827fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48264814)</sub>

<!-- /greptile_comment -->