### PR TITLE
feat(migration-v4): auto-generate API keys on prompt copy

### DIFF
--- a/web/src/__tests__/server/project-api-key-trpc.servertest.ts
+++ b/web/src/__tests__/server/project-api-key-trpc.servertest.ts
@@ -25,7 +25,9 @@ describe("project API keys trpc", () => {
     });
   });
 
-  async function createProjectCaller() {
+  async function createProjectCaller(
+    projectRole: "ADMIN" | "MEMBER" = "ADMIN",
+  ) {
     const { projectId, orgId } = await createOrgProjectAndApiKey();
 
     const session: Session = {
@@ -47,7 +49,7 @@ describe("project API keys trpc", () => {
             projects: [
               {
                 id: projectId,
-                role: "ADMIN",
+                role: projectRole,
                 retentionDays: 30,
                 deletedAt: null,
                 hasTraces: false,
@@ -112,11 +114,31 @@ describe("project API keys trpc", () => {
       });
       expect(dbKey.createdByUserId).toBe("user-1");
       expect(dbKey.createdByApiKeyId).toBeNull();
+      expect(dbKey.scope).toBe("PROJECT");
+      expect(dbKey.projectId).toBe(projectId);
+      expect(dbKey.orgId).toBeNull();
 
       const apiKeys = await caller.projectApiKeys.byProjectId({ projectId });
       const listedKey = apiKeys.find((key) => key.id === apiKeyResult.id);
       expect(listedKey?.createdByUser?.id).toBe("user-1");
       expect(listedKey?.createdByApiKey).toBeNull();
+    });
+
+    it("rejects users without apiKeys:CUD access", async () => {
+      const { caller, projectId } = await createProjectCaller("MEMBER");
+
+      await expect(
+        caller.projectApiKeys.create({
+          projectId,
+          note: "Unauthorized migration key",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      await expect(
+        prisma.apiKey.count({
+          where: { projectId, note: "Unauthorized migration key" },
+        }),
+      ).resolves.toBe(0);
     });
   });
 

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -32,6 +32,7 @@ export type PageHeaderProps = {
   breadcrumb?: { name: string; href?: string }[];
   actionButtonsLeft?: React.ReactNode; // Right-side actions (buttons, etc.)
   actionButtonsRight?: React.ReactNode; // Right-side actions (buttons, etc.)
+  actionButtonsRightClassName?: string;
   /** Mobile-only: the same actions rendered as full-width labeled menu rows
    * (icon + label), for the compact header's `⋯` overflow. Pages pass a
    * `layout="menu"` variant of their actions here (mirrors the table peek's
@@ -57,6 +58,7 @@ const PageHeader = ({
   itemType,
   actionButtonsLeft,
   actionButtonsRight,
+  actionButtonsRightClassName,
   breadcrumb,
   help,
   titleTooltip,
@@ -211,10 +213,14 @@ const PageHeader = ({
               )}
             </div>
 
-            {/* Right side content — right-aligned by the row's
-                justify-between while it shares the line with the title;
-                left-aligned once it wraps to its own line. */}
-            <div className="flex flex-wrap items-center gap-1">
+            {/* Right side content. Pages can override the default alignment
+                when wrapped actions should retain a shared right edge. */}
+            <div
+              className={cn(
+                "flex flex-wrap items-center gap-1",
+                actionButtonsRightClassName,
+              )}
+            >
               {actionButtonsRight}
             </div>
           </div>

--- a/web/src/features/evals/components/manage-default-eval-model.tsx
+++ b/web/src/features/evals/components/manage-default-eval-model.tsx
@@ -43,12 +43,12 @@ export function ManageDefaultEvalModel({
       {defaultModel ? (
         <span
           className={cn(
-            "text-sm font-bold",
+            "text-sm font-bold text-nowrap",
             variant === "color-coded" && "text-dark-green",
             className,
           )}
         >
-          {"Current default model: "}
+          {"Default model: "}
           {defaultModel.provider} / {defaultModel.model}
         </span>
       ) : (

--- a/web/src/features/evals/pages/evaluators.tsx
+++ b/web/src/features/evals/pages/evaluators.tsx
@@ -109,6 +109,7 @@ export default function EvaluatorsPage() {
             </ActionButton>
           </>
         ),
+        actionButtonsRightClassName: "justify-end",
       }}
     >
       <EvaluatorTable projectId={projectId} />

--- a/web/src/features/evals/pages/templates.tsx
+++ b/web/src/features/evals/pages/templates.tsx
@@ -11,6 +11,7 @@ import {
   EVALS_TABS,
 } from "@/src/features/navigation/utils/evals-tabs";
 import { ManageDefaultEvalModel } from "@/src/features/evals/components/manage-default-eval-model";
+import { V4MigrationUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
 
 export default function TemplatesPage() {
   const router = useRouter();
@@ -34,6 +35,7 @@ export default function TemplatesPage() {
     <Page
       headerProps={{
         title: "Evaluators",
+        titleBadges: <V4MigrationUpdateRequiredBadge />,
         help: {
           description: "View all langfuse managed and custom evaluators.",
           href: "https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge",
@@ -68,6 +70,7 @@ export default function TemplatesPage() {
             </Button>
           </>
         ),
+        actionButtonsRightClassName: "justify-end",
       }}
     >
       <EvalsTemplateTable projectId={projectId} />

--- a/web/src/features/v4-migration/V4MigrationBadgeContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationBadgeContent.tsx
@@ -1,0 +1,46 @@
+import { ChevronRight } from "lucide-react";
+
+type V4MigrationBadgeContentProps = {
+  onClick: () => void;
+  title: string;
+  description: string;
+};
+
+export function V4MigrationBadgeContent({
+  onClick,
+  title,
+  description,
+}: V4MigrationBadgeContentProps) {
+  return (
+    <span className="inline-grid flex-none shrink-0">
+      <span
+        aria-hidden
+        className="invisible col-start-1 row-start-1 inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-bold whitespace-nowrap"
+      >
+        <span className="size-1.75 shrink-0 rounded-full" />
+        <span className="flex items-center">
+          {title}.&nbsp;{description}.
+          <ChevronRight className="ml-1 h-3 w-3 shrink-0" />
+        </span>
+      </span>
+
+      <button
+        type="button"
+        onClick={onClick}
+        className="group ring-input hover:bg-muted/50 hover:text-foreground col-start-1 row-start-1 inline-flex w-fit flex-none shrink-0 items-center gap-1.5 justify-self-start rounded-full bg-transparent px-2 py-0.5 text-xs font-bold whitespace-nowrap ring"
+      >
+        <span
+          aria-hidden
+          className="size-1.75 shrink-0 rounded-full bg-orange-400 dark:bg-orange-400"
+        />
+        <span className="flex items-center">
+          {title}
+          <span className="flex max-w-0 items-center overflow-hidden transition-[max-width] duration-300 ease-out group-hover:max-w-96 group-focus-visible:max-w-96">
+            <span className="whitespace-nowrap">.&nbsp;{description}.</span>
+          </span>
+          <ChevronRight className="ml-1 h-3 w-3 shrink-0" />
+        </span>
+      </button>
+    </span>
+  );
+}

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -270,7 +270,7 @@ describe("V4MigrationHeaderContent", () => {
       note: "v4-migration-key",
     });
     await waitFor(() =>
-      expect(screen.getByText("pk-lf-project-1")).toBeInTheDocument(),
+      expect(screen.getByText("pk-lf-pr…ct-1")).toBeInTheDocument(),
     );
   });
 
@@ -298,19 +298,19 @@ describe("V4MigrationHeaderContent", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByText("pk-lf-project-1")).toBeInTheDocument(),
+      expect(screen.getByText("pk-lf-pr…ct-1")).toBeInTheDocument(),
     );
 
     rerender(
       <V4MigrationHeaderContent key="project-2" projectId="project-2" />,
     );
 
-    expect(screen.queryByText("pk-lf-project-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("pk-lf-pr…ct-1")).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: "Update SDK with agents" }),
     );
     await waitFor(() =>
-      expect(screen.getByText("pk-lf-project-2")).toBeInTheDocument(),
+      expect(screen.getByText("pk-lf-pr…ct-2")).toBeInTheDocument(),
     );
     expect(mocks.createProjectApiKey).toHaveBeenLastCalledWith({
       projectId: "project-2",

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1,4 +1,10 @@
-import { render, screen, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -21,6 +27,8 @@ const mocks = vi.hoisted(() => ({
     legacyIntegrations: ["PostHog", "Mixpanel", "Blob Storage"],
   },
   canToggleV4: true,
+  hasApiKeyCreateAccess: true,
+  createProjectApiKey: vi.fn(),
 }));
 
 vi.mock("next/router", () => ({
@@ -43,7 +51,7 @@ vi.mock("@/src/utils/api", () => ({
     projectApiKeys: {
       create: {
         useMutation: () => ({
-          mutateAsync: vi.fn(),
+          mutateAsync: mocks.createProjectApiKey,
           isPending: false,
         }),
       },
@@ -56,7 +64,7 @@ vi.mock("@/src/features/projects/hooks", () => ({
 }));
 
 vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
-  useHasProjectAccess: () => true,
+  useHasProjectAccess: () => mocks.hasApiKeyCreateAccess,
 }));
 
 vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
@@ -199,6 +207,15 @@ describe("V4MigrationHeaderContent", () => {
   beforeEach(() => {
     mocks.migrationData.apis = { status: "loaded", count: 1 };
     mocks.migrationData.exports = { status: "loaded", count: 3 };
+    mocks.hasApiKeyCreateAccess = true;
+    mocks.createProjectApiKey.mockReset();
+    mocks.createProjectApiKey.mockImplementation(
+      ({ projectId }: { projectId: string }) =>
+        Promise.resolve({
+          secretKey: `sk-lf-${projectId}`,
+          publicKey: `pk-lf-${projectId}`,
+        }),
+    );
   });
 
   it("claims the project needs migrating while checks report action needed", () => {
@@ -238,5 +255,66 @@ describe("V4MigrationHeaderContent", () => {
     const link = screen.getByRole("link", { name: "View Status" });
     expect(link).toHaveAttribute("href", "/v4-migration");
     expect(link.parentElement).toHaveClass("pr-6");
+  });
+
+  it("creates project API keys when revealing the migration prompt", async () => {
+    render(<V4MigrationHeaderContent projectId="project-1" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Update SDK with agents" }),
+    );
+
+    expect(screen.getByText("coding-agent-prompt")).toBeInTheDocument();
+    expect(mocks.createProjectApiKey).toHaveBeenCalledWith({
+      projectId: "project-1",
+      note: "v4-migration-key",
+    });
+    await waitFor(() =>
+      expect(screen.getByText("pk-lf-project-1")).toBeInTheDocument(),
+    );
+  });
+
+  it("hides API key creation for users without access", () => {
+    mocks.hasApiKeyCreateAccess = false;
+    const { container } = render(
+      <V4MigrationHeaderContent projectId="project-1" />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Update SDK with agents" }),
+    );
+
+    expect(screen.getByText("coding-agent-prompt")).toBeInTheDocument();
+    expect(mocks.createProjectApiKey).not.toHaveBeenCalled();
+    expect(container.querySelector(".lucide-loader-circle")).toBeNull();
+  });
+
+  it("refreshes generated keys when the project changes", async () => {
+    const { rerender } = render(
+      <V4MigrationHeaderContent key="project-1" projectId="project-1" />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Update SDK with agents" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("pk-lf-project-1")).toBeInTheDocument(),
+    );
+
+    rerender(
+      <V4MigrationHeaderContent key="project-2" projectId="project-2" />,
+    );
+
+    expect(screen.queryByText("pk-lf-project-1")).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Update SDK with agents" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("pk-lf-project-2")).toBeInTheDocument(),
+    );
+    expect(mocks.createProjectApiKey).toHaveBeenLastCalledWith({
+      projectId: "project-2",
+      note: "v4-migration-key",
+    });
   });
 });

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -35,8 +35,28 @@ vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
   usePostHogClientCapture: () => vi.fn(),
 }));
 
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      projectApiKeys: { invalidate: vi.fn() },
+    }),
+    projectApiKeys: {
+      create: {
+        useMutation: () => ({
+          mutateAsync: vi.fn(),
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
 vi.mock("@/src/features/projects/hooks", () => ({
   useProject: () => ({ organization: { id: "org-1" } }),
+}));
+
+vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
 }));
 
 vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -8,10 +8,12 @@ import {
   LibraryBig,
   LifeBuoy,
   TriangleAlert,
+  Loader2,
 } from "lucide-react";
 import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { Button } from "@/src/components/ui/button";
+import { CodeView } from "@/src/components/ui/CodeJsonViewer";
 import { RainbowButton } from "@/src/components/magicui/rainbow-button";
 import { Separator } from "@/src/components/ui/separator";
 import {
@@ -42,6 +44,8 @@ import {
   useEvalUpgradeAssistantPlan,
   V4_CODING_AGENT_PROMPT,
 } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { api } from "@/src/utils/api";
 
 // Single source of truth for the v4-migration copy and content. Both surfaces
 // (side panel and modal) render these components — edit copy here only.
@@ -145,6 +149,32 @@ function ExternalLink({
     >
       {children}
     </a>
+  );
+}
+
+function ApiKeyCopyField({
+  label,
+  value,
+  masked = false,
+}: {
+  label: "PK" | "SK";
+  value: string;
+  masked?: boolean;
+}) {
+  return (
+    <div className="flex min-w-0 items-stretch overflow-hidden rounded-md border">
+      <div className="bg-muted text-muted-foreground flex w-10 shrink-0 items-center justify-center border-r font-mono text-xs font-bold">
+        {label}
+      </div>
+      <CodeView
+        content={
+          masked ? value.slice(0, 4) + "••••••••••••••••••••••••" : value
+        }
+        originalContent={value}
+        className="min-w-0 flex-1 [&>div]:rounded-none [&>div]:border-0"
+        lineWrap={false}
+      />
+    </div>
   );
 }
 
@@ -318,9 +348,40 @@ export function V4MigrationHeaderContent({
     Boolean(projectId) &&
     getProjectMigrationReadiness(migrationData) === "action-needed";
 
+  const [generatedKeys, setGeneratedKeys] = useState<{
+    secretKey: string;
+    publicKey: string;
+  } | null>(null);
+
+  const utils = api.useUtils();
+  const mutCreateProjectApiKey = api.projectApiKeys.create.useMutation({
+    onSuccess: () => utils.projectApiKeys.invalidate(),
+  });
+  const hasApiKeyCreateAccess = useHasProjectAccess({
+    projectId,
+    scope: "apiKeys:CUD",
+  });
+
   const handleShowPrompt = () => {
     capture("v4_migration:coding_agent_prompt_viewed");
     setPromptVisible(true);
+    if (!projectId || !hasApiKeyCreateAccess) return;
+
+    mutCreateProjectApiKey
+      .mutateAsync({
+        projectId,
+        note: "v4-migration-key",
+      })
+      .then(({ secretKey, publicKey }) => {
+        setGeneratedKeys({
+          secretKey,
+          publicKey,
+        });
+        capture(`project_settings:api_key_create`);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
   };
 
   return (
@@ -379,6 +440,26 @@ export function V4MigrationHeaderContent({
             </span>
           )}
         </RainbowButton>
+        {promptVisible &&
+          projectId &&
+          (generatedKeys ? (
+            <div className="mt-1 flex flex-col gap-2">
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                If you are setting up the Langfuse CLI or skills for the first
+                time, use these project API keys.
+              </p>
+              <div className="flex flex-col gap-2">
+                <ApiKeyCopyField label="PK" value={generatedKeys.publicKey} />
+                <ApiKeyCopyField
+                  label="SK"
+                  value={generatedKeys.secretKey}
+                  masked
+                />
+              </div>
+            </div>
+          ) : (
+            <Loader2 className="h-4 w-4 shrink-0" />
+          ))}
       </div>
     </>
   );

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -8,7 +8,6 @@ import {
   LibraryBig,
   LifeBuoy,
   TriangleAlert,
-  Loader2,
 } from "lucide-react";
 import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
@@ -349,9 +348,12 @@ export function V4MigrationHeaderContent({
     getProjectMigrationReadiness(migrationData) === "action-needed";
 
   const [generatedKeys, setGeneratedKeys] = useState<{
+    projectId: string;
     secretKey: string;
     publicKey: string;
   } | null>(null);
+  const generatedKeysForProject =
+    generatedKeys?.projectId === projectId ? generatedKeys : null;
 
   const utils = api.useUtils();
   const mutCreateProjectApiKey = api.projectApiKeys.create.useMutation({
@@ -365,7 +367,12 @@ export function V4MigrationHeaderContent({
   const handleShowPrompt = () => {
     capture("v4_migration:coding_agent_prompt_viewed");
     setPromptVisible(true);
-    if (!projectId || !hasApiKeyCreateAccess) return;
+    if (
+      !projectId ||
+      !hasApiKeyCreateAccess ||
+      mutCreateProjectApiKey.isPending
+    )
+      return;
 
     mutCreateProjectApiKey
       .mutateAsync({
@@ -374,6 +381,7 @@ export function V4MigrationHeaderContent({
       })
       .then(({ secretKey, publicKey }) => {
         setGeneratedKeys({
+          projectId,
           secretKey,
           publicKey,
         });
@@ -442,24 +450,26 @@ export function V4MigrationHeaderContent({
         </RainbowButton>
         {promptVisible &&
           projectId &&
-          (generatedKeys ? (
+          hasApiKeyCreateAccess &&
+          generatedKeysForProject && (
             <div className="mt-1 flex flex-col gap-2">
               <p className="text-muted-foreground text-sm leading-relaxed">
                 If you are setting up the Langfuse CLI or skills for the first
                 time, use these project API keys.
               </p>
               <div className="flex flex-col gap-2">
-                <ApiKeyCopyField label="PK" value={generatedKeys.publicKey} />
+                <ApiKeyCopyField
+                  label="PK"
+                  value={generatedKeysForProject.publicKey}
+                />
                 <ApiKeyCopyField
                   label="SK"
-                  value={generatedKeys.secretKey}
+                  value={generatedKeysForProject.secretKey}
                   masked
                 />
               </div>
             </div>
-          ) : (
-            <Loader2 className="h-4 w-4 shrink-0" />
-          ))}
+          )}
       </div>
     </>
   );

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -154,21 +154,19 @@ function ExternalLink({
 function ApiKeyCopyField({
   label,
   value,
-  masked = false,
 }: {
-  label: "PK" | "SK";
+  label: "Public key" | "Secret key";
   value: string;
-  masked?: boolean;
 }) {
+  const truncatedValue = `${value.slice(0, 8)}…${value.slice(-4)}`;
+
   return (
     <div className="flex min-w-0 items-stretch overflow-hidden rounded-md border">
-      <div className="bg-muted text-muted-foreground flex w-10 shrink-0 items-center justify-center border-r font-mono text-xs font-bold">
+      <div className="bg-muted text-muted-foreground flex w-24 shrink-0 items-center justify-center border-r text-xs font-bold">
         {label}
       </div>
       <CodeView
-        content={
-          masked ? value.slice(0, 4) + "••••••••••••••••••••••••" : value
-        }
+        content={truncatedValue}
         originalContent={value}
         className="min-w-0 flex-1 [&>div]:rounded-none [&>div]:border-0"
         lineWrap={false}
@@ -459,13 +457,12 @@ export function V4MigrationHeaderContent({
               </p>
               <div className="flex flex-col gap-2">
                 <ApiKeyCopyField
-                  label="PK"
+                  label="Public key"
                   value={generatedKeysForProject.publicKey}
                 />
                 <ApiKeyCopyField
-                  label="SK"
+                  label="Secret key"
                   value={generatedKeysForProject.secretKey}
-                  masked
                 />
               </div>
             </div>

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -1,4 +1,3 @@
-import { ChevronRight } from "lucide-react";
 import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -12,36 +11,7 @@ import {
   useInAppAiAgent,
 } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useEvalUpgradeAssistantPlan } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
-
-function BadgeContent({
-  handleClick,
-  title,
-  description,
-}: {
-  handleClick: () => void;
-  title: string;
-  description: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className="group ring-input hover:bg-muted/50 hover:text-foreground inline-flex w-fit flex-none shrink-0 items-center gap-1.5 rounded-full bg-transparent px-2 py-0.5 text-xs font-bold whitespace-nowrap ring"
-    >
-      <span
-        aria-hidden
-        className="size-1.75 shrink-0 rounded-full bg-orange-400 dark:bg-orange-400"
-      ></span>
-      <span className="flex items-center">
-        {title}
-        <span className="flex max-w-0 items-center overflow-hidden transition-[max-width] duration-300 ease-out group-hover:max-w-96">
-          <span className="whitespace-nowrap">.&nbsp;{description}.</span>
-        </span>
-        <ChevronRight className="ml-1 h-3 w-3 shrink-0" />
-      </span>
-    </button>
-  );
-}
+import { V4MigrationBadgeContent } from "@/src/features/v4-migration/V4MigrationBadgeContent";
 
 export function V4MigrationDelayBadge() {
   const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
@@ -64,8 +34,8 @@ export function V4MigrationDelayBadge() {
   };
 
   return (
-    <BadgeContent
-      handleClick={handleClick}
+    <V4MigrationBadgeContent
+      onClick={handleClick}
       title="New data in ~15 min"
       description="Update your SDK for real-time data"
     />
@@ -125,8 +95,8 @@ export function V4MigrationUpdateRequiredBadge() {
   };
 
   return (
-    <BadgeContent
-      handleClick={handleClick}
+    <V4MigrationBadgeContent
+      onClick={handleClick}
       title="Action required"
       description="Start the upgrade now"
     />

--- a/web/src/features/v4-migration/V4MigrationPanel.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanel.tsx
@@ -53,6 +53,7 @@ export const V4MigrationPanel = ({
       <div className="flex-1 overflow-y-auto border-t">
         <div className="bg-background sticky top-0 z-[1] px-4 pt-4">
           <V4MigrationHeaderContent
+            key={project?.id}
             projectName={project?.name}
             projectId={project?.id}
             onNavigate={() => setOpen(false)}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15604.preview.langfuse.com](https://pr-15604.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds automatic project API-key generation to the v4 migration prompt flow and adjusts migration badges and evaluator-header layout.
- Displays newly generated public and masked secret keys beneath the migration prompt.
- Extracts reusable expandable migration-badge content and adds it to evaluator templates.
- Adds right-action alignment customization to PageHeader and updates evaluator model labeling.
- Extends migration content tests with API and RBAC mocks.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until the migration key flow prevents cross-project credential reuse, resolves skipped and failed requests, and avoids leaving unused persistent keys.

The new prompt action can display one project's credentials in another project's panel, permanently strand non-admin and failed requests on a loader, and persist credentials whose one-time secret is abandoned or duplicated.

**Files Needing Attention:** web/src/features/v4-migration/V4MigrationContent.tsx
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Reveal migration prompt] --> B{Has apiKeys:CUD?}
  B -->|No| C[Permanent unresolved loader]
  B -->|Yes| D[Create persistent project API key]
  D -->|Failure| C
  D -->|Success| E[Store credentials in component state]
  E --> F[Display and copy credentials]
  E --> G{Project changes while panel stays open?}
  G -->|Yes| H[Old project's credentials shown in new project]
  D --> I{Surface closes before response?}
  I -->|Yes| J[Valid key remains but secret is lost]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4-migration/V4MigrationContent.tsx:351-354
**Stale cross-project API keys**

When a user generates credentials for project A and navigates to project B while the migration panel remains open, `generatedKeys` retains project A's credentials and renders them in project B's migration UI, causing copied credentials to authenticate and send data to the wrong project.

### Issue 2
web/src/features/v4-migration/V4MigrationContent.tsx:443-462
**Terminal states render as loading**

When a MEMBER or VIEWER reveals the prompt without `apiKeys:CUD`, or key creation fails, `generatedKeys` remains null and this branch permanently renders a static loader with no explanation, error state, or retry action.

### Issue 3
web/src/features/v4-migration/V4MigrationContent.tsx:365-374
**Prompt reveal creates persistent keys**

When an authorized user clicks only to review the prompt, this handler immediately persists a new API key; closing before the response loses the one-time secret while leaving a valid key behind, and reopening the flow creates additional unused keys with the same note.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(migration-v4): auto-generate API ke..."](https://github.com/langfuse/langfuse/commit/4898322f1396a704757f9c58f2792aaf201bc9d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48485140)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)
- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)
</details>

<!-- /greptile_comment -->