### PR TITLE
fix(mcp): Allow disabling Host header validation

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -270,6 +270,7 @@ LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=true
 # LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS=
 
 # Comma-separated additional hostnames/origins accepted by the MCP endpoint.
+# Set to * to disable Host and Origin validation. This is not recommended.
 # LANGFUSE_MCP_ALLOWED_HOSTS=internal-langfuse.example.com,https://api.example.com
 
 # Legacy tracing UI controls

--- a/web/src/__tests__/server/unit/mcp-security.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-security.servertest.ts
@@ -44,4 +44,17 @@ describe("MCP request security", () => {
       validateMcpRequestSecurity(mockRequest({ host: "evil.example.com" })),
     ).toThrow("Invalid Host header: evil.example.com");
   });
+
+  it("disables host and origin validation when LANGFUSE_MCP_ALLOWED_HOSTS is *", () => {
+    mockEnv.env.LANGFUSE_MCP_ALLOWED_HOSTS = ["*"];
+
+    expect(
+      validateMcpRequestSecurity(
+        mockRequest({
+          host: "any-host.example.com",
+          origin: "https://any-origin.example.com",
+        }),
+      ),
+    ).toBe("https://any-origin.example.com");
+  });
 });

--- a/web/src/features/mcp/README.md
+++ b/web/src/features/mcp/README.md
@@ -144,8 +144,10 @@ This outputs your BasicAuth token (e.g., `cGstbGYt...`).
 - If a reverse proxy forwards a different `Host` header than `NEXTAUTH_URL`,
   either preserve the public host at the proxy or set
   `LANGFUSE_MCP_ALLOWED_HOSTS` to a comma-separated list of exact additional
-  hostnames/origins accepted by the MCP endpoint. Wildcards and paths are not
-  supported.
+  hostnames/origins accepted by the MCP endpoint. Wildcard host patterns and
+  paths are not supported. To disable Host and Origin validation completely, set
+  `LANGFUSE_MCP_ALLOWED_HOSTS=*`. This is not recommended because it disables
+  DNS rebinding protection for the MCP endpoint.
 
 **Local Development:**
 

--- a/web/src/features/mcp/server/security.ts
+++ b/web/src/features/mcp/server/security.ts
@@ -68,6 +68,14 @@ function getAllowedMcpOriginsAndHostnames() {
 }
 
 export function validateMcpRequestSecurity(req: NextApiRequest): string | null {
+  const originHeader = Array.isArray(req.headers.origin)
+    ? req.headers.origin[0]
+    : req.headers.origin;
+
+  if (env.LANGFUSE_MCP_ALLOWED_HOSTS.includes("*")) {
+    return originHeader ?? null;
+  }
+
   const { allowedHostnames, allowedOrigins } =
     getAllowedMcpOriginsAndHostnames();
 
@@ -89,9 +97,6 @@ export function validateMcpRequestSecurity(req: NextApiRequest): string | null {
     throw new ForbiddenError(`Invalid Host header: ${hostHeader}`);
   }
 
-  const originHeader = Array.isArray(req.headers.origin)
-    ? req.headers.origin[0]
-    : req.headers.origin;
   if (!originHeader) {
     return null;
   }


### PR DESCRIPTION
Fixes #15534

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an explicit configuration escape hatch for MCP Host and Origin validation.
- Treats `LANGFUSE_MCP_ALLOWED_HOSTS=*` as disabling both checks.
- Adds unit coverage for arbitrary Host and Origin values under the wildcard configuration.
- Documents the behavior and DNS-rebinding risk in the MCP README and production environment example.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new behavior is explicit, documented, tested, and limited to an operator-controlled security opt-out.

The wildcard configuration short-circuits only MCP Host and Origin validation as intended; the endpoint continues to enforce its independent authentication and project-scoping controls.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Allow disabling Host header va..."](https://github.com/langfuse/langfuse/commit/dffbd0247f4dd0eaf7018f2b969b9f188ef5dc5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48329564)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->