### PR TITLE
feat(public-api): add DELETE /api/public/score-configs/{configId}

### DIFF
--- a/fern/apis/server/definition/score-configs.yml
+++ b/fern/apis/server/definition/score-configs.yml
@@ -46,12 +46,24 @@ service:
           docs: The unique langfuse identifier of a score config
       request: UpdateScoreConfigRequest
       response: commons.ScoreConfig
+    delete:
+      docs: Archive a score config. Mirrors the MCP `deleteScoreConfig` tool's existing semantic — the row is soft-archived (isArchived=true), not removed from Postgres. Idempotent: a second call on an already-archived config returns 200 without rewriting the row.
+      method: DELETE
+      path: /score-configs/{configId}
+      path-parameters:
+        configId:
+          type: string
+          docs: The unique langfuse identifier of a score config
+      response: DeleteScoreConfigResponse
 
 types:
   ScoreConfigs:
     properties:
       data: list<commons.ScoreConfig>
       meta: pagination.MetaResponse
+  DeleteScoreConfigResponse:
+    properties:
+      message: string
   CreateScoreConfigRequest:
     properties:
       name:

--- a/web/src/__tests__/server/score-configs.servertest.ts
+++ b/web/src/__tests__/server/score-configs.servertest.ts
@@ -3,6 +3,7 @@ import {
   makeZodVerifiedAPICall,
 } from "@/src/__tests__/test-utils";
 import {
+  DeleteScoreConfigV1Response,
   GetScoreConfigResponse,
   GetScoreConfigsResponse,
   PostScoreConfigResponse,
@@ -807,6 +808,120 @@ describe("/api/public/score-configs API Endpoint", () => {
           { label: "False", value: 0 },
         ],
       });
+    });
+  });
+
+  describe("DELETE /api/public/score-configs/:configId", () => {
+    it("soft-archives the config and returns the success message", async () => {
+      const { body: created } = await makeZodVerifiedAPICall(
+        PostScoreConfigResponse,
+        "POST",
+        "/api/public/score-configs",
+        {
+          name: "to-be-archived",
+          dataType: "NUMERIC",
+          minValue: 0,
+          maxValue: 1,
+        },
+        auth,
+      );
+
+      const { id: configId } = created;
+
+      const deleteResponse = await makeZodVerifiedAPICall(
+        DeleteScoreConfigV1Response,
+        "DELETE",
+        `/api/public/score-configs/${configId}`,
+        undefined,
+        auth,
+      );
+
+      expect(deleteResponse.status).toBe(200);
+      expect(deleteResponse.body).toEqual({
+        message: "Score config successfully archived",
+      });
+
+      // The row is still present but flagged isArchived.
+      const row = await prisma.scoreConfig.findUnique({
+        where: { id: configId },
+      });
+      expect(row).not.toBeNull();
+      expect(row?.isArchived).toBe(true);
+
+      // A follow-up GET still returns the row (archived, not deleted).
+      const getResponse = await makeZodVerifiedAPICall(
+        GetScoreConfigResponse,
+        "GET",
+        `/api/public/score-configs/${configId}`,
+        undefined,
+        auth,
+      );
+      expect(getResponse.status).toBe(200);
+      expect(getResponse.body.isArchived).toBe(true);
+
+      // A second DELETE on the already-archived config is a no-op.
+      const secondDelete = await makeZodVerifiedAPICall(
+        DeleteScoreConfigV1Response,
+        "DELETE",
+        `/api/public/score-configs/${configId}`,
+        undefined,
+        auth,
+      );
+      expect(secondDelete.status).toBe(200);
+      expect(secondDelete.body).toEqual({
+        message: "Score config successfully archived",
+      });
+    });
+
+    it("returns 404 for an unknown configId", async () => {
+      await expect(
+        makeZodVerifiedAPICall(
+          DeleteScoreConfigV1Response,
+          "DELETE",
+          "/api/public/score-configs/does-not-exist",
+          undefined,
+          auth,
+        ),
+      ).rejects.toThrow(/returned status 404/);
+    });
+
+    it("returns 404 when the config belongs to a different project", async () => {
+      // Seed a score config in a different project directly via Prisma. The
+      // public API key in the test harness is scoped to the default test
+      // project, so the {id, projectId} filter in `getScoreConfig` (used
+      // by `archiveScoreConfigForApi`) will miss and the handler must
+      // return 404.
+      const otherProjectId = "01234567-89ab-cdef-0123-456789abcdef";
+      const otherConfig = await prisma.scoreConfig.create({
+        data: {
+          id: v4(),
+          projectId: otherProjectId,
+          name: "in-a-different-project",
+          dataType: "BOOLEAN",
+          isArchived: false,
+        },
+      });
+
+      try {
+        await expect(
+          makeZodVerifiedAPICall(
+            DeleteScoreConfigV1Response,
+            "DELETE",
+            `/api/public/score-configs/${otherConfig.id}`,
+            undefined,
+            auth,
+          ),
+        ).rejects.toThrow(/returned status 404/);
+
+        // The foreign-project row was not modified.
+        const stillThere = await prisma.scoreConfig.findUnique({
+          where: { id: otherConfig.id },
+        });
+        expect(stillThere?.isArchived).toBe(false);
+      } finally {
+        // Cleanup the foreign-project row so the suite stays isolated.
+        await prisma.scoreConfig.delete({ where: { id: otherConfig.id } });
+      }
     });
   });
 });

--- a/web/src/features/public-api/server/score-configs-api-service.ts
+++ b/web/src/features/public-api/server/score-configs-api-service.ts
@@ -120,3 +120,57 @@ export const updateScoreConfig = async ({
 
   return validateDbScoreConfig(config);
 };
+
+// Soft-archive a score config by flipping `isArchived` to true. Mirrors the
+// semantic of the existing MCP `mcp.score_configs.delete` tool so the public
+// API exposes a symmetric surface. Hard delete is intentionally out of scope;
+// see https://github.com/langfuse/langfuse/issues/15642.
+export const archiveScoreConfigForApi = async ({
+  context,
+  configId,
+}: {
+  context: ApiKeyProjectContext;
+  configId: string;
+}) => {
+  const existingConfig = await prisma.scoreConfig.findUnique({
+    where: {
+      id: configId,
+      projectId: context.projectId,
+    },
+  });
+
+  if (!existingConfig) {
+    throw new LangfuseNotFoundError(
+      "Score config not found within authorized project",
+    );
+  }
+
+  // If the config is already archived, treat the request as a no-op rather
+  // than an error. This keeps the verb idempotent and avoids surprising
+  // callers that re-issue the same DELETE.
+  if (existingConfig.isArchived) {
+    return { message: "Score config successfully archived" as const };
+  }
+
+  await prisma.scoreConfig.update({
+    where: {
+      id: configId,
+      projectId: context.projectId,
+    },
+    data: {
+      isArchived: true,
+    },
+  });
+
+  await auditLog({
+    action: "delete",
+    resourceType: "scoreConfig",
+    resourceId: existingConfig.id,
+    projectId: context.projectId,
+    orgId: context.orgId,
+    apiKeyId: context.apiKeyId,
+    before: existingConfig,
+  });
+
+  return { message: "Score config successfully archived" as const };
+};

--- a/web/src/features/public-api/server/score-configs-api-service.ts
+++ b/web/src/features/public-api/server/score-configs-api-service.ts
@@ -152,24 +152,51 @@ export const archiveScoreConfigForApi = async ({
     return { message: "Score config successfully archived" as const };
   }
 
-  await prisma.scoreConfig.update({
-    where: {
-      id: configId,
-      projectId: context.projectId,
-    },
-    data: {
-      isArchived: true,
-    },
-  });
+  // Wrap the conditional archive + audit-log in a single transaction so
+  // the read-then-write race (two DELETEs both seeing isArchived=false
+  // and each writing a delete audit record) collapses to a single
+  // transition with a single audit entry. The conditional updateMany
+  // returns the count of rows actually changed; only emit the audit
+  // log when the count is 1 (i.e. we won the race).
+  // Wrap the conditional archive + audit-log in a single transaction so
+  // the read-then-write race (two DELETEs both seeing isArchived=false
+  // and each writing a delete audit record) collapses to a single
+  // transition with a single audit entry. The conditional updateMany
+  // returns the count of rows actually changed; only emit the audit
+  // log when the count is 1 (i.e. we won the race).
+  await prisma.$transaction(async (tx) => {
+    const updateResult = await tx.scoreConfig.updateMany({
+      where: {
+        id: configId,
+        projectId: context.projectId,
+        isArchived: false,
+      },
+      data: {
+        isArchived: true,
+      },
+    });
 
-  await auditLog({
-    action: "delete",
-    resourceType: "scoreConfig",
-    resourceId: existingConfig.id,
-    projectId: context.projectId,
-    orgId: context.orgId,
-    apiKeyId: context.apiKeyId,
-    before: existingConfig,
+    if (updateResult.count === 0) {
+      // Lost the race: a concurrent DELETE already archived the row.
+      // The pre-check above still saw isArchived=false because the
+      // other transaction had not committed yet. Treat as a no-op so
+      // the verb stays idempotent and no duplicate audit entry is
+      // emitted.
+      return;
+    }
+
+    await auditLog(
+      {
+        action: "delete",
+        resourceType: "scoreConfig",
+        resourceId: existingConfig.id,
+        projectId: context.projectId,
+        orgId: context.orgId,
+        apiKeyId: context.apiKeyId,
+        before: existingConfig,
+      },
+      tx,
+    );
   });
 
   return { message: "Score config successfully archived" as const };

--- a/web/src/features/public-api/types/score-configs.ts
+++ b/web/src/features/public-api/types/score-configs.ts
@@ -147,6 +147,20 @@ export const PutScoreConfigBodyWithoutArchived = z
 
 export const PutScoreConfigResponse = APIScoreConfig;
 
+// DELETE /score-configs/{configId}
+// Soft-archives the config (sets isArchived: true), mirroring the MCP
+// `deleteScoreConfig` tool's existing semantic. Hard delete is intentionally
+// out of scope — see https://github.com/langfuse/langfuse/issues/15642.
+export const DeleteScoreConfigV1Query = z.object({
+  configId: z.string(),
+});
+
+export const DeleteScoreConfigV1Response = z
+  .object({
+    message: z.string(),
+  })
+  .strict();
+
 // GET /score-configs
 export const GetScoreConfigsQuery = z.object({
   ...publicApiPaginationZod,

--- a/web/src/pages/api/public/score-configs/[configId].ts
+++ b/web/src/pages/api/public/score-configs/[configId].ts
@@ -1,10 +1,13 @@
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
+  archiveScoreConfigForApi,
   getScoreConfig,
   updateScoreConfig,
 } from "@/src/features/public-api/server/score-configs-api-service";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import {
+  DeleteScoreConfigV1Query,
+  DeleteScoreConfigV1Response,
   GetScoreConfigQuery,
   GetScoreConfigResponse,
   PutScoreConfigBody as PatchScoreConfigBody,
@@ -36,5 +39,16 @@ export default withMiddlewares({
         body,
       });
     },
+  }),
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete a Score Config",
+    querySchema: DeleteScoreConfigV1Query,
+    responseSchema: DeleteScoreConfigV1Response,
+    rateLimitResource: "score-delete",
+    fn: async ({ query, auth }) =>
+      await archiveScoreConfigForApi({
+        context: auth.scope,
+        configId: query.configId,
+      }),
   }),
 });


### PR DESCRIPTION
## What does this PR do?

Add `DELETE /api/public/score-configs/{configId}` to the public REST API. Today the public API has `GET` (list + by id), `POST` (create), and `PATCH` (update) for score configs but no symmetric remove. The corresponding MCP tool (`mcp.score_configs.delete`) is already wired to soft-archive a config via the public API's PATCH path, so a user invoking the public API directly has no clean way to remove a config.

This PR wires a `DELETE` verb that performs the same soft-archive (`isArchived: true`) the MCP tool already uses, returns 200 with `{ "message": "Score config successfully archived" }`, is idempotent, and is subject to the existing `score-delete` rate-limit bucket.

Fixes #15642

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] New servertest coverage in `web/src/__tests__/server/score-configs.servertest.ts`
- [x] Fern definition updated in `fern/apis/server/definition/score-configs.yml` (the generated `openapi.yml` is regenerated by CI)

## Implementation notes

1. New `DeleteScoreConfigV1Query` / `DeleteScoreConfigV1Response` zod schemas in the public API types module, mirroring the `DeleteDatasetRunV1*` shape.
2. New `archiveScoreConfigForApi` service function in `web/src/features/public-api/server/score-configs-api-service.ts`. Reuses the existing `prisma.scoreConfig.findUnique` + `update` pattern from `updateScoreConfig`, sets `isArchived: true` only, and emits the audit log entry. The handler is idempotent: a second `DELETE` on an already-archived config returns 200 without rewriting the row.
3. DELETE handler wired in `web/src/pages/api/public/score-configs/[configId].ts` under the existing `score-delete` rate-limit bucket. No `allowInAppAgentKey` (matches trace-delete / score-delete), no `rejectInEventsOnlyMode` (score configs live in Postgres, not ClickHouse).
4. Servertest cases added:
   - Happy path: create + DELETE + assert response + assert row is `isArchived=true` + assert follow-up GET still returns the row (archived, not deleted) + assert a second DELETE is a no-op.
   - Missing id returns 404.
   - Cross-project: a config seeded in a different project returns 404 via the default-project API key, and the foreign-project row is not modified.
5. Fern definition updated with the new endpoint and `DeleteScoreConfigResponse` type. Generated `openapi.yml` is left to CI regeneration.

## Local verification

- `pnpm --filter web exec prettier --check` on every changed file → `All matched files use Prettier code style!`
- `pnpm --filter web run lint` on every changed file → no warnings
- `pnpm --filter web exec tsc --noEmit -p tsconfig.json` → no new errors in the touched files (pre-existing baseline failures in `helpers.ts`, `sessions.ts`, `traces.ts`, `extractTools.ts`, and missing optional dev deps are present on upstream `main` and unrelated to this PR)
- Servertests require a full Postgres + Redis + ClickHouse stack via `docker-compose.dev.yml`, same as the rest of the `score-configs.servertest.ts` suite. They were not executed locally in this environment.

## Risks

Minimal. Purely additive: a new endpoint, a new zod schema, a new service function, a new Fern operation, and three new test cases. The exhaustive `switch` in `RateLimitService.ts` makes a forgotten per-plan case a compile-time failure. The new audit log entry uses the same `resourceType: "scoreConfig"` and `resourceId` shape the existing `create` and `update` audit entries use, so the audit log surface is unchanged. The MCP `deleteScoreConfig` tool keeps its current implementation (it now has a public-API equivalent but stays unchanged).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a project-scoped public endpoint for soft-archiving score configurations.
- Defines the DELETE endpoint and response in the Fern API specification.
- Adds request and response schemas, archive service logic, rate-limit wiring, and audit logging.
- Covers successful, repeated, missing-ID, and cross-project requests with server tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The concurrent-delete audit duplication should be fixed before merging so the endpoint's claimed idempotency includes its persisted side effects.

The read-check-update sequence allows concurrent requests to observe the same unarchived state and each persist a delete audit entry for one archive transition; the new public endpoint also records that transition differently from the existing MCP path.

**Files Needing Attention:** web/src/features/public-api/server/score-configs-api-service.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/public-api/server/score-configs-api-service.ts:151-155
**Non-atomic archive idempotency**

When two DELETE requests execute concurrently, both can read `isArchived=false` before either update completes and then each write a delete audit record, causing duplicate audit entries for a single archive transition. Make the state transition conditional and emit the audit record only for the request that actually changed the row.

### Issue 2
web/src/features/public-api/server/score-configs-api-service.ts:165-173
**Inconsistent archive audit semantics**

This path records the soft archive as a `delete` with no `after` snapshot, while the existing MCP deletion performs the same `isArchived=true` transition through `updateScoreConfig`, which records an `update` with both snapshots. Audit queries and reviewers therefore see different action types and state detail for the same operation; route both entry points through one archive implementation or standardize their audit representation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(public-api): cover DELETE /api/publ..."](https://github.com/langfuse/langfuse/commit/0d955147dbc49e830b034c43fcc7ad6cae59fe07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48715657)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->