### PR TITLE
fix(evals): encode Bedrock inference profile ARN routes

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -113,7 +113,7 @@
     "@ag-ui/client": "^0.0.52",
     "@ag-ui/core": "^0.0.52",
     "@ag-ui/mastra": "1.1.1",
-    "@ai-sdk/amazon-bedrock": "^5.0.24",
+    "@ai-sdk/amazon-bedrock": "^5.0.25",
     "@ai-sdk/anthropic": "^4.0.5",
     "@ai-sdk/azure": "^4.0.5",
     "@ai-sdk/google": "^4.0.6",

--- a/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
@@ -596,6 +596,16 @@ describe("AI SDK request shapes", () => {
     expect(request.body.inferenceConfig).toMatchObject({ maxTokens: 64 });
   });
 
+  it("Bedrock: application inference profile ARN stays in one URL segment", async () => {
+    const model =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/profile-id";
+    const { request } = await runBedrockCompletion({ model });
+
+    expect(request.url).toBe(
+      `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(model)}/converse`,
+    );
+  });
+
   it("Bedrock: Sonnet 5 structured output falls back to the JSON tool", async () => {
     const schema = {
       type: "object",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1(@ag-ui/client@0.0.52)(@ag-ui/core@0.0.52)(@copilotkit/runtime@1.63.1(1060c54502e6f347b0aa0d1cbe91322c))(@mastra/client-js@1.21.1(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.21.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(ai@7.0.8(zod@4.3.6))(express@5.2.1)(openapi-types@12.1.3)(rxjs@7.8.1)(zod@4.3.6))(@mastra/core@1.46.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.8(zod@4.3.6))(express@5.2.1)(rxjs@7.8.1)(zod@4.3.6))
       '@ai-sdk/amazon-bedrock':
-        specifier: ^5.0.24
-        version: 5.0.24(zod@4.3.6)
+        specifier: ^5.0.25
+        version: 5.0.25(zod@4.3.6)
       '@ai-sdk/anthropic':
         specifier: ^4.0.5
         version: 4.0.16(zod@4.3.6)
@@ -1286,8 +1286,8 @@ packages:
     peerDependencies:
       zod: 4.3.6
 
-  '@ai-sdk/amazon-bedrock@5.0.24':
-    resolution: {integrity: sha512-DqepS/e0mZfpfFjbCKIG7LzsvrQYeKJT0aoQDC6WyXvR81Vi1VIJVk6IL2q6dq2zwuBNnXIQkUPFF0NTXRXGRQ==}
+  '@ai-sdk/amazon-bedrock@5.0.25':
+    resolution: {integrity: sha512-cWDjIbD6CoFicwGjgwsU6sWMS9gpBBIQlMDgV5YfnPpmQVsQ3G+wBEwRyxCNxFVtxKxkMz8Bt6Uo6oTbfDCCNQ==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: 4.3.6
@@ -5065,12 +5065,20 @@ packages:
     resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.30.0':
+    resolution: {integrity: sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.8':
     resolution: {integrity: sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.4.10':
     resolution: {integrity: sha512-yG1n59zLQMa979xvXlTQ9+FpNmm4RRPR+2rYZo57wk28E27zmKZN4ST9wc2pKkyspLpDal2/84ST72KLJhbP1w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.4.14':
+    resolution: {integrity: sha512-dk/8H8vjgsghRKq0Euout/Q5iQMGVw8pUVSs2gY7DFjZtg1+RB12Q/TNh4Uph6E9D46mKr161WobWFyAQWJdjQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-serde-browser@4.2.12':
@@ -5235,6 +5243,10 @@ packages:
 
   '@smithy/util-utf8@4.4.10':
     resolution: {integrity: sha512-4pWFv2sxrykZqaTixXhkgAsG6+k/VxgAiyZ6M0iLEmsOqcJaR0eidlTCmuKKtMJMIEw8lYwDTvEyR4NyC+V0cw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@4.4.14':
+    resolution: {integrity: sha512-zpHIvgr2NWASkgWgv1O0zPPX7VFdkHKa9NxxjGseGvSY2DRZgRsnoXuEcjETwPeqP92blsINwfbIJz0F0/0Skg==}
     engines: {node: '>=18.0.0'}
 
   '@standard-community/standard-json@0.3.5':
@@ -10198,6 +10210,7 @@ packages:
 
   react-grid-layout@1.5.3:
     resolution: {integrity: sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==}
+    deprecated: 'Ships stray files that were never in the repo: an ip_fetcher binary and its curl-sample source (1.5.0-1.5.3), plus a yarn-error.log containing local paths (1.5.3). Upgrade to 1.5.4, which is byte-identical apart from removing them. See https://github.com/react-grid-layout/react-grid-layout/issues/2269'
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
@@ -11911,14 +11924,14 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 4.3.6
 
-  '@ai-sdk/amazon-bedrock@5.0.24(zod@4.3.6)':
+  '@ai-sdk/amazon-bedrock@5.0.25(zod@4.3.6)':
     dependencies:
       '@ai-sdk/anthropic': 4.0.16(zod@4.3.6)
       '@ai-sdk/openai': 4.0.16(zod@4.3.6)
       '@ai-sdk/provider': 4.0.3
       '@ai-sdk/provider-utils': 5.0.11(zod@4.3.6)
-      '@smithy/eventstream-codec': 4.4.10
-      '@smithy/util-utf8': 4.4.10
+      '@smithy/eventstream-codec': 4.4.14
+      '@smithy/util-utf8': 4.4.14
       aws4fetch: 1.0.20
       zod: 4.3.6
 
@@ -16377,6 +16390,11 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.30.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.8':
     dependencies:
       '@smithy/core': 3.29.5
@@ -16386,6 +16404,11 @@ snapshots:
   '@smithy/eventstream-codec@4.4.10':
     dependencies:
       '@smithy/core': 3.29.5
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.4.14':
+    dependencies:
+      '@smithy/core': 3.30.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.2.12':
@@ -16625,6 +16648,11 @@ snapshots:
   '@smithy/util-utf8@4.4.10':
     dependencies:
       '@smithy/core': 3.29.5
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.4.14':
+    dependencies:
+      '@smithy/core': 3.30.0
       tslib: 2.8.1
 
   '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.21.0)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15619.preview.langfuse.com](https://pr-15619.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

- upgrade the shared `@ai-sdk/amazon-bedrock` provider from 5.0.24 to 5.0.25
- add request-shape coverage proving application inference profile ARNs remain one percent-encoded Converse URL segment
- preserve the existing Sonnet 5 structured-output fallback

## Why

Version 5.0.24 leaves the `/` in application inference profile ARNs unescaped. Bedrock interprets the ARN as multiple route segments and returns `UnknownOperationException` before invoking the model; the AI SDK surfaces this as `Invalid JSON response`.

Upstream fix: https://github.com/vercel/ai/commit/ce56626a761bf0e662500b59b81ed85df171e3e3

Linear: https://linear.app/clickhouse/issue/LFE-14630/encode-bedrock-application-inference-profile-arns-in-converse-urls

## Impacted packages

- `@langfuse/shared`
- worker and web consumers of the shared LLM provider

## Verification

- regression baseline on 5.0.24: `1 failed | 16 passed`; received an unescaped ARN URL
- `pnpm --filter @langfuse/shared run test requestShape.test.ts` — `Tests 17 passed (17)`
- `pnpm --filter worker run test executeLLMAsJudgeEvaluation.test.ts` — `Tests 37 passed (37)`
- `pnpm --filter web run test unit/evaluator-preflight.servertest.ts` — `Tests 7 passed (7)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm dedupe` was evaluated; its unrelated workspace-wide Smithy churn was discarded

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the shared Bedrock provider to fix inference-profile ARN routing.
- Upgrades `@ai-sdk/amazon-bedrock` from 5.0.24 to 5.0.25 and refreshes its lockfile resolution.
- Adds regression coverage requiring application inference-profile ARNs to remain one percent-encoded Converse URL segment.
- Retains existing Bedrock request-shape and Sonnet 5 structured-output fallback coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the dependency update and regression test consistently covering the intended Bedrock URL fix.

The manifest and lockfile resolve the intended provider patch, while the added request-shape assertion verifies that an inference-profile ARN is encoded as one Converse route segment without altering application logic.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): encode Bedrock inference pro..."](https://github.com/langfuse/langfuse/commit/0bd751c31a1206fc35a76892410024dbb2f42ccd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48675159)</sub>

**Context used:**

- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->