### PR TITLE
fix(ci): make SDK generation reruns safe

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -88,7 +88,7 @@ jobs:
           fi
 
           # Create new branch and commit changes
-          BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}"
+          BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}"
@@ -149,7 +149,7 @@ jobs:
           fi
 
           # Create new branch and commit changes
-          BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}"
+          BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --no-verify
@@ -194,13 +194,6 @@ jobs:
           "$GIT_BIN" -C "$PUSH_REPO" init -q
           "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags "$BUNDLE_PATH" "$BRANCH_NAME:refs/heads/$BRANCH_NAME"
 
-          # Close existing api-spec-bot PRs
-          "$GH_BIN" pr list --repo langfuse/langfuse-python --author langfuse-bot --state open --json number --jq '.[].number' | while read -r pr_number; do
-            if [ -n "$pr_number" ]; then
-              "$GH_BIN" pr close --repo langfuse/langfuse-python "$pr_number"
-            fi
-          done
-
           # Resolve the reviewer before pushing so a transient GitHub API failure cannot orphan a branch.
           ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
           REVIEWER_ARGS=()
@@ -216,12 +209,20 @@ jobs:
             -c core.hooksPath=/dev/null \
             push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-python.git" "$BRANCH_NAME"
 
-          "$GH_BIN" pr create \
+          NEW_PR_URL="$("$GH_BIN" pr create \
             --repo langfuse/langfuse-python \
             --head "$BRANCH_NAME" \
             --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" \
             --body "" \
-            "${REVIEWER_ARGS[@]}"
+            "${REVIEWER_ARGS[@]}")"
+          NEW_PR_NUMBER="${NEW_PR_URL##*/}"
+
+          # Only retire stale bot PRs after their replacement exists.
+          "$GH_BIN" pr list --repo langfuse/langfuse-python --author langfuse-bot --state open --json number --jq '.[].number' | while read -r pr_number; do
+            if [ -n "$pr_number" ] && [ "$pr_number" != "$NEW_PR_NUMBER" ]; then
+              "$GH_BIN" pr close --repo langfuse/langfuse-python "$pr_number"
+            fi
+          done
 
   push-typescript-sdk:
     needs: generate-sdk-api-specs
@@ -250,13 +251,6 @@ jobs:
           "$GIT_BIN" -C "$PUSH_REPO" init -q
           "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags "$BUNDLE_PATH" "$BRANCH_NAME:refs/heads/$BRANCH_NAME"
 
-          # Close existing api-spec-bot PRs
-          "$GH_BIN" pr list --repo langfuse/langfuse-js --author langfuse-bot --state open --json number --jq '.[].number' | while read -r pr_number; do
-            if [ -n "$pr_number" ]; then
-              "$GH_BIN" pr close --repo langfuse/langfuse-js "$pr_number"
-            fi
-          done
-
           # Resolve the reviewer before pushing so a transient GitHub API failure cannot orphan a branch.
           ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
           REVIEWER_ARGS=()
@@ -272,12 +266,20 @@ jobs:
             -c core.hooksPath=/dev/null \
             push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-js.git" "$BRANCH_NAME"
 
-          "$GH_BIN" pr create \
+          NEW_PR_URL="$("$GH_BIN" pr create \
             --repo langfuse/langfuse-js \
             --head "$BRANCH_NAME" \
             --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" \
             --body "" \
-            "${REVIEWER_ARGS[@]}"
+            "${REVIEWER_ARGS[@]}")"
+          NEW_PR_NUMBER="${NEW_PR_URL##*/}"
+
+          # Only retire stale bot PRs after their replacement exists.
+          "$GH_BIN" pr list --repo langfuse/langfuse-js --author langfuse-bot --state open --json number --jq '.[].number' | while read -r pr_number; do
+            if [ -n "$pr_number" ] && [ "$pr_number" != "$NEW_PR_NUMBER" ]; then
+              "$GH_BIN" pr close --repo langfuse/langfuse-js "$pr_number"
+            fi
+          done
 
   notify-slack-on-failure:
     needs:


### PR DESCRIPTION
## What

Make manual reruns of the SDK API generation workflow safe.

The workflow previously derived its bot branch only from the core commit SHA. Re-running generation for the same commit therefore:

1. closed the existing generated SDK PR;
2. recreated a divergent local branch with the same name; and
3. failed its non-fast-forward push because the remote branch still existed.

This change:

- includes `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT` in both generated SDK branch names;
- pushes and creates the replacement PR before retiring stale bot PRs;
- excludes the newly created PR when closing older bot PRs;
- applies the same lifecycle to Python and TypeScript generation.

Failed reruns:

- https://github.com/langfuse/langfuse/actions/runs/30451800130
- https://github.com/langfuse/langfuse/actions/runs/30452148867

The first failed rerun closed the previous generated Python PR:
https://github.com/langfuse/langfuse-python/pull/1788

Linear: https://linear.app/clickhouse/issue/LFE-10397

## Impacted packages

- SDK API Spec Generation GitHub Actions workflow
- `langfuse-python` and `langfuse-js` generated-PR publication lifecycle

## Validation

- Workflow YAML parsed successfully with Ruby's YAML parser.
- Both modified push scripts pass `bash -n`.
- `pnpm exec prettier --check .github/workflows/sdk-api-spec.yml` — `All matched files use Prettier code style!`
- `git diff --check` passed.

The cross-repository push and PR lifecycle can only be exercised by the secret-bearing workflow after merge.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Makes generated SDK publication rerun-safe by:
- Adding the workflow run ID and attempt to Python and TypeScript bot branch names.
- Creating replacement SDK PRs before closing older bot-authored PRs.
- Excluding each run's newly created PR from its subsequent cleanup.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until stale-PR cleanup is scoped so concurrent workflow runs cannot close each other's newly generated SDK PRs.

Per-ref concurrency permits simultaneous runs on different refs, and each run now closes every bot-authored SDK PR except its own after creation, allowing valid replacement PRs from another active run to be retired.

**Files Needing Attention:** .github/workflows/sdk-api-spec.yml
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Run A (main)
  participant B as Run B (other ref)
  participant GH as SDK repository
  A->>GH: Create PR A
  B->>GH: Create PR B
  A->>GH: List all open langfuse-bot PRs
  A->>GH: Close every PR except A
  Note over GH: PR B is closed despite being current
  B->>GH: List all open langfuse-bot PRs
  B->>GH: Close every PR except B
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/sdk-api-spec.yml:221-225
**Concurrent runs close current PRs**

When workflow runs execute concurrently on different refs, this cleanup lists every open `langfuse-bot` PR and closes each one except the current run's PR, causing a newly generated Python or TypeScript SDK PR from another active run to be closed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): make SDK generation reruns safe"](https://github.com/langfuse/langfuse/commit/f7bb40d27d70e24888e8eddbf988f75045667936) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48306326)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->