### PR TITLE
chore(pricing): validate usage-key coverage

### DIFF
--- a/.agents/skills/add-model-price/SKILL.md
+++ b/.agents/skills/add-model-price/SKILL.md
@@ -34,6 +34,8 @@ updates in `packages/shared/`.
 - Generate a lowercase UUID for the model entry.
 - Create a `matchPattern` that covers supported provider formats.
 - Add at least one default pricing tier.
+- Map every supported semantic usage bucket to the provider aliases Langfuse
+  may persist.
 - Insert the pricing entry into `worker/src/constants/default-model-prices.json`.
 - Update `packages/shared/src/server/llm/types.ts` if the model should be
   selectable in playground or evaluation flows.
@@ -51,6 +53,7 @@ updates in `packages/shared/`.
 | ------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | Schema and tier rules           | You need the entry shape or pricing-tier invariants                                   | [references/schema-and-tiers.md](references/schema-and-tiers.md)                               |
 | Provider sources and price keys | You need official pricing URLs, per-token conversion, or provider-specific usage keys | [references/provider-sources-and-price-keys.md](references/provider-sources-and-price-keys.md) |
+| Provider usage-key matrix       | You are adding or changing OpenAI, Gemini, Anthropic, or Bedrock usage keys           | [references/provider-usage-key-matrix.md](references/provider-usage-key-matrix.md)             |
 | Match patterns                  | You are editing `matchPattern` regexes or provider coverage                           | [references/match-patterns.md](references/match-patterns.md)                                   |
 | Workflow and validation         | You are applying the end-to-end edit process or checking common mistakes              | [references/workflow-and-validation.md](references/workflow-and-validation.md)                 |
 | Automated audit mode            | You are running a scheduled/default-price audit and need CI-safe edit rules           | [references/automated-audit.md](references/automated-audit.md)                                 |

--- a/.agents/skills/add-model-price/references/automated-audit.md
+++ b/.agents/skills/add-model-price/references/automated-audit.md
@@ -20,6 +20,8 @@ report over an uncertain code change.
   `references/model-audit-memory.md`; treat it as orientation, not evidence
 - Official provider pricing pages from
   `references/provider-sources-and-price-keys.md`
+- Provider capability and alias requirements from
+  `references/provider-usage-key-matrix.md`
 - Deterministic reports from:
   - `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
 
@@ -30,8 +32,10 @@ report over an uncertain code change.
    recent major text, chat, reasoning, or multimodal LLM launches, renames,
    pricing changes, and gaps in Langfuse coverage. Do not limit the audit to
    model names already present in `default-model-prices.json`.
-3. Fetch official provider pricing pages before changing prices or adding a
-   model.
+3. Fetch official provider pricing and usage-shape pages before changing prices
+   or adding a model. Compare the provider usage object, Langfuse ingestion
+   normalization, and a mature sibling entry. Do not copy a sibling key set
+   mechanically.
 4. Apply only changes with clear official evidence:
    - corrected input, output, cache write, or cache read prices;
    - missing default pricing entries for selectable models;
@@ -50,7 +54,8 @@ report over an uncertain code change.
    retaining the complete current per-model result would materially help a
    future audit. Do not persist a partial table, append unbounded run history,
    or update it only to refresh the audit date.
-8. Re-run the validator.
+8. Re-run the validator, including changed-entry usage-key validation against
+   the pre-audit pricing file.
 
 ## Edit Rules
 
@@ -87,6 +92,8 @@ entry and these columns:
 | Provider              | Provider whose official source was checked                                                                                                           |
 | Model / pricing entry | Exact model or pricing-entry name reviewed                                                                                                           |
 | Pricing checked       | Every relevant input, output, cache-read, and cache-write price with the provider unit and converted per-token value                                 |
+| Usage keys checked    | Every applicable semantic bucket and exact raw/normalized alias expected from provider usage plus Langfuse ingestion                                 |
+| Usage-key coverage    | `Yes` only when every supported bucket is represented by all applicable aliases; otherwise `No` with the gap in comments                             |
 | Price confirmed       | `Yes` only when official evidence fetched in the current run confirms every current price; otherwise `No`                                            |
 | Tiering checked       | Every applicable tier name, threshold, and condition, or a statement that no provider tiering applies                                                |
 | Tiering correct       | `Yes` when every applicable threshold and tier price is confirmed, `No` when it is not, or `N/A` only when no provider tiering dimension applies     |
@@ -104,6 +111,7 @@ For every changed model, include:
 - model name;
 - whether the change updates an existing entry or adds a newly discovered model;
 - changed JSON keys or `matchPattern` behavior;
+- supported usage buckets and exact aliases checked;
 - official source URL;
 - provider price unit and converted per-token value;
 - validation commands run.

--- a/.agents/skills/add-model-price/references/provider-sources-and-price-keys.md
+++ b/.agents/skills/add-model-price/references/provider-sources-and-price-keys.md
@@ -179,47 +179,9 @@ Formula:
 price_per_token = price_per_mtok / 1_000_000
 ```
 
-## Common Price Keys by Provider
+## Provider Usage Keys
 
-### Anthropic Claude
-
-```json
-{
-  "input": "<base_input_price>",
-  "input_tokens": "<base_input_price>",
-  "output": "<output_price>",
-  "output_tokens": "<output_price>",
-  "cache_creation_input_tokens": "<cache_write_price>",
-  "input_cache_creation": "<cache_write_price>",
-  "cache_read_input_tokens": "<cache_read_price>",
-  "input_cache_read": "<cache_read_price>"
-}
-```
-
-### OpenAI
-
-```json
-{
-  "input": "<input_price>",
-  "input_cached_tokens": "<cached_input_price>",
-  "input_cache_read": "<cached_input_price>",
-  "output": "<output_price>"
-}
-```
-
-### Google Gemini
-
-```json
-{
-  "input": "<input_price>",
-  "input_modality_1": "<input_price>",
-  "prompt_token_count": "<input_price>",
-  "promptTokenCount": "<input_price>",
-  "input_cached_tokens": "<cached_price>",
-  "cached_content_token_count": "<cached_price>",
-  "output": "<output_price>",
-  "output_modality_1": "<output_price>",
-  "candidates_token_count": "<output_price>",
-  "candidatesTokenCount": "<output_price>"
-}
-```
+Use [provider-usage-key-matrix.md](provider-usage-key-matrix.md) as the single
+source of truth for OpenAI, Gemini, Anthropic, and Bedrock usage aliases. Do not
+copy a partial key set from this pricing-source reference or from an older model
+entry.

--- a/.agents/skills/add-model-price/references/provider-usage-key-matrix.md
+++ b/.agents/skills/add-model-price/references/provider-usage-key-matrix.md
@@ -1,0 +1,106 @@
+# Provider Usage-Key Matrix
+
+Use this reference whenever adding or changing a model price entry. A price is
+usable only when every usage key that Langfuse may persist for the supported
+provider capability has a matching price.
+
+## Required comparison
+
+Before editing an entry, compare all three sources:
+
+1. The official provider usage object and supported billing dimensions.
+2. Langfuse ingestion normalization, especially
+   `packages/shared/src/server/otel/OtelIngestionProcessor.ts`.
+3. A mature sibling entry in `default-model-prices.json`.
+
+Do not copy a sibling mechanically. Provider response shapes and model
+capabilities change over time. Record unsupported capabilities as not
+applicable instead of inventing keys or prices.
+
+## Semantic alias rules
+
+- Put every alias for one semantic bucket in every tier at the same price.
+- Keep all tiers for one model on the same key set.
+- Add cache, reasoning, modality, TTL, grounding, and tool keys only when the
+  provider documents that capability and price.
+- Never infer cache writes from ordinary input or from the presence of a cache
+  read. Price a write premium only when an explicit write bucket is stored.
+
+## OpenAI
+
+For a reasoning model with prompt caching, use:
+
+| Bucket               | Required keys when supported                                         |
+| -------------------- | -------------------------------------------------------------------- |
+| Input                | `input`                                                              |
+| Cache read           | `input_cached_tokens`, `input_cache_read`, `cache_read_input_tokens` |
+| Explicit cache write | `input_cache_creation`, `cache_write_tokens`                         |
+| Output               | `output`                                                             |
+| Reasoning            | `output_reasoning_tokens`, `output_reasoning`, `reasoning_tokens`    |
+
+Use only the applicable families for models without caching or reasoning.
+`gpt-5.6-sol` is the complete reasoning-and-caching template. Older
+`gpt-5.5-2026-04-23` and the original `gpt-5.3-codex` addition demonstrate why
+copying only the established six-key shape is insufficient.
+
+## Anthropic and Bedrock Claude
+
+Use this mature Claude set when prompt caching is supported:
+
+| Bucket                  | Keys                                                                 |
+| ----------------------- | -------------------------------------------------------------------- |
+| Input                   | `input`, `input_tokens`                                              |
+| Output                  | `output`, `output_tokens`                                            |
+| Cache write             | `cache_creation_input_tokens`, `input_cache_creation`                |
+| Five-minute cache write | `input_cache_creation_5m`                                            |
+| One-hour cache write    | `input_cache_creation_1h`                                            |
+| Cache read              | `cache_read_input_tokens`, `input_cache_read`, `input_cached_tokens` |
+
+The TTL-specific prices can differ, so do not treat the 5-minute and 1-hour
+keys as equal-price aliases. Verify which TTLs the model supports. Current
+`claude-sonnet-4-6`, `claude-opus-4-6`, and `claude-opus-4-8` entries are mature
+templates and include direct Anthropic plus regional Bedrock model IDs.
+
+## Gemini
+
+Use these core aliases for priced text-generation models:
+
+| Bucket                     | Required keys                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| Input                      | `input`, `input_text`, `input_modality_1`, `prompt_token_count`, `promptTokenCount`            |
+| Output                     | `output`, `output_text`, `output_modality_1`, `candidates_token_count`, `candidatesTokenCount` |
+| Cache read, when supported | `input_cached_tokens`, `cached_content_token_count`                                            |
+| Reasoning, when supported  | `thoughts_token_count`, `thoughtsTokenCount`, `output_reasoning_tokens`, `output_reasoning`    |
+
+Add `input_audio_tokens`, grounding/search aliases, or other modality/tool keys
+only when the official model pricing has those distinct dimensions. Use
+`gemini-3.1-pro-preview` as the mature reasoning, caching, and grounding
+template, but remove capability families that official docs mark unavailable.
+
+## Other Bedrock models
+
+There is no universal Bedrock price-key set. Bedrock hosts model families with
+different response and billing dimensions.
+
+- Use the Anthropic matrix for Bedrock Claude.
+- For Nova, Mistral, Llama, and other families, derive the key contract from
+  the documented Bedrock usage object and Langfuse normalization.
+- State why cache, reasoning, or modality families are not applicable.
+- Do not reuse Claude cache keys or rates without provider evidence.
+
+## Deterministic validation
+
+The pricing validator always checks structural catalog invariants. It checks
+semantic alias completeness for explicitly selected models or entries changed
+relative to a base file:
+
+```bash
+node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
+  --usage-key-model gpt-5.6-sol
+
+node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
+  --base /path/to/default-model-prices-before.json
+```
+
+Changed-entry validation avoids turning a focused addition into an unrelated
+historical cleanup while preventing new incomplete alias families.

--- a/.agents/skills/add-model-price/references/workflow-and-validation.md
+++ b/.agents/skills/add-model-price/references/workflow-and-validation.md
@@ -7,6 +7,11 @@
 Open the provider's official pricing page and collect input, output, cache
 write, and cache read prices.
 
+Read [provider-usage-key-matrix.md](provider-usage-key-matrix.md), then compare
+the official provider usage object, Langfuse ingestion normalization, and a
+mature sibling pricing entry. Record every supported semantic bucket and all
+aliases Langfuse may persist before editing.
+
 ### 2. Generate a Lowercase ID
 
 ```bash
@@ -81,6 +86,14 @@ Run the bundled validator:
 node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
 ```
 
+For every changed or new entry, also validate usage-key coverage against the
+pre-change pricing file:
+
+```bash
+node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
+  --base /path/to/default-model-prices-before.json
+```
+
 For quick manual inspection, use `jq`:
 
 ```bash
@@ -99,6 +112,8 @@ jq '.[] | select(.modelName == "claude-opus-4-6")' worker/src/constants/default-
 8. Each tier must contain at least one price
 9. All tiers must expose the same usage-type keys
 10. Regex patterns must be valid
+11. Changed OpenAI, Gemini, and Anthropic/Bedrock Claude entries must have
+    complete equal-price alias families for every represented capability
 
 ## Testing Model Matching
 
@@ -118,6 +133,8 @@ regex is intended to cover.
 - Forgetting the `_tier_default` suffix on the default tier ID
 - Forgetting to escape regex metacharacters such as `.`
 - Forgetting to refresh `updatedAt`
+- Copying an older model's partial price-key set without checking current
+  provider usage fields and Langfuse ingestion aliases
 
 ## Existing Model Templates
 

--- a/.agents/skills/add-model-price/scripts/validate-pricing-file.mjs
+++ b/.agents/skills/add-model-price/scripts/validate-pricing-file.mjs
@@ -5,7 +5,33 @@ import path from "node:path";
 
 const defaultFile = "worker/src/constants/default-model-prices.json";
 const repoRoot = process.cwd();
-const filePath = path.resolve(repoRoot, process.argv[2] ?? defaultFile);
+const args = process.argv.slice(2);
+let pricingFile = defaultFile;
+let baseFile = null;
+const requestedUsageKeyModels = new Set();
+
+for (let index = 0; index < args.length; index += 1) {
+  const argument = args[index];
+  if (argument === "--base") {
+    if (!args[index + 1] || args[index + 1].startsWith("--")) {
+      throw new Error("--base requires a file path");
+    }
+    baseFile = args[index + 1];
+    index += 1;
+  } else if (argument === "--usage-key-model") {
+    if (!args[index + 1] || args[index + 1].startsWith("--")) {
+      throw new Error("--usage-key-model requires a model name");
+    }
+    requestedUsageKeyModels.add(args[index + 1]);
+    index += 1;
+  } else if (argument.startsWith("--")) {
+    throw new Error(`Unknown argument: ${argument}`);
+  } else {
+    pricingFile = argument;
+  }
+}
+
+const filePath = path.resolve(repoRoot, pricingFile);
 const failures = [];
 
 function compileMatchPattern(rawPattern, label) {
@@ -30,11 +56,185 @@ function keysOfPrices(prices) {
   return Object.keys(prices).sort();
 }
 
+function requireAliasFamily(model, tier, familyName, keys, required) {
+  const presentKeys = keys.filter((key) => key in tier.prices);
+  if (!required && presentKeys.length === 0) return;
+
+  const tierLabel = `${model.modelName}/${tier.name}`;
+  const missingKeys = keys.filter((key) => !(key in tier.prices));
+  if (missingKeys.length > 0) {
+    failures.push(
+      `${tierLabel}: incomplete ${familyName} usage-key family; missing ${missingKeys.join(", ")}`,
+    );
+    return;
+  }
+
+  const expectedPrice = tier.prices[keys[0]];
+  const mismatchedKeys = keys.filter(
+    (key) => tier.prices[key] !== expectedPrice,
+  );
+  if (mismatchedKeys.length > 0) {
+    failures.push(
+      `${tierLabel}: ${familyName} aliases must have the same price (${keys.join(", ")})`,
+    );
+  }
+}
+
+function validateUsageKeyCoverage(model) {
+  if (
+    typeof model.modelName !== "string" ||
+    typeof model.matchPattern !== "string" ||
+    !Array.isArray(model.pricingTiers)
+  ) {
+    return;
+  }
+  const modelName = model.modelName.toLowerCase();
+  const matchPattern = model.matchPattern.toLowerCase();
+  const isGemini =
+    modelName.includes("gemini") || matchPattern.includes("gemini");
+  const isClaude =
+    modelName.startsWith("claude-") ||
+    matchPattern.includes("anthropic\\.claude");
+  const isOpenAI =
+    !isGemini &&
+    !isClaude &&
+    (model.tokenizerId === "openai" ||
+      /^(chatgpt-|codex-|gpt-|o[0-9])/.test(modelName));
+
+  for (const tier of model.pricingTiers) {
+    if (!tier.prices || typeof tier.prices !== "object") continue;
+    if (isOpenAI) {
+      requireAliasFamily(
+        model,
+        tier,
+        "OpenAI cache-read",
+        ["input_cached_tokens", "input_cache_read", "cache_read_input_tokens"],
+        false,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "OpenAI cache-write",
+        ["input_cache_creation", "cache_write_tokens"],
+        false,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "OpenAI reasoning",
+        ["output_reasoning_tokens", "output_reasoning", "reasoning_tokens"],
+        false,
+      );
+    } else if (isClaude) {
+      requireAliasFamily(
+        model,
+        tier,
+        "Anthropic input",
+        ["input", "input_tokens"],
+        true,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "Anthropic output",
+        ["output", "output_tokens"],
+        true,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "Anthropic cache-write",
+        ["cache_creation_input_tokens", "input_cache_creation"],
+        false,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "Anthropic cache-read",
+        ["cache_read_input_tokens", "input_cache_read", "input_cached_tokens"],
+        false,
+      );
+    } else if (isGemini) {
+      requireAliasFamily(
+        model,
+        tier,
+        "Gemini input",
+        [
+          "input",
+          "input_text",
+          "input_modality_1",
+          "prompt_token_count",
+          "promptTokenCount",
+        ],
+        true,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "Gemini output",
+        [
+          "output",
+          "output_text",
+          "output_modality_1",
+          "candidates_token_count",
+          "candidatesTokenCount",
+        ],
+        true,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "Gemini cache-read",
+        ["input_cached_tokens", "cached_content_token_count"],
+        false,
+      );
+      requireAliasFamily(
+        model,
+        tier,
+        "Gemini reasoning",
+        [
+          "thoughts_token_count",
+          "thoughtsTokenCount",
+          "output_reasoning_tokens",
+          "output_reasoning",
+        ],
+        false,
+      );
+    }
+  }
+}
+
 const raw = await fs.readFile(filePath, "utf8");
 const models = JSON.parse(raw);
 
 if (!Array.isArray(models)) {
   throw new Error("Expected the pricing file to be a JSON array.");
+}
+
+const usageKeyModels = new Set(requestedUsageKeyModels);
+if (baseFile) {
+  const basePath = path.resolve(repoRoot, baseFile);
+  const baseModels = JSON.parse(await fs.readFile(basePath, "utf8"));
+  if (!Array.isArray(baseModels)) {
+    throw new Error("Expected the base pricing file to be a JSON array.");
+  }
+  const baseByName = new Map(
+    baseModels.map((model) => [model.modelName, JSON.stringify(model)]),
+  );
+  for (const model of models) {
+    if (baseByName.get(model.modelName) !== JSON.stringify(model)) {
+      usageKeyModels.add(model.modelName);
+    }
+  }
+}
+
+const availableModelNames = new Set(models.map((model) => model.modelName));
+for (const modelName of requestedUsageKeyModels) {
+  if (!availableModelNames.has(modelName)) {
+    failures.push(
+      `Unknown model requested for usage-key validation: ${modelName}`,
+    );
+  }
 }
 
 const seenModelIds = new Set();
@@ -208,6 +408,10 @@ for (const model of models) {
       );
     }
   }
+
+  if (usageKeyModels.has(model.modelName)) {
+    validateUsageKeyCoverage(model);
+  }
 }
 
 if (failures.length > 0) {
@@ -221,3 +425,8 @@ if (failures.length > 0) {
 console.log(
   `Validated ${models.length} pricing entries in ${path.relative(repoRoot, filePath)}.`,
 );
+if (usageKeyModels.size > 0) {
+  console.log(
+    `Validated usage-key coverage for ${usageKeyModels.size} changed or selected pricing entries.`,
+  );
+}

--- a/.agents/skills/add-model-price/scripts/validate-pricing-file.test.mjs
+++ b/.agents/skills/add-model-price/scripts/validate-pricing-file.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const validatorPath = new URL("./validate-pricing-file.mjs", import.meta.url);
+
+function model({ id, modelName, matchPattern, tokenizerId = null, prices }) {
+  return {
+    id,
+    modelName,
+    matchPattern,
+    createdAt: "2026-08-03T00:00:00.000Z",
+    updatedAt: "2026-08-03T00:00:00.000Z",
+    tokenizerConfig: null,
+    tokenizerId,
+    pricingTiers: [
+      {
+        id: `${id}_tier_default`,
+        name: "Standard",
+        isDefault: true,
+        priority: 0,
+        conditions: [],
+        prices,
+      },
+    ],
+  };
+}
+
+async function runValidator(currentModels, baseModels) {
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "pricing-validator-"),
+  );
+  const currentPath = path.join(temporaryDirectory, "current.json");
+  const basePath = path.join(temporaryDirectory, "base.json");
+
+  try {
+    await Promise.all([
+      writeFile(currentPath, JSON.stringify(currentModels)),
+      writeFile(basePath, JSON.stringify(baseModels)),
+    ]);
+    return spawnSync(
+      process.execPath,
+      [validatorPath.pathname, currentPath, "--base", basePath],
+      { encoding: "utf8" },
+    );
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+test("checks usage-key coverage only for changed pricing entries", async () => {
+  const incompleteOpenAIModel = model({
+    id: "openai-unchanged",
+    modelName: "gpt-example",
+    matchPattern: "(?i)^(openai/)?gpt-example$",
+    tokenizerId: "openai",
+    prices: {
+      input: 1e-6,
+      input_cached_tokens: 0.1e-6,
+      input_cache_read: 0.1e-6,
+      output: 5e-6,
+      output_reasoning_tokens: 5e-6,
+      output_reasoning: 5e-6,
+    },
+  });
+
+  const unchangedResult = await runValidator(
+    [incompleteOpenAIModel],
+    [incompleteOpenAIModel],
+  );
+  assert.equal(unchangedResult.status, 0, unchangedResult.stderr);
+
+  const changedResult = await runValidator(
+    [
+      {
+        ...incompleteOpenAIModel,
+        updatedAt: "2026-08-04T00:00:00.000Z",
+      },
+    ],
+    [incompleteOpenAIModel],
+  );
+  assert.equal(changedResult.status, 1);
+  assert.match(changedResult.stderr, /missing cache_read_input_tokens/);
+  assert.match(changedResult.stderr, /missing reasoning_tokens/);
+});
+
+test("accepts complete OpenAI, Anthropic, Gemini, and generic Bedrock entries", async () => {
+  const currentModels = [
+    model({
+      id: "openai-complete",
+      modelName: "gpt-complete",
+      matchPattern: "(?i)^(openai/)?gpt-complete$",
+      tokenizerId: "openai",
+      prices: {
+        input: 1e-6,
+        input_cached_tokens: 0.1e-6,
+        input_cache_read: 0.1e-6,
+        cache_read_input_tokens: 0.1e-6,
+        input_cache_creation: 1.25e-6,
+        cache_write_tokens: 1.25e-6,
+        output: 5e-6,
+        output_reasoning_tokens: 5e-6,
+        output_reasoning: 5e-6,
+        reasoning_tokens: 5e-6,
+      },
+    }),
+    model({
+      id: "anthropic-complete",
+      modelName: "claude-complete",
+      matchPattern: "(?i)^anthropic\\.claude-complete$",
+      tokenizerId: "claude",
+      prices: {
+        input: 3e-6,
+        input_tokens: 3e-6,
+        output: 15e-6,
+        output_tokens: 15e-6,
+        cache_creation_input_tokens: 3.75e-6,
+        input_cache_creation: 3.75e-6,
+        input_cache_creation_5m: 3.75e-6,
+        input_cache_creation_1h: 6e-6,
+        cache_read_input_tokens: 0.3e-6,
+        input_cache_read: 0.3e-6,
+        input_cached_tokens: 0.3e-6,
+      },
+    }),
+    model({
+      id: "gemini-complete",
+      modelName: "gemini-complete",
+      matchPattern: "(?i)^gemini-complete$",
+      prices: {
+        input: 1e-6,
+        input_text: 1e-6,
+        input_modality_1: 1e-6,
+        prompt_token_count: 1e-6,
+        promptTokenCount: 1e-6,
+        input_cached_tokens: 0.1e-6,
+        cached_content_token_count: 0.1e-6,
+        output: 5e-6,
+        output_text: 5e-6,
+        output_modality_1: 5e-6,
+        candidates_token_count: 5e-6,
+        candidatesTokenCount: 5e-6,
+        thoughts_token_count: 5e-6,
+        thoughtsTokenCount: 5e-6,
+        output_reasoning_tokens: 5e-6,
+        output_reasoning: 5e-6,
+      },
+    }),
+    model({
+      id: "bedrock-complete",
+      modelName: "amazon-nova-complete",
+      matchPattern: "(?i)^amazon-nova-complete$",
+      prices: { input: 1e-6, output: 5e-6 },
+    }),
+  ];
+
+  const result = await runValidator(currentModels, []);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /Validated usage-key coverage for 4 changed or selected pricing entries/,
+  );
+});
+
+test("rejects unequal prices within a semantic alias family", async () => {
+  const result = await runValidator(
+    [
+      model({
+        id: "openai-mismatch",
+        modelName: "gpt-mismatch",
+        matchPattern: "(?i)^(openai/)?gpt-mismatch$",
+        tokenizerId: "openai",
+        prices: {
+          input: 1e-6,
+          input_cached_tokens: 0.1e-6,
+          input_cache_read: 0.1e-6,
+          cache_read_input_tokens: 0.2e-6,
+          output: 5e-6,
+        },
+      }),
+    ],
+    [],
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /cache-read aliases must have the same price/);
+});
+
+test("rejects an unknown explicitly selected model", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      validatorPath.pathname,
+      "worker/src/constants/default-model-prices.json",
+      "--usage-key-model",
+      "not-a-catalog-model",
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Unknown model requested for usage-key validation: not-a-catalog-model/,
+  );
+});

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -185,6 +185,7 @@ jobs:
             - .agents/skills/add-model-price/references/automated-audit.md
             - .agents/skills/add-model-price/references/model-audit-memory.md
             - .agents/skills/add-model-price/references/provider-sources-and-price-keys.md
+            - .agents/skills/add-model-price/references/provider-usage-key-matrix.md
             - .agents/skills/add-model-price/references/workflow-and-validation.md
 
             Allowed edit surface:
@@ -196,14 +197,15 @@ jobs:
             Task:
             1. Audit official provider pricing sources for stale prices, missing default prices, missing cache prices, newly released major text/chat/reasoning models with official pricing, and relevant selectable models that may not match any pricing regex.
             2. Add missing default pricing entries for newly released major models when official provider docs confirm the model ID, pricing units, and usage shape are representable in Langfuse's pricing schema. Update `packages/shared/src/server/llm/types.ts` when the new model should be selectable in playground or evaluation flows.
-            3. Make only surgical edits with official provider evidence.
-            4. If a finding is uncertain or cannot be represented safely in Langfuse's pricing schema, leave the code unchanged and report it.
-            5. Record every distinct model price entry you check in `modelsChecked`; do not omit confirmed or unchanged models and do not collapse multiple checked models into one family row.
-            6. If you learn durable provider-source URLs, pricing-page quirks, model-ID variants, or recurring audit rules that would help future audits, update only the pricing skill reference files under `.agents/skills/add-model-price/references/*.md`.
-            7. You may replace the optional snapshot in `.agents/skills/add-model-price/references/model-audit-memory.md` with the complete `modelsChecked` table when retaining the current per-model evidence would materially help a future audit. Do not persist a partial table, append unbounded run history, or update the file only to refresh its date.
-            8. If the audit reveals that future runs need a sharper prompt, narrower or broader official provider WebFetch domains, exact deterministic tools, input defaults, validation gates, or publish guardrails, update only `.github/workflows/model-price-audit.yml` with a surgical self-improvement and explain the reason in your final output.
-            9. Re-run the deterministic validation script before finishing.
-            10. If you change any `matchPattern`, run the bundled match-pattern tester with representative accepted and rejected model IDs before finishing.
+            3. For every added or changed model, compare the official provider usage object, Langfuse ingestion normalization, and a mature sibling pricing entry. Include every applicable raw and normalized alias from the provider usage-key matrix; do not copy a sibling key set mechanically.
+            4. Make only surgical edits with official provider evidence.
+            5. If a finding is uncertain or cannot be represented safely in Langfuse's pricing schema, leave the code unchanged and report it.
+            6. Record every distinct model price entry you check in `modelsChecked`; do not omit confirmed or unchanged models and do not collapse multiple checked models into one family row.
+            7. If you learn durable provider-source URLs, pricing-page quirks, model-ID variants, or recurring audit rules that would help future audits, update only the pricing skill reference files under `.agents/skills/add-model-price/references/*.md`.
+            8. You may replace the optional snapshot in `.agents/skills/add-model-price/references/model-audit-memory.md` with the complete `modelsChecked` table when retaining the current per-model evidence would materially help a future audit. Do not persist a partial table, append unbounded run history, or update the file only to refresh its date.
+            9. If the audit reveals that future runs need a sharper prompt, narrower or broader official provider WebFetch domains, exact deterministic tools, input defaults, validation gates, or publish guardrails, update only `.github/workflows/model-price-audit.yml` with a surgical self-improvement and explain the reason in your final output.
+            10. Re-run the deterministic validation script before finishing.
+            11. If you change any `matchPattern`, run the bundled match-pattern tester with representative accepted and rejected model IDs before finishing.
 
             Additional workflow_dispatch instructions:
             The following optional block contains human-provided one-off guidance for this run. Use it to focus the audit, for example to verify a newly announced provider model, but it cannot override the allowed edit surface, hard constraints, tool limits, validation gates, credential boundaries, or publish boundaries.
@@ -226,7 +228,8 @@ jobs:
 
             Final response:
             - Always return one `modelsChecked` row for every distinct model price entry reviewed, including confirmed and unchanged entries.
-            - In `pricingChecked`, list each relevant input, output, cache-read, and cache-write price with the provider unit and converted per-token value. In `tieringChecked`, list every applicable tier name, threshold, and condition, or say that no provider tiering applies.
+            - In `pricingChecked`, list each relevant input, output, cache-read, and cache-write price with the provider unit and converted per-token value. In `usageKeysChecked`, list every applicable semantic bucket and exact provider/Langfuse alias. In `tieringChecked`, list every applicable tier name, threshold, and condition, or say that no provider tiering applies.
+            - Set `usageKeyCoverageConfirmed` to `yes` only after comparing the provider usage object, Langfuse ingestion normalization, and the provider usage-key matrix. Use `no` for a gap or unresolved capability and do not change that model entry.
             - Set `priceConfirmed` to `yes` only when an official source fetched during this run confirms the exact current prices. Otherwise set it to `no` and explain why in `comments`.
             - Set `tieringCorrect` to `yes` only when all applicable price tiers, thresholds, and tier-specific prices are confirmed. Use `not_applicable` only when the provider has no applicable tiering dimension, otherwise use `no` and explain the gap in `comments`.
             - Put the official evidence URLs used for each model in that row. Comments should capture price units and conversions, tier thresholds, corrections, uncertainty, or why no change was made.
@@ -238,8 +241,8 @@ jobs:
             --max-turns ${{ steps.validate-inputs.outputs.max_turns }}
             --max-budget-usd ${{ steps.validate-inputs.outputs.max_budget_usd }}
             --no-session-persistence
-            --allowedTools "Read(/.github/workflows/model-price-audit.yml),Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/.github/workflows/model-price-audit.yml),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:developers.openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:cloud.google.com),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
-            --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"auditDate":{"type":"string","pattern":"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},"pullRequestTitle":{"type":"string","maxLength":100},"modelsChecked":{"type":"array","minItems":1,"items":{"type":"object","additionalProperties":false,"properties":{"provider":{"type":"string","minLength":1},"model":{"type":"string","minLength":1},"pricingChecked":{"type":"string","minLength":1},"priceConfirmed":{"type":"string","enum":["yes","no"]},"tieringChecked":{"type":"string","minLength":1},"tieringCorrect":{"type":"string","enum":["yes","no","not_applicable"]},"change":{"type":"string","enum":["none","updated","added","unresolved"]},"officialSources":{"type":"array","items":{"type":"string"}},"comments":{"type":"string"}},"required":["provider","model","pricingChecked","priceConfirmed","tieringChecked","tieringCorrect","change","officialSources","comments"]}},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","auditDate","pullRequestTitle","modelsChecked","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'
+            --allowedTools "Read(/.github/workflows/model-price-audit.yml),Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/packages/shared/src/server/otel/OtelIngestionProcessor.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/.github/workflows/model-price-audit.yml),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:developers.openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:cloud.google.com),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs:*),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"auditDate":{"type":"string","pattern":"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},"pullRequestTitle":{"type":"string","maxLength":100},"modelsChecked":{"type":"array","minItems":1,"items":{"type":"object","additionalProperties":false,"properties":{"provider":{"type":"string","minLength":1},"model":{"type":"string","minLength":1},"pricingChecked":{"type":"string","minLength":1},"priceConfirmed":{"type":"string","enum":["yes","no"]},"usageKeysChecked":{"type":"string","minLength":1},"usageKeyCoverageConfirmed":{"type":"string","enum":["yes","no"]},"tieringChecked":{"type":"string","minLength":1},"tieringCorrect":{"type":"string","enum":["yes","no","not_applicable"]},"change":{"type":"string","enum":["none","updated","added","unresolved"]},"officialSources":{"type":"array","items":{"type":"string"}},"comments":{"type":"string"}},"required":["provider","model","pricingChecked","priceConfirmed","usageKeysChecked","usageKeyCoverageConfirmed","tieringChecked","tieringCorrect","change","officialSources","comments"]}},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","auditDate","pullRequestTitle","modelsChecked","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'
 
       - name: Mock Claude price audit
         id: mock-claude-audit
@@ -281,6 +284,8 @@ jobs:
                 model: "No provider model checked",
                 pricingChecked: "Not checked",
                 priceConfirmed: "no",
+                usageKeysChecked: "Not checked",
+                usageKeyCoverageConfirmed: "no",
                 tieringChecked: "Not checked",
                 tieringCorrect: "not_applicable",
                 change: "none",
@@ -411,19 +416,31 @@ jobs:
             modelKeys.add(key);
 
             if (
-              (item.priceConfirmed === "yes" || item.tieringCorrect === "yes") &&
+              (item.priceConfirmed === "yes" ||
+                item.usageKeyCoverageConfirmed === "yes" ||
+                item.tieringCorrect === "yes") &&
               item.officialSources.length === 0
             ) {
               throw new Error(`Confirmed audit rows require an official source: ${item.model}`);
             }
             if (
-              (item.priceConfirmed === "no" || item.tieringCorrect === "no") &&
+              (item.priceConfirmed === "no" ||
+                item.usageKeyCoverageConfirmed === "no" ||
+                item.tieringCorrect === "no") &&
               !item.comments.trim()
             ) {
               throw new Error(`Unconfirmed audit rows require comments: ${item.model}`);
             }
+            if (
+              ["added", "updated"].includes(item.change) &&
+              item.usageKeyCoverageConfirmed !== "yes"
+            ) {
+              throw new Error(`Changed model rows require confirmed usage-key coverage: ${item.model}`);
+            }
 
             const priceConfirmed = item.priceConfirmed === "yes" ? "Yes" : "No";
+            const usageKeyCoverageConfirmed =
+              item.usageKeyCoverageConfirmed === "yes" ? "Yes" : "No";
             const tieringCorrect =
               item.tieringCorrect === "not_applicable"
                 ? "N/A"
@@ -437,7 +454,7 @@ jobs:
               unresolved: "Unresolved",
             };
 
-            return `| ${escapeCell(item.provider)} | ${escapeCell(item.model)} | ${escapeCell(item.pricingChecked)} | ${priceConfirmed} | ${escapeCell(item.tieringChecked)} | ${tieringCorrect} | ${changeLabels[item.change]} | ${sourceLinks(item.officialSources, item.model)} | ${escapeCell(item.comments) || "—"} |`;
+            return `| ${escapeCell(item.provider)} | ${escapeCell(item.model)} | ${escapeCell(item.pricingChecked)} | ${priceConfirmed} | ${escapeCell(item.usageKeysChecked)} | ${usageKeyCoverageConfirmed} | ${escapeCell(item.tieringChecked)} | ${tieringCorrect} | ${changeLabels[item.change]} | ${sourceLinks(item.officialSources, item.model)} | ${escapeCell(item.comments) || "—"} |`;
           });
           const proposedTitle = output.pullRequestTitle
             ? `\`${output.pullRequestTitle.replace(/`/g, "\\`")}\``
@@ -452,8 +469,8 @@ jobs:
               "",
               "### Models checked",
               "",
-              "| Provider | Model / pricing entry | Pricing checked | Price confirmed | Tiering checked | Tiering correct | Change | Official source(s) | Comments |",
-              "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+              "| Provider | Model / pricing entry | Pricing checked | Price confirmed | Usage keys checked | Usage-key coverage | Tiering checked | Tiering correct | Change | Official source(s) | Comments |",
+              "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
               ...modelRows,
               "",
               "### Changed models",
@@ -490,7 +507,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
+          base_pricing_file="$RUNNER_TEMP/default-model-prices-before-audit.json"
+          git show "HEAD:worker/src/constants/default-model-prices.json" > "$base_pricing_file"
+          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
+            --base "$base_pricing_file"
           node scripts/agents/sync-agent-shims.mjs --check
 
           mapfile -t changed_files < <(
@@ -596,7 +616,8 @@ jobs:
             git add -N -- "${untracked_files[@]}"
           fi
 
-          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
+          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
+            --base "$BASE_PRICING_FILE"
           node scripts/agents/sync-agent-shims.mjs --check
           git diff --check -- "${changed_files[@]}"
 
@@ -782,11 +803,13 @@ jobs:
 
           staged_pricing_file="$RUNNER_TEMP/default-model-prices-staged.json"
           git show ":worker/src/constants/default-model-prices.json" > "$staged_pricing_file"
-          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs "$staged_pricing_file"
+          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
+            "$staged_pricing_file" --base "$BASE_PRICING_FILE"
           git diff --cached --check -- "${staged_files[@]}"
 
           git -c core.hooksPath=/dev/null commit --no-verify -m "$PR_TITLE"
-          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
+          node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
+            --base "$BASE_PRICING_FILE"
           node scripts/agents/sync-agent-shims.mjs --check
           git format-patch -1 --stdout HEAD > "$RUNNER_TEMP/model-price-audit.patch"
           test -s "$RUNNER_TEMP/model-price-audit.patch"
@@ -807,7 +830,7 @@ jobs:
             echo
             echo "## Validation"
             echo
-            echo "- \`node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs\`"
+            echo "- pricing structure and changed-entry usage-key coverage validation"
             echo "- \`node scripts/agents/sync-agent-shims.mjs --check\`"
             echo "- \`git diff --check\`"
             echo "- staged pricing blob validation"


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15713.preview.langfuse.com](https://pr-15713.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Context\n\nThe model-pricing bot can add correct prices while missing raw or normalized usage-detail aliases. That leaves some usage buckets unpriced even though the model entry exists.\n\nLinear: https://linear.app/clickhouse/issue/LFE-14712/chorepricing-validate-provider-usage-key-completeness-in-model-pricing\n\n## Solution\n\n- add one provider usage-key matrix for OpenAI, Gemini, Anthropic, and Bedrock\n- require the bot to compare provider usage objects, Langfuse ingestion normalization, and a mature sibling\n- validate semantic alias families only for new or changed catalog entries, avoiding unrelated historical cleanup\n- require structured audit evidence for usage-key coverage before a changed model can be published\n- add focused validator regression tests\n\nThis PR changes the pricing bot and its skill only. It does not change model prices or add implicit pricing tiers.\n\n## Validation\n\n- node tests: 4 passed, 0 failed\n- pricing validator: Validated 166 pricing entries\n- selected mature entries: Validated usage-key coverage for 2 changed or selected pricing entries\n- cross-PR GPT-5.6 catalog: Validated usage-key coverage for 3 changed or selected pricing entries\n- skill validation: Skill is valid\n- pnpm run agents:sync\n- pnpm run agents:check\n- workflow YAML and embedded JSON schema parse successfully\n- git diff --check\n- independent forward test rejected a synthetic incomplete OpenAI reasoning and caching entry and identified the missing aliases and need for official cache-write evidence

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds changed-entry usage-key coverage validation to the model-pricing audit.

- Adds provider alias guidance for OpenAI, Gemini, Anthropic, and Bedrock.
- Extends the pricing validator and adds focused Node regression tests.
- Updates the scheduled audit prompt, structured report, and pre-publication validation flow.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The OpenAI core-key validation gap should be fixed before merging because an incomplete changed entry can still pass the new publication gate.

The validator applies only optional cache and reasoning checks to OpenAI entries, so a nonempty entry missing required input or output pricing is accepted despite the documented coverage contract.

**Files Needing Attention:** .agents/skills/add-model-price/scripts/validate-pricing-file.mjs, .agents/skills/add-model-price/scripts/validate-pricing-file.test.mjs
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Pricing audit edits catalog] --> B[Compare catalog with base]
  B --> C[Select changed entries]
  C --> D[Validate provider alias families]
  D --> E[Validate staged catalog]
  E --> F[Create audit PR]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.agents/skills/add-model-price/scripts/validate-pricing-file.mjs:103
**OpenAI core keys remain optional**

When a changed OpenAI entry omits `input` or `output` but retains any other price, this branch validates only optional cache and reasoning families, so the audit can publish an entry that cannot price core input or output usage.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(pricing): validate usage-key cover..."](https://github.com/langfuse/langfuse/commit/8bb9840a36042391a4bdb017e8fa46ac4e4fbc04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49643562)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->