### PR TITLE
fix(evals): propagate evaluator metadata to generation spans

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -199,6 +199,16 @@ export function createAiSdkTelemetryCapture(params: {
             [LangfuseOtelSpanAttributes.TRACE_USER_ID]: traceSinkParams.userId,
           }
         : {}),
+      // Evaluator costs are recorded on these generation spans. Preserve the
+      // evaluator metadata here so cost aggregation does not need to rebuild
+      // traces from their root spans.
+      ...(traceSinkParams.metadata
+        ? {
+            [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: JSON.stringify(
+              traceSinkParams.metadata,
+            ),
+          }
+        : {}),
     },
   });
 

--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -185,6 +185,14 @@ export function createAiSdkTelemetryCapture(params: {
       }
     : undefined;
 
+  const childSpanMetadata = traceSinkParams.metadata
+    ? Object.fromEntries(
+        Object.entries(traceSinkParams.metadata).filter(
+          ([key]) => key !== "structured_output_schema",
+        ),
+      )
+    : undefined;
+
   const otelIntegration = createGenerationSpanTelemetry({
     tracer,
     attributes: {
@@ -199,14 +207,12 @@ export function createAiSdkTelemetryCapture(params: {
             [LangfuseOtelSpanAttributes.TRACE_USER_ID]: traceSinkParams.userId,
           }
         : {}),
-      // Evaluator costs are recorded on these generation spans. Preserve the
-      // evaluator metadata here so cost aggregation does not need to rebuild
-      // traces from their root spans.
-      ...(traceSinkParams.metadata
+      // Keep useful trace context on child spans, but leave the potentially
+      // large output schema on the root trace only.
+      ...(childSpanMetadata
         ? {
-            [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: JSON.stringify(
-              traceSinkParams.metadata,
-            ),
+            [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]:
+              JSON.stringify(childSpanMetadata),
           }
         : {}),
     },

--- a/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
@@ -49,6 +49,7 @@ const traceSinkParams: TraceSinkParams = {
   traceId: VALID_TRACE_ID,
   traceName: "Execute evaluator: helpfulness",
   environment: "langfuse-llm-judge",
+  metadata: { job_configuration_id: "evaluator-1" },
 };
 
 const modelParams: ModelParams = {
@@ -224,6 +225,7 @@ describe("AI SDK telemetry integration", () => {
       model: "gpt-4o",
       usageDetails: { input: 3, output: 5 },
       environment: "langfuse-llm-judge",
+      metadata: { job_configuration_id: "evaluator-1" },
     });
   });
 

--- a/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetryIntegration.test.ts
@@ -244,6 +244,16 @@ describe("AI SDK telemetry integration", () => {
         traceId: experimentTraceId,
         traceName: "dataset-run-item-abc12",
         environment: "langfuse-prompt-experiment",
+        metadata: {
+          dataset_id: "dataset-1",
+          dataset_item_id: "item-1",
+          structured_output_schema: {
+            type: "object",
+            properties: { answer: { type: "string" } },
+          },
+          experiment_name: "run name",
+          experiment_run_name: "run-abc",
+        },
         eventsWriter: {
           experimentContext: {
             id: "run-1",
@@ -308,6 +318,13 @@ describe("AI SDK telemetry integration", () => {
       expect(child.environment).toBe("langfuse-prompt-experiment");
       expect(child.experimentItemRootSpanId).toBe(root.spanId);
       expect(child.spanId).not.toBe(root.spanId);
+      expect(child.metadata).toMatchObject({
+        dataset_id: "dataset-1",
+        dataset_item_id: "item-1",
+        experiment_name: "run name",
+        experiment_run_name: "run-abc",
+      });
+      expect(child.metadata).not.toHaveProperty("structured_output_schema");
     }
   });
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3344,6 +3344,8 @@ const getEvaluatorCostMetricsByIds = async <
 
   // Evaluator metadata lives on the parent span while cost lives on child
   // events, so rebuild complete trace totals before filtering evaluators.
+  // Keep this compatibility path until 2026-08-07, when the seven-day reporting
+  // window contains only spans written with evaluator metadata on their children.
   const traceCostsBuilder = new EventsAggQueryBuilder({
     projectId,
     groupByColumn: "e.trace_id",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15665.preview.langfuse.com](https://pr-15665.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Write evaluator trace metadata, including `job_configuration_id`, to AI SDK generation spans where evaluator costs are recorded.
- Keep the existing root-span cost aggregation through 2026-08-07 so the seven-day reporting window remains complete during rollout.
- Add integration coverage for metadata materialization on the generation event.

## Linear

- [LFE-14663](https://linear.app/clickhouse/issue/LFE-14663/write-evaluator-ids-on-all-observations-not-just-parent)

## Major Decisions

- Retain the current cost query during the seven-day transition; simplifying it before then would omit costs from pre-rollout evaluator traces.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Propagates evaluator trace metadata to AI SDK generation spans and verifies that it materializes on generation events, while documenting the temporary root-span cost aggregation compatibility window.
- Serializes trace metadata into the generation span’s observation metadata attribute.
- Extends integration coverage for `job_configuration_id` materialization.
- Documents retaining the existing cost query through 2026-08-07.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with evaluator metadata correctly propagated and covered through the ingestion integration path.

The evaluator path supplies string-valued execution metadata, the generation span serializes it using the established observation metadata attribute, and the integration test confirms the expected stored shape.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): propagate evaluator metadata..."](https://github.com/langfuse/langfuse/commit/68e4541f1c80052b73cf615a9d9ff9742b5f4d7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48974522)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)
- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->