### PR TITLE
fix(ingestion): route exhausted ClickHouse writes to DLQ

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -117,6 +117,7 @@ export * from "./webhooks/validation";
 export * from "./webhooks/ipBlocking";
 export * from "./redis/experimentCreateQueue";
 export * from "./redis/dlqRetryQueue";
+export * from "./redis/clickhouseWriterDeadLetterQueue";
 export * from "./redis/entityChangeQueue";
 export * from "./redis/eventPropagationQueue";
 export * from "./redis/otelProjectTracking";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -267,6 +267,22 @@ export const DeadLetterRetryQueueEventSchema = z.object({
   timestamp: z.date(),
 });
 
+export const ClickhouseWriterTableNameSchema = z.enum([
+  "traces",
+  "traces_null",
+  "scores",
+  "observations",
+  "observations_batch_staging",
+  "blob_storage_file_log",
+  "dataset_run_items_rmt",
+  "events_full",
+]);
+
+export const ClickhouseWriterDeadLetterEventSchema = z.object({
+  tableName: ClickhouseWriterTableNameSchema,
+  fileKey: z.string().min(1),
+});
+
 export const NotificationEventSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("COMMENT_MENTION"),
@@ -367,6 +383,9 @@ export type BlobStorageIntegrationProcessingEventType = z.infer<
 export type DeadLetterRetryQueueEventType = z.infer<
   typeof DeadLetterRetryQueueEventSchema
 >;
+export type ClickhouseWriterDeadLetterEventType = z.infer<
+  typeof ClickhouseWriterDeadLetterEventSchema
+>;
 export type NotificationEventType = z.infer<typeof NotificationEventSchema>;
 
 export const RetryBaggage = z.object({
@@ -409,6 +428,7 @@ export enum QueueName {
   ScoreDelete = "score-delete",
   DatasetDelete = "dataset-delete-queue",
   DeadLetterRetryQueue = "dead-letter-retry-queue",
+  ClickhouseWriterDeadLetterQueue = "clickhouse-writer-dead-letter-queue",
   WebhookQueue = "webhook-queue",
   EntityChangeQueue = "entity-change-queue",
   EventPropagationQueue = "event-propagation-queue",
@@ -447,6 +467,7 @@ export enum QueueJobs {
   ScoreDelete = "score-delete",
   DatasetDelete = "dataset-delete-job",
   DeadLetterRetryJob = "dead-letter-retry-job",
+  ClickhouseWriterDeadLetterJob = "clickhouse-writer-dead-letter-job",
   WebhookJob = "webhook-job",
   EntityChangeJob = "entity-change-job",
   EventPropagationJob = "event-propagation-job",
@@ -599,6 +620,12 @@ export type TQueueJobTypes = {
     id: string;
     payload: DeadLetterRetryQueueEventType;
     name: QueueJobs.DeadLetterRetryJob;
+  };
+  [QueueName.ClickhouseWriterDeadLetterQueue]: {
+    timestamp: Date;
+    id: string;
+    payload: ClickhouseWriterDeadLetterEventType;
+    name: QueueJobs.ClickhouseWriterDeadLetterJob;
   };
   [QueueName.WebhookQueue]: {
     timestamp: Date;

--- a/packages/shared/src/server/redis/clickhouseWriterDeadLetterQueue.ts
+++ b/packages/shared/src/server/redis/clickhouseWriterDeadLetterQueue.ts
@@ -1,0 +1,38 @@
+import { Queue } from "bullmq";
+import { QueueName } from "../queues";
+import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { logger } from "../logger";
+
+export class ClickhouseWriterDeadLetterQueue {
+  private static instance: Queue | null = null;
+
+  public static getInstance(): Queue | null {
+    if (ClickhouseWriterDeadLetterQueue.instance) {
+      return ClickhouseWriterDeadLetterQueue.instance;
+    }
+
+    const queueOptionsWithRedis = createBullMQQueueOptionsWithRedis(
+      QueueName.ClickhouseWriterDeadLetterQueue,
+    );
+    ClickhouseWriterDeadLetterQueue.instance = queueOptionsWithRedis
+      ? new Queue(QueueName.ClickhouseWriterDeadLetterQueue, {
+          ...queueOptionsWithRedis,
+          defaultJobOptions: {
+            removeOnComplete: true,
+            removeOnFail: 10_000,
+            attempts: 5,
+            backoff: {
+              type: "exponential",
+              delay: 5000,
+            },
+          },
+        })
+      : null;
+
+    ClickhouseWriterDeadLetterQueue.instance?.on("error", (error) => {
+      logger.error("ClickhouseWriterDeadLetterQueue error", error);
+    });
+
+    return ClickhouseWriterDeadLetterQueue.instance;
+  }
+}

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -22,6 +22,7 @@ import { BatchActionQueue } from "./batchActionQueue";
 import { CreateEvalQueue } from "./createEvalQueue";
 import { ScoreDeleteQueue } from "./scoreDelete";
 import { DeadLetterRetryQueue } from "./dlqRetryQueue";
+import { ClickhouseWriterDeadLetterQueue } from "./clickhouseWriterDeadLetterQueue";
 import { WebhookQueue } from "./webhookQueue";
 import { EntityChangeQueue } from "./entityChangeQueue";
 import { DatasetDeleteQueue } from "./datasetDelete";
@@ -93,6 +94,8 @@ export function getQueue(
       return ScoreDeleteQueue.getInstance();
     case QueueName.DeadLetterRetryQueue:
       return DeadLetterRetryQueue.getInstance();
+    case QueueName.ClickhouseWriterDeadLetterQueue:
+      return ClickhouseWriterDeadLetterQueue.getInstance();
     case QueueName.WebhookQueue:
       return WebhookQueue.getInstance();
     case QueueName.EntityChangeQueue:

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -33,6 +33,7 @@ import {
   logger,
   BlobStorageIntegrationQueue,
   DeadLetterRetryQueue,
+  ClickhouseWriterDeadLetterQueue,
   IngestionQueue,
   SecondaryIngestionQueue,
   OtelIngestionQueue,
@@ -618,6 +619,17 @@ if (env.QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED === "true") {
     {
       concurrency: 1,
     },
+  );
+}
+
+if (
+  env.QUEUE_CONSUMER_CLICKHOUSE_WRITER_DEAD_LETTER_QUEUE_IS_ENABLED === "true"
+) {
+  ClickhouseWriterDeadLetterQueue.getInstance();
+  WorkerManager.register(
+    QueueName.ClickhouseWriterDeadLetterQueue,
+    DlqRetryService.replayClickhouseWriterRecords,
+    { concurrency: 1 },
   );
 }
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -299,6 +299,9 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("false"),
+  QUEUE_CONSUMER_CLICKHOUSE_WRITER_DEAD_LETTER_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
   QUEUE_CONSUMER_WEBHOOK_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),

--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -6,7 +6,8 @@ import { env } from "../../env";
 import { logger } from "@langfuse/shared/src/server";
 import { ClickhouseWriter, TableName } from "../ClickhouseWriter";
 
-const { mockDlqAdd, mockUploadJson } = vi.hoisted(() => ({
+const { mockDeleteFiles, mockDlqAdd, mockUploadJson } = vi.hoisted(() => ({
+  mockDeleteFiles: vi.fn().mockResolvedValue(undefined),
   mockDlqAdd: vi.fn().mockResolvedValue(undefined),
   mockUploadJson: vi.fn().mockResolvedValue(undefined),
 }));
@@ -24,6 +25,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
       getInstance: vi.fn(() => ({ add: mockDlqAdd })),
     },
     getS3EventStorageClient: vi.fn(() => ({
+      deleteFiles: mockDeleteFiles,
       uploadJson: mockUploadJson,
     })),
     logger: {
@@ -251,6 +253,27 @@ describe("ClickhouseWriter", () => {
       expect.any(Error),
     );
     expect(mockDlqAdd).not.toHaveBeenCalled();
+  });
+
+  it("should delete the uploaded payload when DLQ enqueueing fails", async () => {
+    vi.spyOn(clickhouseClientMock, "insert").mockRejectedValue(
+      new Error("DB Error"),
+    );
+    mockDlqAdd.mockRejectedValueOnce(new Error("Redis unavailable"));
+
+    writer.addToQueue(TableName.Traces, {
+      id: "1",
+      project_id: "project-1",
+      name: "test",
+    } as any);
+
+    for (let i = 0; i < writer.maxAttempts; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    const fileKey = mockUploadJson.mock.calls[0][0];
+    expect(mockDeleteFiles).toHaveBeenCalledWith([fileKey]);
+    expect(writer["queue"][TableName.Traces]).toHaveLength(1);
   });
 
   it("should retry client request timeouts within the same flush", async () => {

--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -6,6 +6,11 @@ import { env } from "../../env";
 import { logger } from "@langfuse/shared/src/server";
 import { ClickhouseWriter, TableName } from "../ClickhouseWriter";
 
+const { mockDlqAdd, mockUploadJson } = vi.hoisted(() => ({
+  mockDlqAdd: vi.fn().mockResolvedValue(undefined),
+  mockUploadJson: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock recordHistogram, recordCount, recordGauge
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   const original = (await importOriginal()) as {};
@@ -15,6 +20,12 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     recordIncrement: vi.fn(),
     recordCount: vi.fn(),
     recordGauge: vi.fn(),
+    ClickhouseWriterDeadLetterQueue: {
+      getInstance: vi.fn(() => ({ add: mockDlqAdd })),
+    },
+    getS3EventStorageClient: vi.fn(() => ({
+      uploadJson: mockUploadJson,
+    })),
     logger: {
       info: vi.fn(),
       debug: vi.fn(),
@@ -163,12 +174,17 @@ describe("ClickhouseWriter", () => {
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
   });
 
-  it("should drop records after max attempts", async () => {
+  it("should persist exhausted records and enqueue a DLQ replay job", async () => {
     const mockInsert = vi
       .spyOn(clickhouseClientMock, "insert")
       .mockRejectedValue(new Error("DB Error"));
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    const trace = {
+      id: "1",
+      project_id: "project-1",
+      name: "test",
+    };
+    writer.addToQueue(TableName.Traces, trace as any);
 
     for (let i = 0; i < writer.maxAttempts; i++) {
       await vi.advanceTimersByTimeAsync(writer.writeInterval);
@@ -178,16 +194,63 @@ describe("ClickhouseWriter", () => {
 
     expect(mockInsert).toHaveBeenCalledTimes(writer.maxAttempts);
     expect(
-      logger.error.mock.calls.some((call) =>
+      logger.warn.mock.calls.some((call) =>
         call[0].includes("Max attempts reached"),
       ),
     ).toBe(true);
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+    expect(mockUploadJson).toHaveBeenCalledWith(
+      expect.stringMatching(/clickhouse-writer-dlq\/traces\/.+\.json$/),
+      [trace],
+    );
+    const fileKey = mockUploadJson.mock.calls[0][0];
+    expect(mockDlqAdd).toHaveBeenCalledWith(
+      serverExports.QueueJobs.ClickhouseWriterDeadLetterJob,
+      expect.objectContaining({
+        name: serverExports.QueueJobs.ClickhouseWriterDeadLetterJob,
+        payload: {
+          tableName: TableName.Traces,
+          fileKey,
+        },
+      }),
+    );
     expect(serverExports.recordIncrement).toHaveBeenCalledWith(
-      "langfuse.queue.clickhouse_writer.rows_dropped",
+      "langfuse.queue.clickhouse_writer.rows_dead_lettered",
       1,
       { entity_type: TableName.Traces },
     );
+    expect(serverExports.recordIncrement).not.toHaveBeenCalledWith(
+      "langfuse.queue.clickhouse_writer.rows_dropped",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("should retain exhausted records when DLQ persistence fails", async () => {
+    vi.spyOn(clickhouseClientMock, "insert").mockRejectedValue(
+      new Error("DB Error"),
+    );
+    mockUploadJson.mockRejectedValueOnce(new Error("S3 unavailable"));
+
+    writer.addToQueue(TableName.Traces, {
+      id: "1",
+      project_id: "project-1",
+      name: "test",
+    } as any);
+
+    for (let i = 0; i < writer.maxAttempts; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    expect(writer["queue"][TableName.Traces]).toHaveLength(1);
+    expect(writer["queue"][TableName.Traces][0].attempts).toBe(
+      writer.maxAttempts,
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("retained them in memory for retry"),
+      expect.any(Error),
+    );
+    expect(mockDlqAdd).not.toHaveBeenCalled();
   });
 
   it("should retry client request timeouts within the same flush", async () => {

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -570,23 +570,36 @@ export class ClickhouseWriter {
     tableName: T,
     records: RecordInsertType<T>[],
   ): Promise<string> {
-    const fileKey = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}clickhouse-writer-dlq/${tableName}/${randomUUID()}.json`;
-    await getS3EventStorageClient(
-      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
-    ).uploadJson(fileKey, records as Record<string, unknown>[]);
-
     const queue = ClickhouseWriterDeadLetterQueue.getInstance();
     if (!queue) {
-      throw new Error("Dead letter retry queue is unavailable");
+      throw new Error("ClickhouseWriter dead letter queue is unavailable");
     }
 
+    const fileKey = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}clickhouse-writer-dlq/${tableName}/${randomUUID()}.json`;
+    const storage = getS3EventStorageClient(
+      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+    );
+    await storage.uploadJson(fileKey, records as Record<string, unknown>[]);
+
     const id = randomUUID();
-    await queue.add(QueueJobs.ClickhouseWriterDeadLetterJob, {
-      timestamp: new Date(),
-      id,
-      name: QueueJobs.ClickhouseWriterDeadLetterJob,
-      payload: { tableName, fileKey },
-    });
+    try {
+      await queue.add(QueueJobs.ClickhouseWriterDeadLetterJob, {
+        timestamp: new Date(),
+        id,
+        name: QueueJobs.ClickhouseWriterDeadLetterJob,
+        payload: { tableName, fileKey },
+      });
+    } catch (error) {
+      try {
+        await storage.deleteFiles([fileKey]);
+      } catch (cleanupError) {
+        logger.error(
+          `ClickhouseWriter: Failed to clean up dead-letter payload ${fileKey} after enqueue failure`,
+          cleanupError,
+        );
+      }
+      throw error;
+    }
 
     return fileKey;
   }

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -14,6 +14,9 @@ import {
   DatasetRunItemRecordInsertType,
   EventRecordInsertType,
   buildClickHouseLogComment,
+  ClickhouseWriterDeadLetterQueue,
+  getS3EventStorageClient,
+  QueueJobs,
 } from "@langfuse/shared/src/server";
 
 import { Decimal } from "decimal.js";
@@ -22,6 +25,7 @@ import { env } from "../../env";
 import { logger } from "@langfuse/shared/src/server";
 import { instrumentAsync } from "@langfuse/shared/src/server";
 import { backOff } from "exponential-backoff";
+import { randomUUID } from "crypto";
 
 // Decimal64(12): valid range is (-10^6, 10^6), i.e. 18 total digits with 12 fractional.
 // JS double can't represent 999999.999999999999 exactly (rounds to 1e6), so we use a
@@ -511,8 +515,7 @@ export class ClickhouseWriter {
     } catch (err) {
       logger.error(`ClickhouseWriter.flush ${tableName}`, err);
 
-      // Re-add the records to the queue with incremented attempts
-      let droppedCount = 0;
+      const exhaustedItems: ClickhouseWriterQueueItem<T>[] = [];
       queueItems.forEach((item) => {
         if (item.attempts < this.maxAttempts) {
           entityQueue.push({
@@ -520,22 +523,24 @@ export class ClickhouseWriter {
             attempts: item.attempts + 1,
           });
         } else {
-          // TODO - Add to a dead letter queue in Redis rather than dropping
           recordIncrement("langfuse.queue.clickhouse_writer.error");
-          droppedCount++;
+          exhaustedItems.push(item);
         }
       });
 
-      if (droppedCount > 0) {
-        recordIncrement(
-          "langfuse.queue.clickhouse_writer.rows_dropped",
-          droppedCount,
-          { entity_type: tableName },
-        );
+      if (exhaustedItems.length > 0) {
+        try {
+          const fileKey = await this.persistDeadLetterRecords(
+            tableName,
+            exhaustedItems.map((item) => item.data),
+          );
+          recordIncrement(
+            "langfuse.queue.clickhouse_writer.rows_dead_lettered",
+            exhaustedItems.length,
+            { entity_type: tableName },
+          );
 
-        const droppedIds = queueItems
-          .filter((item) => item.attempts >= this.maxAttempts)
-          .map((item) => {
+          const deadLetteredIds = exhaustedItems.map((item) => {
             const r = item.data as Record<string, unknown>;
             return {
               project_id: r.project_id,
@@ -544,12 +549,56 @@ export class ClickhouseWriter {
             };
           });
 
-        logger.error(
-          `ClickhouseWriter: Max attempts reached, dropped ${droppedCount} ${tableName} record(s)`,
-          { droppedIds },
-        );
+          logger.warn(
+            `ClickhouseWriter: Max attempts reached, dead-lettered ${exhaustedItems.length} ${tableName} record(s)`,
+            { fileKey, deadLetteredIds },
+          );
+        } catch (deadLetterError) {
+          for (const item of exhaustedItems) {
+            entityQueue.push(item);
+          }
+          logger.error(
+            `ClickhouseWriter: Failed to dead-letter ${exhaustedItems.length} ${tableName} record(s); retained them in memory for retry`,
+            deadLetterError,
+          );
+        }
       }
     }
+  }
+
+  private async persistDeadLetterRecords<T extends TableName>(
+    tableName: T,
+    records: RecordInsertType<T>[],
+  ): Promise<string> {
+    const fileKey = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}clickhouse-writer-dlq/${tableName}/${randomUUID()}.json`;
+    await getS3EventStorageClient(
+      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+    ).uploadJson(fileKey, records as Record<string, unknown>[]);
+
+    const queue = ClickhouseWriterDeadLetterQueue.getInstance();
+    if (!queue) {
+      throw new Error("Dead letter retry queue is unavailable");
+    }
+
+    const id = randomUUID();
+    await queue.add(QueueJobs.ClickhouseWriterDeadLetterJob, {
+      timestamp: new Date(),
+      id,
+      name: QueueJobs.ClickhouseWriterDeadLetterJob,
+      payload: { tableName, fileKey },
+    });
+
+    return fileKey;
+  }
+
+  public async replayDeadLetterRecords(
+    tableName: TableName,
+    records: Record<string, unknown>[],
+  ): Promise<void> {
+    await this.writeToClickhouse({
+      table: tableName,
+      records: records as RecordInsertType<TableName>[],
+    });
   }
 
   public addToQueue<T extends TableName>(

--- a/worker/src/services/dlq/dlqRetryService.test.ts
+++ b/worker/src/services/dlq/dlqRetryService.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueueJobs } from "@langfuse/shared/src/server";
+import { DlqRetryService } from "./dlqRetryService";
+import { TableName } from "../ClickhouseWriter";
+import type { Job } from "bullmq";
+
+const {
+  mockDeleteFiles,
+  mockDownload,
+  mockRecordIncrement,
+  mockReplayDeadLetterRecords,
+} = vi.hoisted(() => ({
+  mockDeleteFiles: vi.fn().mockResolvedValue(undefined),
+  mockDownload: vi.fn(),
+  mockRecordIncrement: vi.fn(),
+  mockReplayDeadLetterRecords: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const original = (await importOriginal()) as {};
+  return {
+    ...original,
+    getS3EventStorageClient: vi.fn(() => ({
+      deleteFiles: mockDeleteFiles,
+      download: mockDownload,
+    })),
+    recordIncrement: mockRecordIncrement,
+  };
+});
+
+vi.mock("../ClickhouseWriter", async (importOriginal) => {
+  const original = (await importOriginal()) as {};
+  return {
+    ...original,
+    ClickhouseWriter: {
+      getInstance: vi.fn(() => ({
+        replayDeadLetterRecords: mockReplayDeadLetterRecords,
+      })),
+    },
+  };
+});
+
+describe("DlqRetryService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("replays persisted ClickhouseWriter records and removes the payload", async () => {
+    const records = [{ id: "trace-1", project_id: "project-1" }];
+    mockDownload.mockResolvedValueOnce(JSON.stringify(records));
+
+    await DlqRetryService.replayClickhouseWriterRecords({
+      name: QueueJobs.ClickhouseWriterDeadLetterJob,
+      data: {
+        payload: {
+          tableName: TableName.Traces,
+          fileKey: "clickhouse-writer-dlq/traces/batch.json",
+        },
+      },
+    } as Job);
+
+    expect(mockReplayDeadLetterRecords).toHaveBeenCalledWith(
+      TableName.Traces,
+      records,
+    );
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      "langfuse.queue.clickhouse_writer.rows_replayed",
+      1,
+      { entity_type: TableName.Traces },
+    );
+    expect(mockDeleteFiles).toHaveBeenCalledWith([
+      "clickhouse-writer-dlq/traces/batch.json",
+    ]);
+  });
+});

--- a/worker/src/services/dlq/dlqRetryService.ts
+++ b/worker/src/services/dlq/dlqRetryService.ts
@@ -1,9 +1,20 @@
 import {
+  ClickhouseWriterDeadLetterEventSchema,
+  getS3EventStorageClient,
   logger,
   QueueName,
   recordHistogram,
+  recordIncrement,
 } from "@langfuse/shared/src/server";
 import { getQueue } from "@langfuse/shared/src/server";
+import type { Job } from "bullmq";
+import { z } from "zod";
+import { env } from "../../env";
+import { ClickhouseWriter, TableName } from "../ClickhouseWriter";
+
+const ClickhouseWriterDeadLetterRecordsSchema = z.array(
+  z.record(z.string(), z.unknown()),
+);
 
 export class DlqRetryService {
   private static retryQueues = [
@@ -13,6 +24,40 @@ export class DlqRetryService {
     QueueName.BatchActionQueue,
     QueueName.DataRetentionProcessingQueue,
   ] as const;
+
+  public static async replayClickhouseWriterRecords(job: Job): Promise<void> {
+    const payload = ClickhouseWriterDeadLetterEventSchema.parse(
+      job.data.payload,
+    );
+    const storage = getS3EventStorageClient(
+      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+    );
+    const records = ClickhouseWriterDeadLetterRecordsSchema.parse(
+      JSON.parse(await storage.download(payload.fileKey)),
+    );
+
+    await ClickhouseWriter.getInstance().replayDeadLetterRecords(
+      payload.tableName as TableName,
+      records,
+    );
+
+    recordIncrement(
+      "langfuse.queue.clickhouse_writer.rows_replayed",
+      records.length,
+      {
+        entity_type: payload.tableName,
+      },
+    );
+
+    try {
+      await storage.deleteFiles([payload.fileKey]);
+    } catch (error) {
+      logger.warn(
+        `ClickhouseWriter DLQ replay succeeded but failed to delete ${payload.fileKey}`,
+        error,
+      );
+    }
+  }
 
   // called each 10 minutes, defined by the bull cron job
   public static async retryDeadLetterQueue() {


### PR DESCRIPTION
## What does this PR do?

Stops `ClickhouseWriter` from dropping normalized records after their insert retry budget is exhausted.

- persists exhausted batches in the existing event object storage and enqueues only an S3 pointer in Redis
- adds a dedicated ClickHouse writer dead-letter queue, enabled by default, with five exponential-backoff replay attempts
- replays every `ClickhouseWriter` table through the same ClickHouse insert path
- retains poison jobs (up to 10,000) and their object-storage payloads for inspection; successfully replayed payloads are deleted best-effort
- removes an uploaded payload when Redis enqueueing fails, preventing orphan accumulation during outages
- keeps exhausted records in the in-memory writer queue when the durable DLQ handoff itself fails
- records `rows_dead_lettered` and `rows_replayed` metrics instead of `rows_dropped`

The existing `DeadLetterRetryQueue` is a periodic sweeper for failed jobs on a fixed set of deletion/action queues and is disabled by default in OSS. `ClickhouseWriter` records do not originate from one of those BullMQ jobs, so this PR reuses the same BullMQ/S3 infrastructure through a dedicated always-on queue rather than changing that sweeper's operational semantics.

## How was it tested?

- `pnpm --filter worker exec dotenv -e '../.env.dev.example' -- vitest run 'ClickhouseWriter.unit.test.ts' 'dlqRetryService.test.ts'`
  - `Test Files 2 passed (2)`
  - `Tests 46 passed (46)`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- `pnpm run typecheck`
  - `Tasks: 7 successful, 7 total`
- `pnpm --filter @langfuse/shared run build`
- `git diff --check`

Closes #15730

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a dedicated durable replay path for exhausted ClickHouse writer batches.
- Persists exhausted records to event object storage and queues S3 pointers in BullMQ.
- Registers an enabled-by-default worker that retries replay through `ClickhouseWriter`.
- Adds queue payload schemas, retry settings, metrics, and unit coverage for handoff and replay.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The partial S3-to-Redis handoff failure must be fixed before merging because it can continuously create unreachable object-storage payloads during a Redis outage.

The producer uploads under a fresh UUID before enqueueing and retains the exhausted batch when enqueueing fails, so every subsequent flush can repeat the upload without removing the prior unreferenced object.

**Files Needing Attention:** worker/src/services/ClickhouseWriter/index.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CW as ClickhouseWriter
  participant S3 as Object Storage
  participant Q as Redis / BullMQ
  participant DLQ as DLQ Worker
  participant CH as ClickHouse
  CW->>CH: Insert exhausted batch
  CH-->>CW: Failure
  CW->>S3: Upload records under UUID key
  CW->>Q: Enqueue S3 pointer
  Q->>DLQ: Deliver retry job
  DLQ->>S3: Download records
  DLQ->>CH: Replay insert
  CH-->>DLQ: Success
  DLQ->>S3: Delete payload best-effort
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/services/ClickhouseWriter/index.ts:574-584
**Partial handoff leaks S3 payloads**

When the S3 upload succeeds but Redis is unavailable or `queue.add` fails, the catch path retains the exhausted batch without deleting the uploaded object. The next flush uploads the same batch under another UUID, causing unreachable S3 objects to accumulate throughout the outage.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): dead-letter exhausted Cl..."](https://github.com/langfuse/langfuse/commit/d6f0ce11a40090dd9041ac958a4e4d9b0cfbbb45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49762894)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)

<!-- /greptile_comment -->