### PR TITLE
fix(experiments): remove baseline enforcement from experiment ID collection

### DIFF
--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -882,7 +882,7 @@ const buildQualificationPlan = (
 
   const allExperimentIds = [
     ...(baseExperimentId ? [baseExperimentId] : []),
-    ...(isBaselineEnforced ? filteredCompExperimentIds : compExperimentIds),
+    ...compExperimentIds,
   ];
 
   const compiledFiltersByExperiment = allExperimentIds.map((experimentId) =>

--- a/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
@@ -1393,7 +1393,7 @@ describe("Clickhouse Experiment Items Repository Test", () => {
         start_time: now,
       });
 
-      // Item 1 in comparison
+      // Item 1 in comparison, created before the baseline
       const event1Comp = createExperimentEvent({
         project_id: projectId,
         trace_id: item1CompTraceId,
@@ -1403,7 +1403,7 @@ describe("Clickhouse Experiment Items Repository Test", () => {
         datasetId: datasetId,
         itemId: item1Id,
         experimentItemRootSpanId: item1CompRootId,
-        start_time: now + 1000,
+        start_time: now - 1000,
       });
 
       // Item 2 ONLY in comparison (not in baseline)


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes baseline-enforced experiment item qualification.
- Includes every comparison experiment when collecting IDs for qualification filters.
- Updates the repository test so a comparison event predates its matching baseline event, covering order-independent baseline qualification.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the focused test covering the corrected order-independent baseline qualification behavior.

The qualification query now considers all requested comparison experiment IDs while retaining baseline-presence enforcement in the aggregation condition, and no concrete regression was identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): remove baseline enforc..."](https://github.com/langfuse/langfuse/commit/8ab69c36fa494e4f9dfe5579662f89edf87c3aae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48303100)</sub>

<!-- /greptile_comment -->