### PR TITLE
fix(v4): detect legacy dataset run GET APIs

### DIFF
--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -346,14 +346,11 @@ describe("v4TransitionRouter", () => {
       "GET /api/public/datasets/{datasetName}/runs/{runName}",
     ].forEach((route) => expect(clickhouseQuery?.query).toContain(route));
     expect(clickhouseQuery?.query).toContain(
-      "route_path = 'GET /api/public/dataset-run-items', 2",
-    );
-    expect(clickhouseQuery?.query).toContain(
       "match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1",
     );
 
     expect(clickhouseQuery?.query).toContain(
-      "'GET /api/public/traces',\n        'GET /api/public/observations',\n        'GET /api/public/scores',\n        'GET /api/public/v2/scores',\n        'GET /api/public/metrics/daily'\n      ), 2",
+      "'GET /api/public/traces',\n        'GET /api/public/observations',\n        'GET /api/public/scores',\n        'GET /api/public/v2/scores',\n        'GET /api/public/metrics/daily',\n        'GET /api/public/dataset-run-items'\n      ), 2",
     );
     expect(clickhouseQuery?.query).toContain(
       "'GET /api/public/sessions',\n        'GET /api/public/metrics'\n      ), 1",

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -334,6 +334,7 @@ describe("v4TransitionRouter", () => {
       "GET /api/public/v2/scores",
       "GET /api/public/metrics",
       "GET /api/public/metrics/daily",
+      "GET /api/public/dataset-run-items",
     ].forEach((route) => expect(clickhouseQuery?.query).toContain(route));
 
     [
@@ -342,7 +343,14 @@ describe("v4TransitionRouter", () => {
       "GET /api/public/observations/{id}",
       "GET /api/public/scores/{id}",
       "GET /api/public/v2/scores/{id}",
+      "GET /api/public/datasets/{datasetName}/runs/{runName}",
     ].forEach((route) => expect(clickhouseQuery?.query).toContain(route));
+    expect(clickhouseQuery?.query).toContain(
+      "route_path = 'GET /api/public/dataset-run-items', 2",
+    );
+    expect(clickhouseQuery?.query).toContain(
+      "match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1",
+    );
 
     expect(clickhouseQuery?.query).toContain(
       "'GET /api/public/traces',\n        'GET /api/public/observations',\n        'GET /api/public/scores',\n        'GET /api/public/v2/scores',\n        'GET /api/public/metrics/daily'\n      ), 2",

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -1134,9 +1134,9 @@ classified AS (
         'GET /api/public/observations',
         'GET /api/public/scores',
         'GET /api/public/v2/scores',
-        'GET /api/public/metrics/daily'
+        'GET /api/public/metrics/daily',
+        'GET /api/public/dataset-run-items'
       ), 2,
-      route_path = 'GET /api/public/dataset-run-items', 2,
       route_path IN (
         'GET /api/public/sessions',
         'GET /api/public/metrics'
@@ -1249,9 +1249,9 @@ classified AS (
         'GET /api/public/observations',
         'GET /api/public/scores',
         'GET /api/public/v2/scores',
-        'GET /api/public/metrics/daily'
+        'GET /api/public/metrics/daily',
+        'GET /api/public/dataset-run-items'
       ), 2,
-      route_path = 'GET /api/public/dataset-run-items', 2,
       route_path IN (
         'GET /api/public/sessions',
         'GET /api/public/metrics'

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -1115,13 +1115,15 @@ classified AS (
         'GET /api/public/scores',
         'GET /api/public/v2/scores',
         'GET /api/public/metrics',
-        'GET /api/public/metrics/daily'
+        'GET /api/public/metrics/daily',
+        'GET /api/public/dataset-run-items'
       ), route_path,
       match(route_path, '^GET /api/public/traces/[^/?#]+$'), 'GET /api/public/traces/{id}',
       match(route_path, '^GET /api/public/sessions/[^/?#]+$'), 'GET /api/public/sessions/{id}',
       match(route_path, '^GET /api/public/observations/[^/?#]+$'), 'GET /api/public/observations/{id}',
       match(route_path, '^GET /api/public/scores/[^/?#]+$'), 'GET /api/public/scores/{id}',
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 'GET /api/public/v2/scores/{id}',
+      match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 'GET /api/public/datasets/{datasetName}/runs/{runName}',
       NULL
     ) AS legacy_route,
     multiIf(
@@ -1134,6 +1136,7 @@ classified AS (
         'GET /api/public/v2/scores',
         'GET /api/public/metrics/daily'
       ), 2,
+      route_path = 'GET /api/public/dataset-run-items', 2,
       route_path IN (
         'GET /api/public/sessions',
         'GET /api/public/metrics'
@@ -1143,6 +1146,7 @@ classified AS (
       match(route_path, '^GET /api/public/observations/[^/?#]+$'), 1,
       match(route_path, '^GET /api/public/scores/[^/?#]+$'), 1,
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 1,
+      match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1,
       NULL
     ) AS clickhouse_queries_per_api_call
   FROM selected
@@ -1226,13 +1230,15 @@ classified AS (
         'GET /api/public/scores',
         'GET /api/public/v2/scores',
         'GET /api/public/metrics',
-        'GET /api/public/metrics/daily'
+        'GET /api/public/metrics/daily',
+        'GET /api/public/dataset-run-items'
       ), route_path,
       match(route_path, '^GET /api/public/traces/[^/?#]+$'), 'GET /api/public/traces/{id}',
       match(route_path, '^GET /api/public/sessions/[^/?#]+$'), 'GET /api/public/sessions/{id}',
       match(route_path, '^GET /api/public/observations/[^/?#]+$'), 'GET /api/public/observations/{id}',
       match(route_path, '^GET /api/public/scores/[^/?#]+$'), 'GET /api/public/scores/{id}',
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 'GET /api/public/v2/scores/{id}',
+      match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 'GET /api/public/datasets/{datasetName}/runs/{runName}',
       NULL
     ) AS legacy_route,
     multiIf(
@@ -1245,6 +1251,7 @@ classified AS (
         'GET /api/public/v2/scores',
         'GET /api/public/metrics/daily'
       ), 2,
+      route_path = 'GET /api/public/dataset-run-items', 2,
       route_path IN (
         'GET /api/public/sessions',
         'GET /api/public/metrics'
@@ -1254,6 +1261,7 @@ classified AS (
       match(route_path, '^GET /api/public/observations/[^/?#]+$'), 1,
       match(route_path, '^GET /api/public/scores/[^/?#]+$'), 1,
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 1,
+      match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1,
       NULL
     ) AS clickhouse_queries_per_api_call
   FROM selected


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15677.preview.langfuse.com](https://pr-15677.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Detect legacy `GET /api/public/dataset-run-items` usage in the v4 migration view.
- Detect and canonicalize legacy `GET /api/public/datasets/{datasetName}/runs/{runName}` usage.
- Use the correct ClickHouse query weights for both routes.

The v4 replacements are documented in the migration guide. These are legacy self-hosted API paths; the POST dataset-run-items endpoint remains intentionally excluded.

The dataset-run list endpoint (`GET /api/public/datasets/{name}/runs`) is intentionally not included in this ClickHouse query-log classifier because its implementation is PostgreSQL-only and produces no ClickHouse query to observe. LFE-10881

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends v4 transition analytics to detect legacy dataset-run GET API usage.
- Classifies dataset-run-item list requests and dataset run detail requests in project and organization usage queries.
- Normalizes query-log counts according to each endpoint’s ClickHouse query fan-out.
- Adds unit assertions covering the new route patterns and divisors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new route patterns and counting weights aligned with the corresponding endpoint behavior.

The exact and dynamic route classifiers match the logged request path format, and their divisors correspond to the two and one ClickHouse queries issued by the respective successful endpoints.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): detect legacy dataset run get A..."](https://github.com/langfuse/langfuse/commit/88b41a1b592d1af0c53cd2148d36270b7cd7885e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49019951)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Datasets, Dataset Runs, and Experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md)

<!-- /greptile_comment -->