### PR TITLE
test(in-app-agent): move window interactions to Storybook

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -5,51 +5,11 @@ import {
   InAppAgentWindow,
   type InAppAgentWindowProps,
 } from "./InAppAgentWindow";
-import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
 
 const capture = vi.fn();
-const controlledAgent = vi.hoisted(() => ({
-  value: {
-    conversations: [],
-    error: null,
-    hasMoreConversations: false,
-    isLoadingMoreConversations: false,
-    isRunning: true,
-    isSelectedConversationHydrating: false,
-    isSubmitting: false,
-    invalidateConversations: vi.fn(),
-    liveMessageVersion: 0,
-    loadMoreConversations: vi.fn(),
-    messages: [],
-    pendingToolApprovals: [] as Array<{ id: string }>,
-    approveToolCall: vi.fn(),
-    rejectToolCall: vi.fn(),
-    selectedConversationId: undefined,
-    selectedConversationIsWriteLocked: false,
-    submit: vi.fn(),
-    submitFeedback: vi.fn(),
-  },
-}));
 
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
   usePostHogClientCapture: () => capture,
-}));
-
-vi.mock("next/router", () => ({
-  useRouter: () => ({ asPath: "/" }),
-}));
-
-vi.mock("./InAppAiAgentProvider", () => ({
-  useInAppAiAgent: () => controlledAgent.value,
-}));
-
-vi.mock("./useSmoothStreamingMessages", () => ({
-  useSmoothStreamingMessages: () => ({
-    isAnimating: false,
-    messages: [],
-    pendingToolApprovals: [],
-    runningToolCallIds: [],
-  }),
 }));
 
 // jsdom does not implement Element scrolling.
@@ -181,121 +141,5 @@ describe("InAppAgentWindow quick actions", () => {
     expect(
       screen.getByRole("button", { name: /^Create a prompt/ }),
     ).toBeInTheDocument();
-  });
-});
-
-describe("ControlledInAppAgentWindow composer", () => {
-  it("keeps a draft editable but prevents submitting it while rate limited", () => {
-    const onSubmit = vi.fn().mockResolvedValue(true);
-    render(
-      windowElement({
-        error: { type: "rate_limit", retryAt: Date.now() + 60_000 },
-        onSubmit,
-      }),
-    );
-
-    const input = screen.getByRole("textbox", {
-      name: "Message the assistant",
-    });
-    fireEvent.change(input, { target: { value: "Follow up" } });
-
-    expect(input).toHaveValue("Follow up");
-    expect(input).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
-
-    const form = input.closest("form");
-    if (!form) {
-      throw new Error("Expected the assistant composer to render a form");
-    }
-
-    fireEvent.submit(form);
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("keeps a draft editable but prevents submitting it while an assistant turn is active", () => {
-    const onSubmit = vi.fn().mockResolvedValue(true);
-    controlledAgent.value.isRunning = true;
-    controlledAgent.value.pendingToolApprovals = [];
-    controlledAgent.value.submit = onSubmit;
-    render(
-      <TooltipProvider>
-        <ControlledInAppAgentWindow
-          isExpanded={false}
-          onClose={vi.fn()}
-          onDeleteConversation={vi.fn()}
-          onExpandedChange={vi.fn()}
-        />
-      </TooltipProvider>,
-    );
-
-    const input = screen.getByRole("textbox", {
-      name: "Message the assistant",
-    });
-    fireEvent.change(input, { target: { value: "Follow up" } });
-
-    expect(input).toHaveValue("Follow up");
-    expect(input).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
-
-    const form = input.closest("form");
-    if (!form) {
-      throw new Error("Expected the assistant composer to render a form");
-    }
-
-    fireEvent.submit(form);
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("keeps navigation disabled while an approval is pending", () => {
-    controlledAgent.value.isRunning = false;
-    controlledAgent.value.pendingToolApprovals = [{ id: "approval-1" }];
-    controlledAgent.value.submit = vi.fn();
-
-    render(
-      <TooltipProvider>
-        <ControlledInAppAgentWindow
-          isExpanded={false}
-          onClose={vi.fn()}
-          onDeleteConversation={vi.fn()}
-          onExpandedChange={vi.fn()}
-        />
-      </TooltipProvider>,
-    );
-
-    expect(
-      screen.getByRole("textbox", { name: "Message the assistant" }),
-    ).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: "Start new conversation" }),
-    ).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: "Conversation history" }),
-    ).toBeDisabled();
-  });
-});
-
-describe("InAppAgentWindow focus", () => {
-  it("refocuses the composer when an active turn completes", () => {
-    const { rerender } = render(
-      <>
-        <button type="button">Other control</button>
-        {windowElement({ isAssistantTurnInProgress: true })}
-      </>,
-    );
-
-    screen.getByRole("button", { name: "Other control" }).focus();
-    expect(screen.getByRole("button", { name: "Other control" })).toHaveFocus();
-
-    rerender(
-      <>
-        <button type="button">Other control</button>
-        {windowElement({ isAssistantTurnInProgress: false })}
-      </>,
-    );
-
-    expect(
-      screen.getByRole("textbox", { name: "Message the assistant" }),
-    ).toHaveFocus();
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -841,6 +841,31 @@ export const Streaming = meta.story({
   render: (args) => <StreamingInAppAgentWindow {...args} />,
 });
 
+export const DraftWhileTurnIsActive = meta.story({
+  name: "(Test) Draft While Turn Is Active",
+  args: {
+    isAssistantTurnInProgress: true,
+    messages: [],
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole("textbox", {
+      name: "Message the assistant",
+    });
+
+    await userEvent.type(textarea, "Follow up");
+
+    await expect(textarea).toHaveValue("Follow up");
+    await expect(textarea).toBeEnabled();
+    await expect(
+      canvas.getByRole("button", { name: "Send message" }),
+    ).toBeDisabled();
+
+    await userEvent.keyboard("{Enter}");
+    await expect(args.onSubmit).not.toHaveBeenCalled();
+  },
+});
+
 export const LoadingResponse = meta.story({
   args: {
     isAssistantTurnInProgress: true,
@@ -1031,17 +1056,25 @@ export const RateLimited = meta.story({
       />
     );
   },
-  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     const alert = canvas.getByRole("alert");
+    const textarea = canvas.getByRole("textbox", {
+      name: "Message the assistant",
+    });
 
     await expect(alert).toHaveTextContent(
       "You've reached the assistant request limit",
     );
     await expect(alert).toHaveTextContent("Try again in about");
+    await userEvent.type(textarea, "Follow up");
+    await expect(textarea).toHaveValue("Follow up");
+    await expect(textarea).toBeEnabled();
     await expect(
-      canvas.getByRole("textbox", { name: "Message the assistant" }),
-    ).toBeEnabled();
+      canvas.getByRole("button", { name: "Send message" }),
+    ).toBeDisabled();
+    await userEvent.keyboard("{Enter}");
+    await expect(args.onSubmit).not.toHaveBeenCalled();
     await expect(
       canvas.getByRole("button", { name: "Confirm" }),
     ).toBeDisabled();
@@ -1062,10 +1095,8 @@ export const RefocusAfterSubmit = meta.story({
   },
   render: function Render(args) {
     const [isExpanded, setIsExpanded] = useState(args.isExpanded);
-    const [
-      isConversationInteractionDisabled,
-      setIsConversationInteractionDisabled,
-    ] = useState(false);
+    const [isAssistantTurnInProgress, setIsAssistantTurnInProgress] =
+      useState(false);
     const [messages, setMessages] = useState<InAppAgentWindowMessage[]>([
       {
         id: "user-1",
@@ -1092,16 +1123,14 @@ export const RefocusAfterSubmit = meta.story({
             {...args}
             isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
             isExpanded={isExpanded}
-            isConversationInteractionDisabled={
-              isConversationInteractionDisabled
-            }
+            isAssistantTurnInProgress={isAssistantTurnInProgress}
             messages={messages}
             onExpandedChange={(isExpanded) => {
               setIsExpanded(isExpanded);
               args.onExpandedChange(isExpanded);
             }}
             onSubmit={(input) => {
-              setIsConversationInteractionDisabled(true);
+              setIsAssistantTurnInProgress(true);
               window.setTimeout(() => {
                 setMessages((currentMessages) => [
                   ...currentMessages,
@@ -1114,7 +1143,7 @@ export const RefocusAfterSubmit = meta.story({
                     },
                   },
                 ]);
-                setIsConversationInteractionDisabled(false);
+                setIsAssistantTurnInProgress(false);
               }, 50);
 
               args.onSubmit(input);


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15679.preview.langfuse.com](https://pr-15679.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- move editable-draft and blocked-submit coverage from mocked client tests into `InAppAgentWindow` Storybook play tests
- extend the rate-limit interaction story with the same composer behavior
- make the refocus story model an assistant turn completing
- remove redundant Provider and streaming mocks from the client suite

## Why

`InAppAgentWindow` is prop-driven and fits the Storybook guidelines. Keeping its interactions in the stories makes the component states visible and prevents duplicated UI coverage; provider-owned code remains outside Storybook.

## Verification

- `pnpm --filter web run test-client src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx` — `Tests 2 passed (2)`
- `pnpm --filter web run test-storybook` — `Test Files 46 passed (46)`, `Tests 246 passed (246)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck`