### PR TITLE
fix(v4-migration): navigate assistant flow to evals

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -212,6 +212,27 @@ describe("V4MigrationDetailsContent", () => {
       { newConversation: true },
     );
   });
+
+  it("opens the assistant when navigation to evals is interrupted", async () => {
+    mocks.migrationData.evals = { status: "loaded", count: 1 };
+    mocks.routerPush.mockRejectedValueOnce(
+      new Error("Abort fetching component for route"),
+    );
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Migrate with assistant" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.setAgentOpen).toHaveBeenCalledWith(true);
+    });
+    expect(mocks.submitAgentMessage).toHaveBeenCalledWith(
+      "eval-upgrade-prompt",
+      { newConversation: true },
+    );
+  });
 });
 
 describe("V4MigrationHeaderContent", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1,4 +1,10 @@
-import { render, screen, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -8,6 +14,15 @@ import {
 import { type MigrationCountState } from "./migrationData";
 
 const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  setAgentOpen: vi.fn(),
+  submitAgentMessage: vi.fn(),
+  upgradePlan: {
+    canUseAssistant: true,
+    mode: "evals-ready" as const,
+    showAssistantButton: true,
+    assistantPrompt: "eval-upgrade-prompt",
+  },
   migrationData: {
     sdk: {
       status: "latest" as const,
@@ -24,7 +39,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("next/router", () => ({
-  useRouter: () => ({ query: { projectId: "project-1" } }),
+  useRouter: () => ({
+    query: { projectId: "project-1" },
+    push: mocks.routerPush,
+  }),
 }));
 
 vi.mock("@/src/features/support-chat/SupportDrawerProvider", () => ({
@@ -48,17 +66,15 @@ vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
 // The plan hook queries tRPC internally; mock it so tests need no provider.
 vi.mock("@/src/features/v4-migration/useV4UpgradeAssistantSupport", () => ({
   V4_CODING_AGENT_PROMPT: "coding-agent-prompt",
-  useEvalUpgradeAssistantPlan: () => ({
-    canUseAssistant: false,
-    mode: "outside",
-    showAssistantButton: false,
-    assistantPrompt: "",
-  }),
+  useEvalUpgradeAssistantPlan: () => mocks.upgradePlan,
 }));
 
 vi.mock("@/src/features/in-app-agent/components/InAppAiAgentProvider", () => ({
-  useCanUseInAppAgent: () => false,
-  useInAppAiAgent: () => ({ setOpen: vi.fn(), submit: vi.fn() }),
+  useCanUseInAppAgent: () => true,
+  useInAppAiAgent: () => ({
+    setOpen: mocks.setAgentOpen,
+    submit: mocks.submitAgentMessage,
+  }),
 }));
 
 // The toggle row pulls in session + tRPC state via useV4Beta; stub it so the
@@ -86,6 +102,10 @@ vi.mock("@/src/components/ui/collapsible", () => ({
 
 describe("V4MigrationDetailsContent", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.routerPush.mockResolvedValue(true);
+    mocks.submitAgentMessage.mockResolvedValue(undefined);
+    mocks.migrationData.evals = { status: "loaded", count: 0 };
     mocks.canToggleV4 = true;
     mocks.migrationData.apis = { status: "loaded", count: 1 };
     mocks.migrationData.exports = { status: "loaded", count: 3 };
@@ -173,10 +193,30 @@ describe("V4MigrationDetailsContent", () => {
       screen.queryByText(/Use this toggle to compare both views/),
     ).not.toBeInTheDocument();
   });
+
+  it("navigates to evals when migrating with the assistant", async () => {
+    mocks.migrationData.evals = { status: "loaded", count: 1 };
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Migrate with assistant" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.routerPush).toHaveBeenCalledWith("/project/project-1/evals");
+    });
+    expect(mocks.setAgentOpen).toHaveBeenCalledWith(true);
+    expect(mocks.submitAgentMessage).toHaveBeenCalledWith(
+      "eval-upgrade-prompt",
+      { newConversation: true },
+    );
+  });
 });
 
 describe("V4MigrationHeaderContent", () => {
   beforeEach(() => {
+    mocks.migrationData.evals = { status: "loaded", count: 0 };
     mocks.migrationData.apis = { status: "loaded", count: 1 };
     mocks.migrationData.exports = { status: "loaded", count: 3 };
   });

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -429,7 +429,7 @@ export function V4MigrationDetailsContent({
     capture("v4_migration:migrate_evals_with_agent_clicked");
     onNavigate?.();
     if (evalsUrl) {
-      await router.push(evalsUrl);
+      await router.push(evalsUrl).catch(() => undefined);
     }
     setAgentOpen(true);
     await submitAgentMessage(upgradePlan.assistantPrompt, {

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -423,16 +423,19 @@ export function V4MigrationDetailsContent({
     orgId: organization?.id,
     enabled: Boolean(projectId),
   });
+  const evalsUrl =
+    typeof projectId === "string" ? `/project/${projectId}/evals` : undefined;
   const handleMigrateEvalsWithAgent = async () => {
     capture("v4_migration:migrate_evals_with_agent_clicked");
     onNavigate?.();
+    if (evalsUrl) {
+      await router.push(evalsUrl);
+    }
     setAgentOpen(true);
     await submitAgentMessage(upgradePlan.assistantPrompt, {
       newConversation: true,
     });
   };
-  const evalsUrl =
-    typeof projectId === "string" ? `/project/${projectId}/evals` : undefined;
   const integrationsUrl =
     typeof projectId === "string"
       ? `/project/${projectId}/settings/integrations`


### PR DESCRIPTION
## Summary

- navigate to the project evaluators page when starting eval migration with the assistant
- wait for navigation before opening and submitting the assistant conversation
- add client regression coverage for the route and assistant submission

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx` — 8 tests passed
- `pnpm exec turbo run lint --output-logs=errors-only` — passed
- `pnpm --filter web run typecheck` — passed after rebuilding `@langfuse/shared` outputs
- commit hooks: Prettier and lint passed (`Tasks: 7 successful, 7 total`)
- PR preview: from `/project/:projectId/traces`, “Migrate with assistant” navigated to `/project/:projectId/evals`, closed the migration drawer, opened the assistant, submitted the eval-upgrade prompt, and rendered the assistant response

## Preview

https://pr-15600.preview.langfuse.com

The fresh preview seed has no deprecated evals and no supported eval-migration seed scenario. Browser verification overrode only the preview UI flag and the read-only deprecated-eval summary response; it did not write ad-hoc database state.