### PR TITLE
perf(worker): batch comment mention preferences

### DIFF
--- a/worker/src/features/notifications/commentMentionHandler.test.ts
+++ b/worker/src/features/notifications/commentMentionHandler.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCommentFindFirst,
+  mockGetUserProjectRoles,
+  mockPreferenceFindMany,
+  mockPreferenceFindUnique,
+  mockSendCommentMentionEmail,
+} = vi.hoisted(() => ({
+  mockCommentFindFirst: vi.fn(),
+  mockGetUserProjectRoles: vi.fn(),
+  mockPreferenceFindMany: vi.fn(),
+  mockPreferenceFindUnique: vi.fn(),
+  mockSendCommentMentionEmail: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  Prisma: { empty: {} },
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    comment: { findFirst: mockCommentFindFirst },
+    notificationPreference: {
+      findMany: mockPreferenceFindMany,
+      findUnique: mockPreferenceFindUnique,
+    },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  getObservationById: vi.fn(),
+  getUserProjectRoles: mockGetUserProjectRoles,
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  sendCommentMentionEmail: mockSendCommentMentionEmail,
+}));
+
+vi.mock("../../env", () => ({
+  env: {
+    EMAIL_FROM_ADDRESS: "notifications@example.com",
+    NEXTAUTH_URL: "https://example.com",
+    SMTP_CONNECTION_URL: "smtp://example.com",
+  },
+}));
+
+import { handleCommentMentionNotification } from "./commentMentionHandler";
+
+describe("handleCommentMentionNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCommentFindFirst.mockResolvedValue({
+      id: "comment-1",
+      projectId: "project-1",
+      objectType: "TRACE",
+      objectId: "trace-1",
+      content: "Hello @[Enabled User](user:user-enabled)",
+      authorUserId: "author-1",
+      project: {
+        id: "project-1",
+        name: "Project One",
+        orgId: "org-1",
+      },
+    });
+    mockGetUserProjectRoles.mockResolvedValue([
+      { id: "author-1", name: "Author", email: "author@example.com" },
+      {
+        id: "user-enabled",
+        name: "Enabled User",
+        email: "enabled@example.com",
+      },
+      {
+        id: "user-disabled",
+        name: "Disabled User",
+        email: "disabled@example.com",
+      },
+    ]);
+    mockPreferenceFindMany.mockResolvedValue([
+      { userId: "user-disabled", enabled: false },
+    ]);
+    mockPreferenceFindUnique.mockResolvedValue(undefined);
+    mockSendCommentMentionEmail.mockResolvedValue(undefined);
+  });
+
+  it("fetches mention preferences once and preserves default-enabled behavior", async () => {
+    await handleCommentMentionNotification({
+      commentId: "comment-1",
+      projectId: "project-1",
+      mentionedUserIds: ["user-enabled", "user-disabled"],
+    });
+
+    expect(mockPreferenceFindMany).toHaveBeenCalledOnce();
+    expect(mockPreferenceFindMany).toHaveBeenCalledWith({
+      where: {
+        projectId: "project-1",
+        channel: "EMAIL",
+        type: "COMMENT_MENTION",
+        userId: { in: ["user-enabled", "user-disabled"] },
+      },
+      select: { userId: true, enabled: true },
+    });
+    expect(mockPreferenceFindUnique).not.toHaveBeenCalled();
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledOnce();
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mentionedUserEmail: "enabled@example.com",
+      }),
+    );
+  });
+});

--- a/worker/src/features/notifications/commentMentionHandler.ts
+++ b/worker/src/features/notifications/commentMentionHandler.ts
@@ -120,6 +120,22 @@ export async function handleCommentMentionNotification(
     // Create lookup map for O(1) access
     const userMap = new Map(projectUsers.map((u) => [u.id, u]));
 
+    const notificationPreferences =
+      await prisma.notificationPreference.findMany({
+        where: {
+          projectId,
+          channel: "EMAIL",
+          type: "COMMENT_MENTION",
+          userId: { in: mentionedUserIds },
+        },
+        select: { userId: true, enabled: true },
+      });
+    const disabledUserIds = new Set(
+      notificationPreferences
+        .filter((preference) => !preference.enabled)
+        .map((preference) => preference.userId),
+    );
+
     // Get author name if author is a project/org member
     let authorName: string | undefined = undefined;
     if (comment.authorUserId && userMap.has(comment.authorUserId)) {
@@ -158,18 +174,7 @@ export async function handleCommentMentionNotification(
         // Check notification preference (default: enabled)
         // If preference exists and is disabled, skip
         // If user/project was deleted, the preference won't exist (cascade delete)
-        const preference = await prisma.notificationPreference.findUnique({
-          where: {
-            userId_projectId_channel_type: {
-              userId,
-              projectId,
-              channel: "EMAIL",
-              type: "COMMENT_MENTION",
-            },
-          },
-        });
-
-        if (preference && !preference.enabled) {
+        if (disabledUserIds.has(userId)) {
           logger.info(
             `User ${userId} has disabled email notifications for comment mentions in project ${projectId}. Skipping.`,
           );


### PR DESCRIPTION
## What does this PR do?

Removes the notification-preference N+1 query from comment mention processing.

Previously, `handleCommentMentionNotification` fetched project users in one query but issued a sequential `notificationPreference.findUnique` for every mentioned user. A comment mentioning N users therefore added N preference round trips before email delivery.

This PR:

- fetches all email/comment-mention preferences for the project and mentioned user IDs with one `findMany`
- selects only `userId` and `enabled`, then builds a `Set` of disabled user IDs for constant-time loop checks
- preserves default-enabled semantics: users without a preference row still receive the notification
- preserves explicit opt-outs: users with `enabled: false` are skipped
- retains the existing project membership check and `projectId` tenant boundary
- leaves link construction and email delivery sequential; concurrency is intentionally outside this PR

Query count for preferences changes from O(N) sequential queries to one query per notification job.

## Impacted package

- `worker`

## How was it tested?

- Added a colocated regression with two valid mentions: one user with no preference row and one explicitly disabled user. It asserts one `findMany`, no `findUnique`, delivery to the default-enabled user, and suppression for the disabled user.
- `pnpm --filter worker exec dotenv -e '../.env.dev.example' -- vitest run 'commentMentionHandler.test.ts'`
  - `Test Files 1 passed (1)`
  - `Tests 1 passed (1)`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- `pnpm run typecheck`
  - `Tasks: 7 successful, 7 total`
- `git diff --check`

Closes #15732

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the per-recipient notification-preference query from comment mention processing.
- Fetches all relevant email mention preferences in one project-scoped query.
- Builds a disabled-user set while preserving default-enabled behavior.
- Adds regression coverage for enabled-by-default and explicitly disabled recipients.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The bulk query retains the existing project, channel, type, and user constraints, while schema uniqueness ensures its disabled-user set preserves the prior per-user lookup semantics.
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(worker): batch mention notification..."](https://github.com/langfuse/langfuse/commit/4d57ce42d87b8c2dc92dafab098ed7a64a490efa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49771237)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->