### PR TITLE
chore: remove sfdc-backfill directory from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-sfdc-backfill
-
 # dependencies
 /node_modules
 /.pnp


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the `sfdc-backfill` entry from `.gitignore`, allowing that directory and its contents to be tracked by Git.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge.

The change only makes the `sfdc-backfill` directory eligible for version control and introduces no runtime, build, or security behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove sfdc-backfill directory fr..."](https://github.com/langfuse/langfuse/commit/0a1f647ff1fc47b88da1dc7c4bb5c9029c4eadfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48614339)</sub>

<!-- /greptile_comment -->