### PR TITLE
feat(mcp): expose indexed observation matches

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -804,8 +804,12 @@ describe("MCP Read Tools", () => {
         expect.objectContaining({
           type: "stringObject",
           requiresKey: true,
+          operators: expect.arrayContaining(["matches"]),
         }),
       );
+      expect(result.columns.input.operators).toContain("matches");
+      expect(result.columns.output.operators).toContain("matches");
+      expect(result.columns.statusMessage.operators).not.toContain("matches");
       expect(result.columns.traceTags).toBeUndefined();
       expect(result.columns.comments).toBeUndefined();
       expect(result.columns.scores).toBeUndefined();
@@ -1261,6 +1265,54 @@ describe("MCP Read Tools", () => {
               type: "string",
               column: "input",
               operator: "contains",
+              value: needle,
+            },
+          ],
+          fields: ["id"],
+          limit: 100,
+        },
+        context,
+      )) as { data: Array<{ id: string; url: string }> };
+
+      expect(result.data).toEqual([
+        {
+          id: matchingObservation.id,
+          url: buildObservationUrl({
+            projectId,
+            traceId,
+            observationId: matchingObservation.id,
+          }),
+        },
+      ]);
+    });
+
+    it("should accept indexed matches filters for observation input", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const traceId = randomUUID();
+      const needle = `indexed-${nanoid()}`;
+      const matchingObservation = createObservationEvent({
+        projectId,
+        traceId,
+        input: `prefix ${needle} suffix`,
+      });
+
+      await createEventsCh([
+        matchingObservation,
+        createObservationEvent({
+          projectId,
+          traceId,
+          input: "different indexed content",
+        }),
+      ]);
+
+      const result = (await handleListObservations(
+        {
+          traceId,
+          filter: [
+            {
+              type: "string",
+              column: "input",
+              operator: "matches",
               value: needle,
             },
           ],

--- a/web/src/features/mcp/features/observations/tools/getObservationFilterSchema.ts
+++ b/web/src/features/mcp/features/observations/tools/getObservationFilterSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   eventsTableCols,
   filterOperators,
+  FTS_MATCH_OPERATOR,
   OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMNS,
 } from "@langfuse/shared";
 import { defineTool } from "../../../core/define-tool";
@@ -25,6 +26,12 @@ const OBSERVATION_MCP_FILTER_COLUMNS = eventsTableCols
 const OBSERVATION_MCP_FILTER_CONFIG_COLUMN_OVERRIDES: Record<string, string> = {
   tags: "traceTags",
 };
+
+const OBSERVATION_MCP_INDEXED_MATCH_COLUMNS = new Set([
+  "input",
+  "output",
+  "metadata",
+]);
 
 export const [
   getObservationFilterSchemaTool,
@@ -54,7 +61,9 @@ export const [
             publicColumn,
             {
               type: column.type,
-              operators: filterOperators[column.type],
+              operators: OBSERVATION_MCP_INDEXED_MATCH_COLUMNS.has(publicColumn)
+                ? [...filterOperators[column.type], FTS_MATCH_OPERATOR]
+                : filterOperators[column.type],
               nullable: Boolean(column.nullable),
               requiresKey:
                 column.type === "stringObject" ||

--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -3,11 +3,13 @@ import {
   OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMNS,
   booleanFilter,
   eventsTableCols,
+  eventsTableSingleFilter,
+  eventsTableStringFilter,
+  eventsTableStringObjectFilter,
   filterOperators,
   numberFilter,
   ObservationLevelDomain,
   ObservationTypeDomain,
-  singleFilter,
   stringFilter,
   stringObjectFilter,
   stringOptionsFilter,
@@ -77,6 +79,11 @@ const OBSERVATION_MCP_FILTER_EXAMPLE_WITH_TYPE_JSON = JSON.stringify(
   OBSERVATION_MCP_FILTER_EXAMPLE_WITH_TYPE,
 );
 
+const OBSERVATION_MCP_INDEXED_MATCH_STRING_COLUMNS = new Set([
+  "input",
+  "output",
+]);
+
 const OBSERVATION_MCP_FILTER_SCHEMA_BY_TYPE = {
   datetime: (column: string, requireType = false) =>
     timeFilter.omit({ type: true, column: true }).extend({
@@ -86,10 +93,17 @@ const OBSERVATION_MCP_FILTER_SCHEMA_BY_TYPE = {
       column: z.literal(column),
     }),
   string: (column: string, requireType = false) =>
-    stringFilter.omit({ type: true, column: true }).extend({
-      type: requireType ? z.literal("string") : z.literal("string").optional(),
-      column: z.literal(column),
-    }),
+    (OBSERVATION_MCP_INDEXED_MATCH_STRING_COLUMNS.has(column)
+      ? eventsTableStringFilter
+      : stringFilter
+    )
+      .omit({ type: true, column: true })
+      .extend({
+        type: requireType
+          ? z.literal("string")
+          : z.literal("string").optional(),
+        column: z.literal(column),
+      }),
   stringOptions: (column: string, requireType = false) =>
     stringOptionsFilter.omit({ type: true, column: true }).extend({
       type: requireType
@@ -112,12 +126,14 @@ const OBSERVATION_MCP_FILTER_SCHEMA_BY_TYPE = {
       column: z.literal(column),
     }),
   stringObject: (column: string, requireType = false) =>
-    stringObjectFilter.omit({ type: true, column: true }).extend({
-      type: requireType
-        ? z.literal("stringObject")
-        : z.literal("stringObject").optional(),
-      column: z.literal(column),
-    }),
+    (column === "metadata" ? eventsTableStringObjectFilter : stringObjectFilter)
+      .omit({ type: true, column: true })
+      .extend({
+        type: requireType
+          ? z.literal("stringObject")
+          : z.literal("stringObject").optional(),
+        column: z.literal(column),
+      }),
   boolean: (column: string, requireType = false) =>
     booleanFilter.omit({ type: true, column: true }).extend({
       type: requireType
@@ -200,7 +216,7 @@ const ObservationMcpFilterSchema = z
     const type =
       filter.type ?? OBSERVATION_MCP_FILTER_COLUMN_TYPES.get(filter.column);
 
-    return singleFilter.parse(
+    return eventsTableSingleFilter.parse(
       filter.column === "tags"
         ? { ...filter, type, column: "traceTags" }
         : { ...filter, type },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15629.preview.langfuse.com](https://pr-15629.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

The observations API already supports indexed literal search with `matches`, but the MCP adapter rejects that operator and omits it from discovery. Agents fall back to less efficient substring filters or receive validation errors (LFE-9995).

## Solution

- Advertise `matches` only for `input`, `output`, and string-valued `metadata`, matching the existing events-table contract.
- Validate and pass those filters through the existing events-table filter schema.
- Keep `matches` rejected for unsupported string columns such as `statusMessage`.

## Contract impact

MCP only and additive: a previously rejected operator is accepted on three already-supported columns. The public REST API and CLI are unchanged; this reuses their existing filter capability.

## Database query risk

Low. This does not add SQL or change query construction. `matches` uses the existing events-table text indexes and token-boundary pruning, while the MCP selective-scope guard still requires trace ID, observation ID, or a bounded time range for input/output/metadata filtering. Tenant filtering remains present and no join or grouping is added.

## Overall risk

Low to medium. The main risk is exposing indexed literal semantics where callers might expect substring matching; discovery and API documentation distinguish `matches` from `contains`.

## Verification

- Complete observation schema/list groups: `Tests 38 passed | 128 skipped (166)`.
- Full repository lint: `Tasks: 7 successful, 7 total`.