### PR TITLE
fix(worker): select earliest S3 event timestamp

### DIFF
--- a/worker/src/queues/__tests__/ingestionQueue.test.ts
+++ b/worker/src/queues/__tests__/ingestionQueue.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { getEarliestFileCreatedAt } from "../getEarliestFileCreatedAt";
+
+describe("getEarliestFileCreatedAt", () => {
+  it("returns the earliest timestamp when Date strings sort non-chronologically", () => {
+    const earlier = new Date("2026-07-29T12:00:00.000Z");
+    const later = new Date("2026-07-30T12:00:00.000Z");
+
+    expect(getEarliestFileCreatedAt([earlier, later])).toEqual(earlier);
+  });
+});

--- a/worker/src/queues/getEarliestFileCreatedAt.ts
+++ b/worker/src/queues/getEarliestFileCreatedAt.ts
@@ -1,0 +1,5 @@
+import { minBy } from "lodash";
+
+export const getEarliestFileCreatedAt = (
+  createdAtDates: readonly Date[],
+): Date | undefined => minBy(createdAtDates, (date) => date.getTime());

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -29,6 +29,7 @@ import { IngestionService } from "../services/IngestionService";
 import { ClickhouseWriter, TableName } from "../services/ClickhouseWriter";
 import { chunk } from "lodash";
 import { randomUUID } from "crypto";
+import { getEarliestFileCreatedAt } from "./getEarliestFileCreatedAt";
 
 export const ingestionQueueProcessorBuilder = (
   enableRedirectToSecondaryQueue: boolean,
@@ -226,10 +227,9 @@ export const ingestionQueueProcessorBuilder = (
       );
 
       const firstS3WriteTime =
-        eventFiles
-          .map((fileRef) => fileRef.createdAt)
-          .sort()
-          .shift() ?? new Date();
+        getEarliestFileCreatedAt(
+          eventFiles.map((fileRef) => fileRef.createdAt),
+        ) ?? new Date();
 
       if (events.length === 0) {
         logger.warn(


### PR DESCRIPTION
## What does this PR do?

The ingestion worker used the default `Array.sort()` behavior to find the earliest S3 event timestamp. `Date` values are therefore compared as strings, where weekday names can place a later date first. That incorrect timestamp is then passed to `IngestionService.mergeAndWrite()` as `createdAtTimestamp`.

This change selects the minimum by epoch time without sorting the input. The regression test uses adjacent dates whose string order is not chronological.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code

## Verification

- `pnpm --filter worker run test ingestionQueue.test.ts`
- `pnpm --filter worker run lint`
- `pnpm --filter worker run build:check`