### PR TITLE
chore(web): Auto-enroll Langfuse team to feature previews

### DIFF
--- a/web/src/__tests__/server/userAccount.servertest.ts
+++ b/web/src/__tests__/server/userAccount.servertest.ts
@@ -6,6 +6,10 @@ import { prisma } from "@langfuse/shared/src/db";
 import { env } from "@/src/env.mjs";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import {
+  getFeaturePreviewOptOutFlag,
+  parseFlags,
+} from "@/src/features/feature-flags/utils";
 
 describe("userAccountRouter.setFeaturePreviewEnabled", () => {
   const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
@@ -87,6 +91,36 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
     expect(user.featureFlags).toEqual(["templateFlag"]);
   });
 
+  it.each(["team.member@langfuse.com", "team.member@clickhouse.com"])(
+    "persists an opt-out when %s disables a preview",
+    async (email) => {
+      const { caller, userId } = await createCaller({
+        email,
+        featureFlags: ["templateFlag"],
+      });
+
+      await caller.userAccount.setFeaturePreviewEnabled({
+        flag: "modernSession",
+        enabled: false,
+      });
+
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { id: userId },
+        select: { featureFlags: true, email: true },
+      });
+      expect(user.featureFlags).toEqual([
+        "templateFlag",
+        getFeaturePreviewOptOutFlag("modernSession"),
+      ]);
+      expect(
+        parseFlags(user.featureFlags, {
+          email: user.email,
+          v4BetaEnabled: true,
+        }).modernSession,
+      ).toBe(false);
+    },
+  );
+
   it("rejects enabling in self-hosted deployments", async () => {
     const { caller } = await createCaller();
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
@@ -105,11 +139,13 @@ async function createCaller({
   aiFeaturesEnabled = true,
   featureFlags = ["templateFlag"],
   includeProjectInSession = true,
+  email,
 }: {
   plan?: Plan;
   aiFeaturesEnabled?: boolean;
   featureFlags?: string[];
   includeProjectInSession?: boolean;
+  email?: string;
 } = {}) {
   const id = randomUUID();
   const orgId = `org-${id}`;
@@ -133,7 +169,7 @@ async function createCaller({
   const user = await prisma.user.create({
     data: {
       id: userId,
-      email: `${userId}@example.com`,
+      email: email ?? `${userId}@example.com`,
       name: "User Account Test User",
       featureFlags,
     },

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -1,14 +1,45 @@
-export const availableFlags = [
+import { assertUnreachable } from "@langfuse/shared";
+
+export const featurePreviewFlags = [
   "modernSession",
   // TODO(remove ~2026-06-19): "searchBar" is retired — the grammar search bar
   // is now GA on the v4 events tables for everyone (see useSearchBarEnabled),
   // no longer a per-user Feature Preview opt-in. Kept as dead plumbing for a
   // safe rollback; drop once the GA rollout is confirmed stable.
   "searchBar",
+  "v4UpgradeUi",
+] as const;
+
+export type FeaturePreviewFlag = (typeof featurePreviewFlags)[number];
+
+export type FeaturePreviewAvailabilityContext = {
+  v4BetaEnabled: boolean;
+};
+
+export const isFeaturePreviewAvailable = (
+  flag: FeaturePreviewFlag,
+  context: FeaturePreviewAvailabilityContext,
+) => {
+  if (flag === "modernSession") {
+    return context.v4BetaEnabled;
+  }
+
+  if (flag === "searchBar") {
+    return true;
+  }
+
+  if (flag === "v4UpgradeUi") {
+    return true;
+  }
+
+  return assertUnreachable(flag);
+};
+
+export const availableFlags = [
+  ...featurePreviewFlags,
   "templateFlag",
   "excludeClickhouseRead",
   "v4BetaToggleVisible",
-  "v4UpgradeUi",
   "observationEvals",
   "experimentsV4Enabled",
 ] as const;

--- a/web/src/features/feature-flags/utils.clienttest.ts
+++ b/web/src/features/feature-flags/utils.clienttest.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getFeaturePreviewOptOutFlag, parseFlags } from "./utils";
+
+describe("parseFlags", () => {
+  it("enables feature previews by default for Langfuse team members", () => {
+    const flags = parseFlags([], {
+      email: "team.member@langfuse.com",
+      v4BetaEnabled: true,
+    });
+
+    expect(flags.modernSession).toBe(true);
+    expect(flags.searchBar).toBe(true);
+  });
+
+  it("enables feature previews by default for ClickHouse team members", () => {
+    const flags = parseFlags([], {
+      email: "team.member@clickhouse.com",
+      v4BetaEnabled: true,
+    });
+
+    expect(flags.modernSession).toBe(true);
+    expect(flags.searchBar).toBe(true);
+  });
+
+  it("does not enable feature previews by default for other users", () => {
+    const flags = parseFlags([], {
+      email: "user@example.com",
+      v4BetaEnabled: true,
+    });
+
+    expect(flags.modernSession).toBe(false);
+    expect(flags.searchBar).toBe(false);
+  });
+
+  it("honors a Langfuse team member's explicit opt-out", () => {
+    const flags = parseFlags([getFeaturePreviewOptOutFlag("modernSession")], {
+      email: "team.member@langfuse.com",
+      v4BetaEnabled: true,
+    });
+
+    expect(flags.modernSession).toBe(false);
+    expect(flags.searchBar).toBe(true);
+  });
+});

--- a/web/src/features/feature-flags/utils.ts
+++ b/web/src/features/feature-flags/utils.ts
@@ -1,10 +1,53 @@
-import { availableFlags } from "./available-flags";
+import {
+  availableFlags,
+  featurePreviewFlags,
+  isFeaturePreviewAvailable,
+} from "./available-flags";
+import type {
+  FeaturePreviewAvailabilityContext,
+  FeaturePreviewFlag,
+} from "./available-flags";
 import { type Flags } from "./types";
 
-export const parseFlags = (dbFlags: string[]): Flags => {
+const isFeaturePreviewFlag = (
+  flag: (typeof availableFlags)[number],
+): flag is FeaturePreviewFlag =>
+  featurePreviewFlags.some((previewFlag) => previewFlag === flag);
+
+export const getFeaturePreviewOptOutFlag = (flag: FeaturePreviewFlag) =>
+  `feature-preview:${flag}:disabled`;
+
+export const receivesFeaturePreviewsByDefault = (
+  email: string | null | undefined,
+) => {
+  const normalizedEmail = email?.toLowerCase();
+  return (
+    normalizedEmail?.endsWith("@langfuse.com") === true ||
+    normalizedEmail?.endsWith("@clickhouse.com") === true
+  );
+};
+
+export const parseFlags = (
+  dbFlags: string[],
+  context: FeaturePreviewAvailabilityContext & {
+    email: string | null | undefined;
+  },
+): Flags => {
   const parsedFlags = {} as Flags;
+  const enableFeaturePreviewsByDefault = receivesFeaturePreviewsByDefault(
+    context.email,
+  );
 
   availableFlags.forEach((flag) => {
+    if (
+      enableFeaturePreviewsByDefault &&
+      isFeaturePreviewFlag(flag) &&
+      isFeaturePreviewAvailable(flag, context)
+    ) {
+      parsedFlags[flag] = !dbFlags.includes(getFeaturePreviewOptOutFlag(flag));
+      return;
+    }
+
     parsedFlags[flag] = dbFlags.includes(flag);
   });
 

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -12,6 +12,7 @@ import {
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
+import type { FeaturePreviewFlag } from "@/src/features/feature-flags/available-flags";
 
 import filterSearchBarDarkIllustration from "../assets/filter-search-bar-dark.svg";
 import filterSearchBarLightIllustration from "../assets/filter-search-bar-light.svg";
@@ -23,7 +24,7 @@ import modernSessionLightIllustration from "../assets/modern-session-light.svg";
  *  `searchBar` is retired and no longer renders a tile — see
  *  ControlledFeaturePreviewModal. It remains as rollback plumbing.
  *  TODO(remove ~2026-06-19): drop "searchBar" once GA is confirmed. */
-export type PreviewFlag = "modernSession" | "searchBar" | "v4UpgradeUi";
+export type PreviewFlag = FeaturePreviewFlag;
 
 type PreviewIllustration = {
   light: React.ComponentProps<typeof Image>["src"];

--- a/web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts
+++ b/web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts
@@ -13,8 +13,9 @@ const mockUseSession = vi.mocked(useSession);
 
 describe("useV4UpgradeUiEnabled", () => {
   it("maps the database flag into the session flag shape", () => {
-    expect(parseFlags(["v4UpgradeUi"]).v4UpgradeUi).toBe(true);
-    expect(parseFlags([]).v4UpgradeUi).toBe(false);
+    const context = { email: undefined, v4BetaEnabled: false };
+    expect(parseFlags(["v4UpgradeUi"], context).v4UpgradeUi).toBe(true);
+    expect(parseFlags([], context).v4UpgradeUi).toBe(false);
   });
 
   it("does not enable the UI for admins or experimental deployments", () => {

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -11,6 +11,11 @@ import { canToggleV4 } from "@/src/features/events/lib/v4Rollout";
 import { V4_PREVIEW_LABEL } from "@/src/features/events/lib/v4PreviewLabel";
 import { env } from "@/src/env.mjs";
 import { getSfdcService } from "@/src/ee/features/sfdc-sync/server";
+import {
+  getFeaturePreviewOptOutFlag,
+  receivesFeaturePreviewsByDefault,
+} from "@/src/features/feature-flags/utils";
+import { featurePreviewFlags } from "@/src/features/feature-flags/available-flags";
 
 const updateDisplayNameSchema = z.object({
   name: StringNoHTML.min(1, "Name cannot be empty").max(
@@ -102,9 +107,7 @@ export const userAccountRouter = createTRPCRouter({
       z.object({
         // Allowlist of user-toggleable Feature Preview flags (the Feature
         // Preview modal). Keep in sync with the modal's preview registry.
-        // `searchBar` is retired — the bar is now GA on v4 events tables —
-        // but remains as rollback plumbing.
-        flag: z.enum(["modernSession", "searchBar", "v4UpgradeUi"]),
+        flag: z.enum(featurePreviewFlags),
         enabled: z.boolean(),
       }),
     )
@@ -130,7 +133,7 @@ export const userAccountRouter = createTRPCRouter({
         async (tx) => {
           const currentUser = await tx.user.findUnique({
             where: { id: userId },
-            select: { featureFlags: true },
+            select: { featureFlags: true, email: true },
           });
           if (!currentUser) {
             throw new TRPCError({
@@ -138,9 +141,15 @@ export const userAccountRouter = createTRPCRouter({
               message: "User not found",
             });
           }
+          const optOutFlag = getFeaturePreviewOptOutFlag(input.flag);
+          const featureFlagsWithoutOverride = currentUser.featureFlags.filter(
+            (flag) => flag !== input.flag && flag !== optOutFlag,
+          );
           const nextFeatureFlags = input.enabled
-            ? Array.from(new Set([...currentUser.featureFlags, input.flag]))
-            : currentUser.featureFlags.filter((flag) => flag !== input.flag);
+            ? [...featureFlagsWithoutOverride, input.flag]
+            : receivesFeaturePreviewsByDefault(currentUser.email)
+              ? [...featureFlagsWithoutOverride, optOutFlag]
+              : featureFlagsWithoutOverride;
           await tx.user.update({
             where: { id: userId },
             data: { featureFlags: { set: nextFeatureFlags } },

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -132,7 +132,12 @@ const staticProviders: Provider[] = [
         email: dbUser.email,
         image: dbUser.image,
         emailVerified: dbUser.emailVerified?.toISOString(),
-        featureFlags: parseFlags(dbUser.featureFlags),
+        featureFlags: parseFlags(dbUser.featureFlags, {
+          email: dbUser.email,
+          // The full session callback resolves deployment and rollout
+          // availability before applying employee defaults.
+          v4BetaEnabled: false,
+        }),
         canCreateOrganizations: canCreateOrganizations(dbUser.email),
         organizations: [],
       };
@@ -861,6 +866,11 @@ export async function getAuthOptions(signupAttribution?: {
           const dualPreviewAvailable =
             isLangfuseCloud ||
             env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
+          const v4BetaEnabled =
+            v4WriteMode === "events_only" ||
+            (v4WriteMode === "dual" &&
+              dualPreviewAvailable &&
+              dbUser?.v4BetaEnabled === true);
 
           return {
             ...session,
@@ -884,12 +894,7 @@ export async function getAuthOptions(signupAttribution?: {
                       : undefined,
                     image: dbUser.image,
                     admin: dbUser.admin,
-                    v4BetaEnabled:
-                      v4WriteMode === "events_only"
-                        ? true
-                        : v4WriteMode === "dual" && dualPreviewAvailable
-                          ? dbUser.v4BetaEnabled
-                          : false,
+                    v4BetaEnabled,
                     canToggleV4:
                       v4WriteMode === "dual" && dualPreviewAvailable
                         ? isLangfuseCloud
@@ -974,7 +979,10 @@ export async function getAuthOptions(signupAttribution?: {
                       },
                     ),
                     emailVerified: dbUser.emailVerified?.toISOString(),
-                    featureFlags: parseFlags(dbUser.featureFlags),
+                    featureFlags: parseFlags(dbUser.featureFlags, {
+                      email: dbUser.email,
+                      v4BetaEnabled,
+                    }),
                     hasPassword: Boolean(dbUser.password),
                   }
                 : null,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15610.preview.langfuse.com](https://pr-15610.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Introduces automatic feature-preview enrollment for Langfuse and ClickHouse team members.
- Adds availability-aware preview flag parsing with persistent per-user opt-outs.
- Updates the account mutation and authentication session construction to apply employee defaults.
- Centralizes preview flag definitions and adds coverage for enrollment and opt-out behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(web): Auto-enroll Langfuse team to..."](https://github.com/langfuse/langfuse/commit/090c965f0274e35d917644845fe7dc95745ce2fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48623008)</sub>

**Context used:**

- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)
- Knowledge Base — [Enterprise Edition (EE), Entitlements, and Billing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/ee-features.md)

<!-- /greptile_comment -->