### PR TITLE
chore(release): stop v3 releases claiming the GitHub latest badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
       "release": true,
       "web": true,
       "autoGenerate": true,
+      "makeLatest": false,
       "releaseName": "v${version}",
       "comments": {
         "submit": true,


### PR DESCRIPTION
One line in the root `package.json`, on the `v3` branch only.

## Why

`v4.0.0` shipped today and currently holds the GitHub **"Latest release"** badge (`repos/langfuse/langfuse/releases/latest` → `v4.0.0`). The `v3` branch's `release-it` config has no `github.makeLatest`, so it defaults to `true` — cutting v3.224.4 as-is would take the badge back from v4.0.0 and point self-hosters at the old major from the repo's front page.

Setting `makeLatest: false` here keeps v3 maintenance releases doing everything they should — tag, GitHub release with generated notes, Docker images — while leaving the badge on v4.

This is the `release-it` half of the v4 GA flip checklist already written down in `.agents/skills/git-workflow/SKILL.md`.

## What this deliberately does NOT do

The Docker `latest` tag gate is untouched. It still keys off `refs/tags/v3` in `pipeline.yml` on **both** branches, so Docker `latest` currently resolves to `3.224.3`:

```
latest  -> sha256:51c9c067426f5ece075bb9dde2ebf9dcd4b7c735569b12fb6b27bdb65bee5f39
3.224.3 -> sha256:51c9c067426f5ece075bb9dde2ebf9dcd4b7c735569b12fb6b27bdb65bee5f39   (same)
4.0.0   -> sha256:8ac1876c688ee15090950d56c36ed1db2632167854224f44f52806469424d7c8   (different)
```

Disabling that gate on `v3` alone would freeze Docker `latest` at `3.224.3` until the next `main` release ships with the gate moved to `refs/tags/v4`. That's a coordinated main+v3 change and a separate call — flagging it here rather than doing it silently.

## Verification

- `node -e "require('./package.json')"` → valid JSON, `makeLatest = false`
- `pnpm run lint` → `Tasks:    7 successful, 7 total` (includes the Prettier check: `All matched files use Prettier code style!`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Prevents future v3 maintenance releases from claiming GitHub’s Latest release badge.
- Adds `github.makeLatest: false` to the root `release-it` configuration.
- Leaves tagging, generated GitHub releases, and Docker image behavior unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The release command consumes the root package.json release-it configuration, and the change is narrowly scoped to disabling GitHub’s Latest designation for subsequent v3 releases.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): stop v3 releases claimin..."](https://github.com/langfuse/langfuse/commit/2a5932caef08df76edcbf7383fa9a189e7dda2d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48418732)</sub>

<!-- /greptile_comment -->