### PR TITLE
fix(evals): restore 7-day evaluator costs

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3341,6 +3341,7 @@ const getEvaluatorCostMetricsByIds = async <
     ].join(", "),
   })
     .whereRaw("e.start_time > today() - 7")
+    .whereRaw("e.is_deleted = 0")
     .havingRaw("evaluator_id IN ({evaluatorIds: Array(String)})", {
       evaluatorIds,
     });

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3305,51 +3305,92 @@ export const getTraceMetadataByIdsFromEvents = async (props: {
   });
 };
 
-export const getAvgCostByEvaluatorIds = async (
+const evaluatorCostFields = {
+  avgCost: {
+    select: "avg(tc.trace_total_cost) as avg_cost",
+    column: "avg_cost",
+  },
+  totalCost: {
+    select: "sum(tc.trace_total_cost) as total_cost",
+    column: "total_cost",
+  },
+  executionCount: {
+    select: "count(*) as execution_count",
+    column: "execution_count",
+  },
+} as const;
+
+const getEvaluatorCostMetricsByIds = async <
+  const TFields extends readonly (keyof typeof evaluatorCostFields)[],
+>(
   projectId: string,
   evaluatorIds: string[],
-): Promise<
-  Array<{ evaluatorId: string; avgCost: number; executionCount: number }>
-> => {
+  fields: TFields,
+) => {
   if (evaluatorIds.length === 0) return [];
 
-  const builder = new EventsAggQueryBuilder({
+  // Evaluator metadata lives on the parent span while cost lives on child
+  // events, so rebuild complete trace totals before filtering evaluators.
+  const traceCostsBuilder = new EventsAggQueryBuilder({
     projectId,
-    groupByColumn:
-      "mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['job_configuration_id']",
+    groupByColumn: "e.trace_id",
     selectExpression: [
-      "mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['job_configuration_id'] as evaluator_id",
-      "avg(e.total_cost) as avg_cost",
-      "count(*) as execution_count",
+      "e.trace_id as trace_id",
+      "anyIf(arrayElement(e.metadata_values, indexOf(e.metadata_names, 'job_configuration_id')), has(e.metadata_names, 'job_configuration_id')) as evaluator_id",
+      "sum(e.total_cost) as trace_total_cost",
     ].join(", "),
   })
-    .whereRaw("e.type = 'GENERATION'")
-    .whereRaw("has(e.metadata_names, 'job_configuration_id')")
-    .whereRaw(
-      "mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['job_configuration_id'] IN ({evaluatorIds: Array(String)})",
-      { evaluatorIds },
+    .whereRaw("e.start_time > today() - 7")
+    .havingRaw("evaluator_id IN ({evaluatorIds: Array(String)})", {
+      evaluatorIds,
+    });
+
+  const traceCosts = traceCostsBuilder.buildWithParams();
+  const queryBuilder = new CTEQueryBuilder()
+    .withCTE("trace_costs", {
+      ...traceCosts,
+      schema: ["trace_id", "evaluator_id", "trace_total_cost"] as const,
+    })
+    .from("trace_costs", "tc")
+    .select(
+      "tc.evaluator_id as evaluator_id",
+      ...fields.map((field) => evaluatorCostFields[field].select),
     )
-    .whereRaw("e.start_time > today() - 7");
+    .groupBy("tc.evaluator_id");
 
-  const { query, params } = builder.buildWithParams();
-
-  const rows = await queryClickhouse<{
-    evaluator_id: string;
-    avg_cost: string;
-    execution_count: string;
-  }>({
+  const { query, params } = queryBuilder.buildWithParams();
+  const rows = await queryClickhouse<Record<string, string>>({
     query,
     params,
     tags: { projectId },
     preferredClickhouseService: "EventsReadOnly",
   });
 
-  return rows.map((row) => ({
-    evaluatorId: row.evaluator_id,
-    avgCost: Number(row.avg_cost),
-    executionCount: Number(row.execution_count),
-  }));
+  return rows.map((row) => {
+    const metrics = Object.fromEntries(
+      fields.map((field) => [
+        field,
+        Number(row[evaluatorCostFields[field].column]),
+      ]),
+    ) as Record<TFields[number], number>;
+
+    return { evaluatorId: row.evaluator_id, ...metrics };
+  });
 };
+
+export const getAvgCostByEvaluatorIds = async (
+  projectId: string,
+  evaluatorIds: string[],
+) =>
+  getEvaluatorCostMetricsByIds(projectId, evaluatorIds, [
+    "avgCost",
+    "executionCount",
+  ]);
+
+export const getTotalCostByEvaluatorIds = async (
+  projectId: string,
+  evaluatorIds: string[],
+) => getEvaluatorCostMetricsByIds(projectId, evaluatorIds, ["totalCost"]);
 
 export const getSessionMetricsFromEvents = async (props: {
   projectId: string;

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -2000,49 +2000,6 @@ export const getObservationCountsByProjectAndDay = async ({
   }));
 };
 
-/**
- * Get total cost grouped by evaluator ID (job_configuration_id) for the last week.
- *
- * @param projectId - Project ID
- * @param evaluatorIds - Array of evaluator IDs (job_configuration_id from metadata)
- * @returns Array of { evaluatorId, totalCost } objects
- */
-export const getCostByEvaluatorIds = async (
-  projectId: string,
-  evaluatorIds: string[],
-): Promise<Array<{ evaluatorId: string; totalCost: number }>> => {
-  if (evaluatorIds.length === 0) return [];
-
-  const query = `
-    SELECT
-      metadata['job_configuration_id'] as evaluator_id,
-      sum(total_cost) as total_cost
-    FROM observations FINAL
-    WHERE project_id = {projectId: String}
-      AND metadata['job_configuration_id'] IN ({evaluatorIds: Array(String)})
-      AND type = 'GENERATION'
-      AND start_time > today() - 7
-    GROUP BY metadata['job_configuration_id']
-  `;
-
-  const rows = await queryClickhouse<{
-    evaluator_id: string;
-    total_cost: string;
-  }>({
-    query,
-    params: {
-      projectId,
-      evaluatorIds,
-    },
-    tags: { projectId },
-  });
-
-  return rows.map((row) => ({
-    evaluatorId: row.evaluator_id,
-    totalCost: Number(row.total_cost),
-  }));
-};
-
 // ─── Public-API observation query helpers ─────────────────────────────────────
 
 export const generateObservationsForPublicApi = async ({

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -2000,6 +2000,40 @@ export const getObservationCountsByProjectAndDay = async ({
   }));
 };
 
+export const getCostByEvaluatorIds = async (
+  projectId: string,
+  evaluatorIds: string[],
+) => {
+  if (evaluatorIds.length === 0) return [];
+
+  const rows = await queryClickhouse<{
+    evaluator_id: string;
+    total_cost: string;
+  }>({
+    query: `
+      SELECT
+        metadata['job_configuration_id'] as evaluator_id,
+        sum(total_cost) as total_cost
+      FROM observations FINAL
+      WHERE project_id = {projectId: String}
+        AND metadata['job_configuration_id'] IN ({evaluatorIds: Array(String)})
+        AND type = 'GENERATION'
+        AND start_time > today() - 7
+      GROUP BY metadata['job_configuration_id']
+    `,
+    params: {
+      projectId,
+      evaluatorIds,
+    },
+    tags: { projectId },
+  });
+
+  return rows.map((row) => ({
+    evaluatorId: row.evaluator_id,
+    totalCost: Number(row.total_cost),
+  }));
+};
+
 // ─── Public-API observation query helpers ─────────────────────────────────────
 
 export const generateObservationsForPublicApi = async ({

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -2000,20 +2000,35 @@ export const getObservationCountsByProjectAndDay = async ({
   }));
 };
 
-export const getCostByEvaluatorIds = async (
+const evaluatorCostFields = {
+  avgCost: {
+    select: "avg(total_cost) as avg_cost",
+    column: "avg_cost",
+  },
+  totalCost: {
+    select: "sum(total_cost) as total_cost",
+    column: "total_cost",
+  },
+  executionCount: {
+    select: "count(*) as execution_count",
+    column: "execution_count",
+  },
+} as const;
+
+const getEvaluatorCostMetricsByIds = async <
+  const TFields extends readonly (keyof typeof evaluatorCostFields)[],
+>(
   projectId: string,
   evaluatorIds: string[],
+  fields: TFields,
 ) => {
   if (evaluatorIds.length === 0) return [];
 
-  const rows = await queryClickhouse<{
-    evaluator_id: string;
-    total_cost: string;
-  }>({
+  const rows = await queryClickhouse<Record<string, string>>({
     query: `
       SELECT
         metadata['job_configuration_id'] as evaluator_id,
-        sum(total_cost) as total_cost
+        ${fields.map((field) => evaluatorCostFields[field].select).join(",\n        ")}
       FROM observations FINAL
       WHERE project_id = {projectId: String}
         AND metadata['job_configuration_id'] IN ({evaluatorIds: Array(String)})
@@ -2028,11 +2043,31 @@ export const getCostByEvaluatorIds = async (
     tags: { projectId },
   });
 
-  return rows.map((row) => ({
-    evaluatorId: row.evaluator_id,
-    totalCost: Number(row.total_cost),
-  }));
+  return rows.map((row) => {
+    const metrics = Object.fromEntries(
+      fields.map((field) => [
+        field,
+        Number(row[evaluatorCostFields[field].column]),
+      ]),
+    ) as Record<TFields[number], number>;
+
+    return { evaluatorId: row.evaluator_id, ...metrics };
+  });
 };
+
+export const getCostByEvaluatorIds = async (
+  projectId: string,
+  evaluatorIds: string[],
+) => getEvaluatorCostMetricsByIds(projectId, evaluatorIds, ["totalCost"]);
+
+export const getAvgCostByEvaluatorIdsFromObservations = async (
+  projectId: string,
+  evaluatorIds: string[],
+) =>
+  getEvaluatorCostMetricsByIds(projectId, evaluatorIds, [
+    "avgCost",
+    "executionCount",
+  ]);
 
 // ─── Public-API observation query helpers ─────────────────────────────────────
 

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -35,7 +35,12 @@ import {
   EvalTemplateType,
 } from "@prisma/client";
 import { prisma } from "@langfuse/shared/src/db";
-import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+import {
+  createEvent,
+  createEventsCh,
+  createOrgProjectAndApiKey,
+} from "@langfuse/shared/src/server";
 import {
   createBooleanEvalOutputDefinition,
   createCategoricalEvalOutputDefinition,
@@ -451,6 +456,43 @@ describe("evals trpc", () => {
           }),
         ]),
         [evalJobConfig2.id]: [],
+      });
+    });
+  });
+
+  describe("evals.costByEvaluatorIds", () => {
+    it("returns total evaluator costs from events", async () => {
+      const { project, caller } = await prepare();
+      const evaluatorId = randomUUID();
+      const traceId = randomUUID();
+      const evaluatorSpanId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: evaluatorSpanId,
+          span_id: evaluatorSpanId,
+          project_id: project.id,
+          trace_id: traceId,
+          type: "SPAN",
+          metadata_names: ["job_configuration_id"],
+          metadata_values: [evaluatorId],
+          cost_details: { total: 0 },
+        }),
+        createEvent({
+          project_id: project.id,
+          trace_id: traceId,
+          parent_span_id: evaluatorSpanId,
+          cost_details: { total: 0.02 },
+        }),
+      ]);
+
+      const response = await caller.evals.costByEvaluatorIds({
+        projectId: project.id,
+        evaluatorIds: [evaluatorId],
+      });
+
+      expect(response).toEqual({
+        [evaluatorId]: 0.02,
       });
     });
   });

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -506,7 +506,7 @@ describe("evals trpc", () => {
       });
     });
 
-    it("returns total evaluator costs from observations in legacy write mode", async () => {
+    it("returns evaluator cost metrics from observations in legacy write mode", async () => {
       const { project, caller } = await prepare();
       const evaluatorId = randomUUID();
       const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
@@ -520,15 +520,32 @@ describe("evals trpc", () => {
             metadata: { job_configuration_id: evaluatorId },
             total_cost: 0.03,
           }),
+          createObservation({
+            project_id: project.id,
+            metadata: { job_configuration_id: evaluatorId },
+            total_cost: 0.01,
+          }),
         ]);
 
-        const response = await caller.evals.costByEvaluatorIds({
-          projectId: project.id,
-          evaluatorIds: [evaluatorId],
-        });
+        const [totalCosts, avgCosts] = await Promise.all([
+          caller.evals.costByEvaluatorIds({
+            projectId: project.id,
+            evaluatorIds: [evaluatorId],
+          }),
+          caller.evals.avgCostByEvaluatorIds({
+            projectId: project.id,
+            evaluatorIds: [evaluatorId],
+          }),
+        ]);
 
-        expect(response).toEqual({
-          [evaluatorId]: 0.03,
+        expect(totalCosts).toEqual({
+          [evaluatorId]: 0.04,
+        });
+        expect(avgCosts).toEqual({
+          [evaluatorId]: {
+            avgCost: 0.02,
+            executionCount: 2,
+          },
         });
       } finally {
         Reflect.set(env, "LANGFUSE_MIGRATION_V4_WRITE_MODE", originalWriteMode);

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -39,6 +39,8 @@ import { randomUUID } from "crypto";
 import {
   createEvent,
   createEventsCh,
+  createObservation,
+  createObservationsCh,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
 import {
@@ -51,6 +53,7 @@ import {
 import { CODE_EVAL_TEMPLATE_VARIABLES } from "@langfuse/shared";
 import { getCodeEvalVariableMapping } from "@/src/features/evals/utils/code-eval-template-utils";
 import type { Session } from "next-auth";
+import { env } from "@/src/env.mjs";
 
 beforeEach(() => {
   runCodeEvalTestForJobConfigMock.mockReset();
@@ -484,6 +487,13 @@ describe("evals trpc", () => {
           parent_span_id: evaluatorSpanId,
           cost_details: { total: 0.02 },
         }),
+        createEvent({
+          project_id: project.id,
+          trace_id: traceId,
+          parent_span_id: evaluatorSpanId,
+          cost_details: { total: 0.5 },
+          is_deleted: 1,
+        }),
       ]);
 
       const response = await caller.evals.costByEvaluatorIds({
@@ -494,6 +504,35 @@ describe("evals trpc", () => {
       expect(response).toEqual({
         [evaluatorId]: 0.02,
       });
+    });
+
+    it("returns total evaluator costs from observations in legacy write mode", async () => {
+      const { project, caller } = await prepare();
+      const evaluatorId = randomUUID();
+      const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+      Reflect.set(env, "LANGFUSE_MIGRATION_V4_WRITE_MODE", "legacy");
+
+      try {
+        await createObservationsCh([
+          createObservation({
+            project_id: project.id,
+            metadata: { job_configuration_id: evaluatorId },
+            total_cost: 0.03,
+          }),
+        ]);
+
+        const response = await caller.evals.costByEvaluatorIds({
+          projectId: project.id,
+          evaluatorIds: [evaluatorId],
+        });
+
+        expect(response).toEqual({
+          [evaluatorId]: 0.03,
+        });
+      } finally {
+        Reflect.set(env, "LANGFUSE_MIGRATION_V4_WRITE_MODE", originalWriteMode);
+      }
     });
   });
 

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -35,6 +35,7 @@ import {
 import {
   getQueue,
   getAvgCostByEvaluatorIds,
+  getCostByEvaluatorIds,
   getTotalCostByEvaluatorIds,
   getEvaluatorExecutionStatusCountsByEvaluatorId,
   getScoresByIds,
@@ -1986,10 +1987,13 @@ export const evalRouter = createTRPCRouter({
         scope: "evalJob:read",
       });
 
-      const costs = await getTotalCostByEvaluatorIds(
-        input.projectId,
-        input.evaluatorIds,
-      );
+      const costs =
+        env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy"
+          ? await getCostByEvaluatorIds(input.projectId, input.evaluatorIds)
+          : await getTotalCostByEvaluatorIds(
+              input.projectId,
+              input.evaluatorIds,
+            );
 
       // Convert array to map for easier lookup
       return costs.reduce(

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -35,6 +35,7 @@ import {
 import {
   getQueue,
   getAvgCostByEvaluatorIds,
+  getAvgCostByEvaluatorIdsFromObservations,
   getCostByEvaluatorIds,
   getTotalCostByEvaluatorIds,
   getEvaluatorExecutionStatusCountsByEvaluatorId,
@@ -2019,10 +2020,13 @@ export const evalRouter = createTRPCRouter({
         scope: "evalJob:read",
       });
 
-      const costs = await getAvgCostByEvaluatorIds(
-        input.projectId,
-        input.evaluatorIds,
-      );
+      const costs =
+        env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy"
+          ? await getAvgCostByEvaluatorIdsFromObservations(
+              input.projectId,
+              input.evaluatorIds,
+            )
+          : await getAvgCostByEvaluatorIds(input.projectId, input.evaluatorIds);
 
       return costs.reduce(
         (acc, { evaluatorId, avgCost, executionCount }) => {

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -35,7 +35,7 @@ import {
 import {
   getQueue,
   getAvgCostByEvaluatorIds,
-  getCostByEvaluatorIds,
+  getTotalCostByEvaluatorIds,
   getEvaluatorExecutionStatusCountsByEvaluatorId,
   getScoresByIds,
   logger,
@@ -1986,7 +1986,7 @@ export const evalRouter = createTRPCRouter({
         scope: "evalJob:read",
       });
 
-      const costs = await getCostByEvaluatorIds(
+      const costs = await getTotalCostByEvaluatorIds(
         input.projectId,
         input.evaluatorIds,
       );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15614.preview.langfuse.com](https://pr-15614.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Read evaluator costs from `events_core` so event-only evaluator executions no longer show a placeholder in the evals table.
- Rebuild costs per trace because evaluator metadata lives on the parent span while cost lives on child events.

## Linear

- [LFE-14604](https://linear.app/clickhouse/issue/LFE-14604/7-day-total-cost-shows-placeholder-in-evals-table)

## Major Decisions

- Use an unlimited, one-pass trace aggregation CTE. Production benchmarking showed this was significantly faster than candidate subqueries and joins while preserving exact seven-day totals.
- Sum `total_cost` across the complete trace, matching the existing trace aggregation semantics.
- Resolve evaluator metadata directly from the parallel metadata arrays for ClickHouse 26 compatibility.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores seven-day evaluator cost reporting from unified events data.
- Reconstructs evaluator costs per trace before calculating totals, averages, and execution counts.
- Routes the evaluator cost endpoint to the new events-based repository helper and removes its legacy observations query.
- Adds a server test covering costs stored on a child event beneath an evaluator span.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The incorrect handling of ClickHouse event versions and deletion markers should be fixed before merging because it can return wrong evaluator cost metrics.

The new query aggregates every visible events_core row, so updated events can be counted more than once and deleted events can continue contributing to totals, averages, and execution counts.

**Files Needing Attention:** packages/shared/src/server/repositories/events.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Evaluator execution events] --> B[events_core]
  B --> C[Group events by trace_id]
  C --> D[Resolve job_configuration_id]
  C --> E[Sum trace total_cost]
  D --> F[Aggregate by evaluator]
  E --> F
  F --> G[Evals table cost metrics]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/repositories/events.ts:3334-3343
**Raw event versions inflate costs**

When an evaluator trace event is updated or deleted before ClickHouse merges its `ReplacingMergeTree` versions, this aggregation sums every visible version without filtering deletion markers or deduplicating by event version, causing incorrect seven-day totals, averages, and execution counts.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): restore 7-day evaluator cost..."](https://github.com/langfuse/langfuse/commit/fd7f3c0dc8d93c27cd0c68f4cc1408b68ac6d8fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48637160)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->