### PR TITLE
fix(trace): decode unicode escapes in client-side trace downloads and copies

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -37,6 +37,10 @@
 - `@langfuse/shared` via `src/index.ts`: default shared surface for
   cross-runtime types, zod schemas, table definitions, domain models, prompt
   helpers, eval/model-pricing helpers, and other frontend-safe utilities.
+  Includes the unicode-decoding JSON serialization helpers (`stringify`,
+  `stringifyForCsv` in `src/utils/stringify.ts`) used by both the server
+  trace-download route and client-side download/copy paths; the server barrel
+  re-exports them for compatibility.
 - `@langfuse/shared/src/server` via `src/server/index.ts`: server-only barrel
   for shared backend services, repositories, queue helpers/contracts, Redis and
   ClickHouse helpers, auth helpers, logger/instrumentation, ingestion helpers,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./constants";
 export { decodeUnicodeEscapesOnly } from "./utils/unicode";
+export { stringify, stringifyForCsv } from "./utils/stringify";
 export * from "./interfaces/filters";
 export * from "./interfaces/orderBy";
 export * from "./interfaces/cloudConfigSchema";

--- a/packages/shared/src/server/utils/transforms/index.ts
+++ b/packages/shared/src/server/utils/transforms/index.ts
@@ -5,7 +5,10 @@ import { transformStreamToCsv } from "./transformStreamToCsv";
 import { transformStreamToJson } from "./transformStreamToJson";
 import { transformStreamToJsonl } from "./transformStreamToJsonl";
 
-export { stringify, stringifyForCsv } from "./stringify";
+// stringify lives in the client-safe utils so the web client (legacy trace
+// download, log view copy/download) serializes through the exact same helper
+// as the server-side trace download route.
+export { stringify, stringifyForCsv } from "../../../utils/stringify";
 
 export const streamTransformations: Record<
   BatchExportFileFormat,

--- a/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
@@ -1,5 +1,5 @@
 import { Transform, type TransformCallback } from "stream";
-import { stringifyForCsv } from "./stringify";
+import { stringifyForCsv } from "../../../utils/stringify";
 
 const DELIMITER = ",";
 const CSV_DOUBLE_QUOTE = /"/g;

--- a/packages/shared/src/server/utils/transforms/transformStreamToJson.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToJson.ts
@@ -1,5 +1,5 @@
 import { Transform, type TransformCallback } from "stream";
-import { stringify } from "./stringify";
+import { stringify } from "../../../utils/stringify";
 
 export function transformStreamToJson(): Transform {
   let isFirstElement = true;

--- a/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
@@ -1,5 +1,5 @@
 import { Transform, type TransformCallback } from "stream";
-import { stringify } from "./stringify";
+import { stringify } from "../../../utils/stringify";
 
 export function transformStreamToJsonl(): Transform {
   return new Transform({

--- a/packages/shared/src/utils/stringify.test.ts
+++ b/packages/shared/src/utils/stringify.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  stringify,
-  stringifyForCsv,
-} from "../../../packages/shared/src/server/utils/transforms/stringify";
+import { stringify, stringifyForCsv } from "./stringify";
 
 describe("stringify", () => {
   it("serializes bigint values as numbers", () => {

--- a/packages/shared/src/utils/stringify.ts
+++ b/packages/shared/src/utils/stringify.ts
@@ -1,4 +1,4 @@
-import { decodeUnicodeEscapesOnly } from "../../../utils/unicode";
+import { decodeUnicodeEscapesOnly } from "./unicode";
 
 // Replacer that keeps bigints JSON-serializable and decodes \uXXXX escapes so
 // that non-ASCII content (e.g. Japanese ingested with Python ensure_ascii=True)

--- a/web/src/components/trace/components/IOPreview/components/ChatMessage.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessage.clienttest.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
+const { copyTextToClipboard } = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(),
+}));
+
+vi.mock("@/src/utils/clipboard", () => ({ copyTextToClipboard }));
+
 import { ChatMessage } from "./ChatMessage";
 import { type ChatMlMessage } from "./chat-message-utils";
 import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
@@ -268,5 +274,34 @@ describe("ChatMessage system prompt collapse", () => {
 
     expect(expandButton()).not.toBeInTheDocument();
     expect(collapseButton()).not.toBeInTheDocument();
+  });
+});
+
+describe("ChatMessage copy", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+    vi.stubGlobal("sessionStorage", createMemoryStorage());
+    copyTextToClipboard.mockClear();
+  });
+
+  it("decodes \\uXXXX escapes when copying a tool-call-only message", () => {
+    // Escaped Japanese as ingested via the Python SDK's ensure_ascii=True.
+    renderChatMessage({
+      role: "assistant",
+      tool_calls: [
+        {
+          id: "call-1",
+          name: "search_traces",
+          arguments: '{"question":"\\u3053\\u3093\\u306b\\u3061\\u306f"}',
+        },
+      ],
+    } as unknown as ChatMlMessage);
+
+    fireEvent.click(screen.getAllByTitle("Copy to clipboard")[0]);
+
+    expect(copyTextToClipboard).toHaveBeenCalledTimes(1);
+    const copied = copyTextToClipboard.mock.calls[0][0] as string;
+    expect(copied).toContain("こんにちは");
+    expect(copied).not.toContain("\\u3053");
   });
 });

--- a/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/src/components/ui/MarkdownJsonView";
 import { ToolCallInvocationsView } from "@/src/components/trace/components/ToolCallInvocationsView";
 import { ListChevronsDownUp, ListChevronsUpDown } from "lucide-react";
+import { stringify } from "@langfuse/shared";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import {
   type ChatMlMessage,
@@ -144,7 +145,10 @@ export function ChatMessage({
           title={title}
           handleOnValueChange={() => {}}
           handleOnCopy={() => {
-            const rawText = JSON.stringify(message, null, 2);
+            // Shared stringify (not raw JSON.stringify) so \uXXXX escapes in
+            // string fields are copied as real characters, like the rendered
+            // view shows them.
+            const rawText = stringify(message, undefined, 2);
             copyTextToClipboard(rawText);
           }}
           controlButtons={passthroughToggleButton}

--- a/web/src/components/trace/components/TraceLogView/useLogViewDownload.clienttest.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewDownload.clienttest.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLogViewDownload } from "./useLogViewDownload";
+import { type ObservationIOData } from "./useLogViewAllObservationsIO";
+
+const { copyTextToClipboard } = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(),
+}));
+
+vi.mock("@/src/utils/clipboard", () => ({ copyTextToClipboard }));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+// jsdom implements neither URL.createObjectURL nor Blob#text.
+const createObjectURL = vi.fn<(blob: Blob) => string>();
+const revokeObjectURL = vi.fn();
+let lastBlob: Blob | undefined;
+
+function readBlobAsText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+// Escaped Japanese as ingested via the Python SDK's ensure_ascii=True.
+const observations: ObservationIOData[] = [
+  {
+    id: "obs-1",
+    type: "GENERATION",
+    name: "generation",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    depth: 0,
+    input: '{"question":"\\u3053\\u3093\\u306b\\u3061\\u306f"}',
+    output: "\\u3042\\u308a\\u304c\\u3068\\u3046",
+  },
+];
+
+function renderDownloadHook() {
+  return renderHook(() =>
+    useLogViewDownload({
+      traceId: "trace-1",
+      isCacheOnly: false,
+      allObservationsData: observations,
+      isLoadingAllData: false,
+      failedObservationIds: [],
+      loadAllData: async () => observations,
+      buildDataFromCache: () => observations,
+    }),
+  );
+}
+
+// jsdom ships no URL.createObjectURL, so capture whatever is (not) there and
+// restore it — Object.assign alone would leak the stub past this file if the
+// client project ever ran with a shared context.
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+describe("useLogViewDownload", () => {
+  beforeEach(() => {
+    lastBlob = undefined;
+    copyTextToClipboard.mockClear();
+    createObjectURL.mockImplementation((blob: Blob) => {
+      lastBlob = blob;
+      return "blob:mock";
+    });
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.assign(URL, {
+      createObjectURL: originalCreateObjectURL,
+      revokeObjectURL: originalRevokeObjectURL,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("decodes \\uXXXX escapes in the copied JSON", async () => {
+    const { result } = renderDownloadHook();
+
+    await act(async () => {
+      await result.current.handleCopyJson();
+    });
+
+    expect(copyTextToClipboard).toHaveBeenCalledTimes(1);
+    const copied = copyTextToClipboard.mock.calls[0][0] as string;
+    expect(copied).toContain("こんにちは");
+    expect(copied).toContain("ありがとう");
+    expect(copied).not.toContain("\\u3053");
+  });
+
+  it("decodes \\uXXXX escapes in the downloaded JSON", async () => {
+    const { result } = renderDownloadHook();
+
+    await act(async () => {
+      await result.current.handleDownloadJson();
+    });
+
+    expect(lastBlob).toBeDefined();
+    const content = await readBlobAsText(lastBlob!);
+    expect(content).toContain("こんにちは");
+    expect(content).toContain("ありがとう");
+    expect(content).not.toContain("\\u3053");
+  });
+});

--- a/web/src/components/trace/components/TraceLogView/useLogViewDownload.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewDownload.ts
@@ -9,6 +9,7 @@
 
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
+import { stringify } from "@langfuse/shared";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { type ObservationIOData } from "./useLogViewAllObservationsIO";
 
@@ -43,10 +44,13 @@ export function useLogViewDownload({
 }: UseLogViewDownloadParams) {
   const [isActionLoading, setIsActionLoading] = useState(false);
 
-  // Helper to download JSON data
+  // Helper to download JSON data. Serializes through the shared stringify
+  // helper (not the raw JSON.stringify) so \uXXXX escapes in string fields
+  // (e.g. Japanese ingested with Python ensure_ascii=True) are decoded to
+  // real characters, matching the server-side trace download route.
   const downloadJsonData = useCallback(
     (data: unknown) => {
-      const blob = new Blob([JSON.stringify(data, null, 2)], {
+      const blob = new Blob([stringify(data, undefined, 2)], {
         type: "application/json",
       });
       const url = URL.createObjectURL(blob);
@@ -67,7 +71,7 @@ export function useLogViewDownload({
       setTimeout(() => {
         try {
           const data = buildDataFromCache();
-          copyTextToClipboard(JSON.stringify(data, null, 2));
+          copyTextToClipboard(stringify(data, undefined, 2));
           toast.success("Copied to clipboard (cache only)");
         } finally {
           setIsActionLoading(false);
@@ -76,7 +80,7 @@ export function useLogViewDownload({
     } else {
       // Load all mode: fetch all data if needed
       if (allObservationsData) {
-        copyTextToClipboard(JSON.stringify(allObservationsData, null, 2));
+        copyTextToClipboard(stringify(allObservationsData, undefined, 2));
         // Show warning if some observations failed to load
         if (failedObservationIds.length > 0) {
           toast.warning(
@@ -89,7 +93,7 @@ export function useLogViewDownload({
         setIsActionLoading(true);
         try {
           const data = await loadAllData();
-          copyTextToClipboard(JSON.stringify(data, null, 2));
+          copyTextToClipboard(stringify(data, undefined, 2));
           // Check for failures after loading
           if (failedObservationIds.length > 0) {
             toast.warning(

--- a/web/src/components/trace/lib/download-trace.clienttest.ts
+++ b/web/src/components/trace/lib/download-trace.clienttest.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadLegacyTraceAsJson } from "./download-trace";
+
+// jsdom does not implement URL.createObjectURL, so we install our own to
+// capture the Blob the download helper builds instead of hitting navigation.
+const createObjectURL = vi.fn<(blob: Blob) => string>();
+const revokeObjectURL = vi.fn();
+
+let lastBlob: Blob | undefined;
+
+// jsdom's Blob has no text(); read it through FileReader instead.
+function readBlobAsText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+// jsdom ships no URL.createObjectURL, so capture whatever is (not) there and
+// restore it — Object.assign alone would leak the stub past this file if the
+// client project ever ran with a shared context.
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+describe("downloadLegacyTraceAsJson", () => {
+  beforeEach(() => {
+    lastBlob = undefined;
+    createObjectURL.mockImplementation((blob: Blob) => {
+      lastBlob = blob;
+      return "blob:mock";
+    });
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.assign(URL, {
+      createObjectURL: originalCreateObjectURL,
+      revokeObjectURL: originalRevokeObjectURL,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("decodes \\uXXXX escapes so non-ASCII content is downloaded as real characters", async () => {
+    downloadLegacyTraceAsJson({
+      trace: {
+        id: "trace-1",
+        input: '{"question":"\\u3053\\u3093\\u306b\\u3061\\u306f"}',
+      },
+      observations: [
+        { id: "obs-1", output: "\\u3042\\u308a\\u304c\\u3068\\u3046" },
+      ],
+    });
+
+    expect(lastBlob).toBeDefined();
+    const content = await readBlobAsText(lastBlob!);
+
+    expect(content).toContain("こんにちは");
+    expect(content).toContain("ありがとう");
+    expect(content).not.toContain("\\u3053");
+  });
+});

--- a/web/src/components/trace/lib/download-trace.ts
+++ b/web/src/components/trace/lib/download-trace.ts
@@ -1,3 +1,5 @@
+import { stringify } from "@langfuse/shared";
+
 export interface ServerTraceDownloadParams {
   traceId: string;
   projectId: string;
@@ -77,7 +79,11 @@ export function downloadLegacyTraceAsJson(params: LegacyTraceDownloadParams) {
   };
 
   downloadBlob({
-    blob: new Blob([JSON.stringify(exportData, null, 2)], {
+    // Use the shared stringify helper (not the raw JSON.stringify) so that
+    // \uXXXX escapes in string fields (e.g. Japanese ingested with Python
+    // ensure_ascii=True) are decoded to real characters, matching the
+    // server-side download route in /api/traces/[traceId]/download.
+    blob: new Blob([stringify(exportData, undefined, 2)], {
       type: "application/json; charset=utf-8",
     }),
     filename: filename || `trace-${trace.id}.json`,


### PR DESCRIPTION
## What does this PR do?

Routes the three remaining **client-side** JSON serialization paths in the trace UI through the shared `stringify` helper (which decodes `\uXXXX` escapes) instead of raw `JSON.stringify`, so downloaded/copied trace data renders non-ASCII content (Japanese, Chinese, Korean, emoji, ...) as real characters.

This is a follow-up to #9686 (IOTableCell), #12882 (batch exports), #13223 (PrettyJsonView) and #14667 (server-side trace download route). #14667 fixed `/api/traces/[traceId]/download`, but that route is only reached when the user has **V4 Beta enabled**. Users without it (the default: `session.user.v4BetaEnabled = false`) take the legacy client-side branch in `TracePanelNavigationHeader`, which still emitted raw `\uXXXX` — along with two more client-side paths found while fixing it.

Refs #10972

### Motivation

The Python SDK defaults to `ensure_ascii=True`, so a payload like `"こんにちは"` is stored as `"\u3053\u3093\u306b\u3061\u306f"`. The rendered UI decodes these, but a user on the default (non-beta) path who clicks "Download trace as JSON" gets a file full of literal `\uXXXX`.

Affected paths (all client-side, all raw `JSON.stringify` before this PR):

1. `downloadLegacyTraceAsJson` — trace download for non-beta users (`web/src/components/trace/lib/download-trace.ts`)
2. `useLogViewDownload` — Log View download + the three copy-to-clipboard branches (`web/src/components/trace/components/TraceLogView/useLogViewDownload.ts`)
3. `ChatMessage` — copy button on tool-call-only messages (`web/src/components/trace/components/IOPreview/components/ChatMessage.tsx`)

### Changes

**`packages/shared/src/utils/stringify.ts`** (moved from `src/server/utils/transforms/`)

- `stringify` / `stringifyForCsv` have no server-only dependencies (only `decodeUnicodeEscapesOnly`), so they move to the client-safe utils and are exported from the root barrel (`@langfuse/shared`). The server barrel re-exports them, so `@langfuse/shared/src/server` consumers are unchanged.
- Client and server download paths now serialize through *literally the same function*, so their output is byte-identical.

**Three client paths** — replace `JSON.stringify(data, null, 2)` with `stringify(data, undefined, 2)` (same call shape as the server download route).

**`packages/shared/src/utils/stringify.test.ts`** (moved from `worker/src/__tests__/`)

- The test moves with the implementation to a colocated shared test, following the same keep-it-in-shared feedback as the unicode helper in #12882.

**New client tests** (each proving a distinct execution path, red before the fix):

- `download-trace.clienttest.ts` — legacy download Blob content is decoded
- `useLogViewDownload.clienttest.ts` — copy (clipboard string) and download (Blob content) are decoded
- `ChatMessage.clienttest.tsx` — tool-call copy is decoded (added to the existing suite)

### Behavior notes

- **bigint**: these client paths previously threw on bigint values (raw `JSON.stringify`); they now serialize them as numbers, matching the server download.
- **Object keys**: `stringify` is replacer-based, so it decodes string *values* but not object *keys* — identical to the server download route. The rendered view (`decodeUnicodeInJson`) also decodes keys, so copied text can differ from the rendered view in keys only. Kept as-is to stay byte-identical with the server download.
- `useLogViewDownload.handleDownloadJson` is currently not wired to any UI element (`TraceLogView.tsx` only consumes `handleCopyJson`), but it is fixed and tested so it behaves correctly when connected.

### Verification

- `pnpm run lint` / `pnpm run typecheck`: 7/7 tasks successful
- Unit tests: shared `stringify.test.ts` (7 passed, 2 skipped), 3 client test files (17 passed)
- Browser-verified all three paths against seeded data containing literal `\uXXXX`:
  - Log View copy and ChatMessage tool-call copy (events mode)
  - Legacy trace download under the exact reported condition (`LANGFUSE_MIGRATION_V4_WRITE_MODE=dual`, `v4BetaEnabled: false`) — downloaded Blob has the legacy `{"trace": ...}` shape with decoded characters and no remaining `\uXXXX`

Repro for reviewers:

```bash
pnpm run seed -- trace-tree --payload-style unicode --v4
LANGFUSE_MIGRATION_V4_WRITE_MODE=dual pnpm run dev:web
# open the seeded trace with a non-beta user → Download trace as JSON
```

### Backward compatibility

- No schema or API changes; `@langfuse/shared/src/server` export surface unchanged (re-export).
- Payloads without `\uXXXX` are unaffected (`decodeUnicodeEscapesOnly` early-returns when there is no backslash).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the shared Unicode-aware JSON serializer to the client-safe shared package and applies it to legacy trace downloads, Log View copy/download actions, and tool-call message copying.
- Preserves the existing server import surface through a compatibility re-export.
- Adds colocated serializer tests and client tests covering each newly updated path.
- Keeps server stream transforms using the relocated implementation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The lossy handling of intentionally literal Unicode escape text needs to be addressed before merging.

The newly routed client paths apply greedy Unicode decoding to arbitrary trace strings, so literal escape syntax in code, prompts, tool definitions, or metadata is changed in copied and downloaded data.

**Files Needing Attention:** web/src/components/trace/lib/download-trace.ts and the other client paths newly using stringify
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/trace/lib/download-trace.ts:85
**Literal Unicode escapes are altered**

When trace input, output, tool definitions, or metadata intentionally contain literal text such as `\u0041`—for example in generated code or an escaping example—`stringify` greedily decodes it to `A`, causing the downloaded trace and the other newly routed copy/download paths to no longer preserve the original data.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): decode unicode escapes in cl..."](https://github.com/langfuse/langfuse/commit/a730c555aa8e90db5f4efb5b9a3220622adee040) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49576083)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->