### PR TITLE
fix(web): gate v4-migration claims on readiness; sync V4 Preview label

### DIFF
--- a/packages/shared/scripts/seeder/README.md
+++ b/packages/shared/scripts/seeder/README.md
@@ -113,7 +113,7 @@ trace-level fields the v4 aggregations read, and root observations hang off
 it. `events_core` fills via the materialized view. Facts that matter:
 
 - `events_full` has no `id` column; `span_id` is the row identifier
-- the v4 read path is the per-user "Fast (Preview)" sidebar toggle or
+- the v4 read path is the per-user "V4 Preview" sidebar toggle or
   `LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only` server-side; the trace URL
   is identical in both modes
 - `many-traces` is deliberately v3-only — its traces correctly show "not

--- a/web/src/components/session/README.md
+++ b/web/src/components/session/README.md
@@ -26,7 +26,7 @@ correction visibility, inline-tool visibility, and system-prompt visibility so
 virtual row remounts do not reset view state. On the events-backed session
 page, `modernSession` is a user Feature Preview flag; disabled users retain the
 card layout without a page-level layout control. The preview toggle is disabled
-unless Fast (Preview) selects this events-backed page.
+unless the V4 Preview toggle selects this events-backed page.
 
 Server/query state remains in tRPC and React Query. Active Modern Session state
 is derived from TanStack Virtual's current scroll offset unless the user

--- a/web/src/features/events/components/V4SidebarToggle.tsx
+++ b/web/src/features/events/components/V4SidebarToggle.tsx
@@ -18,9 +18,10 @@ import {
   toExperimentsResultsUrl,
 } from "@/src/features/experiments/utils/experimentUrlTranslation";
 
-const V4_PREVIEW_LABEL = "V4 Preview";
-const V4_PREVIEW_DESCRIPTION =
-  "Get a more performant Langfuse experience. Upgrade SDKs to the latest major for real-time data. This is a personal setting.";
+import {
+  V4_PREVIEW_LABEL,
+  V4_PREVIEW_DESCRIPTION,
+} from "@/src/features/events/lib/v4PreviewLabel";
 
 function asSingleValue(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;

--- a/web/src/features/events/lib/v4PreviewLabel.ts
+++ b/web/src/features/events/lib/v4PreviewLabel.ts
@@ -1,0 +1,6 @@
+// User-facing name and description of the V4 Preview toggle. Shared by every
+// surface that renders or references the toggle in copy (sidebar, migration
+// panel, feature-preview gating messages) so a rename stays in sync.
+export const V4_PREVIEW_LABEL = "V4 Preview";
+export const V4_PREVIEW_DESCRIPTION =
+  "Get a more performant Langfuse experience. Upgrade SDKs to the latest major for real-time data. This is a personal setting.";

--- a/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
@@ -3,6 +3,7 @@ import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { V4_PREVIEW_LABEL } from "@/src/features/events/lib/v4PreviewLabel";
 import { api } from "@/src/utils/api";
 
 import {
@@ -60,7 +61,7 @@ export function ControlledFeaturePreviewModal({
         !isBetaEnabled ||
         authSession.data?.environment.enableExperimentalFeatures === true,
       warningReason: !isBetaEnabled
-        ? "Compact Session View is only available on the events-backed session view. Turn on Fast (Preview) to enable it."
+        ? `Compact Session View is only available on the events-backed session view. Turn on ${V4_PREVIEW_LABEL} to enable it.`
         : authSession.data?.environment.enableExperimentalFeatures === true
           ? "This preview is enabled by LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES, so a per-user opt-out does not disable it."
           : undefined,

--- a/web/src/features/v4-migration/V4MigrationBanner.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationBanner.clienttest.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { V4MigrationBanner } from "./V4MigrationBanner";
+import { type ProjectMigrationStatus } from "./migrationData";
+
+const mocks = vi.hoisted(() => ({
+  statusByProjectId: new Map<string, object>(),
+  organizationsArg: undefined as unknown,
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: {
+      user: {
+        organizations: [
+          {
+            id: "org-1",
+            name: "Org 1",
+            projects: [
+              { id: "project-1", name: "Project 1", deletedAt: null },
+              { id: "project-deleted", name: "Deleted", deletedAt: new Date() },
+            ],
+          },
+          {
+            id: "demo-org",
+            name: "Demo",
+            projects: [{ id: "demo-project", name: "Demo", deletedAt: null }],
+          },
+        ],
+      },
+    },
+  }),
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: { NEXT_PUBLIC_DEMO_ORG_ID: "demo-org" },
+}));
+
+vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
+  useAccountV4MigrationData: (params: { organizations: unknown }) => {
+    mocks.organizationsArg = params.organizations;
+    return mocks.statusByProjectId;
+  },
+}));
+
+const status = (overrides?: Partial<ProjectMigrationStatus>) =>
+  ({
+    sdk: { status: "latest", sdkUsageSeries: [], upgradeRequiredCount: 0 },
+    evals: { status: "loaded", count: 0 },
+    apis: { status: "loaded", count: 0 },
+    exports: { status: "loaded", count: 0 },
+    ...overrides,
+  }) as ProjectMigrationStatus;
+
+describe("V4MigrationBanner", () => {
+  beforeEach(() => {
+    mocks.statusByProjectId = new Map();
+  });
+
+  it("shows while a project still needs migration work", () => {
+    mocks.statusByProjectId.set(
+      "project-1",
+      status({ evals: { status: "loaded", count: 2 } }),
+    );
+    render(<V4MigrationBanner />);
+    expect(
+      screen.getByText(/All projects need an upgrade/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides once every project is ready", () => {
+    mocks.statusByProjectId.set("project-1", status());
+    render(<V4MigrationBanner />);
+    expect(
+      screen.queryByText(/All projects need an upgrade/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides while readiness is still being checked", () => {
+    mocks.statusByProjectId.set(
+      "project-1",
+      status({ evals: { status: "loading", count: 0 } }),
+    );
+    render(<V4MigrationBanner />);
+    expect(
+      screen.queryByText(/All projects need an upgrade/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("excludes the demo org and deleted projects from the queried scope", () => {
+    mocks.statusByProjectId.set("project-1", status());
+    render(<V4MigrationBanner />);
+    expect(mocks.organizationsArg).toEqual([
+      {
+        id: "org-1",
+        name: "Org 1",
+        projects: [{ id: "project-1", name: "Project 1" }],
+      },
+    ]);
+  });
+});

--- a/web/src/features/v4-migration/V4MigrationBanner.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationBanner.clienttest.tsx
@@ -62,10 +62,25 @@ describe("V4MigrationBanner", () => {
     mocks.statusByProjectId = new Map();
   });
 
-  it("shows while a project still needs migration work", () => {
+  it("shows while the only project still needs migration work", () => {
     mocks.statusByProjectId.set(
       "project-1",
       status({ evals: { status: "loaded", count: 2 } }),
+    );
+    render(<V4MigrationBanner />);
+    expect(
+      screen.getByText(/Your project needs an upgrade/),
+    ).toBeInTheDocument();
+  });
+
+  it("says all projects need an upgrade only when they all do", () => {
+    mocks.statusByProjectId.set(
+      "project-1",
+      status({ evals: { status: "loaded", count: 2 } }),
+    );
+    mocks.statusByProjectId.set(
+      "project-2",
+      status({ apis: { status: "loaded", count: 1 } }),
     );
     render(<V4MigrationBanner />);
     expect(
@@ -73,12 +88,22 @@ describe("V4MigrationBanner", () => {
     ).toBeInTheDocument();
   });
 
+  it("counts the projects needing an upgrade in mixed accounts", () => {
+    mocks.statusByProjectId.set(
+      "project-1",
+      status({ evals: { status: "loaded", count: 2 } }),
+    );
+    mocks.statusByProjectId.set("project-2", status());
+    render(<V4MigrationBanner />);
+    expect(
+      screen.getByText(/1 of your 2 projects needs an upgrade/),
+    ).toBeInTheDocument();
+  });
+
   it("hides once every project is ready", () => {
     mocks.statusByProjectId.set("project-1", status());
     render(<V4MigrationBanner />);
-    expect(
-      screen.queryByText(/All projects need an upgrade/),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/an upgrade/)).not.toBeInTheDocument();
   });
 
   it("hides while readiness is still being checked", () => {
@@ -87,9 +112,7 @@ describe("V4MigrationBanner", () => {
       status({ evals: { status: "loading", count: 0 } }),
     );
     render(<V4MigrationBanner />);
-    expect(
-      screen.queryByText(/All projects need an upgrade/),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/an upgrade/)).not.toBeInTheDocument();
   });
 
   it("excludes the demo org and deleted projects from the queried scope", () => {

--- a/web/src/features/v4-migration/V4MigrationBanner.tsx
+++ b/web/src/features/v4-migration/V4MigrationBanner.tsx
@@ -1,8 +1,12 @@
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import { Zap } from "lucide-react";
 import { Callout } from "@/src/components/ui/callout";
 import { Button } from "@/src/components/ui/button";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { useAccountV4MigrationData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
+import { getProjectMigrationReadiness } from "@/src/features/v4-migration/migrationData";
+import { env } from "@/src/env.mjs";
 
 const V4_DOCS_URL = "https://langfuse.com/docs/v4";
 // Shorter than the Callout default (30d) so the banner resurfaces while the
@@ -11,10 +15,36 @@ const DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Org-overview banner announcing v4 with links to the migration status page
- * and docs. Replaces the agent-tools banner for v4-upgrade users.
+ * and docs. Replaces the agent-tools banner for v4-upgrade users. Only shown
+ * while at least one project still needs migration work — the queries are the
+ * same ones the project tiles' migration chips use, so react-query dedupes
+ * them.
  */
 export function V4MigrationBanner() {
   const capture = usePostHogClientCapture();
+  const session = useSession();
+
+  // The demo org is not the user's to migrate, so it never triggers the banner.
+  const organizations = (session.data?.user?.organizations ?? [])
+    .filter((org) => org.id !== env.NEXT_PUBLIC_DEMO_ORG_ID)
+    .map((org) => ({
+      id: org.id,
+      name: org.name,
+      projects: org.projects
+        .filter((project) => !project.deletedAt)
+        .map((project) => ({ id: project.id, name: project.name })),
+    }));
+  const migrationStatusByProjectId = useAccountV4MigrationData({
+    organizations,
+    enabled: organizations.length > 0,
+  });
+  const someProjectNeedsMigration = Array.from(
+    migrationStatusByProjectId.values(),
+  ).some((status) => getProjectMigrationReadiness(status) === "action-needed");
+
+  if (!someProjectNeedsMigration) {
+    return null;
+  }
 
   return (
     <Callout

--- a/web/src/features/v4-migration/V4MigrationBanner.tsx
+++ b/web/src/features/v4-migration/V4MigrationBanner.tsx
@@ -38,11 +38,12 @@ export function V4MigrationBanner() {
     organizations,
     enabled: organizations.length > 0,
   });
-  const someProjectNeedsMigration = Array.from(
-    migrationStatusByProjectId.values(),
-  ).some((status) => getProjectMigrationReadiness(status) === "action-needed");
+  const statuses = Array.from(migrationStatusByProjectId.values());
+  const projectsNeedingMigration = statuses.filter(
+    (status) => getProjectMigrationReadiness(status) === "action-needed",
+  ).length;
 
-  if (!someProjectNeedsMigration) {
+  if (projectsNeedingMigration === 0) {
     return null;
   }
 
@@ -86,7 +87,11 @@ export function V4MigrationBanner() {
           <span className="font-bold">
             Langfuse v4 is here: real-time and up to 165× faster.
           </span>{" "}
-          All projects need an upgrade.
+          {projectsNeedingMigration === statuses.length
+            ? projectsNeedingMigration === 1
+              ? "Your project needs an upgrade."
+              : "All projects need an upgrade."
+            : `${projectsNeedingMigration} of your ${statuses.length} projects ${projectsNeedingMigration === 1 ? "needs" : "need"} an upgrade.`}
         </span>
       </div>
     </Callout>

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1,7 +1,11 @@
 import { render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { V4MigrationDetailsContent } from "./V4MigrationContent";
+import {
+  V4MigrationDetailsContent,
+  V4MigrationHeaderContent,
+} from "./V4MigrationContent";
+import { type MigrationCountState } from "./migrationData";
 
 const mocks = vi.hoisted(() => ({
   migrationData: {
@@ -10,12 +14,13 @@ const mocks = vi.hoisted(() => ({
       sdkUsageSeries: [],
       upgradeRequiredCount: 0,
     },
-    evals: { status: "loaded" as const, count: 0 },
-    apis: { status: "loaded" as const, count: 1 },
-    exports: { status: "loaded" as const, count: 3 },
+    evals: { status: "loaded", count: 0 } as MigrationCountState,
+    apis: { status: "loaded", count: 1 } as MigrationCountState,
+    exports: { status: "loaded", count: 3 } as MigrationCountState,
     apiUsage: [{ endpoint: "GET /api/public/traces", count: 42 }],
     legacyIntegrations: ["PostHog", "Mixpanel", "Blob Storage"],
   },
+  canToggleV4: true,
 }));
 
 vi.mock("next/router", () => ({
@@ -62,6 +67,11 @@ vi.mock("@/src/features/events/components/V4SidebarToggle", () => ({
   V4PreviewToggleRow: () => null,
 }));
 
+// The details content reads canToggleV4 to gate the toggle section's copy.
+vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
+  useV4Beta: () => ({ canToggleV4: mocks.canToggleV4 }),
+}));
+
 vi.mock("@/src/components/ui/collapsible", () => ({
   Collapsible: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -76,6 +86,7 @@ vi.mock("@/src/components/ui/collapsible", () => ({
 
 describe("V4MigrationDetailsContent", () => {
   beforeEach(() => {
+    mocks.canToggleV4 = true;
     mocks.migrationData.apis = { status: "loaded", count: 1 };
     mocks.migrationData.exports = { status: "loaded", count: 3 };
     mocks.migrationData.apiUsage = [
@@ -143,5 +154,54 @@ describe("V4MigrationDetailsContent", () => {
     expect(
       screen.getByText("No deprecated evals detected."),
     ).toBeInTheDocument();
+  });
+
+  it("shows the preview-toggle section only when the session can toggle v4", () => {
+    const { unmount } = render(
+      <V4MigrationDetailsContent projectId="project-1" />,
+    );
+    expect(screen.getByText("Want to review first?")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Use this toggle to compare both views/),
+    ).toBeInTheDocument();
+    unmount();
+
+    mocks.canToggleV4 = false;
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+    expect(screen.queryByText("Want to review first?")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Use this toggle to compare both views/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("V4MigrationHeaderContent", () => {
+  beforeEach(() => {
+    mocks.migrationData.apis = { status: "loaded", count: 1 };
+    mocks.migrationData.exports = { status: "loaded", count: 3 };
+  });
+
+  it("claims the project needs migrating while checks report action needed", () => {
+    render(<V4MigrationHeaderContent projectId="project-1" />);
+    expect(
+      screen.getByText(/This project still uses the previous setup/),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the status claim once every check is clean", () => {
+    mocks.migrationData.apis = { status: "loaded", count: 0 };
+    mocks.migrationData.exports = { status: "loaded", count: 0 };
+    render(<V4MigrationHeaderContent projectId="project-1" />);
+    expect(
+      screen.queryByText(/This project still uses the previous setup/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("drops the status claim while checks are still loading", () => {
+    mocks.migrationData.apis = { status: "loading", count: 0 };
+    render(<V4MigrationHeaderContent projectId="project-1" />);
+    expect(
+      screen.queryByText(/This project still uses the previous setup/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -29,9 +29,11 @@ import {
 } from "@/src/features/v4-migration/sdkVersionStatus";
 import { useProjectV4MigrationData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 import {
+  getProjectMigrationReadiness,
   V4_MIGRATION_LOOKBACK_DAYS,
   type MigrationCountState,
 } from "@/src/features/v4-migration/migrationData";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { numberFormatter } from "@/src/utils/numbers";
 import { formatCompactRelativeTime } from "@/src/utils/dates";
 import { useProject } from "@/src/features/projects/hooks";
@@ -285,15 +287,30 @@ function V4MigrationSdkSection({ sdk }: { sdk: V4MigrationSdkState }) {
 // agent, the second click copies it.
 export function V4MigrationHeaderContent({
   projectName,
+  projectId,
   onNavigate,
 }: {
   projectName?: string;
+  projectId?: string;
   /** Fires when an internal link is followed so the surface can close. */
   onNavigate?: () => void;
 }) {
   const capture = usePostHogClientCapture();
   const handleCopyPrompt = useCopyMigrationPrompt();
   const [promptVisible, setPromptVisible] = useState(false);
+
+  // Same queries as V4MigrationDetailsContent below, so react-query dedupes
+  // them. Only claim the project needs migrating once the checks confirm it —
+  // a fully migrated project shows the v4 value prop without a status claim.
+  const { organization } = useProject(projectId ?? null);
+  const migrationData = useProjectV4MigrationData({
+    projectId,
+    orgId: organization?.id,
+    enabled: Boolean(projectId),
+  });
+  const needsMigration =
+    Boolean(projectId) &&
+    getProjectMigrationReadiness(migrationData) === "action-needed";
 
   const handleShowPrompt = () => {
     capture("v4_migration:coding_agent_prompt_viewed");
@@ -322,8 +339,9 @@ export function V4MigrationHeaderContent({
           Langfuse v4
         </ExternalLink>{" "}
         is here: real-time, up to 165× faster, plus new dashboards, alerting,
-        sessions, and trace view. This project still uses the previous setup,
-        which stops working soon.
+        sessions, and trace view.
+        {needsMigration &&
+          " This project still uses the previous setup, which stops working soon."}
       </p>
       <div className="flex flex-col gap-2">
         {promptVisible && (
@@ -380,6 +398,7 @@ export function V4MigrationDetailsContent({
     orgId: organization?.id,
     enabled: Boolean(projectId),
   });
+  const { canToggleV4 } = useV4Beta();
 
   const handleEmailEngineer = () => {
     capture("v4_migration:contact_support_clicked");
@@ -410,26 +429,33 @@ export function V4MigrationDetailsContent({
 
   return (
     <>
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 text-base font-bold">
-            <LibraryBig className="h-4 w-4" /> Want to review first?
+      {/* The toggle row hides itself when the session cannot toggle v4
+          (legacy/events_only write mode, post-rollout auto-enrollment), so the
+          copy describing it must hide on the same condition. */}
+      {canToggleV4 && (
+        <>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 text-base font-bold">
+                <LibraryBig className="h-4 w-4" /> Want to review first?
+              </div>
+              <V4PreviewToggleRow projectId={projectId} />
+            </div>
+            <p className="text-muted-foreground text-sm">
+              The latest SDK no longer sets trace input and output; v4{" "}
+              <ExternalLink
+                href={OBSERVATIONS_DATA_MODEL_URL}
+                className="text-inherit underline"
+              >
+                infers them from observations
+              </ExternalLink>
+              . Use this toggle to compare both views while you upgrade.
+            </p>
           </div>
-          <V4PreviewToggleRow projectId={projectId} />
-        </div>
-        <p className="text-muted-foreground text-sm">
-          The latest SDK no longer sets trace input and output; v4{" "}
-          <ExternalLink
-            href={OBSERVATIONS_DATA_MODEL_URL}
-            className="text-inherit underline"
-          >
-            infers them from observations
-          </ExternalLink>
-          . Use this toggle to compare both views while you upgrade.
-        </p>
-      </div>
 
-      <Separator />
+          <Separator />
+        </>
+      )}
 
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-2">

--- a/web/src/features/v4-migration/V4MigrationModal.tsx
+++ b/web/src/features/v4-migration/V4MigrationModal.tsx
@@ -61,6 +61,7 @@ function V4MigrationModalContent({
         <DialogBody className="gap-0 p-4">
           <V4MigrationHeaderContent
             projectName={project.name}
+            projectId={project.id}
             onNavigate={() => setOpen(false)}
           />
           <Separator className="my-6" />

--- a/web/src/features/v4-migration/V4MigrationPanel.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanel.tsx
@@ -54,6 +54,7 @@ export const V4MigrationPanel = ({
         <div className="bg-background sticky top-0 z-[1] px-4 pt-4">
           <V4MigrationHeaderContent
             projectName={project?.name}
+            projectId={project?.id}
             onNavigate={() => setOpen(false)}
           />
           <Separator className="mt-6" />

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -8,6 +8,7 @@ import { StringNoHTML } from "@langfuse/shared";
 import { Role, Prisma } from "@langfuse/shared/src/db";
 import type { PrismaClient } from "@langfuse/shared/src/db";
 import { canToggleV4 } from "@/src/features/events/lib/v4Rollout";
+import { V4_PREVIEW_LABEL } from "@/src/features/events/lib/v4PreviewLabel";
 import { env } from "@/src/env.mjs";
 import { getSfdcService } from "@/src/ee/features/sfdc-sync/server";
 
@@ -117,8 +118,7 @@ export const userAccountRouter = createTRPCRouter({
       if (input.enabled && !canEnableFeaturePreviews) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
-          message:
-            "Feature previews require Fast (Preview) on self-hosted deployments.",
+          message: `Feature previews require ${V4_PREVIEW_LABEL} on self-hosted deployments.`,
         });
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #15543, addressing the three review nits left on that PR:

### Readiness-gated copy
- **Panel/modal header**: "This project still uses the previous setup, which stops working soon." now only renders when the project's migration readiness checks confirm `action-needed`. Fully migrated projects (and loading/error states) see the v4 value prop without a status claim, matching the "Up to date" chips below. The header reuses the same queries as the details section, so react-query dedupes them.
- **Org-overview banner**: only shown while at least one non-demo, non-deleted project is `action-needed`, reusing the same queries the project tiles' migration chips already issue (deduped, no extra network). Fully migrated accounts see no banner.

### Toggle copy gating
- The "Want to review first?" section (header, toggle row, and the "Use this toggle to compare both views" paragraph) hides when the session cannot toggle v4 — the same `canToggleV4` gate `V4PreviewToggleRow` already applies internally — so the copy never describes a toggle that isn't on the page.

### Label sync
- New `v4PreviewLabel.ts` constants module; the two remaining user-facing "Fast (Preview)" strings (`userAccount.ts` precondition error, Compact Session View warning in `ControlledFeaturePreviewModal`) now use `V4_PREVIEW_LABEL` ("V4 Preview"). Also updated two stale README references.

## Impacted packages

- `web`
- `packages/shared` (seeder README only)

## Verification

- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm tc` — Tasks: 7 successful, 7 total
- `pnpm --filter web run test-client v4-migration events feature-previews` — 75 passed; new tests cover header claim per readiness state, banner visibility per readiness state (incl. demo-org/deleted-project exclusion), and toggle-section gating
- Skipped a local browser pass: the changed states are conditional renders (ready project, non-toggleable session) that local seed data doesn't express; the conditions are covered by the new clienttests, and default states are unchanged. Happy to verify on the PR preview if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns V4 Preview terminology and gates migration messaging on current readiness and toggle availability.
- Adds project-readiness gating to migration panel and modal status copy.
- Shows the organization banner only when at least one eligible project needs migration.
- Hides preview-toggle guidance when the current session cannot toggle V4.
- Centralizes the V4 Preview label and updates remaining documentation and error messages.
- Adds client tests for readiness and toggle-gating states.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The inaccurate account-wide migration claim should be corrected before merging because mixed-readiness accounts are told that every project requires an upgrade.

The new banner predicate intentionally activates for any action-needed project while the rendered message still generalizes that status to all projects.

**Files Needing Attention:** web/src/features/v4-migration/V4MigrationBanner.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4-migration/V4MigrationBanner.tsx:41-43
**Banner overstates project readiness**

When an account has both ready and action-needed projects, the new `.some()` predicate displays the banner while its copy says that all projects need an upgrade, giving users an incorrect account-wide migration status.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update Fast (Preview) toggle name ..."](https://github.com/langfuse/langfuse/commit/fa9eec00724d10b4c51447c7480a6de976befaaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48283814)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->