### PR TITLE
fix(dashboards): route legacy trace widgets through v2

### DIFF
--- a/packages/shared/src/features/query/index.ts
+++ b/packages/shared/src/features/query/index.ts
@@ -1,3 +1,4 @@
 export * from "./dataModel";
 export * from "./types";
 export * from "./validateQuery";
+export * from "./widgetVersion";

--- a/packages/shared/src/features/query/types.ts
+++ b/packages/shared/src/features/query/types.ts
@@ -92,7 +92,8 @@ export const views = z.enum([
   // "users",
 ]);
 
-// V2 views - excludes "traces" which is not supported in v2 API
+// Public v2 API views - excludes "traces". Internal dashboard queries still
+// support the events-backed v2 traces declaration for legacy widget parity.
 export const viewsV2 = z.enum([
   "observations",
   "scores-numeric",

--- a/packages/shared/src/features/query/widgetVersion.test.ts
+++ b/packages/shared/src/features/query/widgetVersion.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getWidgetRequiredVersion,
+  resolveWidgetEditorVersion,
+  resolveWidgetRenderVersion,
+  type WidgetQueryShape,
+} from "./widgetVersion";
+
+const v1Shape: WidgetQueryShape = {
+  view: "observations",
+  dimensions: [{ field: "name" }],
+  measures: [{ measure: "count" }],
+  filters: [],
+};
+
+const v2Shape: WidgetQueryShape = {
+  ...v1Shape,
+  dimensions: [{ field: "experimentName" }],
+};
+
+const tracesShape: WidgetQueryShape = {
+  view: "traces",
+  dimensions: [{ field: "name" }],
+  measures: [{ measure: "count" }],
+  filters: [],
+};
+
+describe("widget query version selection", () => {
+  it.each([
+    ["v1-compatible shape", v1Shape, 1],
+    ["v2-only shape", v2Shape, 2],
+    ["legacy traces shape", tracesShape, 1],
+  ] as const)("classifies %s as v%s", (_name, shape, expected) => {
+    expect(getWidgetRequiredVersion(shape)).toBe(expected);
+  });
+
+  it.each([
+    ["v1-compatible observations", v1Shape, 1, "v1", "v1"],
+    ["persisted v2 observations", v1Shape, 2, "v1", "v2"],
+    ["active v2 observations", v1Shape, 1, "v2", "v2"],
+    ["v2-only observations", v2Shape, 1, "v1", "v2"],
+    ["legacy traces in v1", tracesShape, 1, "v1", "v1"],
+    ["legacy traces in v4", tracesShape, 1, "v2", "v2"],
+  ] as const)(
+    "renders %s with the expected declaration",
+    (_name, shape, persistedMinVersion, newestReadableVersion, expected) => {
+      expect(
+        resolveWidgetRenderVersion({
+          shape,
+          persistedMinVersion,
+          newestReadableVersion,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it.each([
+    ["v1 editor", v1Shape, 1, "v1", "v1"],
+    ["frozen v2 editor floor", v1Shape, 2, "v1", "v2"],
+    ["active v2 editor", v1Shape, 1, "v2", "v2"],
+    ["v2-only current edit", v2Shape, 1, "v1", "v2"],
+    ["legacy traces in active v4", tracesShape, 1, "v2", "v2"],
+  ] as const)(
+    "edits %s with the expected declaration",
+    (_name, shape, baseMinVersion, activeVersion, expected) => {
+      expect(
+        resolveWidgetEditorVersion({
+          shape,
+          baseMinVersion,
+          activeVersion,
+        }),
+      ).toBe(expected);
+    },
+  );
+});

--- a/packages/shared/src/features/query/widgetVersion.ts
+++ b/packages/shared/src/features/query/widgetVersion.ts
@@ -1,0 +1,60 @@
+import { requiresV2 } from "./dataModel";
+import type { ViewVersion } from "./types";
+
+export type WidgetQueryVersion = 1 | 2;
+export type WidgetQueryShape = Parameters<typeof requiresV2>[0];
+
+/**
+ * Returns the lowest query-engine version required by a widget definition.
+ * This is shape classification only; persistence policy remains owned by
+ * DashboardService.
+ */
+export function getWidgetRequiredVersion(
+  shape: WidgetQueryShape,
+): WidgetQueryVersion {
+  return requiresV2(shape) ? 2 : 1;
+}
+
+function resolveEffectiveWidgetVersion(params: {
+  shape: WidgetQueryShape;
+  versionFloor?: number;
+  targetVersion: ViewVersion;
+}): ViewVersion {
+  return getWidgetRequiredVersion(params.shape) >= 2 ||
+    (params.versionFloor ?? 1) >= 2 ||
+    params.targetVersion === "v2"
+    ? "v2"
+    : "v1";
+}
+
+/**
+ * Selects the newest readable query declaration for a persisted widget.
+ * This does not decide or mutate the widget's persisted minVersion.
+ */
+export function resolveWidgetRenderVersion(params: {
+  shape: WidgetQueryShape;
+  persistedMinVersion?: number;
+  newestReadableVersion: ViewVersion;
+}): ViewVersion {
+  return resolveEffectiveWidgetVersion({
+    shape: params.shape,
+    versionFloor: params.persistedMinVersion,
+    targetVersion: params.newestReadableVersion,
+  });
+}
+
+/**
+ * Selects the declaration used by the widget editor for the active UI mode.
+ * The editor's base version is a local floor; saving remains server-owned.
+ */
+export function resolveWidgetEditorVersion(params: {
+  shape: WidgetQueryShape;
+  baseMinVersion: number;
+  activeVersion: ViewVersion;
+}): ViewVersion {
+  return resolveEffectiveWidgetVersion({
+    shape: params.shape,
+    versionFloor: params.baseMinVersion,
+    targetVersion: params.activeVersion,
+  });
+}

--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -22,10 +22,9 @@ import { singleFilter } from "../../../";
 import {
   getValidAggregationsForMeasureType,
   getViewDeclaration,
-  requiresV2,
+  getWidgetRequiredVersion,
+  type WidgetQueryShape,
 } from "../../../features/query";
-
-type WidgetQueryShape = Parameters<typeof requiresV2>[0];
 
 /**
  * `minVersion` is the lowest query-engine version that can represent a widget
@@ -38,7 +37,7 @@ export const resolveDashboardWidgetMinVersion = (
   persistedMinVersion?: number,
 ) => {
   const maxVersion = env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy" ? 1 : 2;
-  const requiredVersion = requiresV2(shape) ? 2 : 1;
+  const requiredVersion = getWidgetRequiredVersion(shape);
 
   if (requiredVersion > maxVersion) {
     throw new InvalidRequestError(

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -4,11 +4,10 @@ import {
   buildWidgetOrderBy,
   getResultUnit,
   isV2BreakdownChart,
-  requiresV2,
+  resolveWidgetRenderVersion,
   toQueryChartConfig,
   validateQuery,
   type QueryType,
-  type ViewVersion,
   type metricAggregations,
   type views,
 } from "@langfuse/shared/query";
@@ -137,21 +136,18 @@ export function DashboardWidget({
       enabled: Boolean(projectId),
     },
   );
-  const widgetRequiresV2 = requiresV2({
-    view: widget.data?.view ?? "traces",
-    dimensions: widget.data?.dimensions ?? [],
-    measures:
-      widget.data?.metrics.map((metric) => ({ measure: metric.measure })) ?? [],
-    filters: widget.data?.filters ?? [],
+  const metricsVersion = resolveWidgetRenderVersion({
+    shape: {
+      view: widget.data?.view ?? "traces",
+      dimensions: widget.data?.dimensions ?? [],
+      measures:
+        widget.data?.metrics.map((metric) => ({ measure: metric.measure })) ??
+        [],
+      filters: widget.data?.filters ?? [],
+    },
+    persistedMinVersion: widget.data?.minVersion,
+    newestReadableVersion: isBetaEnabled ? "v2" : "v1",
   });
-  // If widget requires v2 features (minVersion >= 2), must use v2.
-  // Otherwise follow the beta toggle.
-  const metricsVersion: ViewVersion =
-    widgetRequiresV2 || (widget.data?.minVersion ?? 1) >= 2
-      ? "v2"
-      : isBetaEnabled && (widget.data?.view ?? "traces") !== "traces"
-        ? "v2"
-        : "v1";
   const hasRbacCUDAccess = useHasProjectAccess({
     projectId,
     scope: "dashboards:CUD",

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -121,7 +121,7 @@ import {
   effectiveWidgetName,
   makeWidgetFormSchema,
   normalizeWidgetFormValues,
-  resolveWidgetViewVersion,
+  resolveWidgetFormVersion,
   toDefaultValues,
   toSavePayload,
   widgetChartTypeSupportsBreakdown,
@@ -257,6 +257,7 @@ export function WidgetForm({
   // The resolver and live viewVersion additionally derive v2 from the current
   // form shape; the server derives the value that gets persisted.
   const baseMinVersion = deriveWidgetBaseMinVersion(initialValues);
+  const activeVersion: ViewVersion = isBetaEnabled ? "v2" : "v1";
 
   // The auto-suggestions change on every keystroke; a ref keeps the resolver
   // closure from being rebuilt on each one (the filled name/description do not
@@ -279,7 +280,7 @@ export function WidgetForm({
   // The schema version is derived INSIDE the resolver from the (mapped) view
   // being validated — not from a render-written ref — so it is never render
   // stale after a version-flipping view or import. baseMinVersion and
-  // isBetaEnabled are in the dep list so either promotion rebuilds the closure
+  // activeVersion are in the dep list so either promotion rebuilds the closure
   // (react-hook-form re-reads control._options each render).
   const resolver = useMemo<Resolver<WidgetFormValues>>(() => {
     return (values, context, options) => {
@@ -297,23 +298,23 @@ export function WidgetForm({
         // map them to view space independently.
         filters: mapWidgetUiTableFilterToView(v.view, v.filters ?? []),
       };
-      const version = resolveWidgetViewVersion({
+      const version = resolveWidgetFormVersion({
         view: mapped.view,
         baseMinVersion,
-        isBetaEnabled,
+        activeVersion,
         shape: mapped,
       });
       return resolversByVersion[version](mapped as any, context, options);
     };
-  }, [resolversByVersion, baseMinVersion, isBetaEnabled]);
+  }, [resolversByVersion, baseMinVersion, activeVersion]);
 
   // The initial view version, derived from initialValues alone (view is known
   // before the form mounts) so the seed can normalize against the right view
   // declaration.
-  const initialViewVersion = resolveWidgetViewVersion({
+  const initialViewVersion = resolveWidgetFormVersion({
     view: initialValues.view,
     baseMinVersion,
-    isBetaEnabled,
+    activeVersion,
   });
 
   const form = useForm<WidgetFormValues>({
@@ -327,10 +328,10 @@ export function WidgetForm({
 
   const selectedView = values.view;
   const chartType = values.chart.type;
-  const viewVersion = resolveWidgetViewVersion({
+  const viewVersion = resolveWidgetFormVersion({
     view: selectedView,
     baseMinVersion,
-    isBetaEnabled,
+    activeVersion,
     shape: values,
   });
   const suggestions = deriveWidgetSuggestions(values);
@@ -338,7 +339,14 @@ export function WidgetForm({
 
   suggestionsRef.current = suggestions;
 
-  const availableViewOptions = viewVersion === "v2" ? viewsV2 : views;
+  // `viewsV2` is the public/new-widget v2 allowlist and intentionally excludes
+  // `traces`. Existing legacy trace widgets are a compatibility exception:
+  // their v2 query uses the internal events-backed declaration, so the current
+  // `traces` value must remain selectable while editing. Once the user leaves
+  // traces, return to the public allowlist so traces stays unavailable for
+  // new V4 widget definitions.
+  const availableViewOptions =
+    viewVersion === "v2" && selectedView !== "traces" ? viewsV2 : views;
 
   // Valid aggregations for a given measure on the current (view, version).
   const getValidAggregationsForMeasure = (
@@ -858,10 +866,10 @@ export function WidgetForm({
   // resolve/breakdown-wipe healing so the post-view-change state is valid).
   const onViewChange = (newView: z.infer<typeof views>) => {
     if (newView === selectedView) return;
-    const newViewVersion = resolveWidgetViewVersion({
+    const newViewVersion = resolveWidgetFormVersion({
       view: newView,
       baseMinVersion,
-      isBetaEnabled,
+      activeVersion,
       shape: values,
     });
     const newViewDeclaration = viewDeclarations[newViewVersion][newView];
@@ -979,10 +987,10 @@ export function WidgetForm({
       const importIsPivot = snapshot.selectedChartType === "PIVOT_TABLE";
       // The preview version for the imported widget is re-derived from the
       // snapshot's own version hint (not the mount's).
-      const importViewVersion = resolveWidgetViewVersion({
+      const importViewVersion = resolveWidgetFormVersion({
         view: snapshot.selectedView,
         baseMinVersion: snapshot.widgetMinVersion,
-        isBetaEnabled,
+        activeVersion,
       });
       // Explicit user-event reset (allowed — not an effect). The imported name
       // is a non-empty override, so it sticks and does not auto-update. The

--- a/web/src/features/widgets/components/widgetFormAdapters.clienttest.ts
+++ b/web/src/features/widgets/components/widgetFormAdapters.clienttest.ts
@@ -19,7 +19,7 @@ import {
   deriveEffectiveSort,
   deriveWidgetBaseMinVersion,
   deriveWidgetSuggestions,
-  resolveWidgetViewVersion,
+  resolveWidgetFormVersion,
   toDefaultValues,
   toSavePayload,
   type WidgetFormValues,
@@ -29,10 +29,10 @@ import {
 
 /** The view version the app would seed with for a given widget (non-beta). */
 const fixtureViewVersion = (iv: WidgetInitialValues) =>
-  resolveWidgetViewVersion({
+  resolveWidgetFormVersion({
     view: iv.view,
     baseMinVersion: deriveWidgetBaseMinVersion(iv),
-    isBetaEnabled: false,
+    activeVersion: "v1",
   });
 
 /**
@@ -391,14 +391,35 @@ describe("widget form adapters round-trip parity", () => {
 });
 
 describe("widget form view version", () => {
+  it("keeps a v1 base version for a v1-compatible create shape", () => {
+    expect(deriveWidgetBaseMinVersion(fixtures["regular line (create)"])).toBe(
+      1,
+    );
+  });
+
   it("promotes a legacy widget when its current shape requires v2", () => {
     expect(
-      resolveWidgetViewVersion({
+      resolveWidgetFormVersion({
         view: "observations",
         baseMinVersion: 1,
-        isBetaEnabled: false,
+        activeVersion: "v1",
         shape: {
           dimensions: [{ field: "experimentName" }],
+          metrics: [{ measure: "count" }],
+          filters: [],
+        },
+      }),
+    ).toBe("v2");
+  });
+
+  it("uses the events-backed v2 declaration for legacy trace widgets in v4", () => {
+    expect(
+      resolveWidgetFormVersion({
+        view: "traces",
+        baseMinVersion: 1,
+        activeVersion: "v2",
+        shape: {
+          dimensions: [],
           metrics: [{ measure: "count" }],
           filters: [],
         },

--- a/web/src/features/widgets/components/widgetFormSchema.ts
+++ b/web/src/features/widgets/components/widgetFormSchema.ts
@@ -8,8 +8,9 @@ import {
 } from "@langfuse/shared";
 import {
   getValidAggregationsForMeasureType,
+  getWidgetRequiredVersion,
   metricAggregations,
-  requiresV2,
+  resolveWidgetEditorVersion,
   viewDeclarations,
   views,
   type ViewVersion,
@@ -329,7 +330,7 @@ export type WidgetSavePayload = {
 export function deriveWidgetBaseMinVersion(
   initialValues: WidgetInitialValues,
 ): number {
-  return requiresV2({
+  const requiredVersion = getWidgetRequiredVersion({
     view: initialValues.view,
     dimensions:
       initialValues.dimensions ??
@@ -340,40 +341,38 @@ export function deriveWidgetBaseMinVersion(
       measure: metric.measure,
     })) ?? [{ measure: initialValues.measure }],
     filters: initialValues.filters ?? [],
-  })
-    ? 2
-    : (initialValues.minVersion ?? 1);
+  });
+
+  return requiredVersion === 2 ? 2 : (initialValues.minVersion ?? 1);
 }
 
 /**
- * Derives the effective view version (query-engine v1/v2) from the current view,
- * selected query shape, frozen initial hint, and beta flag. The persisted value
- * is a local hint only; shape-required v2 is always promoted.
+ * Adapts editor-space form values to the canonical widget query shape and
+ * resolves the active editor declaration. Persistence remains server-owned.
  */
-export function resolveWidgetViewVersion(params: {
+export function resolveWidgetFormVersion(params: {
   view: z.infer<typeof views>;
   baseMinVersion: number;
-  isBetaEnabled: boolean;
+  activeVersion: ViewVersion;
   shape?: {
     dimensions: { field: string }[];
     metrics: { measure: string }[];
     filters?: FilterState;
   };
 }): ViewVersion {
-  const shapeRequiresV2 = requiresV2({
-    view: params.view,
-    dimensions: params.shape?.dimensions ?? [],
-    measures: params.shape?.metrics ?? [],
-    filters: mapWidgetUiTableFilterToView(
-      params.view,
-      params.shape?.filters ?? [],
-    ),
+  return resolveWidgetEditorVersion({
+    shape: {
+      view: params.view,
+      dimensions: params.shape?.dimensions ?? [],
+      measures: params.shape?.metrics ?? [],
+      filters: mapWidgetUiTableFilterToView(
+        params.view,
+        params.shape?.filters ?? [],
+      ),
+    },
+    baseMinVersion: params.baseMinVersion,
+    activeVersion: params.activeVersion,
   });
-  return shapeRequiresV2 ||
-    params.baseMinVersion >= 2 ||
-    (params.isBetaEnabled && params.view !== "traces")
-    ? "v2"
-    : "v1";
 }
 
 /** Sanitized pivot default sort for the current metric/dimension selection, or undefined when the stored sort no longer applies. */

--- a/web/src/features/widgets/hooks/useWidgetQuery.ts
+++ b/web/src/features/widgets/hooks/useWidgetQuery.ts
@@ -7,7 +7,7 @@ import {
   type ViewVersion,
   type views,
   type metricAggregations,
-  requiresV2,
+  resolveWidgetRenderVersion,
   validateQuery,
   toQueryChartConfig,
   isV2BreakdownChart,
@@ -117,24 +117,16 @@ export function useWidgetQuery({
 
   // Compute version based on widget requirements and beta toggle
   const version: ViewVersion = useMemo(() => {
-    const widgetRequiresV2 = requiresV2({
-      view: widgetConfig.view,
-      dimensions: widgetConfig.dimensions,
-      measures: widgetConfig.metrics.map((m) => ({ measure: m.measure })),
-      filters: widgetConfig.filters,
+    return resolveWidgetRenderVersion({
+      shape: {
+        view: widgetConfig.view,
+        dimensions: widgetConfig.dimensions,
+        measures: widgetConfig.metrics.map((m) => ({ measure: m.measure })),
+        filters: widgetConfig.filters,
+      },
+      persistedMinVersion: widgetConfig.minVersion,
+      newestReadableVersion: isBetaEnabled ? "v2" : "v1",
     });
-
-    // If widget requires v2 features (minVersion >= 2), must use v2.
-    // Otherwise follow the beta toggle (except for traces view which has no v2).
-    if (widgetRequiresV2 || (widgetConfig.minVersion ?? 1) >= 2) {
-      return "v2";
-    }
-
-    if (isBetaEnabled && widgetConfig.view !== "traces") {
-      return "v2";
-    }
-
-    return "v1";
   }, [widgetConfig, isBetaEnabled]);
 
   // Build the query

--- a/web/src/features/widgets/server/public-dashboard-widget-service.ts
+++ b/web/src/features/widgets/server/public-dashboard-widget-service.ts
@@ -56,7 +56,7 @@ const throwInvalidWidget = (params: {
   });
 };
 
-function getWidgetViewVersion(
+function resolvePublicWidgetPersistedViewVersion(
   widget: NormalizedWidgetInput,
   persistedMinVersion?: number,
 ): ViewVersion {
@@ -168,7 +168,10 @@ export function validatePublicDashboardWidgetInput(
   widget: NormalizedWidgetInput,
   persistedMinVersion?: number,
 ): void {
-  const viewVersion = getWidgetViewVersion(widget, persistedMinVersion);
+  const viewVersion = resolvePublicWidgetPersistedViewVersion(
+    widget,
+    persistedMinVersion,
+  );
   const viewDeclaration = getPublicDashboardWidgetViewDeclaration(
     widget,
     viewVersion,

--- a/web/src/features/widgets/utils.ts
+++ b/web/src/features/widgets/utils.ts
@@ -230,7 +230,8 @@ export function buildWidgetDescription({
 /**
  * Returns the default view for the new widget form.
  * When v4 beta is enabled, defaults to "observations" because "traces"
- * is excluded from viewsV2 (no v2-specific API support).
+ * remains excluded from the public `viewsV2` API enum. Existing trace widgets
+ * are still supported by the internal events-backed v2 query declaration.
  */
 export function getDefaultView(
   isBetaEnabled: boolean,

--- a/web/src/features/widgets/utils/import-export-utils.ts
+++ b/web/src/features/widgets/utils/import-export-utils.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import {
   getValidAggregationsForMeasureType,
   metricAggregations,
-  requiresV2,
+  resolveWidgetEditorVersion,
   viewDeclarations,
   views,
   type ViewVersion,
@@ -25,7 +25,6 @@ import {
   MAX_PIVOT_TABLE_DIMENSIONS,
   MAX_PIVOT_TABLE_METRICS,
 } from "@/src/features/widgets/utils/pivot-table-utils";
-
 const dashboardWidgetChartTypeSchema = z.enum(DashboardWidgetChartType);
 const widgetMetricSchema = MetricSchema.extend({
   agg: metricAggregations,
@@ -449,6 +448,9 @@ function normalizeImportedWidgetVersion(widget: WidgetImport): WidgetImport {
     return widget;
   }
 
+  // v2 is a deployment/read-path choice for traces, not a v2-only widget
+  // shape. Keep the persisted hint at the actual minimum while allowing v4
+  // imports to validate against the events-backed trace declaration.
   return {
     ...widget,
     minVersion: 1,
@@ -483,20 +485,18 @@ export function parseImportedWidgetJson(params: {
   });
 
   const normalizedWidget = normalizeImportedWidgetVersion(importedWidget);
-  const shapeRequiresV2 = requiresV2({
-    view: normalizedWidget.view,
-    dimensions: normalizedWidget.dimensions,
-    measures: normalizedWidget.metrics.map((metric) => ({
-      measure: metric.measure,
-    })),
-    filters: normalizedWidget.filters,
+  const importedViewVersion: ViewVersion = resolveWidgetEditorVersion({
+    shape: {
+      view: normalizedWidget.view,
+      dimensions: normalizedWidget.dimensions,
+      measures: normalizedWidget.metrics.map((metric) => ({
+        measure: metric.measure,
+      })),
+      filters: normalizedWidget.filters,
+    },
+    baseMinVersion: normalizedWidget.minVersion ?? 1,
+    activeVersion: params.isBetaEnabled ? "v2" : "v1",
   });
-  const importedViewVersion: ViewVersion =
-    (params.isBetaEnabled && normalizedWidget.view !== "traces") ||
-    shapeRequiresV2 ||
-    (normalizedWidget.minVersion ?? 1) >= 2
-      ? "v2"
-      : "v1";
 
   validateImportedWidget({
     widget: normalizedWidget,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15685.preview.langfuse.com](https://pr-15685.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Fixes legacy trace-based dashboard widgets rendering empty when V4 is active. Existing widgets that use the legacy `traces` view are now rendered through the internal events-backed v2 declaration, so they work in V4-only deployments even when the project has no legacy `traces` or `observations` rows.

This preserves the intended creation and persistence behavior:

- `resolveDashboardWidgetMinVersion` remains the single authoritative save resolver.
- V4 state never changes the persisted widget `minVersion`.
- New `traces` widgets remain blocked in the V4 path.
- The warning remains visible when editing an existing legacy `traces` widget.
- With V4 disabled, legacy widgets continue to use v1 `traces`/`observations` queries. The beta toggle is a user/session setting, so it must be enabled to exercise the events-backed path.

Widget version selection is consolidated into purpose-specific selectors:

- `resolveWidgetRenderVersion` selects the newest readable version for dashboard rendering.
- `resolveWidgetEditorVersion` selects the active version for editing and preview.
- Form and import adapters build canonical query shapes and delegate to those selectors.
- The persisted save policy remains server-owned and is not duplicated in client code.

The affected maintained cost-dashboard widgets include:

- Total Count Traces
- Top 20 Users by Cost
- Top 20 Use Cases (Trace) by Cost

Related: LFE-13786

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes dashboard-widget query-version selection and routes legacy trace widgets through the events-backed v2 declaration when V4 is active.
- Adds shared render/editor version resolvers and unit coverage.
- Applies version resolution across widget rendering, editing, imports, and public widget validation.
- Keeps legacy trace widgets selectable while editing in V4 mode.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the editor stops promoting every v1-compatible widget to the v2 declaration.

The new base-version helper uses a numeric version as a boolean, causing version 1 to take the same branch as version 2 and forcing all widget editor and preview flows onto v2.

**Files Needing Attention:** web/src/features/widgets/components/widgetFormSchema.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Persisted widget shape] --> B[getWidgetRequiredVersion]
  B --> C[Render version resolver]
  B --> D[Editor base version]
  C --> E[v1 or events-backed v2 query]
  D --> F[Editor declaration and preview]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/widgets/components/widgetFormSchema.ts:333-346
**Numeric version always promotes editor**

When a v1-compatible widget opens outside V4, `getWidgetRequiredVersion` returns `1`, but the ternary treats that numeric value as truthy and sets the base floor to `2`, causing the editor and preview to use v2 declarations instead of the persisted/default v1 declaration.

```suggestion
  return getWidgetRequiredVersion({
    view: initialValues.view,
    dimensions:
      initialValues.dimensions ??
      (initialValues.dimension && initialValues.dimension !== "none"
        ? [{ field: initialValues.dimension }]
        : []),
    measures: initialValues.metrics?.map((metric) => ({
      measure: metric.measure,
    })) ?? [{ measure: initialValues.measure }],
    filters: initialValues.filters ?? [],
  }) >= 2
    ? 2
    : (initialValues.minVersion ?? 1);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): consolidate widget vers..."](https://github.com/langfuse/langfuse/commit/83b1f5d65f3f6bd772379d9c1c9d8083a22d4be0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49169003)</sub>

<!-- /greptile_comment -->