### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ The [`@observe()` decorator](https://langfuse.com/docs/sdk/python/decorators) ma
 > [!TIP]
 > Not using OpenAI? Visit [our documentation](https://langfuse.com/docs/get-started#log-your-first-llm-call-to-langfuse) to learn how to log other models and frameworks.
 
+> **Tip:** The instrumented OpenAI client also works with OpenAI-compatible multi-model gateways via `base_url` — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=langfuse&utm_content=readme) at `https://api.daoxe.com/v1`.
+
 ```bash
 pip install langfuse openai
 ```

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The [`@observe()` decorator](https://langfuse.com/docs/sdk/python/decorators) ma
 > [!TIP]
 > Not using OpenAI? Visit [our documentation](https://langfuse.com/docs/get-started#log-your-first-llm-call-to-langfuse) to learn how to log other models and frameworks.
 
-> **Tip:** The instrumented OpenAI client also works with OpenAI-compatible multi-model gateways via `base_url` — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=langfuse&utm_content=readme) at `https://api.daoxe.com/v1`.
+> **Tip:** The instrumented OpenAI client also works with OpenAI-compatible multi-model gateways via `base_url` — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 ```bash
 pip install langfuse openai


### PR DESCRIPTION
Clarify that the OpenAI client `base_url` pattern works with OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=docs&utm_content=pr) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents support for OpenAI-compatible multi-model gateways.
- Adds DaoXE and its OpenAI-compatible API endpoint as a concrete `base_url` example.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation-only change is safe to merge, though explicitly showing `openai.base_url` would prevent confusion with `LANGFUSE_BASE_URL`.

The gateway claim is compatible with the instrumented client, but the adjacent similarly named Langfuse server variable makes the configuration target ambiguous.

**Files Needing Attention:** README.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:186
**Disambiguate the gateway base URL**

The tip names `base_url` without showing that it belongs to the OpenAI client, while the adjacent setup defines `LANGFUSE_BASE_URL` for the Langfuse server. Explicitly showing an `openai.base_url` assignment would prevent readers from sending Langfuse ingestion traffic to the model gateway while leaving model requests pointed at the default endpoint.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: note OpenAI client base\_url for mu..."](https://github.com/langfuse/langfuse/commit/b2a11aa28faf75651163a9e54f36e18f79df151f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49550834)</sub>

<!-- /greptile_comment -->