### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ def main():
 main()
 ```
 
+> **Tip:** The Langfuse OpenAI drop-in works with any OpenAI-compatible endpoint. Set `base_url` (or `OPENAI_BASE_URL`) on the client to point at a multi-model gateway — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=langfuse&utm_content=openai) at `https://api.daoxe.com/v1`.
+
 ### 3️⃣ See traces in Langfuse
 
 See your language model calls and other application logic in Langfuse.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ def main():
 main()
 ```
 
-> **Tip:** The Langfuse OpenAI drop-in works with any OpenAI-compatible endpoint. Set `base_url` (or `OPENAI_BASE_URL`) on the client to point at a multi-model gateway — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=langfuse&utm_content=openai) at `https://api.daoxe.com/v1`.
+> **Tip:** The Langfuse OpenAI drop-in works with any OpenAI-compatible endpoint. Set `base_url` (or `OPENAI_BASE_URL`) on the client to point at a multi-model gateway — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
 
 ### 3️⃣ See traces in Langfuse
 


### PR DESCRIPTION
Clarify that the Langfuse OpenAI drop-in works with any OpenAI-compatible endpoint via `base_url`, using DaoXE (https://api.daoxe.com/v1) as one concrete example.

Docs only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Clarifies OpenAI-compatible endpoint support in the quickstart.
- Documents configuring `base_url` or `OPENAI_BASE_URL` for multi-model gateways.
- Adds DaoXE as a concrete endpoint example.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The added guidance does not alter runtime behavior, configuration defaults, public schemas, or application code, and no actionable documentation defect was identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: note OpenAI client base\_url for mu..."](https://github.com/langfuse/langfuse/commit/efc5f671685d93c2a3f7c5226e2c0986ab22fbde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49550811)</sub>

<!-- /greptile_comment -->