### PR TITLE
fix(dashboards): return 404 instead of 500 when updating a missing dashboard (v3 backport of #15454)

### DIFF
--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -103,6 +103,42 @@ export class DashboardService {
   }
 
   /**
+   * Updates a project-owned dashboard, translating Prisma's P2025 into a 404.
+   */
+  private static async updateDashboardRecord(
+    dashboardId: string,
+    projectId: string,
+    data: Prisma.DashboardUncheckedUpdateInput,
+  ): Promise<DashboardDomain> {
+    try {
+      const updatedDashboard = await prisma.dashboard.update({
+        where: {
+          id: dashboardId,
+          projectId,
+        },
+        data,
+      });
+
+      return DashboardDomainSchema.parse({
+        ...updatedDashboard,
+        owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+      });
+    } catch (e) {
+      // P2025 = row not found; also thrown for cross-project ids, so the 404
+      // does not leak whether the dashboard exists in another project.
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === "P2025"
+      ) {
+        throw new LangfuseNotFoundError(
+          `Dashboard ${dashboardId} not found in project ${projectId}`,
+        );
+      }
+      throw e;
+    }
+  }
+
+  /**
    * Updates a dashboard's definition.
    */
   public static async updateDashboardDefinition(
@@ -111,24 +147,13 @@ export class DashboardService {
     definition: z.infer<typeof DashboardDefinitionSchema>,
     userId?: string,
   ): Promise<DashboardDomain> {
-    const updatedDashboard = await prisma.dashboard.update({
-      where: {
-        id: dashboardId,
-        projectId,
+    return this.updateDashboardRecord(dashboardId, projectId, {
+      updatedBy: userId,
+      definition: {
+        // Already sanitized: the input is parsed against
+        // DashboardDefinitionSchema, which strips unknown keys.
+        widgets: definition.widgets,
       },
-      data: {
-        updatedBy: userId,
-        definition: {
-          // Already sanitized: the input is parsed against
-          // DashboardDefinitionSchema, which strips unknown keys.
-          widgets: definition.widgets,
-        },
-      },
-    });
-
-    return DashboardDomainSchema.parse({
-      ...updatedDashboard,
-      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
     });
   }
 
@@ -142,21 +167,10 @@ export class DashboardService {
     description: string,
     userId?: string,
   ): Promise<DashboardDomain> {
-    const updatedDashboard = await prisma.dashboard.update({
-      where: {
-        id: dashboardId,
-        projectId,
-      },
-      data: {
-        name,
-        description,
-        updatedBy: userId,
-      },
-    });
-
-    return DashboardDomainSchema.parse({
-      ...updatedDashboard,
-      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+    return this.updateDashboardRecord(dashboardId, projectId, {
+      name,
+      description,
+      updatedBy: userId,
     });
   }
 
@@ -169,20 +183,9 @@ export class DashboardService {
     filters: z.infer<typeof singleFilter>[],
     userId?: string,
   ): Promise<DashboardDomain> {
-    const updatedDashboard = await prisma.dashboard.update({
-      where: {
-        id: dashboardId,
-        projectId,
-      },
-      data: {
-        updatedBy: userId,
-        filters,
-      },
-    });
-
-    return DashboardDomainSchema.parse({
-      ...updatedDashboard,
-      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+    return this.updateDashboardRecord(dashboardId, projectId, {
+      updatedBy: userId,
+      filters,
     });
   }
 

--- a/web/src/__tests__/server/dashboard-service-update.servertest.ts
+++ b/web/src/__tests__/server/dashboard-service-update.servertest.ts
@@ -1,0 +1,27 @@
+import { v4 as uuidv4 } from "uuid";
+import {
+  createOrgProjectAndApiKey,
+  DashboardService,
+} from "@langfuse/shared/src/server";
+import { LangfuseNotFoundError } from "@langfuse/shared";
+
+describe("DashboardService update methods", () => {
+  it("throw LangfuseNotFoundError instead of P2025 for a missing dashboard", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const missingId = uuidv4();
+
+    await expect(
+      DashboardService.updateDashboardDefinition(missingId, projectId, {
+        widgets: [],
+      }),
+    ).rejects.toThrow(LangfuseNotFoundError);
+
+    await expect(
+      DashboardService.updateDashboard(missingId, projectId, "name", ""),
+    ).rejects.toThrow(LangfuseNotFoundError);
+
+    await expect(
+      DashboardService.updateDashboardFilters(missingId, projectId, []),
+    ).rejects.toThrow(LangfuseNotFoundError);
+  });
+});


### PR DESCRIPTION
Backport of #15454 (main commit `2d6f60b22`) to `v3`. Cherry-picked with `-x`; both files are byte-identical to `main@2d6f60b22`.

## Problem

`updateDashboardDefinition`, `updateDashboard`, and `updateDashboardFilters` each called `prisma.dashboard.update()` directly, so a missing — or cross-project — dashboard surfaced as an unhandled Prisma `P2025` and an HTTP **500** instead of a **404**. Reachable from the public API through `web/src/features/dashboard/server/public-dashboard-service.ts` (`PATCH /api/public/unstable/dashboards/{id}` and the placement endpoints).

## Change

The three methods are consolidated onto a private `updateDashboardRecord` helper that translates `P2025` into `LangfuseNotFoundError` (LFE-14502). Behaviour is otherwise unchanged.

Shipping this alongside the widget `minVersion` backport (#15597) so v3.224.4 covers both dashboard public-API defects in one release.

## Verification

- `pnpm --filter web run test dashboard-service-update` → `Tests  1 passed (1)`
- Reverted just `DashboardService.ts` to v3's pre-fix state (`5f7a516f0`), rebuilt shared, re-ran: `Tests  1 failed (1)` with `AssertionError: expected error to be instance of LangfuseNotFoundError` — confirms the test catches the v3 behaviour rather than restating the new code.
- `pnpm run lint` → `Tasks:    7 successful, 7 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR normalizes missing-dashboard update failures as not-found errors.
- Consolidates three project-scoped dashboard update methods behind a shared record-update helper.
- Translates Prisma `P2025` errors into `LangfuseNotFoundError` while preserving other errors and update behavior.
- Adds server coverage for definition, metadata, and filter updates against missing dashboards.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The helper preserves each method’s project-scoped predicate, update payload, and domain parsing while translating only Prisma missing-record errors, and existing error middleware maps the resulting application error correctly.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): return 404 instead of 5..."](https://github.com/langfuse/langfuse/commit/87698b2d50729a47f1bbd0e8c7d816a18eea4836) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48418306)</sub>

<!-- /greptile_comment -->