### PR TITLE
chore(deps): bump Snyk-flagged path-to-regexp and @ai-sdk/provider-utils on v3 (backport of #15518)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,11 @@ overrides:
   glob: ^10.5.0
   qs: 6.15.2
   path-to-regexp@0.1.12: 0.1.13
+  path-to-regexp@8.3.0: 8.4.0
   ip-address@10.1.0: 10.2.0
-  '@ai-sdk/provider-utils@<=4.0.26': 4.0.27
-  '@ai-sdk/provider-utils-v5': npm:@ai-sdk/provider-utils@4.0.27
+  '@ai-sdk/provider-utils@<=4.0.32': 4.0.33
+  '@ai-sdk/provider-utils-v5': npm:@ai-sdk/provider-utils@4.0.33
+  '@ai-sdk/provider-utils-v6': npm:@ai-sdk/provider-utils@4.0.33
   '@ai-sdk/ui-utils>@ai-sdk/provider-utils': 2.2.8
   '@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603>@ag-ui/langgraph': 0.0.29
   '@anthropic-ai/vertex-sdk>@anthropic-ai/sdk': 0.104.1
@@ -1293,8 +1295,8 @@ packages:
     peerDependencies:
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+  '@ai-sdk/provider-utils@4.0.33':
+    resolution: {integrity: sha512-nJ0bAfegMAIJtrzMJtbzer1cS3nb7c7DsyU1S4nrPm7ZU0Mn6SBBZv5IGZZGTbpWTJwqKTSPeZJTXalbAxt1BA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 4.3.6
@@ -1325,6 +1327,10 @@ packages:
 
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.12':
+    resolution: {integrity: sha512-sj9DWTJ2Ze0WR9qsiOPqoqzNx3OxL6iMxHImbhvoe9qOspekbzxNDMiJ4TIGfYHYh9w4OmBjz3prvqhzTi96+Q==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
@@ -9757,8 +9763,8 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -10113,6 +10119,7 @@ packages:
 
   react-grid-layout@1.5.3:
     resolution: {integrity: sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==}
+    deprecated: 'Ships stray files that were never in the repo: an ip_fetcher binary and its curl-sample source (1.5.0-1.5.3), plus a yarn-error.log containing local paths (1.5.3). Upgrade to 1.5.4, which is byte-identical apart from removing them. See https://github.com/react-grid-layout/react-grid-layout/issues/2269'
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
@@ -11756,7 +11763,7 @@ snapshots:
     dependencies:
       '@ai-sdk/anthropic': 3.0.62(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       '@smithy/eventstream-codec': 4.4.5
       '@smithy/util-utf8': 4.4.5
       aws4fetch: 1.0.20
@@ -11776,13 +11783,13 @@ snapshots:
   '@ai-sdk/anthropic@2.0.80(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/anthropic@3.0.62(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/anthropic@4.0.5(zod@4.3.6)':
@@ -11808,7 +11815,7 @@ snapshots:
   '@ai-sdk/gateway@2.0.96(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
@@ -11834,7 +11841,7 @@ snapshots:
   '@ai-sdk/google@2.0.74(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/google@4.0.6(zod@4.3.6)':
@@ -11846,7 +11853,7 @@ snapshots:
   '@ai-sdk/mcp@0.0.8(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       pkce-challenge: 5.0.1
       zod: 4.3.6
 
@@ -11859,7 +11866,7 @@ snapshots:
   '@ai-sdk/openai@2.0.106(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai@4.0.5(zod@4.3.6)':
@@ -11875,9 +11882,9 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 3.0.12
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.3.6
@@ -11911,6 +11918,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.12':
     dependencies:
       json-schema: 0.4.0
 
@@ -13919,8 +13930,8 @@ snapshots:
   '@mastra/core@1.37.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.10'
       '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)'
@@ -13969,8 +13980,8 @@ snapshots:
   '@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6)':
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.33(zod@4.3.6)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.10'
       '@isaacs/ttlcache': 2.1.5
@@ -17546,7 +17557,7 @@ snapshots:
     dependencies:
       '@ai-sdk/gateway': 2.0.96(zod@4.3.6)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.33(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
@@ -21656,7 +21667,7 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   pathe@2.0.3: {}
 
@@ -22371,7 +22382,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,12 +71,18 @@ overrides:
   glob: ^10.5.0
   qs: 6.15.2
   path-to-regexp@0.1.12: 0.1.13
+  # ReDoS only affects the 8.x line (CVE-2026-4926/-4923, >=8.0.0 <8.4.0).
+  path-to-regexp@8.3.0: 8.4.0
   ip-address@10.1.0: 10.2.0
-  "@ai-sdk/provider-utils@<=4.0.26": 4.0.27
-  "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@4.0.27"
+  # SSRF + throttling fixes land in 4.0.29/4.0.33. @mastra/core pins its
+  # provider-utils-v6 alias to exactly 4.0.27, which the range key can't
+  # catch — aliased deps need alias-name overrides (same reason -v5 exists).
+  "@ai-sdk/provider-utils@<=4.0.32": 4.0.33
+  "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@4.0.33"
+  "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.33"
   # @ag-ui/mastra imports parsePartialJson from @ai-sdk/ui-utils, whose module
   # evaluation needs exports (validatorSymbol) that only exist in its own
-  # provider-utils 2.x line — exempt it from the blanket 4.0.27 lift above.
+  # provider-utils 2.x line — exempt it from the blanket 4.0.33 lift above.
   "@ai-sdk/ui-utils>@ai-sdk/provider-utils": 2.2.8
   "@copilotkit/runtime@0.0.0-mme-ag-ui-0-0-46-20260227141603>@ag-ui/langgraph": 0.0.29
   # Keep Anthropic's Vertex client on an SDK version that emits Vertex rawPredict URLs.


### PR DESCRIPTION
Backport of #15518 (main commit 996870521) to `v3`.

Re-applied as a fresh bump on v3 rather than a raw cherry-pick since the lockfiles have drifted:

- `path-to-regexp` 8.3.0 → 8.4.0 via a version-scoped override (ReDoS, CVE-2026-4926/-4923 affect `>=8.0.0 <8.4.0`).
- `@ai-sdk/provider-utils` 4.0.27 → 4.0.33: range override widened to `<=4.0.32`, `-v5` alias bumped, and the `-v6` alias override added so @mastra/core's aliased pin is caught too (range keys can't match aliased deps). Pulls in `@ai-sdk/provider` 3.0.12 as its dependency.
- The `@ai-sdk/ui-utils` exemption keeping its own provider-utils 2.x line is unchanged.

Incidental: the lockfile regen picked up a newly published `deprecated` registry notice on `react-grid-layout@1.5.3` (metadata only, no version change) — this would land on any future lockfile touch anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport updates dependency overrides and lockfile resolutions for patched package versions.
- Pins `path-to-regexp` 8.3.0 consumers to 8.4.0.
- Updates `@ai-sdk/provider-utils` 4.x resolutions and v5/v6 aliases to 4.0.33 while preserving the `@ai-sdk/ui-utils` 2.x exemption.
- Regenerates the lockfile with `@ai-sdk/provider` 3.0.12 and registry deprecation metadata for `react-grid-layout`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable changed-code defects identified.

The workspace overrides and generated lockfile consistently resolve the targeted dependency lines to the intended patched versions without changing the exempt provider-utils 2.x path.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump Snyk-flagged path-to-r..."](https://github.com/langfuse/langfuse/commit/df8cfa9cc65c1278716d917800abd5c71ef52b11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48266583)</sub>

<!-- /greptile_comment -->