### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/licencecheck.yml
+++ b/.github/workflows/licencecheck.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install license-checker
         # Deliberate ad-hoc install: the license-check tooling is not part of the workspace lockfile.


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `24` (using `24` where a concrete pin is needed).

- `.github/workflows/licencecheck.yml`
  - `node-version: 18` → `node-version: 24`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `24`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns the licence-check workflow with the repository’s declared Node.js runtime.
- Updates `actions/setup-node` from Node.js 18 to Node.js 24.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the workflow runtime now matches the repository’s declared Node.js version without introducing an established failure.

The only behavioral change updates the licence-check job from Node.js 18 to the repository-standard Node.js 24, and no concrete incompatibility in the invoked workflow commands was found.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): align workflow Node.js version ..."](https://github.com/langfuse/langfuse/commit/e6790fceeb2ea04338cc9cfbd9bc41c7826b6591) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48988364)</sub>

<!-- /greptile_comment -->