### PR TITLE
fix(worker): skip token counts instead of synchronous tokenization fallback

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1320,7 +1320,7 @@ export class IngestionService {
             } catch (error) {
               // No synchronous fallback: payloads that make the worker thread
               // exceed its timeout would block the event loop for minutes if
-              // re-tokenized on the main thread (LFE-9339). Absent counts are
+              // re-tokenized on the main thread. Absent counts are
               // detectable by users, unlike a 0 or a bytes-based estimate.
               logger.warn(
                 `Async tokenization failed for observation ${observationRecord.id} in project ${observationRecord.project_id}. Skipping token counts.`,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -56,7 +56,6 @@ import {
 } from "@langfuse/shared/src/server";
 
 import { tokenCountAsync } from "../../features/tokenisation/async-usage";
-import { tokenCount } from "../../features/tokenisation/usage";
 import { ClickhouseWriter, TableName } from "../ClickhouseWriter";
 import {
   convertJsonSchemaToRecord,
@@ -1275,7 +1274,12 @@ export class IngestionService {
   private async getUsageUnits(
     observationRecord: Pick<
       ObservationRecordInsertType,
-      "provided_usage_details" | "level" | "input" | "output" | "id"
+      | "project_id"
+      | "provided_usage_details"
+      | "level"
+      | "input"
+      | "output"
+      | "id"
     >,
     model: Model | null | undefined,
   ): Promise<
@@ -1314,18 +1318,16 @@ export class IngestionService {
                 }),
               ]);
             } catch (error) {
+              // No synchronous fallback: payloads that make the worker thread
+              // exceed its timeout would block the event loop for minutes if
+              // re-tokenized on the main thread (LFE-9339). Absent counts are
+              // detectable by users, unlike a 0 or a bytes-based estimate.
               logger.warn(
-                `Async tokenization has failed. Falling back to synchronous tokenization`,
+                `Async tokenization failed for observation ${observationRecord.id} in project ${observationRecord.project_id}. Skipping token counts.`,
                 error,
               );
-              newInputCount = tokenCount({
-                text: observationRecord.input,
-                model,
-              });
-              newOutputCount = tokenCount({
-                text: observationRecord.output,
-                model,
-              });
+              span.setAttribute("langfuse.tokenization.skipped", true);
+              recordIncrement("langfuse.tokenisation.skipped", 1);
             }
 
             // Tracing

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1324,7 +1324,21 @@ export class IngestionService {
               // detectable by users, unlike a 0 or a bytes-based estimate.
               logger.warn(
                 `Async tokenization failed for observation ${observationRecord.id} in project ${observationRecord.project_id}. Skipping token counts.`,
-                error,
+                {
+                  projectId: observationRecord.project_id,
+                  observationId: observationRecord.id,
+                  modelId: model.id,
+                  tokenizerId: model.tokenizerId,
+                  inputBytes:
+                    typeof observationRecord.input === "string"
+                      ? observationRecord.input.length
+                      : undefined,
+                  outputBytes:
+                    typeof observationRecord.output === "string"
+                      ? observationRecord.output.length
+                      : undefined,
+                  error,
+                },
               );
               span.setAttribute("langfuse.tokenization.skipped", true);
               recordIncrement("langfuse.tokenisation.skipped", 1);

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1411,8 +1411,8 @@ describe("Token Cost Calculation", () => {
   describe("async tokenization failure handling", () => {
     // Multi-megabyte payloads make the tokenization worker thread exceed its
     // 30s timeout. The former synchronous fallback re-tokenized the same
-    // payload on the main thread and blocked the event loop for minutes
-    // (LFE-9339). On failure, token counts must be skipped entirely — absent
+    // payload on the main thread and blocked the event loop for minutes.
+    // On failure, token counts must be skipped entirely — absent
     // values are detectable by users, unlike a 0 or a bytes-based estimate.
 
     afterEach(() => {

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1421,6 +1421,7 @@ describe("Token Cost Calculation", () => {
     });
 
     it("should skip token counts instead of falling back to synchronous tokenization when async tokenization times out", async () => {
+      const warnSpy = vi.spyOn(logger, "warn");
       tokenisationMocks.tokenCountAsyncOverride = () =>
         Promise.reject(
           new Error("Token count operation timed out after 30000ms"),
@@ -1451,6 +1452,21 @@ describe("Token Cost Calculation", () => {
 
       // The event loop must never run tokenization on the main thread
       expect(tokenisationMocks.syncTokenCountSpy).not.toHaveBeenCalled();
+
+      // Exactly one structured warn identifies the affected tenant and payload
+      const skipWarnings = warnSpy.mock.calls.filter(([message]) =>
+        String(message).includes("Skipping token counts"),
+      );
+      expect(skipWarnings).toHaveLength(1);
+      expect(skipWarnings[0][1]).toMatchObject({
+        projectId,
+        observationId: generationId,
+        modelId: tokenModelData.id,
+        tokenizerId: "openai",
+        inputBytes: expect.any(Number),
+        outputBytes: expect.any(Number),
+        error: expect.any(Error),
+      });
 
       expect(mockAddToClickhouseWriter).toHaveBeenCalled();
       const [tableName, generation] = mockAddToClickhouseWriter.mock.calls[0];

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js";
 import { v4 as uuidv4 } from "uuid";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Price } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
@@ -30,6 +30,44 @@ vi.mock("../../ClickhouseWriter", async (importOriginal) => {
       getInstance: () => ({
         addToQueue: mockAddToClickhouseWriter,
       }),
+    },
+  };
+});
+
+// Tokenisation mocks delegate to the real implementations unless a test sets an
+// override, so tests relying on actual tokenization keep working.
+const tokenisationMocks = vi.hoisted(() => ({
+  tokenCountAsyncOverride: null as
+    | null
+    | ((...args: unknown[]) => Promise<number | undefined>),
+  syncTokenCountSpy: vi.fn(),
+}));
+
+vi.mock(
+  "../../../features/tokenisation/async-usage",
+  async (importOriginal) => {
+    const original = (await importOriginal()) as Record<string, unknown> & {
+      tokenCountAsync: (...args: unknown[]) => Promise<number | undefined>;
+    };
+    return {
+      ...original,
+      tokenCountAsync: (...args: unknown[]) =>
+        tokenisationMocks.tokenCountAsyncOverride
+          ? tokenisationMocks.tokenCountAsyncOverride(...args)
+          : original.tokenCountAsync(...args),
+    };
+  },
+);
+
+vi.mock("../../../features/tokenisation/usage", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown> & {
+    tokenCount: (...args: unknown[]) => number | undefined;
+  };
+  return {
+    ...original,
+    tokenCount: (...args: unknown[]) => {
+      tokenisationMocks.syncTokenCountSpy(...args);
+      return original.tokenCount(...args);
     },
   };
 });
@@ -1367,6 +1405,59 @@ describe("Token Cost Calculation", () => {
 
       expect(generation.usage_details.input).toBe(100);
       expect(generation.usage_details.total).toBe(100);
+    });
+  });
+
+  describe("async tokenization failure handling", () => {
+    // Multi-megabyte payloads make the tokenization worker thread exceed its
+    // 30s timeout. The former synchronous fallback re-tokenized the same
+    // payload on the main thread and blocked the event loop for minutes
+    // (LFE-9339). On failure, token counts must be skipped entirely — absent
+    // values are detectable by users, unlike a 0 or a bytes-based estimate.
+
+    afterEach(() => {
+      tokenisationMocks.tokenCountAsyncOverride = null;
+      tokenisationMocks.syncTokenCountSpy.mockClear();
+    });
+
+    it("should skip token counts instead of falling back to synchronous tokenization when async tokenization times out", async () => {
+      tokenisationMocks.tokenCountAsyncOverride = () =>
+        Promise.reject(
+          new Error("Token count operation timed out after 30000ms"),
+        );
+
+      const events = [
+        {
+          id: uuidv4(),
+          type: "generation-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: generationId,
+            startTime: new Date().toISOString(),
+            model: modelName,
+            input: "hello world",
+            output: "whassup",
+            usage: null,
+          },
+        },
+      ];
+
+      await (mockIngestionService as any).processObservationEventList({
+        projectId,
+        entityId: generationId,
+        createdAtTimestamp: new Date(),
+        observationEventList: events,
+      });
+
+      // The event loop must never run tokenization on the main thread
+      expect(tokenisationMocks.syncTokenCountSpy).not.toHaveBeenCalled();
+
+      expect(mockAddToClickhouseWriter).toHaveBeenCalled();
+      const [tableName, generation] = mockAddToClickhouseWriter.mock.calls[0];
+      expect(tableName).toBe("observations");
+      expect(generation.internal_model_id).toBe(tokenModelData.id);
+      expect(generation.usage_details).toEqual({});
+      expect(generation.cost_details).toEqual({});
     });
   });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15627.preview.langfuse.com](https://pr-15627.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

# Description

When the tokenization worker thread exceeds its 30s timeout on multi-megabyte generation payloads, `IngestionService.getUsageUnits` fell back to re-tokenizing the same payload **synchronously on the main thread**. A payload that a worker thread could not tokenize in 30s blocks the main thread for minutes — we observed 90–260s event-loop freezes on `worker-cpu` containers in prod-eu and prod-us (2026-07-30, ~12:00 UTC, and recurring throughout July).

Consequences of a frozen event loop, all observed in production:

- All in-flight ClickHouse writer flushes stretch to the freeze duration → `[PROD-*] Clickhouse Writer Processing Time` monitors page (EU 19969134 / US 155161565).
- BullMQ lock renewals miss (`could not renew lock`) → jobs get double-processed.
- ECS health checks fail → the task is SIGTERMed mid-work (`Worker stopped with exit code 1`).

The timeout cascade makes it worse: the worker pool never cancels a timed-out computation, so the busy thread causes round-robin requests to time out in bursts — each one previously triggering another synchronous main-thread tokenization.

## Change

On any async tokenization failure, **skip the token counts entirely** — no synchronous fallback, no estimate:

- Absent usage values are detectable by users, unlike a `0` or a bytes/4 heuristic (per team discussion, Steffen/Hassieb; ref [LFE-9339](https://linear.app/clickhouse/issue/LFE-9339/worker-tokenisation-path-causes-prod-us-event-loop-delay-spike)).
- This intentionally goes slightly beyond "timeout only": every async failure (timeout, worker crash, pool shutdown) now skips, since a sync fallback after a worker-thread crash (e.g. OOM on the same giant string) has the same freeze risk.
- Emits a single structured `warn` log with `projectId`, `observationId`, `modelId`, `tokenizerId`, `inputBytes`, `outputBytes`, and the error (the old fallback log carried none of these, which made production attribution painful), plus a `langfuse.tokenisation.skipped` counter and a `langfuse.tokenization.skipped` span attribute.

Closes [LFE-9340](https://linear.app/clickhouse/issue/LFE-9340/remove-synchronous-tokencount-fallback-in-getusageunits). The remaining hardening sub-issues of LFE-9339 (input-size cap LFE-9341, 5s timeout LFE-9342, per-project span/metric tags LFE-9343, timeout counter LFE-9344, pool-cleanup scoping LFE-9345) ship separately — with the sync fallback gone, none of them can freeze the event loop anymore.

Net effect for affected spans: previously most of them were lost anyway (the frozen container was killed by ECS before completing the batch); now they ingest normally, just without estimated token counts.

Follow-ups intentionally out of scope: cancelling/replacing pool workers on timeout (prevents the cascade of skipped counts for innocent spans), and the broader tokenization opt-out/deprecation proposal.

## Impacted packages

- `worker`

## Verification

- `pnpm --filter worker run test calculateTokenCost.unit.test.ts` → `Tests  29 passed (29)`; the new test (`should skip token counts instead of falling back to synchronous tokenization when async tokenization times out`) was written first and failed against the old behavior with the sync tokenizer called twice.
- `pnpm --filter worker run typecheck` → clean.
- `pnpm run lint` → `Tasks:    7 successful, 7 total`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
