### PR TITLE
fix(mcp): support logical root observation filters

### DIFF
--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -437,6 +437,7 @@ const OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMN_IDS = [
   "output",
   "metadata",
   "traceTags",
+  "isRootObservation",
   "hasParentObservation",
 ] as const satisfies readonly EventsTableColumnId[];
 

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -2069,10 +2069,13 @@ describe("MCP Read Tools", () => {
   });
 
   maybeEventsTable("getObservationFilterValues tool", () => {
-    it("should expose read-only semantic-root inputs", () => {
+    it("should have readOnlyHint annotation", () => {
       verifyToolAnnotations(getObservationFilterValuesTool, {
         readOnlyHint: true,
       });
+    });
+
+    it("should expose semantic-root inputs", () => {
       const properties = getObservationFilterValuesTool.inputSchema
         .properties as Record<string, unknown>;
 

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -289,6 +289,7 @@ const createObservationEvent = (params: {
   type?: "GENERATION" | "SPAN" | "EVENT";
   startTime?: Date;
   parentObservationId?: string | null;
+  isAppRoot?: boolean;
   providedModelName?: string;
   input?: string;
   output?: string;
@@ -308,6 +309,7 @@ const createObservationEvent = (params: {
     span_id: observationId,
     trace_id: params.traceId ?? randomUUID(),
     parent_span_id: params.parentObservationId ?? null,
+    is_app_root: params.isAppRoot ?? false,
     project_id: params.projectId,
     name: params.name ?? `mcp-observation-${nanoid()}`,
     type: params.type ?? "GENERATION",
@@ -715,9 +717,10 @@ describe("MCP Read Tools", () => {
     });
 
     it("should return the observation projection field schema", async () => {
-      const { context } = await createMcpTestSetup();
-
-      const result = (await handleGetObservationFieldSchema({}, context)) as {
+      const result = (await handleGetObservationFieldSchema(
+        {},
+        mockServerContext(),
+      )) as {
         resource: string;
         defaultFields: string[];
         fields: Record<
@@ -754,6 +757,7 @@ describe("MCP Read Tools", () => {
       expect(result.fields.providedModelName.nullable).toBe(true);
       expect(result.fields.startTime.type).toBe("datetime");
       expect(result.fields.startTime.nullable).toBe(false);
+      expect(result.fields.isRootObservation.type).toBe("boolean");
       expect(result.fields.costDetails.type).toBe("map<string, number>");
       expect(result.fields.input.expensive).toBe(true);
       expect(result.fields.input.sensitive).toBe(true);
@@ -821,6 +825,7 @@ describe("MCP Read Tools", () => {
       ["modelId", "stringOptions", true],
       ["providedModelName", "stringOptions", true],
       ["tags", "arrayOptions", false],
+      ["isRootObservation", "boolean", false],
       ["hasParentObservation", "boolean", false],
     ])(
       "should expose the %s column used by observation filter values",
@@ -865,9 +870,13 @@ describe("MCP Read Tools", () => {
     });
 
     it("should expose object-shaped advanced filters in the tool schema", () => {
-      const filterSchema = (
-        listObservationsTool.inputSchema.properties as Record<string, unknown>
-      ).filter as
+      const properties = listObservationsTool.inputSchema.properties as Record<
+        string,
+        unknown
+      >;
+      expect(properties.isRootObservation).toMatchObject({ type: "boolean" });
+
+      const filterSchema = properties.filter as
         | {
             type?: string;
             items?: {
@@ -1015,6 +1024,7 @@ describe("MCP Read Tools", () => {
         name: observation.name,
         type: "GENERATION",
         level: "DEFAULT",
+        isRootObservation: true,
         providedModelName: "gpt-4o-mini",
         url: buildObservationUrl({
           projectId,
@@ -1160,6 +1170,68 @@ describe("MCP Read Tools", () => {
           observationId: result.data[0]!.id,
         }),
       });
+    });
+
+    it("should expose semantic roots across list and filter values", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const traceId = randomUUID();
+      const parentlessRoot = createObservationEvent({ projectId, traceId });
+      const appRoot = createObservationEvent({
+        projectId,
+        traceId,
+        parentObservationId: randomUUID(),
+        isAppRoot: true,
+      });
+      const child = createObservationEvent({
+        projectId,
+        traceId,
+        parentObservationId: appRoot.id,
+      });
+
+      await createEventsCh([parentlessRoot, appRoot, child]);
+
+      const rootResult = (await handleListObservations(
+        {
+          traceId,
+          isRootObservation: true,
+          fields: ["id", "parentObservationId", "isRootObservation"],
+          limit: 100,
+        },
+        context,
+      )) as { data: Array<Record<string, unknown> & { id: string }> };
+
+      const getRootValues = async (isRootObservation?: boolean) =>
+        (await handleGetObservationFilterValues(
+          {
+            column: "isRootObservation",
+            isRootObservation,
+            limit: 100,
+          },
+          context,
+        )) as { values: Array<{ value: boolean; count?: number }> };
+      const [allRootValues, scopedRootValues] = await Promise.all([
+        getRootValues(),
+        getRootValues(true),
+      ]);
+
+      expect(new Set(rootResult.data.map(({ id }) => id))).toEqual(
+        new Set([parentlessRoot.id, appRoot.id]),
+      );
+      expect(rootResult.data.find(({ id }) => id === appRoot.id)).toMatchObject(
+        {
+          parentObservationId: appRoot.parent_span_id,
+          isRootObservation: true,
+        },
+      );
+      expect(
+        allRootValues.values.map(({ value, count }) => [value, count]),
+      ).toEqual([
+        [false, 1],
+        [true, 2],
+      ]);
+      expect(
+        scopedRootValues.values.map(({ value, count }) => [value, count]),
+      ).toEqual([[true, 2]]);
     });
 
     it("should match advanced input filters beyond the events_core truncation boundary", async () => {
@@ -1997,9 +2069,16 @@ describe("MCP Read Tools", () => {
   });
 
   maybeEventsTable("getObservationFilterValues tool", () => {
-    it("should have readOnlyHint annotation", () => {
+    it("should expose read-only semantic-root inputs", () => {
       verifyToolAnnotations(getObservationFilterValuesTool, {
         readOnlyHint: true,
+      });
+      const properties = getObservationFilterValuesTool.inputSchema
+        .properties as Record<string, unknown>;
+
+      expect(properties).toMatchObject({
+        column: { enum: expect.arrayContaining(["isRootObservation"]) },
+        isRootObservation: { type: "boolean" },
       });
     });
 

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -549,6 +549,7 @@ export async function getEventFilterValuePage(
   params: GetObservationsFilterOptionsParams & {
     column:
       | "traceTags"
+      | "isRootObservation"
       | "hasParentObservation"
       | "providedModelName"
       | "modelId"

--- a/web/src/features/mcp/features/observations/schema.ts
+++ b/web/src/features/mcp/features/observations/schema.ts
@@ -20,10 +20,8 @@ type ObservationMcpFieldDefinition = ObservationMcpFieldMetadata & {
   group: ObservationFieldGroupPublicApi;
 };
 
-type ObservationMcpField = Exclude<
-  (typeof OBSERVATION_FIELD_GROUP_FIELD_NAMES)[ObservationFieldGroupPublicApi][number],
-  "isRootObservation"
->;
+type ObservationMcpField =
+  (typeof OBSERVATION_FIELD_GROUP_FIELD_NAMES)[ObservationFieldGroupPublicApi][number];
 
 type ObservationMcpFieldType =
   | "array"
@@ -35,11 +33,10 @@ type ObservationMcpFieldType =
   | "string"
   | "unknown";
 
-const OBSERVATION_MCP_FIELDS = OBSERVATION_FIELD_GROUPS_PUBLIC_API.flatMap(
-  (group) => OBSERVATION_FIELD_GROUP_FIELD_NAMES[group],
-).filter(
-  (field): field is ObservationMcpField => field !== "isRootObservation",
-);
+const OBSERVATION_MCP_FIELDS: ObservationMcpField[] =
+  OBSERVATION_FIELD_GROUPS_PUBLIC_API.flatMap(
+    (group) => OBSERVATION_FIELD_GROUP_FIELD_NAMES[group],
+  );
 
 const OBSERVATION_MCP_FIELD_SET = new Set<string>(OBSERVATION_MCP_FIELDS);
 
@@ -53,6 +50,12 @@ const OBSERVATION_MCP_FIELD_METADATA: Record<
   endTime: { type: "datetime", nullable: true, default: true },
   projectId: { type: "string", sensitive: true },
   parentObservationId: { type: "string", nullable: true, default: true },
+  isRootObservation: {
+    type: "boolean",
+    default: true,
+    description:
+      "Whether this observation is a logical root. App-root observations can be roots while retaining a non-null parentObservationId.",
+  },
   type: { type: "string", default: true },
   name: { type: "string", nullable: true, default: true },
   level: { type: "string", default: true },

--- a/web/src/features/mcp/features/observations/schema.ts
+++ b/web/src/features/mcp/features/observations/schema.ts
@@ -33,10 +33,9 @@ type ObservationMcpFieldType =
   | "string"
   | "unknown";
 
-const OBSERVATION_MCP_FIELDS: ObservationMcpField[] =
-  OBSERVATION_FIELD_GROUPS_PUBLIC_API.flatMap(
-    (group) => OBSERVATION_FIELD_GROUP_FIELD_NAMES[group],
-  );
+const OBSERVATION_MCP_FIELDS = OBSERVATION_FIELD_GROUPS_PUBLIC_API.flatMap(
+  (group) => OBSERVATION_FIELD_GROUP_FIELD_NAMES[group],
+);
 
 const OBSERVATION_MCP_FIELD_SET = new Set<string>(OBSERVATION_MCP_FIELDS);
 

--- a/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
+++ b/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
@@ -34,6 +34,7 @@ const OBSERVATION_MCP_FILTER_VALUE_COLUMNS = [
   "latency",
   "timeToFirstToken",
   "tags",
+  "isRootObservation",
   "hasParentObservation",
 ] as const satisfies readonly ObservationMcpFilterColumn[];
 
@@ -46,6 +47,7 @@ const GetObservationFilterValuesBaseSchema = z.object({
   fromStartTime: z.iso.datetime({ offset: true }).optional(),
   toStartTime: z.iso.datetime({ offset: true }).optional(),
   observationType: ObservationTypeDomain.optional(),
+  isRootObservation: z.boolean().optional(),
   hasParentObservation: z.boolean().optional(),
   limit: ObservationLimitSchema,
   cursor: z.string().optional(),
@@ -89,8 +91,8 @@ const normalizeFilterOptions = (
 ): FilterOption[] => {
   const normalizeValue = (value: unknown): string | boolean | null => {
     if (typeof value === "string") {
-      // Special handling for the "hasParentObservation" column to convert "true"/"false" strings to boolean values.
-      if (column === "hasParentObservation") {
+      // ClickHouse returns boolean filter options as "true"/"false" strings.
+      if (column === "isRootObservation" || column === "hasParentObservation") {
         if (value === "true") return true;
         if (value === "false") return false;
       }
@@ -185,6 +187,7 @@ export const [
             column: eventsColumn,
             projectId: context.projectId,
             startTimeFilter,
+            isRootObservation: input.isRootObservation,
             hasParentObservation: input.hasParentObservation,
             observationType: input.observationType,
           });
@@ -203,6 +206,7 @@ export const [
           column: eventsColumn,
           projectId: context.projectId,
           startTimeFilter,
+          isRootObservation: input.isRootObservation,
           hasParentObservation: input.hasParentObservation,
           observationType: input.observationType,
           limit: input.limit,

--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -218,7 +218,16 @@ const ListObservationsBaseSchema = z.object({
   level: ObservationLevelDomain.optional(),
   traceId: z.string().optional(),
   version: z.string().optional(),
-  parentObservationId: z.string().optional(),
+  parentObservationId: z
+    .string()
+    .optional()
+    .describe("Physical parent observation ID to match exactly."),
+  isRootObservation: z
+    .boolean()
+    .optional()
+    .describe(
+      "Filter by logical root status. App-root observations can match true while retaining a non-null parentObservationId.",
+    ),
   // TODO: Re-enable string[] once the public observations API correctly
   // applies allow-multiple environment filters instead of dropping arrays.
   // see: https://linear.app/langfuse/issue/LFE-9852/bug-observations-api-accepts-multiple-environment-params-but-ignores
@@ -346,6 +355,7 @@ export const [listObservationsTool, handleListObservations] = defineTool({
             type: input.type,
             environment: input.environment,
             parentObservationId: input.parentObservationId,
+            isRootObservation: input.isRootObservation,
             fromStartTime: input.fromStartTime,
             toStartTime: input.toStartTime,
             version: input.version,


### PR DESCRIPTION
## What

- expose `isRootObservation` through the MCP observations filter schema and whitelist
- pass the logical-root filter through list and filter-value tools
- cover filtering physical roots, app roots with external parents, and ordinary children

## Stack

1. Base API/shared support: [#15567](https://github.com/langfuse/langfuse/pull/15567)
2. **MCP-only support — this PR**
3. Evaluator-only support: `lfe-13786-bug-app-root-observations-evals`

This PR targets the base branch intentionally so its diff contains only MCP changes.

Issue: [LFE-13786](https://linear.app/clickhouse/issue/LFE-13786/bug-app-root-observations-are-not-exposed-as-roots-in-the-observations)

## Verification

- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- MCP server tests — `Tests 164 passed (164)`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds logical-root observation support across MCP and public API filtering.

- Exposes `isRootObservation` in observation schemas, projections, and filter whitelists.
- Implements ClickHouse projection and filtering for physical roots and SDK-designated app roots.
- Passes the logical-root filter through MCP list and filter-value tools.
- Adds server tests covering root projection, filtering, and filter-value counts.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The logical-root predicate is consistently projected, filtered, converted, and exposed through the MCP and public API paths, with end-to-end coverage for physical roots, app roots, and children.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  MCP[MCP observation tools] --> API[Observation query parameters]
  API --> Filter[Public API filter builder]
  Filter --> CH[(ClickHouse events table)]
  CH --> Root["parent_span_id = '' OR is_app_root"]
  Root --> Projection[isRootObservation projection]
  Projection --> Response[MCP / Public API response]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): address review feedback"](https://github.com/langfuse/langfuse/commit/fd9d74e81009781c1f03e96c9463ac73f5461ee7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48309285)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->