### PR TITLE
fix(mcp): cap expensive observation windows

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -856,7 +856,10 @@ describe("MCP Read Tools", () => {
 
   maybeEventsTable("listObservations tool", () => {
     it("should have readOnlyHint annotation", () => {
-      verifyToolAnnotations(listObservationsTool, { readOnlyHint: true });
+      verifyToolAnnotations(listObservationsTool, {
+        readOnlyHint: true,
+        expensiveHint: true,
+      });
     });
 
     it("should be available to in-app agent keys", async () => {
@@ -1340,6 +1343,24 @@ describe("MCP Read Tools", () => {
           context,
         ),
       ).resolves.toMatchObject({ data: [] });
+    });
+
+    it("should reject expensive observation access over a window longer than 30 days", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleListObservations(
+          {
+            fields: ["input"],
+            fromStartTime: "2026-01-01T00:00:00.000Z",
+            toStartTime: "2026-02-01T00:00:00.000Z",
+            limit: 100,
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        /maximum supported observation time window is 30 days/i,
+      );
     });
 
     it("should infer advanced filter type from the column", async () => {
@@ -2072,6 +2093,7 @@ describe("MCP Read Tools", () => {
     it("should have readOnlyHint annotation", () => {
       verifyToolAnnotations(getObservationFilterValuesTool, {
         readOnlyHint: true,
+        expensiveHint: true,
       });
     });
 
@@ -2096,6 +2118,24 @@ describe("MCP Read Tools", () => {
           context,
         ),
       ).resolves.toBeDefined();
+    });
+
+    it("should reject filter-value windows longer than 30 days", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleGetObservationFilterValues(
+          {
+            column: "name",
+            fromStartTime: "2026-01-01T00:00:00.000Z",
+            toStartTime: "2026-02-01T00:00:00.000Z",
+            limit: 100,
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        /maximum supported observation time window is 30 days/i,
+      );
     });
 
     it("should return values for a dynamic filter column", async () => {

--- a/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
+++ b/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
@@ -15,6 +15,7 @@ import {
   ObservationLimitSchema,
   type ObservationMcpFilterColumn,
 } from "../schema";
+import { assertObservationMcpTimeWindow } from "./observation-time-window";
 
 const OBSERVATION_MCP_FILTER_VALUE_COLUMNS = [
   "name",
@@ -162,7 +163,7 @@ export const [
 ] = defineTool({
   name: "getObservationFilterValues",
   description:
-    "List example values for a string or boolean observation filter field, such as names, types, levels, environments, model names, tags, users, or sessions. For numeric metric fields, returns a range with min, max, avg, and count. Use the returned cursor to page through long value lists.",
+    "List example values for a string or boolean observation filter field, such as names, types, levels, environments, model names, tags, users, or sessions. For numeric metric fields, returns a range with min, max, avg, and count. Use the returned cursor to page through long value lists. Requests without a lower time bound use the backend's default 30-day lookback; explicit lower-bound windows may span at most 30 days.",
   baseSchema: GetObservationFilterValuesBaseSchema,
   inputSchema: GetObservationFilterValuesBaseSchema,
   handler: async (input, context) => {
@@ -174,6 +175,8 @@ export const [
         "mcp.pagination_limit": input.limit,
       },
       fn: async () => {
+        assertObservationMcpTimeWindow(input);
+
         const startTimeFilter = buildStartTimeFilter({
           fromStartTime: input.fromStartTime,
           toStartTime: input.toStartTime,
@@ -237,4 +240,5 @@ export const [
     });
   },
   readOnlyHint: true,
+  expensiveHint: true,
 });

--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -35,6 +35,7 @@ import {
   ObservationLimitSchema,
   projectObservation,
 } from "../schema";
+import { assertObservationMcpTimeWindow } from "./observation-time-window";
 
 const ObservationCursorSchema =
   EncodedObservationsCursorV2String.optional().describe(
@@ -296,12 +297,12 @@ const assertAllowedExpensiveObservationAccess = (
 
   if (expensiveColumns.size === 0) return;
 
-  const hasSelectiveScope =
-    Boolean(input.traceId) ||
-    hasObservationIdFilter(input.filter) ||
-    hasValidStartTimeBound(input);
+  if (input.traceId || hasObservationIdFilter(input.filter)) return;
 
-  if (hasSelectiveScope) return;
+  if (hasValidStartTimeBound(input)) {
+    assertObservationMcpTimeWindow(input);
+    return;
+  }
 
   throw new InvalidRequestError(
     `Accessing observation ${Array.from(expensiveColumns)
@@ -323,6 +324,7 @@ export const [listObservationsTool, handleListObservations] = defineTool({
     'By default this returns compact summary fields. Use fields: ["*"] for the full observation, or pass specific field names to limit the response size.',
     'Important: if you request metadata explicitly, for example fields: ["id", "metadata"], metadata values are truncated to 200 UTF-8 characters per key unless you also pass expandMetadataKeys with the keys that may need full values.',
     "Requests that project or filter input, output, or metadata must include traceId, an id filter, or both fromStartTime and toStartTime.",
+    "When time bounds provide that scope, the maximum supported window is 30 days.",
   ].join("\n"),
   baseSchema: ListObservationsBaseSchema,
   inputSchema: ListObservationsInputSchema,
@@ -422,4 +424,5 @@ export const [listObservationsTool, handleListObservations] = defineTool({
     });
   },
   readOnlyHint: true,
+  expensiveHint: true,
 });

--- a/web/src/features/mcp/features/observations/tools/observation-time-window.ts
+++ b/web/src/features/mcp/features/observations/tools/observation-time-window.ts
@@ -1,0 +1,27 @@
+import { InvalidRequestError } from "@langfuse/shared";
+
+const MAX_OBSERVATION_MCP_TIME_WINDOW_DAYS = 30;
+const MAX_OBSERVATION_MCP_TIME_WINDOW_MS =
+  MAX_OBSERVATION_MCP_TIME_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+export const assertObservationMcpTimeWindow = ({
+  fromStartTime,
+  toStartTime,
+}: {
+  fromStartTime?: string;
+  toStartTime?: string;
+}) => {
+  if (!fromStartTime) return;
+
+  const startTime = new Date(fromStartTime).getTime();
+  const endTime = toStartTime ? new Date(toStartTime).getTime() : Date.now();
+
+  if (
+    endTime > startTime &&
+    endTime - startTime > MAX_OBSERVATION_MCP_TIME_WINDOW_MS
+  ) {
+    throw new InvalidRequestError(
+      `The maximum supported observation time window is ${MAX_OBSERVATION_MCP_TIME_WINDOW_DAYS} days. Narrow fromStartTime and toStartTime and paginate within that window.`,
+    );
+  }
+};


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15628.preview.langfuse.com](https://pr-15628.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

Wide observation payload reads and explicitly widened filter-value scans can time out or exceed ClickHouse memory. The current scope guard accepts any positive time span, including months or years.

## Solution

- Cap time-based input/output/metadata access in `listObservations` at 30 days unless a trace ID or observation ID provides narrower scope.
- Reject explicit lower-bound windows over 30 days in `getObservationFilterValues`.
- Preserve the existing backend 30-day default when filter-value callers omit a lower bound.
- Mark both tools with `expensiveHint` and document the limit.

## Contract impact

Restrictive MCP-only behavior: some previously accepted explicit windows over 30 days now return an actionable error. The public REST API and CLI contracts are unchanged. This is intentionally isolated for product review before merge.

## Database query risk

Risk-reducing. No new query is introduced and no SQL shape changes. Rejected requests stop before ClickHouse; accepted queries retain project filtering and are bounded by trace/ID or at most 30 days. This directly limits rows entering existing payload joins and filter-value aggregations.

## Overall risk

Medium. The operational risk decreases, but legitimate historical MCP workflows must paginate through 30-day windows. Omitted filter-value bounds remain backward compatible because the backend already applies the same lookback.

## Verification

- Complete observation list/filter-value groups: `Tests 31 passed | 136 skipped (167)`.
- Full repository lint: `Tasks: 7 successful, 7 total`.