### PR TITLE
feat(ingestion): trace observation field overflow

### DIFF
--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
@@ -128,6 +128,9 @@ describe("applyObservationFieldOverflow", () => {
       expect.any(Function),
     );
     expect(mocks.span.setAttributes).toHaveBeenCalledWith({
+      "langfuse.project.id": "project-id",
+      "langfuse.trace.id": "trace-id",
+      "langfuse.observation.id": "observation-id",
       "langfuse.ingestion.observation_field_overflow.candidates": 3,
       "langfuse.ingestion.observation_field_overflow.fields": [
         "input",

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
@@ -8,6 +8,12 @@ const mocks = vi.hoisted(() => ({
     LANGFUSE_OBSERVATION_FIELD_OVERFLOW_ENABLED: "true",
     LANGFUSE_OBSERVATION_FIELD_SIZE_LIMIT_BYTES: 10,
   },
+  instrumentAsync: vi.fn(
+    async (
+      _context: unknown,
+      callback: () => Promise<unknown>,
+    ): Promise<unknown> => callback(),
+  ),
   logger: { warn: vi.fn() },
   recordDistribution: vi.fn(),
   recordIncrement: vi.fn(),
@@ -16,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@langfuse/shared/src/server")>()),
+  instrumentAsync: mocks.instrumentAsync,
   logger: mocks.logger,
   recordDistribution: mocks.recordDistribution,
   recordIncrement: mocks.recordIncrement,
@@ -69,6 +76,7 @@ describe("applyObservationFieldOverflow", () => {
     const result = await applyObservationFieldOverflow(eventRecord);
 
     expect(result).toBe(eventRecord);
+    expect(mocks.instrumentAsync).not.toHaveBeenCalled();
     expect(mocks.uploadMediaForTrace).not.toHaveBeenCalled();
   });
 
@@ -106,6 +114,12 @@ describe("applyObservationFieldOverflow", () => {
       }),
     );
     expect(mocks.recordIncrement).toHaveBeenCalledTimes(3);
+    expect(mocks.instrumentAsync).toHaveBeenCalledWith(
+      {
+        name: "langfuse.ingestion.observation_field_overflow.process",
+      },
+      expect.any(Function),
+    );
   });
 
   it("applies the limit to each metadata value rather than their aggregate size", async () => {
@@ -116,6 +130,7 @@ describe("applyObservationFieldOverflow", () => {
     const result = await applyObservationFieldOverflow(eventRecord);
 
     expect(result.metadata_values).toEqual(["123456", "123456"]);
+    expect(mocks.instrumentAsync).not.toHaveBeenCalled();
     expect(mocks.uploadMediaForTrace).not.toHaveBeenCalled();
   });
 

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
@@ -1,24 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EventRecordInsertType } from "@langfuse/shared/src/server";
 
-const mocks = vi.hoisted(() => ({
-  env: {
-    LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: "media-bucket" as string | undefined,
-    LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: "media/",
-    LANGFUSE_OBSERVATION_FIELD_OVERFLOW_ENABLED: "true",
-    LANGFUSE_OBSERVATION_FIELD_SIZE_LIMIT_BYTES: 10,
-  },
-  instrumentAsync: vi.fn(
-    async (
-      _context: unknown,
-      callback: () => Promise<unknown>,
-    ): Promise<unknown> => callback(),
-  ),
-  logger: { warn: vi.fn() },
-  recordDistribution: vi.fn(),
-  recordIncrement: vi.fn(),
-  uploadMediaForTrace: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const span = { setAttributes: vi.fn() };
+  return {
+    env: {
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: "media-bucket" as string | undefined,
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: "media/",
+      LANGFUSE_OBSERVATION_FIELD_OVERFLOW_ENABLED: "true",
+      LANGFUSE_OBSERVATION_FIELD_SIZE_LIMIT_BYTES: 10,
+    },
+    instrumentAsync: vi.fn(
+      async (
+        _context: unknown,
+        callback: (activeSpan: typeof span) => Promise<unknown>,
+      ): Promise<unknown> => callback(span),
+    ),
+    logger: { warn: vi.fn() },
+    recordDistribution: vi.fn(),
+    recordIncrement: vi.fn(),
+    span,
+    uploadMediaForTrace: vi.fn(),
+  };
+});
 
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@langfuse/shared/src/server")>()),
@@ -81,6 +85,9 @@ describe("applyObservationFieldOverflow", () => {
   });
 
   it("replaces oversized input, output, and metadata values by UTF-8 byte size", async () => {
+    const input = "x".repeat(100);
+    const output = "🔥".repeat(30);
+    const metadata = "y".repeat(100);
     mocks.uploadMediaForTrace
       .mockResolvedValueOnce({ mediaId: "input-media", outcome: "uploaded" })
       .mockResolvedValueOnce({ mediaId: "output-media", outcome: "reused" })
@@ -89,9 +96,9 @@ describe("applyObservationFieldOverflow", () => {
         outcome: "uploaded",
       });
     const eventRecord = createEventRecord({
-      input: "x".repeat(11),
-      output: "🔥🔥🔥",
-      metadata_values: ["1234567890", "y".repeat(11)],
+      input,
+      output,
+      metadata_values: ["1234567890", metadata],
     });
 
     const result = await applyObservationFieldOverflow(eventRecord);
@@ -102,15 +109,15 @@ describe("applyObservationFieldOverflow", () => {
       metadata_values: ["1234567890", mediaReference("metadata-media")],
     });
     expect(eventRecord).toMatchObject({
-      input: "x".repeat(11),
-      output: "🔥🔥🔥",
-      metadata_values: ["1234567890", "y".repeat(11)],
+      input,
+      output,
+      metadata_values: ["1234567890", metadata],
     });
     expect(mocks.uploadMediaForTrace).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         field: "output",
-        contentBytes: Buffer.from("🔥🔥🔥"),
+        contentBytes: Buffer.from(output),
       }),
     );
     expect(mocks.recordIncrement).toHaveBeenCalledTimes(3);
@@ -120,6 +127,23 @@ describe("applyObservationFieldOverflow", () => {
       },
       expect.any(Function),
     );
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith({
+      "langfuse.ingestion.observation_field_overflow.candidates": 3,
+      "langfuse.ingestion.observation_field_overflow.fields": [
+        "input",
+        "output",
+        "metadata",
+      ],
+      "langfuse.ingestion.observation_field_overflow.uploaded": 2,
+      "langfuse.ingestion.observation_field_overflow.reused": 1,
+      "langfuse.ingestion.observation_field_overflow.failed": 0,
+      "langfuse.ingestion.observation_field_overflow.bytes_processed": 320,
+      "langfuse.ingestion.observation_field_overflow.bytes_removed":
+        320 -
+        Buffer.byteLength(mediaReference("input-media")) -
+        Buffer.byteLength(mediaReference("output-media")) -
+        Buffer.byteLength(mediaReference("metadata-media")),
+    });
   });
 
   it("applies the limit to each metadata value rather than their aggregate size", async () => {
@@ -213,6 +237,19 @@ describe("applyObservationFieldOverflow", () => {
       "langfuse.ingestion.observation_field_overflow",
       1,
       { field: "input", outcome: "failed" },
+    );
+    expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "langfuse.ingestion.observation_field_overflow.fields": [
+          "input",
+          "output",
+        ],
+        "langfuse.ingestion.observation_field_overflow.uploaded": 1,
+        "langfuse.ingestion.observation_field_overflow.reused": 0,
+        "langfuse.ingestion.observation_field_overflow.failed": 1,
+        "langfuse.ingestion.observation_field_overflow.bytes_processed": 22,
+        "langfuse.ingestion.observation_field_overflow.bytes_removed": 0,
+      }),
     );
   });
 

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
@@ -271,6 +271,7 @@ describe("applyObservationFieldOverflow", () => {
     const result = await applyObservationFieldOverflow(eventRecord);
 
     expect(result).toBe(eventRecord);
+    expect(mocks.instrumentAsync).not.toHaveBeenCalled();
     expect(mocks.uploadMediaForTrace).not.toHaveBeenCalled();
     expect(mocks.logger.warn).toHaveBeenCalledOnce();
     expect(mocks.logger.warn).toHaveBeenCalledWith(

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
@@ -27,6 +27,8 @@ type OverflowCandidate = OverflowTarget & {
 type OverflowResult = {
   candidate: OverflowCandidate;
   overflowedValue: string;
+  outcome: "uploaded" | "reused" | "failed";
+  bytesRemoved: number;
 };
 
 export async function applyObservationFieldOverflow(
@@ -48,7 +50,7 @@ export async function applyObservationFieldOverflow(
       {
         name: "langfuse.ingestion.observation_field_overflow.process",
       },
-      async () => {
+      async (span) => {
         if (!mediaBucket) {
           throw new Error("Media upload bucket is not configured");
         }
@@ -58,6 +60,29 @@ export async function applyObservationFieldOverflow(
           candidates,
           mediaBucket,
         );
+
+        span.setAttributes({
+          "langfuse.ingestion.observation_field_overflow.candidates":
+            candidates.length,
+          "langfuse.ingestion.observation_field_overflow.fields":
+            candidates.map(({ field }) => field),
+          "langfuse.ingestion.observation_field_overflow.uploaded":
+            results.filter(({ outcome }) => outcome === "uploaded").length,
+          "langfuse.ingestion.observation_field_overflow.reused":
+            results.filter(({ outcome }) => outcome === "reused").length,
+          "langfuse.ingestion.observation_field_overflow.failed":
+            results.filter(({ outcome }) => outcome === "failed").length,
+          "langfuse.ingestion.observation_field_overflow.bytes_processed":
+            candidates.reduce(
+              (total, { originalBytes }) => total + originalBytes,
+              0,
+            ),
+          "langfuse.ingestion.observation_field_overflow.bytes_removed":
+            results.reduce(
+              (total, { bytesRemoved }) => total + bytesRemoved,
+              0,
+            ),
+        });
 
         return applyOverflowResults(eventRecord, results);
       },
@@ -207,13 +232,22 @@ async function uploadOverflowCandidate(
     return null;
   });
   if (!uploadResult) {
-    return { candidate, overflowedValue: value };
+    return {
+      candidate,
+      overflowedValue: value,
+      outcome: "failed",
+      bytesRemoved: 0,
+    };
   }
 
   const mediaReference =
     `@@@langfuseMedia:type=text/plain|id=${uploadResult.mediaId}` +
     `|source=${OBSERVATION_FIELD_SIZE_LIMIT_MEDIA_SOURCE}@@@`;
   const metricTags = { field, outcome: uploadResult.outcome };
+  const bytesRemoved = Math.max(
+    originalBytes - Buffer.byteLength(mediaReference, "utf8"),
+    0,
+  );
 
   recordIncrement(
     "langfuse.ingestion.observation_field_overflow",
@@ -222,9 +256,14 @@ async function uploadOverflowCandidate(
   );
   recordDistribution(
     "langfuse.ingestion.observation_field_overflow.bytes_removed",
-    Math.max(originalBytes - Buffer.byteLength(mediaReference, "utf8"), 0),
+    bytesRemoved,
     metricTags,
   );
 
-  return { candidate, overflowedValue: mediaReference };
+  return {
+    candidate,
+    overflowedValue: mediaReference,
+    outcome: uploadResult.outcome,
+    bytesRemoved,
+  };
 }

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
@@ -62,6 +62,9 @@ export async function applyObservationFieldOverflow(
         );
 
         span.setAttributes({
+          "langfuse.project.id": eventRecord.project_id,
+          "langfuse.trace.id": eventRecord.trace_id,
+          "langfuse.observation.id": eventRecord.span_id,
           "langfuse.ingestion.observation_field_overflow.candidates":
             candidates.length,
           "langfuse.ingestion.observation_field_overflow.fields":

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
@@ -1,5 +1,6 @@
 import {
   type EventRecordInsertType,
+  instrumentAsync,
   logger,
   recordDistribution,
   recordIncrement,
@@ -42,17 +43,25 @@ export async function applyObservationFieldOverflow(
     if (candidates.length === 0) {
       return eventRecord;
     }
-    if (!mediaBucket) {
-      throw new Error("Media upload bucket is not configured");
-    }
 
-    const results = await uploadOverflowCandidates(
-      eventRecord,
-      candidates,
-      mediaBucket,
+    return await instrumentAsync(
+      {
+        name: "langfuse.ingestion.observation_field_overflow.process",
+      },
+      async () => {
+        if (!mediaBucket) {
+          throw new Error("Media upload bucket is not configured");
+        }
+
+        const results = await uploadOverflowCandidates(
+          eventRecord,
+          candidates,
+          mediaBucket,
+        );
+
+        return applyOverflowResults(eventRecord, results);
+      },
     );
-
-    return applyOverflowResults(eventRecord, results);
   } catch (error) {
     logger.warn(
       "Observation field overflow processing failed; persisting original record",

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
@@ -45,16 +45,15 @@ export async function applyObservationFieldOverflow(
     if (candidates.length === 0) {
       return eventRecord;
     }
+    if (!mediaBucket) {
+      throw new Error("Media upload bucket is not configured");
+    }
 
     return await instrumentAsync(
       {
         name: "langfuse.ingestion.observation_field_overflow.process",
       },
       async (span) => {
-        if (!mediaBucket) {
-          throw new Error("Media upload bucket is not configured");
-        }
-
         const results = await uploadOverflowCandidates(
           eventRecord,
           candidates,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15649.preview.langfuse.com](https://pr-15649.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

Wrap observation field overflow processing in a single active OpenTelemetry span named `langfuse.ingestion.observation_field_overflow.process`, matching the existing OTEL media-processing instrumentation pattern.

The span is created only when overflow candidates exist. Disabled processing and records without oversized fields keep their existing fast paths and do not create spans.

## Why

The overflow processor already emits outcome, byte-removal, and failure metrics, but there was no span covering the end-to-end upload and replacement work. This makes its latency and unexpected failures visible inside the surrounding ingestion trace.

Linear: [LFE-14407](https://linear.app/clickhouse/issue/LFE-14407/set-a-hard-cap-on-large-observation-field-payloads)

## Impacted packages

- `worker`

## Verification

- `pnpm run lint`
- `pnpm --filter worker run typecheck`
- `pnpm --filter worker run test src/features/observation-field-overflow/processObservationFieldOverflow.test.ts src/features/otel-media/processOtelMedia.test.ts src/services/IngestionService/tests/IngestionService.unit.test.ts`
  - `Test Files  3 passed (3)`
  - `Tests  20 passed (20)`
- `pnpm exec prettier --check worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts`
  - `All matched files use Prettier code style!`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an active OpenTelemetry span around observation-field overflow processing when oversized fields are present.
- Preserves the disabled and no-overflow fast paths without creating spans.
- Keeps existing upload, replacement, and fail-open error behavior inside the new span.
- Adds tests covering span creation and fast-path omission.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The instrumentation wrapper passes callback results through and rethrows errors into the existing fail-open catch, while tests cover both span creation and unchanged fast paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ingestion): trace observation field..."](https://github.com/langfuse/langfuse/commit/3e669b67203fa53ea589f774d9b470f1a2f54f8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48732310)</sub>

<!-- /greptile_comment -->