### PR TITLE
fix(mcp): add metrics query remediation guidance

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -2019,8 +2019,50 @@ describe("MCP Read Tools", () => {
           context,
         ),
       ).rejects.toThrow(
-        /require both 'config\.row_limit' and 'orderBy' with direction 'desc'/i,
+        /"config":\{"row_limit":100\}.*"field":"count_count".*getMetricsSchema/i,
       );
+    });
+
+    it("should direct raw observation payload filters to scoped observation retrieval", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleQueryMetrics(
+          {
+            view: "observations",
+            metrics: [{ measure: "count", aggregation: "count" }],
+            filters: [
+              {
+                type: "string",
+                column: "input",
+                operator: "contains",
+                value: "customer question",
+              },
+            ],
+            ...metricsWindow,
+          } as unknown as Parameters<typeof handleQueryMetrics>[0],
+          context,
+        ),
+      ).rejects.toThrow(
+        /listObservations.*traceId.*getObservationFilterSchema/i,
+      );
+    });
+
+    it("should explain the safe alternative for high-cardinality time series", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleQueryMetrics(
+          {
+            view: "observations",
+            dimensions: [{ field: "traceId" }],
+            metrics: [{ measure: "count", aggregation: "count" }],
+            timeDimension: { granularity: "day" },
+            ...metricsWindow,
+          } as unknown as Parameters<typeof handleQueryMetrics>[0],
+          context,
+        ),
+      ).rejects.toThrow(/Remove.*timeDimension.*getMetricsSchema/i);
     });
   });
 

--- a/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
+++ b/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
@@ -17,6 +17,57 @@ import { runMcpTool } from "../../../core/run-mcp-tool";
 import { z } from "zod";
 
 const DEFAULT_ROW_LIMIT = 100;
+const RAW_OBSERVATION_PAYLOAD_FIELDS = new Set(["input", "output"]);
+
+const getRawObservationPayloadFields = (
+  input: z.infer<typeof MetricsQueryObjectV2>,
+) => {
+  const fields = [
+    ...input.dimensions.map((dimension) => dimension.field),
+    ...input.metrics.map((metric) => metric.measure),
+    ...input.filters.map((filter) => filter.column),
+  ];
+
+  return [...new Set(fields)].filter((field) =>
+    RAW_OBSERVATION_PAYLOAD_FIELDS.has(field),
+  );
+};
+
+const getHighCardinalityDimensionFields = (
+  input: z.infer<typeof MetricsQueryObjectV2>,
+) =>
+  input.dimensions
+    .map((dimension) => dimension.field)
+    .filter(
+      (field) =>
+        viewDeclarations.v2[input.view].dimensions[field]?.highCardinality,
+    );
+
+const getHighCardinalityGuidance = (
+  input: z.infer<typeof MetricsQueryObjectV2>,
+  reason: string,
+) => {
+  const fields = getHighCardinalityDimensionFields(input);
+  if (fields.length === 0) {
+    return reason;
+  }
+
+  const schemaReminder = ` Call getMetricsSchema({"view":"${input.view}"}) for supported fields and metric aliases.`;
+
+  if (input.timeDimension) {
+    return `${reason} Remove ${fields.join(", ")} or remove timeDimension; config.row_limit and orderBy cannot make this combination safe.${schemaReminder}`;
+  }
+
+  const orderByMetric = input.metrics.find(
+    (metric) => metric.aggregation !== "histogram",
+  );
+  if (!orderByMetric) {
+    return `${reason}${schemaReminder}`;
+  }
+
+  const orderByField = `${orderByMetric.aggregation}_${orderByMetric.measure}`;
+  return `${reason} For a non-timeseries top-N query, add {"config":{"row_limit":100},"orderBy":[{"field":"${orderByField}","direction":"desc"}]}.${schemaReminder}`;
+};
 
 const normalizeMetricFilters = (
   input: z.infer<typeof MetricsQueryObjectV2>,
@@ -153,10 +204,21 @@ export const [queryMetricsTool, handleQueryMetrics] = defineTool({
         const normalizedInput = normalizeMetricOrderByFields(
           normalizeMetricFilters(input),
         );
+        const rawPayloadFields =
+          getRawObservationPayloadFields(normalizedInput);
+
+        if (rawPayloadFields.length > 0) {
+          throw new InvalidRequestError(
+            `Raw observation ${rawPayloadFields.join(" and ")} is not available from queryMetrics. Use listObservations with traceId, an exact id filter, or both fromStartTime and toStartTime; call getObservationFilterSchema for supported observation filters.`,
+          );
+        }
+
         const validation = validateQuery(normalizedInput, "v2");
 
         if (!validation.valid) {
-          throw new InvalidRequestError(validation.reason);
+          throw new InvalidRequestError(
+            getHighCardinalityGuidance(normalizedInput, validation.reason),
+          );
         }
 
         const { config, ...query } = normalizedInput;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15672.preview.langfuse.com](https://pr-15672.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

The most frequent MCP metrics failures are unsafe high-cardinality breakdowns and attempts to query raw observation input/output through `queryMetrics`. The existing errors are correct but do not consistently tell an agent which tool or request shape can succeed next.

## Solution

- Reject raw `input`/`output` metrics filters, dimensions, and measures before execution, and direct agents to selectively scoped `listObservations` plus `getObservationFilterSchema`.
- Preserve keyed `metadata` metrics filters; they remain valid aggregate filters.
- Enrich high-cardinality validation errors with either a concrete canonical top-N fragment or, for time series, the safe alternative of removing the high-cardinality dimension or `timeDimension`.

## Risk

Low. MCP-only error guidance; no CLI or Public API contract, shared validator, query-builder, SQL, schema, or ClickHouse query shape changes. The new preflight rejects requests that already fail later, so it prevents unnecessary execution rather than adding database work.

## Verification

- `pnpm --filter web run test src/__tests__/server/mcp-tools-read.servertest.ts` — 170 passed.
- Scoped ESLint and Prettier checks for the two changed files passed.
- `pnpm run lint` is blocked by 289 pre-existing warnings under `web/src/features/in-app-agent/**` on the current main baseline (`Tasks: 6 successful, 7 total`; `web#lint` fails).

Tests cover request behavior only: payload routing, top-N remediation, and the distinct time-series safety path. They do not assert static schema or documentation wording.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds preflight rejection and remediation guidance for unsupported raw observation payload metrics and unsafe high-cardinality queries.
- Directs raw input/output requests toward selectively scoped observation retrieval.
- Supplies canonical top-N guidance or safer time-series alternatives for high-cardinality dimensions.
- Adds server tests covering payload routing, top-N remediation, and time-series guidance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new rejection conditions target unsupported raw payload fields, and each suggested observation-scoping or high-cardinality remediation path is consistent with the corresponding tool and validation contracts.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): add metrics query remediation ..."](https://github.com/langfuse/langfuse/commit/aedfb325f209adaf4eb53f41f6ac4bbfd45cae5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49012920)</sub>

<!-- /greptile_comment -->