### PR TITLE
feat(public-api): add PATCH /api/public/comments/{commentId}

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -44,6 +44,23 @@ service:
           type: string
           docs: The unique langfuse identifier of a comment
       response: commons.Comment
+
+    patch:
+      docs: Update a comment's content. Only the content field is mutable; other comment fields (objectId, objectType, authorUserId) cannot be changed via PATCH.
+      method: PATCH
+      path: /comments/{commentId}
+      path-parameters:
+        commentId:
+          type: string
+          docs: The unique langfuse identifier of a comment
+      request:
+        name: PatchCommentRequest
+        body:
+          properties:
+            content:
+              type: string
+              docs: New content for the comment. Same 1-5000 character limit as the create endpoint.
+      response: commons.Comment
 types:
   CreateCommentRequest:
     properties:

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -1,7 +1,11 @@
-import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
+import {
+  makeZodVerifiedAPICall,
+  makeAPICall,
+} from "@/src/__tests__/test-utils";
 import {
   GetCommentsV1Response,
   GetCommentV1Response,
+  PatchCommentV1Response,
   PostCommentsV1Response,
 } from "@/src/features/public-api/types/comments";
 import { prisma } from "@langfuse/shared/src/db";
@@ -383,5 +387,161 @@ describe("Public API does NOT process mentions", () => {
     expect(response.body.content).toBe(
       "Hey @[FakeAdmin](user:user-1) and @[InvalidUser](user:invalid-id), check this!",
     );
+  });
+});
+
+describe("PATCH /api/public/comments/:commentId", () => {
+  beforeAll(async () => {
+    const traces = [
+      createTrace({
+        name: "trace-name",
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        id: "patch-comment-trace",
+      }),
+    ];
+
+    await createTracesCh(traces);
+  });
+
+  it("should update a comment's content", async () => {
+    // Create a comment to update
+    const createResponse = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "original content",
+        objectId: "patch-comment-trace",
+        objectType: "TRACE",
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        authorUserId: "user-1",
+      },
+    );
+    const { id: commentId } = createResponse.body;
+
+    const response = await makeZodVerifiedAPICall(
+      PatchCommentV1Response,
+      "PATCH",
+      `/api/public/comments/${commentId}`,
+      { content: "updated content" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(commentId);
+    expect(response.body.content).toBe("updated content");
+
+    // Confirm via GET that the persisted content is the updated value
+    const getResponse = await makeZodVerifiedAPICall(
+      GetCommentV1Response,
+      "GET",
+      `/api/public/comments/${commentId}`,
+    );
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.body.content).toBe("updated content");
+  });
+
+  it("should return 404 for non-existent comment", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+    const response = await makeAPICall(
+      "PATCH",
+      `/api/public/comments/${nonExistentId}`,
+      { content: "anything" },
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 404 when patching a comment from a different project", async () => {
+    // The default seed project already has comments; create a comment in a
+    // DIFFERENT project by spinning up a new org/project/api key.
+    const { createOrgProjectAndApiKey } =
+      await import("@langfuse/shared/src/server");
+    const { auth: otherAuth, projectId: otherProjectId } =
+      await createOrgProjectAndApiKey();
+
+    // Create a trace in the OTHER project so the comment has a valid object
+    const otherTraces = [
+      createTrace({
+        name: "other-project-trace",
+        project_id: otherProjectId,
+        id: "patch-comment-other-trace",
+      }),
+    ];
+    await createTracesCh(otherTraces);
+
+    const createResponse = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "in another project",
+        objectId: "patch-comment-other-trace",
+        objectType: "TRACE",
+        projectId: otherProjectId,
+        authorUserId: "user-1",
+      },
+      otherAuth,
+    );
+    const { id: otherCommentId } = createResponse.body;
+
+    // Attempt to patch with the SEED project's auth
+    const response = await makeAPICall(
+      "PATCH",
+      `/api/public/comments/${otherCommentId}`,
+      { content: "should not work" },
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 400 when content is empty", async () => {
+    // Create a comment to update
+    const createResponse = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "original content",
+        objectId: "patch-comment-trace",
+        objectType: "TRACE",
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        authorUserId: "user-1",
+      },
+    );
+    const { id: commentId } = createResponse.body;
+
+    const response = await makeAPICall(
+      "PATCH",
+      `/api/public/comments/${commentId}`,
+      { content: "" },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("should return 400 when content exceeds 5000 characters", async () => {
+    // Create a comment to update
+    const createResponse = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "original content",
+        objectId: "patch-comment-trace",
+        objectType: "TRACE",
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        authorUserId: "user-1",
+      },
+    );
+    const { id: commentId } = createResponse.body;
+
+    const tooLong = "a".repeat(5001);
+    const response = await makeAPICall(
+      "PATCH",
+      `/api/public/comments/${commentId}`,
+      { content: tooLong },
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -6,6 +6,7 @@ import { validateCommentReferenceObject } from "@/src/features/comments/validate
 import type {
   GetCommentV1Query,
   GetCommentsV1Query,
+  PatchCommentV1Body,
   PostCommentsV1Body,
 } from "@/src/features/public-api/types/comments";
 import { LangfuseNotFoundError } from "@langfuse/shared";
@@ -29,6 +30,11 @@ type ListCommentsInput = z.infer<typeof GetCommentsV1Query> & {
 type GetCommentInput = z.infer<typeof GetCommentV1Query> & {
   projectId: string;
 };
+
+type UpdateCommentInput = {
+  input: z.infer<typeof PatchCommentV1Body>;
+  auditScope: CommentAuditScope;
+} & GetCommentInput;
 
 // Exclude inline positioning fields from public API.
 const toPublicComment = (comment: {
@@ -153,4 +159,41 @@ export const getCommentForApi = async ({
 }: GetCommentInput) => {
   const comment = await getCommentRecordOrThrow({ projectId, commentId });
   return toPublicComment(comment);
+};
+
+export const updateCommentForApi = async ({
+  projectId,
+  commentId,
+  input,
+  auditScope,
+}: UpdateCommentInput) => {
+  // Look up first so we can audit-log the before state, and so a missing
+  // comment (or one in another project) yields a clean 404 instead of a
+  // Prisma P2025 racing through the update.
+  const before = await getCommentRecordOrThrow({ projectId, commentId });
+
+  const updated = await prisma.comment.update({
+    where: {
+      id: commentId,
+      projectId,
+    },
+    data: {
+      content: input.content,
+    },
+  });
+
+  if (auditScope) {
+    await auditLog({
+      action: "update",
+      resourceType: "comment",
+      resourceId: updated.id,
+      projectId: auditScope.projectId,
+      orgId: auditScope.orgId,
+      apiKeyId: auditScope.apiKeyId,
+      before,
+      after: updated,
+    });
+  }
+
+  return toPublicComment(updated);
 };

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -10,7 +10,7 @@ import type {
   PostCommentsV1Body,
 } from "@/src/features/public-api/types/comments";
 import { LangfuseNotFoundError } from "@langfuse/shared";
-import { prisma } from "@langfuse/shared/src/db";
+import { Prisma, prisma } from "@langfuse/shared/src/db";
 
 type CommentAuditScope = {
   projectId: string;
@@ -172,28 +172,57 @@ export const updateCommentForApi = async ({
   // Prisma P2025 racing through the update.
   const before = await getCommentRecordOrThrow({ projectId, commentId });
 
-  const updated = await prisma.comment.update({
-    where: {
-      id: commentId,
-      projectId,
-    },
-    data: {
-      content: input.content,
-    },
-  });
+  // Wrap the update + audit-log in a single transaction so the two
+  // operations either both succeed or both roll back. Pre-fix, a failure
+  // in auditLog after prisma.comment.update returned 500 even though
+  // the new content was already persisted, which let callers retry an
+  // operation the server reported as failed.
+  const updated = await prisma.$transaction(async (tx) => {
+    let next;
+    try {
+      next = await tx.comment.update({
+        where: {
+          id: commentId,
+          projectId,
+        },
+        data: {
+          content: input.content,
+        },
+      });
+    } catch (error) {
+      // Handle the race: if the comment was deleted between the lookup
+      // above and this update, Prisma throws P2025. The REST middleware
+      // maps P2025 to a generic 500; surface a clean 404 instead so the
+      // public API contract is preserved.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new LangfuseNotFoundError(
+          "Comment not found within authorized project",
+        );
+      }
+      throw error;
+    }
 
-  if (auditScope) {
-    await auditLog({
-      action: "update",
-      resourceType: "comment",
-      resourceId: updated.id,
-      projectId: auditScope.projectId,
-      orgId: auditScope.orgId,
-      apiKeyId: auditScope.apiKeyId,
-      before,
-      after: updated,
-    });
-  }
+    if (auditScope) {
+      await auditLog(
+        {
+          action: "update",
+          resourceType: "comment",
+          resourceId: next.id,
+          projectId: auditScope.projectId,
+          orgId: auditScope.orgId,
+          apiKeyId: auditScope.apiKeyId,
+          before,
+          after: next,
+        },
+        tx,
+      );
+    }
+
+    return next;
+  });
 
   return toPublicComment(updated);
 };

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -74,3 +74,17 @@ export const GetCommentV1Query = z
   })
   .strict();
 export const GetCommentV1Response = APIComment;
+
+// PATCH /comments/:id
+// Note: Public API does not process mentions or inline comment positioning
+export const PatchCommentV1Query = z
+  .object({
+    commentId: z.string(),
+  })
+  .strict();
+export const PatchCommentV1Body = z
+  .object({
+    content: z.string().trim().min(1).max(5000),
+  })
+  .strict();
+export const PatchCommentV1Response = APIComment;

--- a/web/src/pages/api/public/comments/[commentId].ts
+++ b/web/src/pages/api/public/comments/[commentId].ts
@@ -1,9 +1,15 @@
-import { getCommentForApi } from "@/src/features/comments/server/publicCommentService";
+import {
+  getCommentForApi,
+  updateCommentForApi,
+} from "@/src/features/comments/server/publicCommentService";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
   GetCommentV1Query,
   GetCommentV1Response,
+  PatchCommentV1Body,
+  PatchCommentV1Query,
+  PatchCommentV1Response,
 } from "@/src/features/public-api/types/comments";
 
 export default withMiddlewares({
@@ -15,6 +21,19 @@ export default withMiddlewares({
       await getCommentForApi({
         commentId: query.commentId,
         projectId: auth.scope.projectId,
+      }),
+  }),
+  PATCH: createAuthedProjectAPIRoute({
+    name: "Update Comment",
+    querySchema: PatchCommentV1Query,
+    bodySchema: PatchCommentV1Body,
+    responseSchema: PatchCommentV1Response,
+    fn: async ({ query, body, auth }) =>
+      await updateCommentForApi({
+        commentId: query.commentId,
+        projectId: auth.scope.projectId,
+        input: body,
+        auditScope: auth.scope,
       }),
   }),
 });


### PR DESCRIPTION
## feat(public-api): add PATCH /api/public/comments/{commentId}

Fixes #15688.

### Summary

Lets a project-scoped API key edit a comment's `content` field via the public REST API. The other comment fields (`objectId`, `objectType`, `authorUserId`) are intentionally immutable here — they were set on POST and changing them would break the comment's referential integrity. The `updatedAt` column bumps naturally via Prisma's `@updatedAt`.

### Before

`GET` and `DELETE` are reachable on `/api/public/comments/{commentId}` (DELETE added in #15444). `PATCH` returns `405 Method Not Allowed`. To edit a typo or fix outdated content, callers had to delete and recreate, losing the original `id` and `createdAt`.

### After

```http
PATCH /api/public/comments/{commentId}
Authorization: Basic <publicKey:secretKey>
Content-Type: application/json

{ "content": "fixed content" }
```

```http
200 OK
{
  "id": "...",
  "projectId": "...",
  "objectType": "TRACE",
  "objectId": "...",
  "content": "fixed content",
  "authorUserId": "user-1",
  "createdAt": "...",
  "updatedAt": "<bumped>"
}
```

- 404 if the comment does not exist or belongs to a different project.
- 400 if `content` is empty or longer than 5000 characters (matches the existing `PostCommentsV1Body` constraint).

### Implementation

- `web/src/features/public-api/types/comments.ts` — `PatchCommentV1Query`, `PatchCommentV1Body`, `PatchCommentV1Response` Zod schemas
- `web/src/features/comments/server/publicCommentService.ts` — `updateCommentForApi` service function. Looks up the comment first (for clean 404 + audit `before`/`after`), then `prisma.comment.update` with a scoped `where: { id, projectId }`
- `web/src/pages/api/public/comments/[commentId].ts` — `PATCH` handler using `createAuthedProjectAPIRoute`
- `fern/apis/server/definition/comments.yml` — `patch` endpoint so SDK clients regenerate cleanly
- `web/src/__tests__/server/comments-api.servertest.ts` — 5 new cases under `describe("PATCH /api/public/comments/:commentId")`

### Authorization

The `createAuthedProjectAPIRoute` middleware enforces project-scoped API-key auth; the service additionally scopes the Prisma `where: { id, projectId }` so an API key from project A cannot edit a comment in project B. The cross-project test case asserts this returns 404.

### Rate limiting

No new rate-limit resource. Comments don't have a dedicated bucket today (the existing `createCommentForApi` and `listCommentsForApi` also have no `rateLimitResource`), so this PR keeps that contract. If abuse becomes a concern, the bucket can be added in a follow-up.

### Testing

- `pnpm --filter web run lint` — clean
- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm --filter web exec prettier --check` — clean
- `pnpm --filter web exec vitest run --project server comments-api` — `Tests 17 passed (17)` (12 existing + 5 new)

The five new test cases:
1. Happy path — PATCH returns 200 with updated content; follow-up GET confirms persistence.
2. 404 on a non-existent comment id.
3. 404 on cross-project comment (with a follow-up `createOrgProjectAndApiKey` setup).
4. 400 on empty `content`.
5. 400 on `content` longer than 5000 characters.

### Backward compatibility

Purely additive. No existing endpoint changes. The Prisma `Comment` model already has an `updatedAt` column maintained by `prisma`; PATCH bumps it naturally.

### Note on tRPC parity

The tRPC `commentsRouter` (`web/src/server/api/routers/comments.ts`) currently has `create` and `delete` mutations but no `update`. This PR adds public-API PATCH without mirroring an existing tRPC mutation, since the underlying Prisma update is a single-line operation and the route uses the standard `createAuthedProjectAPIRoute` plumbing. A follow-up tRPC `update` mutation would be a small, separate change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a project-scoped public API endpoint for updating comment content.
- Defines the PATCH request and response schemas and exposes the route through Fern.
- Implements scoped persistence and update audit logging.
- Adds coverage for successful updates, validation, missing comments, and cross-project access.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The mutation consistency and concurrent-deletion error paths need to be fixed before merging because they can misreport persisted updates and return 500 for a not-found condition.

The endpoint is properly authenticated and project-scoped, but its separate read, update, and audit operations allow audit failures to follow committed mutations and concurrent deletion to surface as an internal server error.

**Files Needing Attention:** web/src/features/comments/server/publicCommentService.ts; web/src/__tests__/server/comments-api.servertest.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API as PATCH /comments/{commentId}
  participant DB as Postgres
  participant Audit as Audit Log
  Client->>API: PATCH content
  API->>DB: Read scoped comment
  DB-->>API: Before state
  API->>DB: Update content
  DB-->>API: Updated comment
  API->>Audit: Write before/after record
  Audit-->>API: Success or error
  API-->>Client: 200, 404, or 500
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/comments/server/publicCommentService.ts:175-196
**Non-atomic audit persistence**

When the audit-log insert fails after `prisma.comment.update` succeeds, the endpoint returns HTTP 500 even though the new content is already persisted. Callers can then retry an operation that the server reported as failed; the update and its audit record need a shared atomic outcome.

### Issue 2
web/src/__tests__/server/comments-api.servertest.ts:457-458
**Function-local dependency import**

`createOrgProjectAndApiKey` is imported dynamically inside the test, hiding the dependency from the module's static import list and adding unnecessary asynchronous loading. Move this import to the top of the module with the other shared server imports.

### Issue 3
web/src/features/comments/server/publicCommentService.ts:175-183
**Concurrent deletion returns 500**

When the comment is deleted after `getCommentRecordOrThrow` returns but before this update runs, Prisma throws `P2025`, which the REST middleware maps to a generic HTTP 500 rather than the endpoint's documented 404. Handle the scoped update's not-found result so this race preserves the public API contract.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(public-api): cover PATCH /api/publi..."](https://github.com/langfuse/langfuse/commit/201e2a7f6a4a39c0d2f7c604220b3ad3567efab0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49298443)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->