### PR TITLE
fix(web): use the instance base URL in the MCP & CLI settings snippets

### DIFF
--- a/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
+++ b/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
@@ -2,6 +2,7 @@ import Header from "@/src/components/layouts/header";
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
 import { CodeBlock } from "@/src/components/design-system/Codeblock/Codeblock";
+import { useLangfuseBaseUrl } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
 import Link from "next/link";
 import { Bot, SquareTerminal, Sparkles } from "lucide-react";
 
@@ -22,6 +23,8 @@ const ManageApiKeysButton = ({ projectId }: { projectId: string }) => (
 );
 
 export function DeveloperToolsSettings({ projectId }: { projectId: string }) {
+  const baseUrl = useLangfuseBaseUrl();
+
   return (
     <div>
       <Header title="MCP & CLI" />
@@ -67,7 +70,7 @@ export function DeveloperToolsSettings({ projectId }: { projectId: string }) {
           <CodeBlock
             language="shell"
             value={`claude mcp add --transport http langfuse \\
-  https://cloud.langfuse.com/api/public/mcp \\
+  ${baseUrl}/api/public/mcp \\
   --header "Authorization: Basic {your-base64-token}"`}
           />
           <div className="mt-4 flex items-center gap-2">
@@ -91,6 +94,7 @@ export function DeveloperToolsSettings({ projectId }: { projectId: string }) {
             language="shell"
             value={`export LANGFUSE_PUBLIC_KEY="pk-lf-..."
 export LANGFUSE_SECRET_KEY="sk-lf-..."
+export LANGFUSE_BASE_URL="${baseUrl}"
 
 npx langfuse-cli api <resource> <action>`}
           />

--- a/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
+++ b/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
@@ -23,7 +23,7 @@ const ManageApiKeysButton = ({ projectId }: { projectId: string }) => (
 );
 
 export function DeveloperToolsSettings({ projectId }: { projectId: string }) {
-  const baseUrl = useLangfuseBaseUrl();
+  const baseUrl = useLangfuseBaseUrl().replace(/\/+$/, "");
 
   return (
     <div>


### PR DESCRIPTION
## What does this PR do?

The **MCP & CLI** settings page (`Settings → MCP & CLI`) hardcodes `https://cloud.langfuse.com` in the `claude mcp add` snippet, so on a self-hosted instance the copy-button hands you a command that points at Langfuse Cloud — where the project-scoped keys you just copied don't exist.

This derives the host from the existing `useLangfuseBaseUrl()` hook (already used by the API-key and tracing-setup snippets), which resolves `uiCustomization.hostname ?? window.origin` and appends `NEXT_PUBLIC_BASE_PATH`. On Cloud the rendered snippet is unchanged for EU and now correct for US/JP too, instead of always showing the EU host.

Same class of bug in the CLI card below it: the snippet only exports the key pair, and `langfuse-cli` defaults to Cloud, so `export LANGFUSE_BASE_URL="<instance>"` is now part of the snippet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Reuses the established `useLangfuseBaseUrl()` pattern rather than adding a new base-URL source; no new env vars, no behavior outside these two code snippets.
- Verified against the docs, which already list the self-hosted form (`https://your-domain.com/api/public/mcp`) — only the in-app snippet was out of sync.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the MCP and CLI setup snippets to use the current Langfuse instance base URL.
- Builds the MCP endpoint from `useLangfuseBaseUrl()`.
- Exports `LANGFUSE_BASE_URL` in the CLI example.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge, with a non-blocking URL-normalization issue in the MCP snippet.

The MCP endpoint is appended directly to a base URL that can retain a trailing slash, producing a double-slash path in affected custom-host or base-path configurations.

**Files Needing Attention:** web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/developer-tools/components/DeveloperToolsSettings.tsx:73
**Normalize the MCP base URL**

`useLangfuseBaseUrl()` does not remove a trailing slash from `LANGFUSE_UI_API_HOST` or `NEXT_PUBLIC_BASE_PATH`, so this interpolation renders a double-slash MCP endpoint for those configurations. Normalize the boundary before appending `/api/public/mcp` to keep the copied command aligned with the actual route.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp-cli-settings): use the instance ..."](https://github.com/langfuse/langfuse/commit/5ff641960256d3feacfacb0baf9a65a78910f580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49627721)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->