### PR TITLE
fix(ci): add required cache-key to Blacksmith Docker builder setup

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1141,6 +1141,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@33803e640bd9d674f2843a8c323aa2a7da478d23 # v2.0.0
+        with:
+          cache-key: langfuse/${{ matrix.image_name }}-${{ matrix.platform_tag }}
       - name: Extract metadata (labels) for Docker
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -1235,6 +1237,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@33803e640bd9d674f2843a8c323aa2a7da478d23 # v2.0.0
+        with:
+          cache-key: langfuse/${{ matrix.image_name }}-manifest
       - name: Download release digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1139,10 +1139,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # build-push-action v2 requires this step; it no longer sets up buildkit
+      # itself. Both inputs are load-bearing, do not drop them:
+      # - cache-key is required as of setup-docker-builder v2. Without it the
+      #   action errors and falls back to a local builder, which is how the
+      #   v4.2.0 and v4.3.0 releases silently lost their layer cache.
+      # - nofallback makes that degradation fail the job instead of emitting a
+      #   warning nobody reads. Releases are rare and cache-cold builds are
+      #   slow, so a Blacksmith outage should block the release, not hide in it.
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@33803e640bd9d674f2843a8c323aa2a7da478d23 # v2.0.0
         with:
           cache-key: langfuse/${{ matrix.image_name }}-${{ matrix.platform_tag }}
+          nofallback: "true"
       - name: Extract metadata (labels) for Docker
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1235,10 +1235,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@33803e640bd9d674f2843a8c323aa2a7da478d23 # v2.0.0
-        with:
-          cache-key: langfuse/${{ matrix.image_name }}-manifest
       - name: Download release digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15720.preview.langfuse.com](https://pr-15720.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

`useblacksmith/setup-docker-builder` v2.0.0 (bumped in #15643, merged 2026-07-30T16:30Z) made `cache-key` a required input. Both call sites in `pipeline.yml` invoked it bare, so since that merge the action fails with `Input required and not supplied: cache-key` and silently falls back to a local buildx builder on every `main`-based release.

That fallback builder keeps Blacksmith's registry mirror wired in (per the action's own v1.9.0 changelog: "keep docker mirror on local builder fallback"), which corrupts the Docker Hub manifest-list push in `publish-docker-image-release`. `v4.2.0` and `v4.3.0` both failed with 404s on the new tags and stale-digest mismatches on `latest`/`4`, while `v3.225.0` — released the same morning from the `v3` branch, still pinned to v1.9.0 — succeeded using the identical Docker Hub credentials. That side-by-side rules out the credential-scope theory.

## Changes

**`build-docker-image-release`** (per-platform build job) keeps the builder and gets both required inputs. `useblacksmith/build-push-action@v2` explicitly requires `setup-docker-builder` to run first ("all buildkit setup and stickydisk management functionality has been removed"), so the step is load-bearing here.
- `cache-key: langfuse/<image_name>-<platform_tag>`, following the `<repo>/<build-target>` pattern from the action's docs. Scoped per platform because the two architectures build on different runners and share no layers.
- `nofallback: "true"`, so a future Blacksmith failure fails the job instead of emitting a warning nobody reads. Note the trade-off: for *this* job the fallback costs layer caching rather than correctness — the per-arch digest pushes did land on Docker Hub — so this is about making degradation visible. It does mean a Blacksmith outage now blocks a release rather than producing a slow one.

**`publish-docker-image-release`** (manifest-list publish job) drops the builder setup entirely. `docker buildx imagetools create`/`inspect` talk to the registry directly and never touch a BuildKit daemon — per Docker's docs `--builder` only selects which builder context to resolve config from. This job never builds anything, so the step had no upside and only ever added failure modes: a missing required input (this incident) or a transient Blacksmith outage (the `deadline_exceeded` precedent cited in this job's own retry comment from the v3.223 release). Every one of those paths falls back to a local builder whose config poisons the Docker Hub push. Removing the step removes the whole class rather than patching this one trigger.

## Follow-ups not in this PR

- **`v3` will regress identically.** It still pins v1.9.0, which is why v3.225.0 shipped fine. Whoever reviews the dependabot bump that moves `v3` to v2 must add `cache-key` in the same PR, or v3 releases start silently corrupting their Docker Hub manifests the same way.
- **The already-broken tags need healing.** `langfuse/langfuse:latest` and `:4` still serve v4.1.0 on Docker Hub. Re-running the failed v4.3.0 jobs will not help: Actions re-runs use the workflow file at the triggering ref, which still contains the broken step. Needs a `v4.3.1` cut after this merges, a moved tag, or the two `imagetools create` commands run by hand against the per-arch digests already on Hub.
- **Report the fallback config to Blacksmith.** v2.0.1 and v2.1.0 still ship the same `http`/insecure-on-`docker.io` fallback config, so bumping the action is not a fix.

## Test plan

- [ ] Next `v4.x` release: `build-docker-image-release` logs `Blacksmith builder is ready for use by Docker` with no fallback warning
- [ ] Next `v4.x` release: `publish-docker-image-release` runs no builder-setup step, and the Docker Hub manifest push lands with `latest`/`4`/`4.x` resolving to the new index digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)