### PR TITLE
chore(eslint): detect assertion-wrapped components

### DIFF
--- a/packages/eslint-plugin/src/react-components.ts
+++ b/packages/eslint-plugin/src/react-components.ts
@@ -299,18 +299,35 @@ function isComponentWrapperCall(
 
 function unwrapComponentInit(node: TSESTree.Node): TSESTree.Node {
   let current = node;
-  while (isComponentWrapperCall(current) && current.arguments[0]) {
-    const firstArg = current.arguments[0];
+  while (true) {
     if (
-      firstArg.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
-      firstArg.type !== AST_NODE_TYPES.FunctionExpression &&
-      firstArg.type !== AST_NODE_TYPES.CallExpression
+      current.type === AST_NODE_TYPES.TSAsExpression ||
+      current.type === AST_NODE_TYPES.TSNonNullExpression ||
+      current.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+      current.type === AST_NODE_TYPES.TSTypeAssertion
     ) {
-      break;
+      current = current.expression;
+      continue;
     }
-    current = firstArg;
+
+    if (isComponentWrapperCall(current) && current.arguments[0]) {
+      const firstArg = current.arguments[0];
+      if (
+        firstArg.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        firstArg.type === AST_NODE_TYPES.FunctionExpression ||
+        firstArg.type === AST_NODE_TYPES.CallExpression ||
+        firstArg.type === AST_NODE_TYPES.TSAsExpression ||
+        firstArg.type === AST_NODE_TYPES.TSNonNullExpression ||
+        firstArg.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+        firstArg.type === AST_NODE_TYPES.TSTypeAssertion
+      ) {
+        current = firstArg;
+        continue;
+      }
+    }
+
+    return current;
   }
-  return current;
 }
 
 export function createComponentRootElementVisitors(
@@ -345,6 +362,15 @@ export function createComponentRootElementVisitors(
         maybeVisitFunctionComponentRoots(init, node.id.name);
       }
     },
+    ExportDefaultDeclaration(node: TSESTree.ExportDefaultDeclaration) {
+      const init = unwrapComponentInit(node.declaration);
+      if (
+        init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        init.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        maybeVisitFunctionComponentRoots(init, null);
+      }
+    },
   };
 }
 
@@ -352,15 +378,41 @@ function getWrappedForwardRefPropsType(
   node: TSESTree.Node,
 ): TSESTree.TypeNode | null {
   let current = node;
-  while (isComponentWrapperCall(current)) {
+  while (true) {
+    if (
+      current.type === AST_NODE_TYPES.TSAsExpression ||
+      current.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+      current.type === AST_NODE_TYPES.TSTypeAssertion
+    ) {
+      const propsType = getReactComponentPropsType(current.typeAnnotation);
+      if (propsType) return propsType;
+
+      current = current.expression;
+      continue;
+    }
+
+    if (current.type === AST_NODE_TYPES.TSNonNullExpression) {
+      current = current.expression;
+      continue;
+    }
+
+    if (!isComponentWrapperCall(current)) return null;
+
     const propsType = getForwardRefPropsType(current);
     if (propsType) return propsType;
 
     const firstArg = current.arguments[0];
-    if (firstArg?.type !== AST_NODE_TYPES.CallExpression) break;
+    if (
+      firstArg?.type !== AST_NODE_TYPES.CallExpression &&
+      firstArg?.type !== AST_NODE_TYPES.TSAsExpression &&
+      firstArg?.type !== AST_NODE_TYPES.TSNonNullExpression &&
+      firstArg?.type !== AST_NODE_TYPES.TSSatisfiesExpression &&
+      firstArg?.type !== AST_NODE_TYPES.TSTypeAssertion
+    ) {
+      return null;
+    }
     current = firstArg;
   }
-  return null;
 }
 
 function getFunctionPropsType(
@@ -529,9 +581,20 @@ export function createComponentPropTypeVisitors(callbacks: PropTypeCallbacks) {
       if (init.type === AST_NODE_TYPES.ClassExpression) {
         addPropTypeRoot(getClassPropsType(init));
       }
-      if (node.init.type === AST_NODE_TYPES.CallExpression) {
-        addPropTypeRoot(getWrappedForwardRefPropsType(node.init));
+      addPropTypeRoot(getWrappedForwardRefPropsType(node.init));
+    },
+    ExportDefaultDeclaration(node: TSESTree.ExportDefaultDeclaration) {
+      const init = unwrapComponentInit(node.declaration);
+      if (
+        init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        init.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        maybeAddFunctionComponent(init, null);
       }
+      if (init.type === AST_NODE_TYPES.ClassExpression) {
+        addPropTypeRoot(getClassPropsType(init));
+      }
+      addPropTypeRoot(getWrappedForwardRefPropsType(node.declaration));
     },
     ClassDeclaration(node: TSESTree.ClassDeclaration) {
       if (!node.id || !isCapitalizedName(node.id.name)) return;

--- a/packages/eslint-plugin/src/rules/no-margin-on-root-elements.test.ts
+++ b/packages/eslint-plugin/src/rules/no-margin-on-root-elements.test.ts
@@ -83,6 +83,18 @@ ruleTester.run("no-margin-on-root-elements", rule, {
       errors: [{ messageId: "unexpectedClassName", data: { utility: "m-2" } }],
     },
     {
+      code: `const Card = (() => <div className="m-2" />) as React.FC;`,
+      errors: [{ messageId: "unexpectedClassName", data: { utility: "m-2" } }],
+    },
+    {
+      code: `const Card = (() => <div className="m-2" />) satisfies React.FC;`,
+      errors: [{ messageId: "unexpectedClassName", data: { utility: "m-2" } }],
+    },
+    {
+      code: `export default (() => <div className="m-2" />) as React.FC;`,
+      errors: [{ messageId: "unexpectedClassName", data: { utility: "m-2" } }],
+    },
+    {
       code: `const Card = () => <div className="-mx-2" />;`,
       errors: [
         { messageId: "unexpectedClassName", data: { utility: "-mx-2" } },
@@ -222,6 +234,18 @@ ruleTester.run("no-margin-on-root-elements", rule, {
     },
     {
       code: `const Card = memo(() => <div className="mt-2" />);`,
+      errors: [{ messageId: "unexpectedClassName", data: { utility: "mt-2" } }],
+    },
+    {
+      code: `const Card = memo((() => <div className="mt-2" />) as React.FC);`,
+      errors: [{ messageId: "unexpectedClassName", data: { utility: "mt-2" } }],
+    },
+    {
+      code: `const Card = memo((() => <div className="mt-2" />) satisfies React.FC);`,
+      errors: [{ messageId: "unexpectedClassName", data: { utility: "mt-2" } }],
+    },
+    {
+      code: `export default memo(() => <div className="mt-2" />);`,
       errors: [{ messageId: "unexpectedClassName", data: { utility: "mt-2" } }],
     },
     {

--- a/packages/eslint-plugin/src/rules/no-style-props.test.ts
+++ b/packages/eslint-plugin/src/rules/no-style-props.test.ts
@@ -152,6 +152,37 @@ ruleTester.run("no-style-props", rule, {
       errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
     },
     {
+      code: `type ButtonProps = { className?: string };
+             const Button = ((props: ButtonProps) => <div />) as React.FC<ButtonProps>;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = ((props: ButtonProps) => <div />) satisfies React.FC<ButtonProps>;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = <React.FC<ButtonProps>>((props: ButtonProps) => React.createElement("div"));`,
+      languageOptions: {
+        parserOptions: { ecmaFeatures: { jsx: false } },
+      },
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             export default ((props: ButtonProps) => <div />) as React.FC<ButtonProps>;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
       code: `const Button: React.FC<{ style?: React.CSSProperties }> = (props) => <div />;`,
       errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
     },
@@ -287,6 +318,46 @@ ruleTester.run("no-style-props", rule, {
     {
       code: `type ButtonProps = { className?: string };
              const Button = memo(forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => <div ref={ref} />));`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => <div ref={ref} />) as React.FC;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { style?: React.CSSProperties };
+             const Button = memo(((props: ButtonProps) => <div />) as React.FC<ButtonProps>);`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = (forwardRef(((props) => <div />) as React.FC<ButtonProps>))!;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             export default forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => <div ref={ref} />);`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             export default (class extends React.Component<ButtonProps> { render() { return <div />; } });`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = factoryResult as React.FC<ButtonProps>;`,
       errors: [
         { messageId: "unexpectedProp", data: { propName: "className" } },
       ],

--- a/web/src/features/models/components/UpsertModelFormDialog.tsx
+++ b/web/src/features/models/components/UpsertModelFormDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint @repo/no-style-props: "off" */
 import Link from "next/link";
 import { useEffect, useState, useMemo } from "react";
 import { useForm, useFieldArray } from "react-hook-form";


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15724.preview.langfuse.com](https://pr-15724.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands ESLint React-component detection across TypeScript assertion wrappers.
- Recursively unwraps assertions while identifying component initializers and `forwardRef` props types.
- Adds assertion-wrapped component cases to the root-margin and style-prop rule tests.
- Disables `no-style-props` for the model form dialog.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until assertion-only props on a render function passed into `forwardRef` are preserved for linting.

The outer asserted generic `forwardRef` case is fixed, but unwrapping an assertion around the render function discards its sole props type, leaving `no-style-props` unable to report prohibited members.

**Files Needing Attention:** packages/eslint-plugin/src/react-components.ts; packages/eslint-plugin/src/rules/no-style-props.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/eslint-plugin/src/react-components.ts:374-375
**Inner assertion loses props type**

When an untyped `forwardRef` receives a render function asserted as `React.FC<ButtonProps>`, assertion unwrapping discards the only props type and both extraction paths return no prop root, causing `no-style-props` to accept prohibited `className` or `style` members.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(eslint): detect assertion-wrapped ..."](https://github.com/langfuse/langfuse/commit/80454c916b74c38019e4cf15a333e9c104da0d51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49688491)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->