### PR TITLE
feat(dashboards): forward semantic root filters to v4 tables

### DIFF
--- a/web/src/features/chart-view/lib/chartFilterCompatibility.clienttest.ts
+++ b/web/src/features/chart-view/lib/chartFilterCompatibility.clienttest.ts
@@ -20,6 +20,7 @@ describe("chartFilterExclusionReason", () => {
       "traceTags",
       "toolNames",
       "experimentId",
+      "isRootObservation",
     ]) {
       expect(chartFilterExclusionReason(col)).toBeNull();
     }
@@ -37,12 +38,6 @@ describe("chartFilterExclusionReason", () => {
     expect(chartFilterExclusionReason("promptVersion")).not.toBeNull();
     expect(chartFilterExclusionReason("commentContent")).toMatch(/comments/i);
     expect(chartFilterExclusionReason("metadata")).toMatch(/metadata/i);
-  });
-
-  it("falls back to a generic reason for other unsupported columns", () => {
-    const reason = chartFilterExclusionReason("isRootObservation");
-    expect(reason).not.toBeNull();
-    expect(reason).toMatch(/this field/i);
   });
 });
 
@@ -63,6 +58,12 @@ describe("toChartFilters", () => {
         value: ["prod"],
       },
       {
+        column: "isRootObservation",
+        type: "boolean",
+        operator: "=",
+        value: true,
+      },
+      {
         column: "scores_avg",
         type: "numberObject",
         operator: ">",
@@ -75,7 +76,12 @@ describe("toChartFilters", () => {
     ];
     const result = toChartFilters(filters);
     // scores + latency + the null-check dropped; traceTags -> tags
-    expect(result.map((f) => f.column)).toEqual(["type", "userId", "tags"]);
+    expect(result.map((f) => f.column)).toEqual([
+      "type",
+      "userId",
+      "tags",
+      "isRootObservation",
+    ]);
     // the rename keeps the rest of the filter intact
     const tags = result.find((f) => f.column === "tags");
     expect(tags).toMatchObject({ operator: "all of", value: ["prod"] });

--- a/web/src/features/chart-view/lib/chartFilterCompatibility.ts
+++ b/web/src/features/chart-view/lib/chartFilterCompatibility.ts
@@ -48,6 +48,7 @@ export const FORWARDABLE_CHART_FILTER_COLUMNS: ReadonlySet<string> = new Set([
   "experimentName",
   "experimentDatasetId",
   "experimentId",
+  "isRootObservation",
 ]);
 
 /**

--- a/web/src/features/dashboard/lib/buildTableFilterHref.clienttest.ts
+++ b/web/src/features/dashboard/lib/buildTableFilterHref.clienttest.ts
@@ -14,6 +14,12 @@ const DATE_RANGE = {
   from: new Date("2026-07-01T00:00:00.000Z"),
   to: new Date("2026-07-02T00:00:00.000Z"),
 };
+const ROOT_FILTER = {
+  column: "isRootObservation",
+  type: "boolean" as const,
+  operator: "=" as const,
+  value: true,
+};
 
 // Parse the ?filter= value the way the destination table does: the URL layer
 // decodes the transport-encoding once, then decodeFiltersGeneric parses the
@@ -112,6 +118,27 @@ describe("buildTableFilterHref", () => {
     expect(decoded.map((f) => f.column)).toEqual(["userId"]);
     expect(notApplicable.get("sessionId")).toMatch(/session/i);
   });
+
+  it.each([
+    ["v4", [ROOT_FILTER], false],
+    ["v3", [], true],
+  ] as const)(
+    "%s observations drill-down handles semantic roots",
+    (version, expectedFilters, expectsHint) => {
+      const result = buildTableFilterHref(
+        "proj-1",
+        "observations",
+        [ROOT_FILTER],
+        DATE_RANGE,
+        version,
+      );
+
+      expect(decodeHrefFilters(result.href)).toEqual(expectedFilters);
+      expect(buildViewAsTableHint(result)?.title ?? null).toEqual(
+        expectsHint ? expect.stringMatching(/v4/i) : null,
+      );
+    },
+  );
 
   it('drops a dashboard-global "Version" filter on an observations widget (parity with the widget query, which maps it to the dropped traceVersion)', () => {
     // The "stored" mapping variant the widget query uses resolves the legacy

--- a/web/src/features/dashboard/lib/buildTableFilterHref.ts
+++ b/web/src/features/dashboard/lib/buildTableFilterHref.ts
@@ -9,6 +9,7 @@ import { mapLegacyUiTableFilterToView } from "@/src/features/dashboard/lib/dashb
 import {
   classifyViewFiltersForTable,
   tableTargetForView,
+  type TableVersion,
 } from "@/src/features/dashboard/lib/viewFilterToTableFilter";
 import { rangeToString } from "@/src/utils/date-range-utils";
 
@@ -80,12 +81,16 @@ function encodeFiltersWithinBudget(filters: FilterState): {
  * widget maps to `traceVersion` (which the observations table correctly drops)
  * under the stored variant, but to the observation `version` column under the
  * editor variant — which would filter a different field than the chart did.
+ * `tableVersion` identifies the actual destination table generation. It is
+ * intentionally independent from the widget query version: a v2 widget can
+ * still land on the legacy v3 table when the v4 table toggle is off.
  */
 export function buildTableFilterHref(
   projectId: string,
   view: ViewName,
   filters: FilterState,
   dateRange: { from: Date; to: Date } | undefined,
+  tableVersion: TableVersion = "v3",
 ): TableFilterHrefResult {
   const table = tableTargetForView(view);
 
@@ -93,6 +98,7 @@ export function buildTableFilterHref(
   const { applicable, notApplicable } = classifyViewFiltersForTable(
     view,
     viewFilters,
+    tableVersion,
   );
 
   const { encoded, droppedForLength } = encodeFiltersWithinBudget(applicable);

--- a/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.clienttest.ts
+++ b/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.clienttest.ts
@@ -5,23 +5,27 @@ import {
   mapWidgetUiTableFilterToView,
 } from "./dashboardUiTableToViewMapping";
 
-describe("boolean score widget filter mappings", () => {
-  const booleanFilter = {
-    column: "booleanValue",
-    type: "boolean" as const,
-    operator: "=" as const,
-    value: true,
-  };
+describe("widget filter mappings", () => {
+  it.each([
+    ["scores-boolean", "booleanValue", "Boolean Value"],
+    ["observations", "isRootObservation", "Is Root Observation"],
+  ] as const)(
+    "round-trips the %s boolean filter between editor and query view space",
+    (view, canonicalColumn, editorColumn) => {
+      const canonicalFilter = {
+        column: canonicalColumn,
+        type: "boolean" as const,
+        operator: "=" as const,
+        value: true,
+      };
+      const editorFilter = { ...canonicalFilter, column: editorColumn };
 
-  it("round-trips Boolean Value between editor and query view space", () => {
-    expect(
-      mapWidgetUiTableFilterToView("scores-boolean", [
-        { ...booleanFilter, column: "Boolean Value" },
-      ]),
-    ).toEqual([booleanFilter]);
-
-    expect(
-      mapViewFilterToUiTableFilter("scores-boolean", [booleanFilter]),
-    ).toEqual([{ ...booleanFilter, column: "Boolean Value" }]);
-  });
+      expect(mapWidgetUiTableFilterToView(view, [editorFilter])).toEqual([
+        canonicalFilter,
+      ]);
+      expect(mapViewFilterToUiTableFilter(view, [canonicalFilter])).toEqual([
+        editorFilter,
+      ]);
+    },
+  );
 });

--- a/web/src/features/dashboard/lib/viewFilterToTableFilter.clienttest.ts
+++ b/web/src/features/dashboard/lib/viewFilterToTableFilter.clienttest.ts
@@ -1,9 +1,10 @@
 import {
   type FilterState,
+  eventsTableCols,
   observationsTableCols,
   tracesTableCols,
 } from "@langfuse/shared";
-import { type views } from "@langfuse/shared/query";
+import { getViewDeclaration, type views } from "@langfuse/shared/query";
 import { type z } from "zod";
 import {
   classifyViewFiltersForTable,
@@ -16,6 +17,7 @@ const tableColIds = {
   traces: new Set(tracesTableCols.map((c) => c.id)),
   observations: new Set(observationsTableCols.map((c) => c.id)),
 } as const;
+const v4TableColIds = new Set<string>(eventsTableCols.map((c) => c.id));
 
 const stringFilter = (column: string): FilterState[number] => ({
   column,
@@ -37,6 +39,13 @@ const arrayOptionsFilter = (column: string): FilterState[number] => ({
   operator: "any of",
   value: ["a"],
 });
+
+const rootFilter = {
+  column: "isRootObservation",
+  type: "boolean" as const,
+  operator: "=" as const,
+  value: true,
+};
 
 describe("tableTargetForView", () => {
   it("routes observations to the observations table", () => {
@@ -113,6 +122,75 @@ describe("classifyViewFiltersForTable", () => {
     expect(applicable).toHaveLength(0);
     expect(notApplicable.get("sessionId")).toMatch(/session/i);
   });
+
+  it("drops semantic roots for the v3 observations table with a disclosed reason", () => {
+    const { applicable, notApplicable } = classifyViewFiltersForTable(
+      "observations",
+      [rootFilter],
+      "v3",
+    );
+
+    expect(applicable).toHaveLength(0);
+    expect(notApplicable.get("isRootObservation")).toMatch(/v4/i);
+  });
+
+  it("maps semantic roots and observation ids to the v4 events table", () => {
+    const filters: FilterState = [
+      stringFilter("sessionId"),
+      arrayOptionsFilter("tags"),
+      stringOptionsFilter("providedModelName"),
+      stringOptionsFilter("traceName"),
+      stringFilter("traceVersion"),
+      stringFilter("promptVersion"),
+      rootFilter,
+    ];
+    const { applicable, notApplicable } = classifyViewFiltersForTable(
+      "observations",
+      filters,
+      "v4",
+    );
+
+    expect(applicable.map((f) => f.column)).toEqual([
+      "sessionId",
+      "traceTags",
+      "providedModelName",
+      "traceName",
+      "version",
+      "isRootObservation",
+    ]);
+    expect(applicable.at(-1)).toEqual(rootFilter);
+    expect(notApplicable.get("promptVersion")).toMatch(/numeric/i);
+  });
+
+  it.each([
+    ["traces", "name", "traceName"],
+    ["traces", "id", "traceId"],
+    ["scores-numeric", "tags", "traceTags"],
+    ["traces", "metadata", null],
+    ["traces", "release", null],
+    ["scores-numeric", "traceRelease", null],
+    ["scores-boolean", "traceRelease", null],
+    ["scores-categorical", "traceRelease", null],
+  ] as const)(
+    "applies the v4 $2 mapping for $1",
+    (view, dimension, expectedColumn) => {
+      const { applicable, notApplicable } = classifyViewFiltersForTable(
+        view,
+        [stringFilter(dimension)],
+        "v4",
+      );
+
+      if (expectedColumn) {
+        expect(applicable.map((filter) => filter.column)).toEqual([
+          expectedColumn,
+        ]);
+        expect(notApplicable.size).toBe(0);
+      } else {
+        expect(applicable).toHaveLength(0);
+        expect(notApplicable.has(dimension)).toBe(true);
+      }
+    },
+  );
 
   it("maps only trace-derived score dimensions to the traces table, dropping score-specific ones", () => {
     const filters: FilterState = [
@@ -249,6 +327,19 @@ describe("classifyViewFiltersForTable", () => {
       );
       applicable.forEach((f) => {
         expect(tableColIds[target].has(f.column)).toBe(true);
+      });
+    });
+
+    (Object.keys(probesByView) as ViewName[]).forEach((view) => {
+      const { applicable } = classifyViewFiltersForTable(
+        view,
+        Object.keys(getViewDeclaration(view, "v2").dimensions).map(
+          stringFilter,
+        ),
+        "v4",
+      );
+      applicable.forEach((f) => {
+        expect(v4TableColIds.has(f.column)).toBe(true);
       });
     });
   });

--- a/web/src/features/dashboard/lib/viewFilterToTableFilter.ts
+++ b/web/src/features/dashboard/lib/viewFilterToTableFilter.ts
@@ -26,6 +26,9 @@ type ViewName = z.infer<typeof views>;
 
 /** The data table a widget view opens into. */
 export type TableTarget = "traces" | "observations";
+export type TableVersion = "v3" | "v4";
+
+type TableColumnMap = Readonly<Record<string, string | null>>;
 
 export interface ClassifiedViewFilters {
   /**
@@ -51,15 +54,21 @@ export function tableTargetForView(view: ViewName): TableTarget {
 
 /**
  * Per-view map from a canonical view dimension to the target data-table column
- * **id**. Only dimensions the target table can genuinely express are listed;
- * every other dimension is reported as not-applicable. Column ids are the real
- * ids from `tracesTableCols` / `observationsTableCols` (cross-checked by the
- * unit tests, which fail if an id is invented or drifts).
+ * **id**. Only dimensions the target data table can genuinely express are
+ * listed; every other dimension is reported as not-applicable. The
+ * observations map is versioned because v3 and v4 expose different table
+ * column ids and semantics.
  */
-const VIEW_DIMENSION_TO_TABLE_COL: Record<
-  ViewName,
-  Readonly<Record<string, string>>
-> = {
+const V3_SCORE_VIEW_DIMENSION_TO_TABLE_COL: TableColumnMap = {
+  traceName: "traceName",
+  tags: "traceTags",
+  userId: "userId",
+  sessionId: "sessionId",
+  traceRelease: "release",
+  traceVersion: "version",
+};
+
+const VIEW_DIMENSION_TO_TABLE_COL_V3: Record<ViewName, TableColumnMap> = {
   // traces view -> traces table
   traces: {
     name: "traceName",
@@ -94,42 +103,60 @@ const VIEW_DIMENSION_TO_TABLE_COL: Record<
     traceId: "traceId",
     parentObservationId: "parentObservationId",
   },
-  // scores-numeric view -> traces table. Only the dimensions that resolve from
-  // the parent TRACE (traces.* in the scores view) map to a real traces column;
-  // score-specific dimensions (name/source/value/dataType/...) have no trace
-  // column and are dropped.
-  "scores-numeric": {
-    traceName: "traceName",
-    tags: "traceTags",
-    userId: "userId",
-    sessionId: "sessionId",
-    traceRelease: "release",
-    traceVersion: "version",
+  // Score views land on the traces table and can only preserve trace-derived
+  // dimensions; score-owned dimensions are dropped.
+  "scores-numeric": V3_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
+  "scores-boolean": V3_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
+  "scores-categorical": V3_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
+};
+
+const V4_SCORE_VIEW_DIMENSION_TO_TABLE_COL: TableColumnMap = {
+  ...V3_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
+  traceRelease: null,
+};
+
+// V4 routes are backed by EventsTable. Define only their differences from the
+// legacy table mappings so compatibility decisions remain explicit.
+const VIEW_DIMENSION_TO_TABLE_COL_V4: Record<ViewName, TableColumnMap> = {
+  traces: {
+    ...VIEW_DIMENSION_TO_TABLE_COL_V3.traces,
+    id: "traceId",
+    metadata: null,
+    release: null,
   },
-  // scores-boolean view -> traces table (same trace-derived dimensions).
-  "scores-boolean": {
-    traceName: "traceName",
-    tags: "traceTags",
-    userId: "userId",
+  observations: {
+    ...VIEW_DIMENSION_TO_TABLE_COL_V3.observations,
     sessionId: "sessionId",
-    traceRelease: "release",
-    traceVersion: "version",
-  },
-  // scores-categorical view -> traces table (same trace-derived dimensions).
-  "scores-categorical": {
-    traceName: "traceName",
     tags: "traceTags",
-    userId: "userId",
-    sessionId: "sessionId",
-    traceRelease: "release",
+    providedModelName: "providedModelName",
     traceVersion: "version",
+    promptVersion: null,
+    parentObservationId: null,
+    isRootObservation: "isRootObservation",
+    experimentName: "experimentName",
+    experimentDatasetId: "experimentDatasetId",
+    experimentId: "experimentId",
   },
+  "scores-numeric": V4_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
+  "scores-boolean": V4_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
+  "scores-categorical": V4_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
 };
 
 /**
  * Specific, human reasons for notable dropped dimensions. Any dimension not
  * covered here falls back to `defaultReason`.
  */
+const SCORE_DROPPED_REASONS = {
+  name: "Score name has no equivalent column on the traces table.",
+  source: "Score source has no equivalent column on the traces table.",
+  dataType: "Score data type has no equivalent column on the traces table.",
+  metadata: "Score metadata does not map to trace metadata.",
+  environment:
+    "Score environment does not map to the trace environment column.",
+  observationName:
+    "Observation name has no equivalent column on the traces table.",
+} as const;
+
 const DROPPED_REASONS: Partial<
   Record<ViewName, Readonly<Record<string, string>>>
 > = {
@@ -153,48 +180,50 @@ const DROPPED_REASONS: Partial<
       "Experiment filters are not available on the observations table.",
     experimentDatasetId:
       "Experiment filters are not available on the observations table.",
+    isRootObservation:
+      "Semantic root status is only available on the v4 observations table.",
+    promptVersion:
+      "Prompt version uses a numeric events-table field and is not safely forwarded.",
   },
   "scores-numeric": {
-    name: "Score name has no equivalent column on the traces table.",
-    source: "Score source has no equivalent column on the traces table.",
+    ...SCORE_DROPPED_REASONS,
     value: "Score value has no equivalent column on the traces table.",
-    dataType: "Score data type has no equivalent column on the traces table.",
-    metadata: "Score metadata does not map to trace metadata.",
-    environment:
-      "Score environment does not map to the trace environment column.",
-    observationName:
-      "Observation name has no equivalent column on the traces table.",
   },
   "scores-boolean": {
-    name: "Score name has no equivalent column on the traces table.",
-    source: "Score source has no equivalent column on the traces table.",
+    ...SCORE_DROPPED_REASONS,
     booleanValue: "Score value has no equivalent column on the traces table.",
-    dataType: "Score data type has no equivalent column on the traces table.",
-    metadata: "Score metadata does not map to trace metadata.",
-    environment:
-      "Score environment does not map to the trace environment column.",
-    observationName:
-      "Observation name has no equivalent column on the traces table.",
   },
   "scores-categorical": {
-    name: "Score name has no equivalent column on the traces table.",
-    source: "Score source has no equivalent column on the traces table.",
+    ...SCORE_DROPPED_REASONS,
     stringValue: "Score value has no equivalent column on the traces table.",
-    dataType: "Score data type has no equivalent column on the traces table.",
-    metadata: "Score metadata does not map to trace metadata.",
-    environment:
-      "Score environment does not map to the trace environment column.",
-    observationName:
-      "Observation name has no equivalent column on the traces table.",
   },
 };
 
-function reasonFor(view: ViewName, column: string): string {
+const V4_SCORE_DROPPED_REASONS = {
+  traceRelease: "Trace release is not available on the v4 events table.",
+} as const;
+
+const V4_DROPPED_REASONS: Partial<
+  Record<ViewName, Readonly<Record<string, string>>>
+> = {
+  "scores-numeric": V4_SCORE_DROPPED_REASONS,
+  "scores-boolean": V4_SCORE_DROPPED_REASONS,
+  "scores-categorical": V4_SCORE_DROPPED_REASONS,
+};
+
+function reasonFor(
+  view: ViewName,
+  column: string,
+  tableVersion: TableVersion,
+): string {
   return (
+    (tableVersion === "v4" ? V4_DROPPED_REASONS[view]?.[column] : undefined) ??
     DROPPED_REASONS[view]?.[column] ??
-    `The "${column}" filter is not available on the ${tableTargetForView(
-      view,
-    )} table.`
+    `The "${column}" filter is not available on ${
+      tableVersion === "v4"
+        ? "the v4 events"
+        : `the ${tableTargetForView(view)}`
+    } table.`
   );
 }
 
@@ -207,8 +236,12 @@ function reasonFor(view: ViewName, column: string): string {
 export function classifyViewFiltersForTable(
   view: ViewName,
   filters: FilterState,
+  tableVersion: TableVersion = "v3",
 ): ClassifiedViewFilters {
-  const columnMap = VIEW_DIMENSION_TO_TABLE_COL[view] ?? {};
+  const columnMap =
+    (tableVersion === "v4"
+      ? VIEW_DIMENSION_TO_TABLE_COL_V4
+      : VIEW_DIMENSION_TO_TABLE_COL_V3)[view] ?? {};
   const applicable: FilterState = [];
   const notApplicable = new Map<string, string>();
 
@@ -217,7 +250,10 @@ export function classifyViewFiltersForTable(
     if (tableColId) {
       applicable.push({ ...filter, column: tableColId });
     } else if (!notApplicable.has(filter.column)) {
-      notApplicable.set(filter.column, reasonFor(view, filter.column));
+      notApplicable.set(
+        filter.column,
+        reasonFor(view, filter.column, tableVersion),
+      );
     }
   }
 

--- a/web/src/features/events/components/outlier-strip/lib/filterCompatibility.clienttest.ts
+++ b/web/src/features/events/components/outlier-strip/lib/filterCompatibility.clienttest.ts
@@ -21,14 +21,6 @@ describe("canApplyOutlierStripFilters", () => {
       [{ column: "latency", type: "number", operator: ">", value: 2 }],
       [
         {
-          column: "isRootObservation",
-          type: "boolean",
-          operator: "=",
-          value: true,
-        },
-      ],
-      [
-        {
           column: "name",
           type: "null",
           operator: "is not null",

--- a/web/src/features/monitors/components/MonitorForm.clienttest.ts
+++ b/web/src/features/monitors/components/MonitorForm.clienttest.ts
@@ -107,13 +107,20 @@ describe("buildFilterColumnsParams", () => {
   // (no free-text fallback), so they must list every domain value regardless of
   // what the discovery window returned, otherwise they dead-end on
   // "No results found" (LFE-10616).
-  const getColumn = (view: "observations", id: string) => {
+  const getColumn = (
+    view: "observations",
+    id: string,
+    viewVersion?: "v1" | "v2",
+  ) => {
     const params = buildFilterColumnsParams({
       view,
       filterOptions: undefined, // empty discovery window
       datasets: undefined,
     });
-    return getWidgetFilterColumns(params).find((c) => c.id === id);
+    return getWidgetFilterColumns({
+      ...params,
+      viewVersion: viewVersion ?? params.viewVersion,
+    }).find((c) => c.id === id);
   };
 
   it("offers every Observation Type value even when discovery data is empty", () => {
@@ -197,6 +204,16 @@ describe("buildFilterColumnsParams", () => {
         (column) => column.id === "booleanValue",
       ),
     ).toBe(false);
+  });
+
+  it("offers semantic-root filtering only for v2 observations widgets", () => {
+    expect(getColumn("observations", "isRootObservation")).toMatchObject({
+      name: "Is Root Observation",
+      type: "boolean",
+    });
+    expect(
+      getColumn("observations", "isRootObservation", "v1"),
+    ).toBeUndefined();
   });
 });
 

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -488,8 +488,9 @@ export function DashboardWidget({
       view as z.infer<typeof views>,
       mergedFilters,
       dateRange,
+      isBetaEnabled ? "v4" : "v3",
     );
-  }, [projectId, widget.data, filterState, dateRange]);
+  }, [projectId, widget.data, filterState, dateRange, isBetaEnabled]);
 
   const handleViewAsTable = () => {
     if (!tableView) return;

--- a/web/src/features/widgets/components/widgetFilterColumns.ts
+++ b/web/src/features/widgets/components/widgetFilterColumns.ts
@@ -207,6 +207,14 @@ const getWidgetFilterColumnSpecs = ({
                 internal: "internalValue",
               },
             } satisfies WidgetFilterColumnSpec,
+            {
+              column: {
+                name: "Is Root Observation",
+                id: "isRootObservation",
+                type: "boolean",
+                internal: "internalValue",
+              },
+            } satisfies WidgetFilterColumnSpec,
           ]
         : []),
       {

--- a/web/src/features/widgets/components/widgetFormAdapters.clienttest.ts
+++ b/web/src/features/widgets/components/widgetFormAdapters.clienttest.ts
@@ -404,9 +404,16 @@ describe("widget form view version", () => {
         baseMinVersion: 1,
         activeVersion: "v1",
         shape: {
-          dimensions: [{ field: "experimentName" }],
+          dimensions: [],
           metrics: [{ measure: "count" }],
-          filters: [],
+          filters: [
+            {
+              column: "isRootObservation",
+              type: "boolean",
+              operator: "=",
+              value: true,
+            },
+          ],
         },
       }),
     ).toBe("v2");

--- a/web/src/features/widgets/utils/import-export-utils.clienttest.ts
+++ b/web/src/features/widgets/utils/import-export-utils.clienttest.ts
@@ -153,7 +153,13 @@ describe("parseAndNormalizeImportedWidget", () => {
     expect(result.snapshot.widgetMinVersion).toBe(1);
   });
 
-  it("validates a v2-required imported shape without rewriting its version hint", () => {
+  it("accepts v2-only imported fields without rewriting the version hint", () => {
+    const rootFilter = {
+      column: "isRootObservation",
+      type: "boolean" as const,
+      operator: "=" as const,
+      value: true,
+    };
     const result = parseImportedWidgetJson({
       parsedJson: {
         ...baseWidget,
@@ -161,12 +167,13 @@ describe("parseAndNormalizeImportedWidget", () => {
         dimensions: [{ field: "experimentName" }],
         chartType: "VERTICAL_BAR",
         chartConfig: { type: "VERTICAL_BAR" },
-        filters: [],
+        filters: [rootFilter],
       },
       isBetaEnabled: false,
     });
 
     expect(result.widget.minVersion).toBe(1);
+    expect(result.widget.filters).toEqual([rootFilter]);
   });
 
   it("imports boolean score widgets with boolean filters intact", async () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15635.preview.langfuse.com](https://pr-15635.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Frontend-only support for carrying the semantic-root observation filter through the v4 chart, widget, and table drill-down paths.

The events-backed query/API behavior is already on `main` through [#15633](https://github.com/langfuse/langfuse/pull/15633). This PR intentionally contains no trace-name fallback changes; those are isolated in [#15723](https://github.com/langfuse/langfuse/pull/15723).

## Production changes

- Add `Is Root Observation` to the v2 observations widget filter catalog.
- Allow `isRootObservation` through the chart filter-forwarding allowlist.
- Pass the actual destination table generation (`v3`/`v4`) through the `DashboardWidget` → `buildTableFilterHref` → `viewFilterToTableFilter` path. This is deliberately separate from the widget query version: a v2 widget can still open the legacy table when the v4 table toggle is off.
- Use versioned view-to-table mappings. The root filter is preserved only for the v4 observations table; v3 drops it with the existing visible hint. The same maps keep v4 aliases correct (`tags` → `traceTags`, model name, session ID, and trace version) and drop fields the destination cannot express.

## Test coverage

- Chart forwarding and chart-to-widget preservation.
- Widget label ↔ canonical filter round-tripping.
- v3 dropping versus v4 preservation in table URLs and visible hints.
- Versioned table mappings and validation against actual table column IDs.
- Widget version/import behavior with a root filter.
- Monitor and outlier compatibility.

## Scope

- No query-engine, API, MCP, schema, or trace-name implementation is introduced here; those layers are already merged or isolated elsewhere.
- The heterogeneous dashboard-global filter bar is unchanged.

## Verification

- Focused client suites: 8 files, 99 tests passed.
- Web typecheck and targeted ESLint passed.
- Commit hook: Prettier clean; `Tasks: 7 successful, 7 total`.
