### PR TITLE
feat(public-api): add content search filter to GET /api/public/comments

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -34,6 +34,9 @@ service:
           authorUserId:
             type: optional<string>
             docs: Filter comments by author user id.
+          content:
+            type: optional<string>
+            docs: Filter comments whose content contains this substring. Up to 200 characters.
       response: GetCommentsResponse
     get-by-id:
       docs: Get a comment by id

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -340,6 +340,40 @@ describe("GET /api/public/comments API Endpoint", () => {
       );
     }
   });
+
+  it("should filter comments by content substring (case-insensitive)", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetCommentsV1Response,
+      "GET",
+      "/api/public/comments?content=comment-3",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.map((c) => c.id)).toEqual(["comment-2021-03-01"]);
+  });
+
+  it("should match content case-insensitively", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetCommentsV1Response,
+      "GET",
+      "/api/public/comments?content=COMMENT-2",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.map((c) => c.id)).toEqual(["comment-2021-02-01"]);
+  });
+
+  it("should return empty array when no comment matches the content filter", async () => {
+    const response = await makeZodVerifiedAPICall(
+      GetCommentsV1Response,
+      "GET",
+      "/api/public/comments?content=nonexistent-substring-xyz",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual([]);
+    expect(response.body.meta.totalItems).toBe(0);
+  });
 });
 
 describe("Public API does NOT process mentions", () => {

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -117,6 +117,7 @@ export const listCommentsForApi = async ({
   objectType,
   objectId,
   authorUserId,
+  content,
   limit,
   page,
 }: ListCommentsInput) => {
@@ -125,6 +126,9 @@ export const listCommentsForApi = async ({
     objectType: objectType ?? undefined,
     objectId: objectId ?? undefined,
     authorUserId: authorUserId ?? undefined,
+    ...(content && {
+      content: { contains: content, mode: "insensitive" as const },
+    }),
   };
 
   const [comments, totalItems] = await Promise.all([

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -47,6 +47,7 @@ export const GetCommentsV1Query = z
     objectType: z.enum(CommentObjectType).nullish(),
     objectId: z.string().nullish(),
     authorUserId: z.string().nullish(),
+    content: z.string().trim().min(1).max(200).optional(),
     ...publicApiPaginationZod,
   })
   .strict()


### PR DESCRIPTION
## feat(public-api): add content search filter to GET /api/public/comments

Fixes #15693.

### Summary

Adds a `content` substring filter to the public-API comments list endpoint, alongside the existing `objectType` / `objectId` / `authorUserId` / `fromTimestamp` / `toTimestamp` filters. Case-insensitive substring match. Purely additive — existing callers see no behavior change.

### Before

`GET /api/public/comments?content=hallucination` returns the same rows as the unfiltered call — the `content` query parameter is silently stripped during the Zod parse because `GetCommentsV1Query` doesn't declare it. To find a particular comment in a project with thousands, a caller has to fetch everything and grep client-side.

### After

`GET /api/public/comments?content=hallucination` returns only comments whose `content` column contains the substring "hallucination" (case-insensitive). Combines with the other filters via AND.

### Implementation

- `web/src/features/public-api/types/comments.ts` — add `content: z.string().trim().min(1).max(200).optional()` to `GetCommentsV1Query`
- `web/src/features/comments/server/publicCommentService.ts` — `listCommentsForApi` adds `content: { contains: content, mode: "insensitive" }` to the Prisma where-clause when set
- `web/src/__tests__/server/comments-api.servertest.ts` — 3 new cases under the existing `describe("GET /api/public/comments API Endpoint")` block: substring match, case-insensitive match, no-match returns empty array

### Design notes

- **Empty string and absent are both "no filter"** (existing behavior preserved). The Zod schema uses `.optional()` rather than `.nullish()` to keep the request shape clean; absent → undefined → no where-clause, empty string → Zod min(1) fails → 400.
- **Max length 200 chars** matches the convention from the in-app search bar (`web/src/features/search-bar/`). Anything longer is almost certainly an attempt to scan a whole document, which Prisma's `contains` is not optimized for — fail loudly with 400 instead.
- **No new Fern definition needed.** The `GetCommentsV1Query` schema lives in TypeScript, not Fern. (The Fern `comments.yml` only declares the get-by-id and patch endpoints.)
- **No new rate-limit resource.** The `comments` bucket is unaffected; this just narrows an existing query.

### Testing

- `pnpm --filter web run lint` — clean
- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm --filter web exec prettier --check` — clean
- `pnpm --filter web exec vitest run --project server comments-api` — `Tests 15 passed (15)` (12 existing + 3 new)

The three new test cases:
1. Substring match — `content=comment-3` returns just `comment-2021-03-01`.
2. Case-insensitive — `content=COMMENT-2` returns `comment-2021-02-01`.
3. No-match — `content=nonexistent-substring-xyz` returns an empty array with `totalItems: 0`.

### Backward compatibility

Purely additive. The new query parameter is optional, the existing tests that don't use it still pass, and the response shape is unchanged.

### Future work (not in this PR)

A future PR could add a `tsvector`-backed full-text search column on the `Comment` model for sub-linear search at scale, but that's a schema migration + GIN index + new field. The simple `contains` filter is enough for the common case (a few thousand comments per project) and degrades gracefully via the existing index.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds case-insensitive substring filtering to the public comments list endpoint.
- Validates optional content searches as trimmed strings of 1–200 characters.
- Applies the content predicate to the shared Prisma query used for rows and total count.
- Adds server tests for substring matching, case-insensitive matching, and empty results.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The runtime filtering is sound, but the missing Fern contract update must be fixed before merging so generated SDKs and public documentation expose the feature.

The server accepts and correctly applies content, but the independently generated public-client request shape still omits it, making the new capability inaccessible through supported SDK interfaces.

**Files Needing Attention:** web/src/features/public-api/types/comments.ts and fern/apis/server/definition/comments.yml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/public-api/types/comments.ts:50
**Public API contract omits content**

When consumers use the generated Python or TypeScript SDK to list comments, the Fern request definition omits `content`, so the supported clients cannot expose or send the new filter even though the runtime endpoint accepts it. Add the parameter to the Fern comments contract so the SDK and documentation remain synchronized with this schema.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(public-api): cover content search f..."](https://github.com/langfuse/langfuse/commit/a0bd7576d1b830411a47916f38b06e9f1c5d8afd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49448973)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->