### PR TITLE
fix(models): handle concurrent model name conflicts

### DIFF
--- a/web/src/__tests__/server/unit/models-router.servertest.ts
+++ b/web/src/__tests__/server/unit/models-router.servertest.ts
@@ -6,7 +6,18 @@ import { Role } from "@langfuse/shared";
 import { Prisma } from "@langfuse/shared/src/db";
 import type { Session } from "next-auth";
 
-const createCaller = () => {
+const modelNameConstraintTarget = [
+  "project_id",
+  "model_name",
+  "start_date",
+  "unit",
+];
+
+const createCaller = ({
+  uniqueConstraintTarget = modelNameConstraintTarget,
+}: {
+  uniqueConstraintTarget?: string[];
+} = {}) => {
   const orgId = randomUUID();
   const projectId = randomUUID();
   const session: Session = {
@@ -64,7 +75,7 @@ const createCaller = () => {
           code: "P2002",
           clientVersion: "test",
           meta: {
-            target: ["project_id", "model_name", "start_date", "unit"],
+            target: uniqueConstraintTarget,
           },
         }),
       ),
@@ -110,6 +121,33 @@ describe("modelRouter.upsert", () => {
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: `Model name '${modelName}' already exists in project`,
+    });
+  });
+
+  it("does not report a model name conflict for a primary key collision", async () => {
+    const { caller, projectId } = createCaller({
+      uniqueConstraintTarget: ["id"],
+    });
+    const modelName = `primary-key-race-${randomUUID()}`;
+
+    await expect(
+      caller.upsert({
+        modelId: randomUUID(),
+        projectId,
+        modelName,
+        matchPattern: `^${modelName}$`,
+        pricingTiers: [
+          {
+            name: "Standard",
+            isDefault: true,
+            priority: 0,
+            conditions: [],
+            prices: { input: 1 },
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
     });
   });
 });

--- a/web/src/__tests__/server/unit/models-router.servertest.ts
+++ b/web/src/__tests__/server/unit/models-router.servertest.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+
+import { modelRouter } from "@/src/server/api/routers/models";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { Role } from "@langfuse/shared";
+import { Prisma } from "@langfuse/shared/src/db";
+import type { Session } from "next-auth";
+
+const createCaller = () => {
+  const orgId = randomUUID();
+  const projectId = randomUUID();
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: randomUUID(),
+      name: "Models Router Test User",
+      canCreateOrganizations: true,
+      organizations: [
+        {
+          id: orgId,
+          name: "Models Router Test Organization",
+          role: Role.OWNER,
+          plan: "cloud:pro",
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: false,
+          aiTelemetryEnabled: true,
+          projects: [
+            {
+              id: projectId,
+              name: "Models Router Test Project",
+              role: Role.OWNER,
+              retentionDays: 0,
+              deletedAt: null,
+              hasTraces: false,
+              metadata: {},
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+        v4BetaToggleVisible: false,
+        observationEvals: false,
+        experimentsV4Enabled: false,
+        searchBar: false,
+      },
+      admin: false,
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: "oss",
+    },
+  };
+
+  const transactionClient = {
+    model: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      findFirst: vi.fn().mockResolvedValue(null),
+      upsert: vi.fn().mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: "P2002",
+          clientVersion: "test",
+          meta: {
+            target: ["project_id", "model_name", "start_date", "unit"],
+          },
+        }),
+      ),
+    },
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  const prisma = {
+    $queryRaw: vi.fn().mockResolvedValue([{ matches: true }]),
+    $transaction: vi.fn(
+      async (callback: (tx: typeof transactionClient) => Promise<unknown>) =>
+        callback(transactionClient),
+    ),
+  } as unknown as typeof ctx.prisma;
+
+  return {
+    caller: modelRouter.createCaller({ ...ctx, prisma }),
+    projectId,
+  };
+};
+
+describe("modelRouter.upsert", () => {
+  it("returns BAD_REQUEST when a concurrent create hits the model name constraint", async () => {
+    const { caller, projectId } = createCaller();
+    const modelName = `concurrent-model-${randomUUID()}`;
+
+    await expect(
+      caller.upsert({
+        modelId: null,
+        projectId,
+        modelName,
+        matchPattern: `^${modelName}$`,
+        pricingTiers: [
+          {
+            name: "Standard",
+            isDefault: true,
+            priority: 0,
+            conditions: [],
+            prices: { input: 1 },
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: `Model name '${modelName}' already exists in project`,
+    });
+  });
+});

--- a/web/src/server/api/routers/models.ts
+++ b/web/src/server/api/routers/models.ts
@@ -283,10 +283,10 @@ export const modelRouter = createTRPCRouter({
           });
         }
 
-        // Check if model name is unique within the project
-        // Note: The database has a uniqueness constraint on (projectId, modelName, startDate, unit),
-        // but this constraint is not enforced when startDate or unit are NULL.
-        // We do an explicit check here to ensure uniqueness on just (projectId, modelName).
+        // Return a friendly error before writing when possible. The database
+        // constraint remains authoritative for concurrent creates.
+        // Note: The constraint covers (projectId, modelName, startDate, unit)
+        // and does not apply when startDate or unit are NULL.
         // TODO(LFE-3229): After models table cleanup, enforce uniqueness constraint directly on (projectId, modelName)
         const existingModelName = await tx.model.findFirst({
           where: {
@@ -302,27 +302,41 @@ export const modelRouter = createTRPCRouter({
           });
         }
 
-        const upsertedModel = await tx.model.upsert({
-          where: {
-            id: modelId,
-            projectId: projectId,
-          },
-          create: {
-            id: modelId,
-            projectId,
-            modelName,
-            matchPattern,
-            tokenizerConfig,
-            tokenizerId,
-            startDate: new Date("2010-01-01"), // Set fix start date for uniqueness constraint to work. TODO: drop after cleanup of models table in LFE-3229
-            unit: ModelUsageUnit.Tokens, // Set fix unit for uniqueness constraint to work. TODO: drop after cleanup of models table in LFE-3229
-          },
-          update: {
-            matchPattern,
-            tokenizerConfig,
-            tokenizerId,
-          },
-        });
+        const upsertedModel = await tx.model
+          .upsert({
+            where: {
+              id: modelId,
+              projectId: projectId,
+            },
+            create: {
+              id: modelId,
+              projectId,
+              modelName,
+              matchPattern,
+              tokenizerConfig,
+              tokenizerId,
+              startDate: new Date("2010-01-01"), // Set fix start date for uniqueness constraint to work. TODO: drop after cleanup of models table in LFE-3229
+              unit: ModelUsageUnit.Tokens, // Set fix unit for uniqueness constraint to work. TODO: drop after cleanup of models table in LFE-3229
+            },
+            update: {
+              matchPattern,
+              tokenizerConfig,
+              tokenizerId,
+            },
+          })
+          .catch((error: unknown) => {
+            if (
+              error instanceof Prisma.PrismaClientKnownRequestError &&
+              error.code === "P2002"
+            ) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: `Model name '${modelName}' already exists in project`,
+              });
+            }
+
+            throw error;
+          });
 
         // Delete all existing pricing tiers
         await tx.pricingTier.deleteMany({

--- a/web/src/server/api/routers/models.ts
+++ b/web/src/server/api/routers/models.ts
@@ -28,6 +28,30 @@ const ModelAllOptions = z.object({
   ...paginationZod,
 });
 
+const modelNameUniqueConstraintColumns = [
+  "project_id",
+  "model_name",
+  "start_date",
+  "unit",
+] as const;
+
+const isModelNameUniqueConstraintError = (error: unknown): boolean => {
+  if (
+    !(error instanceof Prisma.PrismaClientKnownRequestError) ||
+    error.code !== "P2002"
+  ) {
+    return false;
+  }
+
+  const target = error.meta?.target;
+  if (!Array.isArray(target)) return false;
+
+  return (
+    target.length === modelNameUniqueConstraintColumns.length &&
+    modelNameUniqueConstraintColumns.every((column) => target.includes(column))
+  );
+};
+
 const paginateArray = <T>(params: {
   limit: number;
   page: number;
@@ -325,10 +349,7 @@ export const modelRouter = createTRPCRouter({
             },
           })
           .catch((error: unknown) => {
-            if (
-              error instanceof Prisma.PrismaClientKnownRequestError &&
-              error.code === "P2002"
-            ) {
+            if (isModelNameUniqueConstraintError(error)) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
                 message: `Model name '${modelName}' already exists in project`,


### PR DESCRIPTION
## What does this PR do?

Closes #15734.

The models tRPC router performs a friendly model-name pre-check before writing. That check is useful for legacy rows whose startDate or unit is NULL, but it cannot serialize concurrent creates under PostgreSQL READ COMMITTED.

The existing composite unique index on (project_id, model_name, start_date, unit) is still authoritative for models created through this router because both sentinel values are non-null and identical. Before this change, a concurrent loser therefore received an INTERNAL_SERVER_ERROR when Prisma surfaced P2002.

This PR:

- keeps the pre-check for early validation and legacy nullable rows;
- catches P2002 specifically at the model upsert statement;
- translates that database-enforced race outcome to the existing BAD_REQUEST response and duplicate-name message;
- rethrows every other error unchanged;
- documents that the database constraint is authoritative for concurrent creates;
- adds a server-unit regression that simulates another transaction winning between the pre-check and upsert.

The sentinel startDate/unit values and composite constraint remain unchanged. Removing them safely requires the broader LFE-3229 schema cleanup, including duplicate remediation/backfill planning, and is deliberately outside this focused fix.

Impacted package: web.

### Error reporting decision

P2002 here is an expected user-facing conflict, so it is returned as a 4xx response and is not captured in Sentry. Unexpected errors continue through the existing server error pipeline.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code.

## Verification

- Regression before the fix: 1 failed (1), receiving INTERNAL_SERVER_ERROR instead of BAD_REQUEST.
- pnpm exec dotenv -e .env.dev.example -- pnpm --filter web run test src/__tests__/server/unit/models-router.servertest.ts
  - Test Files  1 passed (1)
  - Tests  1 passed (1)
- pnpm exec dotenv -e .env.dev.example -- pnpm run lint
  - Tasks: 7 successful, 7 total
- pnpm exec dotenv -e .env.dev.example -- pnpm --filter web run typecheck
  - exited successfully
- pnpm exec prettier --check web/src/server/api/routers/models.ts web/src/__tests__/server/unit/models-router.servertest.ts
  - All matched files use Prettier code style!
- git diff --check
  - passed

No database generation or migration checks were run because this PR does not change the Prisma schema or migrations.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR converts the database-enforced concurrent model-name conflict into the router’s existing client-facing error.
- Retains the pre-write model-name validation for friendly handling of legacy nullable rows.
- Catches Prisma unique-constraint errors around the model upsert.
- Adds a server-unit regression covering a concurrent composite-constraint conflict.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking opportunity to restrict the new error translation to the intended model-name constraint.

The intended concurrent model-name race is handled correctly, but another unique constraint raised by the same upsert can receive an inaccurate client-facing diagnosis.

**Files Needing Attention:** web/src/server/api/routers/models.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/server/api/routers/models.ts:329-337
**Overbroad unique-conflict translation**

The catch translates every `P2002` raised by this upsert into a duplicate model-name response, including a primary-key conflict caused when an insertion races on the caller-provided model ID. Restricting the translation to the composite model-name constraint would avoid directing clients to correct the wrong field.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): handle concurrent model nam..."](https://github.com/langfuse/langfuse/commit/7780d417c272f82ff933b13a58332c9895a78af4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49777979)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->