### PR TITLE
fix(web): align field-limit media test with attachment presentation

### DIFF
--- a/web/src/components/ui/LangfuseMediaView.clienttest.tsx
+++ b/web/src/components/ui/LangfuseMediaView.clienttest.tsx
@@ -22,13 +22,13 @@ vi.mock("./media/useResolvedMedia", () => ({
 }));
 
 describe("LangfuseMediaView", () => {
-  it("renders a field-limit reference as the specialized warning", () => {
+  it("renders a field-limit reference as an attachment chip", () => {
     render(
       <LangfuseMediaView mediaReferenceString="@@@langfuseMedia:type=text/plain|id=oversized-field|source=field_size_limit@@@" />,
     );
 
     expect(
-      screen.getByRole("button", { name: "Field over size limit media" }),
+      screen.getByRole("button", { name: "Full value attached media" }),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15652.preview.langfuse.com](https://pr-15652.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Description

Cross-merge semantic conflict on main: #15350 added a `LangfuseMediaView` client test asserting the old specialized warning (`"Field over size limit media"`), and #15648 — branched before that test existed — changed field-limit references to render as attachment chips (`"Full value attached"`, see `MediaReferenceTag.tsx`). Each PR was green on its own; combined on main, `tests-web (node24, pg15, mode)` fails on every PR (observed on #15638 after updating its branch; main doesn't run the full suite on push, so it looks green there).

Updates the stale assertion to the new accessible name, matching #15648's own `MediaReferenceTag.clienttest.tsx` for the identical reference string.

## Impacted packages

- `web` (test only)

## Verification

- `pnpm --filter web run test-client LangfuseMediaView.clienttest.tsx` → `Tests  1 passed (1)`
- `pnpm --filter web run test-client MediaReferenceTag.clienttest.tsx MediaTag.clienttest.tsx` → `Tests  7 passed (7)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Langfuse media-view client test to expect the accessible name used by field-limit attachment chips.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The updated assertion matches the accessible name produced by the production component path and agrees with sibling component tests.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): align field-limit media test w..."](https://github.com/langfuse/langfuse/commit/e686030275700520d50b80bc9d0d14b7b9b7e2a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48739765)</sub>

<!-- /greptile_comment -->