### PR TITLE
feat(ui): show media size in preview

### DIFF
--- a/web/src/components/ui/media/MediaReferenceTag.clienttest.tsx
+++ b/web/src/components/ui/media/MediaReferenceTag.clienttest.tsx
@@ -8,6 +8,7 @@ vi.mock("./useResolvedMedia", () => ({
   useResolvedMedia: () => ({
     status: "ready",
     url: "data:text/plain,original%20oversized%20field",
+    contentLength: 2.5 * 1024 * 1024,
   }),
 }));
 
@@ -33,5 +34,6 @@ describe("MediaReferenceTag", () => {
     expect(
       screen.getByRole("link", { name: "Open original" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("2.50 MB")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/media/MediaReferenceTag.tsx
+++ b/web/src/components/ui/media/MediaReferenceTag.tsx
@@ -35,7 +35,9 @@ function LangfuseRefMediaTag({
   descriptor: LangfuseRefDescriptor;
 }) {
   const [armed, setArmed] = useState(false);
-  const { status, url } = useResolvedMedia(descriptor, { enabled: armed });
+  const { status, url, contentLength } = useResolvedMedia(descriptor, {
+    enabled: armed,
+  });
   const isOversizedField =
     descriptor.source === OBSERVATION_FIELD_SIZE_LIMIT_MEDIA_SOURCE;
 
@@ -44,6 +46,7 @@ function LangfuseRefMediaTag({
       contentType={descriptor.contentType}
       status={status}
       url={url}
+      contentLength={contentLength}
       label={isOversizedField ? "Full value attached" : undefined}
       description={
         isOversizedField

--- a/web/src/components/ui/media/MediaTag.stories.tsx
+++ b/web/src/components/ui/media/MediaTag.stories.tsx
@@ -125,6 +125,7 @@ export const OversizedField = meta.story({
     open: true,
     status: "ready",
     url: "data:text/plain,original%20oversized%20field",
+    contentLength: 2.5 * 1024 * 1024,
   },
 });
 

--- a/web/src/components/ui/media/MediaTag.tsx
+++ b/web/src/components/ui/media/MediaTag.tsx
@@ -41,6 +41,8 @@ export interface MediaTagProps {
    * meaningful when `status === "ready"`.
    */
   url?: string;
+  /** Resolved file size in bytes, shown in the peek header when available. */
+  contentLength?: number;
   /** Overrides the chip label (defaults to the MIME subtype, e.g. "JPEG"). */
   label?: string;
   /** Optional context shown above the preview in the peek popover. */
@@ -72,6 +74,19 @@ function getMediaKind(contentType: string): MediaKind {
 function getDefaultLabel(contentType: string): string {
   const subtype = contentType.split("/")[1]?.split("+")[0];
   return (subtype || "file").toUpperCase();
+}
+
+function formatFileSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+
+  return `${value.toFixed(2)} ${units[unitIndex]}`;
 }
 
 const MEDIA_KIND_ICON = {
@@ -196,6 +211,7 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
       contentType,
       status = "idle",
       url,
+      contentLength,
       label,
       description,
       openActionLabel,
@@ -277,6 +293,14 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
               >
                 {contentType}
               </span>
+              {contentLength !== undefined ? (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="shrink-0">
+                    {formatFileSize(contentLength)}
+                  </span>
+                </>
+              ) : null}
             </div>
             {canOpen ? (
               <Button

--- a/web/src/components/ui/media/useResolvedMedia.ts
+++ b/web/src/components/ui/media/useResolvedMedia.ts
@@ -17,7 +17,7 @@ type LangfuseRefDescriptor = Extract<MediaDescriptor, { kind: "langfuseRef" }>;
 export function useResolvedMedia(
   descriptor: LangfuseRefDescriptor,
   { enabled }: { enabled: boolean },
-): { status: MediaTagStatus; url?: string } {
+): { status: MediaTagStatus; url?: string; contentLength?: number } {
   const projectId = useProjectIdFromURL();
 
   const query = api.media.getById.useQuery(
@@ -36,6 +36,11 @@ export function useResolvedMedia(
 
   if (!enabled || !projectId) return { status: "idle" };
   if (query.isError) return { status: "error" };
-  if (query.data?.url) return { status: "ready", url: query.data.url };
+  if (query.data?.url)
+    return {
+      status: "ready",
+      url: query.data.url,
+      contentLength: query.data.contentLength,
+    };
   return { status: "loading" };
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15682.preview.langfuse.com](https://pr-15682.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- surface the existing `contentLength` returned by `media.getById` in media hover previews
- format the size beside the MIME type (for example, `text/plain · 2.50 MB`)
- preserve lazy resolution, so this adds no eager media requests or ingestion/reference-format changes

Linear: [LFE-14407](https://linear.app/clickhouse/issue/LFE-14407/set-a-hard-cap-on-large-observation-field-payloads)

## Impacted packages

- `web`

## Verification

- `pnpm exec dotenv -e '.env.dev.example' -e '.env.test.example' -- pnpm --filter web run test-client 'src/components/ui/media/MediaReferenceTag.clienttest.tsx'` — `Tests 1 passed (1)`
- `pnpm exec dotenv -e '.env.dev.example' -e '.env.test.example' -- pnpm --filter web run test-client 'src/components/ui/media/MediaTag.clienttest.tsx'` — `Tests 6 passed (6)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` — passed
- Storybook visual review of `MediaTag / Oversized Field` — popup rendered `text/plain · 2.50 MB` without layout regressions

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds media-size metadata to lazy-loaded media previews.
- Propagates the existing `contentLength` value through `useResolvedMedia` and `MediaReferenceTag`.
- Formats byte counts in the media preview header alongside the MIME type.
- Adds test coverage and a Storybook example for a 2.50 MB attachment.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The size metadata remains gated by the existing lazy media resolution path, is optional throughout the component boundary, and is rendered only when the API supplies it.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): show media size in preview"](https://github.com/langfuse/langfuse/commit/57142a2edd77ac2e105a6d2196d214f635c35aa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49061745)</sub>

<!-- /greptile_comment -->