### PR TITLE
fix(audit-logs): skip no-op assignment audits

### DIFF
--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -368,6 +368,7 @@ describe("MCP public API tools", () => {
         action: "create",
       },
     });
+    expect(assignmentAuditLogCount).toBe(1);
 
     await expect(
       handleCreateAnnotationQueueAssignment(
@@ -380,8 +381,8 @@ describe("MCP public API tools", () => {
       projectId,
     });
 
-    // Assignment creation uses an upsert for public API parity, so duplicate
-    // calls are audited even when the assignment already exists.
+    // Reassigning an existing user is an idempotent no-op and must not create
+    // another audit log entry.
     await expect(
       prisma.auditLog.count({
         where: {
@@ -390,7 +391,7 @@ describe("MCP public API tools", () => {
           action: "create",
         },
       }),
-    ).resolves.toBe(assignmentAuditLogCount + 1);
+    ).resolves.toBe(assignmentAuditLogCount);
 
     const auditLogCreateSpy = vi
       .spyOn(prisma, "$transaction")

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -583,25 +583,23 @@ export const createAnnotationQueueAssignmentForApi = async ({
     userId: input.userId,
   };
 
-  // Create the assignment (upsert to handle duplicates gracefully)
-  const assignment = await prisma.annotationQueueAssignment.upsert({
-    where: {
-      projectId_queueId_userId: assignmentWhere,
-    },
-    create: assignmentWhere,
-    update: {},
-  });
+  // Insert atomically so concurrent or repeated assignments remain idempotent
+  // and only the request that created the row emits an audit log.
+  const [createdAssignment] =
+    await prisma.annotationQueueAssignment.createManyAndReturn({
+      data: assignmentWhere,
+      skipDuplicates: true,
+    });
 
-  // TODO: only create audit log if upsert actually creates a new record
-  if (auditScope) {
+  if (auditScope && createdAssignment) {
     await auditLog({
       action: "create",
       resourceType: "annotationQueueAssignment",
-      resourceId: assignment.id,
+      resourceId: createdAssignment.id,
       projectId: auditScope.projectId,
       orgId: auditScope.orgId,
       apiKeyId: auditScope.apiKeyId,
-      after: assignment,
+      after: createdAssignment,
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

Closes #15735.

Repeated annotation queue assignment requests are intentionally idempotent, but the previous no-op upsert returned the existing row and unconditionally emitted another action: create audit log. This made the audit trail report state changes that never happened.

This PR replaces that upsert with an atomic createManyAndReturn call using skipDuplicates. PostgreSQLs unique key remains the arbiter:

- the request that inserts the assignment receives the created row and writes the create audit log;
- repeated requests receive no created row, remain successful, and write no audit log;
- concurrent requests have the same behavior, so only the winning insert is audited.

This avoids timestamp heuristics and avoids the race inherent in a separate findUnique pre-check.

The existing MCP/public-service regression now asserts both sides of the contract: the first assignment creates exactly one audit record, and an idempotent reassignment leaves that count unchanged.

Impacted package: web.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code.

## Verification

- pnpm exec dotenv -e .env.dev.example -- pnpm run lint
  - Tasks: 7 successful, 7 total
- pnpm exec dotenv -e .env.dev.example -- pnpm --filter web run typecheck
  - exited successfully
- pnpm exec prettier --check web/src/features/annotation-queues/server/publicAnnotationQueueService.ts web/src/__tests__/server/mcp-public-api-tools.servertest.ts
  - All matched files use Prettier code style!
- git diff --check
  - passed

The targeted database-backed test was attempted with:

pnpm exec dotenv -e .env.dev.example -- pnpm --filter web run test src/__tests__/server/mcp-public-api-tools.servertest.ts

It could not reach test execution because the local PostgreSQL and Redis services are unavailable (Cant reach database server at localhost:5432 and ECONNREFUSED 127.0.0.1:6379). The updated regression will run in CI with its service dependencies.

No Prisma generation or migration checks were run because the schema and migrations are unchanged.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes annotation queue assignment creation audit only newly inserted rows.
- Replaces the no-op upsert with duplicate-safe `createManyAndReturn`.
- Skips create audit logs for repeated or concurrent no-op assignments.
- Updates the MCP regression test to verify one audit for the initial assignment and none for reassignment.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The duplicate-safe insert preserves the existing response contract while ensuring only the request that creates the assignment emits a create audit log.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(audit-logs): skip no-op assignment a..."](https://github.com/langfuse/langfuse/commit/d02d8adc86e92126fff76848d18f4b3ca34defea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49779482)</sub>

<!-- /greptile_comment -->