### PR TITLE
feat(v4): show deprecated API last seen time

### DIFF
--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -244,6 +244,7 @@ describe("v4TransitionRouter", () => {
         time: "2026-06-24T12:00:00Z",
         entrypoint: "publicapi: GET /api/public/traces/{id}",
         count: "0.6666666666666666",
+        lastSeen: "2026-06-24T12:34:56.789Z",
       },
     ]);
   });
@@ -268,21 +269,25 @@ describe("v4TransitionRouter", () => {
       time: "2026-06-24T00:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[12]).toEqual({
       time: "2026-06-24T12:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[13]).toEqual({
       time: "2026-06-24T12:00:00Z",
       entrypoint: "publicapi: GET /api/public/traces/{id}",
       count: 0.6666666666666666,
+      lastSeen: "2026-06-24T12:34:56.789Z",
     });
     expect(rows[24]).toEqual({
       time: "2026-06-24T23:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
 
     expect(mockedQueryClickhouse).toHaveBeenCalledTimes(1);
@@ -298,6 +303,9 @@ describe("v4TransitionRouter", () => {
     );
     expect(clickhouseQuery?.query).toContain(
       "sum(1.0 / clickhouse_queries_per_api_call) AS count",
+    );
+    expect(clickhouseQuery?.query).toContain(
+      "formatDateTime(max(event_time_microseconds)",
     );
     expect(clickhouseQuery?.query).toContain(
       "SETTINGS skip_unavailable_shards = 1",
@@ -353,6 +361,7 @@ describe("v4TransitionRouter", () => {
         time: "2026-06-10T00:00:00Z",
         entrypoint: "publicapi: GET /api/public/traces",
         count: "42",
+        lastSeen: "2026-06-10T17:42:00Z",
       },
     ]);
 
@@ -373,21 +382,25 @@ describe("v4TransitionRouter", () => {
       time: "2026-05-26T00:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[15]).toEqual({
       time: "2026-06-10T00:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[16]).toEqual({
       time: "2026-06-10T00:00:00Z",
       entrypoint: "publicapi: GET /api/public/traces",
       count: 42,
+      lastSeen: "2026-06-10T17:42:00Z",
     });
     expect(rows[30]).toEqual({
       time: "2026-06-24T00:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
 
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
@@ -402,6 +415,7 @@ describe("v4TransitionRouter", () => {
         time: "2026-06-24T00:20:00Z",
         entrypoint: "publicapi: GET /api/public/traces",
         count: "8",
+        lastSeen: "2026-06-24T00:21:30Z",
       },
     ]);
 
@@ -420,21 +434,25 @@ describe("v4TransitionRouter", () => {
       time: "2026-06-24T00:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[10]).toEqual({
       time: "2026-06-24T00:20:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[11]).toEqual({
       time: "2026-06-24T00:20:00Z",
       entrypoint: "publicapi: GET /api/public/traces",
       count: 8,
+      lastSeen: "2026-06-24T00:21:30Z",
     });
     expect(rows[30]).toEqual({
       time: "2026-06-24T00:58:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
 
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
@@ -449,6 +467,7 @@ describe("v4TransitionRouter", () => {
         time: "2026-06-24T00:16:00Z",
         entrypoint: "publicapi: GET /api/public/traces",
         count: "8",
+        lastSeen: "2026-06-24T00:17:45Z",
       },
     ]);
 
@@ -467,21 +486,25 @@ describe("v4TransitionRouter", () => {
       time: "2026-06-24T00:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[8]).toEqual({
       time: "2026-06-24T00:16:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[9]).toEqual({
       time: "2026-06-24T00:16:00Z",
       entrypoint: "publicapi: GET /api/public/traces",
       count: 8,
+      lastSeen: "2026-06-24T00:17:45Z",
     });
     expect(rows[23]).toEqual({
       time: "2026-06-24T00:44:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
 
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
@@ -496,6 +519,7 @@ describe("v4TransitionRouter", () => {
         time: "2026-06-24T01:00:00Z",
         entrypoint: "publicapi: GET /api/public/traces",
         count: "12",
+        lastSeen: "2026-06-24T01:04:59Z",
       },
     ]);
 
@@ -514,21 +538,25 @@ describe("v4TransitionRouter", () => {
       time: "2026-06-24T00:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[12]).toEqual({
       time: "2026-06-24T01:00:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
     expect(rows[13]).toEqual({
       time: "2026-06-24T01:00:00Z",
       entrypoint: "publicapi: GET /api/public/traces",
       count: 12,
+      lastSeen: "2026-06-24T01:04:59Z",
     });
     expect(rows[36]).toEqual({
       time: "2026-06-24T02:55:00Z",
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
 
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -244,7 +244,7 @@ describe("v4TransitionRouter", () => {
         time: "2026-06-24T12:00:00Z",
         entrypoint: "publicapi: GET /api/public/traces/{id}",
         count: "0.6666666666666666",
-        lastSeen: "2026-06-24T12:34:56.789Z",
+        lastSeen: "2026-06-24T12:34:56.789123Z",
       },
     ]);
   });
@@ -281,7 +281,7 @@ describe("v4TransitionRouter", () => {
       time: "2026-06-24T12:00:00Z",
       entrypoint: "publicapi: GET /api/public/traces/{id}",
       count: 0.6666666666666666,
-      lastSeen: "2026-06-24T12:34:56.789Z",
+      lastSeen: "2026-06-24T12:34:56.789123Z",
     });
     expect(rows[24]).toEqual({
       time: "2026-06-24T23:00:00Z",
@@ -305,7 +305,7 @@ describe("v4TransitionRouter", () => {
       "sum(1.0 / clickhouse_queries_per_api_call) AS count",
     );
     expect(clickhouseQuery?.query).toContain(
-      "formatDateTime(max(event_time_microseconds)",
+      "formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen",
     );
     expect(clickhouseQuery?.query).toContain(
       "SETTINGS skip_unavailable_shards = 1",

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -32,7 +32,13 @@ const mocks = vi.hoisted(() => ({
     evals: { status: "loaded", count: 0 } as MigrationCountState,
     apis: { status: "loaded", count: 1 } as MigrationCountState,
     exports: { status: "loaded", count: 3 } as MigrationCountState,
-    apiUsage: [{ endpoint: "GET /api/public/traces", count: 42 }],
+    apiUsage: [
+      {
+        endpoint: "GET /api/public/traces",
+        count: 42,
+        lastSeen: "2026-07-23T10:37:00Z",
+      },
+    ],
     legacyIntegrations: ["PostHog", "Mixpanel", "Blob Storage"],
   },
   canToggleV4: true,
@@ -110,7 +116,11 @@ describe("V4MigrationDetailsContent", () => {
     mocks.migrationData.apis = { status: "loaded", count: 1 };
     mocks.migrationData.exports = { status: "loaded", count: 3 };
     mocks.migrationData.apiUsage = [
-      { endpoint: "GET /api/public/traces", count: 42 },
+      {
+        endpoint: "GET /api/public/traces",
+        count: 42,
+        lastSeen: "2026-07-23T10:37:00Z",
+      },
     ];
     mocks.migrationData.legacyIntegrations = [
       "PostHog",
@@ -132,6 +142,10 @@ describe("V4MigrationDetailsContent", () => {
     ).toHaveAttribute(
       "href",
       "https://langfuse.com/faq/all/deprecated-api-migration",
+    );
+    expect(screen.getByText(/42 calls · last seen/)).toHaveAttribute(
+      "title",
+      "Last seen at 2026-07-23T10:37:00Z",
     );
 
     const expectedIntegrationGuides = {

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -592,7 +592,7 @@ export function V4MigrationDetailsContent({
                   {migrationData.apiUsage.map((usage) => (
                     <div
                       key={usage.endpoint}
-                      className="flex items-center justify-between gap-2 py-0.5"
+                      className="flex flex-wrap items-baseline justify-between gap-x-2 py-0.5"
                     >
                       <ExternalLink
                         href={DEPRECATED_API_MIGRATION_URL}
@@ -600,8 +600,12 @@ export function V4MigrationDetailsContent({
                       >
                         {usage.endpoint}
                       </ExternalLink>
-                      <span className="text-muted-foreground text-xs whitespace-nowrap">
-                        {numberFormatter(usage.count, 0, 2)} calls
+                      <span
+                        className="text-muted-foreground text-xs whitespace-nowrap"
+                        title={`Last seen at ${usage.lastSeen}`}
+                      >
+                        {numberFormatter(usage.count, 0, 2)} calls · last seen{" "}
+                        {formatCompactRelativeTime(new Date(usage.lastSeen))}
                       </span>
                     </div>
                   ))}

--- a/web/src/features/v4-migration/migrationData.clienttest.ts
+++ b/web/src/features/v4-migration/migrationData.clienttest.ts
@@ -91,19 +91,28 @@ describe("v4 migration data", () => {
           time: "2026-07-23T09:00:00Z",
           entrypoint: "publicapi: GET /api/public/traces",
           count: 2,
+          lastSeen: "2026-07-23T09:42:00Z",
         },
         {
           time: "2026-07-23T10:00:00Z",
           entrypoint: "publicapi: GET /api/public/traces",
           count: 3,
+          lastSeen: "2026-07-23T10:37:00Z",
         },
         {
           time: "2026-07-23T10:00:00Z",
           entrypoint: "",
           count: 0,
+          lastSeen: null,
         },
       ]),
-    ).toEqual([{ endpoint: "GET /api/public/traces", count: 5 }]);
+    ).toEqual([
+      {
+        endpoint: "GET /api/public/traces",
+        count: 5,
+        lastSeen: "2026-07-23T10:37:00Z",
+      },
+    ]);
   });
 
   it("returns only enabled legacy integration labels", () => {

--- a/web/src/features/v4-migration/migrationData.ts
+++ b/web/src/features/v4-migration/migrationData.ts
@@ -96,25 +96,33 @@ type LegacyApiUsagePoint =
 type LegacyApiUsageSummary = {
   endpoint: string;
   count: number;
+  lastSeen: string;
 };
 
 export const aggregateLegacyApiUsage = (
   rows: LegacyApiUsagePoint[] | undefined,
 ): LegacyApiUsageSummary[] => {
-  const countsByEndpoint = new Map<string, number>();
+  const usageByEndpoint = new Map<
+    string,
+    { count: number; lastSeen: string }
+  >();
 
   for (const row of rows ?? []) {
     const endpoint = normalizeLegacyApiEntrypoint(row.entrypoint);
-    if (!endpoint || row.count <= 0) continue;
-    countsByEndpoint.set(
-      endpoint,
-      (countsByEndpoint.get(endpoint) ?? 0) + row.count,
-    );
+    if (!endpoint || row.count <= 0 || !row.lastSeen) continue;
+    const current = usageByEndpoint.get(endpoint);
+    usageByEndpoint.set(endpoint, {
+      count: (current?.count ?? 0) + row.count,
+      lastSeen:
+        current && current.lastSeen > row.lastSeen
+          ? current.lastSeen
+          : row.lastSeen,
+    });
   }
 
-  return Array.from(countsByEndpoint, ([endpoint, count]) => ({
+  return Array.from(usageByEndpoint, ([endpoint, usage]) => ({
     endpoint,
-    count,
+    ...usage,
   })).sort(
     (left, right) =>
       right.count - left.count || left.endpoint.localeCompare(right.endpoint),

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -1263,7 +1263,7 @@ SELECT
   formatDateTime(bucket_time, '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS time,
   concat('publicapi: ', legacy_route) AS entrypoint,
   sum(1.0 / clickhouse_queries_per_api_call) AS count,
-  formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS lastSeen
+  formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen
 FROM classified
 WHERE legacy_route IS NOT NULL
   AND clickhouse_queries_per_api_call IS NOT NULL

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -97,12 +97,14 @@ type LegacyApiUsageRow = {
   time: string;
   entrypoint: string;
   count: string | number;
+  lastSeen: string;
 };
 
 type LegacyApiUsageResultRow = {
   time: string;
   entrypoint: string;
   count: number;
+  lastSeen: string | null;
 };
 
 type LegacyApiUsageSummaryByProjectRow = {
@@ -208,6 +210,7 @@ const getEmptyTimelineBuckets = (
       time: formatTimelineBucket(bucket),
       entrypoint: "",
       count: 0,
+      lastSeen: null,
     });
   }
 
@@ -1196,6 +1199,7 @@ SETTINGS skip_unavailable_shards = 1
 WITH selected AS (
   SELECT
     ${bucketTimeSql} AS bucket_time,
+    event_time_microseconds,
     splitByChar('?', JSONExtractString(log_comment, 'route'))[1] AS route_path
   FROM ${systemTableRef("system.query_log")}
   WHERE
@@ -1211,6 +1215,7 @@ WITH selected AS (
 classified AS (
   SELECT
     bucket_time,
+    event_time_microseconds,
     multiIf(
       route_path IN (
         'GET /api/public/spans',
@@ -1257,7 +1262,8 @@ classified AS (
 SELECT
   formatDateTime(bucket_time, '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS time,
   concat('publicapi: ', legacy_route) AS entrypoint,
-  sum(1.0 / clickhouse_queries_per_api_call) AS count
+  sum(1.0 / clickhouse_queries_per_api_call) AS count,
+  formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS lastSeen
 FROM classified
 WHERE legacy_route IS NOT NULL
   AND clickhouse_queries_per_api_call IS NOT NULL
@@ -1284,6 +1290,7 @@ SETTINGS skip_unavailable_shards = 1
         time: row.time,
         entrypoint: row.entrypoint,
         count: Number(row.count),
+        lastSeen: row.lastSeen,
       }));
 
       return dataRows.length === 0


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15609.preview.langfuse.com](https://pr-15609.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- capture the exact latest ClickHouse query timestamp for deprecated public API usage
- aggregate the latest timestamp per normalized endpoint
- show a compact “last seen” value next to each endpoint's call count in the v4 migration sidebar

## Impacted packages
- `web`

## Verification
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-client src/features/v4-migration/migrationData.clienttest.ts src/features/v4-migration/V4MigrationContent.clienttest.tsx` — `Tests 14 passed (14)`
- `pnpm --filter web run test src/__tests__/server/unit/v4TransitionRouter.servertest.ts` — `Tests 27 passed (27)`
- `pnpm exec prettier --check <changed files>` — all matched files use Prettier code style

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds collection, endpoint-level aggregation, and sidebar display of the latest deprecated public API usage timestamp.
- Extends the ClickHouse usage query and timeline rows with lastSeen.
- Aggregates the latest timestamp alongside call counts for normalized endpoints.
- Renders compact relative “last seen” text and adds server/client coverage.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The timestamp formatting defect should be fixed before merging because the new “exact latest timestamp” data is silently truncated.

The source column has microsecond precision, but the changed SQL emits only whole seconds, contradicting the feature contract and the fractional timestamp represented in the tests.

**Files Needing Attention:** web/src/features/v4/server/v4TransitionRouter.ts and its server test
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  QL[ClickHouse query log] --> SQL[Aggregate count and max event timestamp]
  SQL --> RPC[timeSeriesByEntrypoint]
  RPC --> AGG[Normalize endpoint and select latest lastSeen]
  AGG --> UI[Migration sidebar call count and relative last seen]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4/server/v4TransitionRouter.ts:1266
**Fractional timestamp precision is lost**

When `event_time_microseconds` contains a fractional second, this whole-second format truncates `lastSeen`, causing the feature to report a less precise timestamp than the source value and the fractional timestamp represented by the server test.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(v4): show deprecated API last seen ..."](https://github.com/langfuse/langfuse/commit/c4c02ef8b7fcf7d323244ed177ece927beeb0727) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48620545)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->