### PR TITLE
fix(traces): Make outlier bar show count by default

### DIFF
--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -10,10 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import {
-  chartFilterExclusionReason,
-  toChartFilters,
-} from "@/src/features/chart-view/lib/chartFilterCompatibility";
+import { toChartFilters } from "@/src/features/chart-view/lib/chartFilterCompatibility";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import {
   OutlierBarStrip,
@@ -34,6 +31,7 @@ import {
   useOutlierStripSettings,
   type OutlierStripSettings,
 } from "./lib/useOutlierStripSettings";
+import { canApplyOutlierStripFilters } from "./lib/filterCompatibility";
 
 /**
  * Production container for the outlier strip ("Pulse") above the events table
@@ -45,10 +43,9 @@ import {
  * table's time range to that bucket; the browser Back button restores the
  * outer view.
  *
- * Filters forward exactly like the in-view chart (`toChartFilters`); filters
- * the aggregate query can't express are disclosed by a small "not applied"
- * hint on the strip (unlike chart mode's sidebar dimming: here the TABLE
- * still honors those filters, only the strip doesn't).
+ * Filters forward exactly like the in-view chart (`toChartFilters`). If the
+ * aggregate query cannot represent the table's complete filter/search state,
+ * the query stays disabled rather than reporting a partial distribution.
  */
 
 /** Target horizontal pixels per bar for granularity picking. */
@@ -56,7 +53,7 @@ const BAR_SLOT_TARGET_PX = 5;
 
 type StripMode = OutlierStripSettings["mode"];
 
-const MODE_OPTIONS: StripMode[] = ["cost", "latency"];
+const MODE_OPTIONS: StripMode[] = ["count", "cost", "latency"];
 
 const modeLabel = (mode: StripMode): string =>
   OUTLIER_STRIP_METRICS[mode].shortLabel;
@@ -168,20 +165,6 @@ const ModeDropdown = ({
   );
 };
 
-/** Filters the strip's aggregate query cannot express — excluding the ones
- * whose dropping is by design (the explicit from/to carries startTime; root
- * scoping is deliberately ignored per the LFE-14451 product call).
- * `has:`/`-has:` presence filters (type "null") are dropped by toChartFilters
- * even on forwardable columns, so they count regardless of column. */
-const countIgnoredFilters = (filterState: FilterState): number =>
-  filterState.filter(
-    (f) =>
-      !(f.type === "datetime" && f.column === "startTime") &&
-      f.column !== "isRootObservation" &&
-      f.column !== "hasParentObservation" &&
-      (f.type === "null" || chartFilterExclusionReason(f.column) !== null),
-  ).length;
-
 export function EventsOutlierStrip({
   projectId,
   filterState,
@@ -228,8 +211,10 @@ export function EventsOutlierStrip({
   });
 
   const filters = useMemo(() => toChartFilters(filterState), [filterState]);
-  const ignoredFilterCount =
-    countIgnoredFilters(filterState) + (searchIgnored ? 1 : 0);
+  const canApplyFilters = canApplyOutlierStripFilters(
+    filterState,
+    searchIgnored,
+  );
 
   const query: QueryType = useMemo(
     () => ({
@@ -251,8 +236,9 @@ export function EventsOutlierStrip({
   const queryResult = api.dashboard.executeQuery.useQuery(
     { projectId, query, version: "v2" },
     {
-      // Wait for the first width measurement — it decides the bucket size.
-      enabled: validRange && width > 0,
+      // Wait for the first width measurement, and never run a partially
+      // filtered query when the table state cannot be represented.
+      enabled: validRange && width > 0 && canApplyFilters,
       // Keep the previous bins ONLY across same-grid refetches (auto-refresh
       // ticks re-key the query via the re-evaluated relative window) — a
       // persistent band must not flash to a skeleton every interval. A grid
@@ -286,16 +272,20 @@ export function EventsOutlierStrip({
     [queryResult.data],
   );
 
-  const aggregationFor = (metric: OutlierStripMetricKey): OutlierStripAggKey =>
-    metric === "latency" ? settings.latencyAgg : settings.costAgg;
+  const aggregationFor = (
+    metric: OutlierStripMetricKey,
+  ): OutlierStripAggKey => {
+    if (metric === "count") return "count";
+    return metric === "latency" ? settings.latencyAgg : settings.costAgg;
+  };
+  const aggregation = aggregationFor(mode);
 
   const series = useMemo(
     () =>
       prepareOutlierSeries({
         bins,
         metric: mode,
-        aggregation:
-          mode === "latency" ? settings.latencyAgg : settings.costAgg,
+        aggregation,
         fromMs,
         toMs,
         stepSeconds: granularity.stepSeconds,
@@ -307,8 +297,7 @@ export function EventsOutlierStrip({
       toMs,
       granularity.stepSeconds,
       mode,
-      settings.latencyAgg,
-      settings.costAgg,
+      aggregation,
       chartWidth,
     ],
   );
@@ -323,7 +312,7 @@ export function EventsOutlierStrip({
     capture("pulse:drill_in", {
       trigger: meta.trigger,
       metric: mode,
-      aggregation: aggregationFor(mode),
+      aggregation,
       mode,
       stepSeconds: granularity.stepSeconds,
       spanBuckets: Math.max(
@@ -395,7 +384,27 @@ export function EventsOutlierStrip({
     <div ref={wrapperRef} className="shrink-0 border-b">
       {size === undefined ? null : (
         <div className="relative px-2 pt-1 pb-1">
-          {isLoading || width === 0 ? (
+          {!canApplyFilters ? (
+            <div>
+              <div className="flex items-baseline gap-1.5">
+                <ModeDropdown
+                  value={mode}
+                  options={MODE_OPTIONS}
+                  onChange={handleModeChange}
+                />
+              </div>
+              <OutlierBarStrip
+                className="mt-2"
+                dense={[]}
+                maxValue={0}
+                ticks={[]}
+                stepMs={stepMs}
+                metric={mode}
+                widthPx={chartWidth}
+                disabledReason="Chart unavailable for the current filters"
+              />
+            </div>
+          ) : isLoading || width === 0 ? (
             <div className="bg-muted h-[76px] animate-pulse rounded" />
           ) : queryResult.isError ? (
             <div className="text-muted-foreground flex h-[76px] items-center justify-center text-[11px]">
@@ -424,22 +433,10 @@ export function EventsOutlierStrip({
                 {aggOptions.length > 1 && (
                   <AggDropdown
                     metricLabel={def.shortLabel}
-                    value={aggregationFor(mode)}
+                    value={aggregation}
                     options={aggOptions}
                     onChange={(agg) => setAggregation(mode, agg)}
                   />
-                )}
-                {/* Unlike full chart mode (which dims sidebar facets),
-                    the TABLE still honors these filters — only the strip
-                    can't express them, so the disclosure lives here. */}
-                {ignoredFilterCount > 0 && (
-                  <span
-                    className="text-muted-foreground/70 text-[11px] leading-none"
-                    title="Some active filters (measures, scores, comments, metadata, free-text search) cannot be applied to this chart's aggregate query. The table still honors them; the chart shows the unfiltered distribution for those."
-                  >
-                    · {ignoredFilterCount} filter
-                    {ignoredFilterCount > 1 ? "s" : ""} not applied
-                  </span>
                 )}
               </div>
               <OutlierBarStrip

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
@@ -5,8 +5,8 @@ import { makeFixtureSeries } from "./lib/fixtures";
 
 /**
  * Design surface for the outlier strip above the trace table (LFE-14451).
- * Each bar aggregates its time bucket (summed cost, p95/avg latency, event
- * count) — the strip exists to click into spikes, so the visual must read
+ * Each bar aggregates its time bucket (observation count, summed cost, or
+ * p95/avg latency) — the strip exists to click into spikes, so the visual must read
  * at a glance: compact, Firefox-devtools-inspired, exact values on hover,
  * horizontal value gridlines with left sans labels (no vertical lines), a
  * baseline that keeps the plot boundary visible where data is absent.
@@ -22,6 +22,14 @@ const spikyCost = makeFixtureSeries({
   widthPx: 720,
 });
 
+const spikyCount = makeFixtureSeries({
+  rangeMs: 24 * 3600 * 1000,
+  stepSeconds: 600,
+  profile: "spiky",
+  metric: "count",
+  widthPx: 720,
+});
+
 const meta = preview.meta({
   component: OutlierBarStrip,
   args: {
@@ -31,8 +39,16 @@ const meta = preview.meta({
 
 export const Default = meta.story({
   args: {
-    ...spikyCost,
-    metric: "cost",
+    ...spikyCount,
+    metric: "count",
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    ...spikyCount,
+    metric: "count",
+    disabledReason: "Chart unavailable for the current filters",
   },
 });
 
@@ -95,7 +111,7 @@ export const SparseData = meta.story({
   },
 });
 
-/** Events exist but carry no cost data (e.g. root-only shapes) — the strip
+/** Observations exist but carry no cost data (e.g. root-only shapes) — the strip
  * shows activity ticks + an honest hint instead of a fake-zero skyline. */
 export const NoMetricData = meta.story({
   args: {

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -15,9 +15,9 @@ import {
 /**
  * OutlierBarStrip — compact, Firefox-devtools-inspired bar strip (LFE-14451).
  * Pure visualiser: renders the dense series `prepareOutlierSeries` produced
- * and decides nothing about data. Every bar is the worst single event in its
- * time bucket; clicking a bar reports the bucket's range so the caller can
- * narrow the table's time window.
+ * and decides nothing about data. Each bar is a prepared aggregate for its
+ * time bucket; clicking it reports the bucket's range so the caller can narrow
+ * the table's time window.
  *
  * The strip always spans the full `widthPx` (fractional bar slots), with a
  * baseline and horizontal value gridlines so the chart's boundaries stay
@@ -26,6 +26,7 @@ import {
  */
 
 const METRIC_COLOR: Record<OutlierStripMetricKey, string> = {
+  count: "hsl(var(--chart-4))",
   cost: "hsl(var(--chart-1))",
   latency: "hsl(var(--chart-2))",
 };
@@ -57,7 +58,7 @@ export type OutlierBarStripProps = {
    * readable while outliers still dominate.
    */
   scale?: "linear" | "sqrt";
-  /** 1px baseline tick where events exist but carry no metric data. */
+  /** 1px baseline tick where observations exist but carry no metric data. */
   showActivityTicks?: boolean;
   /** Sparse time labels under the gridline ticks. */
   showTimeLabels?: boolean;
@@ -72,6 +73,8 @@ export type OutlierBarStripProps = {
    *  drag on one strip highlights on all (LF-34, Grafana-style). */
   selection?: { fromMs: number; toMs: number } | null;
   onSelectionChange?: (range: { fromMs: number; toMs: number } | null) => void;
+  /** Why the chart cannot represent the current table state. */
+  disabledReason?: string;
   className?: string;
 };
 
@@ -92,6 +95,7 @@ export function OutlierBarStrip({
   onPreviewPinned,
   selection = null,
   onSelectionChange,
+  disabledReason,
   className,
 }: OutlierBarStripProps) {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
@@ -226,7 +230,7 @@ export function OutlierBarStrip({
         {/* Bars */}
         {dense.map((bin, i) => {
           if (bin.value === null) {
-            // Events without metric data get a subtle activity tick so the
+            // Observations without metric data get a subtle activity tick so the
             // strip never reads "nothing happened" when data is merely absent.
             return showActivityTicks && bin.count > 0 ? (
               <rect
@@ -343,6 +347,21 @@ export function OutlierBarStrip({
   const previewHalfWidth = (previewSize?.width ?? 0) / 2;
   const viewportWidth =
     typeof window !== "undefined" ? window.innerWidth : Number.MAX_SAFE_INTEGER;
+
+  if (disabledReason) {
+    return (
+      <div
+        className={cn(
+          "text-muted-foreground bg-muted/30 flex items-center justify-center rounded text-[11px]",
+          className,
+        )}
+        style={{ width: widthPx, height: heightPx + labelHeight }}
+        aria-disabled="true"
+      >
+        {disabledReason}
+      </div>
+    );
+  }
 
   return (
     <div className={cn("relative", className)} style={{ width: widthPx }}>
@@ -522,7 +541,7 @@ export function OutlierBarStrip({
         <span className="text-muted-foreground/70 pointer-events-none absolute inset-0 flex items-center justify-center text-[10px]">
           {hasActivity
             ? `No ${metricSpec.shortLabel.toLowerCase()} data in range`
-            : "No events in range"}
+            : "No observations in range"}
         </span>
       )}
 
@@ -558,9 +577,11 @@ export function OutlierBarStrip({
                 : hovered.count > 0
                   ? "no data"
                   : metricSpec.format(0)}
-              <span className="text-muted-foreground ml-1.5 font-normal">
-                · {hovered.count} events
-              </span>
+              {metric !== "count" && (
+                <span className="text-muted-foreground ml-1.5 font-normal">
+                  · {hovered.count} observations
+                </span>
+              )}
             </div>
           </div>
         </Layer>
@@ -606,9 +627,11 @@ export function OutlierBarStrip({
                     : previewStats.count > 0
                       ? "no data"
                       : metricSpec.format(0)}
-                  <span className="text-muted-foreground ml-1.5 font-normal">
-                    · {previewStats.count} events
-                  </span>
+                  {metric !== "count" && (
+                    <span className="text-muted-foreground ml-1.5 font-normal">
+                      · {previewStats.count} observations
+                    </span>
+                  )}
                 </div>
               </div>
               <button

--- a/web/src/features/events/components/outlier-strip/lib/binning.clienttest.ts
+++ b/web/src/features/events/components/outlier-strip/lib/binning.clienttest.ts
@@ -98,6 +98,7 @@ describe("rowsToOutlierBins", () => {
     expect(bins).toHaveLength(1);
     expect(bins[0].count).toBe(2);
     expect(bins[0].values).toEqual({
+      count_count: 2,
       sum_totalCost: 2.5,
       p95_latency: 1000,
       p50_latency: 800,
@@ -114,6 +115,7 @@ describe("prepareOutlierSeries", () => {
     bucketStart: new Date(bucketStartMs),
     count: value === null ? 0 : 1,
     values: {
+      count_count: value === null ? null : 1,
       sum_totalCost: value,
       p95_latency: value === null ? null : value * 500,
       p50_latency: value === null ? null : value * 250,
@@ -174,7 +176,7 @@ describe("prepareOutlierSeries", () => {
   it("selects the aggregation's result column via the registry", () => {
     const step = 60;
     const t0 = Math.floor(Date.UTC(2025, 2, 10, 10, 0, 0) / 60000) * 60000;
-    const run = (metric: "cost" | "latency", aggregation: string) =>
+    const run = (metric: "count" | "cost" | "latency", aggregation: string) =>
       prepareOutlierSeries({
         bins: [bin(t0, 8)],
         metric,
@@ -184,6 +186,7 @@ describe("prepareOutlierSeries", () => {
         stepSeconds: step,
       }).dense[0].value;
 
+    expect(run("count", "count")).toBe(1);
     expect(run("latency", "p95")).toBe(4); // 4000ms → 4s
     expect(run("latency", "p50")).toBe(2); // 2000ms → 2s
     expect(run("cost", "sum")).toBe(8);

--- a/web/src/features/events/components/outlier-strip/lib/binning.ts
+++ b/web/src/features/events/components/outlier-strip/lib/binning.ts
@@ -1,5 +1,9 @@
 import { format } from "date-fns";
-import { latencyFormatter, usdFormatter } from "@/src/utils/numbers";
+import {
+  latencyFormatter,
+  numberFormatter,
+  usdFormatter,
+} from "@/src/utils/numbers";
 import { parseChartTimestamp } from "@/src/features/widgets/chart-library/prepareTimeAxis";
 
 /**
@@ -104,16 +108,19 @@ export function pickChartGranularity(params: {
 // Metric registry
 // ---------------------------------------------------------------------------
 
-export type OutlierStripMetricKey = "cost" | "latency";
+export type OutlierStripMetricKey = "count" | "cost" | "latency";
 export type OutlierStripLatencyAgg = "p95" | "p50";
 export type OutlierStripCostAgg = "sum";
-export type OutlierStripAggKey = OutlierStripLatencyAgg | OutlierStripCostAgg;
+export type OutlierStripAggKey =
+  | "count"
+  | OutlierStripLatencyAgg
+  | OutlierStripCostAgg;
 
 type AggregationDef = {
   /** The user-facing option key (currently 1:1 with the query aggregation). */
   key: OutlierStripAggKey;
   /** The executeQuery aggregation this option lowers to. */
-  queryAggregation: "sum" | "p95" | "p50";
+  queryAggregation: "count" | "sum" | "p95" | "p50";
 };
 
 export type OutlierStripMetricDef = {
@@ -178,6 +185,13 @@ export const OUTLIER_STRIP_METRICS: Record<
   OutlierStripMetricKey,
   OutlierStripMetricDef
 > = {
+  count: {
+    shortLabel: "Count",
+    measure: "count",
+    aggregations: [{ key: "count", queryAggregation: "count" }],
+    fromRaw: (raw) => raw,
+    format: (value) => numberFormatter(value, 0),
+  },
   cost: {
     shortLabel: "Cost",
     measure: "totalCost",
@@ -230,16 +244,14 @@ export const outlierStripResultColumn = (
  */
 export const outlierStripQueryMetrics = (): {
   measure: string;
-  aggregation: "count" | AggregationDef["queryAggregation"];
-}[] => [
-  { measure: "count", aggregation: "count" },
-  ...Object.values(OUTLIER_STRIP_METRICS).flatMap((def) =>
+  aggregation: AggregationDef["queryAggregation"];
+}[] =>
+  Object.values(OUTLIER_STRIP_METRICS).flatMap((def) =>
     def.aggregations.map((agg) => ({
       measure: def.measure,
       aggregation: agg.queryAggregation,
     })),
-  ),
-];
+  );
 
 /** Resolves an aggregation option, falling back to the metric's default. */
 export const resolveAggregation = (

--- a/web/src/features/events/components/outlier-strip/lib/filterCompatibility.clienttest.ts
+++ b/web/src/features/events/components/outlier-strip/lib/filterCompatibility.clienttest.ts
@@ -1,0 +1,48 @@
+import { type FilterState } from "@langfuse/shared";
+import { canApplyOutlierStripFilters } from "./filterCompatibility";
+
+describe("canApplyOutlierStripFilters", () => {
+  it("accepts chart-compatible filters and the represented time range", () => {
+    const filters: FilterState = [
+      { column: "environment", type: "string", operator: "=", value: "prod" },
+      {
+        column: "startTime",
+        type: "datetime",
+        operator: ">=",
+        value: new Date("2025-01-01T00:00:00.000Z"),
+      },
+    ];
+
+    expect(canApplyOutlierStripFilters(filters, false)).toBe(true);
+  });
+
+  it("rejects filters the aggregate query cannot represent", () => {
+    const unsupportedFilters: FilterState[] = [
+      [{ column: "latency", type: "number", operator: ">", value: 2 }],
+      [
+        {
+          column: "isRootObservation",
+          type: "boolean",
+          operator: "=",
+          value: true,
+        },
+      ],
+      [
+        {
+          column: "name",
+          type: "null",
+          operator: "is not null",
+          value: "",
+        },
+      ],
+    ];
+
+    for (const filters of unsupportedFilters) {
+      expect(canApplyOutlierStripFilters(filters, false)).toBe(false);
+    }
+  });
+
+  it("rejects active free-text search", () => {
+    expect(canApplyOutlierStripFilters([], true)).toBe(false);
+  });
+});

--- a/web/src/features/events/components/outlier-strip/lib/filterCompatibility.ts
+++ b/web/src/features/events/components/outlier-strip/lib/filterCompatibility.ts
@@ -1,0 +1,17 @@
+import { type FilterState } from "@langfuse/shared";
+import { chartFilterExclusionReason } from "@/src/features/chart-view/lib/chartFilterCompatibility";
+
+export const canApplyOutlierStripFilters = (
+  filterState: FilterState,
+  hasSearchQuery: boolean,
+) => {
+  if (hasSearchQuery) return false;
+
+  return filterState.every((filter) => {
+    if (filter.type === "datetime" && filter.column === "startTime") {
+      return true;
+    }
+    if (filter.type === "null") return false;
+    return chartFilterExclusionReason(filter.column) === null;
+  });
+};

--- a/web/src/features/events/components/outlier-strip/lib/fixtures.ts
+++ b/web/src/features/events/components/outlier-strip/lib/fixtures.ts
@@ -69,6 +69,7 @@ export function makeFixtureBins(params: {
       bucketStart: new Date(t),
       count,
       values: {
+        count_count: count,
         sum_totalCost: noData ? null : 0.02 * base * outlier * 5,
         p95_latency: noData ? null : 2000 * base * outlier * 0.6,
         p50_latency: noData ? null : 2000 * base * outlier * 0.35,

--- a/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
+++ b/web/src/features/events/components/outlier-strip/lib/useOutlierStripSettings.ts
@@ -11,13 +11,24 @@ import useLocalStorage from "@/src/components/useLocalStorage";
  */
 const outlierStripSettingsSchema = z
   .object({
-    mode: z.enum(["cost", "latency"]).catch("cost"),
+    mode: z.enum(["count", "cost", "latency"]).catch("count"),
     latencyAgg: z.enum(["p95", "p50"]).catch("p95"),
     costAgg: z.enum(["sum"]).catch("sum"),
   })
-  .catch({ mode: "cost", latencyAgg: "p95", costAgg: "sum" });
+  .catch({ mode: "count", latencyAgg: "p95", costAgg: "sum" });
 
 export type OutlierStripSettings = z.infer<typeof outlierStripSettingsSchema>;
+
+const OUTLIER_STRIP_SETTINGS_VERSION = 1;
+
+export const parseOutlierStripSettings = (raw: unknown) => {
+  const settings = outlierStripSettingsSchema.parse(raw ?? {});
+  const isCurrentVersion = z
+    .object({ version: z.literal(OUTLIER_STRIP_SETTINGS_VERSION) })
+    .safeParse(raw).success;
+
+  return isCurrentVersion ? settings : { ...settings, mode: "count" as const };
+};
 
 export function useOutlierStripSettings(): {
   settings: OutlierStripSettings;
@@ -27,12 +38,14 @@ export function useOutlierStripSettings(): {
     "events-pulse-chart-settings",
     {},
   );
-  const settings = useMemo(
-    () => outlierStripSettingsSchema.parse(raw ?? {}),
-    [raw],
-  );
+  const settings = useMemo(() => parseOutlierStripSettings(raw), [raw]);
   return {
     settings,
-    update: (patch) => setRaw({ ...settings, ...patch }),
+    update: (patch) =>
+      setRaw({
+        version: OUTLIER_STRIP_SETTINGS_VERSION,
+        ...settings,
+        ...patch,
+      }),
   };
 }


### PR DESCRIPTION
The PR will now show count instead of cost by default. Also, if the selected filters are not available on metrics, it will disable the chart instead of showing invalid data.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the events outlier strip to show observation count by default.
- Adds count as a supported metric and persists it as the default setting.
- Disables the aggregate chart when active filters or search cannot be represented accurately.
- Adds disabled-state rendering, fixtures, stories, and tests for count and filter compatibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The count aggregation is supported by the query schema and result-column conventions, settings remain backward compatible, and incompatible filter states consistently disable both querying and chart interaction.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Events table state] --> B{Filters compatible?}
  B -->|No| C[Show disabled outlier strip]
  B -->|Yes| D[Execute aggregate query]
  D --> E[Prepare count, cost, or latency series]
  E --> F[Render interactive outlier bars]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Show count in outlier bar strip by defau..."](https://github.com/langfuse/langfuse/commit/fdada996304b5739e0a86a83924fe02086e3463b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48309234)</sub>

<!-- /greptile_comment -->