### PR TITLE
fix(web): cap non-streaming LLM requests

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -28,8 +28,6 @@ export const redisSocketTimeoutMsSchema = z.coerce
   .default(30_000);
 
 const DEFAULT_LLM_COMPLETION_TIMEOUT_MS = 120_000;
-// Finish client-initiated non-streaming calls before the 102-second load balancer timeout.
-export const CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS = 95_000;
 
 const EnvSchema = z.object({
   NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: z.string().optional(),

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -27,6 +27,10 @@ export const redisSocketTimeoutMsSchema = z.coerce
   })
   .default(30_000);
 
+const DEFAULT_LLM_COMPLETION_TIMEOUT_MS = 120_000;
+// Finish client-initiated non-streaming calls before the 102-second load balancer timeout.
+export const CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS = 95_000;
+
 const EnvSchema = z.object({
   NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: z.string().optional(),
   // Dev-only override: set to an ISO datetime string to shift the legacy blob
@@ -484,7 +488,7 @@ const EnvSchema = z.object({
     .number()
     .int()
     .positive()
-    .default(120_000), // 2 minutes
+    .default(DEFAULT_LLM_COMPLETION_TIMEOUT_MS), // 2 minutes
 
   LANGFUSE_AWS_BEDROCK_REGION: z.string().optional(),
   LANGFUSE_AWS_BEDROCK_MODEL: z.string().optional(),

--- a/packages/shared/src/server/llm/langfuseAiCompletion.ts
+++ b/packages/shared/src/server/llm/langfuseAiCompletion.ts
@@ -43,6 +43,7 @@ export async function generateLangfuseAIText(params: {
   model?: string;
   maxTokens?: number;
   traceSinkParams?: TraceSinkParams;
+  timeout?: number;
 }): Promise<string> {
   const model = params.model ?? env.LANGFUSE_AWS_BEDROCK_MODEL;
 
@@ -69,6 +70,7 @@ export async function generateLangfuseAIText(params: {
       credentialSource: "langfuse",
     }),
     trace: params.traceSinkParams,
+    timeout: params.timeout,
   });
 
   return result.text;

--- a/packages/shared/src/server/llm/llmText.test.ts
+++ b/packages/shared/src/server/llm/llmText.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import { createOpenAI } from "@ai-sdk/openai";
@@ -6,11 +6,13 @@ import { APICallError, tool } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
 
 import { encrypt } from "../../encryption";
+import { env } from "../../env";
 import { LLMValidationError } from "./errors";
 import {
   createLLMOutput,
   createLLMToolSet,
   generateLLMText,
+  getClientInitiatedNonStreamingLlmTimeoutMs,
   mapLegacyLLMCompletionParams,
   streamLLMText,
 } from "./llmText";
@@ -55,6 +57,26 @@ function openAIOptions() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("getClientInitiatedNonStreamingLlmTimeoutMs", () => {
+  const configuredTimeout = env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS;
+
+  afterEach(() => {
+    env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS = configuredTimeout;
+  });
+
+  it.each([
+    { configured: 120_000, expected: 95_000 },
+    { configured: 60_000, expected: 60_000 },
+  ])(
+    "returns $expected for a configured $configured ms timeout",
+    ({ configured, expected }) => {
+      env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS = configured;
+
+      expect(getClientInitiatedNonStreamingLlmTimeoutMs()).toBe(expected);
+    },
+  );
 });
 
 describe("generateLLMText", () => {

--- a/packages/shared/src/server/llm/llmText.ts
+++ b/packages/shared/src/server/llm/llmText.ts
@@ -60,6 +60,15 @@ import { decryptAndParseExtraHeaders } from "./utils";
 type RuntimeContext = Record<string, unknown>;
 type ProviderOptions = Record<string, Record<string, JSONValue>>;
 
+const CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_CAP_MS = 95_000;
+
+// Finish client-initiated non-streaming calls before the 102-second load balancer timeout.
+export const getClientInitiatedNonStreamingLlmTimeoutMs = () =>
+  Math.min(
+    env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS,
+    CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_CAP_MS,
+  );
+
 export type LLMModelRef = {
   adapter: LLMAdapter;
   id: string;

--- a/packages/shared/src/server/llm/testModelCall.ts
+++ b/packages/shared/src/server/llm/testModelCall.ts
@@ -20,12 +20,14 @@ export const testModelCall = async ({
   apiKey,
   modelConfig,
   structuredOutputSchema,
+  timeout,
 }: {
   provider: string;
   model: string;
   apiKey: z.infer<typeof LLMApiKeySchema>;
   modelConfig?: ModelConfig | null;
   structuredOutputSchema?: StructuredOutputSchema;
+  timeout?: number;
 }) => {
   const schema =
     structuredOutputSchema ??
@@ -53,5 +55,6 @@ export const testModelCall = async ({
       },
     }),
     output: createLLMOutput(schema),
+    timeout,
   });
 };

--- a/packages/shared/src/server/services/DefaultEvaluationModelService/DefaultEvalModelService.ts
+++ b/packages/shared/src/server/services/DefaultEvaluationModelService/DefaultEvalModelService.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 import { prisma } from "../../../db";
 import { ForbiddenError, LangfuseNotFoundError } from "../../../errors";
+import { getClientInitiatedNonStreamingLlmTimeoutMs } from "../../llm/llmText";
 import { LLMAdapter, LLMApiKeySchema, ZodModelConfig } from "../../llm/types";
 import { testModelCall } from "../../llm/testModelCall";
 
@@ -57,6 +58,7 @@ export class DefaultEvalModelService {
           model,
           apiKey: llmApiKey as z.infer<typeof LLMApiKeySchema>,
           modelConfig: modelParams,
+          timeout: getClientInitiatedNonStreamingLlmTimeoutMs(),
         });
       }
     } catch (err) {

--- a/web/src/__tests__/server/llm-api-key.servertest.ts
+++ b/web/src/__tests__/server/llm-api-key.servertest.ts
@@ -511,6 +511,9 @@ describe("llmApiKey.all RPC", () => {
 
     expect(result).toEqual({ success: true });
     expect(mockGenerateLLMText).toHaveBeenCalledTimes(1);
+    expect(mockGenerateLLMText).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 95_000 }),
+    );
   });
 
   it("should allow testUpdate without a new secret key when the base URL is unchanged", async () => {

--- a/web/src/__tests__/server/unit/chat-completion-handler.servertest.ts
+++ b/web/src/__tests__/server/unit/chat-completion-handler.servertest.ts
@@ -100,6 +100,7 @@ describe("chatCompletionHandler", () => {
       model: { adapter: "openai", id: "gpt-4.1" },
       connection: { secretKey: "encrypted-key" },
       messages: [{ role: "user", content: "Hello" }],
+      timeout: 95_000,
     });
   });
 
@@ -213,6 +214,11 @@ describe("chatCompletionHandler", () => {
       "text/plain; charset=utf-8",
     );
     expect(mocks.generate).not.toHaveBeenCalled();
+    expect(mocks.stream).toHaveBeenCalledWith({
+      model: { adapter: "openai", id: "gpt-4.1" },
+      connection: { secretKey: "encrypted-key" },
+      messages: [{ role: "user", content: "Hello" }],
+    });
   });
 
   it("preserves terminal LLM configuration status codes", async () => {

--- a/web/src/__tests__/server/unit/evaluator-preflight.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluator-preflight.servertest.ts
@@ -130,7 +130,7 @@ describe("evaluator preflight", () => {
     expect(mockGetLLMErrorInfo).not.toHaveBeenCalled();
   });
 
-  describe("live provider call failures", () => {
+  describe("live provider calls", () => {
     // The preflight skips the provider call in test-like environments;
     // stub these so the mocked testModelCall is actually reached.
     beforeEach(() => {
@@ -140,6 +140,21 @@ describe("evaluator preflight", () => {
 
     afterEach(() => {
       vi.unstubAllEnvs();
+    });
+
+    it("limits the non-streaming model call to 95 seconds", async () => {
+      const result = await getEvaluatorDefinitionPreflightError({
+        projectId: "project_test",
+        template: {
+          name: "Answer correctness",
+          outputDefinition: numericOutputDefinition,
+        },
+      });
+
+      expect(result).toBeNull();
+      expect(mockTestModelCall).toHaveBeenCalledWith(
+        expect.objectContaining({ timeout: 95_000 }),
+      );
     });
 
     it("returns a clean model-not-found message when the provider responds with 404", async () => {

--- a/web/src/features/evals/server/evalTemplateCreation.ts
+++ b/web/src/features/evals/server/evalTemplateCreation.ts
@@ -9,6 +9,7 @@ import {
 import {
   CODE_EVAL_SOURCE_MAX_BYTES,
   DefaultEvalModelService,
+  getClientInitiatedNonStreamingLlmTimeoutMs,
   testModelCall,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
@@ -17,7 +18,6 @@ import {
   isCodeEvalEnabled,
   isCodeEvalSourceCodeLanguageSupported,
 } from "@/src/features/evals/server/isCodeEvalEnabled";
-import { CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS } from "@langfuse/shared/src/env";
 
 const CreateEvalTemplateIntentSchema = z.discriminatedUnion("intent", [
   z.object({ intent: z.literal("new") }),
@@ -127,7 +127,7 @@ async function validateLlmAsJudgeTemplateModel(
       structuredOutputSchema: compilePersistedEvalOutputDefinition(
         input.outputDefinition,
       ).outputResultSchema,
-      timeout: CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS,
+      timeout: getClientInitiatedNonStreamingLlmTimeoutMs(),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/web/src/features/evals/server/evalTemplateCreation.ts
+++ b/web/src/features/evals/server/evalTemplateCreation.ts
@@ -17,6 +17,7 @@ import {
   isCodeEvalEnabled,
   isCodeEvalSourceCodeLanguageSupported,
 } from "@/src/features/evals/server/isCodeEvalEnabled";
+import { CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS } from "@langfuse/shared/src/env";
 
 const CreateEvalTemplateIntentSchema = z.discriminatedUnion("intent", [
   z.object({ intent: z.literal("new") }),
@@ -126,6 +127,7 @@ async function validateLlmAsJudgeTemplateModel(
       structuredOutputSchema: compilePersistedEvalOutputDefinition(
         input.outputDefinition,
       ).outputResultSchema,
+      timeout: CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/web/src/features/evals/server/evaluator-preflight.ts
+++ b/web/src/features/evals/server/evaluator-preflight.ts
@@ -8,6 +8,7 @@ import {
   getLLMErrorInfo,
   testModelCall,
 } from "@langfuse/shared/src/server";
+import { CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS } from "@langfuse/shared/src/env";
 
 export type EvaluatorPreflightDefinition = {
   name: string;
@@ -73,6 +74,7 @@ export async function getEvaluatorDefinitionPreflightError(params: {
       apiKey: modelConfig.config.apiKey,
       modelConfig: modelConfig.config.modelParams,
       structuredOutputSchema: compiledOutputDefinition.outputResultSchema,
+      timeout: CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS,
     });
   } catch (err) {
     const llmError = getLLMErrorInfo(err);

--- a/web/src/features/evals/server/evaluator-preflight.ts
+++ b/web/src/features/evals/server/evaluator-preflight.ts
@@ -5,10 +5,10 @@ import {
 } from "@langfuse/shared";
 import {
   DefaultEvalModelService,
+  getClientInitiatedNonStreamingLlmTimeoutMs,
   getLLMErrorInfo,
   testModelCall,
 } from "@langfuse/shared/src/server";
-import { CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS } from "@langfuse/shared/src/env";
 
 export type EvaluatorPreflightDefinition = {
   name: string;
@@ -74,7 +74,7 @@ export async function getEvaluatorDefinitionPreflightError(params: {
       apiKey: modelConfig.config.apiKey,
       modelConfig: modelConfig.config.modelParams,
       structuredOutputSchema: compiledOutputDefinition.outputResultSchema,
-      timeout: CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS,
+      timeout: getClientInitiatedNonStreamingLlmTimeoutMs(),
     });
   } catch (err) {
     const llmError = getLLMErrorInfo(err);

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -33,6 +33,7 @@ import { encrypt, decrypt } from "@langfuse/shared/encryption";
 import {
   ChatMessageType,
   generateLLMText,
+  getClientInitiatedNonStreamingLlmTimeoutMs,
   LLMAdapter,
   logger,
   mapLegacyLLMCompletionParams,
@@ -162,6 +163,7 @@ async function testLLMConnection(
         messages: testMessages,
       }),
       maxRetries: 1,
+      timeout: getClientInitiatedNonStreamingLlmTimeoutMs(),
     });
 
     return { success: true };

--- a/web/src/features/natural-language-filters/server/router.ts
+++ b/web/src/features/natural-language-filters/server/router.ts
@@ -9,6 +9,7 @@ import {
   LangfuseInternalTraceEnvironment,
   logger,
   generateLangfuseAIText,
+  getClientInitiatedNonStreamingLlmTimeoutMs,
   getLangfuseAITraceSinkParams,
   isLangfuseAITracingConfigured,
 } from "@langfuse/shared/src/server";
@@ -122,6 +123,7 @@ export const naturalLanguageFilterRouter = createTRPCRouter({
             type: ChatMessageType.PublicAPICreated,
           })),
           maxTokens: 1000,
+          timeout: getClientInitiatedNonStreamingLlmTimeoutMs(),
           traceSinkParams: aiTelemetryEnabled
             ? getLangfuseAITraceSinkParams({
                 environment:

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -23,6 +23,7 @@ import {
   mapLegacyLLMCompletionParams,
   streamLLMText,
 } from "@langfuse/shared/src/server";
+import { CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS } from "@langfuse/shared/src/env";
 import * as opentelemetry from "@opentelemetry/api";
 
 export default async function chatCompletionHandler(req: NextRequest) {
@@ -110,10 +111,14 @@ export default async function chatCompletionHandler(req: NextRequest) {
         messages: fixedMessages,
         modelParams,
       });
+      const nonStreamingCompletionParams = {
+        ...completionParams,
+        timeout: CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS,
+      };
 
       if (structuredOutputSchema) {
         const result = await generateLLMText({
-          ...completionParams,
+          ...nonStreamingCompletionParams,
           output: createLLMOutput(structuredOutputSchema),
         });
         return NextResponse.json(result.output);
@@ -121,7 +126,7 @@ export default async function chatCompletionHandler(req: NextRequest) {
 
       if ((tools && tools.length > 0) || hasToolResults) {
         const result = await generateLLMText({
-          ...completionParams,
+          ...nonStreamingCompletionParams,
           tools: createLLMToolSet(tools ?? []),
         });
         return NextResponse.json({
@@ -154,7 +159,7 @@ export default async function chatCompletionHandler(req: NextRequest) {
           },
         );
       }
-      const completion = await generateLLMText(completionParams);
+      const completion = await generateLLMText(nonStreamingCompletionParams);
       return NextResponse.json({
         content: completion.text,
         ...(completion.finalStep.reasoningText

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -17,13 +17,13 @@ import {
   createLLMOutput,
   createLLMToolSet,
   generateLLMText,
+  getClientInitiatedNonStreamingLlmTimeoutMs,
   getLLMErrorInfo,
   logger,
   contextWithLangfuseProps,
   mapLegacyLLMCompletionParams,
   streamLLMText,
 } from "@langfuse/shared/src/server";
-import { CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS } from "@langfuse/shared/src/env";
 import * as opentelemetry from "@opentelemetry/api";
 
 export default async function chatCompletionHandler(req: NextRequest) {
@@ -113,7 +113,7 @@ export default async function chatCompletionHandler(req: NextRequest) {
       });
       const nonStreamingCompletionParams = {
         ...completionParams,
-        timeout: CLIENT_INITIATED_NON_STREAMING_LLM_TIMEOUT_MS,
+        timeout: getClientInitiatedNonStreamingLlmTimeoutMs(),
       };
 
       if (structuredOutputSchema) {

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -25,6 +25,7 @@ import {
   LangfuseInternalTraceEnvironment,
   logger,
   generateLangfuseAIText,
+  getClientInitiatedNonStreamingLlmTimeoutMs,
   getLangfuseAITraceSinkParams,
   isLangfuseAITracingConfigured,
 } from "@langfuse/shared/src/server";
@@ -201,6 +202,7 @@ export const searchBarRouter = createTRPCRouter({
           messages,
           model,
           maxTokens: 2048,
+          timeout: getClientInitiatedNonStreamingLlmTimeoutMs(),
           traceSinkParams: aiTelemetryEnabled
             ? getLangfuseAITraceSinkParams({
                 traceId,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15613.preview.langfuse.com](https://pr-15613.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Cap client-initiated non-streaming evaluator and playground model calls at 95 seconds so the application can return JSON before the 102-second load balancer idle timeout.
- Keep streaming and background model calls on the existing 120-second default.
- Cover evaluator preflight and playground streaming/non-streaming behavior with regression tests.

## Linear

- [LFE-9861](https://linear.app/clickhouse/issue/LFE-9861/evaluator-createedit-returns-html-instead-of-json)

## Major Decisions

- Apply the shorter timeout only at synchronous client request boundaries; do not persist it or change background execution defaults.

## Review Focus

- Confirm the timeout remains limited to evaluator creation and non-streaming playground requests.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a shared 95-second timeout for synchronous client-initiated LLM calls.
- Applies the timeout to evaluator template validation and evaluator preflight calls.
- Applies it to structured-output, tool-enabled, and plain non-streaming Playground completions.
- Leaves streaming Playground calls and background LLM execution on the existing 120-second default.
- Adds regression coverage for evaluator preflight and Playground streaming/non-streaming behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the shorter timeout confined to the intended synchronous non-streaming request boundaries.

The new timeout is forwarded through the shared LLM call interface only by evaluator validation/preflight and non-streaming Playground branches, while streaming and background execution retain their existing defaults.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request[Client LLM request] --> Boundary{Request boundary}
  Boundary -->|Evaluator template validation| Short[95-second timeout]
  Boundary -->|Evaluator preflight| Short
  Boundary -->|Playground| Mode{Streaming execution?}
  Mode -->|No: structured output, tools, or plain completion| Short
  Mode -->|Yes| Default[Existing 120-second default]
  Boundary -->|Background execution| Default
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): cap non-streaming LLM requests"](https://github.com/langfuse/langfuse/commit/779ac406f1dc18f9a3f1bc7a6bcf70a7986b86cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48631391)</sub>

**Context used:**

- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)
- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->