### PR TITLE
chore: move entity change event queued log to debug

### DIFF
--- a/web/src/features/prompts/server/promptChangeEventSourcing.ts
+++ b/web/src/features/prompts/server/promptChangeEventSourcing.ts
@@ -44,7 +44,7 @@ export const promptChangeEventSourcing = async (
       event,
     );
 
-    logger.info(
+    logger.debug(
       `Queued entity change event for prompt ${promptData.id} in project ${promptData.projectId} with action ${action}`,
     );
   } catch (error) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15705.preview.langfuse.com](https://pr-15705.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Lowers the successful prompt entity-change queue log from info to debug level.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change only reduces the verbosity of a success log from info to debug while preserving the queue operation and existing error handling.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: move entity change event queued l..."](https://github.com/langfuse/langfuse/commit/d25c8bebbab1aa1e2c5cbe0d7394b6411c164aae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49592486)</sub>

<!-- /greptile_comment -->