### PR TITLE
fix(evals): route assistant fallback to migration page

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -72,6 +72,7 @@ const PeekViewEvaluatorConfigDetail = ({
             <DeactivateEvalConfig
               projectId={projectId}
               evalConfig={evalConfig}
+              onStatusChange={() => setIsEditMode(false)}
             />
           </div>
         </div>
@@ -161,7 +162,7 @@ const PeekViewEvaluatorConfigDetail = ({
           }
           mode="edit"
           disabled={!isEditMode}
-          runOnLiveStatusOnly
+          showLiveIncomingStatus
           shouldWrapVariables={true}
           useDialog={false}
           onFormSuccess={() => {

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -161,6 +161,7 @@ const PeekViewEvaluatorConfigDetail = ({
           }
           mode="edit"
           disabled={!isEditMode}
+          runOnLiveStatusOnly
           shouldWrapVariables={true}
           useDialog={false}
           onFormSuccess={() => {

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/CreateEvaluatorDialog.tsx
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/CreateEvaluatorDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   EvalTargetObject,
+  JobConfigState,
   type EvalTargetObject as EvalTargetObjectType,
 } from "@langfuse/shared";
 import { api } from "@/src/utils/api";
@@ -115,7 +116,7 @@ export function CreateEvaluatorDialog(props: CreateEvaluatorDialogProps) {
                 templateId={templateId}
                 hideTargetSelection
                 hidePreviewTable
-                defaultRunOnLive={false}
+                createStatus={JobConfigState.INACTIVE}
                 defaultTarget={targetObject}
                 onFormSuccess={() => {
                   handleClose(false);
@@ -133,13 +134,9 @@ export function CreateEvaluatorDialog(props: CreateEvaluatorDialogProps) {
                   ...values,
                   target: targetObject,
                   timeScope: ["NEW"],
-                  ...(values.runOnLive
-                    ? {}
-                    : {
-                        filter: [],
-                        sampling: 1,
-                        delay: 0,
-                      }),
+                  filter: [],
+                  sampling: 1,
+                  delay: 0,
                 })}
               />
             </div>

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -16,9 +16,11 @@ import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilit
 export function DeactivateEvalConfig({
   projectId,
   evalConfig,
+  onStatusChange,
 }: {
   projectId: string;
   evalConfig: RouterOutputs["evals"]["configById"];
+  onStatusChange?: () => void;
 }) {
   const utils = api.useUtils();
   const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
@@ -36,40 +38,31 @@ export function DeactivateEvalConfig({
 
   const mutEvaluator = api.evals.updateEvalJob.useMutation({
     onSuccess: () => {
+      onStatusChange?.();
       utils.evals.invalidate();
     },
   });
 
-  const onClick = () => {
-    if (!projectId) {
-      console.error("Project ID is missing");
-      return;
-    }
+  const handleConfirm = () => {
     // The popover trigger wraps the switch, so guard the action itself too.
     if (reactivationBlocked) {
       setIsOpen(false);
       return;
     }
 
-    const prevStatus = evalConfig?.status;
-
-    mutEvaluator.mutateAsync({
+    mutEvaluator.mutate({
       projectId,
       evalConfigId: evalConfig?.id ?? "",
       config: {
         status: isActive ? EvaluatorStatus.INACTIVE : EvaluatorStatus.ACTIVE,
       },
     });
-    capture(
-      prevStatus === EvaluatorStatus.ACTIVE
-        ? "eval_config:deactivate"
-        : "eval_config:activate",
-    );
+    capture(isActive ? "eval_config:deactivate" : "eval_config:activate");
     setIsOpen(false);
   };
 
   return (
-    <Popover open={isOpen} onOpenChange={() => setIsOpen(!isOpen)}>
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
         <div className="flex items-center">
           <Switch
@@ -102,7 +95,7 @@ export function DeactivateEvalConfig({
               evalConfig?.status === "ACTIVE" ? "destructive" : "default"
             }
             loading={mutEvaluator.isPending}
-            onClick={onClick}
+            onClick={handleConfirm}
           >
             {evalConfig?.status === "ACTIVE" ? "Deactivate" : "Activate"}
           </Button>

--- a/web/src/features/evals/components/evaluator-form.tsx
+++ b/web/src/features/evals/components/evaluator-form.tsx
@@ -24,6 +24,7 @@ export const EvaluatorForm = (props: {
   preventRedirect?: boolean;
   preprocessFormValues?: (values: any) => any;
   defaultRunOnLive?: boolean;
+  runOnLiveStatusOnly?: boolean;
   hidePreviewTable?: boolean;
   defaultTarget?: EvalTargetObject;
 }) => {
@@ -72,6 +73,7 @@ export const EvaluatorForm = (props: {
           useDialog={props.useDialog}
           evalCapabilities={evalCapabilities}
           defaultRunOnLive={props.defaultRunOnLive}
+          runOnLiveStatusOnly={props.runOnLiveStatusOnly}
           hidePreviewTable={props.hidePreviewTable}
           defaultTarget={props.defaultTarget}
         />

--- a/web/src/features/evals/components/evaluator-form.tsx
+++ b/web/src/features/evals/components/evaluator-form.tsx
@@ -23,8 +23,8 @@ export const EvaluatorForm = (props: {
   hideTargetSelection?: boolean;
   preventRedirect?: boolean;
   preprocessFormValues?: (values: any) => any;
-  defaultRunOnLive?: boolean;
-  runOnLiveStatusOnly?: boolean;
+  createStatus?: PartialConfig["status"];
+  showLiveIncomingStatus?: boolean;
   hidePreviewTable?: boolean;
   defaultTarget?: EvalTargetObject;
 }) => {
@@ -72,8 +72,8 @@ export const EvaluatorForm = (props: {
           preprocessFormValues={props.preprocessFormValues}
           useDialog={props.useDialog}
           evalCapabilities={evalCapabilities}
-          defaultRunOnLive={props.defaultRunOnLive}
-          runOnLiveStatusOnly={props.runOnLiveStatusOnly}
+          createStatus={props.createStatus}
+          showLiveIncomingStatus={props.showLiveIncomingStatus}
           hidePreviewTable={props.hidePreviewTable}
           defaultTarget={props.defaultTarget}
         />

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -336,6 +336,7 @@ export const InnerEvaluatorForm = (props: {
   hidePreviewTable?: boolean;
   evalCapabilities: EvalCapabilities;
   defaultRunOnLive?: boolean;
+  runOnLiveStatusOnly?: boolean;
   defaultTarget?: EvalTargetObject;
   renderFooter?: (params: { isLoading: boolean }) => React.ReactNode;
   oldConfigId?: string;
@@ -544,6 +545,7 @@ export const InnerEvaluatorForm = (props: {
   );
 
   const watchedTarget = form.watch("target");
+  const watchedRunOnLive = form.watch("runOnLive");
   const watchedScoreName = form.watch("scoreName");
   const watchedFilter = form.watch("filter") ?? EMPTY_FILTER_STATE;
   const shouldShowExperimentEventsPreview =
@@ -789,6 +791,9 @@ export const InnerEvaluatorForm = (props: {
     !props.disabled &&
     isExperimentTarget(watchedTarget) &&
     !isBetaEnabled;
+  const runOnLiveTargetLabel = isEventTarget(watchedTarget)
+    ? "incoming observations"
+    : "new experiments";
 
   const formBody = (
     <div
@@ -1074,9 +1079,25 @@ export const InnerEvaluatorForm = (props: {
                 />
               )}
 
+            {props.runOnLiveStatusOnly &&
+              !isLegacyEvalTarget(watchedTarget) && (
+                <div className="flex max-w-4xl flex-col gap-0.5 rounded-lg border p-3">
+                  <p className="text-sm font-medium">
+                    {watchedRunOnLive ? "Running" : "Not running"} on{" "}
+                    {runOnLiveTargetLabel}
+                  </p>
+                  <p className="text-muted-foreground text-sm">
+                    {watchedRunOnLive
+                      ? `Automatically evaluates matching ${getTargetDisplayName(watchedTarget)}.`
+                      : "The evaluator will remain inactive after saving."}
+                  </p>
+                </div>
+              )}
+
             {/* Run on Live toggle for modern (non-legacy) targets */}
-            {!props.hideAdvancedSettings &&
-              !isLegacyEvalTarget(form.watch("target")) && (
+            {!props.runOnLiveStatusOnly &&
+              !props.hideAdvancedSettings &&
+              !isLegacyEvalTarget(watchedTarget) && (
                 <FormField
                   control={form.control}
                   name="runOnLive"

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -791,9 +791,6 @@ export const InnerEvaluatorForm = (props: {
     !props.disabled &&
     isExperimentTarget(watchedTarget) &&
     !isBetaEnabled;
-  const runOnLiveTargetLabel = isEventTarget(watchedTarget)
-    ? "incoming observations"
-    : "new experiments";
 
   const formBody = (
     <div
@@ -1082,14 +1079,11 @@ export const InnerEvaluatorForm = (props: {
             {props.runOnLiveStatusOnly &&
               !isLegacyEvalTarget(watchedTarget) && (
                 <div className="flex max-w-4xl flex-col gap-0.5 rounded-lg border p-3">
-                  <p className="text-sm font-medium">
-                    {watchedRunOnLive ? "Running" : "Not running"} on{" "}
-                    {runOnLiveTargetLabel}
-                  </p>
+                  <p className="text-sm font-medium">Run on live incoming</p>
                   <p className="text-muted-foreground text-sm">
                     {watchedRunOnLive
-                      ? `Automatically evaluates matching ${getTargetDisplayName(watchedTarget)}.`
-                      : "The evaluator will remain inactive after saving."}
+                      ? `Automatically evaluates new matching ${getTargetDisplayName(watchedTarget)}.`
+                      : `Inactive. Enable the evaluator to evaluate new matching ${getTargetDisplayName(watchedTarget)}.`}
                   </p>
                 </div>
               )}

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -42,7 +42,6 @@ import { Slider } from "@/src/components/ui/slider";
 import { Card } from "@/src/components/ui/card";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
-import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   evalConfigFormSchema,
   type EvalFormType,
@@ -335,8 +334,8 @@ export const InnerEvaluatorForm = (props: {
   hideTargetSelection?: boolean;
   hidePreviewTable?: boolean;
   evalCapabilities: EvalCapabilities;
-  defaultRunOnLive?: boolean;
-  runOnLiveStatusOnly?: boolean;
+  createStatus?: PartialConfig["status"];
+  showLiveIncomingStatus?: boolean;
   defaultTarget?: EvalTargetObject;
   renderFooter?: (params: { isLoading: boolean }) => React.ReactNode;
   oldConfigId?: string;
@@ -459,9 +458,6 @@ export const InnerEvaluatorForm = (props: {
         (option): option is "NEW" | "EXISTING" =>
           ["NEW", "EXISTING"].includes(option),
       ),
-      runOnLive: props.existingEvaluator
-        ? props.existingEvaluator.status === "ACTIVE"
-        : (props.defaultRunOnLive ?? true),
     },
   }) as UseFormReturn<EvalFormType>;
 
@@ -545,7 +541,6 @@ export const InnerEvaluatorForm = (props: {
   );
 
   const watchedTarget = form.watch("target");
-  const watchedRunOnLive = form.watch("runOnLive");
   const watchedScoreName = form.watch("scoreName");
   const watchedFilter = form.watch("filter") ?? EMPTY_FILTER_STATE;
   const shouldShowExperimentEventsPreview =
@@ -668,13 +663,7 @@ export const InnerEvaluatorForm = (props: {
     const filter = validatedFilter.data;
     const scoreName = values.scoreName;
 
-    // For modern targets, derive status from runOnLive
     const isModern = !isLegacyEvalTarget(values.target);
-    const status = isModern
-      ? values.runOnLive
-        ? JobConfigState.ACTIVE
-        : JobConfigState.INACTIVE
-      : undefined;
 
     (props.mode === "edit" && props.existingEvaluator?.id
       ? updateJobMutation.mutateAsync({
@@ -687,7 +676,6 @@ export const InnerEvaluatorForm = (props: {
             sampling,
             scoreName,
             timeScope: isModern ? ["NEW"] : values.timeScope,
-            ...(status ? { status } : {}),
           },
         })
       : createJobMutation.mutateAsync({
@@ -700,7 +688,9 @@ export const InnerEvaluatorForm = (props: {
           sampling,
           delay,
           timeScope: isModern ? ["NEW"] : values.timeScope,
-          ...(status ? { status } : {}),
+          ...(props.createStatus !== undefined
+            ? { status: props.createStatus }
+            : {}),
         })
     )
       .then(() => {
@@ -776,7 +766,6 @@ export const InnerEvaluatorForm = (props: {
           : [],
     );
     form.setValue("mapping", newMapping);
-    form.setValue("runOnLive", props.defaultRunOnLive ?? true);
     setAvailableVariables(targetState.getAvailableVariables(actualTarget));
     return actualTarget;
   }
@@ -791,6 +780,10 @@ export const InnerEvaluatorForm = (props: {
     !props.disabled &&
     isExperimentTarget(watchedTarget) &&
     !isBetaEnabled;
+  const runsOnLiveIncoming =
+    (props.existingEvaluator?.status ??
+      props.createStatus ??
+      JobConfigState.ACTIVE) === JobConfigState.ACTIVE;
 
   const formBody = (
     <div
@@ -1076,71 +1069,18 @@ export const InnerEvaluatorForm = (props: {
                 />
               )}
 
-            {props.runOnLiveStatusOnly &&
+            {props.showLiveIncomingStatus &&
               !isLegacyEvalTarget(watchedTarget) && (
                 <div className="flex max-w-4xl flex-col gap-0.5 rounded-lg border p-3">
-                  <p className="text-sm font-medium">Run on live incoming</p>
                   <p className="text-muted-foreground text-sm">
-                    {watchedRunOnLive
-                      ? `Automatically evaluates new matching ${getTargetDisplayName(watchedTarget)}.`
+                    {runsOnLiveIncoming
+                      ? `Automatically evaluates new live incoming ${getTargetDisplayName(watchedTarget)}.`
                       : `Inactive. Enable the evaluator to evaluate new matching ${getTargetDisplayName(watchedTarget)}.`}
                   </p>
                 </div>
               )}
 
-            {/* Run on Live toggle for modern (non-legacy) targets */}
-            {!props.runOnLiveStatusOnly &&
-              !props.hideAdvancedSettings &&
-              !isLegacyEvalTarget(watchedTarget) && (
-                <FormField
-                  control={form.control}
-                  name="runOnLive"
-                  render={({ field }) => {
-                    const target = form.watch("target");
-                    return (
-                      <div className="flex max-w-4xl flex-col gap-2">
-                        <FormItem className="flex items-center justify-between rounded-lg border p-3">
-                          <div className="space-y-0.5">
-                            <FormLabel>
-                              {isEventTarget(target)
-                                ? "Run on live incoming observations"
-                                : "Run on new experiments"}
-                            </FormLabel>
-                            <FormDescription>
-                              Automatically evaluate new incoming{" "}
-                              {getTargetDisplayName(target)}.
-                            </FormDescription>
-                          </div>
-                          <FormControl>
-                            <Switch
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                              disabled={props.disabled}
-                            />
-                          </FormControl>
-                        </FormItem>
-                        {!field.value && isEventTarget(target) && (
-                          <p className="text-muted-foreground text-xs">
-                            This evaluator can still be used for batched
-                            evaluation of historic observations.{" "}
-                            <a
-                              href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-dark-blue hover:opacity-80"
-                            >
-                              Read the docs
-                            </a>
-                          </p>
-                        )}
-                      </div>
-                    );
-                  }}
-                />
-              )}
-
-            {(isLegacyEvalTarget(form.watch("target")) ||
-              form.watch("runOnLive")) && (
+            {(isLegacyEvalTarget(watchedTarget) || runsOnLiveIncoming) && (
               <>
                 <FormField
                   control={form.control}

--- a/web/src/features/evals/pages/evaluators.tsx
+++ b/web/src/features/evals/pages/evaluators.tsx
@@ -13,7 +13,6 @@ import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
 import { SupportOrUpgradePage } from "@/src/ee/features/billing/components/SupportOrUpgradePage";
 import { EvaluatorsOnboarding } from "@/src/components/onboarding/EvaluatorsOnboarding";
 import { ManageDefaultEvalModel } from "@/src/features/evals/components/manage-default-eval-model";
-import { V4MigrationModal } from "@/src/features/v4-migration/V4MigrationModal";
 import { V4MigrationUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
 
 export default function EvaluatorsPage() {
@@ -75,47 +74,44 @@ export default function EvaluatorsPage() {
   }
 
   return (
-    <>
-      <V4MigrationModal />
-      <Page
-        headerProps={{
-          title: "Evaluators",
-          titleBadges: <V4MigrationUpdateRequiredBadge />,
-          help: {
-            description:
-              "Configure a langfuse managed or custom evaluator to evaluate incoming traces.",
-            href: "https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge",
-          },
-          tabsProps: {
-            tabs: getEvalsTabs(projectId),
-            activeTab: EVALS_TABS.CONFIGS,
-          },
-          actionButtonsRight: (
-            <>
-              <ManageDefaultEvalModel projectId={projectId} />
-              <ActionButton
-                hasAccess={hasWriteAccess}
-                href={`/project/${projectId}/evals/new`}
-                icon={<Plus className="h-4 w-4" />}
-                trackingEventName="eval_config:new_form_open"
-                variant="default"
-                usageLimit={
-                  typeof evaluatorLimit === "number"
-                    ? {
-                        current: countsQuery.data?.configActiveCount ?? 0,
-                        max: evaluatorLimit,
-                      }
-                    : undefined
-                }
-              >
-                Set up evaluator
-              </ActionButton>
-            </>
-          ),
-        }}
-      >
-        <EvaluatorTable projectId={projectId} />
-      </Page>
-    </>
+    <Page
+      headerProps={{
+        title: "Evaluators",
+        titleBadges: <V4MigrationUpdateRequiredBadge />,
+        help: {
+          description:
+            "Configure a langfuse managed or custom evaluator to evaluate incoming traces.",
+          href: "https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge",
+        },
+        tabsProps: {
+          tabs: getEvalsTabs(projectId),
+          activeTab: EVALS_TABS.CONFIGS,
+        },
+        actionButtonsRight: (
+          <>
+            <ManageDefaultEvalModel projectId={projectId} />
+            <ActionButton
+              hasAccess={hasWriteAccess}
+              href={`/project/${projectId}/evals/new`}
+              icon={<Plus className="h-4 w-4" />}
+              trackingEventName="eval_config:new_form_open"
+              variant="default"
+              usageLimit={
+                typeof evaluatorLimit === "number"
+                  ? {
+                      current: countsQuery.data?.configActiveCount ?? 0,
+                      max: evaluatorLimit,
+                    }
+                  : undefined
+              }
+            >
+              Set up evaluator
+            </ActionButton>
+          </>
+        ),
+      }}
+    >
+      <EvaluatorTable projectId={projectId} />
+    </Page>
   );
 }

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -267,7 +267,7 @@ export default function RemapEvaluatorPage() {
                   hideTargetSelection={true}
                   preventRedirect={true}
                   hideAdvancedSettings={true}
-                  runOnLiveStatusOnly
+                  showLiveIncomingStatus
                   evalCapabilities={evalCapabilities}
                   oldConfigId={evalConfigId}
                   renderFooter={({ isLoading }) => (

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -22,6 +22,7 @@ import {
 import { ChevronDown } from "lucide-react";
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import { DEFAULT_OBSERVATION_FILTER_WHEN_REMAPPING } from "@/src/features/evals/utils/evaluator-constants";
+import { Switch } from "@/src/components/design-system/Switch/Switch";
 
 type LegacyEvalAction = "keep-active" | "mark-inactive" | "delete";
 
@@ -198,16 +199,36 @@ export default function RemapEvaluatorPage() {
             <div className="grid grid-cols-[1fr_2px_1fr] items-start">
               {/* LEFT: Read-only old config */}
               <div className="space-y-4 p-3">
-                <div className="flex items-center gap-2 pb-2">
-                  <h3 className="text-lg font-bold">
-                    Legacy Configuration{" "}
-                    {isTraceTarget(oldConfig.targetObject)
-                      ? "(runs on traces)"
-                      : ""}
-                  </h3>
-                  <span className="text-muted-foreground text-xs">
-                    Read-only
-                  </span>
+                <div className="flex items-start justify-between gap-4 pb-2">
+                  <div className="flex items-center gap-2">
+                    <h3 className="text-lg font-bold">
+                      Legacy Configuration{" "}
+                      {isTraceTarget(oldConfig.targetObject)
+                        ? "(runs on traces)"
+                        : ""}
+                    </h3>
+                    <span className="text-muted-foreground text-xs">
+                      Read-only
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <label
+                      htmlFor="keep-legacy-evaluator-active"
+                      className="text-sm font-medium"
+                    >
+                      Keep active after upgrade
+                    </label>
+                    <Switch
+                      id="keep-legacy-evaluator-active"
+                      checked={legacyAction === "keep-active"}
+                      onCheckedChange={(checked) =>
+                        setLegacyAction(
+                          checked ? "keep-active" : "mark-inactive",
+                        )
+                      }
+                      aria-label="Keep legacy evaluator active"
+                    />
+                  </div>
                 </div>
                 <InnerEvaluatorForm
                   projectId={projectId}
@@ -246,6 +267,7 @@ export default function RemapEvaluatorPage() {
                   hideTargetSelection={true}
                   preventRedirect={true}
                   hideAdvancedSettings={true}
+                  runOnLiveStatusOnly
                   evalCapabilities={evalCapabilities}
                   oldConfigId={evalConfigId}
                   renderFooter={({ isLoading }) => (

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -21,7 +21,6 @@ export const evalConfigFormSchema = z.object({
   sampling: z.coerce.number().gt(0).lte(1),
   delay: z.coerce.number().min(0).optional().default(10),
   timeScope: TimeScopeSchema,
-  runOnLive: z.boolean().optional().default(true),
 });
 
 export type EvalFormType = z.infer<typeof evalConfigFormSchema>;

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from "lucide-react";
+import { useRouter } from "next/router";
 import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -7,10 +8,7 @@ import {
   useProjectV4EvalData,
   useProjectV4SdkData,
 } from "@/src/features/v4-migration/hooks/useV4MigrationData";
-import {
-  useCanUseInAppAgent,
-  useInAppAiAgent,
-} from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useEvalUpgradeAssistantPlan } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
 
 function BadgeContent({
@@ -120,12 +118,11 @@ export function V4MigrationUpdateRequiredBadge() {
 
 /** Starts the eval upgrade in the in-app assistant — for overlay surfaces
  * like the table peek, where the assistant (`agent` layer) renders above the
- * peek (`panel` layer) while the migration drawer would open behind it.
- * Falls back to the drawer when the assistant is unavailable. */
+ * peek (`panel` layer). When the assistant is unavailable, navigate to the
+ * full migration page instead of opening a drawer behind the peek. */
 export function V4MigrationUpdateRequiredAssistantBadge() {
-  const openMigrationPanel = useOpenV4MigrationPanel();
+  const router = useRouter();
   const capture = usePostHogClientCapture();
-  const canUseAgent = useCanUseInAppAgent();
   const { setOpen: setAgentOpen, submit: submitAgentMessage } =
     useInAppAiAgent();
   const { project, organization, enabled, visible } =
@@ -142,21 +139,25 @@ export function V4MigrationUpdateRequiredAssistantBadge() {
 
   const handleClick = async () => {
     capture("v4_migration:update_required_badge_clicked");
-    if (canUseAgent) {
+    if (upgradePlan.canUseAssistant) {
       setAgentOpen(true);
       await submitAgentMessage(upgradePlan.assistantPrompt, {
         newConversation: true,
       });
       return;
     }
-    openMigrationPanel({ id: project.id, name: project.name });
+    await router.push("/v4-migration");
   };
 
   return (
     <BadgeContent
       handleClick={handleClick}
       title="Action required"
-      description="Click here to start the upgrade now"
+      description={
+        upgradePlan.canUseAssistant
+          ? "Click here to start the upgrade now"
+          : "Open the migration guide"
+      }
     />
   );
 }

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -118,10 +118,11 @@ export function V4MigrationUpdateRequiredBadge() {
 
 /** Starts the eval upgrade in the in-app assistant — for overlay surfaces
  * like the table peek, where the assistant (`agent` layer) renders above the
- * peek (`panel` layer). When the assistant is unavailable, navigate to the
- * full migration page instead of opening a drawer behind the peek. */
+ * peek (`panel` layer). When the assistant is unavailable, close the peek by
+ * returning to the evals page before opening the migration panel. */
 export function V4MigrationUpdateRequiredAssistantBadge() {
   const router = useRouter();
+  const openMigrationPanel = useOpenV4MigrationPanel();
   const capture = usePostHogClientCapture();
   const { setOpen: setAgentOpen, submit: submitAgentMessage } =
     useInAppAiAgent();
@@ -146,7 +147,8 @@ export function V4MigrationUpdateRequiredAssistantBadge() {
       });
       return;
     }
-    await router.push("/v4-migration");
+    await router.push(`/project/${project.id}/evals`);
+    openMigrationPanel({ id: project.id, name: project.name });
   };
 
   return (


### PR DESCRIPTION
## What changed

- keep the in-app assistant flow when it is available
- route users without assistant access to the full v4 migration page
- clarify the fallback CTA in the evaluator peek view

## Verification

- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm run format`
- `git diff --check`

Impacted package: `web`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Routes the evaluator migration badge to the appropriate upgrade experience.
- Preserves the in-app assistant flow when assistant access is available.
- Navigates users without assistant access to the full v4 migration page.
- Updates the fallback CTA to describe the migration guide destination.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The assistant plan reuses the existing in-app agent availability check, while the fallback navigates to a valid migration page designed to derive its project and organization context from the session.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): route assistant fallback to ..."](https://github.com/langfuse/langfuse/commit/855a90482b84c1f2256482e5e6d0801e046d9f1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48304968)</sub>

<!-- /greptile_comment -->