### PR TITLE
fix(experiments): return stable experiment id upon POST /dataset-run-items to perserve SDK expectations

### DIFF
--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -1084,29 +1084,43 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(runItemBoth.status).toBe(200);
   }, 90000);
 
-  // events_only mode is exercised against the helper directly: makeAPICall hits
-  // a real HTTP server whose write mode we cannot flip from the test process.
-  it("events_only returns a stable experiment id per run without persisting", async () => {
-    const dataset = await makeZodVerifiedAPICall(
-      PostDatasetsV1Response,
-      "POST",
-      "/api/public/datasets",
-      { name: "events-only-dataset" },
-      auth,
-    );
-    await makeZodVerifiedAPICall(
-      PostDatasetItemsV1Response,
-      "POST",
-      "/api/public/dataset-items",
-      {
-        datasetName: "events-only-dataset",
-        id: "events-only-item",
-        input: { key: "value" },
-      },
-      auth,
-    );
+  // The experiment id is what the SDK reuses across every item POST of a run,
+  // so it must be identical for the same (projectId, datasetId, runName) and
+  // carry the SDK's seeded id shape (16 hex chars).
+  it("createStableExperimentId is deterministic and matches the SDK id shape", () => {
+    const args = {
+      projectId: "p-1",
+      datasetId: "d-1",
+      runName: "run-1",
+    };
+    const id = createStableExperimentId(args);
 
-    const datasetId = dataset.body.id;
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+    expect(createStableExperimentId(args)).toBe(id);
+    expect(createStableExperimentId({ ...args, runName: "run-2" })).not.toBe(
+      id,
+    );
+    expect(createStableExperimentId({ ...args, datasetId: "d-2" })).not.toBe(
+      id,
+    );
+  });
+
+  // events_only is exercised against the helper directly: makeAPICall hits a
+  // real HTTP server whose write mode we cannot flip from the test process.
+  it("events_only returns a stable experiment id per run without persisting", async () => {
+    const datasetId = v4();
+    await prisma.dataset.create({
+      data: { id: datasetId, name: "events-only-dataset", projectId },
+    });
+    const itemResult = await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { key: "value" },
+      validateOpts: { normalizeUndefinedToNull: true },
+    });
+    if (!itemResult.success) throw new Error(itemResult.message);
+    const datasetItemId = itemResult.datasetItem.id;
+
     const runName = "events-only-run";
     // The helper only reads auth.scope.projectId.
     const helperAuth = { scope: { projectId } } as any;
@@ -1114,18 +1128,16 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     const first = await buildStableDatasetRunItemResponseEventsOnly({
       auth: helperAuth,
       body: {
-        datasetItemId: "events-only-item",
-        traceId: traceId,
+        datasetItemId,
+        traceId,
         runName,
         metadata: { key: "value" },
       } as any,
     });
 
     expect(first.datasetRunName).toBe(runName);
-    expect(first.datasetItemId).toBe("events-only-item");
+    expect(first.datasetItemId).toBe(datasetItemId);
     expect(first.traceId).toBe(traceId);
-    // Matches the SDK's seeded id shape (16 hex chars) and our own algorithm.
-    expect(first.datasetRunId).toMatch(/^[0-9a-f]{16}$/);
     expect(first.datasetRunId).toBe(
       createStableExperimentId({ projectId, datasetId, runName }),
     );
@@ -1133,15 +1145,11 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     // Stable across separate POSTs of the same run, even with a different trace.
     const second = await buildStableDatasetRunItemResponseEventsOnly({
       auth: helperAuth,
-      body: {
-        datasetItemId: "events-only-item",
-        traceId: v4(),
-        runName,
-      } as any,
+      body: { datasetItemId, traceId: v4(), runName } as any,
     });
     expect(second.datasetRunId).toBe(first.datasetRunId);
 
-    // Nothing is persisted: no legacy dataset run row is created in Postgres.
+    // Nothing is persisted: no dataset run row is created in Postgres.
     const dbRun = await prisma.datasetRuns.findFirst({
       where: { projectId, name: runName },
     });
@@ -1152,11 +1160,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     await expect(
       buildStableDatasetRunItemResponseEventsOnly({
         auth: helperAuth,
-        body: {
-          datasetItemId: "does-not-exist",
-          traceId: traceId,
-          runName,
-        } as any,
+        body: { datasetItemId: "does-not-exist", traceId, runName } as any,
       }),
     ).rejects.toThrow("Dataset item not found");
   });

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -1112,21 +1112,20 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       expect(first.body.datasetRunId).toEqual(expect.any(String));
       expect(first.body.id).toEqual(expect.any(String));
 
-      // Stable: repeating the call for the same run + item returns the same
-      // experiment id (datasetRunId) and run item id, even with a new traceId.
+      // Stable: repeating the call for the same run returns the same experiment
+      // id (datasetRunId), even with a different item and traceId.
       const second = await makeZodVerifiedAPICall(
         PostDatasetRunItemsV1Response,
         "POST",
         "/api/public/dataset-run-items",
         {
-          datasetItemId,
+          datasetItemId: `events-only-item-${v4()}`,
           traceId: v4(),
           runName,
         },
         auth,
       );
       expect(second.body.datasetRunId).toBe(first.body.datasetRunId);
-      expect(second.body.id).toBe(first.body.id);
 
       // Nothing is persisted: no legacy dataset run row is created in Postgres
       // and no dataset item lookup is required.

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -4,7 +4,10 @@ process.env.LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION =
 process.env.LANGFUSE_DATASET_SERVICE_WRITE_TO_VERSIONED_IMPLEMENTATION = "true";
 
 import { prisma } from "@langfuse/shared/src/db";
-import { env } from "@/src/env.mjs";
+import {
+  buildStableDatasetRunItemResponseEventsOnly,
+  createStableExperimentId,
+} from "@/src/features/datasets/server/publicDatasetService";
 import {
   makeAPICall,
   makeZodVerifiedAPICall,
@@ -1081,61 +1084,81 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(runItemBoth.status).toBe(200);
   }, 90000);
 
-  it("POST /dataset-run-items returns a stable experiment id without persisting in events_only mode", async () => {
-    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
-    try {
-      const runName = `events-only-run-${v4()}`;
-      const datasetItemId = `events-only-item-${v4()}`;
-      const eventsOnlyTraceId = v4();
+  // events_only mode is exercised against the helper directly: makeAPICall hits
+  // a real HTTP server whose write mode we cannot flip from the test process.
+  it("events_only returns a stable experiment id per run without persisting", async () => {
+    const dataset = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      { name: "events-only-dataset" },
+      auth,
+    );
+    await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName: "events-only-dataset",
+        id: "events-only-item",
+        input: { key: "value" },
+      },
+      auth,
+    );
 
-      const first = await makeZodVerifiedAPICall(
-        PostDatasetRunItemsV1Response,
-        "POST",
-        "/api/public/dataset-run-items",
-        {
-          datasetItemId,
-          traceId: eventsOnlyTraceId,
+    const datasetId = dataset.body.id;
+    const runName = "events-only-run";
+    // The helper only reads auth.scope.projectId.
+    const helperAuth = { scope: { projectId } } as any;
+
+    const first = await buildStableDatasetRunItemResponseEventsOnly({
+      auth: helperAuth,
+      body: {
+        datasetItemId: "events-only-item",
+        traceId: traceId,
+        runName,
+        metadata: { key: "value" },
+      } as any,
+    });
+
+    expect(first.datasetRunName).toBe(runName);
+    expect(first.datasetItemId).toBe("events-only-item");
+    expect(first.traceId).toBe(traceId);
+    // Matches the SDK's seeded id shape (16 hex chars) and our own algorithm.
+    expect(first.datasetRunId).toMatch(/^[0-9a-f]{16}$/);
+    expect(first.datasetRunId).toBe(
+      createStableExperimentId({ projectId, datasetId, runName }),
+    );
+
+    // Stable across separate POSTs of the same run, even with a different trace.
+    const second = await buildStableDatasetRunItemResponseEventsOnly({
+      auth: helperAuth,
+      body: {
+        datasetItemId: "events-only-item",
+        traceId: v4(),
+        runName,
+      } as any,
+    });
+    expect(second.datasetRunId).toBe(first.datasetRunId);
+
+    // Nothing is persisted: no legacy dataset run row is created in Postgres.
+    const dbRun = await prisma.datasetRuns.findFirst({
+      where: { projectId, name: runName },
+    });
+    expect(dbRun).toBeNull();
+
+    // A genuinely missing dataset item still 404s (not the "endpoint
+    // unavailable" 404 we removed).
+    await expect(
+      buildStableDatasetRunItemResponseEventsOnly({
+        auth: helperAuth,
+        body: {
+          datasetItemId: "does-not-exist",
+          traceId: traceId,
           runName,
-          metadata: { key: "value" },
-        },
-        auth,
-      );
-
-      expect(first.status).toBe(200);
-      expect(first.body).toMatchObject({
-        datasetRunName: runName,
-        datasetItemId,
-        traceId: eventsOnlyTraceId,
-        observationId: null,
-      });
-      expect(first.body.datasetRunId).toEqual(expect.any(String));
-      expect(first.body.id).toEqual(expect.any(String));
-
-      // Stable: repeating the call for the same run returns the same experiment
-      // id (datasetRunId), even with a different item and traceId.
-      const second = await makeZodVerifiedAPICall(
-        PostDatasetRunItemsV1Response,
-        "POST",
-        "/api/public/dataset-run-items",
-        {
-          datasetItemId: `events-only-item-${v4()}`,
-          traceId: v4(),
-          runName,
-        },
-        auth,
-      );
-      expect(second.body.datasetRunId).toBe(first.body.datasetRunId);
-
-      // Nothing is persisted: no legacy dataset run row is created in Postgres
-      // and no dataset item lookup is required.
-      const dbRun = await prisma.datasetRuns.findFirst({
-        where: { projectId, name: runName },
-      });
-      expect(dbRun).toBeNull();
-    } finally {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
-    }
+        } as any,
+      }),
+    ).rejects.toThrow("Dataset item not found");
   });
 
   it("GET /api/public/datasets/{datasetName}/runs", async () => {

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -4,6 +4,7 @@ process.env.LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION =
 process.env.LANGFUSE_DATASET_SERVICE_WRITE_TO_VERSIONED_IMPLEMENTATION = "true";
 
 import { prisma } from "@langfuse/shared/src/db";
+import { env } from "@/src/env.mjs";
 import {
   makeAPICall,
   makeZodVerifiedAPICall,
@@ -1079,6 +1080,64 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(dbRunBoth?.metadata).toMatchObject({ key: "value" });
     expect(runItemBoth.status).toBe(200);
   }, 90000);
+
+  it("POST /dataset-run-items returns a stable experiment id without persisting in events_only mode", async () => {
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
+    try {
+      const runName = `events-only-run-${v4()}`;
+      const datasetItemId = `events-only-item-${v4()}`;
+      const eventsOnlyTraceId = v4();
+
+      const first = await makeZodVerifiedAPICall(
+        PostDatasetRunItemsV1Response,
+        "POST",
+        "/api/public/dataset-run-items",
+        {
+          datasetItemId,
+          traceId: eventsOnlyTraceId,
+          runName,
+          metadata: { key: "value" },
+        },
+        auth,
+      );
+
+      expect(first.status).toBe(200);
+      expect(first.body).toMatchObject({
+        datasetRunName: runName,
+        datasetItemId,
+        traceId: eventsOnlyTraceId,
+        observationId: null,
+      });
+      expect(first.body.datasetRunId).toEqual(expect.any(String));
+      expect(first.body.id).toEqual(expect.any(String));
+
+      // Stable: repeating the call for the same run + item returns the same
+      // experiment id (datasetRunId) and run item id, even with a new traceId.
+      const second = await makeZodVerifiedAPICall(
+        PostDatasetRunItemsV1Response,
+        "POST",
+        "/api/public/dataset-run-items",
+        {
+          datasetItemId,
+          traceId: v4(),
+          runName,
+        },
+        auth,
+      );
+      expect(second.body.datasetRunId).toBe(first.body.datasetRunId);
+      expect(second.body.id).toBe(first.body.id);
+
+      // Nothing is persisted: no legacy dataset run row is created in Postgres
+      // and no dataset item lookup is required.
+      const dbRun = await prisma.datasetRuns.findFirst({
+        where: { projectId, name: runName },
+      });
+      expect(dbRun).toBeNull();
+    } finally {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    }
+  });
 
   it("GET /api/public/datasets/{datasetName}/runs", async () => {
     // create multiple runs

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -1,5 +1,5 @@
 import type { NextApiResponse } from "next";
-import { v4 } from "uuid";
+import { v4, v5 } from "uuid";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { addDatasetRunItemsToEvalQueue } from "@/src/features/evals/server/addDatasetRunItemsToEvalQueue";
 import { createOrFetchDatasetRun } from "@/src/features/public-api/server/dataset-runs";
@@ -726,6 +726,60 @@ export const deleteDatasetItemForApi = async ({
   return {
     message: "Dataset item successfully deleted" as const,
   };
+};
+
+// Stable namespace for experiment/run ids minted in events_only mode. Keep this
+// constant: changing it would change every id we return for the same input.
+const EVENTS_ONLY_DATASET_RUN_NAMESPACE =
+  "6f8b2c9a-3d4e-4f1a-b2c7-8e5d1a2b3c4d";
+
+/**
+ * events_only deployments no longer write dataset run items into the legacy
+ * dataset_run_items ClickHouse table, so the full createDatasetRunItemForApi
+ * flow has nothing to persist. Legacy SDK callers of POST /dataset-run-items
+ * still expect a 200 with an id they can hold onto, so we mint a *stable*
+ * experiment id (== dataset run id) deterministically from (projectId, runName).
+ * Repeated calls for the same run return the same id, and every item of a run
+ * shares one experiment id.
+ *
+ * In v4 the trace ↔ experiment link is established through OTel experiment span
+ * attributes instead, so here we only echo the caller's identifiers and skip
+ * all legacy side effects (dataset item / trace lookups, ClickHouse ingestion,
+ * eval enqueue).
+ */
+export const createMockDatasetRunItemForApi = ({
+  body,
+  auth,
+}: Pick<CreateDatasetRunItemInput, "body" | "auth">) => {
+  const projectId = auth.scope.projectId;
+
+  if (!projectId) {
+    throw new UnauthorizedError(
+      "Missing projectId in scope. Are you using an organization key?",
+    );
+  }
+
+  const experimentId = v5(
+    JSON.stringify(["dataset-run", projectId, body.runName]),
+    EVENTS_ONLY_DATASET_RUN_NAMESPACE,
+  );
+  const runItemId = v4();
+  const createdAt = body.createdAt ? new Date(body.createdAt) : new Date();
+
+  const datasetRunItem: APIDatasetRunItem = {
+    id: runItemId,
+    datasetRunId: experimentId,
+    datasetRunName: body.runName,
+    datasetItemId: body.datasetItemId,
+    // events_only skips the observation→trace lookup; echo whatever the caller
+    // provided (the body schema requires traceId or observationId).
+    traceId: body.traceId ?? "",
+    observationId: body.observationId ?? null,
+    createdAt,
+    updatedAt: createdAt,
+  };
+
+  return PostDatasetRunItemsV1Response.parse(datasetRunItem);
 };
 
 export const createDatasetRunItemForApi = async ({

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -747,7 +747,7 @@ const EVENTS_ONLY_DATASET_RUN_NAMESPACE =
  * all legacy side effects (dataset item / trace lookups, ClickHouse ingestion,
  * eval enqueue).
  */
-export const createMockDatasetRunItemForApi = ({
+export const buildStableDatasetRunItemResponseEventsOnly = ({
   body,
   auth,
 }: Pick<CreateDatasetRunItemInput, "body" | "auth">) => {

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -1,5 +1,6 @@
 import type { NextApiResponse } from "next";
-import { v4, v5 } from "uuid";
+import { createHash } from "node:crypto";
+import { v4 } from "uuid";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { addDatasetRunItemsToEvalQueue } from "@/src/features/evals/server/addDatasetRunItemsToEvalQueue";
 import { createOrFetchDatasetRun } from "@/src/features/public-api/server/dataset-runs";
@@ -728,26 +729,48 @@ export const deleteDatasetItemForApi = async ({
   };
 };
 
-// Stable namespace for experiment/run ids minted in events_only mode. Keep this
-// constant: changing it would change every id we return for the same input.
-const EVENTS_ONLY_DATASET_RUN_NAMESPACE =
-  "6f8b2c9a-3d4e-4f1a-b2c7-8e5d1a2b3c4d";
+/**
+ * Deterministic, stable experiment id (== dataset run id) for a
+ * (projectId, datasetId, runName) triple.
+ *
+ * The Langfuse experiment runner calls POST /dataset-run-items once per dataset
+ * item and uses the returned dataset run id as the experiment id shared by every
+ * item of the run (see langfuse-python client.py: `experiment_id = dataset_run_id
+ * or fallback`). So the value MUST be identical across the separate, stateless
+ * POST requests that make up one run — hashing the run's identity gives us that
+ * without persisting anything.
+ *
+ * We take the first 8 bytes of a sha256 digest (16 hex chars), matching the
+ * shape of the SDK's own seeded id helper (`sha256(seed).digest()[:8].hex()`).
+ */
+export const createStableExperimentId = ({
+  projectId,
+  datasetId,
+  runName,
+}: {
+  projectId: string;
+  datasetId: string;
+  runName: string;
+}): string =>
+  createHash("sha256")
+    .update(JSON.stringify(["langfuse-experiment-v1", projectId, datasetId, runName]), "utf8")
+    .digest("hex")
+    .slice(0, 16);
 
 /**
  * events_only deployments no longer write dataset run items into the legacy
  * dataset_run_items ClickHouse table, so the full createDatasetRunItemForApi
- * flow has nothing to persist. Legacy SDK callers of POST /dataset-run-items
- * still expect a 200 with an id they can hold onto, so we mint a *stable*
- * experiment id (== dataset run id) deterministically from (projectId, runName).
- * Repeated calls for the same run return the same id, and every item of a run
- * shares one experiment id.
+ * flow has nothing to persist. The experiment runner still calls POST
+ * /dataset-run-items per item and expects a dataset run id it can reuse as the
+ * experiment id across the whole run, so we resolve the item's dataset and
+ * return a stable experiment id derived from (projectId, datasetId, runName).
  *
  * In v4 the trace ↔ experiment link is established through OTel experiment span
- * attributes instead, so here we only echo the caller's identifiers and skip
- * all legacy side effects (dataset item / trace lookups, ClickHouse ingestion,
- * eval enqueue).
+ * attributes instead, so beyond the dataset-item lookup (needed for datasetId
+ * and to 404 on genuinely missing items) we skip every legacy side effect:
+ * the observation→trace lookup, ClickHouse ingestion, and the eval enqueue.
  */
-export const buildStableDatasetRunItemResponseEventsOnly = ({
+export const buildStableDatasetRunItemResponseEventsOnly = async ({
   body,
   auth,
 }: Pick<CreateDatasetRunItemInput, "body" | "auth">) => {
@@ -759,18 +782,29 @@ export const buildStableDatasetRunItemResponseEventsOnly = ({
     );
   }
 
-  const experimentId = v5(
-    JSON.stringify(["dataset-run", projectId, body.runName]),
-    EVENTS_ONLY_DATASET_RUN_NAMESPACE,
-  );
-  const runItemId = v4();
+  const datasetItem = await getDatasetItemById({
+    projectId,
+    datasetItemId: body.datasetItemId,
+    status: "ACTIVE",
+    version: body.datasetVersion ?? undefined,
+  });
+
+  if (!datasetItem) {
+    throw new LangfuseNotFoundError("Dataset item not found");
+  }
+
+  const experimentId = createStableExperimentId({
+    projectId,
+    datasetId: datasetItem.datasetId,
+    runName: body.runName,
+  });
   const createdAt = body.createdAt ? new Date(body.createdAt) : new Date();
 
   const datasetRunItem: APIDatasetRunItem = {
-    id: runItemId,
+    id: v4(),
     datasetRunId: experimentId,
     datasetRunName: body.runName,
-    datasetItemId: body.datasetItemId,
+    datasetItemId: datasetItem.id,
     // events_only skips the observation→trace lookup; echo whatever the caller
     // provided (the body schema requires traceId or observationId).
     traceId: body.traceId ?? "",

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -753,7 +753,10 @@ export const createStableExperimentId = ({
   runName: string;
 }): string =>
   createHash("sha256")
-    .update(JSON.stringify(["langfuse-experiment-v1", projectId, datasetId, runName]), "utf8")
+    .update(
+      JSON.stringify(["langfuse-experiment-v1", projectId, datasetId, runName]),
+      "utf8",
+    )
     .digest("hex")
     .slice(0, 16);
 

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -816,7 +816,7 @@ export const buildStableDatasetRunItemResponseEventsOnly = async ({
     updatedAt: createdAt,
   };
 
-  return PostDatasetRunItemsV1Response.parse(datasetRunItem);
+  return datasetRunItem;
 };
 
 export const createDatasetRunItemForApi = async ({

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -23,12 +23,12 @@ export default withMiddlewares({
     // Writes a dataset-run-item event into the legacy dataset_run_items
     // ClickHouse table. events_only deployments no longer populate that table,
     // so instead of writing anything we return a stable experiment id (== the
-    // dataset run id) minted deterministically from (projectId, runName). The
-    // trace ↔ experiment link is established through OTel experiment span
-    // attributes on ingestion instead.
+    // dataset run id) derived deterministically from (projectId, datasetId,
+    // runName). The trace ↔ experiment link is established through OTel
+    // experiment span attributes on ingestion instead.
     fn: async ({ body, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only") {
-        return buildStableDatasetRunItemResponseEventsOnly({ body, auth });
+        return await buildStableDatasetRunItemResponseEventsOnly({ body, auth });
       }
       return await createDatasetRunItemForApi({ body, auth, res });
     },

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -8,9 +8,11 @@ import {
 } from "@/src/features/public-api/types/datasets";
 import {
   createDatasetRunItemForApi,
+  createMockDatasetRunItemForApi,
   listDatasetRunItemsForApi,
 } from "@/src/features/datasets/server/publicDatasetService";
 import { DATASET_RUN_ITEMS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
+import { env } from "@/src/env.mjs";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -19,10 +21,15 @@ export default withMiddlewares({
     responseSchema: PostDatasetRunItemsV1Response,
     rateLimitResource: "datasets",
     // Writes a dataset-run-item event into the legacy dataset_run_items
-    // ClickHouse table; events_only deployments expect the experiment runner
-    // SDK or OTel ingestion with experiment attributes instead.
-    rejectInEventsOnlyMode: true,
+    // ClickHouse table. events_only deployments no longer populate that table,
+    // so instead of writing anything we return a stable experiment id (== the
+    // dataset run id) minted deterministically from (projectId, runName). The
+    // trace ↔ experiment link is established through OTel experiment span
+    // attributes on ingestion instead.
     fn: async ({ body, auth, res }) => {
+      if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only") {
+        return createMockDatasetRunItemForApi({ body, auth });
+      }
       return await createDatasetRunItemForApi({ body, auth, res });
     },
   }),

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -8,7 +8,7 @@ import {
 } from "@/src/features/public-api/types/datasets";
 import {
   createDatasetRunItemForApi,
-  createMockDatasetRunItemForApi,
+  buildStableDatasetRunItemResponseEventsOnly,
   listDatasetRunItemsForApi,
 } from "@/src/features/datasets/server/publicDatasetService";
 import { DATASET_RUN_ITEMS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
@@ -28,7 +28,7 @@ export default withMiddlewares({
     // attributes on ingestion instead.
     fn: async ({ body, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only") {
-        return createMockDatasetRunItemForApi({ body, auth });
+        return buildStableDatasetRunItemResponseEventsOnly({ body, auth });
       }
       return await createDatasetRunItemForApi({ body, auth, res });
     },

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -28,7 +28,10 @@ export default withMiddlewares({
     // experiment span attributes on ingestion instead.
     fn: async ({ body, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only") {
-        return await buildStableDatasetRunItemResponseEventsOnly({ body, auth });
+        return await buildStableDatasetRunItemResponseEventsOnly({
+          body,
+          auth,
+        });
       }
       return await createDatasetRunItemForApi({ body, auth, res });
     },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15616.preview.langfuse.com](https://pr-15616.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an events-only compatibility response for legacy dataset-run-item creation.
- Derives a stable experiment/dataset-run ID from the project and run name without legacy persistence.
- Routes events-only POST requests through the new compatibility helper.
- Adds a server test covering stable identifiers and absence of a Postgres dataset-run row.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until the events-only response returns the promised stable run-item ID and handles observation-only requests without emitting an empty trace ID.

The new helper necessarily fails its added retry-stability assertion because it generates a fresh UUID per request, and another schema-valid input produces a successful response containing no usable trace identifier.

**Files Needing Attention:** web/src/features/datasets/server/publicDatasetService.ts, web/src/__tests__/server/datasets-api.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/server/publicDatasetService.ts:766
**Run-item ID remains unstable**

When the same dataset item and run name are submitted repeatedly in `events_only` mode, this fresh `v4()` produces a different run-item ID each time, causing the newly added stability assertion to fail and retrying clients to receive inconsistent IDs for the same logical item.

### Issue 2
web/src/features/datasets/server/publicDatasetService.ts:776
**Observation-only requests lose trace ID**

When a valid request supplies `observationId` without `traceId`, this fallback returns an empty trace ID instead of resolving the observation's trace as the legacy path does, leaving clients unable to locate or correlate the associated trace.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): return stable experime..."](https://github.com/langfuse/langfuse/commit/e00ade38219b3cd8f331baa5744f35db1fdafe6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48638713)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Datasets, Dataset Runs, and Experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md)
- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->