### PR TITLE
fix(v4-migration): hide ready project hints

### DIFF
--- a/web/src/features/v4-migration/V4MigrationEntryPoints.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationEntryPoints.clienttest.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { V4MigrationNavItem } from "./V4MigrationNavItem";
+import { V4MigrationProjectChip } from "./V4MigrationProjectChip";
+import { type ProjectMigrationStatus } from "./migrationData";
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  openMigrationPanel: vi.fn(),
+  setOpenMobileSidebar: vi.fn(),
+  migrationData: undefined as unknown as ProjectMigrationStatus,
+}));
+
+vi.mock("@/src/components/ui/sidebar", () => ({
+  SidebarMenuButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  useSidebar: () => ({
+    isMobile: false,
+    setOpenMobile: mocks.setOpenMobileSidebar,
+  }),
+}));
+
+vi.mock("@/src/features/v4-migration/useV4UpgradeUiEnabled", () => ({
+  useV4UpgradeUiEnabled: () => true,
+}));
+
+vi.mock("@/src/features/projects/hooks", () => ({
+  useQueryProject: () => ({
+    project: { id: "project-1", name: "Project 1" },
+    organization: { id: "org-1" },
+  }),
+}));
+
+vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
+  useProjectV4MigrationData: () => mocks.migrationData,
+}));
+
+vi.mock("@/src/features/v4-migration/hooks/useOpenV4MigrationPanel", () => ({
+  useOpenV4MigrationPanel: () => mocks.openMigrationPanel,
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => mocks.capture,
+}));
+
+const migrationStatus = (
+  overrides?: Partial<ProjectMigrationStatus>,
+): ProjectMigrationStatus => ({
+  sdk: {
+    status: "latest",
+    sdkUsageSeries: [],
+    upgradeRequiredCount: 0,
+    delayedOtelIngestionCount: 0,
+  },
+  evals: { status: "loaded", count: 0 },
+  apis: { status: "loaded", count: 0 },
+  exports: { status: "loaded", count: 0 },
+  ...overrides,
+});
+
+describe("v4 migration entry points", () => {
+  beforeEach(() => {
+    mocks.migrationData = migrationStatus();
+  });
+
+  it("hides the project chip and sidebar item when the project is up to date", () => {
+    render(
+      <>
+        <V4MigrationProjectChip
+          project={{ id: "project-1", name: "Project 1" }}
+          status={mocks.migrationData}
+        />
+        <V4MigrationNavItem />
+      </>,
+    );
+
+    expect(screen.queryByText("Up to date")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("shows both entry points when the project needs an update", () => {
+    mocks.migrationData = migrationStatus({
+      evals: { status: "loaded", count: 1 },
+    });
+
+    render(
+      <>
+        <V4MigrationProjectChip
+          project={{ id: "project-1", name: "Project 1" }}
+          status={mocks.migrationData}
+        />
+        <V4MigrationNavItem />
+      </>,
+    );
+
+    expect(screen.getByText("Update")).toBeInTheDocument();
+    expect(screen.getByText("Action required")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/v4-migration/V4MigrationNavItem.tsx
+++ b/web/src/features/v4-migration/V4MigrationNavItem.tsx
@@ -28,14 +28,16 @@ export function V4MigrationNavItem() {
     apis: migrationData.apis,
     exports: migrationData.exports,
   });
+  if (readiness === "ready") {
+    return null;
+  }
+
   const label =
-    readiness === "ready"
-      ? "Up to date"
-      : readiness === "checking"
-        ? "Checking"
-        : readiness === "unavailable"
-          ? "Check status"
-          : "Action required";
+    readiness === "checking"
+      ? "Checking"
+      : readiness === "unavailable"
+        ? "Check status"
+        : "Action required";
 
   const handleClick = () => {
     capture("sidebar:v4_migration_card_clicked");
@@ -55,13 +57,7 @@ export function V4MigrationNavItem() {
         tooltip={label}
         className="border-input w-full gap-1.5 rounded-full border pr-2 pl-[9px]"
       >
-        <span
-          className={
-            readiness === "ready"
-              ? "h-2 w-2 shrink-0 rounded-full bg-green-500 dark:bg-green-500"
-              : "h-2 w-2 shrink-0 rounded-full bg-orange-400 dark:bg-orange-400"
-          }
-        />
+        <span className="h-2 w-2 shrink-0 rounded-full bg-orange-400 dark:bg-orange-400" />
         <span className="truncate font-bold" title={label}>
           {label}
         </span>

--- a/web/src/features/v4-migration/V4MigrationProjectChip.tsx
+++ b/web/src/features/v4-migration/V4MigrationProjectChip.tsx
@@ -17,14 +17,16 @@ export function V4MigrationProjectChip({
   const capture = usePostHogClientCapture();
 
   const readiness = status ? getProjectMigrationReadiness(status) : "checking";
+  if (readiness === "ready") {
+    return null;
+  }
+
   const label =
-    readiness === "ready"
-      ? "Up to date"
-      : readiness === "checking"
-        ? "Checking"
-        : readiness === "unavailable"
-          ? "Check status"
-          : "Update";
+    readiness === "checking"
+      ? "Checking"
+      : readiness === "unavailable"
+        ? "Check status"
+        : "Update";
 
   const handleClick = () => {
     capture("v4_migration:project_chip_clicked");
@@ -39,11 +41,7 @@ export function V4MigrationProjectChip({
     >
       <span
         aria-hidden
-        className={
-          readiness === "ready"
-            ? "size-1.75 shrink-0 rounded-full bg-green-500 dark:bg-green-500"
-            : "size-1.75 shrink-0 rounded-full bg-orange-400 dark:bg-orange-400"
-        }
+        className="size-1.75 shrink-0 rounded-full bg-orange-400 dark:bg-orange-400"
       ></span>
       {label}
     </button>


### PR DESCRIPTION
## What changed

- hide the v4 migration chip on organization project cards once a project is ready
- hide the matching project-sidebar migration item once a project is ready
- retain checking, unavailable, and action-required states
- add client regression coverage for both ready and action-needed projects

## Why

The migration entry points rendered a green “Up to date” state even when there was no migration work left. This created persistent UI noise on finished projects and in the product sidebar.

## Impacted package

- `web`

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter web run test-client V4MigrationEntryPoints.clienttest.tsx` — `Tests 2 passed (2)`
- `pnpm exec prettier --check web/src/features/v4-migration/V4MigrationProjectChip.tsx web/src/features/v4-migration/V4MigrationNavItem.tsx web/src/features/v4-migration/V4MigrationEntryPoints.clienttest.tsx`
- browser review of organization cards and the project sidebar for both ready and action-required states; no console errors

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes completed-project V4 migration entry points while preserving visible checking, unavailable, and action-required states.
- Hides the organization project-card migration chip when readiness is `ready`.
- Hides the project-sidebar migration item when readiness is `ready`.
- Adds client regression tests for ready and action-needed projects.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new visibility condition matches the established readiness semantics and preserves actionable migration states.

The early returns occur after all hooks, apply only when the SDK and migration counts classify the project as fully ready, and leave checking, unavailable, and action-needed paths unchanged.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4-migration): hide ready project hi..."](https://github.com/langfuse/langfuse/commit/f4af1246237ec854f80eb77a3e43d077293568d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48461556)</sub>

<!-- /greptile_comment -->