### PR TITLE
feat(media): track association origin

### DIFF
--- a/packages/shared/prisma/migrations/20260731100000_add_media_association_origin/migration.sql
+++ b/packages/shared/prisma/migrations/20260731100000_add_media_association_origin/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "MediaAssociationOrigin" AS ENUM (
+  'UNKNOWN',
+  'CLIENT_UPLOAD',
+  'INGESTION_MEDIA_EXTRACTION',
+  'INGESTION_FIELD_OVERFLOW'
+);
+
+-- AlterTable
+-- PostgreSQL 11+ stores this non-volatile default in table metadata, so the
+-- large association tables are not rewritten or scanned.
+ALTER TABLE "trace_media"
+ADD COLUMN "origin" "MediaAssociationOrigin" NOT NULL DEFAULT 'UNKNOWN';
+
+ALTER TABLE "observation_media"
+ADD COLUMN "origin" "MediaAssociationOrigin" NOT NULL DEFAULT 'UNKNOWN';

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1258,6 +1258,13 @@ model Media {
   @@map("media")
 }
 
+enum MediaAssociationOrigin {
+  UNKNOWN
+  CLIENT_UPLOAD
+  INGESTION_MEDIA_EXTRACTION
+  INGESTION_FIELD_OVERFLOW
+}
+
 model TraceMedia {
   id        String   @id @default(cuid())
   projectId String   @map("project_id")
@@ -1266,6 +1273,7 @@ model TraceMedia {
   mediaId   String   @map("media_id")
   traceId   String   @map("trace_id")
   field     String   @map("field")
+  origin    MediaAssociationOrigin @default(UNKNOWN)
 
   @@unique([projectId, traceId, mediaId, field])
   @@index([projectId, mediaId])
@@ -1281,6 +1289,7 @@ model ObservationMedia {
   traceId       String   @map("trace_id")
   observationId String   @map("observation_id")
   field         String   @map("field")
+  origin        MediaAssociationOrigin @default(UNKNOWN)
 
   @@unique([projectId, traceId, observationId, mediaId, field])
   @@index([projectId, mediaId])

--- a/packages/shared/src/server/media/mediaService.test.ts
+++ b/packages/shared/src/server/media/mediaService.test.ts
@@ -29,6 +29,8 @@ vi.mock("../s3", () => ({
   getS3MediaStorageClient: vi.fn(() => ({ uploadFile: mocks.uploadFile })),
 }));
 
+import { MediaAssociationOrigin } from "@prisma/client";
+
 import { MediaContentType } from "../../domain/media";
 import { recordHistogram, recordIncrement } from "../instrumentation";
 import { uploadMediaForTrace } from "./mediaService";
@@ -55,6 +57,7 @@ describe("uploadMediaForTrace", () => {
       contentBytes: CONTENT_BYTES,
       mediaBucket: "media-bucket",
       mediaPrefix: "media/",
+      origin: MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
     });
 
     expect(result).toEqual({
@@ -63,6 +66,9 @@ describe("uploadMediaForTrace", () => {
     });
     expect(mocks.executeRaw).toHaveBeenCalledTimes(1);
     expect(mocks.queryRaw).toHaveBeenCalledTimes(1);
+    expect(mocks.queryRaw.mock.calls[0]).toContain(
+      MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
+    );
     expect(mocks.uploadFile).toHaveBeenCalledWith(
       expect.objectContaining({
         fileName: "media/project-id/n-vgG9Qb-2loPinXEdit_8.png",
@@ -106,6 +112,7 @@ describe("uploadMediaForTrace", () => {
         contentBytes: CONTENT_BYTES,
         mediaBucket: "media-bucket",
         mediaPrefix: "media/",
+        origin: MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
       }),
     ).rejects.toBe(uploadError);
 
@@ -139,6 +146,7 @@ describe("uploadMediaForTrace", () => {
       contentBytes: CONTENT_BYTES,
       mediaBucket: "media-bucket",
       mediaPrefix: "media/",
+      origin: MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
     });
 
     expect(result).toEqual({
@@ -146,6 +154,9 @@ describe("uploadMediaForTrace", () => {
       outcome: "reused",
     });
     expect(mocks.queryRaw).toHaveBeenCalledTimes(1);
+    expect(mocks.queryRaw.mock.calls[0]).toContain(
+      MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
+    );
     expect(mocks.executeRaw).not.toHaveBeenCalled();
     expect(mocks.uploadFile).not.toHaveBeenCalled();
   });
@@ -165,9 +176,13 @@ describe("uploadMediaForTrace", () => {
       contentBytes: CONTENT_BYTES,
       mediaBucket: "media-bucket",
       mediaPrefix: "media/",
+      origin: MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
     });
 
     const query = mocks.queryRaw.mock.calls[0]?.[0] as TemplateStringsArray;
     expect(query.join(" ")).toContain('INSERT INTO "trace_media"');
+    expect(mocks.queryRaw.mock.calls[0]).toContain(
+      MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
+    );
   });
 });

--- a/packages/shared/src/server/media/mediaService.ts
+++ b/packages/shared/src/server/media/mediaService.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "crypto";
 import { Readable } from "stream";
 
+import type { MediaAssociationOrigin } from "@prisma/client";
+
 import { Prisma, prisma } from "../../db";
 import {
   getFileExtensionFromContentType,
@@ -112,8 +114,9 @@ export async function linkMediaToTraceOrObservation(params: {
   observationId?: string | null;
   mediaId: string;
   field: string;
+  origin: MediaAssociationOrigin;
 }): Promise<void> {
-  const { projectId, traceId, observationId, mediaId, field } = params;
+  const { projectId, traceId, observationId, mediaId, field, origin } = params;
 
   if (observationId) {
     await prisma.$queryRaw`
@@ -123,7 +126,8 @@ export async function linkMediaToTraceOrObservation(params: {
         "trace_id",
         "observation_id",
         "media_id",
-        "field"
+        "field",
+        "origin"
       )
       VALUES (
         ${randomUUID()},
@@ -131,7 +135,8 @@ export async function linkMediaToTraceOrObservation(params: {
         ${traceId},
         ${observationId},
         ${mediaId},
-        ${field}
+        ${field},
+        ${origin}::"MediaAssociationOrigin"
       )
       ON CONFLICT DO NOTHING
     `;
@@ -144,14 +149,16 @@ export async function linkMediaToTraceOrObservation(params: {
       "project_id",
       "trace_id",
       "media_id",
-      "field"
+      "field",
+      "origin"
     )
     VALUES (
       ${randomUUID()},
       ${projectId},
       ${traceId},
       ${mediaId},
-      ${field}
+      ${field},
+      ${origin}::"MediaAssociationOrigin"
     )
     ON CONFLICT DO NOTHING
   `;
@@ -182,6 +189,7 @@ export async function uploadMediaForTrace(params: {
   contentBytes: Buffer;
   mediaBucket: string;
   mediaPrefix: string;
+  origin: MediaAssociationOrigin;
 }): Promise<UploadMediaForTraceResult> {
   const {
     projectId,
@@ -192,6 +200,7 @@ export async function uploadMediaForTrace(params: {
     contentBytes,
     mediaBucket,
     mediaPrefix,
+    origin,
   } = params;
   const sha256Hash = createHash("sha256").update(contentBytes).digest("base64");
   const mediaId = getMediaId(sha256Hash);
@@ -216,6 +225,7 @@ export async function uploadMediaForTrace(params: {
       observationId,
       mediaId: existingMedia.id,
       field,
+      origin,
     });
     return { mediaId: existingMedia.id, outcome: "reused" };
   }
@@ -290,6 +300,7 @@ export async function uploadMediaForTrace(params: {
     observationId,
     mediaId,
     field,
+    origin,
   });
 
   recordIncrement("langfuse.media.upload_http_status", 1, {

--- a/web/src/__tests__/server/media.servertest.ts
+++ b/web/src/__tests__/server/media.servertest.ts
@@ -15,6 +15,7 @@ import {
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import {
+  MediaAssociationOrigin,
   type Media,
   type ObservationMedia,
   prisma,
@@ -319,6 +320,7 @@ describe("Media Upload API", () => {
         traceId,
         mediaId: result.mediaRecord?.id,
         field,
+        origin: MediaAssociationOrigin.CLIENT_UPLOAD,
       });
       expect(result.observationMediaRecord).toBeNull();
       expect(result.fetchMediaAssetResponse?.status).toBe(200);
@@ -372,6 +374,7 @@ describe("Media Upload API", () => {
         observationId,
         mediaId: result.mediaRecord?.id,
         field,
+        origin: MediaAssociationOrigin.CLIENT_UPLOAD,
       });
       expect(result.fetchMediaAssetResponse?.status).toBe(200);
       expect(result.fetchMediaAssetResponse?.headers.get("content-type")).toBe(

--- a/web/src/features/media/server/mediaService.ts
+++ b/web/src/features/media/server/mediaService.ts
@@ -10,6 +10,7 @@ import {
   type DatasetItemMediaField,
   InternalServerError,
   LangfuseNotFoundError,
+  MediaAssociationOrigin,
 } from "@langfuse/shared";
 import { Prisma, prisma } from "@langfuse/shared/src/db";
 import {
@@ -58,6 +59,7 @@ export async function createMediaUploadUrl(params: {
         observationId,
         mediaId,
         field,
+        origin: MediaAssociationOrigin.CLIENT_UPLOAD,
       });
     }
   };

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MediaAssociationOrigin } from "@langfuse/shared";
 import type { EventRecordInsertType } from "@langfuse/shared/src/server";
 
 const mocks = vi.hoisted(() => {
@@ -118,6 +119,7 @@ describe("applyObservationFieldOverflow", () => {
       expect.objectContaining({
         field: "output",
         contentBytes: Buffer.from(output),
+        origin: MediaAssociationOrigin.INGESTION_FIELD_OVERFLOW,
       }),
     );
     expect(mocks.recordIncrement).toHaveBeenCalledTimes(3);

--- a/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
+++ b/worker/src/features/observation-field-overflow/processObservationFieldOverflow.ts
@@ -7,6 +7,7 @@ import {
   uploadMediaForTrace,
 } from "@langfuse/shared/src/server";
 import {
+  MediaAssociationOrigin,
   MediaContentType,
   OBSERVATION_FIELD_SIZE_LIMIT_MEDIA_SOURCE,
 } from "@langfuse/shared";
@@ -216,6 +217,7 @@ async function uploadOverflowCandidate(
     contentBytes: Buffer.from(value, "utf8"),
     mediaBucket,
     mediaPrefix: env.LANGFUSE_S3_MEDIA_UPLOAD_PREFIX,
+    origin: MediaAssociationOrigin.INGESTION_FIELD_OVERFLOW,
   }).catch((error) => {
     logger.warn(
       "Oversized observation field upload failed; persisting original field",

--- a/worker/src/features/otel-media/processOtelMedia.test.ts
+++ b/worker/src/features/otel-media/processOtelMedia.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => {
     logger: { warn: vi.fn() },
     recordDistribution: vi.fn(),
     span,
+    uploadMediaForTrace: vi.fn(),
   };
 });
 
@@ -22,9 +23,10 @@ vi.mock("@langfuse/shared/src/server", () => ({
   logger: mocks.logger,
   processOtelMedia: vi.fn(),
   recordDistribution: mocks.recordDistribution,
-  uploadMediaForTrace: vi.fn(),
+  uploadMediaForTrace: mocks.uploadMediaForTrace,
 }));
 
+import { MediaAssociationOrigin } from "@langfuse/shared";
 import type { IngestionEventType } from "@langfuse/shared/src/server";
 import {
   createDirectOtelMediaTargets,
@@ -90,6 +92,22 @@ describe("processOtelEventMedia", () => {
           },
         ],
         writePath: "direct",
+      }),
+    );
+    const uploadMedia = processMedia.mock.calls[0]?.[0].uploadMedia;
+    await uploadMedia({
+      projectId: "project-id",
+      traceId: "trace-id",
+      observationId: "observation-id",
+      field: "input",
+      contentType: "image/png",
+      contentBytes: Buffer.from("media"),
+      mediaBucket: "media-bucket",
+      mediaPrefix: "media/",
+    });
+    expect(mocks.uploadMediaForTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
       }),
     );
     expect(mocks.instrumentAsync).toHaveBeenCalledWith(

--- a/worker/src/features/otel-media/processOtelMedia.ts
+++ b/worker/src/features/otel-media/processOtelMedia.ts
@@ -10,6 +10,7 @@ import {
   type OtelMediaWritePath,
   uploadMediaForTrace,
 } from "@langfuse/shared/src/server";
+import { MediaAssociationOrigin } from "@langfuse/shared";
 
 const MEDIA_FIELDS = ["input", "output", "metadata"] as const;
 
@@ -71,7 +72,11 @@ export async function processOtelEventMedia(params: {
             writePath,
             mediaBucket,
             mediaPrefix,
-            uploadMedia: uploadMediaForTrace,
+            uploadMedia: (uploadParams) =>
+              uploadMediaForTrace({
+                ...uploadParams,
+                origin: MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
+              }),
           });
 
           span.setAttributes({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15668.preview.langfuse.com](https://pr-15668.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

- add an `origin` enum to trace and observation media associations
- distinguish client uploads, ingestion media extraction, and ingestion field overflow
- default existing and otherwise-unclassified rows to `UNKNOWN`
- preserve existing association uniqueness semantics

## Migration safety

The new columns are `NOT NULL DEFAULT 'UNKNOWN'`. On PostgreSQL 11+, this constant default uses the metadata-only fast path rather than rewriting either large association table. A local PostgreSQL 17 migration deploy confirmed `atthasmissing = true` and `attmissingval = {UNKNOWN}` for both columns.

The ALTER statements still take a brief `ACCESS EXCLUSIVE` lock while catalog metadata is changed.

## Validation

- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm run typecheck` — Tasks: 7 successful, 7 total
- shared media service — Tests 4 passed (4)
- OTEL media processor — Tests 4 passed (4)
- observation field overflow — Tests 7 passed (7)
- `prisma migrate deploy` against isolated PostgreSQL 17 — All migrations have been successfully applied
- `git diff --cached --check` — passed

The local web media end-to-end suite was not counted as passing: it requires a separately seeded API-key fixture for the running web process; the isolated run reached the migrated database but stopped at HTTP 401. CI will exercise the repository-managed environment.

Linear: https://linear.app/clickhouse/issue/LFE-14670/track-media-association-origin-for-trace-and-observation-links

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds origin metadata to trace and observation media associations.
- Adds the MediaAssociationOrigin enum and defaulted PostgreSQL columns.
- Labels client uploads, OTel media extraction, and observation-field overflow associations.
- Propagates origin through shared media linking and updates coverage for each producer.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The rolling-deployment schema ordering issue should be fixed before merging because new workers can temporarily lose media associations.

Worker processes can execute inserts referencing the new enum and columns before the concurrently deployed web service applies the migration, and the ingestion adapters fail open after those writes fail.

**Files Needing Attention:** packages/shared/src/server/media/mediaService.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Deploy as Concurrent deployment
  participant Web as Web container
  participant DB as PostgreSQL
  participant Worker as Worker container
  Deploy->>Web: Start new web task
  Deploy->>Worker: Start new worker task
  Web->>DB: prisma migrate deploy
  Worker->>DB: INSERT association with origin
  alt Migration completed
    DB-->>Worker: Association stored
  else Migration still pending
    DB-->>Worker: Missing type or column error
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/media/mediaService.ts:138
**Migration race drops associations**

When a new worker processes OTel media extraction or observation-field overflow before the concurrently deployed web container finishes applying the migration, this insert references an enum type and column that do not exist yet. PostgreSQL rejects the association write, and the fail-open ingestion paths continue without recording the media association.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(media): track association origin"](https://github.com/langfuse/langfuse/commit/908041be55d79eb7decccd16c7bcb740f607784b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49026827)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->