### PR TITLE
feat(experiments): enhance MultiStepExperimentForm with review step validation and error messaging

### DIFF
--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -435,9 +435,7 @@ export const MultiStepExperimentForm = ({
 
   const invalidRequiredStepLabels = steps
     .filter((step) => ["prompt", "dataset", "details"].includes(step.id))
-    .filter(
-      (step) => step.id !== "dataset" || !isDatasetValidationPending,
-    )
+    .filter((step) => step.id !== "dataset" || !isDatasetValidationPending)
     .filter((step) => !isStepValid(step.id))
     .map((step) => step.label);
   const reviewErrorMessage =

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -16,7 +16,7 @@ import {
   DialogBody,
   DialogFooter,
 } from "@/src/components/ui/dialog";
-import { Check, ChevronLeft, ChevronRight } from "lucide-react";
+import { Check, ChevronLeft, ChevronRight, CircleX } from "lucide-react";
 import Link from "next/link";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, type UseFormReturn } from "react-hook-form";
@@ -106,6 +106,7 @@ export const MultiStepExperimentForm = ({
 }) => {
   const capture = usePostHogClientCapture();
   const [activeStep, setActiveStep] = useState("prompt");
+  const [hasAttemptedReview, setHasAttemptedReview] = useState(false);
   const [selectedPromptName, setSelectedPromptName] = useState<string>(
     promptDefault?.name ?? "",
   );
@@ -399,6 +400,44 @@ export const MultiStepExperimentForm = ({
     }
   };
 
+  const handleStepChange = (stepId: string) => {
+    if (stepId === "review") {
+      setHasAttemptedReview(true);
+    }
+    setActiveStep(stepId);
+  };
+
+  const renderStepStatusIcon = (stepId: string, stepLabel: string) => {
+    if (isStepValid(stepId)) {
+      return <Check className="mr-1.5 h-3.5 w-3.5 text-green-600" />;
+    }
+
+    if (
+      hasAttemptedReview &&
+      ["prompt", "dataset", "details"].includes(stepId)
+    ) {
+      return (
+        <CircleX
+          aria-label={`${stepLabel} has errors`}
+          className="mr-1.5 h-3.5 w-3.5 text-red-500"
+        />
+      );
+    }
+
+    return null;
+  };
+
+  const invalidRequiredStepLabels = steps
+    .filter((step) => ["prompt", "dataset", "details"].includes(step.id))
+    .filter((step) => !isStepValid(step.id))
+    .map((step) => step.label);
+  const reviewErrorMessage =
+    invalidRequiredStepLabels.length === 0
+      ? undefined
+      : invalidRequiredStepLabels.length === 1
+        ? `Complete the ${invalidRequiredStepLabels[0]} step before running the experiment.`
+        : `Complete the following steps before running the experiment: ${invalidRequiredStepLabels.join(", ")}.`;
+
   if (
     !promptsByName ||
     !datasets.data ||
@@ -409,7 +448,7 @@ export const MultiStepExperimentForm = ({
 
   // Prepare grouped props
   const formState = { form: form as UseFormReturn<CreateExperiment> };
-  const navigationState = { setActiveStep };
+  const navigationState = { setActiveStep: handleStepChange };
   const promptModelState = {
     selectedPromptName,
     setSelectedPromptName,
@@ -501,19 +540,15 @@ export const MultiStepExperimentForm = ({
                     <BreadcrumbItem>
                       {step.id === activeStep ? (
                         <BreadcrumbPage className="flex items-center">
-                          {isStepValid(step.id) && (
-                            <Check className="mr-1.5 h-3.5 w-3.5 text-green-600" />
-                          )}
+                          {renderStepStatusIcon(step.id, step.label)}
                           {step.label}
                         </BreadcrumbPage>
                       ) : (
                         <BreadcrumbLink
-                          onClick={() => setActiveStep(step.id)}
+                          onClick={() => handleStepChange(step.id)}
                           className="flex cursor-pointer items-center"
                         >
-                          {isStepValid(step.id) && (
-                            <Check className="mr-1.5 h-3.5 w-3.5 text-green-600" />
-                          )}
+                          {renderStepStatusIcon(step.id, step.label)}
                           {step.label}
                         </BreadcrumbLink>
                       )}
@@ -564,6 +599,7 @@ export const MultiStepExperimentForm = ({
                 <ReviewStep
                   formState={formState}
                   navigationState={navigationState}
+                  errorMessage={reviewErrorMessage}
                   summary={reviewSummary}
                 />
               )}
@@ -580,7 +616,7 @@ export const MultiStepExperimentForm = ({
                   const stepIds = steps.map((s) => s.id);
                   const currentIndex = stepIds.indexOf(activeStep);
                   if (currentIndex > 0) {
-                    setActiveStep(stepIds[currentIndex - 1]);
+                    handleStepChange(stepIds[currentIndex - 1]);
                   }
                 }}
                 disabled={activeStep === "prompt"}
@@ -598,7 +634,7 @@ export const MultiStepExperimentForm = ({
                       const stepIds = steps.map((s) => s.id);
                       const currentIndex = stepIds.indexOf(activeStep);
                       if (currentIndex < steps.length - 1) {
-                        setActiveStep(stepIds[currentIndex + 1]);
+                        handleStepChange(stepIds[currentIndex + 1]);
                       }
                     }}
                   >

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -326,7 +326,7 @@ export const MultiStepExperimentForm = ({
       selectedPromptVersion,
       selectedDataset.name,
     );
-    form.setValue("name", defaultName);
+    form.setValue("name", defaultName, { shouldValidate: true });
 
     const defaultDescription = generateDefaultExperimentDescription(
       selectedPromptName,
@@ -366,6 +366,8 @@ export const MultiStepExperimentForm = ({
     selectedPromptToolConfig,
     structuredOutputEnabled,
   );
+  const isDatasetValidationPending =
+    Boolean(promptIdFromHook && datasetId) && validationResult.isPending;
 
   // Step validation function
   const isStepValid = (stepId: string): boolean => {
@@ -408,6 +410,10 @@ export const MultiStepExperimentForm = ({
   };
 
   const renderStepStatusIcon = (stepId: string, stepLabel: string) => {
+    if (stepId === "dataset" && isDatasetValidationPending) {
+      return null;
+    }
+
     if (isStepValid(stepId)) {
       return <Check className="mr-1.5 h-3.5 w-3.5 text-green-600" />;
     }
@@ -429,6 +435,9 @@ export const MultiStepExperimentForm = ({
 
   const invalidRequiredStepLabels = steps
     .filter((step) => ["prompt", "dataset", "details"].includes(step.id))
+    .filter(
+      (step) => step.id !== "dataset" || !isDatasetValidationPending,
+    )
     .filter((step) => !isStepValid(step.id))
     .map((step) => step.label);
   const reviewErrorMessage =
@@ -644,12 +653,7 @@ export const MultiStepExperimentForm = ({
                 ) : (
                   <Button
                     type="submit"
-                    disabled={
-                      (Boolean(promptIdFromHook && datasetId) &&
-                        !validationResult.data?.isValid) ||
-                      hasToolStructuredOutputConflict ||
-                      !!form.formState.errors.name
-                    }
+                    disabled={!isStepValid("review")}
                     loading={form.formState.isSubmitting}
                   >
                     Run Experiment

--- a/web/src/features/experiments/components/shared/StepHeader.tsx
+++ b/web/src/features/experiments/components/shared/StepHeader.tsx
@@ -1,18 +1,26 @@
 import React from "react";
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
 
 export interface StepHeaderProps {
   title: string;
   description: string;
+  errorMessage?: string;
 }
 
 export const StepHeader: React.FC<StepHeaderProps> = ({
   title,
   description,
+  errorMessage,
 }) => {
   return (
     <div className="space-y-2">
       <h3 className="text-lg font-bold">{title}</h3>
       <p className="text-muted-foreground text-sm">{description}</p>
+      {errorMessage && (
+        <Alert variant="destructive">
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
+      )}
     </div>
   );
 };

--- a/web/src/features/experiments/components/steps/ReviewStep.tsx
+++ b/web/src/features/experiments/components/steps/ReviewStep.tsx
@@ -18,6 +18,7 @@ import { StepHeader } from "@/src/features/experiments/components/shared/StepHea
 export const ReviewStep: React.FC<ReviewStepProps> = ({
   formState,
   navigationState,
+  errorMessage,
   summary,
 }) => {
   const { form } = formState;
@@ -39,6 +40,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
       <StepHeader
         title="Review & Run"
         description="Review your experiment configuration before running it. You can go back to any step to make changes."
+        errorMessage={errorMessage}
       />
 
       {/* Two-column grid layout */}

--- a/web/src/features/experiments/types/stepProps.ts
+++ b/web/src/features/experiments/types/stepProps.ts
@@ -126,6 +126,7 @@ export interface ExperimentDetailsStepProps {
 export interface ReviewStepProps {
   formState: FormState;
   navigationState: NavigationState;
+  errorMessage?: string;
   summary: {
     selectedPromptName: string;
     selectedPromptVersion: number | null;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15560.preview.langfuse.com](https://pr-15560.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds review-step validation feedback to the multi-step experiment form.
- Tracks whether Review has been visited and adds success/error breadcrumb icons.
- Builds an alert identifying incomplete required steps.
- Extends ReviewStep and StepHeader props to render the alert.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should be fixed before merging because the new review feedback can approve an invalid name and report an in-progress dataset validation as an error.

The aggregate review status does not consistently match either the form schema or the asynchronous dataset validation lifecycle, producing misleading validation state on reachable form flows.

**Files Needing Attention:** web/src/features/experiments/components/MultiStepExperimentForm.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/experiments/components/MultiStepExperimentForm.tsx:430-439
**Whitespace names bypass review validation**

When the experiment name contains only whitespace, the details check treats the raw value as valid and excludes the step from this error message, while `CreateExperimentData` trims and rejects it. Review therefore reports no configuration error and leaves Run Experiment enabled until submission fails validation.

### Issue 2
web/src/features/experiments/components/MultiStepExperimentForm.tsx:430-439
**Pending validation becomes an error**

When dataset configuration validation is still loading or retrying, `validationResult.data` is undefined and this logic classifies the Dataset step as incomplete. A valid selection consequently receives a red error icon and destructive “Complete the Dataset step” alert instead of a pending-validation state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(experiments): enhance MultiStepExpe..."](https://github.com/langfuse/langfuse/commit/a1192adcc018046d6b8793f0ddd730038f80a603) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48266085)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Datasets, Dataset Runs, and Experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md)

<!-- /greptile_comment -->