### PR TITLE
feat(public-api): add DELETE /api/public/annotation-queues/{queueId}

### DIFF
--- a/fern/apis/server/definition/annotation-queues.yml
+++ b/fern/apis/server/definition/annotation-queues.yml
@@ -39,6 +39,16 @@ service:
           docs: The unique identifier of the annotation queue
       response: AnnotationQueue
 
+    deleteQueue:
+      docs: Delete an annotation queue and (via Prisma cascade) all of its items and assignments
+      method: DELETE
+      path: /annotation-queues/{queueId}
+      path-parameters:
+        queueId:
+          type: string
+          docs: The unique identifier of the annotation queue
+      response: DeleteAnnotationQueueResponse
+
     listQueueItems:
       docs: Get items for a specific annotation queue
       method: GET
@@ -196,6 +206,11 @@ types:
         type: optional<AnnotationQueueStatus>
 
   DeleteAnnotationQueueItemResponse:
+    properties:
+      success: boolean
+      message: string
+
+  DeleteAnnotationQueueResponse:
     properties:
       success: boolean
       message: string

--- a/web/src/__tests__/server/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queues-api.servertest.ts
@@ -4,6 +4,7 @@ import {
   makeAPICall,
 } from "@/src/__tests__/test-utils";
 import {
+  DeleteAnnotationQueueResponse,
   GetAnnotationQueuesResponse,
   GetAnnotationQueueByIdResponse,
   GetAnnotationQueueItemsResponse,
@@ -858,6 +859,117 @@ describe("Annotation Queues API Endpoints", () => {
       );
 
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /annotation-queues/:queueId", () => {
+    let queueId: string;
+
+    beforeEach(async () => {
+      const queue = await createQueue();
+      queueId = queue.id;
+    });
+
+    it("should delete an annotation queue", async () => {
+      // Seed items and an assignment so we can verify the cascade
+      await prisma.annotationQueueItem.create({
+        data: {
+          queueId,
+          objectId: uuidv4(),
+          objectType: AnnotationQueueObjectType.TRACE,
+          status: AnnotationQueueStatus.PENDING,
+          projectId,
+        },
+      });
+
+      const user = await prisma.user.create({
+        data: {
+          id: `user-${uuidv4()}`,
+          email: `${uuidv4()}@example.com`,
+          name: "Test User",
+        },
+      });
+      await prisma.annotationQueueAssignment.create({
+        data: {
+          projectId,
+          queueId,
+          userId: user.id,
+        },
+      });
+
+      const response = await makeZodVerifiedAPICall(
+        DeleteAnnotationQueueResponse,
+        "DELETE",
+        `/api/public/annotation-queues/${queueId}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(typeof response.body.message).toBe("string");
+
+      // Verify the queue is deleted
+      const deletedQueue = await prisma.annotationQueue.findUnique({
+        where: { id: queueId, projectId },
+      });
+      expect(deletedQueue).toBeNull();
+
+      // Verify items and assignments were cascaded out
+      const remainingItems = await prisma.annotationQueueItem.count({
+        where: { queueId },
+      });
+      expect(remainingItems).toBe(0);
+
+      const remainingAssignments = await prisma.annotationQueueAssignment.count(
+        {
+          where: { queueId },
+        },
+      );
+      expect(remainingAssignments).toBe(0);
+    });
+
+    it("should return 404 for non-existent queue", async () => {
+      const nonExistentId = uuidv4();
+      const response = await makeAPICall(
+        "DELETE",
+        `/api/public/annotation-queues/${nonExistentId}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 when deleting a queue from a different project", async () => {
+      // Create a second org+project+api key
+      const { projectId: otherProjectId } = await createOrgProjectAndApiKey();
+
+      // Create a queue in the SECOND project
+      const otherProjectQueue = await prisma.annotationQueue.create({
+        data: {
+          name: "Other Project Queue",
+          description: "Belongs to a different project",
+          scoreConfigIds: [],
+          projectId: otherProjectId,
+        },
+      });
+
+      // Attempt to delete with the FIRST project's auth
+      const response = await makeAPICall(
+        "DELETE",
+        `/api/public/annotation-queues/${otherProjectQueue.id}`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(404);
+
+      // The other project's queue should still exist
+      const stillThere = await prisma.annotationQueue.findUnique({
+        where: { id: otherProjectQueue.id },
+      });
+      expect(stillThere).not.toBeNull();
     });
   });
 });

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -692,3 +692,50 @@ export const deleteAnnotationQueueAssignmentForApi = async ({
     throw error;
   }
 };
+
+export const deleteAnnotationQueueForApi = async ({
+  projectId,
+  queueId,
+  auditScope,
+}: {
+  projectId: string;
+  queueId: string;
+} & OptionalAuditScope): Promise<{
+  success: boolean;
+  message: string;
+}> => {
+  // Look up first so we can audit-log the full record before deletion, and so
+  // a missing queue (or one in another project) yields a clean 404 instead of
+  // a Prisma P2025 racing through the cascade.
+  const existingQueue = await getAnnotationQueueRecordOrThrow({
+    projectId,
+    queueId,
+  });
+
+  // Hard-delete. The Prisma schema cascades AnnotationQueueItem and
+  // AnnotationQueueAssignment on queue deletion, so items and assignments
+  // are removed in the same transaction.
+  await prisma.annotationQueue.delete({
+    where: {
+      id: queueId,
+      projectId,
+    },
+  });
+
+  if (auditScope) {
+    await auditLog({
+      action: "delete",
+      resourceType: "annotationQueue",
+      resourceId: existingQueue.id,
+      projectId: auditScope.projectId,
+      orgId: auditScope.orgId,
+      apiKeyId: auditScope.apiKeyId,
+      before: existingQueue,
+    });
+  }
+
+  return {
+    success: true,
+    message: "Annotation queue deleted successfully",
+  };
+};

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -21,7 +21,7 @@ import {
   MethodNotAllowedError,
   Prisma,
 } from "@langfuse/shared";
-import { prisma } from "@langfuse/shared/src/db";
+import { Prisma, prisma } from "@langfuse/shared/src/db";
 import { getUserProjectRoles } from "@langfuse/shared/src/server";
 import type { z } from "zod";
 
@@ -712,27 +712,52 @@ export const deleteAnnotationQueueForApi = async ({
     queueId,
   });
 
-  // Hard-delete. The Prisma schema cascades AnnotationQueueItem and
-  // AnnotationQueueAssignment on queue deletion, so items and assignments
-  // are removed in the same transaction.
-  await prisma.annotationQueue.delete({
-    where: {
-      id: queueId,
-      projectId,
-    },
-  });
+  // Wrap the delete + audit-log in a single transaction so the two
+  // operations either both succeed or both roll back. Pre-fix, a failure
+  // in auditLog after prisma.annotationQueue.delete returned 500 even
+  // though the queue and its cascading children were already deleted,
+  // and a retry returned 404 with no audit entry. Now both are part of
+  // the same atomic outcome.
+  await prisma.$transaction(async (tx) => {
+    try {
+      // Hard-delete. The Prisma schema cascades AnnotationQueueItem and
+      // AnnotationQueueAssignment on queue deletion, so items and
+      // assignments are removed in the same transaction.
+      await tx.annotationQueue.delete({
+        where: {
+          id: queueId,
+          projectId,
+        },
+      });
+    } catch (error) {
+      // Handle the race: if a concurrent DELETE already removed the
+      // queue between the lookup above and this delete, Prisma throws
+      // P2025. withMiddlewares maps P2025 to a generic 500; surface a
+      // clean 404 instead so the public API contract is preserved.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new LangfuseNotFoundError("Annotation queue not found");
+      }
+      throw error;
+    }
 
-  if (auditScope) {
-    await auditLog({
-      action: "delete",
-      resourceType: "annotationQueue",
-      resourceId: existingQueue.id,
-      projectId: auditScope.projectId,
-      orgId: auditScope.orgId,
-      apiKeyId: auditScope.apiKeyId,
-      before: existingQueue,
-    });
-  }
+    if (auditScope) {
+      await auditLog(
+        {
+          action: "delete",
+          resourceType: "annotationQueue",
+          resourceId: existingQueue.id,
+          projectId: auditScope.projectId,
+          orgId: auditScope.orgId,
+          apiKeyId: auditScope.apiKeyId,
+          before: existingQueue,
+        },
+        tx,
+      );
+    }
+  });
 
   return {
     success: true,

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -79,6 +79,20 @@ export const GetAnnotationQueueByIdQuery = z
 /** @alias */
 export const GetAnnotationQueueByIdResponse = AnnotationQueueSchema;
 
+// DELETE /annotation-queues/:queueId
+export const DeleteAnnotationQueueQuery = z
+  .object({
+    queueId: z.string(),
+  })
+  .strict();
+
+export const DeleteAnnotationQueueResponse = z
+  .object({
+    success: z.boolean(),
+    message: z.string(),
+  })
+  .strict();
+
 // GET /annotation-queues/:queueId/items
 export const GetAnnotationQueueItemsQuery = z
   .object({

--- a/web/src/pages/api/public/annotation-queues/[queueId]/index.ts
+++ b/web/src/pages/api/public/annotation-queues/[queueId]/index.ts
@@ -1,10 +1,15 @@
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
+  DeleteAnnotationQueueQuery,
+  DeleteAnnotationQueueResponse,
   GetAnnotationQueueByIdQuery,
   GetAnnotationQueueByIdResponse,
 } from "@/src/features/public-api/types/annotation-queues";
-import { getAnnotationQueueForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
+import {
+  deleteAnnotationQueueForApi,
+  getAnnotationQueueForApi,
+} from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -16,6 +21,18 @@ export default withMiddlewares({
       await getAnnotationQueueForApi({
         projectId: auth.scope.projectId,
         queueId: query.queueId,
+      }),
+  }),
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete annotation queue",
+    querySchema: DeleteAnnotationQueueQuery,
+    responseSchema: DeleteAnnotationQueueResponse,
+    rateLimitResource: "annotation-queues",
+    fn: async ({ query, auth }) =>
+      await deleteAnnotationQueueForApi({
+        projectId: auth.scope.projectId,
+        queueId: query.queueId,
+        auditScope: auth.scope,
       }),
   }),
 });


### PR DESCRIPTION
## feat(public-api): add DELETE /api/public/annotation-queues/{queueId}

Fixes #15680.

### Summary

Adds a public REST endpoint to delete an annotation queue, mirroring the existing tRPC `annotationQueue.delete` mutation. The endpoint hard-deletes the queue and (via the Prisma schema's `onDelete: Cascade` on `AnnotationQueueItem` and `AnnotationQueueAssignment`) cascades the deletion to all of its items and assignments.

### Before

`GET`, `POST`, and the nested item/assignment routes were all reachable via the public REST API, but the queue-level `DELETE` was only available through the tRPC `annotationQueue.delete` mutation. Programmatic SDK users had to drop down to tRPC or fall back to the UI to remove a queue.

### After

```http
DELETE /api/public/annotation-queues/{queueId}
Authorization: Basic <publicKey:secretKey>

200 OK
{ "success": true, "message": "Annotation queue deleted successfully" }
```

404 if the queue does not exist or belongs to a different project.

### Implementation

- `web/src/features/public-api/types/annotation-queues.ts` — `DeleteAnnotationQueueQuery`, `DeleteAnnotationQueueResponse` Zod schemas
- `web/src/features/annotation-queues/server/publicAnnotationQueueService.ts` — `deleteAnnotationQueueForApi` service function. Looks up the queue first (for audit + clean 404), then hard-deletes. Audit-logged when `auditScope` is provided.
- `web/src/pages/api/public/annotation-queues/[queueId]/index.ts` — `DELETE` handler using `createAuthedProjectAPIRoute`
- `fern/apis/server/definition/annotation-queues.yml` — `deleteQueue` endpoint + `DeleteAnnotationQueueResponse` type so SDK clients regenerate cleanly
- `web/src/__tests__/server/annotation-queues-api.servertest.ts` — 3 new cases under `describe("DELETE /annotation-queues/:queueId")`

### Authorization

The `createAuthedProjectAPIRoute` middleware enforces project-scoped API-key auth; the service additionally scopes the Prisma `where: { id, projectId }` so an API key from project A cannot delete a queue in project B. The cross-project test case asserts this returns 404 and leaves the other project's queue intact.

### Rate limiting

Reuses the existing `annotation-queues` rate-limit bucket (100 / 1000 / 1000 per minute across hobby / core / pro), added in #15233. No new resource needed.

### Testing

- `pnpm --filter web run lint` — clean
- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm --filter web exec vitest run --project server annotation-queues-api` — `Tests 33 passed (33)` (30 existing + 3 new)

The three new test cases:
1. Happy path — DELETE returns 200 + `{ success: true, message }`, and the queue, its items, and its assignments are all gone.
2. 404 on a non-existent queue id.
3. 404 when the queue belongs to a different project (and a follow-up assertion that the other project's queue still exists).

### Backward compatibility

Purely additive. No existing endpoint changes. The Prisma cascade behavior already matches the documented contract of the existing tRPC route; this PR only widens the public API surface.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a project-authenticated public endpoint for hard-deleting annotation queues.
- Defines matching Zod request and response schemas.
- Adds the endpoint to the Fern API definition for SDK generation.
- Adds service-level project scoping, audit logging, and cascade-deletion tests.
- Covers successful deletion, missing queues, and cross-project isolation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The concurrent-delete error mapping and partial-success behavior on audit failure should be fixed before merging.

The new service can return an internal error for a normal deletion race, and it can report failure after the queue and its children have already been permanently deleted without recording the audit event.

**Files Needing Attention:** web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Public DELETE API
    participant DB as Prisma / Database
    participant Audit as Audit Log
    Client->>API: "DELETE /annotation-queues/{queueId}"
    API->>DB: Find queue by id + projectId
    DB-->>API: Queue record
    API->>DB: Delete queue
    DB-->>DB: Cascade items and assignments
    DB-->>API: Deletion committed
    API->>Audit: Write deletion audit record
    Audit-->>API: Success or error
    API-->>Client: 200 or propagated 500
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/annotation-queues/server/publicAnnotationQueueService.ts:718-723
**Concurrent deletion returns 500**

When two authorized DELETE requests pass the preliminary lookup before either deletion completes, the second Prisma delete raises P2025 and the middleware returns HTTP 500 instead of the documented 404 response.

### Issue 2
web/src/features/annotation-queues/server/publicAnnotationQueueService.ts:718-726
**Deletion commits before audit**

When `auditLog` throws after the queue deletion succeeds, the endpoint returns HTTP 500 even though the queue and its children are permanently deleted, and retrying returns 404 while the destructive operation has no audit entry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(public-api): cover DELETE /api/publ..."](https://github.com/langfuse/langfuse/commit/50aa7f5740888ecb1430fc3101e4041da38dbf46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49145767)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->