### PR TITLE
fix(evals): preserve configured model while options load

### DIFF
--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -46,6 +46,7 @@ export const useModelParams = (
     },
     { enabled: Boolean(projectId) },
   );
+  const hasLoadedLlmConnections = availableLLMApiKeys.data !== undefined;
 
   // Generate window-specific localStorage keys
   const modelNameKey = getModelNameKey(windowId ?? "");
@@ -200,7 +201,7 @@ export const useModelParams = (
   ]);
 
   useEffect(() => {
-    if (availableModels.length === 0) return;
+    if (!hasLoadedLlmConnections) return;
 
     if (
       !modelParams.model.value ||
@@ -213,6 +214,7 @@ export const useModelParams = (
       }
     }
   }, [
+    hasLoadedLlmConnections,
     availableModels,
     modelParams.model.value,
     updateModelParamValue,

--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -200,8 +200,10 @@ export const useModelParams = (
   ]);
 
   useEffect(() => {
+    if (availableModels.length === 0) return;
+
     if (
-      (availableModels.length > 0 && !modelParams.model.value) ||
+      !modelParams.model.value ||
       !availableModels.includes(modelParams.model.value)
     ) {
       if (persistedModelName && availableModels.includes(persistedModelName)) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15583.preview.langfuse.com](https://pr-15583.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- wait for available models to load before applying model fallback logic
- prevent a configured evaluator model from being temporarily overwritten by the UI default

## Impacted package

- `web`

## Verification

- Manual: confirmed the evaluator UI retains and displays the model configured on the evaluation template after model options load
- `git diff --check origin/main...HEAD`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Preserves the configured evaluator model while model options load.
- Defers model fallback logic until at least one available model has loaded.
- Avoids temporarily replacing the configured model with the UI default.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The stale-model path after removing a selected provider connection needs to be fixed before merging.

The unconditional empty-list return preserves a deleted connection's model value, allowing submission to proceed with an unusable provider/model configuration.

**Files Needing Attention:** web/src/features/playground/page/hooks/useModelParams.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/playground/page/hooks/useModelParams.ts:203
**Stale model survives connection removal**

When the selected provider connection is removed while the form is open, `availableModels` becomes empty and this return preserves the deleted connection's model. Because the model remains non-empty, submission bypasses the missing-model validation and sends an unusable provider/model configuration, causing the request to fail.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): prevent stale default model ..."](https://github.com/langfuse/langfuse/commit/39d0422594e3cdead6836677c83de0569a2a5435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48328890)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->