### PR TITLE
chore(shared): tag S3 requests with the Langfuse version

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -21,6 +21,7 @@ import {
 import { Storage, Bucket, GetSignedUrlConfig } from "@google-cloud/storage";
 import { logger } from "../logger";
 import { env } from "../../env";
+import { VERSION } from "../../constants/VERSION";
 import { backOff } from "exponential-backoff";
 import { ServiceUnavailableError } from "../../errors";
 import {
@@ -665,6 +666,11 @@ class AzureBlobStorageService implements StorageService {
   }
 }
 
+// Appended to the AWS SDK user agent so bucket operators can attribute requests
+// to Langfuse in their access logs, matching the `application` string the
+// ClickHouse client sends.
+const S3_CUSTOM_USER_AGENT = `langfuse/${VERSION.replace("v", "")}`;
+
 class S3StorageService implements StorageService {
   private client: S3Client;
   private signedUrlClient: S3Client;
@@ -702,6 +708,7 @@ class S3StorageService implements StorageService {
       endpoint: params.endpoint,
       region: params.region,
       forcePathStyle: params.forcePathStyle,
+      customUserAgent: S3_CUSTOM_USER_AGENT,
       // Restore pre-v3.729 default so CompleteMultipartUpload doesn't send a
       // composite CRC32 header, which GCS's S3-compat layer rejects with 412.
       requestChecksumCalculation: "WHEN_REQUIRED",
@@ -725,6 +732,7 @@ class S3StorageService implements StorageService {
           endpoint: params.externalEndpoint,
           region: params.region,
           forcePathStyle: params.forcePathStyle,
+          customUserAgent: S3_CUSTOM_USER_AGENT,
           requestChecksumCalculation: "WHEN_REQUIRED",
           responseChecksumValidation: "WHEN_REQUIRED",
           requestHandler,


### PR DESCRIPTION
## What does this PR do?

`S3StorageService` builds its AWS SDK v3 clients without `customUserAgent`, so every S3 request Langfuse makes is only identifiable as `aws-sdk-js/<version>`. This sets `customUserAgent` on both the main client and the presigned URL client to `langfuse/<version>`, reusing the existing `VERSION` constant and matching the `application` string the ClickHouse client already sends (`packages/shared/src/server/clickhouse/client.ts:199`).

The SDK appends `customUserAgent` to its own user agent rather than replacing it, so nothing is lost:

```
user-agent:       aws-sdk-js/3.1074.0 ua/2.1 os/darwin#25.6.0 lang/js md/nodejs#24.18.0 api/s3#3.1074.0 m/N,a,c,U,E,e langfuse/4.2.0
x-amz-user-agent: aws-sdk-js/3.1074.0 langfuse/4.2.0
```

This makes Langfuse traffic attributable in bucket access logs, which helps when debugging a self-hosted deployment against Amazon S3 or against any S3-compatible endpoint configured through `LANGFUSE_S3_*_ENDPOINT`.

Presigned URLs are unaffected: `X-Amz-SignedHeaders` stays `host` (plus `content-type` on uploads), so the user agent is neither signed nor added to the query string.

No new config keys, env vars, or dependencies.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm --filter @langfuse/shared run lint`: clean
- `pnpm --filter @langfuse/shared run typecheck`: clean
- `pnpm --filter worker run typecheck`: clean
- `pnpm --filter @langfuse/shared run test StorageService.test.ts`: `Tests  11 passed (11)`
- `pnpm run format:check`: `All matched files use Prettier code style!`
- The header values above were captured off the real outgoing request using the middleware harness already in `StorageService.test.ts`, and the presigned URL claim was checked the same way. Both probes were scratch files and are not part of this diff.