### PR TITLE
feat(ingestion): measure overflow processing duration

### DIFF
--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
@@ -147,6 +147,10 @@ describe("applyObservationFieldOverflow", () => {
         Buffer.byteLength(mediaReference("output-media")) -
         Buffer.byteLength(mediaReference("metadata-media")),
     });
+    expect(mocks.recordDistribution).toHaveBeenCalledWith(
+      "langfuse.ingestion.observation_field_overflow.processing_duration_ms",
+      expect.any(Number),
+    );
   });
 
   it("applies the limit to each metadata value rather than their aggregate size", async () => {
@@ -323,6 +327,10 @@ describe("applyObservationFieldOverflow", () => {
     outputUpload.resolve({ mediaId: "output-media", outcome: "uploaded" });
 
     await expect(resultPromise).resolves.toBe(eventRecord);
+    expect(mocks.recordDistribution).toHaveBeenCalledWith(
+      "langfuse.ingestion.observation_field_overflow.processing_duration_ms",
+      expect.any(Number),
+    );
     expect(mocks.logger.warn).toHaveBeenCalledWith(
       "Observation field overflow processing failed; persisting original record",
       {

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
@@ -54,39 +54,48 @@ export async function applyObservationFieldOverflow(
         name: "langfuse.ingestion.observation_field_overflow.process",
       },
       async (span) => {
-        const results = await uploadOverflowCandidates(
-          eventRecord,
-          candidates,
-          mediaBucket,
-        );
+        const startedAt = Date.now();
 
-        span.setAttributes({
-          "langfuse.project.id": eventRecord.project_id,
-          "langfuse.trace.id": eventRecord.trace_id,
-          "langfuse.observation.id": eventRecord.span_id,
-          "langfuse.ingestion.observation_field_overflow.candidates":
-            candidates.length,
-          "langfuse.ingestion.observation_field_overflow.fields":
-            candidates.map(({ field }) => field),
-          "langfuse.ingestion.observation_field_overflow.uploaded":
-            results.filter(({ outcome }) => outcome === "uploaded").length,
-          "langfuse.ingestion.observation_field_overflow.reused":
-            results.filter(({ outcome }) => outcome === "reused").length,
-          "langfuse.ingestion.observation_field_overflow.failed":
-            results.filter(({ outcome }) => outcome === "failed").length,
-          "langfuse.ingestion.observation_field_overflow.bytes_processed":
-            candidates.reduce(
-              (total, { originalBytes }) => total + originalBytes,
-              0,
-            ),
-          "langfuse.ingestion.observation_field_overflow.bytes_removed":
-            results.reduce(
-              (total, { bytesRemoved }) => total + bytesRemoved,
-              0,
-            ),
-        });
+        try {
+          const results = await uploadOverflowCandidates(
+            eventRecord,
+            candidates,
+            mediaBucket,
+          );
 
-        return applyOverflowResults(eventRecord, results);
+          span.setAttributes({
+            "langfuse.project.id": eventRecord.project_id,
+            "langfuse.trace.id": eventRecord.trace_id,
+            "langfuse.observation.id": eventRecord.span_id,
+            "langfuse.ingestion.observation_field_overflow.candidates":
+              candidates.length,
+            "langfuse.ingestion.observation_field_overflow.fields":
+              candidates.map(({ field }) => field),
+            "langfuse.ingestion.observation_field_overflow.uploaded":
+              results.filter(({ outcome }) => outcome === "uploaded").length,
+            "langfuse.ingestion.observation_field_overflow.reused":
+              results.filter(({ outcome }) => outcome === "reused").length,
+            "langfuse.ingestion.observation_field_overflow.failed":
+              results.filter(({ outcome }) => outcome === "failed").length,
+            "langfuse.ingestion.observation_field_overflow.bytes_processed":
+              candidates.reduce(
+                (total, { originalBytes }) => total + originalBytes,
+                0,
+              ),
+            "langfuse.ingestion.observation_field_overflow.bytes_removed":
+              results.reduce(
+                (total, { bytesRemoved }) => total + bytesRemoved,
+                0,
+              ),
+          });
+
+          return applyOverflowResults(eventRecord, results);
+        } finally {
+          recordDistribution(
+            "langfuse.ingestion.observation_field_overflow.processing_duration_ms",
+            Date.now() - startedAt,
+          );
+        }
       },
     );
   } catch (error) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15654.preview.langfuse.com](https://pr-15654.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

- record `langfuse.ingestion.observation_field_overflow.processing_duration_ms` around overflow upload processing
- emit the duration from `finally` so successful processing and unexpected processing failures are measured
- cover both outcomes in the existing processor tests

## Why

This completes the observability added in #15649 with the same duration signal used by OTEL media processing.

## Validation

- `Tests  20 passed (20)`
- worker typecheck passed
- `Tasks: 7 successful, 7 total` (lint)
- Prettier check passed

Linear: [LFE-14407](https://linear.app/clickhouse/issue/LFE-14407/set-a-hard-cap-on-large-observation-field-payloads)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an overflow-processing duration distribution metric emitted from a `finally` block, with tests covering successful and failed processing outcomes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new metric is emitted unconditionally after overflow processing, and the tests specifically exercise and verify both successful and exceptional outcomes.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ingestion): measure overflow proces..."](https://github.com/langfuse/langfuse/commit/f42a308bcf779ae2237260cbd053c7365b2f0ce5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48748901)</sub>

<!-- /greptile_comment -->