### PR TITLE
fix(web): hide migration activity indicator for dormant env-gated migrations

### DIFF
--- a/web/src/__tests__/server/unit/background-migrations-status.servertest.ts
+++ b/web/src/__tests__/server/unit/background-migrations-status.servertest.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import type { Session } from "next-auth";
+
+import { env } from "@/src/env.mjs";
+import { backgroundMigrationsRouter } from "@/src/features/background-migrations/server/background-migrations-router";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { type BackgroundMigration } from "@langfuse/shared";
+
+// Real gate declared in the worker env (worker/src/env.ts); the status endpoint
+// mirrors the worker's gate discovery, which only considers env vars with the
+// LANGFUSE_BACKGROUND_MIGRATION_ prefix.
+const GATE = "LANGFUSE_BACKGROUND_MIGRATION_V4_DROP_PID_TID_SORTING_TABLES";
+const UNPREFIXED_GATE = "SOME_UNRELATED_FLAG";
+
+const session: Session = {
+  expires: "1",
+  user: {
+    id: `background-migrations-user-${randomUUID()}`,
+    canCreateOrganizations: true,
+    name: "Background Migrations Test User",
+    organizations: [],
+    featureFlags: {
+      searchBar: false,
+      excludeClickhouseRead: false,
+      templateFlag: true,
+      v4BetaToggleVisible: false,
+      observationEvals: false,
+      experimentsV4Enabled: false,
+    },
+    admin: false,
+  },
+  environment: {
+    enableExperimentalFeatures: false,
+    selfHostedInstancePlan: "oss",
+  },
+};
+
+const migrationRow = (
+  overrides: Partial<BackgroundMigration>,
+): BackgroundMigration => ({
+  id: randomUUID(),
+  name: `migration-${randomUUID()}`,
+  script: "noop",
+  args: {},
+  state: {},
+  finishedAt: null,
+  failedAt: null,
+  failedReason: null,
+  workerId: null,
+  lockedAt: null,
+  ...overrides,
+});
+
+const createCaller = (migrations: BackgroundMigration[]) => {
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  return backgroundMigrationsRouter.createCaller({
+    ...ctx,
+    prisma: {
+      backgroundMigration: {
+        findMany: async () => migrations,
+      },
+    } as unknown as typeof ctx.prisma,
+  });
+};
+
+describe("backgroundMigrations.status", () => {
+  const envRecord = env as unknown as Record<string, string | undefined>;
+  const originalCloudRegion = envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+  const originalGate = envRecord[GATE];
+  const originalUnprefixedGate = envRecord[UNPREFIXED_GATE];
+
+  beforeEach(() => {
+    // The endpoint is self-host only; the local dev .env marks the test
+    // process as cloud ("DEV"), which would trip the cloud guard.
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    envRecord[GATE] = "false";
+  });
+
+  afterEach(() => {
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    envRecord[GATE] = originalGate;
+    if (originalUnprefixedGate === undefined) {
+      delete envRecord[UNPREFIXED_GATE];
+    } else {
+      envRecord[UNPREFIXED_GATE] = originalUnprefixedGate;
+    }
+  });
+
+  it("reports FINISHED when the only pending migrations are dormant behind inactive env gates", async () => {
+    const caller = createCaller([
+      migrationRow({ args: { envGate: GATE } }),
+      migrationRow({ finishedAt: new Date() }),
+    ]);
+
+    await expect(caller.status()).resolves.toEqual({ status: "FINISHED" });
+  });
+
+  it("reports ACTIVE when a pending migration's env gate is set to true", async () => {
+    envRecord[GATE] = "true";
+    const caller = createCaller([migrationRow({ args: { envGate: GATE } })]);
+
+    await expect(caller.status()).resolves.toEqual({ status: "ACTIVE" });
+  });
+
+  it("reports ACTIVE for a gated pending migration already claimed by a worker", async () => {
+    // Gates only need to be set on the worker for a migration to run, so a
+    // claimed row counts as active even when the web container lacks the gate.
+    const caller = createCaller([
+      migrationRow({ args: { envGate: GATE }, workerId: randomUUID() }),
+    ]);
+
+    await expect(caller.status()).resolves.toEqual({ status: "ACTIVE" });
+  });
+
+  it("reports ACTIVE for ungated pending migrations", async () => {
+    const caller = createCaller([migrationRow({})]);
+
+    await expect(caller.status()).resolves.toEqual({ status: "ACTIVE" });
+  });
+
+  it("ignores gates without the LANGFUSE_BACKGROUND_MIGRATION_ prefix like the worker does", async () => {
+    envRecord[UNPREFIXED_GATE] = "true";
+    const caller = createCaller([
+      migrationRow({ args: { envGate: UNPREFIXED_GATE } }),
+    ]);
+
+    await expect(caller.status()).resolves.toEqual({ status: "FINISHED" });
+  });
+
+  it("reports FAILED when any migration failed, even a dormant one", async () => {
+    const caller = createCaller([
+      migrationRow({
+        args: { envGate: GATE },
+        failedAt: new Date(),
+        failedReason: "boom",
+      }),
+    ]);
+
+    await expect(caller.status()).resolves.toEqual({ status: "FAILED" });
+  });
+
+  it("reports FINISHED when all migrations finished", async () => {
+    const caller = createCaller([migrationRow({ finishedAt: new Date() })]);
+
+    await expect(caller.status()).resolves.toEqual({ status: "FINISHED" });
+  });
+});

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -483,6 +483,18 @@ export const env = createEnv({
       .enum(["legacy", "dual", "events_only"])
       .default("events_only"),
 
+    // Background-migration env gates. Mirror worker/src/env.ts (names, defaults)
+    // so the background-migrations status endpoint can tell dormant, env-gated
+    // rows apart from migrations the worker will actually pick up. The worker
+    // owns execution; the web only reads these to decide whether the sidebar
+    // migration indicator should light up.
+    LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL: z
+      .enum(["true", "false"])
+      .default("true"),
+    LANGFUSE_BACKGROUND_MIGRATION_V4_DROP_PID_TID_SORTING_TABLES: z
+      .enum(["true", "false"])
+      .default("false"),
+
     // Temporary kill-switch for the observations v2 subquery-IN rewrite.
     LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE: z
       .enum(["true", "false"])
@@ -967,6 +979,10 @@ export const env = createEnv({
       process.env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN,
     LANGFUSE_MIGRATION_V4_WRITE_MODE:
       process.env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
+    LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL:
+      process.env.LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL,
+    LANGFUSE_BACKGROUND_MIGRATION_V4_DROP_PID_TID_SORTING_TABLES:
+      process.env.LANGFUSE_BACKGROUND_MIGRATION_V4_DROP_PID_TID_SORTING_TABLES,
     // Legacy tracing search controls
     LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH:
       process.env.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH,

--- a/web/src/features/background-migrations/server/background-migrations-router.ts
+++ b/web/src/features/background-migrations/server/background-migrations-router.ts
@@ -16,6 +16,39 @@ const denyOnLangfuseCloud = () => {
   }
 };
 
+const ENV_GATE_PREFIX = "LANGFUSE_BACKGROUND_MIGRATION_";
+
+// Mirrors the worker's gate discovery
+// (worker/src/backgroundMigrations/backgroundMigrationManager.ts): a row may
+// declare `args.envGate = "<ENV_VAR>"` and stays dormant until the operator
+// sets that env var to "true". Only gates sharing the
+// LANGFUSE_BACKGROUND_MIGRATION_ prefix are considered, matching the worker.
+// A row already claimed by a worker (workerId set) is never dormant — the
+// gate only needs to be enabled on the worker for the migration to run.
+const isDormant = (migration: {
+  args: unknown;
+  workerId: string | null;
+}): boolean => {
+  if (migration.workerId !== null) {
+    return false;
+  }
+
+  const envGate =
+    typeof migration.args === "object" &&
+    migration.args !== null &&
+    !Array.isArray(migration.args)
+      ? (migration.args as Record<string, unknown>).envGate
+      : undefined;
+  if (typeof envGate !== "string") {
+    return false;
+  }
+
+  return (
+    !envGate.startsWith(ENV_GATE_PREFIX) ||
+    (env as unknown as Record<string, unknown>)[envGate] !== "true"
+  );
+};
+
 export const backgroundMigrationsRouter = createTRPCRouter({
   all: authenticatedProcedure.query(async ({ ctx }) => {
     denyOnLangfuseCloud();
@@ -39,9 +72,11 @@ export const backgroundMigrationsRouter = createTRPCRouter({
       return { status: "FAILED" };
     }
 
+    // Dormant rows are excluded: they wait on an env gate the operator has not
+    // set, so nothing is running and the sidebar should not show activity.
     if (
       backgroundMigrations.some(
-        (m) => m.finishedAt === null && m.failedAt === null,
+        (m) => m.finishedAt === null && m.failedAt === null && !isDormant(m),
       )
     ) {
       return { status: "ACTIVE" };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15676.preview.langfuse.com](https://pr-15676.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Self-hosted instances show a green pulsing "active" indicator on the sidebar version label whenever any background migration is unfinished. Migration rows shipped dormant behind an `args.envGate` (e.g. `LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL`) are never picked up by the worker until the operator sets that env var to `"true"`, so instances with only gated-off pending rows showed a perpetual green pulse while nothing was running.

This PR makes the `backgroundMigrations.status` tRPC endpoint mirror the worker's gate discovery (`worker/src/backgroundMigrations/backgroundMigrationManager.ts`), so dormant rows no longer count as `ACTIVE`:

- `web/src/features/background-migrations/server/background-migrations-router.ts`: pending migrations whose `args.envGate` is not enabled are excluded from the `ACTIVE` check (same `LANGFUSE_BACKGROUND_MIGRATION_` prefix rule as the worker). Rows already claimed by a worker (`workerId` set) still count as active, since gates only need to be enabled on the worker container. `FAILED` still wins over dormancy.
- `web/src/env.mjs`: declares the two gate env vars with the same defaults as `worker/src/env.ts` so the web's view of the gates matches the worker under a shared env config.
- `web/src/__tests__/server/unit/background-migrations-status.servertest.ts`: new suite covering dormant → `FINISHED`, gate enabled → `ACTIVE`, claimed-while-gated → `ACTIVE`, ungated pending → `ACTIVE`, unprefixed-gate parity with the worker, and `FAILED`/`FINISHED` regressions. The two dormancy cases fail against the previous status logic.

The per-row badges on the Background Migrations page are unchanged; dormant rows still show "queued" there.

Impacted packages: `web`.

Verification:
- `pnpm --filter web run test src/__tests__/server/unit/background-migrations-status.servertest.ts` → `Tests  7 passed (7)`
- `pnpm run lint` → `Tasks:    7 successful, 7 total`
- `pnpm --filter web run typecheck` → exit 0

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the self-hosted background-migration status calculation so dormant env-gated rows do not activate the sidebar indicator.
- Declares the two existing migration gates in the web environment schema with worker-matching defaults.
- Adds gate-aware status logic while preserving failed and claimed migration handling.
- Adds server tests for enabled, disabled, claimed, ungated, failed, and completed migration states.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The orphaned-claim path should be fixed before merging because a gated migration can still leave the sidebar activity indicator pulsing indefinitely after its worker exits.

The new status logic relies on persisted `workerId` alone for claimed rows, while worker shutdown and crash recovery can leave that field set without a live lock or terminal state, and disabled gates prevent another worker from reclaiming the row.

**Files Needing Attention:** web/src/features/background-migrations/server/background-migrations-router.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load migration rows] --> B{Any failed row?}
  B -- Yes --> F[FAILED]
  B -- No --> C{Any unfinished row?}
  C -- No --> D[FINISHED]
  C -- Yes --> E{workerId is set?}
  E -- Yes --> G[ACTIVE]
  E -- No --> H{Valid prefixed gate enabled?}
  H -- Yes --> G
  H -- No --> D
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/background-migrations/server/background-migrations-router.ts:30-32
**Stale claims remain active forever**

When a worker claims a gated migration and then exits before recording a terminal state, `workerId` remains set even after the lock is cleared or expires. This branch therefore bypasses the disabled gate indefinitely, causing the sidebar to keep pulsing although no worker can execute the migration.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): hide migration activity indica..."](https://github.com/langfuse/langfuse/commit/6c0882cd9f1f55b3b9fc6d240005fabf4eba0596) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49016738)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->