### PR TITLE
fix: optimize ClickHouse score filtering without dropping score data

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -25,7 +25,7 @@ export interface Filter {
   operator: ClickhouseOperator;
   field: string;
 }
-type ClickhouseFilter = {
+export type ClickhouseFilter = {
   query: string;
   params: { [x: string]: any } | {};
 };

--- a/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-observation-row-selection.ts
@@ -1,5 +1,6 @@
 import { eventsTableCols } from "../../../eventsTable";
 import { InvalidRequestError } from "../../../errors";
+import type { OrderByState } from "../../../interfaces/orderBy";
 import type { TracingSearchType } from "../../../interfaces/search";
 import { findUiColumnMapping } from "../../../tableDefinitions";
 import type { FilterCondition } from "../../../types";
@@ -22,6 +23,10 @@ import {
   eventsScoresAggregation,
   eventsTracesScoresAggregationFromObservationStart,
 } from "./query-fragments";
+import {
+  planScoreFilterPushdown,
+  resolveScoreDataRequirement,
+} from "./score-filter-pushdown";
 import { clickhouseSearchCondition } from "./search";
 
 const EVENT_SEARCH_COLUMNS = [
@@ -61,52 +66,19 @@ export type EventsObservationRowSelectionInput = {
   filter: FilterCondition[] | null;
   searchQuery?: string;
   searchType?: TracingSearchType[];
+  /** Used to add the required score CTE and keep its source complete. */
+  orderBy?: OrderByState;
 };
 
-type ObservationScoreDependency = {
-  cte: ReturnType<typeof eventsScoresAggregation>;
-  joinTable: string;
-  joinCondition: string;
-  selectExpressions?: string[];
-  /**
-   * Blob export: also join the trace-score CTE (with tuple encoding) so the
-   * `ts.*` select expressions resolve and trace-level scores land in the
-   * export like they do in the UI's unified Scores column (LFE-10596).
-   */
-  includeTraceScores?: boolean;
-};
+type ScoreProjection = "none" | "blob-export";
 
-type ObservationScoreDependencyFactory = (input: {
-  projectId: string;
-  startTimeFrom: string | null;
-}) => ObservationScoreDependency;
-
-const buildObservationScoreFilterDependency: ObservationScoreDependencyFactory =
-  ({ projectId, startTimeFrom }) => ({
-    cte: eventsScoresAggregation({ projectId, startTimeFrom }),
-    joinTable: "scores_agg AS s",
-    joinCondition: "ON s.observation_id = e.span_id",
-  });
-
-const buildBlobExportObservationScoreDependency: ObservationScoreDependencyFactory =
-  ({ projectId, startTimeFrom }) => ({
-    cte: eventsScoresAggregation({
-      projectId,
-      startTimeFrom,
-      includeTupleEncoding: true,
-    }),
-    joinTable: "scores_agg s",
-    joinCondition:
-      "ON s.trace_id = e.trace_id AND s.observation_id = e.span_id",
-    selectExpressions: [
-      "s.scores_avg as scores_avg",
-      "s.score_categories as score_categories",
-      "s.score_categories_tuples as score_categories_tuples",
-      "ts.scores_avg as trace_scores_avg",
-      "ts.score_categories_tuples as trace_score_categories_tuples",
-    ],
-    includeTraceScores: true,
-  });
+const BLOB_EXPORT_SCORE_SELECTS = [
+  "s.scores_avg as scores_avg",
+  "s.score_categories as score_categories",
+  "s.score_categories_tuples as score_categories_tuples",
+  "ts.scores_avg as trace_scores_avg",
+  "ts.score_categories_tuples as trace_score_categories_tuples",
+];
 
 // LFE-10596: in v4 the events table splits scores into observation-scoped
 // columns (`s.scores_avg` / `s.score_categories` / `s.score_booleans`, joined
@@ -250,8 +222,9 @@ const buildEventsObservationRowSelectionInternal = (
     filter,
     searchQuery,
     searchType,
+    orderBy,
   }: EventsObservationRowSelectionInput,
-  observationScoreDependencyFactory?: ObservationScoreDependencyFactory,
+  scoreProjection: ScoreProjection,
 ): {
   queryBuilder: EventsQueryBuilder;
   filterGroups: EventsObservationFilterGroups;
@@ -269,82 +242,106 @@ const buildEventsObservationRowSelectionInternal = (
   // Observation-scoped score filters are rewritten into a level-agnostic
   // union across the obs (`s.`) and trace (`ts.`) score columns (LFE-10596),
   // for every caller of this planner (events list, blob export, stream).
+  const rawEventsFilters = createFilterFromFilterState(
+    filter ?? [],
+    eventsTableUiColumnDefinitions,
+    eventsTableCols,
+  );
+  const includeScoreProjection = scoreProjection === "blob-export";
+  const orderByColumn = findUiColumnMapping(
+    eventsTableUiColumnDefinitions,
+    orderBy?.column,
+  );
+  const scoreOrderField =
+    orderByColumn?.clickhouseTableName === "scores"
+      ? orderByColumn.clickhouseSelect
+      : undefined;
+  const ordersByTraceScore = scoreOrderField?.startsWith("ts.") ?? false;
+  const ordersByObservationScore =
+    scoreOrderField !== undefined && !ordersByTraceScore;
+  const scoreDataRequirement = resolveScoreDataRequirement({
+    selectsScoreData: includeScoreProjection,
+    ordersByScoreData: scoreOrderField !== undefined,
+  });
+  const scoreRowsFilter = planScoreFilterPushdown({
+    filters: new FilterList(rawEventsFilters),
+    scoreDataRequirement,
+  });
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter ?? [],
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ).map(toLevelAgnosticScoreFilter),
+    rawEventsFilters.map(toLevelAgnosticScoreFilter),
   );
   const startTimeFrom = extractTimeFilter(eventsFilter);
   const hasObservationScoreFilter = filterGroups.observationScores.length > 0;
-  const queryBuilder = new EventsQueryBuilder({ projectId });
-  const observationScoreDependency =
-    observationScoreDependencyFactory?.({ projectId, startTimeFrom }) ??
-    (hasObservationScoreFilter
-      ? buildObservationScoreFilterDependency({ projectId, startTimeFrom })
-      : undefined);
-  // The trace-score CTE is needed for explicit trace-only filters, for the
-  // level-agnostic union (an observation-scoped filter now references `ts.*`
-  // too), and whenever the score dependency selects `ts.*` so trace-level
-  // scores land in exports like they do in the UI's unified Scores column.
-  const hasTraceScoreFilter =
+  const needsObservationScores =
+    hasObservationScoreFilter ||
+    ordersByObservationScore ||
+    includeScoreProjection;
+  // Observation score filters are level-agnostic and therefore need both
+  // observation and trace aggregates. Blob exports project both explicitly.
+  const needsTraceScores =
     filterGroups.traceScores.length > 0 ||
     hasObservationScoreFilter ||
-    Boolean(observationScoreDependency?.includeTraceScores);
-  const search = eventSearchCondition({ query: searchQuery, searchType });
+    ordersByTraceScore ||
+    includeScoreProjection;
+  const queryBuilder = new EventsQueryBuilder({ projectId });
 
-  if (observationScoreDependency) {
+  if (needsObservationScores) {
     queryBuilder
-      .withCTE("scores_agg", observationScoreDependency.cte)
+      .withCTE(
+        "scores_agg",
+        eventsScoresAggregation({
+          projectId,
+          startTimeFrom,
+          includeTupleEncoding: includeScoreProjection,
+          scoreRowsFilter,
+        }),
+      )
       .leftJoin(
-        observationScoreDependency.joinTable,
-        observationScoreDependency.joinCondition,
+        includeScoreProjection ? "scores_agg s" : "scores_agg AS s",
+        includeScoreProjection
+          ? "ON s.trace_id = e.trace_id AND s.observation_id = e.span_id"
+          : "ON s.observation_id = e.span_id",
       );
-
-    if (observationScoreDependency.selectExpressions) {
-      queryBuilder.selectRaw(...observationScoreDependency.selectExpressions);
-    }
   }
 
-  queryBuilder
-    .when(hasTraceScoreFilter, (builder) =>
-      builder.withCTE(
+  if (needsTraceScores) {
+    queryBuilder
+      .withCTE(
         "trace_scores_agg",
         eventsTracesScoresAggregationFromObservationStart({
           projectId,
           startTimeFrom,
           hasScoreAggregationFilters: true,
-          includeTupleEncoding: Boolean(
-            observationScoreDependency?.includeTraceScores,
-          ),
+          scoreRowsFilter,
+          includeTupleEncoding: includeScoreProjection,
         }),
-      ),
-    )
-    .when(hasTraceScoreFilter, (builder) =>
-      builder.leftJoin(
+      )
+      .leftJoin(
         "trace_scores_agg AS ts",
         "ON ts.trace_id = e.trace_id AND ts.project_id = e.project_id",
-      ),
-    )
+      );
+  }
+
+  if (includeScoreProjection) {
+    queryBuilder.selectRaw(...BLOB_EXPORT_SCORE_SELECTS);
+  }
+
+  const search = eventSearchCondition({ query: searchQuery, searchType });
+  queryBuilder
     .when(
       search.requiresEventsFull || filtersRequireEventsFull(eventsFilter),
       (builder) => builder.forceFullTable(),
-    );
-
-  queryBuilder.applyFilters(eventsFilter).where(search);
+    )
+    .applyFilters(eventsFilter)
+    .where(search);
 
   return { queryBuilder, filterGroups, search, startTimeFrom };
 };
 
 export const buildEventsObservationRowSelection = (
   input: EventsObservationRowSelectionInput,
-) => buildEventsObservationRowSelectionInternal(input);
+) => buildEventsObservationRowSelectionInternal(input, "none");
 
 export const buildEventsObservationRowSelectionForBlobExport = (
   input: EventsObservationRowSelectionInput,
-) =>
-  buildEventsObservationRowSelectionInternal(
-    input,
-    buildBlobExportObservationScoreDependency,
-  );
+) => buildEventsObservationRowSelectionInternal(input, "blob-export");

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
@@ -1,4 +1,5 @@
 import type { FilterCondition } from "../../../types";
+import type { OrderByState } from "../../../interfaces/orderBy";
 import { InvalidRequestError } from "../../../errors";
 import { describe, expect, it } from "vitest";
 import {
@@ -18,13 +19,27 @@ const nativeFilter: FilterCondition = {
   value: ["GENERATION"],
   type: "stringOptions",
 };
+const scoreFilter: FilterCondition = {
+  type: "numberObject",
+  column: "scores_avg",
+  operator: ">",
+  key: "quality",
+  value: 0.5,
+};
 
 const normalizeSql = (query: string) => query.replace(/\s+/g, " ").trim();
 
-const buildSelection = ({ filter }: { filter: FilterCondition[] }) => {
+const buildSelection = ({
+  filter,
+  orderBy,
+}: {
+  filter: FilterCondition[];
+  orderBy?: OrderByState;
+}) => {
   const selection = buildEventsObservationRowSelection({
     projectId,
     filter,
+    orderBy,
   });
 
   const built = selection.queryBuilder
@@ -122,13 +137,7 @@ describe("buildEventsStreamQuery", () => {
           operator: ">=",
           value: new Date("2025-01-02T03:04:05.678Z"),
         },
-        {
-          type: "numberObject",
-          column: "scores_avg",
-          operator: ">",
-          key: "quality",
-          value: 0.5,
-        },
+        scoreFilter,
       ],
       rowLimit: 7,
     });
@@ -147,6 +156,7 @@ describe("buildEventsStreamQuery", () => {
     expect(query).toContain(
       "AND timestamp >= {startTimeFrom: DateTime64(3)} - INTERVAL 1 HOUR",
     );
+    expect(query).not.toContain("name IN ({");
   });
 
   it("exports trace-level scores alongside observation-level ones (LFE-10596)", () => {
@@ -224,6 +234,11 @@ describe("buildEventsObservationRowSelection", () => {
     expect(filterGroups.traceScores).toHaveLength(1);
     expect(Object.values(params)).toContain("observation-quality");
     expect(Object.values(params)).toContain("trace-quality");
+    expect(Object.values(params)).toContainEqual([
+      "observation-quality",
+      "trace-quality",
+    ]);
+    expect(query.match(/\bname IN \(\{/g)).toHaveLength(2);
     expect(query).toContain(
       "AND timestamp >= {startTimeFrom: DateTime64(3)} - INTERVAL 1 HOUR",
     );
@@ -254,6 +269,26 @@ describe("buildEventsObservationRowSelection", () => {
 
     expect(startTimeFrom).toBeNull();
     expect(query).not.toContain("AND timestamp >=");
+  });
+
+  it("keeps complete score data when ordering by a score", () => {
+    const { query } = buildSelection({
+      filter: [scoreFilter],
+      orderBy: { column: "scores_avg", order: "DESC" },
+    });
+
+    expect(query).not.toContain("name IN ({");
+
+    for (const [column, expectedJoin] of [
+      ["scores_avg", "LEFT JOIN scores_agg AS s"],
+      ["trace_scores_avg", "LEFT JOIN trace_scores_agg AS ts"],
+    ] as const) {
+      const scoreOrderQuery = buildSelection({
+        filter: [],
+        orderBy: { column, order: "DESC" },
+      }).query;
+      expect(scoreOrderQuery).toContain(expectedJoin);
+    }
   });
 
   it.each([

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -15,6 +15,7 @@ import {
   OBSERVATIONS_TO_TRACE_INTERVAL,
   SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
 } from "../../repositories/constants";
+import type { ClickhouseFilter } from "./clickhouse-filter";
 
 /**
  * Lightweight trace metadata query: one row per trace with name, user_id, tags.
@@ -148,6 +149,8 @@ interface BaseScoresParams {
 interface BaseScoresAggregationParams extends BaseScoresParams {
   hasScoreAggregationFilters?: boolean;
   startTimeLookbackIntervals: readonly string[];
+  /** Optional predicate applied to raw score rows before aggregation. */
+  scoreRowsFilter?: ClickhouseFilter;
   /**
    * When true, adds an extra `score_categories_tuples` column with
    * `tuple(name, string_value, data_type)` encoding alongside the default concat-encoded
@@ -180,6 +183,7 @@ export const buildScoresAggregationCTE = (
 ): { query: string; params: Record<string, any> } => {
   const queryParams: Record<string, any> = {
     projectId: params.projectId,
+    ...params.scoreRowsFilter?.params,
   };
 
   if (params.startTimeFrom) {
@@ -219,6 +223,7 @@ export const buildScoresAggregationCTE = (
         FROM scores FINAL
         WHERE project_id = {projectId: String}
           ${observationFilter}
+          ${params.scoreRowsFilter ? `AND ${params.scoreRowsFilter.query}` : ""}
           ${scoreTimestampLowerBound(params.startTimeFrom, params.startTimeLookbackIntervals)}
         GROUP BY
           ${primaryKey},
@@ -239,6 +244,7 @@ interface EventsScoresAggregationParams {
   projectId: string;
   startTimeFrom?: string | null;
   includeTupleEncoding?: boolean;
+  scoreRowsFilter?: ClickhouseFilter;
 }
 
 /**
@@ -264,6 +270,7 @@ interface EventsTracesScoresAggregationParams {
   projectId: string;
   startTimeFrom?: string | null;
   hasScoreAggregationFilters?: boolean;
+  scoreRowsFilter?: ClickhouseFilter;
   /**
    * Adds the `score_categories_tuples` column for programmatic parsing (see
    * BaseScoresAggregationParams). Only meaningful together with
@@ -297,6 +304,7 @@ const buildEventsTracesScoresAggregation = (
 
   const queryParams: Record<string, any> = {
     projectId: params.projectId,
+    ...params.scoreRowsFilter?.params,
   };
 
   if (params.startTimeFrom) {
@@ -312,6 +320,7 @@ const buildEventsTracesScoresAggregation = (
     FROM scores
     WHERE project_id = {projectId: String}
       AND observation_id IS NULL
+      ${params.scoreRowsFilter ? `AND ${params.scoreRowsFilter.query}` : ""}
       ${scoreTimestampLowerBound(params.startTimeFrom, startTimeLookbackIntervals)}
     GROUP BY
       trace_id,

--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-pushdown.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-pushdown.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../repositories", () => ({
+  clickhouseCompliantRandomCharacters: () => "test",
+}));
+
+import { type Filter, FilterList } from "./clickhouse-filter";
+import {
+  planScoreFilterPushdown,
+  resolveScoreDataRequirement,
+  type ScoreDataRequirement,
+} from "./score-filter-pushdown";
+
+type TestFilter = Filter & { key?: string };
+
+const makeFilter = ({
+  field,
+  key,
+  clickhouseTable = "scores",
+}: {
+  field: string;
+  key?: string;
+  clickhouseTable?: string;
+}): TestFilter => ({
+  clickhouseTable,
+  field,
+  key,
+  operator: "=",
+  apply: () => ({ query: "", params: {} }),
+});
+
+const plan = (
+  filters: Filter[],
+  scoreDataRequirement: ScoreDataRequirement = "filter-only",
+) =>
+  planScoreFilterPushdown({
+    filters: new FilterList(filters),
+    scoreDataRequirement,
+  });
+
+describe("planScoreFilterPushdown", () => {
+  it("keeps the union of score names needed by filter-only consumers", () => {
+    const pushdown = plan([
+      makeFilter({ field: "s.scores_avg", key: "quality" }),
+      makeFilter({ field: "s.score_categories", key: "sentiment" }),
+      makeFilter({ field: "s.score_booleans", key: "approved" }),
+      makeFilter({ field: "ts.scores_avg", key: "quality" }),
+      makeFilter({ clickhouseTable: "traces", field: "name" }),
+    ]);
+
+    expect(pushdown).toEqual({
+      query: "name IN ({stringOptionsFiltertest: Array(String)})",
+      params: {
+        stringOptionsFiltertest: ["quality", "sentiment", "approved"],
+      },
+    });
+  });
+
+  it("does not restrict consumers that require complete score data", () => {
+    expect(
+      plan([makeFilter({ field: "s.scores_avg", key: "quality" })], "complete"),
+    ).toBeUndefined();
+  });
+
+  it("resolves reusable consumer guards", () => {
+    expect(resolveScoreDataRequirement({})).toBe("filter-only");
+    expect(resolveScoreDataRequirement({ selectsScoreData: true })).toBe(
+      "complete",
+    );
+    expect(resolveScoreDataRequirement({ ordersByScoreData: true })).toBe(
+      "complete",
+    );
+  });
+
+  it("does not restrict when any score filter lacks a safe source predicate", () => {
+    expect(
+      plan([
+        makeFilter({ field: "s.scores_avg", key: "quality" }),
+        makeFilter({ field: "s.score_categories" }),
+      ]),
+    ).toBeUndefined();
+    expect(plan([makeFilter({ field: "metadata", key: "customer" })])).toBe(
+      undefined,
+    );
+  });
+});

--- a/packages/shared/src/server/queries/clickhouse-sql/score-filter-pushdown.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/score-filter-pushdown.ts
@@ -1,0 +1,83 @@
+import {
+  type ClickhouseFilter,
+  type Filter,
+  type FilterList,
+  StringOptionsFilter,
+} from "./clickhouse-filter";
+
+export type ScoreDataRequirement = "filter-only" | "complete";
+
+/**
+ * A query may narrow the score source only when scores are used exclusively
+ * for filtering. Selecting score arrays/ids or ordering by score aggregates
+ * requires the complete source.
+ */
+export const resolveScoreDataRequirement = ({
+  selectsScoreData = false,
+  ordersByScoreData = false,
+}: {
+  selectsScoreData?: boolean;
+  ordersByScoreData?: boolean;
+}): ScoreDataRequirement =>
+  selectsScoreData || ordersByScoreData ? "complete" : "filter-only";
+
+const KEYED_SCORE_AGGREGATE_FIELDS = new Set([
+  "scores_avg",
+  "score_categories",
+  "score_booleans",
+]);
+
+const scoreNameForSourcePushdown = (filter: Filter): string | undefined => {
+  const field = filter.field.split(".").at(-1);
+  if (!field || !KEYED_SCORE_AGGREGATE_FIELDS.has(field)) {
+    return undefined;
+  }
+
+  const keyedFilter = filter as Filter & { key?: unknown };
+  return typeof keyedFilter.key === "string" ? keyedFilter.key : undefined;
+};
+
+/**
+ * Restricts raw score rows to the names referenced by post-aggregation score
+ * filters. The optimization is all-or-nothing: complete-data consumers and
+ * unsupported score filters keep the unmodified score source.
+ */
+export const planScoreFilterPushdown = ({
+  filters,
+  scoreDataRequirement,
+}: {
+  filters: FilterList;
+  scoreDataRequirement: ScoreDataRequirement;
+}): ClickhouseFilter | undefined => {
+  if (scoreDataRequirement === "complete") {
+    return undefined;
+  }
+
+  const scoreNames = new Set<string>();
+  let hasUnsupportedScoreFilter = false;
+
+  filters.forEach((filter) => {
+    if (filter.clickhouseTable !== "scores") {
+      return;
+    }
+
+    const scoreName = scoreNameForSourcePushdown(filter);
+    if (scoreName === undefined) {
+      hasUnsupportedScoreFilter = true;
+      return;
+    }
+
+    scoreNames.add(scoreName);
+  });
+
+  if (hasUnsupportedScoreFilter || scoreNames.size === 0) {
+    return undefined;
+  }
+
+  return new StringOptionsFilter({
+    clickhouseTable: "scores",
+    field: "name",
+    operator: "any of",
+    values: Array.from(scoreNames),
+  }).apply();
+};

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -49,6 +49,10 @@ import {
   ObservationPriceFields,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
+import {
+  planScoreFilterPushdown,
+  resolveScoreDataRequirement,
+} from "../queries/clickhouse-sql/score-filter-pushdown";
 import type { EventsTableFilterState, FilterState } from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
 import {
@@ -770,6 +774,7 @@ async function getObservationsFromEventsTableInternal<T>(
     filter: baseFilter,
     searchQuery: opts.searchQuery,
     searchType: opts.searchType,
+    orderBy,
   });
 
   if (opts.select === "count") {
@@ -1775,6 +1780,12 @@ async function getTracesFromEventsTableForPublicApiInternal<T>(
       f.field === "s.score_categories" ||
       f.field === "s.score_booleans",
   );
+  const scoreRowsFilter = planScoreFilterPushdown({
+    filters: tracesFilter,
+    scoreDataRequirement: resolveScoreDataRequirement({
+      selectsScoreData: opts.select === "rows" && includeScores,
+    }),
+  });
 
   // Build traces CTE using eventsTracesAggregation WITHOUT filters
   // Filters must be applied AFTER aggregation to ensure filters on aggregated
@@ -1797,6 +1808,7 @@ async function getTracesFromEventsTableForPublicApiInternal<T>(
       projectId,
       startTimeFrom,
       hasScoreAggregationFilters,
+      scoreRowsFilter,
     });
     queryBuilder = queryBuilder
       .withCTE("score_stats", {

--- a/packages/shared/src/server/repositories/traces.test.ts
+++ b/packages/shared/src/server/repositories/traces.test.ts
@@ -18,13 +18,28 @@ vi.mock("../queries/clickhouse-sql/query-options", () => ({
   shouldSkipObservationsFinal: mockShouldSkipObservationsFinal,
 }));
 
-import { getTracesCountForPublicApi } from "./traces";
+import {
+  generateTracesForPublicApi,
+  getTracesCountForPublicApi,
+} from "./traces";
 import {
   FilterList,
+  NumberObjectFilter,
   StringFilter,
 } from "../queries/clickhouse-sql/clickhouse-filter";
 
-describe("getTracesCountForPublicApi — FINAL modifier", () => {
+const makeScoreFilter = () =>
+  new FilterList([
+    new NumberObjectFilter({
+      clickhouseTable: "scores",
+      field: "s.scores_avg",
+      key: "quality",
+      operator: ">",
+      value: 0.5,
+    }),
+  ]);
+
+describe("public trace query construction", () => {
   beforeEach(() => {
     charCounter = 0;
     vi.clearAllMocks();
@@ -81,5 +96,28 @@ describe("getTracesCountForPublicApi — FINAL modifier", () => {
     expect(mockQueryClickhouse).toHaveBeenCalledOnce();
     const { query } = mockQueryClickhouse.mock.calls[0][0];
     expect(query).toMatch(/FROM\s+traces\s+t\s+FINAL/);
+  });
+
+  it("pushes score names down for filter-only count queries", async () => {
+    await getTracesCountForPublicApi({
+      projectId: "proj-1",
+      filter: makeScoreFilter(),
+    });
+
+    const { query, params } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).toContain("name IN ({");
+    expect(Object.values(params)).toContainEqual(["quality"]);
+  });
+
+  it("keeps all score ids when scores are selected", async () => {
+    await generateTracesForPublicApi({
+      projectId: "proj-1",
+      filter: makeScoreFilter(),
+      orderBy: null,
+      fields: ["core", "scores"],
+    });
+
+    const { query } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).not.toContain("name IN ({");
   });
 });

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -14,6 +14,10 @@ import {
 import { orderByToClickhouseSql } from "../queries";
 import { scoreBooleansAggregation } from "../queries/clickhouse-sql/query-fragments";
 import { shouldSkipObservationsFinal } from "../queries/clickhouse-sql/query-options";
+import {
+  planScoreFilterPushdown,
+  resolveScoreDataRequirement,
+} from "../queries/clickhouse-sql/score-filter-pushdown";
 import { LISTABLE_SCORE_TYPES } from "../../domain/scores";
 import { OrderByState } from "../../interfaces/orderBy";
 import snakeCase from "lodash/snakeCase";
@@ -1617,6 +1621,12 @@ async function buildTracesBaseQuery(
       f.field === "s.score_categories" ||
       f.field === "s.score_booleans",
   );
+  const scoreRowsFilter = planScoreFilterPushdown({
+    filters: filter,
+    scoreDataRequirement: resolveScoreDataRequirement({
+      selectsScoreData: select.includeScores,
+    }),
+  });
 
   const ctes = [];
 
@@ -1683,6 +1693,7 @@ async function buildTracesBaseQuery(
         AND data_type IN ({dataTypes: Array(String)})
         ${fromTimeFilter ? `AND timestamp >= {cteFromTimeFilter: DateTime64(3)}` : ""}
         ${environmentFilter.length() > 0 ? `AND ${appliedEnvironmentFilter.query}` : ""}
+        ${scoreRowsFilter ? `AND ${scoreRowsFilter.query}` : ""}
         GROUP BY
           project_id,
           trace_id,
@@ -1709,6 +1720,7 @@ async function buildTracesBaseQuery(
       AND data_type IN ({dataTypes: Array(String)})
       ${fromTimeFilter ? `AND timestamp >= {cteFromTimeFilter: DateTime64(3)}` : ""}
       ${environmentFilter.length() > 0 ? `AND ${appliedEnvironmentFilter.query}` : ""}
+      ${scoreRowsFilter ? `AND ${scoreRowsFilter.query}` : ""}
       GROUP BY project_id, trace_id
     )`);
     }
@@ -1850,6 +1862,7 @@ async function buildTracesBaseQuery(
   const params = {
     ...appliedEnvironmentFilter.params,
     ...appliedFilter.params,
+    ...scoreRowsFilter?.params,
     projectId,
     dataTypes: LISTABLE_SCORE_TYPES,
     ...(pagination !== undefined

--- a/packages/shared/src/server/services/traces-ui-table-service.test.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.test.ts
@@ -17,7 +17,34 @@ vi.mock("../queries/clickhouse-sql/query-options", () => ({
   shouldSkipObservationsFinal: mockShouldSkipObservationsFinal,
 }));
 
-import { getTraceDeleteCursorPageFromTraces } from "./traces-ui-table-service";
+import {
+  getTraceDeleteCursorPageFromTraces,
+  getTracesTable,
+  getTracesTableMetrics,
+} from "./traces-ui-table-service";
+import type { FilterState } from "../../types";
+
+const scoreFilter: FilterState = [
+  {
+    column: "scores_avg",
+    type: "numberObject",
+    key: "quality",
+    operator: ">",
+    value: 0.5,
+  },
+];
+
+const getCapturedQuery = () => {
+  const { query, params } = mockQueryClickhouse.mock.calls.at(-1)![0] as {
+    query: string;
+    params: Record<string, unknown>;
+  };
+
+  return {
+    query: query.replace(/\s+/g, " "),
+    params,
+  };
+};
 
 describe("getTraceDeleteCursorPageFromTraces", () => {
   beforeEach(() => {
@@ -51,5 +78,41 @@ describe("getTraceDeleteCursorPageFromTraces", () => {
     );
     expect(normalizedQuery).toContain("LIMIT 1 BY id, project_id");
     expect(normalizedQuery).toContain("LIMIT {limit: Int32}");
+  });
+
+  it("pushes referenced score names into filter-only score aggregation", async () => {
+    await getTracesTable({
+      projectId: "project-1",
+      filter: scoreFilter,
+      limit: 50,
+      page: 0,
+    });
+
+    const { query, params } = getCapturedQuery();
+    expect(query).toContain("name IN ({");
+    expect(Object.values(params)).toContainEqual(["quality"]);
+  });
+
+  it("keeps complete score aggregation for metrics", async () => {
+    await getTracesTableMetrics({
+      projectId: "project-1",
+      filter: scoreFilter,
+      limit: 50,
+      page: 0,
+    });
+
+    expect(getCapturedQuery().query).not.toContain("name IN ({");
+  });
+
+  it("keeps complete score aggregation when ordering by scores", async () => {
+    await getTracesTable({
+      projectId: "project-1",
+      filter: scoreFilter,
+      orderBy: { column: "scores_avg", order: "ASC" },
+      limit: 50,
+      page: 0,
+    });
+
+    expect(getCapturedQuery().query).not.toContain("name IN ({");
   });
 });

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -31,6 +31,10 @@ import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import { shouldSkipObservationsFinal } from "../queries/clickhouse-sql/query-options";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import type { TraceDeleteBatchActionCursor } from "../../features/batchAction/types";
+import {
+  planScoreFilterPushdown,
+  resolveScoreDataRequirement,
+} from "../queries/clickhouse-sql/score-filter-pushdown";
 
 export type TracesTableReturnType = Pick<
   TraceRecordReadType,
@@ -274,10 +278,12 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       f.field === "timestamp" && (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
-  const requiresScoresJoin =
-    tracesFilter.find((f) => f.clickhouseTable === "scores") !== undefined ||
+  const ordersByScoreData =
     findUiColumnMapping(tracesTableUiColumnDefinitions, orderBy?.column)
       ?.clickhouseTableName === "scores";
+  const requiresScoresJoin =
+    tracesFilter.find((f) => f.clickhouseTable === "scores") !== undefined ||
+    ordersByScoreData;
 
   const requiresObservationsJoin =
     tracesFilter.find((f) => f.clickhouseTable === "observations") !==
@@ -288,6 +294,13 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
   const tracesFilterRes = tracesFilter.apply();
   const scoresFilterRes = scoresFilter.apply();
   const observationFilterRes = observationsFilter.apply();
+  const scoreRowsFilter = planScoreFilterPushdown({
+    filters: tracesFilter,
+    scoreDataRequirement: resolveScoreDataRequirement({
+      selectsScoreData: select === "metrics",
+      ordersByScoreData,
+    }),
+  });
 
   const observationsAndScoresCTE = `
     WITH observations_stats AS (
@@ -343,6 +356,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
                     project_id = {projectId: String}
                     ${timeStampFilter ? `AND s.timestamp >= {traceTimestamp: DateTime64(3)} - ${SCORE_TO_TRACE_OBSERVATIONS_INTERVAL}` : ""}
                     ${scoresFilterRes ? `AND ${scoresFilterRes.query}` : ""}
+                    ${scoreRowsFilter ? `AND ${scoreRowsFilter.query}` : ""}
                   GROUP BY
                     project_id,
                     trace_id,
@@ -518,6 +532,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       ...tracesFilterRes.params,
       ...observationFilterRes.params,
       ...scoresFilterRes.params,
+      ...scoreRowsFilter?.params,
       ...search.params,
     },
     tags: { ...(props.tags ?? {}), projectId },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15591.preview.langfuse.com](https://pr-15591.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Push score-name filters down into ClickHouse score aggregations when only filtering is required.
- Preserve complete score data for exports, selection, and score ordering.
- Share score dependency planning across event, trace, and public API queries.
- Add regression coverage for score pushdown and ordering behavior.

Addresses https://github.com/langfuse/langfuse/issues/15553
Supersedes https://github.com/langfuse/langfuse/pull/15556

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Improves ClickHouse score-filter query planning while preserving complete score aggregates where required.
- Pushes referenced score names into raw score queries for filter-only event and trace consumers.
- Disables score-name narrowing for exports, metrics, score projection, and score-based ordering.
- Shares score dependency planning across events-table, legacy trace, and public API query paths.
- Adds regression coverage for pushdown, score projection, and ordering behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with score-name narrowing guarded wherever complete score aggregates are required.

The new planner applies parameterized name predicates only to supported filter-only score aggregations, while export, projection, metrics, and score-ordering paths retain the complete score source.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Q[Trace or observation query] --> F{Has supported score filters?}
  F -->|No| A[Use complete score source]
  F -->|Yes| C{Selects or orders by score data?}
  C -->|Yes| A
  C -->|No| P[Push score names into raw score query]
  P --> G[Aggregate filtered score rows]
  A --> H[Aggregate complete score rows]
  G --> R[Apply post-aggregation filters]
  H --> R
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Push down score filters while preserving..."](https://github.com/langfuse/langfuse/commit/0d06e3d565ccd2cdecd40e43397d53a463c53511) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48383185)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->