### PR TITLE
feat(mcp): expose semantic root observation filters

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -110,6 +110,7 @@ import {
   queryMetricsTool,
   handleQueryMetrics,
 } from "@/src/features/mcp/features/metrics/tools/queryMetrics";
+import { metricsFeature } from "@/src/features/mcp/features/metrics";
 import {
   getPromptTool,
   handleGetPrompt,
@@ -193,11 +194,15 @@ import {
 } from "@/src/features/mcp/features/datasets/schema";
 
 const maybeEventsTable =
-  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true" &&
+  env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "legacy"
     ? describe
     : describe.skip;
 const maybeEventsTableIt =
-  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true" ? it : it.skip;
+  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true" &&
+  env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "legacy"
+    ? it
+    : it.skip;
 
 const createLlmEvaluatorForMcpReadTest = async (
   setup: Awaited<ReturnType<typeof createMcpTestSetup>>,
@@ -1621,6 +1626,24 @@ describe("MCP Read Tools", () => {
     });
   });
 
+  it("enables Metrics MCP only when preview and events writes are available", async () => {
+    const originalPreviewOptIn = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+    try {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      await expect(metricsFeature.isEnabled()).resolves.toBe(false);
+
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      await expect(metricsFeature.isEnabled()).resolves.toBe(true);
+    } finally {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalPreviewOptIn;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    }
+  });
+
   maybeEventsTable("queryMetrics tool", () => {
     const metricsWindow = {
       fromTimestamp: "2025-12-31T00:00:00.000Z",
@@ -2083,6 +2106,7 @@ describe("MCP Read Tools", () => {
                 highCardinality: true,
                 constraints: expect.any(String),
               },
+              isRootObservation: { type: "boolean" },
             },
             measures: {
               count: {

--- a/web/src/features/mcp/features/metrics/index.ts
+++ b/web/src/features/mcp/features/metrics/index.ts
@@ -21,5 +21,6 @@ export const metricsFeature = {
     },
   ],
   isEnabled: async () =>
-    env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
+    env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true" &&
+    env.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "legacy",
 } as const satisfies McpFeatureModule;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15634.preview.langfuse.com](https://pr-15634.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

This is the MCP-specific follow-up for semantic-root support in Metrics v2.
The `isRootObservation` query dimension, boolean filtering/grouping, and
events-backed query implementation are already on `main` through [#15633](https://github.com/langfuse/langfuse/pull/15633).
This PR contains the remaining MCP deployment gate and its regression coverage.

## Current diff

### Production change

- `metricsFeature.isEnabled` now requires both the v4 preview opt-in and a
  non-legacy write mode (`dual` or `events_only`). Metrics MCP queries the
  events-backed v2 model; exposing the feature in `legacy` mode would advertise
  a tool against data that deployment cannot serve.

### Test-only changes

- Skip events-backed MCP read cases when the test is running in legacy mode.
- Verify Metrics MCP is disabled in `legacy` mode and enabled in `dual` mode.
- Assert that the existing Metrics MCP schema exposes
  `isRootObservation` as a boolean dimension. The field is inherited from the
  shared events/query schema; this PR does not add another query or SQL path.

## Non-scope and stack

- Observation MCP root filtering was merged in [#15568](https://github.com/langfuse/langfuse/pull/15568).
- Metrics v2 API/query support was merged in [#15633](https://github.com/langfuse/langfuse/pull/15633).
- Dashboard and chart forwarding remains in [#15635](https://github.com/langfuse/langfuse/pull/15635).

## Verification

- Targeted MCP read/schema suite: `pnpm --filter web run test src/__tests__/server/mcp-tools-read.servertest.ts`
- Web typecheck and repository lint run in CI.
