### PR TITLE
fix(in-app-agent): keep drafts editable while running

### DIFF
--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -71,7 +71,7 @@ export function ControlledInAppAgentWindow(
     pendingToolApprovals,
     shouldFlush: error !== null,
   });
-  const isInputDisabled =
+  const isConversationInteractionDisabled =
     selectedConversationIsWriteLocked || isSelectedConversationHydrating;
   const isAssistantTurnInProgress =
     isRunning ||
@@ -127,7 +127,7 @@ export function ControlledInAppAgentWindow(
       isAssistantTurnInProgress={isAssistantTurnInProgress}
       isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}
-      isInputDisabled={isInputDisabled}
+      isConversationInteractionDisabled={isConversationInteractionDisabled}
       disablePendingToolApprovalActions={selectedConversationIsWriteLocked}
       messages={drawerMessages}
       quickActionContext={quickActionContext}

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -73,6 +73,12 @@ export function ControlledInAppAgentWindow(
   });
   const isInputDisabled =
     selectedConversationIsWriteLocked || isSelectedConversationHydrating;
+  const isAssistantTurnInProgress =
+    isRunning ||
+    isAnimating ||
+    isSubmitting ||
+    pendingToolApprovals.length > 0 ||
+    displayedPendingToolApprovals.length > 0;
   const displayError = selectedConversationIsWriteLocked
     ? ({
         type: "generic",
@@ -118,12 +124,7 @@ export function ControlledInAppAgentWindow(
   return (
     <InAppAgentWindow
       error={displayError}
-      isAssistantTurnInProgress={
-        isRunning ||
-        isAnimating ||
-        isSubmitting ||
-        displayedPendingToolApprovals.length > 0
-      }
+      isAssistantTurnInProgress={isAssistantTurnInProgress}
       isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}
       isInputDisabled={isInputDisabled}

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -72,12 +72,7 @@ export function ControlledInAppAgentWindow(
     shouldFlush: error !== null,
   });
   const isInputDisabled =
-    isRunning ||
-    isAnimating ||
-    isSubmitting ||
-    selectedConversationIsWriteLocked ||
-    isSelectedConversationHydrating ||
-    pendingToolApprovals.length > 0;
+    selectedConversationIsWriteLocked || isSelectedConversationHydrating;
   const displayError = selectedConversationIsWriteLocked
     ? ({
         type: "generic",
@@ -124,7 +119,10 @@ export function ControlledInAppAgentWindow(
     <InAppAgentWindow
       error={displayError}
       isAssistantTurnInProgress={
-        isRunning || isAnimating || displayedPendingToolApprovals.length > 0
+        isRunning ||
+        isAnimating ||
+        isSubmitting ||
+        displayedPendingToolApprovals.length > 0
       }
       isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -21,7 +21,7 @@ const controlledAgent = vi.hoisted(() => ({
     liveMessageVersion: 0,
     loadMoreConversations: vi.fn(),
     messages: [],
-    pendingToolApprovals: [],
+    pendingToolApprovals: [] as Array<{ id: string }>,
     approveToolCall: vi.fn(),
     rejectToolCall: vi.fn(),
     selectedConversationId: undefined,
@@ -187,6 +187,8 @@ describe("InAppAgentWindow quick actions", () => {
 describe("ControlledInAppAgentWindow composer", () => {
   it("keeps a draft editable but prevents submitting it while an assistant turn is active", () => {
     const onSubmit = vi.fn().mockResolvedValue(true);
+    controlledAgent.value.isRunning = true;
+    controlledAgent.value.pendingToolApprovals = [];
     controlledAgent.value.submit = onSubmit;
     render(
       <TooltipProvider>
@@ -215,5 +217,58 @@ describe("ControlledInAppAgentWindow composer", () => {
 
     fireEvent.submit(form);
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("keeps navigation disabled while an approval is pending", () => {
+    controlledAgent.value.isRunning = false;
+    controlledAgent.value.pendingToolApprovals = [{ id: "approval-1" }];
+    controlledAgent.value.submit = vi.fn();
+
+    render(
+      <TooltipProvider>
+        <ControlledInAppAgentWindow
+          isExpanded={false}
+          onClose={vi.fn()}
+          onDeleteConversation={vi.fn()}
+          onExpandedChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Start new conversation" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Conversation history" }),
+    ).toBeDisabled();
+  });
+});
+
+describe("InAppAgentWindow focus", () => {
+  it("refocuses the composer when an active turn completes", () => {
+    const { rerender } = render(
+      <>
+        <button type="button">Other control</button>
+        {windowElement({ isAssistantTurnInProgress: true })}
+      </>,
+    );
+
+    screen.getByRole("button", { name: "Other control" }).focus();
+    expect(screen.getByRole("button", { name: "Other control" })).toHaveFocus();
+
+    rerender(
+      <>
+        <button type="button">Other control</button>
+        {windowElement({ isAssistantTurnInProgress: false })}
+      </>,
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "Message the assistant" }),
+    ).toHaveFocus();
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -66,7 +66,7 @@ function windowElement(
     hasMoreConversations: false,
     isAssistantTurnInProgress: false,
     isExpanded: false,
-    isInputDisabled: false,
+    isConversationInteractionDisabled: false,
     isLoadingMoreConversations: false,
     messages: [],
     onApproveToolCall: vi.fn(),

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -185,6 +185,33 @@ describe("InAppAgentWindow quick actions", () => {
 });
 
 describe("ControlledInAppAgentWindow composer", () => {
+  it("keeps a draft editable but prevents submitting it while rate limited", () => {
+    const onSubmit = vi.fn().mockResolvedValue(true);
+    render(
+      windowElement({
+        error: { type: "rate_limit", retryAt: Date.now() + 60_000 },
+        onSubmit,
+      }),
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Message the assistant",
+    });
+    fireEvent.change(input, { target: { value: "Follow up" } });
+
+    expect(input).toHaveValue("Follow up");
+    expect(input).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+
+    const form = input.closest("form");
+    if (!form) {
+      throw new Error("Expected the assistant composer to render a form");
+    }
+
+    fireEvent.submit(form);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("keeps a draft editable but prevents submitting it while an assistant turn is active", () => {
     const onSubmit = vi.fn().mockResolvedValue(true);
     controlledAgent.value.isRunning = true;

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -5,11 +5,51 @@ import {
   InAppAgentWindow,
   type InAppAgentWindowProps,
 } from "./InAppAgentWindow";
+import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
 
 const capture = vi.fn();
+const controlledAgent = vi.hoisted(() => ({
+  value: {
+    conversations: [],
+    error: null,
+    hasMoreConversations: false,
+    isLoadingMoreConversations: false,
+    isRunning: true,
+    isSelectedConversationHydrating: false,
+    isSubmitting: false,
+    invalidateConversations: vi.fn(),
+    liveMessageVersion: 0,
+    loadMoreConversations: vi.fn(),
+    messages: [],
+    pendingToolApprovals: [],
+    approveToolCall: vi.fn(),
+    rejectToolCall: vi.fn(),
+    selectedConversationId: undefined,
+    selectedConversationIsWriteLocked: false,
+    submit: vi.fn(),
+    submitFeedback: vi.fn(),
+  },
+}));
 
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
   usePostHogClientCapture: () => capture,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ asPath: "/" }),
+}));
+
+vi.mock("./InAppAiAgentProvider", () => ({
+  useInAppAiAgent: () => controlledAgent.value,
+}));
+
+vi.mock("./useSmoothStreamingMessages", () => ({
+  useSmoothStreamingMessages: () => ({
+    isAnimating: false,
+    messages: [],
+    pendingToolApprovals: [],
+    runningToolCallIds: [],
+  }),
 }));
 
 // jsdom does not implement Element scrolling.
@@ -141,5 +181,39 @@ describe("InAppAgentWindow quick actions", () => {
     expect(
       screen.getByRole("button", { name: /^Create a prompt/ }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("ControlledInAppAgentWindow composer", () => {
+  it("keeps a draft editable but prevents submitting it while an assistant turn is active", () => {
+    const onSubmit = vi.fn().mockResolvedValue(true);
+    controlledAgent.value.submit = onSubmit;
+    render(
+      <TooltipProvider>
+        <ControlledInAppAgentWindow
+          isExpanded={false}
+          onClose={vi.fn()}
+          onDeleteConversation={vi.fn()}
+          onExpandedChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Message the assistant",
+    });
+    fireEvent.change(input, { target: { value: "Follow up" } });
+
+    expect(input).toHaveValue("Follow up");
+    expect(input).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+
+    const form = input.closest("form");
+    if (!form) {
+      throw new Error("Expected the assistant composer to render a form");
+    }
+
+    fireEvent.submit(form);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -589,7 +589,7 @@ const meta = preview.meta({
   args: {
     error: null,
     isExpanded: false,
-    isInputDisabled: false,
+    isConversationInteractionDisabled: false,
     conversations,
     hasMoreConversations: false,
     isLoadingMoreConversations: false,
@@ -617,7 +617,7 @@ const meta = preview.meta({
 export const ToolApprovalRequired = meta.story({
   args: {
     isAssistantTurnInProgress: true,
-    isInputDisabled: true,
+    isConversationInteractionDisabled: true,
     selectedConversationId: "conversation-1",
     messages: [
       {
@@ -867,7 +867,7 @@ export const LoadingResponse = meta.story({
 export const LoadingAfterToolCall = meta.story({
   args: {
     isAssistantTurnInProgress: true,
-    isInputDisabled: true,
+    isConversationInteractionDisabled: true,
     messages: [
       {
         id: "user-1",
@@ -952,7 +952,7 @@ export const LoadingAfterToolCall = meta.story({
 export const Connecting = meta.story({
   args: {
     isAssistantTurnInProgress: true,
-    isInputDisabled: true,
+    isConversationInteractionDisabled: true,
     messages: [
       {
         id: "user-1",
@@ -998,7 +998,7 @@ export const RateLimited = meta.story({
   args: {
     error: null,
     isAssistantTurnInProgress: true,
-    isInputDisabled: true,
+    isConversationInteractionDisabled: true,
     messages: [
       {
         id: "approval-1",
@@ -1062,7 +1062,10 @@ export const RefocusAfterSubmit = meta.story({
   },
   render: function Render(args) {
     const [isExpanded, setIsExpanded] = useState(args.isExpanded);
-    const [isInputDisabled, setIsInputDisabled] = useState(false);
+    const [
+      isConversationInteractionDisabled,
+      setIsConversationInteractionDisabled,
+    ] = useState(false);
     const [messages, setMessages] = useState<InAppAgentWindowMessage[]>([
       {
         id: "user-1",
@@ -1089,14 +1092,16 @@ export const RefocusAfterSubmit = meta.story({
             {...args}
             isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
             isExpanded={isExpanded}
-            isInputDisabled={isInputDisabled}
+            isConversationInteractionDisabled={
+              isConversationInteractionDisabled
+            }
             messages={messages}
             onExpandedChange={(isExpanded) => {
               setIsExpanded(isExpanded);
               args.onExpandedChange(isExpanded);
             }}
             onSubmit={(input) => {
-              setIsInputDisabled(true);
+              setIsConversationInteractionDisabled(true);
               window.setTimeout(() => {
                 setMessages((currentMessages) => [
                   ...currentMessages,
@@ -1109,7 +1114,7 @@ export const RefocusAfterSubmit = meta.story({
                     },
                   },
                 ]);
-                setIsInputDisabled(false);
+                setIsConversationInteractionDisabled(false);
               }, 50);
 
               args.onSubmit(input);
@@ -1147,7 +1152,7 @@ export const FeedbackControlsWaitForTurnEnd = meta.story({
   name: "(Test) Feedback Controls Wait For Turn End",
   args: {
     selectedConversationId: "conversation-1",
-    isInputDisabled: true,
+    isConversationInteractionDisabled: true,
     isAssistantTurnInProgress: true,
     onSubmitFeedback: fn(),
     messages: [

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -998,7 +998,7 @@ export const RateLimited = meta.story({
   args: {
     error: null,
     isAssistantTurnInProgress: true,
-    isConversationInteractionDisabled: true,
+    isConversationInteractionDisabled: false,
     messages: [
       {
         id: "approval-1",
@@ -1041,7 +1041,7 @@ export const RateLimited = meta.story({
     await expect(alert).toHaveTextContent("Try again in about");
     await expect(
       canvas.getByRole("textbox", { name: "Message the assistant" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     await expect(
       canvas.getByRole("button", { name: "Confirm" }),
     ).toBeDisabled();

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -263,7 +263,7 @@ export type InAppAgentWindowProps = {
   isAssistantTurnInProgress: boolean;
   isHeaderDragHandleEnabled?: boolean;
   isExpanded: boolean;
-  isInputDisabled: boolean;
+  isConversationInteractionDisabled: boolean;
   isLoadingMoreConversations: boolean;
   messages: InAppAgentWindowMessage[];
   onExpandedChange: (isExpanded: boolean) => void;
@@ -364,7 +364,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     isAssistantTurnInProgress,
     isHeaderDragHandleEnabled = false,
     isExpanded,
-    isInputDisabled: baseIsInputDisabled,
+    isConversationInteractionDisabled,
     isLoadingMoreConversations,
     messages,
     onDeleteConversation,
@@ -390,13 +390,13 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   // No auto-focus on mobile — it springs the keyboard and buries the panel.
   const isMobile = useIsMobile();
   const isRateLimited = isInAppAgentRateLimited(error);
-  const isInputDisabled = baseIsInputDisabled || isRateLimited;
-  const isSubmitDisabled = isInputDisabled || isAssistantTurnInProgress;
+  const isComposerDisabled = isConversationInteractionDisabled || isRateLimited;
+  const isSubmitDisabled = isComposerDisabled || isAssistantTurnInProgress;
   const viewportRef = useRef<HTMLDivElement>(null);
   const isAutoScrollAttachedRef = useRef(true);
   const previousScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const previousIsInputDisabledRef = useRef(isInputDisabled);
+  const previousIsInputDisabledRef = useRef(isComposerDisabled);
   const previousIsAssistantTurnInProgressRef = useRef(
     isAssistantTurnInProgress,
   );
@@ -474,9 +474,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
 
   // Update after refs commit so setInputRef can compare the previous disabled state.
   useEffect(() => {
-    previousIsInputDisabledRef.current = isInputDisabled;
+    previousIsInputDisabledRef.current = isComposerDisabled;
     previousIsAssistantTurnInProgressRef.current = isAssistantTurnInProgress;
-  }, [isAssistantTurnInProgress, isInputDisabled]);
+  }, [isAssistantTurnInProgress, isComposerDisabled]);
 
   const setInputRef = useCallback(
     (input: HTMLTextAreaElement | null) => {
@@ -485,7 +485,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
       // Skip on mobile: refocusing after a turn re-springs the keyboard, even
       // for the quick-action flow that never focused the input.
       const shouldRefocusInput =
-        ((previousIsInputDisabledRef.current && !isInputDisabled) ||
+        ((previousIsInputDisabledRef.current && !isComposerDisabled) ||
           (previousIsAssistantTurnInProgressRef.current &&
             !isAssistantTurnInProgress)) &&
         !isMobile;
@@ -494,7 +494,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         input.focus();
       }
     },
-    [isAssistantTurnInProgress, isInputDisabled, isMobile],
+    [isAssistantTurnInProgress, isComposerDisabled, isMobile],
   );
 
   useEffect(() => {
@@ -542,7 +542,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={baseIsInputDisabled || isAssistantTurnInProgress}
+                disabled={
+                  isConversationInteractionDisabled || isAssistantTurnInProgress
+                }
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -568,7 +570,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     variant="ghost"
                     size="icon"
                     className="size-6 shrink-0"
-                    disabled={baseIsInputDisabled || isAssistantTurnInProgress}
+                    disabled={
+                      isConversationInteractionDisabled ||
+                      isAssistantTurnInProgress
+                    }
                     aria-label="Conversation history"
                   >
                     <History className="size-3" />
@@ -616,7 +621,8 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                         size="icon-xs"
                         className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
                         disabled={
-                          baseIsInputDisabled || isAssistantTurnInProgress
+                          isConversationInteractionDisabled ||
+                          isAssistantTurnInProgress
                         }
                         aria-label="Delete conversation"
                         onClick={(event) => {
@@ -786,7 +792,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       role={message.role}
                       content={message.content}
                       isCompact={!isExpanded}
-                      isFeedbackDisabled={baseIsInputDisabled}
+                      isFeedbackDisabled={isConversationInteractionDisabled}
                       onSubmitFeedback={
                         feedbackRunId
                           ? (params) =>
@@ -945,7 +951,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   event.currentTarget.form?.requestSubmit();
                 }
               }}
-              disabled={isInputDisabled}
+              disabled={isComposerDisabled}
               aria-label="Message the assistant"
               placeholder="Let me know what I can do for you..."
               rows={1}

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -397,6 +397,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const previousScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const previousIsInputDisabledRef = useRef(isInputDisabled);
+  const previousIsAssistantTurnInProgressRef = useRef(
+    isAssistantTurnInProgress,
+  );
   const [input, setInput] = useState("");
   const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
     useState(false);
@@ -472,7 +475,8 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   // Update after refs commit so setInputRef can compare the previous disabled state.
   useEffect(() => {
     previousIsInputDisabledRef.current = isInputDisabled;
-  }, [isInputDisabled]);
+    previousIsAssistantTurnInProgressRef.current = isAssistantTurnInProgress;
+  }, [isAssistantTurnInProgress, isInputDisabled]);
 
   const setInputRef = useCallback(
     (input: HTMLTextAreaElement | null) => {
@@ -481,13 +485,16 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
       // Skip on mobile: refocusing after a turn re-springs the keyboard, even
       // for the quick-action flow that never focused the input.
       const shouldRefocusInput =
-        previousIsInputDisabledRef.current && !isInputDisabled && !isMobile;
+        ((previousIsInputDisabledRef.current && !isInputDisabled) ||
+          (previousIsAssistantTurnInProgressRef.current &&
+            !isAssistantTurnInProgress)) &&
+        !isMobile;
 
       if (input && shouldRefocusInput) {
         input.focus();
       }
     },
-    [isInputDisabled, isMobile],
+    [isAssistantTurnInProgress, isInputDisabled, isMobile],
   );
 
   useEffect(() => {
@@ -535,7 +542,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={baseIsInputDisabled}
+                disabled={baseIsInputDisabled || isAssistantTurnInProgress}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -561,7 +568,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     variant="ghost"
                     size="icon"
                     className="size-6 shrink-0"
-                    disabled={baseIsInputDisabled}
+                    disabled={baseIsInputDisabled || isAssistantTurnInProgress}
                     aria-label="Conversation history"
                   >
                     <History className="size-3" />
@@ -608,7 +615,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                         variant="ghost"
                         size="icon-xs"
                         className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
-                        disabled={baseIsInputDisabled}
+                        disabled={
+                          baseIsInputDisabled || isAssistantTurnInProgress
+                        }
                         aria-label="Delete conversation"
                         onClick={(event) => {
                           event.preventDefault();

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -390,8 +390,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   // No auto-focus on mobile — it springs the keyboard and buries the panel.
   const isMobile = useIsMobile();
   const isRateLimited = isInAppAgentRateLimited(error);
-  const isComposerDisabled = isConversationInteractionDisabled || isRateLimited;
-  const isSubmitDisabled = isComposerDisabled || isAssistantTurnInProgress;
+  const isComposerDisabled = isConversationInteractionDisabled;
+  const isSubmitDisabled =
+    isComposerDisabled || isRateLimited || isAssistantTurnInProgress;
   const viewportRef = useRef<HTMLDivElement>(null);
   const isAutoScrollAttachedRef = useRef(true);
   const previousScrollTopRef = useRef(0);

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -391,6 +391,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const isMobile = useIsMobile();
   const isRateLimited = isInAppAgentRateLimited(error);
   const isInputDisabled = baseIsInputDisabled || isRateLimited;
+  const isSubmitDisabled = isInputDisabled || isAssistantTurnInProgress;
   const viewportRef = useRef<HTMLDivElement>(null);
   const isAutoScrollAttachedRef = useRef(true);
   const previousScrollTopRef = useRef(0);
@@ -432,7 +433,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const submitInput = (content: string, options?: InAppAgentSubmitOptions) => {
     const trimmedContent = content.trim();
 
-    if (!trimmedContent || isInputDisabled) {
+    if (!trimmedContent || isSubmitDisabled) {
       return;
     }
 
@@ -717,7 +718,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   key={`${selectedConversationId ?? "new"}:${quickActionResetKey}`}
                   focusedActions={focusedQuickActions}
                   initialContext={quickActionContext}
-                  isDisabled={isInputDisabled}
+                  isDisabled={isSubmitDisabled}
                   onSelectAction={(action, context, position) => {
                     capture("in_app_agent:quick_action_started", {
                       quickActionKey: action.id,
@@ -953,7 +954,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 className="h-8 w-8 rounded-md border"
                 aria-label="Send message"
                 variant="outline"
-                disabled={isInputDisabled || !input.trim()}
+                disabled={isSubmitDisabled || !input.trim()}
               >
                 <SendHorizontal className="h-4 w-4" />
               </Button>
@@ -965,7 +966,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   type="submit"
                   className="h-8 w-fit rounded-md px-3"
                   aria-label="Send message"
-                  disabled={isInputDisabled || !input.trim()}
+                  disabled={isSubmitDisabled || !input.trim()}
                   onClick={(e) => {
                     e.stopPropagation();
                   }}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15666.preview.langfuse.com](https://pr-15666.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Fixes [LFE-14358](https://linear.app/clickhouse/issue/LFE-14358/assistant-we-shouldnt-block-input-while-the-agent-is-in-progress) with a component-only change:

- keep the assistant composer editable while a turn is running, streaming, submitting, or awaiting tool approval
- continue blocking every submission path (Send, Enter/form submission, and quick actions) until the turn completes
- retain existing write-lock, hydration, and rate-limit input restrictions

No client queue, persistence, or backend changes are introduced.

## Why

The composer treated an active assistant turn as a full input lock, preventing users from drafting their next request while waiting. Editing and submitting now have separate guards.

## Verification

- `pnpm --filter web run test-client src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx` — `Tests 3 passed (3)`
- `pnpm --filter web run typecheck` — passed
- Browser review in Storybook's `Streaming` state: entered a draft during streaming; the text stayed editable and `Send message` remained disabled.
- focused ESLint check for the changed test passed.

`pnpm --filter web run lint` and the repository pre-commit hook remain blocked by 291 pre-existing warnings in the in-app-agent area (`web#lint`); this diff introduces no lint errors.

Impacted package: `web`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates composer editing restrictions from submission restrictions.
- Keeps drafts editable while an assistant turn is running, streaming, submitting, or awaiting approval.
- Applies the active-turn submission guard to forms, send buttons, Enter submission, and quick actions.
- Adds a client test covering editable drafts and blocked form submission during a running turn.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The pending-approval transition must be fixed before merging because it briefly permits a new submission while approval remains unresolved.

The submission guard relies on a smoothed approval list that can lag behind provider state after suspension, and the provider has no pending-approval check to close that window.

**Files Needing Attention:** web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx:125
**Pending approval guard lags**

When an agent run suspends for tool approval, `displayedPendingToolApprovals` can lag behind the provider's authoritative approval state after `isRunning` clears, enabling the composer to submit another message while the approval remains unresolved.

```suggestion
        pendingToolApprovals.length > 0
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): keep drafts editable ..."](https://github.com/langfuse/langfuse/commit/b1c432b3e1e0e9f63810035b828b0c2ef37d3f94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48979710)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->