### PR TITLE
fix(ingestion): promote model-less provided costs

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -265,6 +265,11 @@ export class IngestionService {
       "events",
     );
 
+    const shouldEnrichUsageAndCost =
+      Boolean(eventData.modelName) ||
+      Object.keys(eventData.providedUsageDetails ?? {}).length > 0 ||
+      Object.keys(eventData.providedCostDetails ?? {}).length > 0;
+
     // Perform lookups for prompt and model/usage enrichment
     const [prompt, generationUsage] = await Promise.all([
       // Lookup prompt by name and version
@@ -279,8 +284,8 @@ export class IngestionService {
             label: undefined,
           })
         : null,
-      // Lookup model and enrich usage/cost details (includes tokenization if needed)
-      eventData.modelName
+      // Promote provided usage/cost and enrich from the model when available.
+      shouldEnrichUsageAndCost
         ? this.getGenerationUsage({
             projectId: eventData.projectId,
             observationRecord: {

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -125,6 +125,38 @@ describe("IngestionService unit tests", () => {
     });
   });
 
+  it("promotes provided usage and cost for model-less direct events", async () => {
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const eventRecord = await ingestionService.createEventRecord(
+      {
+        projectId: "project-id",
+        traceId: "trace-id",
+        spanId: "observation-id",
+        name: "provided-cost",
+        type: "GENERATION",
+        environment: "default",
+        startTimeISO: "2026-08-03T00:00:00.000Z",
+        endTimeISO: "2026-08-03T00:00:01.000Z",
+        providedUsageDetails: { total: 3 },
+        providedCostDetails: { total: 0.03 },
+        metadata: {},
+        source: "otel",
+      },
+      "otel/project-id/raw-event.json",
+    );
+
+    expect(eventRecord.provided_usage_details).toEqual({ total: 3 });
+    expect(eventRecord.usage_details).toEqual({ total: 3 });
+    expect(eventRecord.provided_cost_details).toEqual({ total: 0.03 });
+    expect(eventRecord.cost_details).toEqual({ total: 0.03 });
+  });
+
   it("does not overflow legacy observation or dual-write staging records", async () => {
     const addToQueue = vi.fn();
     const ingestionService = new IngestionService(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15717.preview.langfuse.com](https://pr-15717.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- run the existing usage/cost enrichment for direct events when they contain provided usage or cost, even without a model
- add a focused regression test for the model-less OTel path

## Why

Direct OTel events stored manually supplied values in `provided_usage_details` and `provided_cost_details`, but skipped promotion into the effective fields whenever `modelName` was absent. Events-backed tables and trace views therefore rendered the observation as zero-cost even though legacy and aggregate surfaces counted the supplied cost.

The fix reuses the existing authoritative provided-cost behavior and avoids changing query, schema, API, or SDK contracts.

Linear: [LFE-14697](https://linear.app/clickhouse/issue/LFE-14697/ingested-cost-details-without-a-pricing-table-model-match-never)
GitHub issue: #15696

## Validation

- Red test before production change: `Tests 1 failed | 9 passed (10)`
- `pnpm exec dotenv -e .env.dev.example -- pnpm --filter worker run test IngestionService.unit.test.ts`
  - `Tests 10 passed (10)`
- `pnpm exec dotenv -e .env.dev.example -- pnpm --filter worker run typecheck`
  - exited successfully
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- `pnpm exec prettier --check worker/src/services/IngestionService/index.ts worker/src/services/IngestionService/tests/IngestionService.unit.test.ts`
  - `All matched files use Prettier code style!`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Promotes manually provided usage and cost into effective event fields even when no model name is present.
- Expands direct-event enrichment eligibility to events containing provided usage or cost details.
- Adds a regression test covering model-less OTel events with supplied usage and cost.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The expanded condition reaches the existing enrichment implementation, which safely handles absent models and promotes authoritative provided usage and cost as intended.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): promote model-less provi..."](https://github.com/langfuse/langfuse/commit/d9a12793ecdfaabd398b0a7b05e78ca55c494529) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49661098)</sub>

<!-- /greptile_comment -->