### PR TITLE
fix(evals): propagate evaluator metadata to generation spans

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -199,6 +199,16 @@ export function createAiSdkTelemetryCapture(params: {
             [LangfuseOtelSpanAttributes.TRACE_USER_ID]: traceSinkParams.userId,
           }
         : {}),
+      // Evaluator costs are recorded on these generation spans. Preserve the
+      // evaluator metadata here so cost aggregation does not need to rebuild
+      // traces from their root spans.
+      ...(traceSinkParams.metadata
+        ? {
+            [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: JSON.stringify(
+              traceSinkParams.metadata,
+            ),
+          }
+        : {}),
     },
   });
 

--- a/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
@@ -49,6 +49,7 @@ const traceSinkParams: TraceSinkParams = {
   traceId: VALID_TRACE_ID,
   traceName: "Execute evaluator: helpfulness",
   environment: "langfuse-llm-judge",
+  metadata: { job_configuration_id: "evaluator-1" },
 };
 
 const modelParams: ModelParams = {
@@ -224,6 +225,7 @@ describe("AI SDK telemetry integration", () => {
       model: "gpt-4o",
       usageDetails: { input: 3, output: 5 },
       environment: "langfuse-llm-judge",
+      metadata: { job_configuration_id: "evaluator-1" },
     });
   });
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3344,6 +3344,8 @@ const getEvaluatorCostMetricsByIds = async <
 
   // Evaluator metadata lives on the parent span while cost lives on child
   // events, so rebuild complete trace totals before filtering evaluators.
+  // Keep this compatibility path until 2026-08-07, when the seven-day reporting
+  // window contains only spans written with evaluator metadata on their children.
   const traceCostsBuilder = new EventsAggQueryBuilder({
     projectId,
     groupByColumn: "e.trace_id",


### PR DESCRIPTION
## Summary

- Write evaluator trace metadata, including `job_configuration_id`, to AI SDK generation spans where evaluator costs are recorded.
- Keep the existing root-span cost aggregation through 2026-08-07 so the seven-day reporting window remains complete during rollout.
- Add integration coverage for metadata materialization on the generation event.

## Linear

- [LFE-14663](https://linear.app/clickhouse/issue/LFE-14663/write-evaluator-ids-on-all-observations-not-just-parent)

## Major Decisions

- Retain the current cost query during the seven-day transition; simplifying it before then would omit costs from pre-rollout evaluator traces.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Propagates evaluator trace metadata to AI SDK generation spans so evaluator costs can be attributed directly.
- Serializes trace metadata into the generation span’s observation metadata attribute.
- Extends integration coverage to verify `job_configuration_id` materialization on generation events.
- Documents the temporary root-span cost aggregation compatibility window.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The generation span uses the established JSON encoding for observation metadata, the ingestion processor materializes that representation correctly, and the integration test covers the intended evaluator metadata flow.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Evaluator
    participant Telemetry as AI SDK Telemetry
    participant Generation as Generation Span
    participant Ingestion
    Evaluator->>Telemetry: TraceSinkParams with evaluator metadata
    Telemetry->>Generation: Set observation metadata attribute
    Generation->>Ingestion: Export completed span
    Ingestion->>Ingestion: Parse metadata onto generation event
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): propagate evaluator metadata..."](https://github.com/langfuse/langfuse/commit/68e4541f1c80052b73cf615a9d9ff9742b5f4d7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48974214)</sub>

<!-- /greptile_comment -->