### PR TITLE
refactor(v4-migration): rename migration badge component and update logic

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -28,7 +28,6 @@ import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/Langfu
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
-import { EvaluatorStatus } from "@/src/features/evals/types";
 
 const PeekViewEvaluatorConfigDetail = ({
   projectId,

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -9,7 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { V4MigrationUpdateRequiredAssistantBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
+import { V4MigrationUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
 import { UserCircle2Icon } from "lucide-react";
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { DeleteEvalConfigButton } from "@/src/components/deleteButton";
@@ -26,6 +26,9 @@ import { useLazyEvaluatorExecutionCounts } from "@/src/features/evals/hooks/useL
 import { TablePeekView } from "@/src/components/table/peek";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
+import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
+import { EvaluatorStatus } from "@/src/features/evals/types";
 
 const PeekViewEvaluatorConfigDetail = ({
   projectId,
@@ -46,6 +49,7 @@ const PeekViewEvaluatorConfigDetail = ({
     evaluatorId: evalConfig?.id,
     evaluator: evalConfig,
   });
+  const canUseAgent = useCanUseInAppAgent();
 
   const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
 
@@ -72,6 +76,9 @@ const PeekViewEvaluatorConfigDetail = ({
             <DeactivateEvalConfig
               projectId={projectId}
               evalConfig={evalConfig}
+              // Status changes remount the form below; drop edit mode so
+              // in-progress form state cannot fight the new status.
+              onStatusChange={() => setIsEditMode(false)}
             />
           </div>
         </div>
@@ -88,15 +95,16 @@ const PeekViewEvaluatorConfigDetail = ({
           </span>
           <Switch
             disabled={
-              !hasAccess || (evaluatorRequiresMigration && !allowLegacy)
+              !hasAccess ||
+              (isLegacyEvalTarget(evalConfig.targetObject) && !allowLegacy)
             }
             checked={isEditMode}
             onCheckedChange={setIsEditMode}
-            {...(evaluatorRequiresMigration &&
-              !allowLegacy && {
-                title:
-                  "Deprecated evaluators are only available in read-only mode",
-              })}
+            title={
+              isLegacyEvalTarget(evalConfig.targetObject) && !allowLegacy
+                ? "Deprecated evaluators are only available in read-only mode"
+                : undefined
+            }
           />
           <DeleteEvalConfigButton
             aria-label="delete"
@@ -114,8 +122,8 @@ const PeekViewEvaluatorConfigDetail = ({
         </div>
       </div>
 
-      {evaluatorRequiresMigration && evalConfig.evalTemplate && (
-        <V4MigrationUpdateRequiredAssistantBadge />
+      {evaluatorRequiresMigration && evalConfig.evalTemplate && canUseAgent && (
+        <V4MigrationUpdateRequiredBadge />
       )}
 
       <EvaluatorPausedCallout projectId={projectId} evalConfig={evalConfig} />

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -43,7 +43,7 @@ export function DeactivateEvalConfig({
     },
   });
 
-  const onClick = () => {
+  const onClick = async () => {
     if (!projectId) {
       console.error("Project ID is missing");
       return;
@@ -56,13 +56,19 @@ export function DeactivateEvalConfig({
 
     const prevStatus = evalConfig?.status;
 
-    mutEvaluator.mutateAsync({
-      projectId,
-      evalConfigId: evalConfig?.id ?? "",
-      config: {
-        status: isActive ? EvaluatorStatus.INACTIVE : EvaluatorStatus.ACTIVE,
-      },
-    });
+    try {
+      await mutEvaluator.mutateAsync({
+        projectId,
+        evalConfigId: evalConfig?.id ?? "",
+        config: {
+          status: isActive ? EvaluatorStatus.INACTIVE : EvaluatorStatus.ACTIVE,
+        },
+      });
+    } catch {
+      // The default mutation error toast reports the failure; the status is
+      // unchanged, so keep the popover open and skip the change callbacks.
+      return;
+    }
     capture(
       prevStatus === EvaluatorStatus.ACTIVE
         ? "eval_config:deactivate"

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -16,9 +16,12 @@ import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilit
 export function DeactivateEvalConfig({
   projectId,
   evalConfig,
+  onStatusChange,
 }: {
   projectId: string;
   evalConfig: RouterOutputs["evals"]["configById"];
+  /** Called when the user confirms an activate/deactivate toggle. */
+  onStatusChange?: () => void;
 }) {
   const utils = api.useUtils();
   const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
@@ -65,6 +68,7 @@ export function DeactivateEvalConfig({
         ? "eval_config:deactivate"
         : "eval_config:activate",
     );
+    onStatusChange?.();
     setIsOpen(false);
   };
 

--- a/web/src/features/evals/pages/evaluators.tsx
+++ b/web/src/features/evals/pages/evaluators.tsx
@@ -13,7 +13,6 @@ import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
 import { SupportOrUpgradePage } from "@/src/ee/features/billing/components/SupportOrUpgradePage";
 import { EvaluatorsOnboarding } from "@/src/components/onboarding/EvaluatorsOnboarding";
 import { ManageDefaultEvalModel } from "@/src/features/evals/components/manage-default-eval-model";
-import { V4MigrationModal } from "@/src/features/v4-migration/V4MigrationModal";
 import { V4MigrationUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
 
 export default function EvaluatorsPage() {
@@ -75,47 +74,44 @@ export default function EvaluatorsPage() {
   }
 
   return (
-    <>
-      <V4MigrationModal />
-      <Page
-        headerProps={{
-          title: "Evaluators",
-          titleBadges: <V4MigrationUpdateRequiredBadge />,
-          help: {
-            description:
-              "Configure a langfuse managed or custom evaluator to evaluate incoming traces.",
-            href: "https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge",
-          },
-          tabsProps: {
-            tabs: getEvalsTabs(projectId),
-            activeTab: EVALS_TABS.CONFIGS,
-          },
-          actionButtonsRight: (
-            <>
-              <ManageDefaultEvalModel projectId={projectId} />
-              <ActionButton
-                hasAccess={hasWriteAccess}
-                href={`/project/${projectId}/evals/new`}
-                icon={<Plus className="h-4 w-4" />}
-                trackingEventName="eval_config:new_form_open"
-                variant="default"
-                usageLimit={
-                  typeof evaluatorLimit === "number"
-                    ? {
-                        current: countsQuery.data?.configActiveCount ?? 0,
-                        max: evaluatorLimit,
-                      }
-                    : undefined
-                }
-              >
-                Set up evaluator
-              </ActionButton>
-            </>
-          ),
-        }}
-      >
-        <EvaluatorTable projectId={projectId} />
-      </Page>
-    </>
+    <Page
+      headerProps={{
+        title: "Evaluators",
+        titleBadges: <V4MigrationUpdateRequiredBadge />,
+        help: {
+          description:
+            "Configure a langfuse managed or custom evaluator to evaluate incoming traces.",
+          href: "https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge",
+        },
+        tabsProps: {
+          tabs: getEvalsTabs(projectId),
+          activeTab: EVALS_TABS.CONFIGS,
+        },
+        actionButtonsRight: (
+          <>
+            <ManageDefaultEvalModel projectId={projectId} />
+            <ActionButton
+              hasAccess={hasWriteAccess}
+              href={`/project/${projectId}/evals/new`}
+              icon={<Plus className="h-4 w-4" />}
+              trackingEventName="eval_config:new_form_open"
+              variant="default"
+              usageLimit={
+                typeof evaluatorLimit === "number"
+                  ? {
+                      current: countsQuery.data?.configActiveCount ?? 0,
+                      max: evaluatorLimit,
+                    }
+                  : undefined
+              }
+            >
+              Set up evaluator
+            </ActionButton>
+          </>
+        ),
+      }}
+    >
+      <EvaluatorTable projectId={projectId} />
+    </Page>
   );
 }

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -93,43 +93,15 @@ function useEvalUpdateRequiredBadgeState() {
   return { project, organization, enabled, visible };
 }
 
-/** Opens the v4 migration drawer — for page-level surfaces where the drawer
- * is fully visible (e.g. the evaluators page header). */
+/** Opens the v4 migration drawer if no in-app agent is available, otherwise opens the in-app agent */
 export function V4MigrationUpdateRequiredBadge() {
   const openMigrationPanel = useOpenV4MigrationPanel();
   const capture = usePostHogClientCapture();
-  const { project, visible } = useEvalUpdateRequiredBadgeState();
-
-  if (!visible || !project) {
-    return null;
-  }
-
-  const handleClick = () => {
-    capture("v4_migration:update_required_badge_clicked");
-    openMigrationPanel({ id: project.id, name: project.name });
-  };
-
-  return (
-    <BadgeContent
-      handleClick={handleClick}
-      title="Action required"
-      description="Update your eval set up"
-    />
-  );
-}
-
-/** Starts the eval upgrade in the in-app assistant — for overlay surfaces
- * like the table peek, where the assistant (`agent` layer) renders above the
- * peek (`panel` layer) while the migration drawer would open behind it.
- * Falls back to the drawer when the assistant is unavailable. */
-export function V4MigrationUpdateRequiredAssistantBadge() {
-  const openMigrationPanel = useOpenV4MigrationPanel();
-  const capture = usePostHogClientCapture();
   const canUseAgent = useCanUseInAppAgent();
+  const { project, visible, enabled, organization } =
+    useEvalUpdateRequiredBadgeState();
   const { setOpen: setAgentOpen, submit: submitAgentMessage } =
     useInAppAiAgent();
-  const { project, organization, enabled, visible } =
-    useEvalUpdateRequiredBadgeState();
   const upgradePlan = useEvalUpgradeAssistantPlan({
     projectId: project?.id,
     orgId: organization?.id,
@@ -156,7 +128,7 @@ export function V4MigrationUpdateRequiredAssistantBadge() {
     <BadgeContent
       handleClick={handleClick}
       title="Action required"
-      description="Click here to start the upgrade now"
+      description="Start the upgrade now"
     />
   );
 }

--- a/web/src/features/v4-migration/useV4UpgradeAssistantSupport.ts
+++ b/web/src/features/v4-migration/useV4UpgradeAssistantSupport.ts
@@ -43,11 +43,9 @@ export type V4UpgradeAssistantMode =
 
 /**
  * Plans how the in-app assistant participates in the v4 upgrade:
- * - "evals-ready": deprecated evals remain, all trivially repointable
- *   (dataset targets or single-observation mappings, computed server-side as
- *   `allAssistantMigratable`), and the SDK upgrade is not known to be
- *   pending → the assistant migrates the evals.
- * - "sdk-first-choice": evals are assistant-migratable and the SDK upgrade is
+ * - "evals-ready": deprecated evals remain, all repointable
+ *   → the assistant migrates the evals
+ * - "sdk-first-choice": the SDK upgrade is
  *   known to be pending → the assistant asks whether to do the SDK first
  *   (recommended, outside Langfuse) or migrate evals now; legacy and new
  *   evaluators run side by side until the SDK upgrade lands.
@@ -72,15 +70,12 @@ export function useEvalUpgradeAssistantPlan(params: {
     sdk.status === "otel_header_required" ||
     sdk.upgradeRequiredCount > 0;
   const evalsPending = (evalQuery.data?.traceLevelEvalCount ?? 0) > 0;
-  const allAssistantMigratable =
-    evalQuery.data?.allAssistantMigratable === true;
 
-  const mode: V4UpgradeAssistantMode =
-    evalsPending && allAssistantMigratable
-      ? sdkUpgradeKnownPending
-        ? "sdk-first-choice"
-        : "evals-ready"
-      : "outside";
+  const mode: V4UpgradeAssistantMode = evalsPending
+    ? sdkUpgradeKnownPending
+      ? "sdk-first-choice"
+      : "evals-ready"
+    : "outside";
 
   return {
     canUseAssistant,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates the v4 migration badge around the in-app assistant flow and adjusts evaluator migration and status-change behavior.
- Renames and unifies the migration badge component.
- Broadens assistant upgrade modes to all pending trace-level evaluators.
- Restricts legacy evaluator editing based directly on target type.
- Exits evaluator edit mode when activation status is toggled.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the hidden migration fallback and premature edit-state reset are fixed.

Users without agent access lose the migration action in the evaluator peek, and failed status mutations can discard unsaved evaluator edits before the server confirms any change.

**Files Needing Attention:** web/src/components/table/peek/peek-evaluator-config-detail.tsx; web/src/features/evals/components/deactivate-config.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/peek/peek-evaluator-config-detail.tsx:124-126
**Migration fallback is unreachable**

When a self-hosted or non-entitled user opens a migration-required evaluator, the `canUseAgent` condition hides the entire badge, causing the migration action to disappear even though `V4MigrationUpdateRequiredBadge` provides a migration-drawer fallback for this exact condition.

### Issue 2
web/src/features/evals/components/deactivate-config.tsx:68-71
**Status callback runs prematurely**

When the activation mutation is rejected, `onStatusChange` has already run because `mutateAsync` is not awaited, causing the evaluator form to remount and discard unsaved edits while the persisted status remains unchanged.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(v4-migration): rename migration..."](https://github.com/langfuse/langfuse/commit/36cccfdb52b8793ed666b91a3d3a32492a17b4f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48388378)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->