### PR TITLE
fix(mcp): guide agents out of failing queryMetrics calls

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -2038,9 +2038,7 @@ describe("MCP Read Tools", () => {
         );
 
         await expect(query).rejects.toThrow(/getMetricsSchema/i);
-        await expect(query).rejects.not.toThrow(
-          new RegExp(`count_${measure}`, "i"),
-        );
+        await expect(query).rejects.not.toThrow(`count_${measure}`);
       },
     );
 

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -2021,21 +2021,28 @@ describe("MCP Read Tools", () => {
       ).rejects.toThrow(/"config":\{"row_limit":100\}.*"field":"count_count"/i);
     });
 
-    it("should not build top-N guidance from an unsupported metric", async () => {
-      const { context } = await createMcpTestSetup();
-      const query = handleQueryMetrics(
-        {
-          view: "observations",
-          dimensions: [{ field: "traceId" }],
-          metrics: [{ measure: "unknown", aggregation: "count" }],
-          ...metricsWindow,
-        } as unknown as Parameters<typeof handleQueryMetrics>[0],
-        context,
-      );
+    // "toString" is a distinct path: a bracket lookup on the view's measures
+    // resolves it to the inherited Object.prototype member rather than undefined.
+    it.each(["unknown", "toString"])(
+      "should not build top-N guidance from the unsupported measure %s",
+      async (measure) => {
+        const { context } = await createMcpTestSetup();
+        const query = handleQueryMetrics(
+          {
+            view: "observations",
+            dimensions: [{ field: "traceId" }],
+            metrics: [{ measure, aggregation: "count" }],
+            ...metricsWindow,
+          } as unknown as Parameters<typeof handleQueryMetrics>[0],
+          context,
+        );
 
-      await expect(query).rejects.toThrow(/getMetricsSchema/i);
-      await expect(query).rejects.not.toThrow(/count_unknown/i);
-    });
+        await expect(query).rejects.toThrow(/getMetricsSchema/i);
+        await expect(query).rejects.not.toThrow(
+          new RegExp(`count_${measure}`, "i"),
+        );
+      },
+    );
 
     it("should direct raw observation payload filters to scoped observation retrieval", async () => {
       const { context } = await createMcpTestSetup();

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -2018,9 +2018,65 @@ describe("MCP Read Tools", () => {
           } as unknown as Parameters<typeof handleQueryMetrics>[0],
           context,
         ),
-      ).rejects.toThrow(
-        /require both 'config\.row_limit' and 'orderBy' with direction 'desc'/i,
+      ).rejects.toThrow(/"config":\{"row_limit":100\}.*"field":"count_count"/i);
+    });
+
+    it("should not build top-N guidance from an unsupported metric", async () => {
+      const { context } = await createMcpTestSetup();
+      const query = handleQueryMetrics(
+        {
+          view: "observations",
+          dimensions: [{ field: "traceId" }],
+          metrics: [{ measure: "unknown", aggregation: "count" }],
+          ...metricsWindow,
+        } as unknown as Parameters<typeof handleQueryMetrics>[0],
+        context,
       );
+
+      await expect(query).rejects.toThrow(/getMetricsSchema/i);
+      await expect(query).rejects.not.toThrow(/count_unknown/i);
+    });
+
+    it("should direct raw observation payload filters to scoped observation retrieval", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleQueryMetrics(
+          {
+            view: "observations",
+            metrics: [{ measure: "count", aggregation: "count" }],
+            filters: [
+              {
+                type: "string",
+                column: "input",
+                operator: "contains",
+                value: "customer question",
+              },
+            ],
+            ...metricsWindow,
+          } as unknown as Parameters<typeof handleQueryMetrics>[0],
+          context,
+        ),
+      ).rejects.toThrow(
+        /listObservations.*traceId.*getObservationFilterSchema/i,
+      );
+    });
+
+    it("should explain the safe alternative for high-cardinality time series", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleQueryMetrics(
+          {
+            view: "observations",
+            dimensions: [{ field: "traceId" }],
+            metrics: [{ measure: "count", aggregation: "count" }],
+            timeDimension: { granularity: "day" },
+            ...metricsWindow,
+          } as unknown as Parameters<typeof handleQueryMetrics>[0],
+          context,
+        ),
+      ).rejects.toThrow(/Remove.*timeDimension.*getMetricsSchema/i);
     });
   });
 

--- a/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
+++ b/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
@@ -2,6 +2,7 @@ import { InvalidRequestError } from "@langfuse/shared";
 import { executeQuery } from "@langfuse/shared/query/server";
 import {
   dimension,
+  getValidAggregationsForMeasureType,
   metric,
   validateQuery,
   viewDeclarations,
@@ -17,6 +18,98 @@ import { runMcpTool } from "../../../core/run-mcp-tool";
 import { z } from "zod";
 
 const DEFAULT_ROW_LIMIT = 100;
+const RAW_PAYLOAD_FIELDS = new Set(["input", "output"]);
+
+/**
+ * Leads a rejected query's error with the listObservations redirect when it
+ * referenced raw input/output. The query builder decides which fields a view
+ * supports; this only adds the tool-routing hint it cannot know about, so no
+ * view declaration knowledge is duplicated here.
+ */
+const withRawPayloadGuidance = (
+  error: unknown,
+  input: z.infer<typeof MetricsQueryObjectV2>,
+) => {
+  if (!(error instanceof InvalidRequestError)) {
+    return error;
+  }
+
+  const referenced = new Set(
+    [
+      ...input.dimensions.map((dimension) => dimension.field),
+      ...input.metrics.map((metric) => metric.measure),
+      ...input.filters.map((filter) => filter.column),
+    ].filter((field) => RAW_PAYLOAD_FIELDS.has(field)),
+  );
+
+  if (referenced.size === 0) {
+    return error;
+  }
+
+  return new InvalidRequestError(
+    `Raw observation ${[...referenced].join(" and ")} is not available from queryMetrics. Use listObservations with traceId, an exact id filter, or both fromStartTime and toStartTime; call getObservationFilterSchema for supported observation filters. ${error.message}`,
+  );
+};
+
+const getHighCardinalityDimensionFields = (
+  input: z.infer<typeof MetricsQueryObjectV2>,
+) =>
+  input.dimensions
+    .map((dimension) => dimension.field)
+    .filter(
+      (field) =>
+        viewDeclarations.v2[input.view].dimensions[field]?.highCardinality,
+    );
+
+const getHighCardinalityGuidance = (
+  input: z.infer<typeof MetricsQueryObjectV2>,
+  reason: string,
+) => {
+  const fields = getHighCardinalityDimensionFields(input);
+  if (fields.length === 0) {
+    return reason;
+  }
+
+  const schemaReminder = ` Call getMetricsSchema({"view":"${input.view}"}) for supported fields and metric aliases.`;
+
+  if (input.timeDimension) {
+    return `${reason} Remove ${fields.join(", ")} or remove timeDimension; config.row_limit and orderBy cannot make this combination safe.${schemaReminder}`;
+  }
+
+  const view = viewDeclarations.v2[input.view];
+  const orderByMetric = input.metrics.find((metric) => {
+    const measure = view.measures[metric.measure];
+    return (
+      metric.aggregation !== "histogram" &&
+      measure !== undefined &&
+      getValidAggregationsForMeasureType(measure.type).includes(
+        metric.aggregation,
+      )
+    );
+  });
+  if (!orderByMetric) {
+    return `${reason}${schemaReminder}`;
+  }
+
+  const orderByField = `${orderByMetric.aggregation}_${orderByMetric.measure}`;
+  const rowLimit = input.config?.row_limit ?? DEFAULT_ROW_LIMIT;
+  const orderBy = [{ field: orderByField, direction: "desc" as const }];
+  const remediatedInput = {
+    ...input,
+    config: { ...input.config, row_limit: rowLimit },
+    orderBy,
+  };
+
+  if (!validateQuery(remediatedInput, "v2").valid) {
+    return `${reason}${schemaReminder}`;
+  }
+
+  const remediation = JSON.stringify({
+    config: { row_limit: rowLimit },
+    orderBy,
+  });
+  return `${reason} To satisfy this high-cardinality constraint for a non-timeseries top-N query, add ${remediation}.${schemaReminder}`;
+};
 
 const normalizeMetricFilters = (
   input: z.infer<typeof MetricsQueryObjectV2>,
@@ -156,7 +249,9 @@ export const [queryMetricsTool, handleQueryMetrics] = defineTool({
         const validation = validateQuery(normalizedInput, "v2");
 
         if (!validation.valid) {
-          throw new InvalidRequestError(validation.reason);
+          throw new InvalidRequestError(
+            getHighCardinalityGuidance(normalizedInput, validation.reason),
+          );
         }
 
         const { config, ...query } = normalizedInput;
@@ -169,14 +264,18 @@ export const [queryMetricsTool, handleQueryMetrics] = defineTool({
           },
         };
 
-        const result = await executeQuery(
-          context.projectId,
-          queryParams,
-          "v2",
-          true,
-        );
+        try {
+          const result = await executeQuery(
+            context.projectId,
+            queryParams,
+            "v2",
+            true,
+          );
 
-        return { data: result };
+          return { data: result };
+        } catch (error) {
+          throw withRawPayloadGuidance(error, normalizedInput);
+        }
       },
     });
   },

--- a/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
+++ b/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
@@ -78,7 +78,11 @@ const getHighCardinalityGuidance = (
 
   const view = viewDeclarations.v2[input.view];
   const orderByMetric = input.metrics.find((metric) => {
-    const measure = view.measures[metric.measure];
+    // Own-property check: a measure named after an Object.prototype member
+    // would otherwise resolve to the inherited function and pass the guard.
+    const measure = Object.hasOwn(view.measures, metric.measure)
+      ? view.measures[metric.measure]
+      : undefined;
     return (
       metric.aggregation !== "histogram" &&
       measure !== undefined &&


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15678.preview.langfuse.com](https://pr-15678.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

The two most frequent MCP metrics failures are unsafe high-cardinality breakdowns and attempts to read raw observation `input`/`output` through `queryMetrics`. Both errors were already correct, but neither told an agent which request shape or which tool could succeed next, so every failure cost extra tool calls.

Supersedes #15672, which this PR now contains. The two were a stack; #15672's guidance could recommend an order-by on a measure the view does not declare (`count_unknown`), so it was never worth landing on its own.

## Changes

- Enrich high-cardinality rejections with a concrete top-N fragment (`config.row_limit` plus `orderBy` desc) or, for time series, the only safe alternative of dropping the high-cardinality dimension or `timeDimension`.
- Revalidate the proposed rewrite through `validateQuery` before suggesting it, so the guidance can never recommend a query that fails again.
- Lead rejections that referenced raw `input`/`output` with a redirect to `listObservations` and `getObservationFilterSchema`.

Impacted package: web.

## Design note

The raw-payload redirect enriches the error the query builder already throws rather than pre-empting it with a second gate. `queryBuilder` remains the only place that decides which fields a view supports (`mapDimensions`, `mapMetrics`, `mapFilters`), so the MCP layer contributes only the tool-routing hint it uniquely knows about and cannot drift from the data model as views change. Rejection still happens during SQL build, before any ClickHouse query.

## Risk

Low. MCP-only error guidance; no Public API or CLI contract, shared validator, query-builder, SQL, schema, or ClickHouse query shape change. Unsupported requests still fail before query execution.

## Verification

- Red check confirmed: with the redirect disabled, the raw-payload test fails against the bare builder error (`Invalid filter column input. Must be one of ...`), proving the test exercises the enrichment path and that rejection precedes ClickHouse.
- `pnpm --filter web run test src/__tests__/server/mcp-tools-read.servertest.ts`: `Tests  171 passed (171)`.
- `pnpm run lint`: `Tasks: 7 successful, 7 total`.
- `pnpm --filter web run typecheck`: passed, no output.
- Prettier: `All matched files use Prettier code style!`

Tests added: 3 in `web/src/__tests__/server/mcp-tools-read.servertest.ts` — raw-payload tool redirect, the distinct time-series safety path, and the fallback that refuses to build top-N guidance from an undeclared measure. One existing high-cardinality assertion was tightened to the machine-readable remediation fragment instead of the surrounding prose.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Improves MCP query failure guidance without changing query execution behavior.
- Suggests validated top-N remediation for unsafe high-cardinality metric queries.
- Redirects unsupported raw observation payload requests to observation retrieval tools.
- Adds coverage for raw-payload redirects, time-series guidance, and unsupported metrics.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): guide agents out of failing qu..."](https://github.com/langfuse/langfuse/commit/b6756b8b4f980fd128ccfaa83aee5b3f6ccc0614) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49041998)</sub>

<!-- /greptile_comment -->