### PR TITLE
feat(preview): expose v4 migration UI flag

### DIFF
--- a/web/src/__tests__/server/userAccount.servertest.ts
+++ b/web/src/__tests__/server/userAccount.servertest.ts
@@ -41,6 +41,29 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
     expect(user.featureFlags).toEqual(["templateFlag", "modernSession"]);
   });
 
+  it("enables the V4 migration UI preview, leaving other flags intact", async () => {
+    const { caller, userId } = await createCaller({
+      featureFlags: ["templateFlag"],
+    });
+
+    const result = await caller.userAccount.setFeaturePreviewEnabled({
+      flag: "v4UpgradeUi",
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      flag: "v4UpgradeUi",
+      enabled: true,
+    });
+
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { featureFlags: true },
+    });
+    expect(user.featureFlags).toEqual(["templateFlag", "v4UpgradeUi"]);
+  });
+
   it("disables a preview flag without touching the others", async () => {
     const { caller, userId } = await createCaller({
       featureFlags: ["templateFlag", "modernSession"],
@@ -153,6 +176,7 @@ async function createCaller({
         modernSession: featureFlags.includes("modernSession"),
         searchBar: featureFlags.includes("searchBar"),
         templateFlag: featureFlags.includes("templateFlag"),
+        v4UpgradeUi: featureFlags.includes("v4UpgradeUi"),
         excludeClickhouseRead: false,
         observationEvals: false,
         v4BetaToggleVisible: false,

--- a/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
@@ -20,6 +20,7 @@ type ControlledFeaturePreviewModalProps = {
 const PREVIEW_LABEL: Record<PreviewFlag, string> = {
   modernSession: "Compact Session View",
   searchBar: "Filter Search Bar",
+  v4UpgradeUi: "V4 Migration",
 };
 
 export function ControlledFeaturePreviewModal({
@@ -66,6 +67,11 @@ export function ControlledFeaturePreviewModal({
           ? "This preview is enabled by LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES, so a per-user opt-out does not disable it."
           : undefined,
       onToggle: onToggle("modernSession"),
+      isToggling: setFeaturePreviewEnabled.isPending,
+    },
+    v4UpgradeUi: {
+      enabled: authSession.data?.user?.featureFlags.v4UpgradeUi === true,
+      onToggle: onToggle("v4UpgradeUi"),
       isToggling: setFeaturePreviewEnabled.isPending,
     },
     // The "Filter Search Bar" preview is retired — the bar is now generally

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
@@ -57,6 +57,7 @@ const meta = preview.meta({
     onOpenChange: fn(),
     state: {
       modernSession: { enabled: false, onToggle: fn(), isToggling: false },
+      v4UpgradeUi: { enabled: false, onToggle: fn(), isToggling: false },
     },
   },
   render: StatefulFeaturePreviewModal,

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -23,12 +23,14 @@ import modernSessionLightIllustration from "../assets/modern-session-light.svg";
  *  `searchBar` is retired and no longer renders a tile — see
  *  ControlledFeaturePreviewModal. It remains as rollback plumbing.
  *  TODO(remove ~2026-06-19): drop "searchBar" once GA is confirmed. */
-export type PreviewFlag = "modernSession" | "searchBar";
+export type PreviewFlag = "modernSession" | "searchBar" | "v4UpgradeUi";
 
 type PreviewIllustration = {
   light: React.ComponentProps<typeof Image>["src"];
   dark: React.ComponentProps<typeof Image>["src"];
   alt: string;
+  width?: number;
+  height?: number;
 };
 
 type PreviewRegistryItem = {
@@ -67,6 +69,23 @@ const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
       light: modernSessionLightIllustration,
       dark: modernSessionDarkIllustration,
       alt: "Compact Session View showing a trace minimap beside a continuous session conversation feed.",
+    },
+  },
+  {
+    flag: "v4UpgradeUi",
+    title: "V4 Migration",
+    sidebarLabel: "V4 Migration",
+    description:
+      "Review each project's readiness for Langfuse v4 and get guided steps for anything that still needs an update.",
+    details:
+      "The V4 Migration experience adds a migration status page, project-level readiness indicators, and contextual upgrade guidance for SDKs, evaluators, deprecated APIs, and integrations.",
+    feedbackUrl: "https://github.com/orgs/langfuse/discussions",
+    illustration: {
+      light: "/assets/v4-beta-intro.jpg",
+      dark: "/assets/v4-beta-intro.jpg",
+      alt: "Langfuse v4 performance improvements across common observability workflows.",
+      width: 1024,
+      height: 598,
     },
   },
   // TODO(remove ~2026-06-19): dead registry entry — "searchBar" is GA on the v4
@@ -231,11 +250,15 @@ function PreviewMockupPanel({
       <Image
         src={illustration.light}
         alt={illustration.alt}
+        width={illustration.width}
+        height={illustration.height}
         className="block h-auto w-full dark:hidden"
       />
       <Image
         src={illustration.dark}
         alt={illustration.alt}
+        width={illustration.width}
+        height={illustration.height}
         className="hidden h-auto w-full dark:block"
       />
     </div>

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -102,9 +102,9 @@ export const userAccountRouter = createTRPCRouter({
       z.object({
         // Allowlist of user-toggleable Feature Preview flags (the Feature
         // Preview modal). Keep in sync with the modal's preview registry.
-        // `modernSession` is the active preview. `searchBar` is retired — the
-        // bar is now GA on v4 events tables — but remains as rollback plumbing.
-        flag: z.enum(["modernSession", "searchBar"]),
+        // `searchBar` is retired — the bar is now GA on v4 events tables —
+        // but remains as rollback plumbing.
+        flag: z.enum(["modernSession", "searchBar", "v4UpgradeUi"]),
         enabled: z.boolean(),
       }),
     )


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15651.preview.langfuse.com](https://pr-15651.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- expose the existing `v4UpgradeUi` flag in the user-level Feature Preview modal
- allow `userAccount.setFeaturePreviewEnabled` to persist the flag for the signed-in user
- add V4 Migration preview copy, illustration, and Storybook coverage
- cover the settings mutation with a focused server regression test

## Why

The V4 migration experience was already gated by the per-user `v4UpgradeUi` feature flag, but users had no self-service way to opt in. This adds the existing flag to user settings so each user can enable the migration UI for themselves.

## User impact

Users can select **Feature Preview → V4 Migration** and toggle the experience on or off. The existing `user_settings:feature_preview_toggled` analytics event records the feature key and enabled state; no user content is added.

## Verification

- `pnpm --filter web run test userAccount.servertest.ts` — `Tests 4 passed (4)`
- `pnpm --filter web run test-storybook FeaturePreviewModal.stories.tsx` — `Tests 3 passed (3)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- Browser review at desktop and 390×844: entry, selection, switch transition, illustration, and responsive bounds verified

## Local baseline caveats

- `pnpm --filter web run typecheck` reaches unrelated repository-wide type errors outside the changed preview files.
- `pnpm test` reaches unrelated integration failures because local ClickHouse/S3 services and portions of the local dev schema are unavailable (`Tasks: 3 successful, 5 total`).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds self-service control for the existing V4 migration preview.
- Exposes `v4UpgradeUi` in the Feature Preview modal with migration copy and illustration.
- Allows the authenticated user settings mutation to persist the flag.
- Refreshes the session after toggling so existing migration UI consumers receive the updated value.
- Adds Storybook state and a focused server regression test.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The new flag follows the existing authenticated persistence and session-refresh path, matches the downstream session flag consumed by the migration UI, and preserves the established cloud and self-hosted preview gating.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(preview): expose v4 migration UI fl..."](https://github.com/langfuse/langfuse/commit/b81652e666f5a9f6cbdad3c53766e836c67df416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48737714)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Enterprise Edition (EE), Entitlements, and Billing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/ee-features.md)

<!-- /greptile_comment -->