### PR TITLE
fix(ui): present oversized fields as attachments

### DIFF
--- a/web/src/components/ui/media/MediaReferenceTag.clienttest.tsx
+++ b/web/src/components/ui/media/MediaReferenceTag.clienttest.tsx
@@ -1,15 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { MediaReferenceTag } from "./MediaReferenceTag";
 import { classifyMediaValue } from "./mediaUtils";
 
 vi.mock("./useResolvedMedia", () => ({
-  useResolvedMedia: () => ({ status: "idle", url: undefined }),
+  useResolvedMedia: () => ({
+    status: "ready",
+    url: "data:text/plain,original%20oversized%20field",
+  }),
 }));
 
 describe("MediaReferenceTag", () => {
-  it("renders a bare field-limit media reference as the specialized warning", () => {
+  it("renders a field-limit media reference as an attachment", () => {
     const descriptor = classifyMediaValue(
       "@@@langfuseMedia:type=text/plain|id=oversized-field|source=field_size_limit@@@",
     );
@@ -17,8 +20,18 @@ describe("MediaReferenceTag", () => {
     expect(descriptor).not.toBeNull();
     render(<MediaReferenceTag descriptor={descriptor!} />);
 
+    const attachment = screen.getByRole("button", {
+      name: "Full value attached media",
+    });
+    fireEvent.click(attachment);
+
     expect(
-      screen.getByRole("button", { name: "Field over size limit media" }),
+      screen.getByText(
+        "This field was too large to process inline, so Langfuse saved the complete original value as an attachment at ingestion.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open original" }),
     ).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/media/MediaReferenceTag.tsx
+++ b/web/src/components/ui/media/MediaReferenceTag.tsx
@@ -44,13 +44,14 @@ function LangfuseRefMediaTag({
       contentType={descriptor.contentType}
       status={status}
       url={url}
-      label={isOversizedField ? "Field over size limit" : undefined}
+      label={isOversizedField ? "Full value attached" : undefined}
       description={
         isOversizedField
-          ? "This field exceeded the configured storage limit. Open the file to view the original content."
+          ? "This field was too large to process inline, so Langfuse saved the complete original value as an attachment at ingestion."
           : undefined
       }
-      warning={isOversizedField}
+      openActionLabel={isOversizedField ? "Open original" : undefined}
+      intent={isOversizedField ? "attachment" : undefined}
       onOpenChange={(open) => {
         if (open) setArmed(true);
       }}

--- a/web/src/components/ui/media/MediaTag.clienttest.tsx
+++ b/web/src/components/ui/media/MediaTag.clienttest.tsx
@@ -79,30 +79,33 @@ describe("MediaTag", () => {
     expect(await screen.findByText("Failed to load media")).toBeInTheDocument();
   });
 
-  it("renders an oversized-field warning with download context", () => {
+  it("renders an attachment with an explicit open action", () => {
     render(
       <MediaTag
         contentType="text/plain"
         status="ready"
         url="https://example.com/oversized.txt"
-        label="Field over size limit"
-        description="This field exceeded the configured storage limit. Open the file to view the original content."
-        warning
+        label="Full value attached"
+        description="This field was too large to process inline, so Langfuse saved the complete original value as an attachment at ingestion."
+        openActionLabel="Open original"
+        intent="attachment"
         open
       />,
     );
 
     expect(
-      screen.getByRole("button", { name: "Field over size limit media" }),
+      screen.getByRole("button", { name: "Full value attached media" }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This field exceeded the configured storage limit. Open the file to view the original content.",
+        "This field was too large to process inline, so Langfuse saved the complete original value as an attachment at ingestion.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByTitle("Open in new tab")).toHaveAttribute(
+    const openOriginal = screen.getByRole("link", { name: "Open original" });
+    expect(openOriginal).toHaveAttribute(
       "href",
       "https://example.com/oversized.txt",
     );
+    expect(openOriginal).toHaveClass("gap-1.5");
   });
 });

--- a/web/src/components/ui/media/MediaTag.stories.tsx
+++ b/web/src/components/ui/media/MediaTag.stories.tsx
@@ -112,15 +112,16 @@ export const PreviewFile = meta.story({
   },
 });
 
-// Oversized observation fields use the media surface as a deliberate warning,
-// rather than looking like ordinary user-attached media.
+// Oversized observation fields are preserved as attachments rather than
+// looking like discarded data.
 export const OversizedField = meta.story({
   args: {
     contentType: "text/plain",
-    label: "Field over size limit",
+    label: "Full value attached",
     description:
-      "This field exceeded the configured storage limit. Open the file to view the original content.",
-    warning: true,
+      "This field was too large to process inline, so Langfuse saved the complete original value as an attachment at ingestion.",
+    openActionLabel: "Open original",
+    intent: "attachment",
     open: true,
     status: "ready",
     url: "data:text/plain,original%20oversized%20field",

--- a/web/src/components/ui/media/MediaTag.tsx
+++ b/web/src/components/ui/media/MediaTag.tsx
@@ -4,11 +4,12 @@ import {
   File,
   Image as ImageIcon,
   ImageOff,
-  TriangleAlert,
+  Paperclip,
   Video,
   Volume2,
   type LucideIcon,
 } from "lucide-react";
+import { cva } from "class-variance-authority";
 
 import { Button } from "@/src/components/ui/button";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -25,6 +26,7 @@ import {
  * itself never fetches, which keeps it pure and Storybook-able.
  */
 export type MediaTagStatus = "idle" | "loading" | "ready" | "error";
+export type MediaTagIntent = "default" | "attachment";
 
 export interface MediaTagProps {
   /**
@@ -43,8 +45,10 @@ export interface MediaTagProps {
   label?: string;
   /** Optional context shown above the preview in the peek popover. */
   description?: string;
-  /** Renders the chip as a warning rather than a generic media attachment. */
-  warning?: boolean;
+  /** Optional text label for the open action. The default is icon-only. */
+  openActionLabel?: string;
+  /** Visual framing for the collapsed chip. */
+  intent?: MediaTagIntent;
   /** Controlled open state of the peek popover (used by stories/tests). */
   open?: boolean;
   /**
@@ -76,6 +80,22 @@ const MEDIA_KIND_ICON = {
   video: Video,
   file: File,
 } satisfies Record<MediaKind, LucideIcon>;
+
+const mediaTagVariants = cva(
+  "focus-visible:ring-ring inline-flex h-3.5 max-w-full items-center gap-1 rounded-sm border px-1 py-0 align-middle text-xs leading-none transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
+  {
+    variants: {
+      intent: {
+        default: "hover:bg-accent bg-background",
+        attachment:
+          "border-blue-500/40 bg-blue-50 text-blue-800 hover:bg-blue-100 dark:bg-blue-950/30 dark:text-blue-200 dark:hover:bg-blue-950/50",
+      },
+    },
+    defaultVariants: {
+      intent: "default",
+    },
+  },
+);
 
 function KindIcon({
   kind,
@@ -178,7 +198,8 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
       url,
       label,
       description,
-      warning = false,
+      openActionLabel,
+      intent,
       open,
       onOpenChange,
     },
@@ -218,11 +239,7 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
             data-media-tag=""
             aria-label={`${chipLabel} media`}
             aria-expanded={isOpen}
-            className={
-              warning
-                ? "focus-visible:ring-ring inline-flex h-3.5 max-w-full items-center gap-1 rounded-sm border border-amber-500/60 bg-amber-50 px-1 py-0 align-middle text-xs leading-none text-amber-900 transition-colors hover:bg-amber-100 focus-visible:ring-2 focus-visible:outline-hidden dark:bg-amber-950/40 dark:text-amber-200 dark:hover:bg-amber-950/60"
-                : "hover:bg-accent focus-visible:ring-ring bg-background inline-flex h-3.5 max-w-full items-center gap-1 rounded-sm border px-1 py-0 align-middle text-xs leading-none transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
-            }
+            className={mediaTagVariants({ intent })}
             onClick={openPeek}
             onPointerDown={(event) => {
               if (event.pointerType !== "mouse") {
@@ -231,8 +248,8 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
               }
             }}
           >
-            {warning ? (
-              <TriangleAlert className="h-2.5 w-2.5 shrink-0" />
+            {intent === "attachment" ? (
+              <Paperclip className="h-2.5 w-2.5 shrink-0" />
             ) : (
               <KindIcon kind={kind} className="h-2.5 w-2.5 shrink-0" />
             )}
@@ -265,20 +282,24 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
               <Button
                 asChild
                 variant="outline"
-                size="icon-xs"
+                size={openActionLabel ? "sm" : "icon-xs"}
+                className={openActionLabel ? "gap-1.5" : undefined}
                 title="Open in new tab"
               >
                 <a href={url} target="_blank" rel="noopener noreferrer">
+                  {openActionLabel ? <span>{openActionLabel}</span> : null}
                   <ExternalLink className="h-3 w-3" />
                 </a>
               </Button>
             ) : (
               <Button
                 variant="outline"
-                size="icon-xs"
+                size={openActionLabel ? "sm" : "icon-xs"}
+                className={openActionLabel ? "gap-1.5" : undefined}
                 disabled
                 title="Open in new tab"
               >
+                {openActionLabel ? <span>{openActionLabel}</span> : null}
                 <ExternalLink className="h-3 w-3" />
               </Button>
             )}


### PR DESCRIPTION
## What

- render server-created observation field overflow references as blue paperclip attachments instead of amber warnings
- label the chip `Full value attached` and provide an explicit `Open original` action
- explain that the complete value was attached during ingestion
- keep ordinary media-reference rendering unchanged

## Why

The warning-first presentation looked like the oversized value had been discarded. In reality, the complete original value was successfully uploaded and remains available as media, so the UI should lead with that outcome.

## Verification

- `pnpm --filter web run lint`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run test-client src/components/ui/media/MediaTag.clienttest.tsx src/components/ui/media/MediaReferenceTag.clienttest.tsx` — 7 tests passed
- Storybook browser review in dark mode at 340 px; verified the collapsed chip, explanatory copy, explicit action, button/icon spacing, and popover bounds

## Scope

- Package: `web`
- UI-only follow-up to https://linear.app/clickhouse/issue/LFE-14407/set-a-hard-cap-on-large-observation-field-payloads
- No ingestion or storage behavior changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates oversized observation-field references to present successfully preserved values as attachments.
- Replaces amber warning styling and iconography with a blue attachment variant and paperclip icon.
- Adds “Full value attached” messaging and an explicit “Open original” action.
- Keeps ordinary media-reference rendering unchanged.
- Updates component tests and the Storybook example for the new presentation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete regressions identified in the changed media-reference behavior.

The updated component API is applied consistently across all callers, oversized references are only created after successful media persistence, and the ordinary media path retains its existing defaults.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): present oversized fields as att..."](https://github.com/langfuse/langfuse/commit/3385388c572cc77db3fa56e48e1aa43607925817) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48724765)</sub>

<!-- /greptile_comment -->