### PR TITLE
fix: reject bad methods on api/public/signup route

### DIFF
--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -60,7 +60,9 @@ export async function signupApiHandler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  if (req.method !== "POST") return;
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
 
   // Block direct signup when email verification is required
   if (isEmailVerificationRequired()) {

--- a/web/src/pages/api/auth/check-sso.ts
+++ b/web/src/pages/api/auth/check-sso.ts
@@ -16,8 +16,9 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  if (req.method !== "POST")
+  if (req.method !== "POST") {
     return res.status(405).json({ message: "Method not allowed" });
+  }
 
   const validBody = requestSchema.safeParse(req.body);
   if (!validBody.success) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15670.preview.langfuse.com](https://pr-15670.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes unsupported HTTP methods return an explicit error from the credentials signup handler and adds braces around the equivalent check-sso guard.
- Returns HTTP 405 with a JSON error for non-POST signup requests.
- Makes the existing check-sso method guard syntactically explicit without changing behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking HTTP compliance issue in the new signup response.

The method rejection works as intended, but the newly introduced 405 response does not advertise POST through the Allow header.

**Files Needing Attention:** web/src/features/auth-credentials/server/signupApiHandler.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/auth-credentials/server/signupApiHandler.ts:64
**405 omits allowed methods**

The new 405 response does not include an `Allow: POST` header, unlike the sibling signup-verification endpoint. This leaves the response non-compliant with the HTTP method-rejection contract and can fail strict client, gateway, or conformance validation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reject bad methods on api/public/si..."](https://github.com/langfuse/langfuse/commit/5a125409ca93a4880965317e6cd9bb1c586fbea9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48995402)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->