### PR TITLE
fix(ingestion): drop provider-broadcast duplicate judge traces

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -78,6 +78,7 @@ export * from "../utils/IORepresentation/chatML/types";
 export * from "../server/ingestion/types";
 export * from "../server/ingestion/modelMatch";
 export * from "./ingestion/ingestionAttribution";
+export * from "./ingestion/reservedInternalEnvironments";
 export * from "./ingestion/processEventBatch";
 export * from "../server/ingestion/validateAndInflateScore";
 export * from "./ingestion/extractToolsBackend";

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -44,6 +44,10 @@ import {
   markProjectS3Slowdown,
 } from "../redis/s3SlowdownTracking";
 import { markProjectIngestFailure } from "../redis/ingestionFailureTracking";
+import {
+  getIngestionEventEnvironment,
+  shouldDropPublicIngestionForEnvironment,
+} from "./reservedInternalEnvironments";
 
 let s3StorageServiceClient: StorageService;
 
@@ -163,6 +167,7 @@ export const processEventBatch = async (
 
   const validationErrors: { id: string; error: unknown }[] = [];
   const authenticationErrors: { id: string; error: unknown }[] = [];
+  const droppedReservedEnvironmentEventIds: string[] = [];
 
   const ingestionSchema = createIngestionEventSchema(isLangfuseInternal);
   const batch: z.infer<typeof ingestionSchema>[] = input
@@ -193,6 +198,29 @@ export const processEventBatch = async (
       if (event.type === eventTypes.SDK_LOG) {
         // Log SDK_LOG events, but remove them from further processing
         logger.info("SDK Log Event", { event });
+        return [];
+      }
+      if (
+        shouldDropPublicIngestionForEnvironment(
+          getIngestionEventEnvironment(event),
+          { isLangfuseInternal, attribution },
+        )
+      ) {
+        logger.debug(
+          "Dropping public ingestion event for reserved internal environment",
+          {
+            environment: getIngestionEventEnvironment(event),
+            eventId: event.id,
+            eventType: event.type,
+            projectId: authCheck.scope.projectId,
+          },
+        );
+        recordIncrement(
+          "langfuse.ingestion.dropped_reserved_internal_environment",
+          1,
+          { source },
+        );
+        droppedReservedEnvironmentEventIds.push(event.id);
         return [];
       }
       return [event];
@@ -412,7 +440,10 @@ export const processEventBatch = async (
 
   return aggregateBatchResult(
     [...validationErrors, ...authenticationErrors],
-    sortedBatch.map((event) => ({ id: event.id, result: event })),
+    [
+      ...sortedBatch.map((event) => ({ id: event.id, result: event })),
+      ...droppedReservedEnvironmentEventIds.map((id) => ({ id, result: {} })),
+    ],
     authCheck.scope.projectId,
   );
 };

--- a/packages/shared/src/server/ingestion/reservedInternalEnvironments.test.ts
+++ b/packages/shared/src/server/ingestion/reservedInternalEnvironments.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { LangfuseInternalTraceEnvironment } from "../llm/types";
+import {
+  isInternalEnvironmentNamespace,
+  RESERVED_PUBLIC_INTERNAL_ENVIRONMENT_ALIASES,
+  shouldDropExternalIngestionForReservedEnvironment,
+  shouldDropPublicIngestionForEnvironment,
+  stripLangfuseEnvironmentPrefix,
+} from "./reservedInternalEnvironments";
+
+describe("reservedInternalEnvironments", () => {
+  it("strips repeated langfuse prefixes", () => {
+    expect(stripLangfuseEnvironmentPrefix("langfuse-llm-as-a-judge")).toBe(
+      "llm-as-a-judge",
+    );
+    expect(stripLangfuseEnvironmentPrefix("langfuselangfuse-x")).toBe("x");
+  });
+
+  it("includes all internal trace environments as public aliases", () => {
+    for (const environment of Object.values(LangfuseInternalTraceEnvironment)) {
+      const alias = environment.replace(/^(?:langfuse[-_]?)+/, "");
+      expect(RESERVED_PUBLIC_INTERNAL_ENVIRONMENT_ALIASES.has(alias)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("detects internal namespace for full and stripped names", () => {
+    expect(
+      isInternalEnvironmentNamespace(LangfuseInternalTraceEnvironment.LLMJudge),
+    ).toBe(true);
+    expect(isInternalEnvironmentNamespace("llm-as-a-judge")).toBe(true);
+    expect(isInternalEnvironmentNamespace("code-eval")).toBe(true);
+    expect(isInternalEnvironmentNamespace("default")).toBe(false);
+    expect(isInternalEnvironmentNamespace("production")).toBe(false);
+  });
+
+  it("drops external ingestion for reserved environments unless internal SDK", () => {
+    const externalAttribution = {
+      ingestionApiKey: "pk",
+      ingestionSdkName: "openrouter",
+      ingestionSdkVersion: "1.0.0",
+    };
+    const internalAttribution = {
+      ingestionApiKey: "pk",
+      ingestionSdkName: "langfuse-internal-ai-sdk",
+      ingestionSdkVersion: "1.0.0",
+    };
+
+    expect(
+      shouldDropExternalIngestionForReservedEnvironment(
+        "llm-as-a-judge",
+        externalAttribution,
+      ),
+    ).toBe(true);
+    expect(
+      shouldDropExternalIngestionForReservedEnvironment(
+        LangfuseInternalTraceEnvironment.LLMJudge,
+        internalAttribution,
+      ),
+    ).toBe(false);
+    expect(
+      shouldDropExternalIngestionForReservedEnvironment(
+        "default",
+        externalAttribution,
+      ),
+    ).toBe(false);
+  });
+
+  it("never drops when isLangfuseInternal is set", () => {
+    expect(
+      shouldDropPublicIngestionForEnvironment("llm-as-a-judge", {
+        isLangfuseInternal: true,
+        attribution: {
+          ingestionApiKey: "pk",
+          ingestionSdkName: "unknown",
+          ingestionSdkVersion: "unknown",
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/server/ingestion/reservedInternalEnvironments.ts
+++ b/packages/shared/src/server/ingestion/reservedInternalEnvironments.ts
@@ -1,0 +1,95 @@
+import { LangfuseInternalTraceEnvironment } from "../llm/types";
+import {
+  INTERNAL_INGESTION_SDK_NAMES,
+  type IngestionAttribution,
+} from "./ingestionAttribution";
+import type { IngestionEventType } from "./types";
+
+const LANGFUSE_ENVIRONMENT_PREFIX = /^(?:langfuse[-_]?)+/;
+
+/** Strip reserved `langfuse-` namespace prefix from an environment value. */
+export const stripLangfuseEnvironmentPrefix = (environment: string): string =>
+  environment.replace(LANGFUSE_ENVIRONMENT_PREFIX, "");
+
+const INTERNAL_ENVIRONMENT_VALUES = [
+  ...Object.values(LangfuseInternalTraceEnvironment),
+  "langfuse-evaluation",
+  "sdk-experiment",
+] as const;
+
+/**
+ * Public-ingestion aliases (post-prefix-strip) for reserved internal environments.
+ * Public ingestion lowercases and strips the `langfuse-` prefix, so provider
+ * broadcast callbacks (e.g. OpenRouter) arrive as `llm-as-a-judge` instead of
+ * `langfuse-llm-as-a-judge`.
+ */
+export const RESERVED_PUBLIC_INTERNAL_ENVIRONMENT_ALIASES: ReadonlySet<string> =
+  new Set(
+    INTERNAL_ENVIRONMENT_VALUES.map((environment) =>
+      stripLangfuseEnvironmentPrefix(environment).toLowerCase(),
+    ),
+  );
+
+/**
+ * Whether an environment belongs to Langfuse's reserved internal namespace.
+ * Matches full internal names (`langfuse-*`) and public-ingestion aliases
+ * (`llm-as-a-judge`, `code-eval`, …) that result from prefix stripping.
+ */
+export const isInternalEnvironmentNamespace = (
+  environment: string | null | undefined,
+): boolean => {
+  if (!environment) {
+    return false;
+  }
+
+  const normalized = environment.toLowerCase();
+  if (normalized.startsWith("langfuse")) {
+    return true;
+  }
+
+  return RESERVED_PUBLIC_INTERNAL_ENVIRONMENT_ALIASES.has(normalized);
+};
+
+const isInternalIngestionSdk = (sdkName: string): boolean =>
+  (INTERNAL_INGESTION_SDK_NAMES as readonly string[]).includes(sdkName);
+
+/**
+ * Drop external/public ingestion of telemetry for reserved internal environments.
+ * Langfuse-internal writers use `langfuse-internal-*` SDK names and the internal
+ * ingestion schema; provider broadcast callbacks reuse the project's public key
+ * and must not create duplicate judge/eval traces (see #12958).
+ */
+export const shouldDropExternalIngestionForReservedEnvironment = (
+  environment: string | null | undefined,
+  attribution: IngestionAttribution,
+): boolean => {
+  if (!isInternalEnvironmentNamespace(environment)) {
+    return false;
+  }
+
+  return !isInternalIngestionSdk(attribution.ingestionSdkName);
+};
+
+export const shouldDropPublicIngestionForEnvironment = (
+  environment: string | null | undefined,
+  opts: {
+    isLangfuseInternal?: boolean;
+    attribution: IngestionAttribution;
+  },
+): boolean => {
+  if (opts.isLangfuseInternal) {
+    return false;
+  }
+
+  return shouldDropExternalIngestionForReservedEnvironment(
+    environment,
+    opts.attribution,
+  );
+};
+
+export const getIngestionEventEnvironment = (
+  event: IngestionEventType,
+): string | undefined => {
+  const body = event.body as { environment?: string };
+  return body.environment;
+};

--- a/worker/src/__tests__/processEventBatch.test.ts
+++ b/worker/src/__tests__/processEventBatch.test.ts
@@ -147,4 +147,89 @@ describe("processEventBatch", () => {
       ingestionSdkVersion: UNKNOWN_INGESTION_SDK_VALUE,
     });
   });
+
+  it("drops public ingestion for reserved internal environments but returns success", async () => {
+    const authCheck = {
+      validKey: true as const,
+      scope: {
+        projectId: "project-id",
+        accessLevel: "project" as const,
+        publicKey: "pk-lf-public",
+      },
+    };
+
+    const timestamp = "2024-10-12T12:13:14.123Z";
+    const result = await processEventBatch(
+      [
+        {
+          id: "broadcast-event-id",
+          timestamp,
+          type: eventTypes.TRACE_CREATE,
+          body: {
+            id: "judge-trace-id",
+            timestamp,
+            name: "judge",
+            environment: "llm-as-a-judge",
+          },
+        },
+      ],
+      authCheck,
+      {
+        delay: 0,
+        attribution: {
+          ingestionApiKey: "pk-lf-public",
+          ingestionSdkName: "openrouter",
+          ingestionSdkVersion: "1.0.0",
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      successes: [{ id: "broadcast-event-id", status: 201 }],
+      errors: [],
+    });
+    expect(queueAddMock).not.toHaveBeenCalled();
+    expect(uploadJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps internal SDK ingestion for reserved environments", async () => {
+    const authCheck = {
+      validKey: true as const,
+      scope: {
+        projectId: "project-id",
+        accessLevel: "project" as const,
+        publicKey: "pk-lf-public",
+      },
+    };
+
+    const timestamp = "2024-10-12T12:13:14.123Z";
+    const result = await processEventBatch(
+      [
+        {
+          id: "internal-event-id",
+          timestamp,
+          type: eventTypes.TRACE_CREATE,
+          body: {
+            id: "internal-judge-trace-id",
+            timestamp,
+            name: "judge",
+            environment: "langfuse-llm-as-a-judge",
+          },
+        },
+      ],
+      authCheck,
+      {
+        delay: 0,
+        isLangfuseInternal: true,
+        attribution: {
+          ingestionApiKey: "pk-lf-public",
+          ingestionSdkName: "langfuse-internal-ai-sdk",
+          ingestionSdkVersion: "1.0.0",
+        },
+      },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(queueAddMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.test.ts
+++ b/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.test.ts
@@ -18,8 +18,11 @@ describe("isEvalTargetEnvironmentAllowed", () => {
       "langfuse-llm-as-a-judge",
       "llm-as-a-judge",
       "langfuse-code-eval",
+      "code-eval",
       "langfuse-natural-language-filter",
+      "natural-language-filter",
       "langfuse-in-app-agent",
+      "in-app-agent",
       "langfuse",
     ]) {
       expect(isEvalTargetEnvironmentAllowed(environment)).toBe(false);

--- a/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.ts
+++ b/worker/src/features/evaluation/isEvalTargetEnvironmentAllowed.ts
@@ -1,16 +1,12 @@
-import { LangfuseInternalTraceEnvironment } from "@langfuse/shared/src/server";
-
-// Public ingestion strips the reserved `langfuse-` prefix from environments
-// originating outside Langfuse, including OpenRouter Broadcast callbacks.
-const PUBLIC_LLM_JUDGE_ENVIRONMENT = "llm-as-a-judge";
+import {
+  LangfuseInternalTraceEnvironment,
+  isInternalEnvironmentNamespace,
+} from "@langfuse/shared/src/server";
 
 export function isInternalEvalEnvironment(
   environment: string | null | undefined,
 ): boolean {
-  return (
-    environment?.startsWith("langfuse") === true ||
-    environment === PUBLIC_LLM_JUDGE_ENVIRONMENT
-  );
+  return isInternalEnvironmentNamespace(environment);
 }
 
 /**

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -22,6 +22,8 @@ import {
   ResourceSpan,
   type IngestionAttribution,
   UNKNOWN_INGESTION_SDK_VALUE,
+  getIngestionEventEnvironment,
+  shouldDropExternalIngestionForReservedEnvironment,
 } from "@langfuse/shared/src/server";
 import {
   applyIngestionMasking,
@@ -336,14 +338,38 @@ export const otelIngestionQueueProcessorBuilder = (
       const events: IngestionEventType[] =
         await processor.processToIngestionEvents(parsedSpans);
 
+      const shouldDropExternalReservedEnvironmentEvent = (
+        event: IngestionEventType,
+      ) =>
+        !isLangfuseInternal &&
+        shouldDropExternalIngestionForReservedEnvironment(
+          getIngestionEventEnvironment(event),
+          attribution,
+        );
+
+      const droppedExternalReservedEnvironmentCount = events.filter(
+        shouldDropExternalReservedEnvironmentEvent,
+      ).length;
+      if (droppedExternalReservedEnvironmentCount > 0) {
+        recordIncrement(
+          "langfuse.ingestion.dropped_reserved_internal_environment",
+          droppedExternalReservedEnvironmentCount,
+          { source: "otel" },
+        );
+      }
+
+      const filteredEvents = events.filter(
+        (event) => !shouldDropExternalReservedEnvironmentEvent(event),
+      );
+
       // Here, we split the events into observations and non-observations.
       // Observations go into the IngestionService directly whereas the non-observations make another run through the processEventBatch method.
-      const traces = events.filter(
+      const traces = filteredEvents.filter(
         (e) => getClickhouseEntityType(e.type) !== "observation",
       );
       // We need to parse each incoming observation through our ingestion schema to make use of its included transformations.
       const ingestionSchema = createIngestionEventSchema(isLangfuseInternal);
-      const observations = events
+      const observations = filteredEvents
         .filter((e) => getClickhouseEntityType(e.type) === "observation")
         .map((o) => ingestionSchema.safeParse(o))
         .flatMap((o) => {
@@ -519,7 +545,16 @@ export const otelIngestionQueueProcessorBuilder = (
       //
       // Both require enriched event records with trace-level attributes
       // (userId, sessionId, tags, release) that processToEvent provides.
-      const eventInputs = processor.processToEvent(parsedSpans);
+      const eventInputs = processor
+        .processToEvent(parsedSpans)
+        .filter(
+          (eventInput) =>
+            isLangfuseInternal ||
+            !shouldDropExternalIngestionForReservedEnvironment(
+              eventInput.environment,
+              attribution,
+            ),
+        );
 
       if (eventInputs.length === 0) {
         return;

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -53,6 +53,8 @@ import {
   hasNoEvalConfigsCache,
   buildClickHouseLogComment,
   type IngestionAttribution,
+  getIngestionEventEnvironment,
+  shouldDropExternalIngestionForReservedEnvironment,
 } from "@langfuse/shared/src/server";
 
 import { tokenCountAsync } from "../../features/tokenisation/async-usage";
@@ -188,6 +190,33 @@ export class IngestionService {
     logger.debug(
       `Merging ingestion ${eventType} event for project ${projectId} and event ${entityId}`,
     );
+
+    if (eventType === "trace" || eventType === "observation") {
+      const environment = getIngestionEventEnvironment(events[0]);
+      if (
+        shouldDropExternalIngestionForReservedEnvironment(
+          environment,
+          attribution,
+        )
+      ) {
+        logger.debug(
+          "Skipping ingestion for reserved internal environment from external source",
+          {
+            projectId,
+            entityId,
+            eventType,
+            environment,
+            ingestionSdkName: attribution.ingestionSdkName,
+          },
+        );
+        recordIncrement(
+          "langfuse.ingestion.dropped_reserved_internal_environment",
+          1,
+          { source: "ingestion_service" },
+        );
+        return;
+      }
+    }
 
     switch (eventType) {
       case "trace":


### PR DESCRIPTION
## Summary

Fixes #12958.

When an LLM-as-Judge evaluator uses a provider (e.g. OpenRouter) that also reports traces back to the same Langfuse project, judge telemetry was ingested twice:

1. Langfuse's internal writer (`langfuse-llm-as-a-judge`, `langfuse-internal-ai-sdk`)
2. Provider broadcast via public ingestion (`llm-as-a-judge` after the reserved `langfuse-` prefix is stripped)

Eval-loop guards already blocked recursion, but duplicate traces still flooded the project and counted toward quota.

This PR drops **external/public** ingestion for reserved internal environments while keeping Langfuse-internal SDK writers, and expands eval safeguards to all public aliases (`code-eval`, `in-app-agent`, etc.).

## Changes

- Add `reservedInternalEnvironments` helper in `@langfuse/shared`
- Filter in `processEventBatch`, `IngestionService.mergeAndWrite`, and OTel ingestion (including v4 direct events path)
- Expand `isInternalEvalEnvironment` to cover all stripped public aliases

## Test plan

- [x] `reservedInternalEnvironments.test.ts` (5 tests)
- [x] `processEventBatch.test.ts` — drop external `llm-as-a-judge`, keep internal SDK ingestion
- [x] `isEvalTargetEnvironmentAllowed.test.ts` — public alias coverage

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR suppresses provider-broadcast duplicates for reserved internal environments.
- Adds shared environment normalization, alias detection, and ingestion filtering helpers.
- Applies filtering to batch ingestion, legacy merge/write processing, and both OTel write paths.
- Broadens evaluation-loop safeguards to recognize stripped public aliases.
- Adds focused tests for environment classification and batch-ingestion behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The internal-ingestion provenance loss must be fixed before merging because legitimate reserved-environment telemetry can be silently discarded.

processEventBatch exempts internal events, but its queue payload omits that provenance while carrying an unknown SDK name, causing mergeAndWrite to classify the same events as external and return without persisting them.

**Files Needing Attention:** worker/src/services/IngestionService/index.ts and packages/shared/src/server/ingestion/processEventBatch.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  I[Internal trace writer] -->|isLangfuseInternal=true; SDK=unknown| P[processEventBatch]
  P -->|internal exemption| Q[IngestionQueue payload]
  Q -->|isLangfuseInternal omitted| M[IngestionService.mergeAndWrite]
  M -->|unknown SDK classified external| D[Reserved trace or observation dropped]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/services/IngestionService/index.ts:197-200
**Internal provenance is lost**

When `getInternalTracingHandler` submits a reserved-environment trace or observation, `processEventBatch` exempts it using `isLangfuseInternal` but omits that flag from the queue payload. `mergeAndWrite` then classifies the forwarded `unknown` SDK attribution as external and silently discards legitimate internal telemetry before it reaches ClickHouse.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): drop provider-broadcast ..."](https://github.com/langfuse/langfuse/commit/d4d0dc3769f8d95dd8e5700f1ec0ca69b7407348) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49591334)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Ingestion Pipeline: SDK/OTel Event to ClickHouse](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/ingestion-pipeline.md)
- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)

<!-- /greptile_comment -->