### PR TITLE
chore(release): retire latest markers on the v3 maintenance line

### DIFF
--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -56,10 +56,10 @@ operations.
 - Promote `main` to `production` without a release via
   `.github/workflows/promote-main-to-production.yml` or
   `pnpm run release:cloud` (both main-only).
-- At v4 GA, flip the latest-release markers: in `pipeline.yml`, move the
-  Docker `latest` tag gate from `refs/tags/v3` to `refs/tags/v4` on `main`
-  and disable it on the `v3` branch; set `release-it.github.makeLatest:
-  false` in the `v3` branch's root `package.json` so maintenance releases
-  stop claiming the GitHub "Latest release" badge.
+- The latest-release markers track the current major line on `main`. This
+  `v3` branch disables the Docker `latest` tag gate in `pipeline.yml` and
+  sets `release-it.github.makeLatest: false` in the root `package.json`, so
+  maintenance releases never claim the Docker `latest` tag or the GitHub
+  "Latest release" badge.
 - Do not change release/versioning flow without updating this skill and the
   impacted package guides.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1139,7 +1139,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=false
       - name: Build and push image by digest to GitHub Container Registry (${{ matrix.component }}, ${{ matrix.platform_tag }})
         id: build-ghcr
         uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
@@ -1237,7 +1237,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=false
       - name: Extract metadata (tags) for Docker Hub
         id: meta-dockerhub
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
@@ -1252,7 +1252,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=false
       - name: Publish multi-platform manifest to GitHub Container Registry
         env:
           STEPS_META_GHCR_OUTPUTS_TAGS: ${{ steps.meta-ghcr.outputs.tags }}

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     },
     "github": {
       "release": true,
+      "makeLatest": false,
       "web": true,
       "autoGenerate": true,
       "releaseName": "v${version}",


### PR DESCRIPTION
## Summary

v4 is GA, so this walks through the `v3` half of the v4 GA flip checklist from the git-workflow skill:

- `.github/workflows/pipeline.yml`: disable the Docker `latest` tag gate (`enable=false` in all three metadata steps) so v3 maintenance releases never move `latest`
- `package.json`: set `release-it.github.makeLatest: false` so v3 GitHub releases stop claiming the "Latest release" badge
- `.agents/skills/git-workflow/SKILL.md`: replace the flip instruction with the branch's steady state

Companion to #15607, which points the `latest` gate at `refs/tags/v4` on `main`.

## Verification

- `node scripts/agents/sync-agent-shims.mjs --check` (clean)
- `package.json` parses (`JSON_OK`)
- Changed files are YAML/JSON/Markdown only; full pipeline runs in PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Retires mutable `latest` markers from the v3 maintenance release flow.
- Disables Docker `latest` tag generation for GHCR and Docker Hub while preserving versioned semver tags.
- Configures release-it so v3 GitHub releases no longer receive the “Latest release” designation.
- Updates the git workflow skill to document the v3 branch’s steady state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the release configuration and documentation consistently retiring v3 latest markers.

Versioned Docker tags remain available, both registries stop receiving new v3 `latest` tags, and the supported release-it setting prevents v3 GitHub releases from claiming the latest designation.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): retire latest markers on..."](https://github.com/langfuse/langfuse/commit/3ee0db80a86ffbbfba9893be57c5963076abedcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48619150)</sub>

<!-- /greptile_comment -->