### PR TITLE
fix(events): preserve trace names across v4 surfaces

### DIFF
--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -1,12 +1,19 @@
 import { type ColumnDefinition } from "./tableDefinitions";
 
 export const eventsTableHasParentObservationSql = "e.parent_span_id != ''";
-export const eventsTableIsRootObservationSqlForAlias = (alias: string) =>
-  `(${alias}.parent_span_id = '' OR ${alias}.is_app_root = true)`;
+export const eventsTableIsRootObservationSqlForAlias = (alias: string) => {
+  const prefix = alias ? `${alias}.` : "";
+  return `(${prefix}parent_span_id = '' OR ${prefix}is_app_root = true)`;
+};
 export const eventsTableIsRootObservationSql =
   eventsTableIsRootObservationSqlForAlias("e");
-export const eventsTableTraceNameSql =
-  "COALESCE(nullIf(e.trace_name, ''), if(e.parent_span_id = '', nullIf(e.name, ''), NULL))";
+export const eventsTableTraceNameSqlForAlias = (alias: string) =>
+  `COALESCE(nullIf(${alias}.trace_name, ''), if(${eventsTableIsRootObservationSqlForAlias(alias)}, nullIf(${alias}.name, ''), NULL))`;
+export const eventsTableTraceNameSql = eventsTableTraceNameSqlForAlias("e");
+export const eventsTableTraceNameAggregationSqlForAlias = (alias: string) =>
+  `COALESCE(nullIf(argMaxIf(${alias}.trace_name, ${alias}.event_ts, ${alias}.trace_name <> ''), ''), nullIf(argMaxIf(${alias}.name, ${alias}.event_ts, ${eventsTableIsRootObservationSqlForAlias(alias)} AND ${alias}.name <> ''), ''))`;
+export const eventsTableTraceNameAggregationSql =
+  eventsTableTraceNameAggregationSqlForAlias("e");
 
 export const isRootObservation = ({
   parentObservationId,

--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -5,6 +5,8 @@ export const eventsTableIsRootObservationSqlForAlias = (alias: string) =>
   `(${alias}.parent_span_id = '' OR ${alias}.is_app_root = true)`;
 export const eventsTableIsRootObservationSql =
   eventsTableIsRootObservationSqlForAlias("e");
+export const eventsTableTraceNameSql =
+  "COALESCE(nullIf(e.trace_name, ''), if(e.parent_span_id = '', nullIf(e.name, ''), NULL))";
 
 export const isRootObservation = ({
   parentObservationId,
@@ -108,7 +110,7 @@ const eventsTableColsDefinition = [
     name: "Trace Name",
     id: "traceName",
     type: "stringOptions",
-    internal: "e.trace_name",
+    internal: eventsTableTraceNameSql,
     options: [], // to be added at runtime
     nullable: true,
   },

--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -348,6 +348,8 @@ export const eventsTracesView: ViewDeclarationType = {
   },
   segments: [],
   timeDimension: "start_time",
+  // Trace aggregation can use either semantic-root representation without
+  // changing result cardinality, so app roots remain useful here.
   rootEventCondition: {
     column: "trace_id",
     condition: eventsTableIsRootObservationSqlForAlias("events_traces"),
@@ -925,7 +927,13 @@ const createScoreTableRelations = (
   return {
     events_traces: {
       name: "events_core",
-      joinConditionSql: `ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND ${eventsTableIsRootObservationSqlForAlias("events_traces")}`,
+      // Legacy and dual-write ingestion materialize a parentless synthetic
+      // trace event and propagate trace metadata to it. Native V4 may not, but
+      // its app roots come from newer SDKs and are expected to carry trace_name.
+      // A semantic-root join can match both rows in dual-write data and
+      // multiply scores for little fallback value.
+      joinConditionSql:
+        "ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND events_traces.parent_span_id = ''",
       timeDimension: "start_time",
       useFinal: false,
     },

--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -350,7 +350,7 @@ export const eventsTracesView: ViewDeclarationType = {
   timeDimension: "start_time",
   rootEventCondition: {
     column: "trace_id",
-    condition: eventsTableIsRootObservationSqlForAlias(""),
+    condition: eventsTableIsRootObservationSqlForAlias("events_traces"),
   },
   baseCte: `events_core events_traces`,
 };

--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -6,7 +6,11 @@ import {
   type views,
 } from "./types";
 import { InvalidRequestError } from "../../errors";
-import { eventsTableIsRootObservationSqlForAlias } from "../../eventsTable";
+import {
+  eventsTableIsRootObservationSqlForAlias,
+  eventsTableTraceNameAggregationSqlForAlias,
+  eventsTableTraceNameSqlForAlias,
+} from "../../eventsTable";
 
 // The data model defines all available dimensions, measures, and the timeDimension for a given view.
 // Make sure to update web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts if you make changes
@@ -173,14 +177,14 @@ export const eventsTracesView: ViewDeclarationType = {
       // This is the GROUP BY identity column
     },
     name: {
-      sql: "COALESCE(nullIf(events_traces.trace_name, ''), if(events_traces.parent_span_id = '', nullIf(events_traces.name, ''), NULL))",
+      sql: eventsTableTraceNameSqlForAlias("events_traces"),
       alias: "name",
       type: "string",
       description:
         "Name assigned to the trace (often the endpoint or operation).",
       // First try most-recent non-empty trace_name, then fall back to root event's name
       aggregationFunction:
-        "COALESCE(nullIf(argMaxIf(events_traces.trace_name, events_traces.event_ts, events_traces.trace_name <> ''), ''), argMaxIf(events_traces.name, events_traces.event_ts, events_traces.parent_span_id = '' AND events_traces.name <> ''))",
+        eventsTableTraceNameAggregationSqlForAlias("events_traces"),
       // Pruning columns for WHERE: OR'd together to help ClickHouse skip blocks,
       // then dimension.sql is AND'd for exact row-level match.
       filterSql: {
@@ -346,7 +350,7 @@ export const eventsTracesView: ViewDeclarationType = {
   timeDimension: "start_time",
   rootEventCondition: {
     column: "trace_id",
-    condition: "parent_span_id = ''",
+    condition: eventsTableIsRootObservationSqlForAlias(""),
   },
   baseCte: `events_core events_traces`,
 };
@@ -731,7 +735,7 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
   },
   // Trace metadata on events table (accessed via events_traces JOIN)
   traceName: {
-    sql: "COALESCE(nullIf(events_traces.trace_name, ''), nullIf(events_traces.name, ''))",
+    sql: eventsTableTraceNameSqlForAlias("events_traces"),
     alias: "traceName",
     type: "string",
     relationTable: "events_traces",
@@ -921,8 +925,7 @@ const createScoreTableRelations = (
   return {
     events_traces: {
       name: "events_core",
-      joinConditionSql:
-        "ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND events_traces.parent_span_id = ''",
+      joinConditionSql: `ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND ${eventsTableIsRootObservationSqlForAlias("events_traces")}`,
       timeDimension: "start_time",
       useFinal: false,
     },
@@ -1189,7 +1192,7 @@ export const eventsObservationsView: ViewDeclarationType = {
     },
     // Backwards-compatible field definitions (for API parity with v1)
     traceName: {
-      sql: "COALESCE(nullIf(events_observations.trace_name, ''), if(events_observations.parent_span_id = '', nullIf(events_observations.name, ''), NULL))",
+      sql: eventsTableTraceNameSqlForAlias("events_observations"),
       alias: "traceName",
       type: "string",
       description: "Name of the parent trace (backwards-compatible with v1).",

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -972,12 +972,11 @@ export class QueryBuilder {
 
     // Optionally wrap in aggregation function (e.g., "any" for two-level inner SELECT).
     // When the view has a rootEventCondition, prefer the root event's timestamp for
-    // time bucketing. Falls back to min(start_time) when no root event exists for a
-    // trace (e.g. parent_span_id is not populated).
+    // time bucketing. Falls back to min(start_time) when no semantic-root event
+    // exists for a trace.
     let wrappedSql: string;
     if (wrapInAgg && view.rootEventCondition) {
-      const alias = this.tableAlias(view);
-      wrappedSql = `ifNull(anyIf(toNullable(${timeDimensionSql}), ${alias}.${view.rootEventCondition.condition}), min(${timeDimensionSql}))`;
+      wrappedSql = `ifNull(anyIf(toNullable(${timeDimensionSql}), ${view.rootEventCondition.condition}), min(${timeDimensionSql}))`;
     } else if (wrapInAgg) {
       wrappedSql = `${wrapInAgg}(${timeDimensionSql})`;
     } else {

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -976,6 +976,8 @@ export class QueryBuilder {
     // exists for a trace.
     let wrappedSql: string;
     if (wrapInAgg && view.rootEventCondition) {
+      // The condition owns its qualification because prefixing a compound SQL
+      // expression here would produce invalid SQL such as `alias.(a OR b)`.
       wrappedSql = `ifNull(anyIf(toNullable(${timeDimensionSql}), ${view.rootEventCondition.condition}), min(${timeDimensionSql}))`;
     } else if (wrapInAgg) {
       wrappedSql = `${wrapInAgg}(${timeDimensionSql})`;
@@ -1654,13 +1656,14 @@ export class QueryBuilder {
         const toP = `subTo${uid}`;
         const projP = `subProj${uid}`;
         const baseTable = this.actualTableName(view);
+        const tableAlias = this.tableAlias(view);
         const { column, condition } = view.rootEventCondition;
         const subquery =
-          `SELECT ${column} FROM ${baseTable} ` +
-          `WHERE project_id = {${projP}: String} ` +
+          `SELECT ${tableAlias}.${column} FROM ${baseTable} ${tableAlias} ` +
+          `WHERE ${tableAlias}.project_id = {${projP}: String} ` +
           `AND ${condition} ` +
-          `AND ${view.timeDimension} >= {${fromP}: DateTime64(3)} ` +
-          `AND ${view.timeDimension} <= {${toP}: DateTime64(3)}`;
+          `AND ${tableAlias}.${view.timeDimension} >= {${fromP}: DateTime64(3)} ` +
+          `AND ${tableAlias}.${view.timeDimension} <= {${toP}: DateTime64(3)}`;
         fromClause +=
           ` AND (${baseTable}.${column} IN (${subquery})` +
           ` OR NOT EXISTS (${subquery} LIMIT 1))`;

--- a/packages/shared/src/features/query/types.ts
+++ b/packages/shared/src/features/query/types.ts
@@ -102,7 +102,7 @@ export const viewDeclaration = z.object({
     .object({
       // The column used to match root entities between outer query and subquery (e.g., "trace_id").
       column: z.string(),
-      // Self-contained SQL condition identifying root events.
+      // Fully qualified, self-contained SQL condition identifying root events.
       condition: z.string(),
     })
     .optional(),

--- a/packages/shared/src/features/query/types.ts
+++ b/packages/shared/src/features/query/types.ts
@@ -102,7 +102,7 @@ export const viewDeclaration = z.object({
     .object({
       // The column used to match root entities between outer query and subquery (e.g., "trace_id").
       column: z.string(),
-      // SQL condition identifying root events (e.g., "parent_span_id = ''").
+      // Self-contained SQL condition identifying root events.
       condition: z.string(),
     })
     .optional(),

--- a/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-filter-options.ts
@@ -3,6 +3,7 @@ import {
   eventsTableCols,
   eventsTableHasParentObservationSql,
   eventsTableIsRootObservationSql,
+  eventsTableTraceNameSql,
 } from "../../../eventsTable";
 import type { FilterState } from "../../../types";
 import { eventsTableUiColumnDefinitions } from "../../tableMappings/mapEventsTable";
@@ -64,8 +65,8 @@ const EVENTS_FILTER_OPTION_DEFINITIONS = {
   },
   traceName: {
     kind: "scalar",
-    expression: "e.trace_name",
-    includeWhen: "e.trace_name IS NOT NULL AND length(e.trace_name) > 0",
+    expression: eventsTableTraceNameSql,
+    includeWhen: `${eventsTableTraceNameSql} IS NOT NULL`,
     sort: "countDesc",
   },
   type: {

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.test.ts
@@ -34,6 +34,9 @@ describe("EventsAggregationQueryBuilder", () => {
     expect(query).toContain(
       "length(groupUniqArrayIf(span_id, span_id <> '' AND span_id <> concat('t-', trace_id))) AS observation_count",
     );
+    expect(query).toContain(
+      "(e.parent_span_id = '' OR e.is_app_root = true) AND e.name <> ''",
+    );
   });
 });
 

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../domain/observation-field-groups";
 import {
   eventsTableIsRootObservationSql,
+  eventsTableTraceNameAggregationSql,
   eventsTableTraceNameSql,
 } from "../../../eventsTable";
 import { OBSERVATIONS_TO_TRACE_INTERVAL } from "../../repositories/constants";
@@ -524,7 +525,7 @@ const EVENTS_AGGREGATION_FIELDS = {
   projectId: "project_id",
 
   // Aggregated fields
-  name: "argMaxIf(trace_name, event_ts, trace_name <> '') AS name",
+  name: `${eventsTableTraceNameAggregationSql} AS name`,
   timestamp: "min(start_time) as timestamp",
   environment:
     "argMaxIf(environment, event_ts, environment <> '') AS environment",

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -2,7 +2,10 @@ import {
   OBSERVATION_FIELD_GROUPS_PUBLIC_API,
   type ObservationFieldGroupPublicApi,
 } from "../../../domain/observation-field-groups";
-import { eventsTableIsRootObservationSql } from "../../../eventsTable";
+import {
+  eventsTableIsRootObservationSql,
+  eventsTableTraceNameSql,
+} from "../../../eventsTable";
 import { OBSERVATIONS_TO_TRACE_INTERVAL } from "../../repositories/constants";
 import { FilterList, StringFilter } from "./clickhouse-filter";
 
@@ -128,7 +131,7 @@ const EVENTS_FIELDS = {
   public: "e.public as public",
   userId: 'e.user_id as "user_id"',
   sessionId: 'e.session_id as "session_id"',
-  traceName: 'e.trace_name as "trace_name"',
+  traceName: `${eventsTableTraceNameSql} as "trace_name"`,
 
   // Time fields
   startTime: 'e.start_time as "start_time"',

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -16,20 +16,21 @@ import {
   SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
 } from "../../repositories/constants";
 import type { ClickhouseFilter } from "./clickhouse-filter";
+import { eventsTableTraceNameSql } from "../../../eventsTable";
 
 /**
  * Lightweight trace metadata query: one row per trace with name, user_id, tags.
- * Picks a row with non-empty trace_name via LIMIT 1 BY trace_id.
+ * Picks one row with a resolved trace name via LIMIT 1 BY trace_id.
  */
 export const eventsTraceMetadata = (projectId: string): EventsQueryBuilder =>
   new EventsQueryBuilder({ projectId })
     .selectRaw(
       "e.trace_id AS id",
-      "e.trace_name AS name",
+      `${eventsTableTraceNameSql} AS name`,
       "e.user_id AS user_id",
       "e.tags AS tags",
     )
-    .whereRaw("e.trace_name <> ''")
+    .whereRaw(`${eventsTableTraceNameSql} IS NOT NULL`)
     .whereRaw("e.is_deleted = 0")
     .limitBy("e.trace_id");
 

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -13,6 +13,7 @@ import {
 import { InvalidRequestError, InternalServerError } from "../../errors";
 import {
   eventsTableIsRootObservationSql,
+  eventsTableTraceNameSql,
   eventsTableTraceNameAggregationSql,
 } from "../../eventsTable";
 import type { APIScoreV3 } from "../../features/scores/interfaces/api/v3/schemas";
@@ -1410,16 +1411,15 @@ const getScoresUiGeneric = async <T>(props: {
 
 /**
  * Trace column mapping for building WHERE filters inside the flat events CTE.
- * References actual events_core columns (trace_name, user_id, tags) with the
- * "e" prefix used by EventsQueryBuilder.
+ * References actual events_core columns with the "e" prefix used by
+ * EventsQueryBuilder.
  */
 const scoresTraceFilterEventsMapping = [
   {
     uiTableName: "Trace Name",
     uiTableId: "traceName",
     clickhouseTableName: "traces",
-    clickhouseSelect: "trace_name",
-    queryPrefix: "e",
+    clickhouseSelect: eventsTableTraceNameSql,
   },
   {
     uiTableName: "User ID",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -11,7 +11,10 @@ import {
   ScoreDataTypeEnum,
 } from "../../domain/scores";
 import { InvalidRequestError, InternalServerError } from "../../errors";
-import { eventsTableIsRootObservationSql } from "../../eventsTable";
+import {
+  eventsTableIsRootObservationSql,
+  eventsTableTraceNameAggregationSql,
+} from "../../eventsTable";
 import type { APIScoreV3 } from "../../features/scores/interfaces/api/v3/schemas";
 import type { ScoreFieldGroupV3 } from "../../features/scores/interfaces/api/v3/endpoints";
 import { filterAndValidateV3GetScoreList } from "../../features/scores/interfaces/api/v3/validation";
@@ -2390,14 +2393,11 @@ const buildAnalyticsScoreTraceAttributesCte = (
 // lookback mirrors the legacy CTE so delayed scores stay enriched.
 //
 // Hand-written rather than eventsTracesAggregation: aggregating only
-// root-span rows keeps the GROUP BY state ~one row per trace (the full-span
-// aggregation OOMed the largest tenants), and the field expressions carry
+// semantic-root rows keeps the GROUP BY state ~one row per trace (the
+// full-span aggregation OOMed the largest tenants). Trace-name selection is
+// shared with eventsTracesAggregation; the remaining field expressions keep
 // the parity fixes byte-verified against prod dual-write data in the
-// LFE-14383 benchmark — NULL semantics via nullIf, trace-name fallback
-// strictly from parent_span_id = '' rows, tags as sorted union across
-// writes, release latest-write-wins, metadata keys via indexOf instead of
-// per-row map construction. eventsTracesAggregation lacks all five
-// (tracked in LFE-11009).
+// LFE-14383 benchmark (tracked in LFE-11009).
 const buildAnalyticsScoreTraceAttributesFromEventsCte = (
   projectId: string,
   minTimestamp: Date,
@@ -2407,7 +2407,7 @@ const buildAnalyticsScoreTraceAttributesFromEventsCte = (
       SELECT
         e.project_id as project_id,
         e.trace_id as id,
-        coalesce(nullIf(argMaxIf(e.trace_name, e.event_ts, e.trace_name <> ''), ''), nullIf(argMaxIf(e.name, e.event_ts, e.parent_span_id = '' AND e.name <> ''), ''), '') as name,
+        coalesce(${eventsTableTraceNameAggregationSql}, '') as name,
         nullIf(argMaxIf(e.session_id, e.event_ts, e.session_id <> ''), '') as session_id,
         nullIf(argMaxIf(e.user_id, e.event_ts, e.user_id <> ''), '') as user_id,
         nullIf(argMax(e.release, e.event_ts), '') as release,

--- a/packages/shared/src/server/tableMappings/mapEventsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapEventsTable.ts
@@ -7,6 +7,7 @@ import {
   eventsTableIsRootObservationSql,
   eventsTableHasInputSql,
   eventsTableHasOutputSql,
+  eventsTableTraceNameSql,
 } from "../../eventsTable";
 
 export const eventsTableNativeUiColumnDefinitions: UiColumnMappings = [
@@ -222,7 +223,7 @@ export const eventsTableNativeUiColumnDefinitions: UiColumnMappings = [
     uiTableName: "Trace Name",
     uiTableId: "traceName",
     clickhouseTableName: "events_proto",
-    clickhouseSelect: 'e."trace_name"',
+    clickhouseSelect: eventsTableTraceNameSql,
   },
   {
     uiTableName: "User ID",

--- a/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
+++ b/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
@@ -1497,9 +1497,9 @@ describe("dashboard v1 vs v2 consistency", () => {
     });
   });
 
-  // ─── v2 empty trace_name fallback to root event name ─────────────────
+  // ─── v2 empty trace_name fallback to semantic-root name ─────────────
 
-  maybe("v2 empty trace_name fallback to root event name", () => {
+  maybe("v2 empty trace_name fallback to semantic-root name", () => {
     let fallbackProjectId: string;
     let fallbackFromTimestamp: string;
     let fallbackToTimestamp: string;
@@ -1515,7 +1515,7 @@ describe("dashboard v1 vs v2 consistency", () => {
       // events_core uses DateTime64(6) — timestamps in microseconds
       const baseTimeUs = baseTime * 1000;
 
-      // ── Trace 1: empty trace_name, root event name = "FallbackTraceName" ──
+      // ── Trace 1: empty trace_name, app-root name = "FallbackTraceName" ──
       emptyTraceNameTraceId = v4();
       const childObsId = v4();
 
@@ -1525,7 +1525,8 @@ describe("dashboard v1 vs v2 consistency", () => {
           span_id: `t-${emptyTraceNameTraceId}`,
           trace_id: emptyTraceNameTraceId,
           project_id: fallbackProjectId,
-          parent_span_id: "",
+          parent_span_id: "external-parent",
+          is_app_root: true,
           name: "FallbackTraceName",
           type: "SPAN",
           environment: "default",
@@ -1830,7 +1831,7 @@ describe("dashboard v1 vs v2 consistency", () => {
       const nameMap = new Map(
         result.map((r) => [r.traceName as string, Number(r.count_count)]),
       );
-      // Score on trace with empty trace_name should resolve via root event name
+      // Score on trace with empty trace_name should resolve via semantic-root name
       expect(nameMap.get("FallbackTraceName")).toBe(1);
       // Score on trace with populated trace_name should resolve normally
       expect(nameMap.get("PopulatedTraceName")).toBe(1);

--- a/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
+++ b/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
@@ -1497,9 +1497,9 @@ describe("dashboard v1 vs v2 consistency", () => {
     });
   });
 
-  // ─── v2 empty trace_name fallback to semantic-root name ─────────────
+  // ─── v2 empty trace_name fallback to semantic-root names ────────────
 
-  maybe("v2 empty trace_name fallback to semantic-root name", () => {
+  maybe("v2 empty trace_name fallback to semantic-root names", () => {
     let fallbackProjectId: string;
     let fallbackFromTimestamp: string;
     let fallbackToTimestamp: string;
@@ -1515,7 +1515,7 @@ describe("dashboard v1 vs v2 consistency", () => {
       // events_core uses DateTime64(6) — timestamps in microseconds
       const baseTimeUs = baseTime * 1000;
 
-      // ── Trace 1: empty trace_name, app-root name = "FallbackTraceName" ──
+      // ── Trace 1: empty trace_name, app-root fallback ──
       emptyTraceNameTraceId = v4();
       const childObsId = v4();
 
@@ -1527,7 +1527,7 @@ describe("dashboard v1 vs v2 consistency", () => {
           project_id: fallbackProjectId,
           parent_span_id: "external-parent",
           is_app_root: true,
-          name: "FallbackTraceName",
+          name: "AppRootFallbackName",
           type: "SPAN",
           environment: "default",
           trace_name: "",
@@ -1592,7 +1592,24 @@ describe("dashboard v1 vs v2 consistency", () => {
         }),
       );
 
-      // ── Trace 2: populated trace_name (happy path) ──
+      // ── Trace 2: empty trace_name, physical-root fallback ──
+      const physicalRootTraceId = v4();
+      const physicalRootTimeUs = baseTimeUs + 750_000;
+      const physicalRootEvent = createEvent({
+        trace_id: physicalRootTraceId,
+        project_id: fallbackProjectId,
+        parent_span_id: "",
+        is_app_root: false,
+        name: "PhysicalRootFallbackName",
+        type: "SPAN",
+        trace_name: "",
+        start_time: physicalRootTimeUs,
+        created_at: physicalRootTimeUs,
+        updated_at: physicalRootTimeUs,
+        event_ts: physicalRootTimeUs,
+      });
+
+      // ── Trace 3: populated trace_name (happy path) ──
       populatedTraceNameTraceId = v4();
       const childObsId2 = v4();
 
@@ -1668,7 +1685,7 @@ describe("dashboard v1 vs v2 consistency", () => {
         }),
       );
 
-      // ── Scores for both traces (for scores view test) ──
+      // ── Scores for all traces (for scores view test) ──
       const scoreTs = baseTime + 200;
       const scoreEmpty = createTraceScore({
         project_id: fallbackProjectId,
@@ -1698,15 +1715,26 @@ describe("dashboard v1 vs v2 consistency", () => {
         updated_at: scoreTs + 100,
         event_ts: scoreTs + 100,
       });
+      const scorePhysicalRoot = createTraceScore({
+        project_id: fallbackProjectId,
+        trace_id: physicalRootTraceId,
+        name: "fb-score",
+        value: 0.7,
+        timestamp: scoreTs + 50,
+        created_at: scoreTs + 50,
+        updated_at: scoreTs + 50,
+        event_ts: scoreTs + 50,
+      });
 
       await Promise.all([
         createEventsCh([
           rootEventEmpty,
           childEventEmpty,
+          physicalRootEvent,
           rootEventPopulated,
           childEventPopulated,
         ]),
-        createScoresCh([scoreEmpty, scorePopulated]),
+        createScoresCh([scoreEmpty, scorePhysicalRoot, scorePopulated]),
       ]);
 
       fallbackFromTimestamp = new Date(
@@ -1738,7 +1766,9 @@ describe("dashboard v1 vs v2 consistency", () => {
         result.map((r) => [r.name as string, Number(r.count_count)]),
       );
       // Trace with empty trace_name should resolve via root event's name
-      expect(nameMap.get("FallbackTraceName")).toBe(1);
+      expect(nameMap.get("AppRootFallbackName")).toBe(1);
+      // A physical root remains a valid semantic-root fallback
+      expect(nameMap.get("PhysicalRootFallbackName")).toBe(1);
       // Trace with populated trace_name should resolve normally
       expect(nameMap.get("PopulatedTraceName")).toBe(1);
       // Child observation name should never appear as a trace name
@@ -1764,7 +1794,8 @@ describe("dashboard v1 vs v2 consistency", () => {
       );
 
       const allNames = allResult.map((r) => r.traceName);
-      expect(allNames).toContain("FallbackTraceName");
+      expect(allNames).toContain("AppRootFallbackName");
+      expect(allNames).toContain("PhysicalRootFallbackName");
       expect(allNames).toContain("PopulatedTraceName");
       // Child observation name must never leak as traceName
       expect(allNames).not.toContain("ChildObservationName");
@@ -1800,7 +1831,8 @@ describe("dashboard v1 vs v2 consistency", () => {
           Number(r.uniq_traceId),
         ]),
       );
-      expect(nameMap.get("FallbackTraceName")).toBe(1);
+      expect(nameMap.get("AppRootFallbackName")).toBe(1);
+      expect(nameMap.get("PhysicalRootFallbackName")).toBe(1);
       expect(nameMap.get("PopulatedTraceName")).toBe(1);
     });
 
@@ -1832,7 +1864,8 @@ describe("dashboard v1 vs v2 consistency", () => {
         result.map((r) => [r.traceName as string, Number(r.count_count)]),
       );
       // Score on trace with empty trace_name should resolve via semantic-root name
-      expect(nameMap.get("FallbackTraceName")).toBe(1);
+      expect(nameMap.get("AppRootFallbackName")).toBe(1);
+      expect(nameMap.get("PhysicalRootFallbackName")).toBe(1);
       // Score on trace with populated trace_name should resolve normally
       expect(nameMap.get("PopulatedTraceName")).toBe(1);
       // Child observation name should never appear

--- a/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
+++ b/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
@@ -1521,8 +1521,8 @@ describe("dashboard v1 vs v2 consistency", () => {
 
       const rootEventEmpty = createEvent(
         asEventInsert({
-          id: `t-${emptyTraceNameTraceId}`,
-          span_id: `t-${emptyTraceNameTraceId}`,
+          id: `app-${emptyTraceNameTraceId}`,
+          span_id: `app-${emptyTraceNameTraceId}`,
           trace_id: emptyTraceNameTraceId,
           project_id: fallbackProjectId,
           parent_span_id: "external-parent",
@@ -1553,13 +1553,27 @@ describe("dashboard v1 vs v2 consistency", () => {
         }),
       );
 
+      // Production ingestion also materializes one parentless trace event.
+      // Scores join this canonical row; including the app root as well would
+      // duplicate a score before aggregation.
+      const syntheticTraceEventEmpty = createEvent({
+        id: `t-${emptyTraceNameTraceId}`,
+        span_id: `t-${emptyTraceNameTraceId}`,
+        trace_id: emptyTraceNameTraceId,
+        project_id: fallbackProjectId,
+        parent_span_id: "",
+        name: "AppRootFallbackName",
+        trace_name: "AppRootFallbackName",
+        start_time: baseTimeUs,
+      });
+
       const childEventEmpty = createEvent(
         asEventInsert({
           id: childObsId,
           span_id: childObsId,
           trace_id: emptyTraceNameTraceId,
           project_id: fallbackProjectId,
-          parent_span_id: `t-${emptyTraceNameTraceId}`,
+          parent_span_id: `app-${emptyTraceNameTraceId}`,
           name: "ChildObservationName",
           type: "GENERATION",
           environment: "default",
@@ -1729,6 +1743,7 @@ describe("dashboard v1 vs v2 consistency", () => {
       await Promise.all([
         createEventsCh([
           rootEventEmpty,
+          syntheticTraceEventEmpty,
           childEventEmpty,
           physicalRootEvent,
           rootEventPopulated,
@@ -1836,13 +1851,13 @@ describe("dashboard v1 vs v2 consistency", () => {
       expect(nameMap.get("PopulatedTraceName")).toBe(1);
     });
 
-    it("scores view: traceName resolves via COALESCE on joined root events", async () => {
+    it("scores view: joins only the parentless trace event when an app root coexists", async () => {
       const result = await executeQuery(
         fallbackProjectId,
         {
           view: "scores-numeric",
           dimensions: [{ field: "traceName" }],
-          metrics: [{ measure: "count", aggregation: "count" }],
+          metrics: [{ measure: "value", aggregation: "sum" }],
           timeDimension: null,
           filters: [
             {
@@ -1861,14 +1876,13 @@ describe("dashboard v1 vs v2 consistency", () => {
       );
 
       const nameMap = new Map(
-        result.map((r) => [r.traceName as string, Number(r.count_count)]),
+        result.map((r) => [r.traceName as string, Number(r.sum_value)]),
       );
-      // Score on trace with empty trace_name should resolve via semantic-root name
-      expect(nameMap.get("AppRootFallbackName")).toBe(1);
-      expect(nameMap.get("PhysicalRootFallbackName")).toBe(1);
-      // Score on trace with populated trace_name should resolve normally
-      expect(nameMap.get("PopulatedTraceName")).toBe(1);
-      // Child observation name should never appear
+      // Summing makes duplicate JOIN matches observable: the app-root score
+      // must remain 0.8 rather than being counted once per semantic root.
+      expect(nameMap.get("AppRootFallbackName")).toBeCloseTo(0.8);
+      expect(nameMap.get("PhysicalRootFallbackName")).toBeCloseTo(0.7);
+      expect(nameMap.get("PopulatedTraceName")).toBeCloseTo(0.9);
       expect(nameMap.has("ChildObservationName")).toBe(false);
     });
 

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -147,7 +147,7 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
       "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String})",
     );
     expect(built.query).toContain(
-      "COALESCE(nullIf(e.trace_name, ''), if(e.parent_span_id = '', nullIf(e.name, ''), NULL))",
+      "COALESCE(nullIf(e.trace_name, ''), if((e.parent_span_id = '' OR e.is_app_root = true), nullIf(e.name, ''), NULL))",
     );
     expect(built.query).toContain("GROUP BY value");
     expect(built.params).toMatchObject({

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -146,6 +146,9 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
     expect(built.query).toContain(
       "e.trace_id IN (SELECT DISTINCT trace_id FROM scores WHERE project_id = {projectId: String})",
     );
+    expect(built.query).toContain(
+      "COALESCE(nullIf(e.trace_name, ''), if(e.parent_span_id = '', nullIf(e.name, ''), NULL))",
+    );
     expect(built.query).toContain("GROUP BY value");
     expect(built.params).toMatchObject({
       projectId: "test-project",

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -100,6 +100,8 @@ describe("/api/public/v2/observations API Endpoint", () => {
         span_id: observationId,
         trace_id: traceId,
         project_id: projectId,
+        parent_span_id: "external-parent",
+        is_app_root: true,
         name: "test-observation",
         type: "GENERATION",
         level: "DEFAULT",

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -115,9 +115,9 @@ describe("/api/public/v2/observations API Endpoint", () => {
 
       await createEventsCh([observation]);
 
-      // Request only basic field group (core is always included)
+      // Request only basic and trace context field groups (core is always included)
       const response = await getObservations(
-        `/api/public/v2/observations?fields=basic&traceId=${traceId}`,
+        `/api/public/v2/observations?fields=basic,trace_context&traceId=${traceId}`,
       );
 
       expect(response.status).toBe(200);
@@ -142,6 +142,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       // Verify basic fields are present
       expect(createdObs?.name).toBe("test-observation");
       expect(createdObs?.level).toBe("DEFAULT");
+      expect(createdObs?.traceName).toBe("test-observation");
 
       // Verify fields from non-requested groups are not present
       expect(createdObs?.input).toBeUndefined();

--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -5147,6 +5147,8 @@ describe("query builder measure-aggregation validation", () => {
   });
 
   describe("rootEventCondition threshold gating", () => {
+    const rootEventSubqueryPrefix =
+      "IN (SELECT events_traces.trace_id FROM events_core events_traces";
     const tracesV2Query: QueryType = {
       view: "traces",
       dimensions: [{ field: "name" }],
@@ -5162,8 +5164,17 @@ describe("query builder measure-aggregation validation", () => {
       // 168 hours (7 days) threshold, 72-hour window → should include subquery
       const builder = new QueryBuilder(undefined, "v2");
       builder.setRootEventConditionMaxWindowHours(168);
-      const { query: sql } = await builder.build(tracesV2Query, randomUUID());
-      expect(sql).toContain("IN (SELECT trace_id");
+      const { query: sql } = await builder.build(
+        {
+          ...tracesV2Query,
+          timeDimension: { granularity: "day" },
+        },
+        randomUUID(),
+      );
+      expect(sql).toContain(
+        "anyIf(toNullable(toDate(events_core.start_time)), (events_traces.parent_span_id = '' OR events_traces.is_app_root = true))",
+      );
+      expect(sql).toContain(rootEventSubqueryPrefix);
     });
 
     it("should skip rootEventCondition subquery when window exceeds threshold", async () => {
@@ -5171,7 +5182,7 @@ describe("query builder measure-aggregation validation", () => {
       const builder = new QueryBuilder(undefined, "v2");
       builder.setRootEventConditionMaxWindowHours(24);
       const { query: sql } = await builder.build(tracesV2Query, randomUUID());
-      expect(sql).not.toContain("IN (SELECT trace_id");
+      expect(sql).not.toContain(rootEventSubqueryPrefix);
     });
 
     it("should always include rootEventCondition subquery when threshold is 0", async () => {
@@ -5186,7 +5197,7 @@ describe("query builder measure-aggregation validation", () => {
         },
         randomUUID(),
       );
-      expect(sql).toContain("IN (SELECT trace_id");
+      expect(sql).toContain(rootEventSubqueryPrefix);
     });
   });
 });

--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -5068,7 +5068,7 @@ describe("query builder measure-aggregation validation", () => {
   });
 
   describe("useFinal flag on events_core joins", () => {
-    it("should omit FINAL for events_core joins in v2 scores-numeric view", async () => {
+    it("should join the parentless trace event without FINAL in v2 scores-numeric view", async () => {
       const projectId = randomUUID();
       const builder = new QueryBuilder(undefined, "v2");
       const { query: compiledQuery } = await builder.build(
@@ -5092,6 +5092,7 @@ describe("query builder measure-aggregation validation", () => {
       expect(compiledQuery).not.toContain(
         "JOIN events_core AS events_traces FINAL",
       );
+      expect(compiledQuery).toContain("AND events_traces.parent_span_id = ''");
       // scores base CTE should still use FINAL
       expect(compiledQuery).toContain("scores scores_numeric FINAL");
     });

--- a/web/src/__tests__/server/scores-trpc.servertest.ts
+++ b/web/src/__tests__/server/scores-trpc.servertest.ts
@@ -38,6 +38,8 @@ import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { ScoreConfigDataType } from "@langfuse/shared";
 import {
+  createEvent,
+  createEventsCh,
   createObservation,
   createObservationsCh,
   createTrace,
@@ -49,7 +51,13 @@ import {
   QueueJobs,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
 import { randomUUID } from "crypto";
+
+const maybeEvents =
+  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+    ? describe
+    : describe.skip;
 
 describe("scores trpc", () => {
   let projectId: string;
@@ -175,6 +183,47 @@ describe("scores trpc", () => {
       expect(resultFromEvents.scores.map((score) => score.id)).toEqual([
         trueBooleanScore.id,
       ]);
+    });
+  });
+
+  maybeEvents("scores.allFromEvents trace-name filters", () => {
+    it("keeps scores for semantic roots without a stored trace name", async () => {
+      const traceId = randomUUID();
+      const score = createTraceScore({
+        project_id: projectId,
+        trace_id: traceId,
+        name: "semantic-root-score",
+        value: 0.9,
+      });
+
+      await createEventsCh([
+        createEvent({
+          trace_id: traceId,
+          project_id: projectId,
+          parent_span_id: "external-parent",
+          is_app_root: true,
+          name: "semantic-root-trace",
+          trace_name: "",
+        }),
+      ]);
+      await createScoresCh([score]);
+
+      const result = await caller.scores.allFromEvents({
+        projectId,
+        filter: [
+          {
+            column: "traceName",
+            operator: "=",
+            value: "semantic-root-trace",
+            type: "string",
+          },
+        ],
+        orderBy: { column: "timestamp", order: "DESC" },
+        page: 0,
+        limit: 50,
+      });
+
+      expect(result.scores.map(({ id }) => id)).toContain(score.id);
     });
   });
 

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -5030,8 +5030,8 @@ maybeDescribe("getEventsForBlobStorageExport", () => {
     expect(row.release).toBe("");
     // parent_span_id is non-nullable String; createEvent sets it to null → stored as ""
     expect(row.parent_observation_id).toBe("");
-    // trace_name is non-nullable String; not populated (no trace inserted) → ""
-    expect(row.trace_name).toBe("");
+    // With no stored trace name, exports use the semantic root's observation name.
+    expect(row.trace_name).toBe("column-contract-event");
 
     // --- Nullable columns (NULL when unset) ---
     // usage_pricing_tier_id is Nullable(String) in events_core

--- a/worker/src/__tests__/scoresAnalyticsIntegrationEnrichment.test.ts
+++ b/worker/src/__tests__/scoresAnalyticsIntegrationEnrichment.test.ts
@@ -230,7 +230,7 @@ maybeDescribe(
     // dual-write data. Both cases fail on the eventsTracesAggregation field
     // expressions (no root-name fallback; latest-write-only tags).
 
-    it("falls back to the root span's own name when no explicit trace name exists", async () => {
+    it("falls back to the app root's own name when no explicit trace name exists", async () => {
       const projectId = randomUUID();
       const traceId = randomUUID();
       const now = Date.now();
@@ -239,7 +239,8 @@ maybeDescribe(
         createEvent({
           project_id: projectId,
           trace_id: traceId,
-          parent_span_id: "",
+          parent_span_id: "external-parent",
+          is_app_root: true,
           type: "SPAN",
           name: "root-span-name",
           trace_name: null,
@@ -272,8 +273,8 @@ maybeDescribe(
       );
 
       expect(rows).toHaveLength(1);
-      // Legacy parity: the traces upsert derives the trace name from the root
-      // span when no explicit trace name was set; absent attributes stay null.
+      // The trace name falls back to the semantic root when no explicit trace
+      // name was set; absent attributes stay null.
       expect(rows[0].langfuse_trace_name).toBe("root-span-name");
       expect(rows[0].langfuse_user_id).toBe("user-1");
       expect(rows[0].langfuse_release).toBeNull();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15723.preview.langfuse.com](https://pr-15723.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Preserve the canonical trace-name fallback across events-backed v4 surfaces. When `trace_name` is empty, both physical roots and app roots with an external parent resolve the trace name from the root observation's `name`.

This reuses the existing semantic-root definition; propagation of the `isRootObservation` field itself remains in #15635.

## Changes

- Centralize alias-aware row-level and `argMaxIf` trace-name SQL.
- Reuse the row expression for table values, public API projections, filters, facets, and native mappings.
- Reuse the aggregation expression for generic event trace aggregation and analytics score enrichment.
- Apply semantic-root selection to v4 trace, observation, and score metrics definitions, including the trace root-window condition.
- Cover an app root with a non-empty external parent in existing API, metrics, query-builder, worker, and export suites.

## Verification

- `pnpm --filter @langfuse/shared run test event-query-builder.test.ts` — `Tests 10 passed (10)`
- `pnpm --filter web run test event-query-builder.servertest.ts` — `Tests 24 passed (24)`
- `pnpm --filter web run test observations-api-v2.servertest.ts` — `Tests 40 passed (40)`
- Focused dashboard consistency block — `Tests 4 passed | 31 skipped (35)`
- `pnpm --filter worker run test scoresAnalyticsIntegrationEnrichment.test.ts` — `Tests 4 passed (4)`
- Focused batch-export contract — `Tests 1 passed | 75 skipped (76)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- GitHub Actions — `all-ci-passed` on `140044698`

No ClickHouse schema, index, or join-algorithm changes.
