### PR TITLE
feat(public-api): add fromTimestamp/toTimestamp filters to GET /api/public/comments

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -34,6 +34,12 @@ service:
           authorUserId:
             type: optional<string>
             docs: Filter comments by author user id.
+          fromTimestamp:
+            type: optional<nullable<datetime>>
+            docs: Optional ISO 8601 timestamp (inclusive lower bound). Returns comments whose `createdAt` is >= this value.
+          toTimestamp:
+            type: optional<nullable<datetime>>
+            docs: Optional ISO 8601 timestamp (exclusive upper bound). Returns comments whose `createdAt` is < this value.
       response: GetCommentsResponse
     get-by-id:
       docs: Get a comment by id

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -340,6 +340,67 @@ describe("GET /api/public/comments API Endpoint", () => {
       );
     }
   });
+
+  it("should filter comments by fromTimestamp", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetCommentsV1Response,
+      "GET",
+      "/api/public/comments?fromTimestamp=2021-02-01T00:00:00Z",
+    );
+
+    expect(response.status).toBe(200);
+    // The test data has comments at 2021-01-01, 2021-02-01, 2021-03-01, 2021-04-01, 2021-05-01
+    // fromTimestamp=2021-02-01 should return the 4 comments on or after 2021-02-01
+    expect(response.body.data.map((c) => c.id)).toEqual([
+      "comment-2021-02-01",
+      "comment-2021-03-01",
+      "comment-2021-04-01",
+      "comment-2021-05-01",
+    ]);
+  });
+
+  it("should filter comments by toTimestamp", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetCommentsV1Response,
+      "GET",
+      "/api/public/comments?toTimestamp=2021-02-01T00:00:00Z",
+    );
+
+    expect(response.status).toBe(200);
+    // toTimestamp is exclusive (<): only 2021-01-01 should be returned
+    expect(response.body.data.map((c) => c.id)).toEqual(["comment-2021-01-01"]);
+  });
+
+  it("should filter comments by both fromTimestamp and toTimestamp", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetCommentsV1Response,
+      "GET",
+      "/api/public/comments?fromTimestamp=2021-02-01T00:00:00Z&toTimestamp=2021-04-01T00:00:00Z",
+    );
+
+    expect(response.status).toBe(200);
+    // 2021-02-01 inclusive, 2021-04-01 exclusive: 2021-02-01 and 2021-03-01
+    expect(response.body.data.map((c) => c.id)).toEqual([
+      "comment-2021-02-01",
+      "comment-2021-03-01",
+    ]);
+  });
+
+  it("should return 400 when fromTimestamp is not a valid date", async () => {
+    try {
+      await makeZodVerifiedAPICall(
+        z.object({
+          message: z.string(),
+          error: z.array(z.object({})),
+        }),
+        "GET",
+        "/api/public/comments?fromTimestamp=not-a-date",
+      );
+    } catch (error) {
+      expect((error as Error).message).toContain("API call did not return 200");
+      expect((error as Error).message).toContain("400");
+    }
+  });
 });
 
 describe("Public API does NOT process mentions", () => {

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -117,6 +117,8 @@ export const listCommentsForApi = async ({
   objectType,
   objectId,
   authorUserId,
+  fromTimestamp,
+  toTimestamp,
   limit,
   page,
 }: ListCommentsInput) => {
@@ -125,6 +127,12 @@ export const listCommentsForApi = async ({
     objectType: objectType ?? undefined,
     objectId: objectId ?? undefined,
     authorUserId: authorUserId ?? undefined,
+    ...((fromTimestamp || toTimestamp) && {
+      createdAt: {
+        ...(fromTimestamp && { gte: new Date(fromTimestamp) }),
+        ...(toTimestamp && { lt: new Date(toTimestamp) }),
+      },
+    }),
   };
 
   const [comments, totalItems] = await Promise.all([

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -2,6 +2,7 @@ import {
   CommentObjectType,
   paginationMetaResponseZod,
   publicApiPaginationZod,
+  stringDateTime,
 } from "@langfuse/shared";
 import { z } from "zod";
 
@@ -47,6 +48,8 @@ export const GetCommentsV1Query = z
     objectType: z.enum(CommentObjectType).nullish(),
     objectId: z.string().nullish(),
     authorUserId: z.string().nullish(),
+    fromTimestamp: stringDateTime,
+    toTimestamp: stringDateTime,
     ...publicApiPaginationZod,
   })
   .strict()


### PR DESCRIPTION
## feat(public-api): add fromTimestamp/toTimestamp filters to GET /api/public/comments

Fixes #15691.

### Summary

Adds `fromTimestamp` and `toTimestamp` filters to the public-API comments list endpoint, mirroring the existing pattern on `GET /api/public/traces` and `GET /api/public/sessions`. The two new query parameters are optional; existing callers see no behavior change.

### Before

`GET /api/public/comments?page=1&limit=50&objectType=TRACE` returns the first 50 comments across the project's entire history, ordered by some default. Adding `fromTimestamp=...&toTimestamp=...` is silently ignored — both params are stripped during the Zod parse because `GetCommentsV1Query` doesn't declare them, and the service has no `createdAt` filter.

### After

```
GET /api/public/comments
  ?fromTimestamp=2026-07-01T00:00:00Z
  &toTimestamp=2026-08-01T00:00:00Z
  &objectType=TRACE
```

returns only comments whose `createdAt` falls in `[fromTimestamp, toTimestamp)`. Either bound is optional. A request with `fromTimestamp` only returns comments on or after that time; a request with `toTimestamp` only returns comments strictly before that time. Malformed timestamps return 400 via the existing Zod schema (`stringDateTime`).

### Implementation

- `web/src/features/public-api/types/comments.ts` — add `fromTimestamp: stringDateTime` and `toTimestamp: stringDateTime` to `GetCommentsV1Query`, sharing the existing `stringDateTime` definition from `@langfuse/shared` (same as the traces and sessions list endpoints)
- `web/src/features/comments/server/publicCommentService.ts` — `listCommentsForApi` adds a `createdAt: { gte, lt }` Prisma where-clause when either bound is set; both bounds are optional and the existing `take`/`skip` pagination is unchanged
- `web/src/__tests__/server/comments-api.servertest.ts` — 4 new cases under the existing `describe("GET /api/public/comments API Endpoint")` block: `fromTimestamp` only, `toTimestamp` only, both bounds together, 400 on malformed timestamp

### Design notes

- `toTimestamp` is exclusive (`<`), matching the existing traces and sessions semantics. This means `fromTimestamp=X&toTimestamp=X` returns an empty set, which is the standard half-open interval convention.
- The where-clause is only emitted when at least one bound is set. The base `where` is unchanged, so callers that don't pass either param see exactly the same query as before.
- No new rate-limit resource. The `comments` bucket (100/1000/1000 per minute, added in #15233) is unaffected.
- No new Fern definition needed. The `GetCommentsV1Query` schema lives in TypeScript, not Fern.

### Testing

- `pnpm --filter web run lint` — clean
- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm --filter web exec prettier --check` — clean
- `pnpm --filter web exec vitest run --project server comments-api` — `Tests 16 passed (16)` (12 existing + 4 new)

The four new test cases:
1. `fromTimestamp` only — returns comments on or after the bound (4 of 5 in the fixture data).
2. `toTimestamp` only — returns comments strictly before the bound (1 of 5).
3. Both bounds together — half-open interval (2 of 5).
4. 400 on malformed `fromTimestamp`.

### Backward compatibility

Purely additive. The two new query parameters are optional, the existing tests that don't use them still pass, and the response shape is unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds optional half-open created-at filtering to the public comments list endpoint.
- Extends the comments query schema with fromTimestamp and toTimestamp.
- Applies inclusive lower and exclusive upper bounds in the Prisma query.
- Adds endpoint tests for individual and combined bounds and malformed input.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the generated public API contract exposes the new filters; the malformed-input test should also be made non-vacuous.

The server correctly applies the timestamp predicates, but generated SDK consumers cannot use them because Fern remains unchanged, and the negative validation test does not fail if the request unexpectedly succeeds.

**Files Needing Attention:** web/src/features/public-api/types/comments.ts, fern/apis/server/definition/comments.yml, web/src/__tests__/server/comments-api.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/public-api/types/comments.ts:51-52
**Fern contract omits timestamp filters**

When customers use the generated SDKs or published OpenAPI contract, the unchanged Fern definition does not expose or transmit `fromTimestamp` and `toTimestamp`, causing requests to return comments outside the intended time range.

### Issue 2
web/src/__tests__/server/comments-api.servertest.ts:389-403
**Negative test can pass vacuously**

When the endpoint unexpectedly accepts the malformed timestamp and returns 200, execution completes without entering the `catch` block, so this test records no assertions and passes without detecting the validation regression.

```suggestion
  it("should return 400 when fromTimestamp is not a valid date", async () => {
    expect.assertions(2);

    try {
      await makeZodVerifiedAPICall(
        z.object({
          message: z.string(),
          error: z.array(z.object({})),
        }),
        "GET",
        "/api/public/comments?fromTimestamp=not-a-date",
      );
    } catch (error) {
      expect((error as Error).message).toContain("API call did not return 200");
      expect((error as Error).message).toContain("400");
    }
  });
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(public-api): cover fromTimestamp/to..."](https://github.com/langfuse/langfuse/commit/ddbb2a5d33b65981b76b25120b92420f9f9187f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49439590)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->