### PR TITLE
fix(evals): restore observation evaluator status toggle

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -21,10 +21,7 @@ import { cn } from "@/src/utils/tailwind";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { api } from "@/src/utils/api";
 import { EvaluatorPausedCallout } from "@/src/features/evals/components/evaluator-paused-callout";
-import {
-  isLegacyEvalTarget,
-  requiresLegacyMigrationAction,
-} from "@/src/features/evals/utils/typeHelpers";
+import { requiresLegacyMigrationAction } from "@/src/features/evals/utils/typeHelpers";
 import { useLazyEvaluatorExecutionCounts } from "@/src/features/evals/hooks/useLazyEvaluatorExecutionCounts";
 import { TablePeekView } from "@/src/components/table/peek";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
@@ -72,15 +69,10 @@ const PeekViewEvaluatorConfigDetail = ({
           <span className="max-h-fit text-lg font-bold">Configuration</span>
           <div className="flex items-center gap-2">
             <StatusBadge type={displayStatus.toLowerCase()} isLive />
-            {/* Quick-deactivate is a migration aid: only shown where legacy
-                evals can no longer be set up (cloud), consistent with the
-                read-only edit gate. */}
-            {isLegacyEvalTarget(evalConfig.targetObject) && !allowLegacy && (
-              <DeactivateEvalConfig
-                projectId={projectId}
-                evalConfig={evalConfig}
-              />
-            )}
+            <DeactivateEvalConfig
+              projectId={projectId}
+              evalConfig={evalConfig}
+            />
           </div>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- restore the active/inactive switch for observation and experiment evaluators
- preserve the existing reactivation guard for deprecated trace and dataset evaluators

## Verification
- `pnpm --filter web exec eslint src/components/table/peek/peek-evaluator-config-detail.tsx --max-warnings 0`
- commit hook before the test removal: `Tasks: 7 successful, 7 total`

## Browser review
- Not run: no local server was running.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores evaluator status controls while retaining the existing legacy-reactivation guard.
- Always displays the active/inactive toggle for observation and experiment evaluators.
- Keeps deprecated trace and dataset evaluators from being reactivated where legacy evaluators are disallowed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The status control’s existing internal logic permits observation and experiment toggles while continuing to disable forbidden legacy reactivation, so broadening its visibility preserves the intended safeguards.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): restore observation evaluato..."](https://github.com/langfuse/langfuse/commit/b03b48d8719fb7f4899b8b9116397a6c5f375973) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48328850)</sub>

<!-- /greptile_comment -->