### PR TITLE
fix(pricing): add missing output_reasoning price keys to gpt-5.3-codex

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3875,7 +3875,7 @@
     "modelName": "gpt-5.3-codex",
     "matchPattern": "(?i)^(openai\/)?(gpt-5.3-codex)$",
     "createdAt": "2026-07-27T00:00:00.000Z",
-    "updatedAt": "2026-07-27T00:00:00.000Z",
+    "updatedAt": "2026-07-29T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -3893,7 +3893,9 @@
           "input": 1.75e-6,
           "input_cached_tokens": 0.175e-6,
           "input_cache_read": 0.175e-6,
-          "output": 14e-6
+          "output": 14e-6,
+          "output_reasoning_tokens": 14e-6,
+          "output_reasoning": 14e-6
         }
       }
     ]


### PR DESCRIPTION
The gpt-5.3-codex default pricing entry added in #15442 only defines `input`, `input_cached_tokens`, `input_cache_read`, and `output` — it is missing `output_reasoning` and `output_reasoning_tokens`, which every other non-mini/non-nano OpenAI 5.x reasoning entry in the file defines at the same rate as `output`.

Why it matters: `OtelIngestionProcessor` unconditionally splits reasoning tokens out of the `output` usage bucket into `output_reasoning_tokens` and subtracts them from `output`, and `IngestionService.calculateUsageCosts` silently skips any usage-detail key without a matching price. So every gpt-5.3-codex generation with reasoning tokens had those tokens priced at $0, understating cost by exactly the reasoning-token share.

Fix: add both keys at `14e-6` (same as `output`), matching the gpt-5.2 convention, and refresh `updatedAt`. Found by the review bot on the v3 backport (#15564), which carries the same fix.

Validated with `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs` (166 entries OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the default `gpt-5.3-codex` pricing entry.
- Adds `output_reasoning_tokens` and `output_reasoning` prices at the existing output-token rate.
- Advances `updatedAt` so the revised pricing data is synchronized.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new keys match the reasoning usage-detail names emitted by ingestion, use the same rate as ordinary output tokens, and the timestamp update ensures existing default pricing records receive the correction.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): add missing output\_reasoni..."](https://github.com/langfuse/langfuse/commit/c34e3ea8e6c50a0e9d754d461a4df9185d81df13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48285575)</sub>

<!-- /greptile_comment -->