### PR TITLE
feat(mcp): Add canonical MCP tool outcome telemetry to DD

### DIFF
--- a/web/src/__tests__/server/unit/run-mcp-tool.servertest.ts
+++ b/web/src/__tests__/server/unit/run-mcp-tool.servertest.ts
@@ -1,5 +1,6 @@
 import type { Span } from "@opentelemetry/api";
 import { InvalidRequestError } from "@langfuse/shared";
+import { z } from "zod";
 import type { ServerContext } from "@/src/features/mcp/types";
 
 const { addUserToSpanMock, fakeSpan, instrumentAsyncMock } = vi.hoisted(() => {
@@ -51,6 +52,11 @@ describe("runMcpTool outcome telemetry", () => {
       execute: async () => {
         throw new InvalidRequestError("invalid input");
       },
+      expectedOutcome: "request_error",
+    },
+    {
+      name: "in-handler schema validation error",
+      execute: async () => z.string().parse(42),
       expectedOutcome: "request_error",
     },
     {

--- a/web/src/__tests__/server/unit/run-mcp-tool.servertest.ts
+++ b/web/src/__tests__/server/unit/run-mcp-tool.servertest.ts
@@ -1,0 +1,78 @@
+import type { Span } from "@opentelemetry/api";
+import { InvalidRequestError } from "@langfuse/shared";
+import type { ServerContext } from "@/src/features/mcp/types";
+
+const { addUserToSpanMock, fakeSpan, instrumentAsyncMock } = vi.hoisted(() => {
+  const fakeSpan = {
+    setAttribute: vi.fn(),
+    setAttributes: vi.fn(),
+  };
+
+  return {
+    addUserToSpanMock: vi.fn(),
+    fakeSpan,
+    instrumentAsyncMock: vi.fn(async (_options, callback) =>
+      callback(fakeSpan),
+    ),
+  };
+});
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
+  ...(await importOriginal()),
+  addUserToSpan: addUserToSpanMock,
+  instrumentAsync: instrumentAsyncMock,
+}));
+
+import { runMcpTool } from "@/src/features/mcp/core/run-mcp-tool";
+
+const context: ServerContext = {
+  projectId: "project-id",
+  orgId: "org-id",
+  apiKeyId: "api-key-id",
+  accessLevel: "project",
+  publicKey: "pk-lf-test",
+  plan: "oss",
+  rateLimitOverrides: [],
+};
+
+describe("runMcpTool outcome telemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      name: "successful execution",
+      execute: async () => "ok",
+      expectedOutcome: "success",
+    },
+    {
+      name: "actionable request error",
+      execute: async () => {
+        throw new InvalidRequestError("invalid input");
+      },
+      expectedOutcome: "request_error",
+    },
+    {
+      name: "unexpected server error",
+      execute: async () => {
+        throw new Error("database unavailable");
+      },
+      expectedOutcome: "server_error",
+    },
+  ])(
+    "records a bounded outcome for $name",
+    async ({ execute, expectedOutcome }) => {
+      await runMcpTool({
+        spanName: "mcp.test",
+        context,
+        fn: execute as (span: Span) => Promise<string>,
+      }).catch(() => undefined);
+
+      expect(fakeSpan.setAttribute).toHaveBeenCalledWith(
+        "mcp.outcome",
+        expectedOutcome,
+      );
+    },
+  );
+});

--- a/web/src/features/mcp/core/run-mcp-tool.ts
+++ b/web/src/features/mcp/core/run-mcp-tool.ts
@@ -1,6 +1,7 @@
 import { BaseError } from "@langfuse/shared";
 import { addUserToSpan, instrumentAsync } from "@langfuse/shared/src/server";
 import { SpanKind, type Span } from "@opentelemetry/api";
+import { ZodError } from "zod";
 
 import { UnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 
@@ -47,7 +48,11 @@ export const runMcpTool = async <TResult>({
         span.setAttribute("mcp.outcome", "success");
         return result;
       } catch (error) {
+        // Keep telemetry aligned with formatErrorForUser, which reports Zod
+        // validation failures as InvalidParams. Response validators should
+        // wrap schema-drift failures in a server-side BaseError.
         const isRequestError =
+          error instanceof ZodError ||
           isUserInputError(error) ||
           (error instanceof BaseError && error.httpCode < 500);
 

--- a/web/src/features/mcp/core/run-mcp-tool.ts
+++ b/web/src/features/mcp/core/run-mcp-tool.ts
@@ -4,6 +4,7 @@ import { SpanKind, type Span } from "@opentelemetry/api";
 
 import { UnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 
+import { isUserInputError } from "./errors";
 import type { ServerContext } from "../types";
 
 type McpToolAttribute = string | number | boolean;
@@ -42,8 +43,19 @@ export const runMcpTool = async <TResult>({
       });
 
       try {
-        return await fn(span);
+        const result = await fn(span);
+        span.setAttribute("mcp.outcome", "success");
+        return result;
       } catch (error) {
+        const isRequestError =
+          isUserInputError(error) ||
+          (error instanceof BaseError && error.httpCode < 500);
+
+        span.setAttribute(
+          "mcp.outcome",
+          isRequestError ? "request_error" : "server_error",
+        );
+
         // Expose the error cause on the span so trace analyses can group by
         // cause instead of a single error class name.
         if (error instanceof BaseError) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15620.preview.langfuse.com](https://pr-15620.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

MCP reliability analysis currently has to infer whether a failed tool span was caused by an actionable request mistake or a server failure. That makes aggregate error-rate dashboards noisy and slows root-cause analysis.

## Solution

- Record a bounded `mcp.outcome` attribute for every execution that reaches `runMcpTool`:
  - `success`
  - `request_error`
  - `server_error`
- Keep the existing HTTP status and unstable API error-code attributes.
- Classify in-handler Zod validation failures consistently with the MCP `InvalidParams` response.
- Avoid error messages, request values, or other high-cardinality/user-provided span attributes.

## Contract impact

None. This changes internal OpenTelemetry span attributes only. It does not change MCP inputs or outputs, the Public API, or the CLI.

## Database/query risk

None. The change does not create, alter, retry, or broaden any PostgreSQL or ClickHouse query. It adds one bounded span attribute after execution or in the error path.

## Risk

Low.

- The three outcome values have bounded cardinality.
- Existing errors are rethrown unchanged.
- Input-schema failures that occur before `runMcpTool` remain outside this classification.
- Response-schema validators must wrap schema-drift failures as server errors rather than returning a raw Zod error.

## Verification

- `pnpm --filter web run test src/__tests__/server/unit/run-mcp-tool.servertest.ts`
  - `Tests  4 passed (4)`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`

Impacted package: `web`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds canonical MCP tool outcome telemetry.
- Records `success`, `request_error`, or `server_error` on completed MCP tool spans.
- Preserves existing HTTP status and unstable API error-code attributes.
- Adds unit coverage for successful execution, request errors, and server errors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

Every successful or rejected tool execution assigns exactly one bounded outcome before the span ends, and existing errors continue to propagate unchanged.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mcp): add canonical tool outcome te..."](https://github.com/langfuse/langfuse/commit/7c7fcc644b67404d0ddb97bdd18b81b4b0e16fea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48682071)</sub>

<!-- /greptile_comment -->