### PR TITLE
chore(release): flip Docker latest markers to the v4 line

### DIFF
--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -56,10 +56,12 @@ operations.
 - Promote `main` to `production` without a release via
   `.github/workflows/promote-main-to-production.yml` or
   `pnpm run release:cloud` (both main-only).
-- At v4 GA, flip the latest-release markers: in `pipeline.yml`, move the
-  Docker `latest` tag gate from `refs/tags/v3` to `refs/tags/v4` on `main`
-  and disable it on the `v3` branch; set `release-it.github.makeLatest:
-  false` in the `v3` branch's root `package.json` so maintenance releases
-  stop claiming the GitHub "Latest release" badge.
+- The latest-release markers track the current major line: `pipeline.yml`
+  gates the Docker `latest` tag on `refs/tags/v4`, and maintenance branches
+  disable that gate and set `release-it.github.makeLatest: false` in their
+  root `package.json` so their releases never claim the Docker `latest` tag
+  or the GitHub "Latest release" badge. At the next major GA (v5), repeat
+  the flip: move the gate to `refs/tags/v5` on `main`, then disable it and
+  set `makeLatest: false` on the new `v4` maintenance branch.
 - Do not change release/versioning flow without updating this skill and the
   impacted package guides.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1142,7 +1142,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v4') && !contains(github.ref, '-rc') }}
       - name: Build and push image by digest to GitHub Container Registry (${{ matrix.component }}, ${{ matrix.platform_tag }})
         id: build-ghcr
         uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
@@ -1240,7 +1240,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v4') && !contains(github.ref, '-rc') }}
       - name: Extract metadata (tags) for Docker Hub
         id: meta-dockerhub
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
@@ -1255,7 +1255,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v4') && !contains(github.ref, '-rc') }}
       - name: Publish multi-platform manifest to GitHub Container Registry
         env:
           STEPS_META_GHCR_OUTPUTS_TAGS: ${{ steps.meta-ghcr.outputs.tags }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 # External connections from other machines will not be able to reach these services directly.
 services:
   langfuse-worker:
-    image: docker.io/langfuse/langfuse-worker:3
+    image: docker.io/langfuse/langfuse-worker:4
     restart: always
     depends_on: &langfuse-depends-on
       postgres:
@@ -70,7 +70,7 @@ services:
       SMTP_CONNECTION_URL: ${SMTP_CONNECTION_URL:-}
 
   langfuse-web:
-    image: docker.io/langfuse/langfuse:3
+    image: docker.io/langfuse/langfuse:4
     restart: always
     depends_on: *langfuse-depends-on
     ports:


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15607.preview.langfuse.com](https://pr-15607.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

v4.0.0 is GA, so this walks through the `main` half of the v4 GA flip checklist from the git-workflow skill:

- `docker-compose.yml`: bump `langfuse/langfuse` and `langfuse/langfuse-worker` images from `:3` to `:4`
- `.github/workflows/pipeline.yml`: move the Docker `latest` tag gate from `refs/tags/v3` to `refs/tags/v4` (all three metadata steps), so v3 maintenance releases no longer move `latest` and the next v4.x tag pushes it
- `.agents/skills/git-workflow/SKILL.md`: re-target the flip checklist at the next major (v5) instead of removing it

A companion PR on the `v3` branch disables the `latest` gate there and sets `release-it.github.makeLatest: false`.

Note: since v4.0.0 was tagged before this flip, Docker `latest` still points at the last v3 release until the next v4.x tag (or a manual `imagetools create` retag).

## Verification

- `pnpm run agents:sync` + `pnpm run agents:check` (clean)
- pre-commit prettier + `turbo run lint`: `Tasks: 7 successful, 7 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR advances the release and deployment defaults from v3 to the GA v4 line.
- Updates the default Docker Compose web and worker images to major version 4.
- Moves Docker Hub and GHCR `latest` tagging from stable v3 tags to stable v4 tags.
- Revises the release checklist to describe the future v5 major-version flip.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the Docker image defaults, release tag gates, and future release guidance aligned on v4.

The changed Compose services retain compatible v4 configuration defaults, and every explicit Docker latest-tag path is consistently moved to the v4 release line without leaving a mismatched registry or component.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): gate Docker latest tag o..."](https://github.com/langfuse/langfuse/commit/34d92422838eb2cb9ffac2a02729ecd716100a11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48618388)</sub>

<!-- /greptile_comment -->