### PR TITLE
fix(ui): unify trace heatmap root aggregation

### DIFF
--- a/web/src/components/trace/components/TraceTimeline/index.tsx
+++ b/web/src/components/trace/components/TraceTimeline/index.tsx
@@ -59,6 +59,7 @@ import { useDesktopLayoutContextOptional } from "../_layout/TraceLayoutDesktop";
 import { useMobileLayoutContextOptional } from "../_layout/TraceLayoutMobile";
 import { type TreeNode } from "../../lib/types";
 import { cn } from "@/src/utils/tailwind";
+import { computeRootAggregates } from "../../lib/trace-aggregation";
 
 // Width of the left name gutter. Resizable; these bound it. Kept slim so the
 // waterfall (the point of the timeline) gets the central space.
@@ -445,21 +446,8 @@ export function TraceTimeline() {
     }
   }, []);
 
-  // Parent totals for heatmap coloring (aggregate across all roots).
-  const parentTotalCost = useMemo(() => {
-    return roots.reduce(
-      (acc, r) => {
-        if (!r.totalCost) return acc;
-        return acc ? acc.plus(r.totalCost) : r.totalCost;
-      },
-      undefined as (typeof roots)[0]["totalCost"],
-    );
-  }, [roots]);
-  // MILLISECONDS: TimelineBar heat-maps ownDurationMs against this max, and
-  // the tree path (TraceTree rootTotalDuration) is ms too. traceDuration is
-  // seconds — passing it raw inflated the heat ratio ×1000, painting every
-  // duration label dark red.
-  const parentTotalDuration = traceDuration * 1000;
+  const { totalCost: parentTotalCost, totalDurationMs: parentTotalDuration } =
+    useMemo(() => computeRootAggregates(roots), [roots]);
 
   // Score lookup: one pass over the scores instead of an O(scores) filter per
   // row per render. Two maps preserve the exact TRACE-vs-observation keying:

--- a/web/src/components/trace/components/TraceTree.tsx
+++ b/web/src/components/trace/components/TraceTree.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/src/utils/tailwind";
 import type Decimal from "decimal.js";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useTraceAnalyticsDimensions } from "../hooks/useTraceAnalyticsDimensions";
+import { computeRootAggregates } from "../lib/trace-aggregation";
 
 /**
  * Feature-scoped row container: subscribes to the row's OWN playback-active
@@ -113,22 +114,8 @@ export function TraceTree() {
     if (id) mobileLayout?.switchToInfoTab();
   };
 
-  // TODO: Extract aggregation logic to shared utility - duplicated in tree-building.ts and TraceTimeline/index.tsx
-  // Calculate aggregated totals across all roots for heatmap color scaling
-  const rootTotalCost = roots.reduce(
-    (acc, r) => {
-      if (!r.totalCost) return acc;
-      return acc ? acc.plus(r.totalCost) : r.totalCost;
-    },
-    undefined as (typeof roots)[0]["totalCost"],
-  );
-
-  const rootTotalDuration =
-    roots.length > 0
-      ? Math.max(
-          ...roots.map((r) => (r.latency != null ? r.latency * 1000 : 0)),
-        )
-      : undefined;
+  const { totalCost: rootTotalCost, totalDurationMs: rootTotalDuration } =
+    computeRootAggregates(roots);
 
   return (
     <VirtualizedTree

--- a/web/src/components/trace/lib/helpers.ts
+++ b/web/src/components/trace/lib/helpers.ts
@@ -9,6 +9,7 @@ import {
   type TraceDomain,
 } from "@langfuse/shared";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+import { computeRootAggregates } from "./trace-aggregation";
 
 export function nestObservations(
   list: ObservationReturnType[],
@@ -432,61 +433,8 @@ export function buildTraceUiData(
     minLevel,
   );
 
-  // Calculate total cost directly from TreeNode structure
-  // This avoids unnecessary type conversions and is more straightforward
-  const calculateTreeNodeTotalCost = (node: TreeNode): Decimal | undefined => {
-    // Check if this node has cost data
-    let nodeCost: Decimal | undefined;
-
-    if (node.calculatedTotalCost != null) {
-      const cost = new Decimal(node.calculatedTotalCost);
-      if (!cost.isZero()) {
-        nodeCost = cost;
-      }
-    } else if (
-      node.calculatedInputCost != null ||
-      node.calculatedOutputCost != null
-    ) {
-      const inputCost =
-        node.calculatedInputCost != null
-          ? new Decimal(node.calculatedInputCost)
-          : new Decimal(0);
-      const outputCost =
-        node.calculatedOutputCost != null
-          ? new Decimal(node.calculatedOutputCost)
-          : new Decimal(0);
-      const combinedCost = inputCost.plus(outputCost);
-      if (!combinedCost.isZero()) {
-        nodeCost = combinedCost;
-      }
-    }
-
-    // Calculate total from all children
-    const childrenCost = node.children.reduce<Decimal | undefined>(
-      (acc, child) => {
-        const childCost = calculateTreeNodeTotalCost(child);
-        if (!childCost) return acc;
-        return acc ? acc.plus(childCost) : childCost;
-      },
-      undefined,
-    );
-
-    // Return the sum of node cost and children cost
-    if (nodeCost && childrenCost) {
-      return nodeCost.plus(childrenCost);
-    }
-    return nodeCost || childrenCost;
-  };
-
-  const rootTotalCost =
-    tree.type === "TRACE"
-      ? tree.children.reduce<Decimal | undefined>((acc, child) => {
-          const childCost = calculateTreeNodeTotalCost(child);
-          if (!childCost) return acc;
-          return acc ? acc.plus(childCost) : childCost;
-        }, undefined)
-      : calculateTreeNodeTotalCost(tree);
-  const rootDuration = tree.latency ? tree.latency * 1000 : undefined;
+  const { totalCost: rootTotalCost, totalDurationMs: rootDuration } =
+    computeRootAggregates([tree]);
 
   const out: TraceSearchListItem[] = [];
   const visit = (node: TreeNode) => {

--- a/web/src/components/trace/lib/trace-aggregation.ts
+++ b/web/src/components/trace/lib/trace-aggregation.ts
@@ -7,6 +7,7 @@
 
 import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
 import { type ObservationType, isGenerationLike } from "@langfuse/shared";
+import { type Decimal } from "decimal.js";
 import { type TreeNode } from "./types";
 
 export interface AggregatedTraceMetrics {
@@ -17,6 +18,41 @@ export interface AggregatedTraceMetrics {
   outputUsage: number;
   usageDetails: Record<string, number> | undefined;
   hasGenerationLike: boolean;
+}
+
+export interface RootAggregates {
+  totalCost?: Decimal;
+  totalDurationMs?: number;
+}
+
+/**
+ * Aggregates root-level cost and duration for trace heatmap scaling.
+ *
+ * Root costs are already aggregated bottom-up during tree construction, so
+ * summing them covers the full forest without double-counting descendants.
+ * Duration prefers an explicit latency (including zero) and otherwise falls
+ * back to the root's wall-clock span.
+ */
+export function computeRootAggregates(roots: TreeNode[]): RootAggregates {
+  const totalCost = roots.reduce<Decimal | undefined>((acc, root) => {
+    if (root.totalCost == null) return acc;
+    return acc ? acc.plus(root.totalCost) : root.totalCost;
+  }, undefined);
+
+  const totalDurationMs =
+    roots.length > 0
+      ? Math.max(
+          ...roots.map((root) =>
+            root.latency != null
+              ? root.latency * 1000
+              : root.endTime
+                ? root.endTime.getTime() - root.startTime.getTime()
+                : 0,
+          ),
+        )
+      : undefined;
+
+  return { totalCost, totalDurationMs };
 }
 
 /**

--- a/web/src/components/trace/lib/tree-building.clienttest.ts
+++ b/web/src/components/trace/lib/tree-building.clienttest.ts
@@ -11,6 +11,7 @@ import {
   getObservationLevels,
 } from "./tree-building";
 import { getSubtreeDurationOverflowMs } from "./helpers";
+import { computeRootAggregates } from "./trace-aggregation";
 import { type TreeNode } from "./types";
 import { type ObservationReturnType } from "@/src/server/api/routers/traces";
 import Decimal from "decimal.js";
@@ -81,6 +82,45 @@ const createMockTrace = (overrides: Record<string, unknown> = {}) => ({
   environment: "default",
   latency: 1.5,
   ...overrides,
+});
+
+describe("computeRootAggregates", () => {
+  it("sums root costs and uses the longest explicit or wall-clock duration", () => {
+    const roots: TreeNode[] = [
+      {
+        id: "zero-latency-root",
+        type: "SPAN",
+        name: "Zero latency",
+        startTime: new Date("2024-01-01T00:00:00.000Z"),
+        endTime: new Date("2024-01-01T00:00:05.000Z"),
+        children: [],
+        latency: 0,
+        totalCost: new Decimal(0.2),
+        startTimeSinceTrace: 0,
+        startTimeSinceParentStart: null,
+        depth: 0,
+        childrenDepth: 0,
+      },
+      {
+        id: "wall-clock-root",
+        type: "SPAN",
+        name: "Wall clock fallback",
+        startTime: new Date("2024-01-01T00:00:01.000Z"),
+        endTime: new Date("2024-01-01T00:00:04.000Z"),
+        children: [],
+        totalCost: new Decimal(0.3),
+        startTimeSinceTrace: 1000,
+        startTimeSinceParentStart: null,
+        depth: 0,
+        childrenDepth: 0,
+      },
+    ];
+
+    const result = computeRootAggregates(roots);
+
+    expect(result.totalCost?.equals(new Decimal(0.5))).toBe(true);
+    expect(result.totalDurationMs).toBe(3000);
+  });
 });
 
 describe("buildTraceUiData", () => {

--- a/web/src/components/trace/lib/tree-building.ts
+++ b/web/src/components/trace/lib/tree-building.ts
@@ -28,6 +28,7 @@ import {
   type TraceDomain,
 } from "@langfuse/shared";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+import { computeRootAggregates } from "./trace-aggregation";
 
 type TraceType = Omit<
   WithStringifiedMetadata<TraceDomain>,
@@ -544,25 +545,8 @@ export function buildTraceUiData(
     return { roots, searchItems: [], nodeMap };
   }
 
-  // TODO: Extract aggregation logic to shared utility - duplicated in TraceTree.tsx and TraceTimeline/index.tsx
-  // Calculate aggregated totals across all roots for heatmap scaling
-  const rootTotalCost = roots.reduce<Decimal | undefined>((acc, r) => {
-    if (!r.totalCost) return acc;
-    return acc ? acc.plus(r.totalCost) : r.totalCost;
-  }, undefined);
-
-  const rootDuration =
-    roots.length > 0
-      ? Math.max(
-          ...roots.map((r) =>
-            r.latency
-              ? r.latency * 1000
-              : r.endTime
-                ? r.endTime.getTime() - r.startTime.getTime()
-                : 0,
-          ),
-        )
-      : undefined;
+  const { totalCost: rootTotalCost, totalDurationMs: rootDuration } =
+    computeRootAggregates(roots);
 
   // Build flat search items list (iterative to avoid stack overflow on deep trees)
   const searchItems: TraceSearchListItem[] = [];


### PR DESCRIPTION
## Summary

- centralize trace heatmap root cost and duration aggregation in `computeRootAggregates`
- use the same root denominator in the tree, timeline, search list, and legacy tree builder
- preserve explicit zero latency, fall back to root wall-clock duration only when latency is absent, and take the maximum across v4 roots
- sum the pre-aggregated root costs without recursively double-counting descendants

Closes #15729.

## Impacted package

- `web`

## Verification

- `pnpm --filter web exec dotenv -e '../.env.dev.example' -- vitest run --project client 'tree-building.clienttest.ts'`
  - `Tests  82 passed | 23 skipped (105)`
- `pnpm exec turbo run lint --output-logs=errors-only --log-order=stream`
  - `Tasks: 7 successful, 7 total`
- `pnpm --filter web exec dotenv -e '../.env.dev.example' -- tsc -p 'tsconfig.json' --noEmit --skipLibCheck --incremental --tsBuildInfoFile '.tsbuildinfo'`
  - exited successfully
- `pnpm exec prettier --check` on all changed files
  - `All matched files use Prettier code style!`

## Browser review

Browser verification was not run because the local seed doctor found Postgres, ClickHouse, Redis, blob storage, and the web app stopped. The changed behavior is covered by the focused client regression test and this patch does not alter layout or styling.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Centralizes trace heatmap aggregation in `computeRootAggregates`.
- Sums pre-aggregated root costs without recursively counting descendants twice.
- Uses the maximum root latency, with a wall-clock fallback only when latency is absent.
- Applies the shared cost and duration denominators across the tree, timeline, search list, and legacy tree builder.
- Adds regression coverage for multiple roots, explicit zero latency, wall-clock fallback, and cost summation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The shared helper preserves pre-aggregated root costs, explicit zero latency, and millisecond duration semantics across the migrated consumers, with focused regression coverage for the key aggregation behavior.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[TreeNode roots] --> B[computeRootAggregates]
  B --> C[Sum root totalCost]
  B --> D[Max root duration]
  D --> E[Explicit latency in ms]
  D --> F[Wall-clock fallback]
  C --> G[Shared heatmap denominator]
  E --> G
  F --> G
  G --> H[Trace tree]
  G --> I[Timeline]
  G --> J[Search list]
  G --> K[Legacy builder]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): unify trace heatmap root aggreg..."](https://github.com/langfuse/langfuse/commit/d514789da8f0f4fc45e184f3e2ed37ef2e31c58c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49758153)</sub>

<!-- /greptile_comment -->