### PR TITLE
fix(pricing): harden audit metadata validation

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -227,7 +227,7 @@ jobs:
             - Use the allowed exact `date -u +%Y-%m-%dT00:00:00.000Z` command if you need the current timestamp.
 
             Final response:
-            - Always return one `modelsChecked` row for every distinct model price entry reviewed, including confirmed and unchanged entries.
+            - Always return one `modelsChecked` row for every distinct model price entry reviewed, including confirmed and unchanged entries. Set `model` to the exact `modelName` from `default-model-prices.json` for existing entries; put aliases and match-pattern details in `comments`, never in `model`.
             - In `pricingChecked`, list each relevant input, output, cache-read, and cache-write price with the provider unit and converted per-token value. In `usageKeysChecked`, list every applicable semantic bucket and exact provider/Langfuse alias. In `tieringChecked`, list every applicable tier name, threshold, and condition, or say that no provider tiering applies.
             - Set `usageKeyCoverageConfirmed` to `yes` only after comparing the provider usage object, Langfuse ingestion normalization, and the provider usage-key matrix. Use `no` for a gap or unresolved capability and do not change that model entry.
             - Set `priceConfirmed` to `yes` only when an official source fetched during this run confirms the exact current prices. Otherwise set it to `no` and explain why in `comments`.
@@ -585,16 +585,8 @@ jobs:
 
           CHANGED_PRICING_JSON=false
           CHANGED_MODEL_TYPES=false
-          CHANGED_SKILL_REFERENCES=false
-          CHANGED_WORKFLOW=false
           for changed_file in "${changed_files[@]}"; do
             case "$changed_file" in
-              .agents/skills/add-model-price/references/*.md)
-                CHANGED_SKILL_REFERENCES=true
-                ;;
-              .github/workflows/model-price-audit.yml)
-                CHANGED_WORKFLOW=true
-                ;;
               worker/src/constants/default-model-prices.json)
                 CHANGED_PRICING_JSON=true
                 ;;
@@ -609,7 +601,7 @@ jobs:
           TYPES_DIFF_FILE="$RUNNER_TEMP/llm-types.diff"
           git show "HEAD:$CURRENT_PRICING_FILE" > "$BASE_PRICING_FILE"
           git diff --unified=0 -- "packages/shared/src/server/llm/types.ts" > "$TYPES_DIFF_FILE"
-          export BASE_PRICING_FILE CHANGED_MODEL_TYPES CHANGED_PRICING_JSON CHANGED_SKILL_REFERENCES CHANGED_WORKFLOW CURRENT_PRICING_FILE TYPES_DIFF_FILE
+          export BASE_PRICING_FILE CHANGED_MODEL_TYPES CHANGED_PRICING_JSON CURRENT_PRICING_FILE TYPES_DIFF_FILE
 
           mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
           if [ "${#untracked_files[@]}" -gt 0 ]; then
@@ -628,152 +620,7 @@ jobs:
           STRUCTURED_OUTPUT_PATH="$RUNNER_TEMP/claude-model-price-audit.json"
           PR_TITLE_PATH="$RUNNER_TEMP/model-price-audit-pr-title.txt"
           export STRUCTURED_OUTPUT_PATH
-          node <<'NODE' > "$PR_TITLE_PATH"
-          const fs = require("node:fs");
-          const output = JSON.parse(fs.readFileSync(process.env.STRUCTURED_OUTPUT_PATH, "utf8"));
-          const title = output.pullRequestTitle.trim();
-          const normalize = (value) => value.trim().toLowerCase();
-
-          if (!/^chore\(pricing\): [^\r\n]+$/.test(title) || title.length > 100) {
-            console.error("::error::pullRequestTitle must be a single-line Conventional Commit title starting with 'chore(pricing): ' and no longer than 100 characters");
-            process.exit(1);
-          }
-
-          const description = title.slice("chore(pricing): ".length).trim().toLowerCase();
-          if (/^(audit|refresh|update)( default)? (model )?(prices?|pricing)( data)?$/.test(description)) {
-            console.error("::error::pullRequestTitle must identify the specific models or audit behavior changed");
-            process.exit(1);
-          }
-
-          const basePrices = JSON.parse(fs.readFileSync(process.env.BASE_PRICING_FILE, "utf8"));
-          const currentPrices = JSON.parse(fs.readFileSync(process.env.CURRENT_PRICING_FILE, "utf8"));
-          const basePricesByName = new Map(basePrices.map((item) => [normalize(item.modelName), item]));
-          const currentPricesByName = new Map(
-            currentPrices.map((item) => [normalize(item.modelName), item]),
-          );
-          const pricingModelChanges = [];
-          for (const modelName of new Set([
-            ...basePricesByName.keys(),
-            ...currentPricesByName.keys(),
-          ])) {
-            const before = basePricesByName.get(modelName);
-            const after = currentPricesByName.get(modelName);
-            if (JSON.stringify(before) !== JSON.stringify(after)) {
-              pricingModelChanges.push({
-                modelName: after?.modelName ?? before.modelName,
-                expectedChange: before ? "updated" : "added",
-              });
-            }
-          }
-
-          const typeModelChanges = new Set();
-          for (const line of fs.readFileSync(process.env.TYPES_DIFF_FILE, "utf8").split("\n")) {
-            const match = line.match(/^[+-]\s*"([^"]+)"(?:,|:)/);
-            if (match) typeModelChanges.add(match[1]);
-          }
-
-          if (process.env.CHANGED_PRICING_JSON === "true" && pricingModelChanges.length === 0) {
-            console.error("::error::Pricing JSON changed without a concrete model-entry change");
-            process.exit(1);
-          }
-          if (process.env.CHANGED_MODEL_TYPES === "true" && typeModelChanges.size === 0) {
-            console.error("::error::Selectable-model types changed without a concrete model identifier change");
-            process.exit(1);
-          }
-
-          const changedModelRows = output.modelsChecked.filter((item) =>
-            ["added", "updated"].includes(item.change),
-          );
-          const changedRowsByModel = new Map(
-            changedModelRows.map((item) => [normalize(item.model), item]),
-          );
-          for (const change of pricingModelChanges) {
-            const row = changedRowsByModel.get(normalize(change.modelName));
-            if (!row || row.change !== change.expectedChange) {
-              console.error(`::error::modelsChecked must report the actual ${change.expectedChange} pricing entry: ${change.modelName}`);
-              process.exit(1);
-            }
-          }
-
-          const affectedModels = new Map();
-          for (const change of pricingModelChanges) {
-            affectedModels.set(normalize(change.modelName), change.modelName);
-          }
-          for (const modelName of typeModelChanges) {
-            affectedModels.set(normalize(modelName), modelName);
-            if (!changedRowsByModel.has(normalize(modelName))) {
-              console.error(`::error::modelsChecked must report the selectable-model change: ${modelName}`);
-              process.exit(1);
-            }
-          }
-          for (const row of changedModelRows) {
-            if (!affectedModels.has(normalize(row.model))) {
-              console.error(`::error::modelsChecked reports a model without a matching pricing or selectable-model diff: ${row.model}`);
-              process.exit(1);
-            }
-          }
-
-          if (affectedModels.size > 0) {
-            const ignoredWords = new Set([
-              "default",
-              "flash",
-              "latest",
-              "lite",
-              "mini",
-              "model",
-              "models",
-              "nano",
-              "preview",
-              "price",
-              "prices",
-              "pricing",
-              "pro",
-              "turbo",
-            ]);
-            const descriptionWords = new Set(description.split(/[^a-z0-9]+/));
-            const unrepresentedModels = [...affectedModels.values()].filter((modelName) => {
-              const identifyingWords = normalize(modelName)
-                .split(/[^a-z0-9]+/)
-                .filter(
-                  (word) =>
-                    (word.length >= 3 || /[a-z][0-9]|[0-9][a-z]/.test(word)) &&
-                    !ignoredWords.has(word),
-                );
-              return (
-                identifyingWords.length > 0 &&
-                !identifyingWords.some((word) => descriptionWords.has(word))
-              );
-            });
-
-            if (unrepresentedModels.length > 0) {
-              console.error(`::error::pullRequestTitle does not represent these model families from the actual diff: ${unrepresentedModels.join(", ")}`);
-              process.exit(1);
-            }
-          } else if (
-            process.env.CHANGED_WORKFLOW === "true" ||
-            process.env.CHANGED_SKILL_REFERENCES === "true"
-          ) {
-            const auditChangeWords = [
-              "audit",
-              "guardrail",
-              "memory",
-              "prompt",
-              "reference",
-              "report",
-              "source",
-              "table",
-              "title",
-              "validation",
-              "workflow",
-            ];
-            if (!auditChangeWords.some((word) => description.includes(word))) {
-              console.error("::error::pullRequestTitle must identify the audit workflow or skill-reference behavior changed");
-              process.exit(1);
-            }
-          }
-
-          process.stdout.write(title);
-          NODE
+          node scripts/model-price-audit/prepare-metadata.mjs > "$PR_TITLE_PATH"
           PR_TITLE="$(cat "$PR_TITLE_PATH")"
 
           GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -c core.hooksPath=/dev/null add -- "${changed_files[@]}"

--- a/scripts/model-price-audit/prepare-metadata.mjs
+++ b/scripts/model-price-audit/prepare-metadata.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+process.on("uncaughtException", (error) => {
+  console.error(`::error::${error.message}`);
+  process.exit(1);
+});
+
+const requiredEnvironment = [
+  "BASE_PRICING_FILE",
+  "CURRENT_PRICING_FILE",
+  "STRUCTURED_OUTPUT_PATH",
+  "TYPES_DIFF_FILE",
+];
+
+for (const name of requiredEnvironment) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+const output = JSON.parse(
+  fs.readFileSync(process.env.STRUCTURED_OUTPUT_PATH, "utf8"),
+);
+const title = output.pullRequestTitle.trim();
+const normalize = (value) => value.trim().toLowerCase();
+const normalizeReportedModel = (value) =>
+  normalize(value).replace(/\s+\((?:also\s+)?matches\b[^)]*\)$/u, "");
+
+if (!/^chore\(pricing\): [^\r\n]+$/.test(title) || title.length > 100) {
+  throw new Error(
+    "pullRequestTitle must be a single-line Conventional Commit title starting with 'chore(pricing): ' and no longer than 100 characters",
+  );
+}
+
+const description = title.slice("chore(pricing): ".length).trim().toLowerCase();
+if (
+  /^(audit|refresh|update)( default)? (model )?(prices?|pricing)( data)?$/.test(
+    description,
+  )
+) {
+  throw new Error(
+    "pullRequestTitle must identify the specific models or audit behavior changed",
+  );
+}
+
+const basePrices = JSON.parse(
+  fs.readFileSync(process.env.BASE_PRICING_FILE, "utf8"),
+);
+const currentPrices = JSON.parse(
+  fs.readFileSync(process.env.CURRENT_PRICING_FILE, "utf8"),
+);
+const basePricesByName = new Map(
+  basePrices.map((item) => [normalize(item.modelName), item]),
+);
+const currentPricesByName = new Map(
+  currentPrices.map((item) => [normalize(item.modelName), item]),
+);
+const pricingModelChanges = [];
+for (const modelName of new Set(
+  Array.from(basePricesByName.keys()).concat(currentPricesByName.keys()),
+)) {
+  const before = basePricesByName.get(modelName);
+  const after = currentPricesByName.get(modelName);
+  if (JSON.stringify(before) !== JSON.stringify(after)) {
+    pricingModelChanges.push({
+      modelName: after?.modelName ?? before.modelName,
+      expectedChange: before ? "updated" : "added",
+    });
+  }
+}
+
+const typeModelChanges = new Set();
+for (const line of fs
+  .readFileSync(process.env.TYPES_DIFF_FILE, "utf8")
+  .split("\n")) {
+  const match = line.match(/^[+-]\s*"([^"]+)"(?:,|:)/);
+  if (match) typeModelChanges.add(match[1]);
+}
+
+if (
+  process.env.CHANGED_PRICING_JSON === "true" &&
+  pricingModelChanges.length === 0
+) {
+  throw new Error("Pricing JSON changed without a concrete model-entry change");
+}
+if (process.env.CHANGED_MODEL_TYPES === "true" && typeModelChanges.size === 0) {
+  throw new Error(
+    "Selectable-model types changed without a concrete model identifier change",
+  );
+}
+
+const changedModelRows = output.modelsChecked.filter((item) =>
+  ["added", "updated"].includes(item.change),
+);
+const changedRowsByModel = new Map(
+  changedModelRows.map((item) => [normalizeReportedModel(item.model), item]),
+);
+for (const change of pricingModelChanges) {
+  const row = changedRowsByModel.get(normalize(change.modelName));
+  if (!row || row.change !== change.expectedChange) {
+    throw new Error(
+      `modelsChecked must report the actual ${change.expectedChange} pricing entry: ${change.modelName}`,
+    );
+  }
+}
+
+const affectedModels = new Map();
+for (const change of pricingModelChanges) {
+  affectedModels.set(normalize(change.modelName), change.modelName);
+}
+for (const modelName of typeModelChanges) {
+  affectedModels.set(normalize(modelName), modelName);
+  if (!changedRowsByModel.has(normalize(modelName))) {
+    throw new Error(
+      `modelsChecked must report the selectable-model change: ${modelName}`,
+    );
+  }
+}
+for (const row of changedModelRows) {
+  if (!affectedModels.has(normalizeReportedModel(row.model))) {
+    throw new Error(
+      `modelsChecked reports a model without a matching pricing or selectable-model diff: ${row.model}`,
+    );
+  }
+}
+
+process.stdout.write(title);

--- a/scripts/model-price-audit/prepare-metadata.test.mjs
+++ b/scripts/model-price-audit/prepare-metadata.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.join(import.meta.dirname, "prepare-metadata.mjs");
+
+function runValidator({
+  basePrices = [],
+  currentPrices = basePrices,
+  output,
+  typesDiff = "",
+  changedPricingJson = false,
+  changedModelTypes = false,
+}) {
+  const fixtureDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "model-price-audit-metadata-"),
+  );
+  const files = {
+    base: path.join(fixtureDirectory, "base.json"),
+    current: path.join(fixtureDirectory, "current.json"),
+    output: path.join(fixtureDirectory, "output.json"),
+    typesDiff: path.join(fixtureDirectory, "types.diff"),
+  };
+  fs.writeFileSync(files.base, JSON.stringify(basePrices));
+  fs.writeFileSync(files.current, JSON.stringify(currentPrices));
+  fs.writeFileSync(files.output, JSON.stringify(output));
+  fs.writeFileSync(files.typesDiff, typesDiff);
+
+  const result = spawnSync(process.execPath, [scriptPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      BASE_PRICING_FILE: files.base,
+      CHANGED_MODEL_TYPES: String(changedModelTypes),
+      CHANGED_PRICING_JSON: String(changedPricingJson),
+      CURRENT_PRICING_FILE: files.current,
+      STRUCTURED_OUTPUT_PATH: files.output,
+      TYPES_DIFF_FILE: files.typesDiff,
+    },
+  });
+  fs.rmSync(fixtureDirectory, { force: true, recursive: true });
+  return result;
+}
+
+const modelName = "gpt-5.5-2026-04-23";
+const changedPrices = {
+  before: [{ modelName, pricingTiers: [{ prices: { input: 5 } }] }],
+  after: [{ modelName, pricingTiers: [{ prices: { input: 10 } }] }],
+};
+
+test("accepts a unique trailing match-alias annotation", () => {
+  const result = runValidator({
+    basePrices: changedPrices.before,
+    currentPrices: changedPrices.after,
+    changedPricingJson: true,
+    output: {
+      pullRequestTitle: "chore(pricing): update gpt-5.5 large-context tier",
+      modelsChecked: [
+        {
+          model: `${modelName} (also matches gpt-5.5)`,
+          change: "updated",
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    result.stdout,
+    "chore(pricing): update gpt-5.5 large-context tier",
+  );
+});
+
+test("accepts a concrete title for a reference-only diff", () => {
+  const result = runValidator({
+    output: {
+      pullRequestTitle:
+        "chore(pricing): confirm gpt-5 alias and Opus 4.5 evidence",
+      modelsChecked: [{ model: modelName, change: "none" }],
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("rejects an unrelated decorated model row", () => {
+  const result = runValidator({
+    basePrices: changedPrices.before,
+    currentPrices: changedPrices.after,
+    changedPricingJson: true,
+    output: {
+      pullRequestTitle: "chore(pricing): update gpt-5.5 large-context tier",
+      modelsChecked: [
+        {
+          model: "gpt-5.4 (also matches gpt-5.5)",
+          change: "updated",
+        },
+      ],
+    },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /modelsChecked must report the actual updated pricing entry/,
+  );
+});
+
+test("rejects a generic pull request title", () => {
+  const result = runValidator({
+    output: {
+      pullRequestTitle: "chore(pricing): update model prices",
+      modelsChecked: [{ model: modelName, change: "none" }],
+    },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /must identify the specific models or audit behavior changed/,
+  );
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15719.preview.langfuse.com](https://pr-15719.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- extract the model-price-audit PR metadata validator into a focused, testable Node script
- require exact pricing-entry names in the Claude prompt while tolerating only the observed trailing `(also matches ...)` annotation during deterministic reconciliation
- remove brittle PR-title keyword heuristics while retaining Conventional Commit shape, 100-character length, and generic-title rejection
- add regression coverage for the two observed failure classes and negative safety cases

## Why

9 of the 20 scheduled audit runs from July 15 through August 3 failed after the Claude audit and pricing validation succeeded. Six failures were caused by `gpt-5.5-2026-04-23 (also matches gpt-5.5)` not exactly equaling the changed pricing entry `gpt-5.5-2026-04-23`; three older failures came from title wording heuristics. The same SHA failed twice and then succeeded when Claude happened to use exact strings.

Linear: [LFE-14714](https://linear.app/clickhouse/issue/LFE-14714/fixpricing-harden-model-price-audit-metadata-validation)

## Scope and security

No pricing data, provider sources, action permissions, credentials, LLM tool/network allowlists, changed-file allowlists, staged-blob checks, artifact handling, or audit/publish job boundaries changed.

## Validation

- `node --test scripts/model-price-audit/prepare-metadata.test.mjs`
  - `tests 4`
  - `pass 4`
  - `fail 0`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
  - `Validated 166 pricing entries in worker/src/constants/default-model-prices.json.`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- `pnpm exec prettier --check .github/workflows/model-price-audit.yml scripts/model-price-audit/prepare-metadata.mjs scripts/model-price-audit/prepare-metadata.test.mjs`
  - `All matched files use Prettier code style!`
- Ruby YAML parse
  - `Parsed .github/workflows/model-price-audit.yml`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extracts audit metadata reconciliation into a Node script and relaxes model-name/title validation for observed audit outputs.
- Adds deterministic pricing-entry and selectable-model reconciliation.
- Permits trailing model match annotations during reconciliation.
- Adds regression tests for decorated model names and generic titles.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The duplicate canonical-model path should be rejected before merging because it can publish conflicting audit metadata while validation succeeds.

Differently annotated rows evade the workflow's original-string duplicate check and then collapse into one normalized Map entry; the normalization also accepts annotation syntax beyond the intended compatibility form.

**Files Needing Attention:** scripts/model-price-audit/prepare-metadata.mjs, .github/workflows/model-price-audit.yml
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Claude structured output] --> B[Deduplicate original model strings]
  B --> C[Write audit metadata]
  C --> D[Normalize trailing match annotations]
  D --> E[Map rows by canonical model name]
  E --> F[Reconcile pricing and type changes]
  C --> G[Render original rows in PR body]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/model-price-audit/prepare-metadata.mjs:96-98
**Duplicate canonical rows collapse**

When `modelsChecked` contains two changed rows for the same model with different trailing annotations, the workflow's original-string duplicate check accepts both and this normalized `Map` silently retains only the latter row. Reconciliation therefore succeeds while both conflicting rows are published in the pull request audit table.

### Issue 2
scripts/model-price-audit/prepare-metadata.mjs:28-29
**Normalization accepts unobserved syntax**

The optional `also` group accepts bare `(matches ...)` annotations even though this compatibility path targets the observed `(also matches ...)` form. Requiring `also` keeps deterministic reconciliation limited to the intended exception and prevents other noncanonical model values from passing validation.

```suggestion
const normalizeReportedModel = (value) =>
  normalize(value).replace(/\s+\(also\s+matches\b[^)]*\)$/u, "");
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): harden audit metadata vali..."](https://github.com/langfuse/langfuse/commit/d84f0ac73bc0e58721e506f750f8367137564dc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49660818)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->