### PR TITLE
fix(pricing): add GPT-5.6 usage aliases

### DIFF
--- a/worker/src/__tests__/pricing-tier-matcher.test.ts
+++ b/worker/src/__tests__/pricing-tier-matcher.test.ts
@@ -304,6 +304,69 @@ describe("default-model-prices.json", () => {
       }
     }
   });
+
+  it("should price explicit GPT-5.6 usage aliases without implicit tiers", () => {
+    const modelNames = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+
+    for (const modelName of modelNames) {
+      const model = defaultModelPrices.find(
+        (candidate) => candidate.modelName === modelName,
+      );
+      expect(model, modelName).toBeDefined();
+      expect(model!.pricingTiers.map((tier) => tier.name)).toEqual([
+        "Standard",
+        "Large Context (>272K)",
+      ]);
+
+      for (const tier of model!.pricingTiers) {
+        const prices = tier.prices as Record<string, number>;
+        expect(prices.cache_read_input_tokens).toBe(prices.input_cached_tokens);
+        expect(prices.reasoning_tokens).toBe(prices.output_reasoning_tokens);
+        expect(prices.input_cache_creation).toBeCloseTo(
+          prices.input * 1.25,
+          15,
+        );
+        expect(prices.cache_write_tokens).toBeCloseTo(prices.input * 1.25, 15);
+      }
+    }
+
+    const sol = defaultModelPrices.find(
+      (model) => model.modelName === "gpt-5.6-sol",
+    );
+    expect(sol).toBeDefined();
+
+    const tiers: PricingTierWithPrices[] = sol!.pricingTiers.map((tier) => ({
+      id: tier.id,
+      name: tier.name,
+      isDefault: tier.isDefault,
+      priority: tier.priority,
+      conditions: tier.conditions,
+      prices: Object.entries(tier.prices).map(([usageType, price]) => ({
+        usageType,
+        price: new Decimal(price),
+      })),
+    }));
+
+    const reportedUsage = {
+      input: 786,
+      cache_read_input_tokens: 718398,
+      output: 242,
+      reasoning_tokens: 25,
+    };
+    const reportedResult = matchPricingTier(tiers, reportedUsage);
+    expect(reportedResult?.pricingTierName).toBe("Large Context (>272K)");
+
+    const reportedCost = Object.entries(reportedUsage).reduce(
+      (total, [usageType, units]) =>
+        total + (reportedResult?.prices[usageType]?.toNumber() ?? 0) * units,
+      0,
+    );
+    expect(reportedCost).toBeCloseTo(0.738273, 12);
+
+    expect(
+      matchPricingTier(tiers, { cache_write_tokens: 272001 })?.pricingTierName,
+    ).toBe("Large Context (>272K)");
+  });
 });
 
 describe("validateRegexPattern", () => {

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -4191,7 +4191,7 @@
     "modelName": "gpt-5.6-sol",
     "matchPattern": "(?i)^(openai/)?(gpt-5.6-sol)$",
     "createdAt": "2026-07-09T00:00:00.000Z",
-    "updatedAt": "2026-07-09T00:00:00.000Z",
+    "updatedAt": "2026-08-03T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -4209,9 +4209,13 @@
           "input": 5e-6,
           "input_cached_tokens": 0.5e-6,
           "input_cache_read": 0.5e-6,
+          "cache_read_input_tokens": 0.5e-6,
+          "input_cache_creation": 6.25e-6,
+          "cache_write_tokens": 6.25e-6,
           "output": 30e-6,
           "output_reasoning_tokens": 30e-6,
-          "output_reasoning": 30e-6
+          "output_reasoning": 30e-6,
+          "reasoning_tokens": 30e-6
         }
       },
       {
@@ -4221,7 +4225,7 @@
         "priority": 1,
         "conditions": [
           {
-            "usageDetailPattern": "input",
+            "usageDetailPattern": "(input|cache_write)",
             "operator": "gt",
             "value": 272000,
             "caseSensitive": false
@@ -4231,9 +4235,13 @@
           "input": 10e-6,
           "input_cached_tokens": 1e-6,
           "input_cache_read": 1e-6,
+          "cache_read_input_tokens": 1e-6,
+          "input_cache_creation": 12.5e-6,
+          "cache_write_tokens": 12.5e-6,
           "output": 45e-6,
           "output_reasoning_tokens": 45e-6,
-          "output_reasoning": 45e-6
+          "output_reasoning": 45e-6,
+          "reasoning_tokens": 45e-6
         }
       }
     ]
@@ -4243,7 +4251,7 @@
     "modelName": "gpt-5.6-terra",
     "matchPattern": "(?i)^(openai/)?(gpt-5.6-terra)$",
     "createdAt": "2026-07-09T00:00:00.000Z",
-    "updatedAt": "2026-07-31T00:00:00.000Z",
+    "updatedAt": "2026-08-03T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -4261,9 +4269,13 @@
           "input": 2e-6,
           "input_cached_tokens": 0.2e-6,
           "input_cache_read": 0.2e-6,
+          "cache_read_input_tokens": 0.2e-6,
+          "input_cache_creation": 2.5e-6,
+          "cache_write_tokens": 2.5e-6,
           "output": 12e-6,
           "output_reasoning_tokens": 12e-6,
-          "output_reasoning": 12e-6
+          "output_reasoning": 12e-6,
+          "reasoning_tokens": 12e-6
         }
       },
       {
@@ -4273,7 +4285,7 @@
         "priority": 1,
         "conditions": [
           {
-            "usageDetailPattern": "input",
+            "usageDetailPattern": "(input|cache_write)",
             "operator": "gt",
             "value": 272000,
             "caseSensitive": false
@@ -4283,9 +4295,13 @@
           "input": 4e-6,
           "input_cached_tokens": 0.4e-6,
           "input_cache_read": 0.4e-6,
+          "cache_read_input_tokens": 0.4e-6,
+          "input_cache_creation": 5e-6,
+          "cache_write_tokens": 5e-6,
           "output": 18e-6,
           "output_reasoning_tokens": 18e-6,
-          "output_reasoning": 18e-6
+          "output_reasoning": 18e-6,
+          "reasoning_tokens": 18e-6
         }
       }
     ]
@@ -4295,7 +4311,7 @@
     "modelName": "gpt-5.6-luna",
     "matchPattern": "(?i)^(openai/)?(gpt-5.6-luna)$",
     "createdAt": "2026-07-09T00:00:00.000Z",
-    "updatedAt": "2026-07-31T00:00:00.000Z",
+    "updatedAt": "2026-08-03T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -4313,9 +4329,13 @@
           "input": 0.2e-6,
           "input_cached_tokens": 0.02e-6,
           "input_cache_read": 0.02e-6,
+          "cache_read_input_tokens": 0.02e-6,
+          "input_cache_creation": 0.25e-6,
+          "cache_write_tokens": 0.25e-6,
           "output": 1.2e-6,
           "output_reasoning_tokens": 1.2e-6,
-          "output_reasoning": 1.2e-6
+          "output_reasoning": 1.2e-6,
+          "reasoning_tokens": 1.2e-6
         }
       },
       {
@@ -4325,7 +4345,7 @@
         "priority": 1,
         "conditions": [
           {
-            "usageDetailPattern": "input",
+            "usageDetailPattern": "(input|cache_write)",
             "operator": "gt",
             "value": 272000,
             "caseSensitive": false
@@ -4335,9 +4355,13 @@
           "input": 0.4e-6,
           "input_cached_tokens": 0.04e-6,
           "input_cache_read": 0.04e-6,
+          "cache_read_input_tokens": 0.04e-6,
+          "input_cache_creation": 0.5e-6,
+          "cache_write_tokens": 0.5e-6,
           "output": 1.8e-6,
           "output_reasoning_tokens": 1.8e-6,
-          "output_reasoning": 1.8e-6
+          "output_reasoning": 1.8e-6,
+          "reasoning_tokens": 1.8e-6
         }
       }
     ]


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15712.preview.langfuse.com](https://pr-15712.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Fixes the explicitly persisted GPT-5.6 usage buckets reported in https://github.com/langfuse/langfuse/issues/15139 and tracked by [LFE-13817](https://linear.app/clickhouse/issue/LFE-13817/bug-gpt-56-sol-totalcost-ignores-cached-input-reasoning-and-cache).

- Adds `cache_read_input_tokens` at the existing cached-input rate.
- Adds `reasoning_tokens` at the existing output/reasoning rate.
- Adds explicit `input_cache_creation` and `cache_write_tokens` prices at 1.25x input.
- Counts raw `cache_write_tokens` when selecting the existing >272K tier.
- Applies the aliases to Sol, Terra, and Luna across their two existing tiers.

This deliberately does **not** add implicit-cache-write tiers or infer that ordinary `input` represents a cache write when no explicit bucket exists. The reported explicit usage shape prices to `$0.738273`.

Historical recosting is out of scope.

## Impacted package

- `worker`

## Verification

- `pnpm exec dotenv -e .env.test.example -e .env.dev.example -- pnpm --filter worker run test src/__tests__/pricing-tier-matcher.test.ts`
  - `Tests 55 passed (55)`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
  - `Validated 166 pricing entries`
- `pnpm --filter worker run lint`
  - passed
- `pnpm exec dotenv -e .env.test.example -e .env.dev.example -- pnpm --filter worker run typecheck`
  - passed
- `pnpm exec prettier --check worker/src/__tests__/pricing-tier-matcher.test.ts worker/src/constants/default-model-prices.json`
  - `All matched files use Prettier code style!`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds GPT-5.6 pricing aliases and tier matching coverage.
- Prices explicit cached-input, cache-write, cache-creation, and reasoning usage for Sol, Terra, and Luna.
- Includes cache-write usage when selecting the existing large-context tier.
- Adds regression tests for alias rates, tier structure, reported cost, and cache-write tier selection.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The new aliases use the corresponding existing rates across both tiers, the updated timestamps trigger default-price synchronization, and the tests cover the reported pricing path and cache-write tier selection.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): add GPT-5.6 usage aliases"](https://github.com/langfuse/langfuse/commit/4fdc1d0903ede4ea60948203452bd7b0d3fef062) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49643264)</sub>

<!-- /greptile_comment -->