### PR TITLE
fix(web): validate unsupported evaluator JSONPath

### DIFF
--- a/web/src/features/evals/components/eval-form-descriptions.tsx
+++ b/web/src/features/evals/components/eval-form-descriptions.tsx
@@ -7,7 +7,7 @@ export function VariableMappingDescription(p: {
   href: string;
 }) {
   return (
-    <div className="flex w-1/2 items-center">
+    <div className="flex h-8 w-1/2 items-center">
       <Label className="text-sm font-normal">{p.title}</Label>
       <DocPopup description={p.description} href={p.href} />
     </div>

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -45,7 +45,7 @@ import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   evalConfigFormSchema,
-  getJsonPathCompatibilityWarning,
+  getActiveJsonPathCompatibilityWarning,
   type EvalFormType,
   getTargetDisplayName,
   inferDefaultMapping,
@@ -469,9 +469,8 @@ export const InnerEvaluatorForm = (props: {
   }) as UseFormReturn<EvalFormType>;
 
   const currentMapping = form.watch("mapping") ?? [];
-  const hasJsonPathCompatibilityError = currentMapping.some(
-    ({ jsonSelector }) =>
-      Boolean(getJsonPathCompatibilityWarning(jsonSelector)),
+  const hasJsonPathCompatibilityError = currentMapping.some((mappingRow) =>
+    Boolean(getActiveJsonPathCompatibilityWarning(mappingRow)),
   );
   const syncStatus = useVariableMappingSync({
     templateVars: isCodeEvalConfig ? [] : props.evalTemplate?.vars,

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -45,6 +45,7 @@ import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import {
   evalConfigFormSchema,
+  getJsonPathCompatibilityWarning,
   type EvalFormType,
   getTargetDisplayName,
   inferDefaultMapping,
@@ -337,7 +338,10 @@ export const InnerEvaluatorForm = (props: {
   evalCapabilities: EvalCapabilities;
   defaultRunOnLive?: boolean;
   defaultTarget?: EvalTargetObject;
-  renderFooter?: (params: { isLoading: boolean }) => React.ReactNode;
+  renderFooter?: (params: {
+    isLoading: boolean;
+    isSaveDisabled: boolean;
+  }) => React.ReactNode;
   oldConfigId?: string;
 }) => {
   const capture = usePostHogClientCapture();
@@ -465,6 +469,10 @@ export const InnerEvaluatorForm = (props: {
   }) as UseFormReturn<EvalFormType>;
 
   const currentMapping = form.watch("mapping") ?? [];
+  const hasJsonPathCompatibilityError = currentMapping.some(
+    ({ jsonSelector }) =>
+      Boolean(getJsonPathCompatibilityWarning(jsonSelector)),
+  );
   const syncStatus = useVariableMappingSync({
     templateVars: isCodeEvalConfig ? [] : props.evalTemplate?.vars,
     currentMapping: currentMapping,
@@ -1340,13 +1348,17 @@ export const InnerEvaluatorForm = (props: {
     createJobMutation.isPending || updateJobMutation.isPending;
 
   const formFooter = props.renderFooter ? (
-    props.renderFooter({ isLoading: mutationIsLoading })
+    props.renderFooter({
+      isLoading: mutationIsLoading,
+      isSaveDisabled: hasJsonPathCompatibilityError,
+    })
   ) : (
     <div className="flex w-full flex-col items-end gap-4">
       {!props.disabled ? (
         <Button
           type="submit"
           loading={mutationIsLoading}
+          disabled={hasJsonPathCompatibilityError}
           className="mt-3 max-w-fit"
         >
           {props.mode === "edit" ? "Update" : "Execute"}

--- a/web/src/features/evals/components/variable-mapping-card.tsx
+++ b/web/src/features/evals/components/variable-mapping-card.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/src/utils/tailwind";
 import {
   type EvalFormType,
   fieldHasJsonSelectorOption,
+  getJsonPathCompatibilityWarning,
 } from "@/src/features/evals/utils/evaluator-form-utils";
 import { EvalTargetObject } from "@langfuse/shared";
 import { VariableMappingDescription } from "@/src/features/evals/components/eval-form-descriptions";
@@ -343,7 +344,7 @@ export const VariableMappingCard = ({
                             key={`${mappingField.id}-langfuseObject`}
                             name={`mapping.${index}.langfuseObject`}
                             render={({ field }) => (
-                              <div className="flex items-center gap-2">
+                              <div className="flex items-start gap-2">
                                 <VariableMappingDescription
                                   title="Object"
                                   description="Langfuse object to retrieve the data from."
@@ -404,7 +405,7 @@ export const VariableMappingCard = ({
                                   (field.value &&
                                     !nameOptions.includes(field.value));
                                 return (
-                                  <div className="flex items-center gap-2">
+                                  <div className="flex items-start gap-2">
                                     <VariableMappingDescription
                                       title="Object Name"
                                       description="Name of the Langfuse object to retrieve the data from."
@@ -500,7 +501,7 @@ export const VariableMappingCard = ({
                             key={`${mappingField.id}-selectedColumnId`}
                             name={`mapping.${index}.selectedColumnId`}
                             render={({ field }) => (
-                              <div className="flex items-center gap-2">
+                              <div className="flex items-start gap-2">
                                 <VariableMappingDescription
                                   title="Object Field"
                                   description="Field on the Langfuse object to insert into the template."
@@ -563,26 +564,33 @@ export const VariableMappingCard = ({
                               control={form.control}
                               key={`${mappingField.id}-jsonSelector`}
                               name={`mapping.${index}.jsonSelector`}
-                              render={({ field }) => (
-                                <div className="flex items-center gap-2">
-                                  <VariableMappingDescription
-                                    title="JsonPath"
-                                    description="Optional selection: Use JsonPath syntax to select from a JSON object stored on a trace. If not selected, we will pass the entire object into the prompt."
-                                    href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
-                                  />
-                                  <FormItem className="w-2/3">
-                                    <FormControl>
-                                      <Input
-                                        {...field}
-                                        value={field.value ?? ""}
-                                        disabled={disabled}
-                                        placeholder="Optional"
-                                      />
-                                    </FormControl>
-                                    <FormMessage />
-                                  </FormItem>
-                                </div>
-                              )}
+                              render={({ field }) => {
+                                const compatibilityWarning =
+                                  getJsonPathCompatibilityWarning(field.value);
+
+                                return (
+                                  <div className="flex items-start gap-2">
+                                    <VariableMappingDescription
+                                      title="JsonPath"
+                                      description="Optional selection: Use JsonPath syntax to select from a JSON object stored on a trace. If not selected, we will pass the entire object into the prompt."
+                                      href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
+                                    />
+                                    <FormItem className="w-2/3">
+                                      <FormControl>
+                                        <Input
+                                          {...field}
+                                          value={field.value ?? ""}
+                                          disabled={disabled}
+                                          placeholder="Optional"
+                                        />
+                                      </FormControl>
+                                      <FormMessage>
+                                        {compatibilityWarning}
+                                      </FormMessage>
+                                    </FormItem>
+                                  </div>
+                                );
+                              }}
                             />
                           ) : undefined}
                         </Card>
@@ -605,7 +613,7 @@ export const VariableMappingCard = ({
                             />
                           </div>
                           {hideAdvancedSettings && (
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-start gap-2">
                               <VariableMappingDescription
                                 title="Object"
                                 description="Type of object to retrieve the data from."
@@ -636,7 +644,7 @@ export const VariableMappingCard = ({
                                   : experimentTargetEvalVariableColumns;
 
                               return (
-                                <div className="flex items-center gap-2">
+                                <div className="flex items-start gap-2">
                                   <VariableMappingDescription
                                     title="Object Field"
                                     description="Observation field to insert into the template."
@@ -677,26 +685,33 @@ export const VariableMappingCard = ({
                               control={form.control}
                               key={`${mappingField.id}-jsonSelector`}
                               name={`mapping.${index}.jsonSelector`}
-                              render={({ field }) => (
-                                <div className="flex items-center gap-2">
-                                  <VariableMappingDescription
-                                    title="JsonPath"
-                                    description="Optional selection: Use JsonPath syntax to select from a JSON object. If not selected, we will pass the entire object into the prompt."
-                                    href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
-                                  />
-                                  <FormItem className="w-2/3">
-                                    <FormControl>
-                                      <Input
-                                        {...field}
-                                        value={field.value ?? ""}
-                                        disabled={disabled}
-                                        placeholder="Optional"
-                                      />
-                                    </FormControl>
-                                    <FormMessage />
-                                  </FormItem>
-                                </div>
-                              )}
+                              render={({ field }) => {
+                                const compatibilityWarning =
+                                  getJsonPathCompatibilityWarning(field.value);
+
+                                return (
+                                  <div className="flex items-start gap-2">
+                                    <VariableMappingDescription
+                                      title="JsonPath"
+                                      description="Optional selection: Use JsonPath syntax to select from a JSON object. If not selected, we will pass the entire object into the prompt."
+                                      href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
+                                    />
+                                    <FormItem className="w-2/3">
+                                      <FormControl>
+                                        <Input
+                                          {...field}
+                                          value={field.value ?? ""}
+                                          disabled={disabled}
+                                          placeholder="Optional"
+                                        />
+                                      </FormControl>
+                                      <FormMessage>
+                                        {compatibilityWarning}
+                                      </FormMessage>
+                                    </FormItem>
+                                  </div>
+                                );
+                              }}
                             />
                           )}
                         </Card>

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -248,12 +248,13 @@ export default function RemapEvaluatorPage() {
                   hideAdvancedSettings={true}
                   evalCapabilities={evalCapabilities}
                   oldConfigId={evalConfigId}
-                  renderFooter={({ isLoading }) => (
+                  renderFooter={({ isLoading, isSaveDisabled }) => (
                     <div className="flex w-full flex-col items-end gap-4">
                       <div className="flex items-center">
                         <Button
                           type="submit"
                           loading={isLoading}
+                          disabled={isSaveDisabled}
                           className="mt-3 rounded-l-md rounded-r-none"
                         >
                           {legacyAction === "keep-active"

--- a/web/src/features/evals/utils/evaluator-form-utils.clienttest.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.clienttest.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  evalConfigFormSchema,
+  getJsonPathCompatibilityWarning,
+} from "./evaluator-form-utils";
+
+describe("getJsonPathCompatibilityWarning", () => {
+  it.each([
+    {
+      selector: "$.items[?(@.status === 'active')]",
+      expected:
+        "Filter expressions ([?...]) are not supported and will not be applied.",
+    },
+    {
+      selector: "$.items[?@.status]",
+      expected:
+        "Filter expressions ([?...]) are not supported and will not be applied.",
+    },
+    {
+      selector: "$.items[(@.length - 1)]",
+      expected:
+        "Script expressions ([(...)]) are not supported. The evaluator will use the unfiltered value instead.",
+    },
+    {
+      selector: "$.items[-1]",
+      expected:
+        "Negative array indices (for example, [-1]) are not supported. Use a slice such as [-1:] instead.",
+    },
+    {
+      selector: "$[‘items’]",
+      expected:
+        "Smart quotes are not supported in JSONPath. Use straight quotes (' or \") instead.",
+    },
+    {
+      selector: "$[‘items’][?@.a]",
+      expected:
+        "Smart quotes are not supported in JSONPath. Use straight quotes (' or \") instead.",
+    },
+  ])("warns about unsupported selector $selector", ({ selector, expected }) => {
+    expect(getJsonPathCompatibilityWarning(selector)).toBe(expected);
+  });
+
+  it.each([
+    undefined,
+    "",
+    "$.items[0]",
+    "$.items[-1:]",
+    "$['property[-1]']",
+    "$['property[?(@.active)]']",
+    "$['property[(@.length - 1)]']",
+    '$["Don’t"]',
+    "$['it’s'].a",
+  ])("does not warn about supported selector %s", (selector) => {
+    expect(getJsonPathCompatibilityWarning(selector)).toBeNull();
+  });
+});
+
+describe("evalConfigFormSchema", () => {
+  it("blocks configurations with unsupported JSONPath selectors", () => {
+    const result = evalConfigFormSchema.safeParse({
+      scoreName: "Correctness",
+      target: "trace",
+      filter: [],
+      mapping: [
+        {
+          templateVariable: "input",
+          langfuseObject: "trace",
+          objectName: null,
+          selectedColumnId: "input",
+          jsonSelector: "$.items[?@.status]",
+        },
+      ],
+      sampling: 1,
+      delay: 0,
+      timeScope: ["NEW"],
+      runOnLive: true,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["mapping", 0, "jsonSelector"],
+          message:
+            "Filter expressions ([?...]) are not supported and will not be applied.",
+        }),
+      );
+    }
+  });
+});

--- a/web/src/features/evals/utils/evaluator-form-utils.clienttest.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.clienttest.ts
@@ -84,4 +84,29 @@ describe("evalConfigFormSchema", () => {
       );
     }
   });
+
+  // A target switch nulls selectedColumnId but keeps jsonSelector, hiding the
+  // JsonPath input and the only place its warning could render.
+  it("ignores unsupported selectors on columns that have no JsonPath input", () => {
+    const result = evalConfigFormSchema.safeParse({
+      scoreName: "Correctness",
+      target: "event",
+      filter: [],
+      mapping: [
+        {
+          templateVariable: "input",
+          langfuseObject: "event",
+          objectName: null,
+          selectedColumnId: null,
+          jsonSelector: "$.items[?@.status]",
+        },
+      ],
+      sampling: 1,
+      delay: 0,
+      timeScope: ["NEW"],
+      runOnLive: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/web/src/features/evals/utils/evaluator-form-utils.clienttest.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.clienttest.ts
@@ -27,14 +27,9 @@ describe("getJsonPathCompatibilityWarning", () => {
         "Negative array indices (for example, [-1]) are not supported. Use a slice such as [-1:] instead.",
     },
     {
-      selector: "$[‘items’]",
-      expected:
-        "Smart quotes are not supported in JSONPath. Use straight quotes (' or \") instead.",
-    },
-    {
       selector: "$[‘items’][?@.a]",
       expected:
-        "Smart quotes are not supported in JSONPath. Use straight quotes (' or \") instead.",
+        "Filter expressions ([?...]) are not supported and will not be applied.",
     },
   ])("warns about unsupported selector $selector", ({ selector, expected }) => {
     expect(getJsonPathCompatibilityWarning(selector)).toBe(expected);
@@ -50,6 +45,8 @@ describe("getJsonPathCompatibilityWarning", () => {
     "$['property[(@.length - 1)]']",
     '$["Don’t"]',
     "$['it’s'].a",
+    "$.Don’t",
+    "$[‘items’]",
   ])("does not warn about supported selector %s", (selector) => {
     expect(getJsonPathCompatibilityWarning(selector)).toBeNull();
   });

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -25,8 +25,9 @@ export const evalConfigFormSchema = z
     runOnLive: z.boolean().optional().default(true),
   })
   .superRefine(({ mapping }, ctx) => {
-    mapping.forEach(({ jsonSelector }, index) => {
-      const compatibilityError = getJsonPathCompatibilityWarning(jsonSelector);
+    mapping.forEach((mappingRow, index) => {
+      const compatibilityError =
+        getActiveJsonPathCompatibilityWarning(mappingRow);
 
       if (compatibilityError) {
         ctx.addIssue({
@@ -117,6 +118,21 @@ export function getJsonPathCompatibilityWarning(
   }
 
   return null;
+}
+
+/**
+ * Only warns while the row's JsonPath input is rendered: a target switch nulls
+ * selectedColumnId but keeps jsonSelector
+ * (`useEvaluatorTarget.transformMapping`), orphaning the value behind a hidden
+ * input. Reporting it then would disable submit with no visible cause.
+ */
+export function getActiveJsonPathCompatibilityWarning(mappingRow: {
+  selectedColumnId?: string | null;
+  jsonSelector?: string | null;
+}): string | null {
+  if (!fieldHasJsonSelectorOption(mappingRow.selectedColumnId)) return null;
+
+  return getJsonPathCompatibilityWarning(mappingRow.jsonSelector);
 }
 
 export const getTargetDisplayName = (target: string): string => {

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -13,16 +13,30 @@ import { OUTPUT_MAPPING } from "@/src/features/evals/utils/evaluator-constants";
 export const isLegacyEvalTarget = (target: string): boolean =>
   target === "trace" || target === "dataset";
 
-export const evalConfigFormSchema = z.object({
-  scoreName: z.string(),
-  target: EvalTargetObjectSchema,
-  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
-  mapping: z.array(wipVariableMapping),
-  sampling: z.coerce.number().gt(0).lte(1),
-  delay: z.coerce.number().min(0).optional().default(10),
-  timeScope: TimeScopeSchema,
-  runOnLive: z.boolean().optional().default(true),
-});
+export const evalConfigFormSchema = z
+  .object({
+    scoreName: z.string(),
+    target: EvalTargetObjectSchema,
+    filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
+    mapping: z.array(wipVariableMapping),
+    sampling: z.coerce.number().gt(0).lte(1),
+    delay: z.coerce.number().min(0).optional().default(10),
+    timeScope: TimeScopeSchema,
+    runOnLive: z.boolean().optional().default(true),
+  })
+  .superRefine(({ mapping }, ctx) => {
+    mapping.forEach(({ jsonSelector }, index) => {
+      const compatibilityError = getJsonPathCompatibilityWarning(jsonSelector);
+
+      if (compatibilityError) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["mapping", index, "jsonSelector"],
+          message: compatibilityError,
+        });
+      }
+    });
+  });
 
 export type EvalFormType = z.infer<typeof evalConfigFormSchema>;
 
@@ -53,6 +67,61 @@ export const fieldHasJsonSelectorOption = (
   selectedColumnId === "experimentItemExpectedOutput" ||
   selectedColumnId === "experimentItemMetadata" ||
   selectedColumnId === "toolCalls";
+
+const stripJsonPathStringLiterals = (selector: string): string => {
+  let quote: "'" | '"' | "`" | null = null;
+  let isEscaped = false;
+
+  // Ignore expression-like text inside quoted property names to avoid false warnings.
+  return [...selector]
+    .map((character) => {
+      if (quote) {
+        if (isEscaped) {
+          isEscaped = false;
+        } else if (character === "\\") {
+          isEscaped = true;
+        } else if (character === quote) {
+          quote = null;
+        }
+
+        return " ";
+      }
+
+      if (character === "'" || character === '"' || character === "`") {
+        quote = character;
+        return " ";
+      }
+
+      return character;
+    })
+    .join("");
+};
+
+export function getJsonPathCompatibilityWarning(
+  selector: string | null | undefined,
+): string | null {
+  if (!selector) return null;
+
+  const selectorWithoutStrings = stripJsonPathStringLiterals(selector);
+
+  if (/[\u2018\u2019\u201c\u201d]/u.test(selectorWithoutStrings)) {
+    return "Smart quotes are not supported in JSONPath. Use straight quotes (' or \") instead.";
+  }
+
+  if (/\[\s*\?/u.test(selectorWithoutStrings)) {
+    return "Filter expressions ([?...]) are not supported and will not be applied.";
+  }
+
+  if (/\[\s*\(/u.test(selectorWithoutStrings)) {
+    return "Script expressions ([(...)]) are not supported. The evaluator will use the unfiltered value instead.";
+  }
+
+  if (/\[\s*-\d+\s*\]/u.test(selectorWithoutStrings)) {
+    return "Negative array indices (for example, [-1]) are not supported. Use a slice such as [-1:] instead.";
+  }
+
+  return null;
+}
 
 export const getTargetDisplayName = (target: string): string => {
   switch (target) {

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -104,10 +104,6 @@ export function getJsonPathCompatibilityWarning(
 
   const selectorWithoutStrings = stripJsonPathStringLiterals(selector);
 
-  if (/[\u2018\u2019\u201c\u201d]/u.test(selectorWithoutStrings)) {
-    return "Smart quotes are not supported in JSONPath. Use straight quotes (' or \") instead.";
-  }
-
   if (/\[\s*\?/u.test(selectorWithoutStrings)) {
     return "Filter expressions ([?...]) are not supported and will not be applied.";
   }


### PR DESCRIPTION
## Summary

- Detect unsupported JSONPath filters, script expressions, negative singular indices, and smart-quote delimiters in evaluator variable mappings before execution.
- Show actionable inline form errors and block standard and remap saves until selectors are corrected.
- Keep mapping controls aligned when validation messages appear and suggest `[-1:]` as the supported last-element alternative.

## Linear

- [LFE-13634](https://linear.app/clickhouse/issue/LFE-13634/bug-faulty-json-parsing-in-llm-as-a-judge)
- [LFE-13723](https://linear.app/clickhouse/issue/LFE-13723/bug-eval-expr-prevented-error-blocks-jsonpath-filters-in-llm-as-a)

## Major Decisions

- Preserve `eval: false`; filter and script evaluation remain disabled because changing the execution policy would reintroduce security risk.
- Keep execution behavior unchanged in the worker and surface incompatibilities in the frontend form instead.
- Use quote-aware static detection so expression-like text and smart apostrophes inside valid quoted property names do not cause false positives.

## Review Focus

- JSONPath compatibility detection and its supported-selector false-positive coverage.
- Validation and disabled-save behavior across standard evaluator and remap forms.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds pre-save compatibility validation for evaluator JSONPath mappings.
- Detects unsupported filters, scripts, negative singular indices, and smart-quote delimiters.
- Displays inline mapping errors and disables standard and remap save actions.
- Adjusts mapping-row alignment and adds compatibility test coverage.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until stale selectors from hidden JSONPath controls no longer make evaluator forms impossible to save.

Switching a mapping away from a JSONPath-capable field hides the only control for its selector while retaining and validating that selector, so unsupported stale values keep the submit action disabled.

**Files Needing Attention:** web/src/features/evals/utils/evaluator-form-utils.ts, web/src/features/evals/components/inner-evaluator-form.tsx, web/src/features/evals/components/variable-mapping-card.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/utils/evaluator-form-utils.ts:28-29
**Hidden selectors block saving**

When a user enters an unsupported selector and then switches to a field that does not expose JSONPath, the form retains and validates the now-hidden `jsonSelector`, leaving the save action disabled with no visible control for correcting or removing the value.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): validate unsupported evaluator..."](https://github.com/langfuse/langfuse/commit/9229bd6537d52af57acbfc5b8ef0cc694a964593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48384938)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)

<!-- /greptile_comment -->