### PR TITLE
fix(assistant): Perform side effects after tool calls

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -56,6 +56,10 @@ import {
 } from "@/src/features/in-app-agent/components/utils/utils";
 import { evaluateSetStateAction } from "@/src/utils/evaluate-set-state-action";
 import { InAppAgentDisabledDialog } from "@/src/features/in-app-agent/components/InAppAgentDisabledDialog";
+import {
+  performToolSideEffects,
+  shouldPerformToolSideEffects,
+} from "@/src/features/in-app-agent/components/utils/side-effects";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
@@ -303,6 +307,7 @@ function InAppAiAgentProviderInner({
   const [error, setError] = useState<InAppAgentError | null>(null);
   const agentRef = useRef<HttpAgent | null>(null);
   const activeRunIdRef = useRef<string | null>(null);
+  const toolCallNamesRef = useRef(new Map<string, string>());
   const intentionalAbortRef = useRef(false);
   const submitInFlightRef = useRef(false);
   const runInFlightRef = useRef(false);
@@ -505,7 +510,6 @@ function InAppAiAgentProviderInner({
     },
     [publishLiveMessages],
   );
-
   const resetAgent = useCallback(() => {
     if (agentRef.current?.isRunning) {
       intentionalAbortRef.current = true;
@@ -516,6 +520,7 @@ function InAppAiAgentProviderInner({
     agentRef.current?.abortRun();
     agentRef.current = null;
     activeRunIdRef.current = null;
+    toolCallNamesRef.current.clear();
     setDisplayState(createInAppAgentDisplayState());
     pendingToolApprovalsRef.current = [];
     setPendingToolApprovals([]);
@@ -604,6 +609,7 @@ function InAppAiAgentProviderInner({
           }
 
           if (event.type === EventType.TOOL_CALL_START) {
+            toolCallNamesRef.current.set(event.toolCallId, event.toolCallName);
             setDisplayState((currentState) =>
               recordInAppAgentToolCallForDisplay(
                 currentState,
@@ -658,6 +664,19 @@ function InAppAiAgentProviderInner({
           });
         },
         onToolCallResultEvent: ({ event }) => {
+          const toolName = toolCallNamesRef.current.get(event.toolCallId);
+          toolCallNamesRef.current.delete(event.toolCallId);
+          if (toolName && shouldPerformToolSideEffects(event.error)) {
+            performToolSideEffects({ toolName, utils }).catch(
+              (error: unknown) => {
+                console.error(
+                  "Failed to invalidate tRPC routes after in-app agent tool call",
+                  { error, toolName },
+                );
+              },
+            );
+          }
+
           updatePendingToolApprovals((currentApprovals) =>
             currentApprovals.filter(
               (approval) =>
@@ -684,6 +703,7 @@ function InAppAiAgentProviderInner({
     [
       clearLoadingEvents,
       publishAgentMessages,
+      utils,
       updateLoadingEvent,
       updatePendingToolApprovals,
     ],

--- a/web/src/features/in-app-agent/components/utils/side-effects.ts
+++ b/web/src/features/in-app-agent/components/utils/side-effects.ts
@@ -1,0 +1,211 @@
+import type { InAppAgentLangfuseMcpToolName } from "@langfuse/shared/in-app-agent/server/tools";
+import { safeJsonParse } from "@langfuse/shared";
+import { IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE } from "@langfuse/shared/in-app-agent";
+
+import type { api } from "@/src/utils/api";
+import { assertUnreachable } from "@/src/utils/types";
+
+export type InAppAgentTrpcInvalidationTarget =
+  | "annotationQueues"
+  | "annotationQueueItems"
+  | "annotationQueueAssignments"
+  | "comments"
+  | "dashboard"
+  | "dashboardWidgets"
+  | "datasets"
+  | "evals"
+  | "experiments"
+  | "models"
+  | "prompts"
+  | "scoreAnalytics"
+  | "scoreConfigs"
+  | "scores";
+
+type InAppAgentMcpToolName = `langfuse_${InAppAgentLangfuseMcpToolName}`;
+
+const IN_APP_AGENT_TOOL_TRPC_INVALIDATION_TARGETS = {
+  langfuse_listAnnotationQueues: [],
+  langfuse_createAnnotationQueue: ["annotationQueues"],
+  langfuse_getAnnotationQueue: [],
+  langfuse_listAnnotationQueueItems: [],
+  langfuse_getAnnotationQueueItem: [],
+  langfuse_createAnnotationQueueItem: [
+    "annotationQueues",
+    "annotationQueueItems",
+  ],
+  langfuse_updateAnnotationQueueItem: [
+    "annotationQueues",
+    "annotationQueueItems",
+  ],
+  langfuse_deleteAnnotationQueueItem: [
+    "annotationQueues",
+    "annotationQueueItems",
+  ],
+  langfuse_createAnnotationQueueAssignment: [
+    "annotationQueues",
+    "annotationQueueAssignments",
+  ],
+  langfuse_deleteAnnotationQueueAssignment: [
+    "annotationQueues",
+    "annotationQueueAssignments",
+  ],
+  langfuse_createComment: ["comments"],
+  langfuse_listComments: [],
+  langfuse_getComment: [],
+  langfuse_upsertDataset: ["datasets"],
+  langfuse_listDatasets: [],
+  langfuse_getDataset: [],
+  langfuse_upsertDatasetItem: ["datasets"],
+  langfuse_listDatasetItems: [],
+  langfuse_getDatasetItem: [],
+  langfuse_deleteDatasetItem: ["datasets"],
+  langfuse_createDatasetRunItem: ["datasets", "experiments"],
+  langfuse_listDatasetRunItems: [],
+  langfuse_listDatasetRuns: [],
+  langfuse_getDatasetRun: [],
+  langfuse_deleteDatasetRun: ["datasets", "experiments"],
+  langfuse_listEvaluators: [],
+  langfuse_getEvaluator: [],
+  langfuse_upsertEvaluator: ["evals", "models"],
+  langfuse_deleteEvaluator: ["evals", "models"],
+  langfuse_listEvaluationRules: [],
+  langfuse_getEvaluationRule: [],
+  langfuse_createEvaluationRule: ["evals"],
+  langfuse_updateEvaluationRule: ["evals"],
+  langfuse_deleteEvaluationRule: ["evals"],
+  langfuse_listExperiments: [],
+  langfuse_listExperimentItems: [],
+  langfuse_submitFeedback: ["scores", "scoreAnalytics"],
+  langfuse_getHealth: [],
+  langfuse_getMedia: [],
+  langfuse_queryMetrics: [],
+  langfuse_getMetricsSchema: [],
+  langfuse_listModels: [],
+  langfuse_createModel: ["models"],
+  langfuse_getModel: [],
+  langfuse_deleteModel: ["models"],
+  langfuse_listObservations: [],
+  langfuse_getObservation: [],
+  langfuse_getObservationFieldSchema: [],
+  langfuse_getObservationFilterSchema: [],
+  langfuse_getObservationFilterValues: [],
+  langfuse_getPrompt: [],
+  langfuse_getPromptUnresolved: [],
+  langfuse_listMonitors: [],
+  langfuse_getMonitor: [],
+  langfuse_listPrompts: [],
+  langfuse_createTextPrompt: ["prompts"],
+  langfuse_createChatPrompt: ["prompts"],
+  langfuse_updatePromptLabels: ["prompts"],
+  langfuse_listScores: [],
+  langfuse_getScore: [],
+  langfuse_createScore: ["scores", "scoreAnalytics"],
+  langfuse_listScoreConfigs: [],
+  langfuse_getScoreConfig: [],
+  langfuse_createScoreConfig: ["scoreConfigs"],
+  langfuse_updateScoreConfig: ["scoreConfigs"],
+  langfuse_deleteScoreConfig: ["scoreConfigs"],
+  langfuse_createDashboardWidget: ["dashboard", "dashboardWidgets"],
+  langfuse_listDashboardWidgets: [],
+  langfuse_getDashboardWidget: [],
+  langfuse_updateDashboardWidget: ["dashboard", "dashboardWidgets"],
+  langfuse_deleteDashboardWidget: ["dashboard", "dashboardWidgets"],
+  langfuse_listDashboards: [],
+  langfuse_getDashboard: [],
+  langfuse_createDashboard: ["dashboard"],
+  langfuse_updateDashboard: ["dashboard"],
+  langfuse_deleteDashboard: ["dashboard"],
+  langfuse_addDashboardPlacement: ["dashboard"],
+  langfuse_updateDashboardPlacement: ["dashboard"],
+  langfuse_deleteDashboardPlacement: ["dashboard"],
+} as const satisfies Record<
+  InAppAgentMcpToolName,
+  readonly InAppAgentTrpcInvalidationTarget[]
+>;
+
+export function getInAppAgentTrpcInvalidationTargets(toolName: string) {
+  return (
+    IN_APP_AGENT_TOOL_TRPC_INVALIDATION_TARGETS[
+      toolName as keyof typeof IN_APP_AGENT_TOOL_TRPC_INVALIDATION_TARGETS
+    ] ?? []
+  );
+}
+
+export function shouldPerformToolSideEffects(toolError: unknown) {
+  const parsedError =
+    typeof toolError === "string" ? safeJsonParse(toolError) : toolError;
+
+  if (
+    typeof parsedError !== "object" ||
+    parsedError === null ||
+    !("code" in parsedError)
+  ) {
+    return true;
+  }
+
+  return parsedError.code !== IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE;
+}
+
+export function performTargetInvalidation(
+  target: InAppAgentTrpcInvalidationTarget,
+  utils: ReturnType<typeof api.useUtils>,
+) {
+  if (target === "annotationQueues") {
+    return utils.annotationQueues.invalidate();
+  }
+  if (target === "annotationQueueItems") {
+    return utils.annotationQueueItems.invalidate();
+  }
+  if (target === "annotationQueueAssignments") {
+    return utils.annotationQueueAssignments.invalidate();
+  }
+  if (target === "comments") {
+    return utils.comments.invalidate();
+  }
+  if (target === "dashboard") {
+    return utils.dashboard.invalidate();
+  }
+  if (target === "dashboardWidgets") {
+    return utils.dashboardWidgets.invalidate();
+  }
+  if (target === "datasets") {
+    return utils.datasets.invalidate();
+  }
+  if (target === "evals") {
+    return utils.evals.invalidate();
+  }
+  if (target === "experiments") {
+    return utils.experiments.invalidate();
+  }
+  if (target === "models") {
+    return utils.models.invalidate();
+  }
+  if (target === "prompts") {
+    return utils.prompts.invalidate();
+  }
+  if (target === "scoreAnalytics") {
+    return utils.scoreAnalytics.invalidate();
+  }
+  if (target === "scoreConfigs") {
+    return utils.scoreConfigs.invalidate();
+  }
+  if (target === "scores") {
+    return utils.scores.invalidate();
+  }
+
+  return assertUnreachable(target);
+}
+
+export function performToolSideEffects({
+  toolName,
+  utils,
+}: {
+  toolName: string;
+  utils: ReturnType<typeof api.useUtils>;
+}) {
+  const targets = getInAppAgentTrpcInvalidationTargets(toolName);
+
+  return Promise.all(
+    targets.map((target) => performTargetInvalidation(target, utils)),
+  );
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes in-app assistant cache synchronization after tool calls.
- Tracks tool names by tool-call ID until their results arrive.
- Skips side effects for explicitly rejected calls.
- Adds a tool-to-tRPC-router mapping and invalidates affected caches after results.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until annotation queue item tool mutations invalidate the annotationQueueItems cache.

The new side-effect mapping leaves the separate annotationQueueItems query cache untouched after create, update, and delete operations, so active queue item views can continue displaying stale data.

**Files Needing Attention:** web/src/features/in-app-agent/components/utils/side-effects.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Agent
  participant Provider as InAppAiAgentProvider
  participant Effects as Tool side effects
  participant Cache as tRPC cache
  Agent->>Provider: TOOL_CALL_START(id, name)
  Provider->>Provider: Store id → name
  Agent->>Provider: TOOL_CALL_RESULT(id, error)
  Provider->>Provider: Resolve and remove tool name
  alt Not explicitly rejected
    Provider->>Effects: performToolSideEffects(name)
    Effects->>Cache: Invalidate mapped routers
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/in-app-agent/components/utils/side-effects.ts:29-31
**Queue item caches remain stale**

When the assistant creates, updates, or deletes an annotation queue item, these mappings invalidate only `annotationQueues`, while the affected list, detail, and pending-count queries belong to the separate `annotationQueueItems` router. Those views therefore continue displaying stale data after the tool completes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): Perform side effects aft..."](https://github.com/langfuse/langfuse/commit/cfaacc1307270c7878457c84c3142d438767441f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48345523)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->