### PR TITLE
fix(web): restore dataset cell scrollbar by removing inner overflow-hidden in JSONView

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -122,7 +122,7 @@ export function JSONView(props: {
           </code>
         ) : (
           <div
-            className="max-w-full min-w-0 flex-1 overflow-hidden"
+            className="max-w-full min-w-0 flex-1"
             onClick={() => {
               // If externally collapsed and user clicks to expand, sync the state
               if (props.externalJsonCollapsed && props.onToggleCollapse) {

--- a/web/src/components/ui/IOTableCell.clienttest.tsx
+++ b/web/src/components/ui/IOTableCell.clienttest.tsx
@@ -192,4 +192,26 @@ describe("IOTableCell media chip rendering", () => {
 
     expect(container.textContent).toContain("truncated");
   });
+
+  it("multi-line: scrollable content is not clipped by an inner overflow-hidden", () => {
+    // Regression for #15631: the JSONView content div used to carry
+    // `overflow-hidden`, which clipped text that overflowed the fixed table
+    // row height (h-24) before the scrollable `io-message-content` wrapper
+    // could scroll it — long cell text became unreachable. The scroll container
+    // must remain the outermost overflow so `overflow-y-auto` can take effect.
+    const { container } = renderCell({
+      data: "y".repeat(2000),
+      singleLine: false,
+    });
+
+    const scrollContainer = container.querySelector(
+      ".io-message-content.overflow-y-auto",
+    );
+    expect(scrollContainer).not.toBeNull();
+
+    // The JSONView body div must not force `overflow-hidden` on top of the
+    // scroll container (this was the regression from #14489).
+    const contentDiv = scrollContainer?.querySelector(".flex-1");
+    expect(contentDiv?.classList.contains("overflow-hidden")).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #15631

## Problem

Since ~v3.196, long text cells in the datasets view lost their scrollbar: content overflowing the fixed row height (`h-24`) is clipped and unreachable, with no way to scroll. The only workaround was copying the cell content elsewhere.

## Root cause

`JSONView` (`web/src/components/ui/CodeJsonViewer.tsx`) gained an `overflow-hidden` on its content wrapper in #14489 (a trace-overflow fix). In table cells, `IOTableCell` passes `codeClassName="min-h-0 h-full overflow-y-auto"` to `JSONView`, which is applied to the `io-message-content` wrapper — that is the intended scroll container. But the inner content `<div>` (the one #14489 touched) also carries `overflow-hidden`, so overflow is clipped there *before* the scrollable wrapper sees it:

```
div.io-message-content (overflow-y-auto)   ← intended scroll container
  └─ div (flex-1 overflow-hidden)           ← #14489, clips the overflow
```

The inner `overflow-hidden` wins, the `overflow-y-auto` on the wrapper never triggers, and long text is silently truncated.

## Fix

Drop `overflow-hidden` from the inner content div in `JSONView`, keeping `max-w-full min-w-0 flex-1` (the width constraint #14489 added is preserved). The scrollable `io-message-content` wrapper now sees the overflow and scrolls it, restoring the pre-3.196 behavior in table cells without affecting the trace-overflow scenario (the `scrollable` branch of `JSONView` is untouched).

## Test

Added a regression test in `web/src/components/ui/IOTableCell.clienttest.tsx` asserting the scroll container carries `overflow-y-auto` and the inner content div does **not** carry `overflow-hidden`. Verified fail-before (on the buggy code the test fails) / pass-after (on the fix it passes).

```
$ pnpm --filter web run test-client src/components/ui/IOTableCell.clienttest.tsx
Test Files  1 passed (1)
Tests  14 passed (14)
```

Note: I could not complete a live-browser verification locally (the dev environment requires Node 24 and a specific `@langfuse/shared` ESM build; my environment couldn't bring it up), so the fix is verified via the unit regression test above. The change is a 1-line class removal with a regression test pinning the behavior.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores scrolling for long dataset table cells by:
- Removing the inner `overflow-hidden` constraint from `JSONView` while preserving its width constraints.
- Adding a regression test that verifies the intended outer scroll container retains `overflow-y-auto` and the inner content wrapper no longer clips overflow.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the focused CSS change restoring the intended outer scroll behavior and no concrete regressions identified.

The modified content wrapper now permits overflow to reach the existing scroll container, while surrounding width constraints and caller-owned overflow boundaries remain intact; the regression test pins the relevant class structure.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): restore dataset cell scroll by..."](https://github.com/langfuse/langfuse/commit/98ea33bf97cbc3f2466b270c8c0dfa8550903c8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49584773)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->