### PR TITLE
fix(api): derive dashboard widget minVersion from the deployment write mode (v3 backport of #15565)

### DIFF
--- a/web/src/__tests__/server/unit/dashboard-widget-min-version.servertest.ts
+++ b/web/src/__tests__/server/unit/dashboard-widget-min-version.servertest.ts
@@ -1,0 +1,72 @@
+// The public widget API stamps the internal `minVersion` that decides whether a
+// widget queries the v1 tables or the v2 events_* tables. Only the deployment
+// knows which of the two it can serve, so these cases pin the behavior on a
+// deployment without a v4 write mode — the v3 default (LFE-14581).
+const envMock = vi.hoisted(() => ({}) as Record<string, unknown>);
+
+// Partial mock — real env underneath so the rest of the imported graph keeps
+// working; envMock keeps its object identity so per-test mutations stay visible.
+vi.mock("@/src/env.mjs", async (importOriginal) => {
+  const actual = (await importOriginal()) as { env: Record<string, unknown> };
+  Object.assign(envMock, actual.env);
+  return { env: envMock };
+});
+
+import {
+  normalizePublicDashboardWidgetInput,
+  validatePublicDashboardWidgetInput,
+} from "@/src/features/widgets/server/public-dashboard-widget-service";
+
+const baseInput = {
+  name: "API widget",
+  description: "",
+  view: "observations" as const,
+  dimensions: [],
+  metrics: [{ measure: "count", agg: "count" as const }],
+  filters: [],
+  chartType: "BAR_TIME_SERIES" as const,
+};
+
+describe("public dashboard widget minVersion", () => {
+  describe("legacy write mode, where the events_* tables are empty", () => {
+    beforeEach(() => {
+      envMock.LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+    });
+
+    it("stamps a v1-expressible widget as v1 so it can render", () => {
+      const normalized = normalizePublicDashboardWidgetInput(baseInput);
+
+      expect(normalized.minVersion).toBe(1);
+      expect(() =>
+        validatePublicDashboardWidgetInput(normalized),
+      ).not.toThrow();
+    });
+
+    it("rejects a widget that genuinely needs v2 instead of persisting it unrenderable", () => {
+      const normalized = normalizePublicDashboardWidgetInput({
+        ...baseInput,
+        metrics: [{ measure: "traceId", agg: "uniq" as const }],
+      });
+
+      expect(() => validatePublicDashboardWidgetInput(normalized)).toThrow(
+        /Measure "traceId" is not available for view "observations" in version "v1"/,
+      );
+    });
+
+    it("caps a stored v2 widget back to v1 so a patch heals it", () => {
+      expect(normalizePublicDashboardWidgetInput(baseInput, 2).minVersion).toBe(
+        1,
+      );
+    });
+  });
+
+  // dual writes the events_* tables, so v2 is servable there whatever the
+  // preview opt-in says — Monitors ships on exactly that test and its charts
+  // are v2-only. Capping here would break them.
+  it("keeps stamping v2 in dual write mode with the preview opt-in off", () => {
+    envMock.LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+    envMock.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+
+    expect(normalizePublicDashboardWidgetInput(baseInput).minVersion).toBe(2);
+  });
+});

--- a/web/src/__tests__/server/unstable-dashboard-widgets-api.servertest.ts
+++ b/web/src/__tests__/server/unstable-dashboard-widgets-api.servertest.ts
@@ -9,6 +9,7 @@ import {
   PostUnstableDashboardWidgetResponse,
 } from "@/src/features/public-api/types/unstable-dashboard-widgets";
 import { UnstablePublicApiErrorResponse } from "@/src/features/public-api/types/unstable-public-evals-contract";
+import { env } from "@/src/env.mjs";
 import { DashboardWidgetViews } from "@langfuse/shared/src/db";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -38,6 +39,18 @@ const legacyTracesWidgetInput = {
   chartConfig: { type: "NUMBER" as const },
   minVersion: 1,
 };
+
+// The API stamps new widgets with the version the deployment can actually query
+// rather than a hard-coded 2 (LFE-14581), so what this suite observes depends on
+// the write mode of the deployment under test. CI exercises both: `.env.dev.example`
+// sets `dual`, while the `-azure` and `-redis-cluster` matrix legs leave the
+// variable unset and so run as `legacy`.
+//
+// This derives the expectation from the raw env rather than calling the service's
+// own helper, so an inverted or broken mapping still fails here. The mapping itself
+// is owned by dashboard-widget-min-version.servertest.ts.
+const isLegacyDeployment = env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy";
+const expectedApiMinVersion = isLegacyDeployment ? 1 : 2;
 
 const expectUnstableError = (
   response: Awaited<ReturnType<typeof makeAPICall>>,
@@ -82,8 +95,8 @@ describe("/api/public/unstable/dashboard-widgets API", () => {
       projectId,
       name: "API widget",
       view: "OBSERVATIONS",
-      // widgets created via the public API are always v2 internally
-      minVersion: 2,
+      // stamped from what the deployment can query, not hard-coded to v2
+      minVersion: expectedApiMinVersion,
     });
 
     await expect(
@@ -233,7 +246,8 @@ describe("/api/public/unstable/dashboard-widgets API", () => {
     const afterViewChange = await prisma.dashboardWidget.findUniqueOrThrow({
       where: { id: v1Widget.id, projectId },
     });
-    expect(afterViewChange.minVersion).toBe(2);
+    // changing the view re-stamps from the deployment; the cap never promotes
+    expect(afterViewChange.minVersion).toBe(expectedApiMinVersion);
   });
 
   it("rejects patching a widget into the legacy traces view", async () => {
@@ -296,7 +310,11 @@ describe("/api/public/unstable/dashboard-widgets API", () => {
       status: 400,
       code: "invalid_request",
     });
-    expect(body.details).toMatchObject({ field: "metrics[0].agg" });
+    // `uniqueUserIds` exists only on the v2 observations view, so a v1 deployment
+    // rejects the measure outright while a v2 one gets as far as the aggregation.
+    expect(body.details).toMatchObject({
+      field: isLegacyDeployment ? "metrics[0].measure" : "metrics[0].agg",
+    });
   });
 
   it("rejects filter columns that widget JSON import would remove", async () => {

--- a/web/src/features/widgets/server/public-dashboard-widget-service.ts
+++ b/web/src/features/widgets/server/public-dashboard-widget-service.ts
@@ -26,6 +26,7 @@ import {
   getWidgetImportFilterConfig,
   partitionStoredUiTableFiltersToView,
 } from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
+import { env } from "@/src/env.mjs";
 import {
   MAX_PIVOT_TABLE_DIMENSIONS,
   MAX_PIVOT_TABLE_METRICS,
@@ -101,9 +102,29 @@ type PublicDashboardWidgetInput = Omit<
   "view"
 > & { view: DashboardWidgetViewOutputType };
 
+/**
+ * v2 widgets read the `events_*` tables, which the worker only writes in `dual`
+ * and `events_only` mode. Under `legacy` they stay empty — and on a v3
+ * deployment they do not exist at all — so a v2 query cannot succeed there.
+ *
+ * `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` is deliberately not consulted:
+ * it gates whether users are *offered* the v4 read path, not whether the data
+ * is there. The same write-mode-only test is what ships Monitors, whose charts
+ * are v2-only (`web/src/components/layouts/routes.tsx` → `show`).
+ */
+function deploymentMinWidgetVersion(): number {
+  return env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy" ? 1 : 2;
+}
+
+/**
+ * `requestedMinVersion` is capped to what the deployment can actually query, so
+ * the API never persists a widget that can never render (LFE-14581). Omit it to
+ * take the deployment's own default, as create does. The cap never promotes, so
+ * a legacy v1 widget stays v1 on a v4 deployment.
+ */
 export function normalizePublicDashboardWidgetInput(
   input: PublicDashboardWidgetInput,
-  minVersion = 2,
+  requestedMinVersion?: number,
 ): NormalizedWidgetInput {
   const { mappedFilters, unsupportedFilters } =
     partitionStoredUiTableFiltersToView(input.view, input.filters);
@@ -152,6 +173,8 @@ export function normalizePublicDashboardWidgetInput(
     });
   }
 
+  const deploymentMinVersion = deploymentMinWidgetVersion();
+
   return {
     ...input,
     filters: mappedFilters.map((filter) => ({
@@ -159,7 +182,10 @@ export function normalizePublicDashboardWidgetInput(
       column: columnAliases[filter.column] ?? filter.column,
     })),
     chartConfig: chartConfig.data,
-    minVersion,
+    minVersion:
+      requestedMinVersion === undefined
+        ? deploymentMinVersion
+        : Math.min(requestedMinVersion, deploymentMinVersion),
   };
 }
 
@@ -344,9 +370,12 @@ export async function updatePublicDashboardWidget(params: {
     params.input.chartType !== undefined &&
     params.input.chartType !== currentPublic.chartType;
   // Keep the stored minVersion (and thus v1/v2 query semantics) unless the
-  // caller explicitly changes the view; view changes land on v2 like create.
+  // caller explicitly changes the view; view changes take the deployment
+  // default like create. Either way normalize caps the result, so patching a
+  // widget that was stamped v2 on a deployment that cannot serve v2 heals it.
   const mergedView = params.input.view ?? currentPublic.view;
-  const minVersion = mergedView === currentPublic.view ? current.minVersion : 2;
+  const requestedMinVersion =
+    mergedView === currentPublic.view ? current.minVersion : undefined;
   const input = normalizePublicDashboardWidgetInput(
     {
       ...currentPublic,
@@ -360,7 +389,7 @@ export async function updatePublicDashboardWidget(params: {
           ? { type: params.input.chartType }
           : currentPublic.chartConfig),
     },
-    minVersion,
+    requestedMinVersion,
   );
   validatePublicDashboardWidgetInput(input);
   const updated = await DashboardService.updateWidget(


### PR DESCRIPTION
Backport of #15565 (main commit `aae067ce7`) to `v3`. Cherry-picked with `-x`; both files are byte-identical to `main@aae067ce7`.

Fixes #15549.

## Why this matters on v3 specifically

`normalizePublicDashboardWidgetInput` hard-codes `minVersion = 2`, so every widget created through `POST /api/public/unstable/dashboard-widgets` is pinned to the v2 query engine. v2 reads the `events_*` tables — and **v3 has no `events_*` tables at all**: its only event migration is `0007_add_event_log`, while `0039_create_events_full` onward exist only on `main`. The result is an unrecoverable `Internal Server Error` on `dashboard.executeQuery` that no API edit can heal. Widgets built in the UI were unaffected, because the UI stamps `requiresV2(...) ? 2 : 1`.

The fix is inert on `main` (write mode defaults to `events_only` there) and only takes effect on the `v3` line, where `LANGFUSE_MIGRATION_V4_WRITE_MODE` defaults to `legacy` — so this backport is where it actually lands for affected deployments.

## Review point — deliberately kept identical to main

On `v3` the `events_*` tables are absent in **every** write mode, not just `legacy`. A v3 operator who sets `LANGFUSE_MIGRATION_V4_WRITE_MODE=dual` or `events_only` would therefore still get v2-stamped, unrenderable widgets — `deploymentMinWidgetVersion()` would return 2 with no table behind it.

I kept the backport byte-identical to main rather than hard-pinning v3 to `minVersion = 1`, because divergence on a maintenance branch is the more expensive default. Flagging it so the decision is explicit: if you'd rather v3 always stamp v1, say so and I'll adjust.

## Verification

- `pnpm --filter web run test dashboard-widget-min-version` → `Tests  4 passed (4)`
- Reverted just `public-dashboard-widget-service.ts` to v3's pre-fix state (`5f7a516f0`) and re-ran: `Tests  3 failed | 1 passed (4)` — confirms the test genuinely catches the v3 bug rather than restating the new code. The one passing case is the `dual` write-mode test, where `minVersion = 2` is correct either way.
- `pnpm run lint` → `Tasks:    7 successful, 7 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport derives public dashboard-widget query versions from the deployment write mode and adds focused normalization tests.
- Adds a deployment-aware widget-version helper.
- Caps retained widget versions during updates and uses the deployment default after view changes.
- Tests legacy-mode creation, validation and patch normalization, plus dual-mode creation.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until v3 deployments configured for dual or events-only mode stop stamping widgets with the unsupported v2 query version.

The new helper persists version 2 for two valid deployment modes, while version 2 renders through `events_*` tables that are absent from this branch, leaving affected public-API widgets unable to render.

**Files Needing Attention:** web/src/features/widgets/server/public-dashboard-widget-service.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[Public widget create or update] --> Mode{V4 write mode}
  Mode -->|legacy| V1[minVersion 1]
  Mode -->|dual or events_only| V2[minVersion 2]
  V1 --> Legacy[Legacy query tables]
  V2 --> Events[events_* query tables]
  Events --> Missing[Tables absent on v3]
  Missing --> Error[Widget render fails]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/widgets/server/public-dashboard-widget-service.ts:115-117
**Non-legacy modes select missing tables**

When a v3 deployment uses `dual` or `events_only`, this helper stamps public API widgets with `minVersion: 2`, causing their queries to target the `events_*` tables that do not exist on this branch and fail with an internal server error.

```suggestion
function deploymentMinWidgetVersion(): number {
  return 1;
}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): derive dashboard widget minVer..."](https://github.com/langfuse/langfuse/commit/7e4929c4594a4f0c3153c007a289d37a1d45b2c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48417738)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->