### PR TITLE
fix(web): update oversized media attachment test

### DIFF
--- a/web/src/components/ui/LangfuseMediaView.clienttest.tsx
+++ b/web/src/components/ui/LangfuseMediaView.clienttest.tsx
@@ -22,13 +22,13 @@ vi.mock("./media/useResolvedMedia", () => ({
 }));
 
 describe("LangfuseMediaView", () => {
-  it("renders a field-limit reference as the specialized warning", () => {
+  it("renders a field-limit reference as an attachment", () => {
     render(
       <LangfuseMediaView mediaReferenceString="@@@langfuseMedia:type=text/plain|id=oversized-field|source=field_size_limit@@@" />,
     );
 
     expect(
-      screen.getByRole("button", { name: "Field over size limit media" }),
+      screen.getByRole("button", { name: "Full value attached media" }),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15650.preview.langfuse.com](https://pr-15650.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Align the oversized-field media view test with the attachment UI introduced in #15648.
- The old assertion expected the retired warning label, causing a deterministic client-test failure.

## Linear

- [LFE-14407](https://linear.app/clickhouse/issue/LFE-14407/set-a-hard-cap-on-large-observation-field-payloads)

## Context

Follow-up to #15648.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the oversized-field media client test to match the attachment UI introduced previously.
- Renames the test to describe attachment rendering.
- Updates the expected accessible button name to “Full value attached media”.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the updated assertion uniquely matches the current oversized-field attachment branch.

The change only synchronizes a client-test expectation with the existing accessible label and introduces no production behavior changes or test coverage gaps.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): update oversized media attachm..."](https://github.com/langfuse/langfuse/commit/a1df3bd0d0f31013e58d24219a397b1d3bba6ff5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48735173)</sub>

<!-- /greptile_comment -->