### PR TITLE
feat(in-app-agent): add per-user run rate limit

### DIFF
--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -1084,6 +1084,11 @@ describe("in-app agent public API route auth", () => {
           projectId: project.id,
         }),
         "in-app-agent-run",
+        {
+          type: "user",
+          userId: sessionUser.id,
+          pointsMultiplier: 0.5,
+        },
       );
       expect(instrumentationMocks.addUserToSpan).toHaveBeenLastCalledWith({
         userId: sessionUser.id,
@@ -1126,6 +1131,10 @@ describe("in-app agent public API route auth", () => {
         admin: true,
         includeProjectMembership: false,
       });
+      const sessionUser = session.user;
+      if (!sessionUser) {
+        throw new Error("Expected an authenticated session user");
+      }
       authMocks.getServerSession.mockResolvedValue(session);
       rateLimitMocks.rateLimitRequest.mockResolvedValue({
         isRateLimited: () => true,
@@ -1178,6 +1187,11 @@ describe("in-app agent public API route auth", () => {
           plan: "cloud:team",
         }),
         "in-app-agent-run",
+        {
+          type: "user",
+          userId: sessionUser.id,
+          pointsMultiplier: 0.5,
+        },
       );
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;

--- a/web/src/__tests__/server/rate-limit.servertest.ts
+++ b/web/src/__tests__/server/rate-limit.servertest.ts
@@ -207,6 +207,66 @@ describe("RateLimitService", () => {
     ).resolves.toBeNull();
   });
 
+  it("should allow a one-point user bucket and refund its consumption", async () => {
+    const scope = {
+      orgId,
+      plan: "cloud:team" as const,
+      projectId,
+      accessLevel: "project" as const,
+      rateLimitOverrides: [
+        {
+          resource: "in-app-agent-run" as const,
+          points: 2,
+          durationInSec: 60,
+        },
+      ],
+    };
+    const rateLimitService = RateLimitService.getInstance(redis as Redis);
+    const userScope = {
+      type: "user" as const,
+      userId: "one-point-user",
+      pointsMultiplier: 0.5,
+    };
+
+    const firstResult = await rateLimitService.rateLimitRequest(
+      asScope(scope),
+      "in-app-agent-run",
+      userScope,
+    );
+    expect(firstResult.isRateLimited()).toBe(false);
+    expect(firstResult.res).toMatchObject({
+      points: 1,
+      remainingPoints: 0,
+      consumedPoints: 1,
+    });
+
+    await firstResult.refund();
+
+    const resultAfterRefund = await rateLimitService.rateLimitRequest(
+      asScope(scope),
+      "in-app-agent-run",
+      userScope,
+    );
+    expect(resultAfterRefund.isRateLimited()).toBe(false);
+    expect(resultAfterRefund.res).toMatchObject({
+      points: 1,
+      remainingPoints: 0,
+      consumedPoints: 1,
+    });
+
+    const rejectedResult = await rateLimitService.rateLimitRequest(
+      asScope(scope),
+      "in-app-agent-run",
+      userScope,
+    );
+    expect(rejectedResult.isRateLimited()).toBe(true);
+    expect(rejectedResult.res).toMatchObject({
+      points: 1,
+      remainingPoints: 0,
+      consumedPoints: 2,
+    });
+  });
+
   it("should reset the rate limit count after the window expires", async () => {
     const scope = {
       orgId: orgId,

--- a/web/src/__tests__/server/rate-limit.servertest.ts
+++ b/web/src/__tests__/server/rate-limit.servertest.ts
@@ -26,7 +26,7 @@ const asScope = (scope: TestApiAccessScope): ApiAccessScope =>
 describe("RateLimitService", () => {
   const orgId = `rate-limit-test-org-${randomUUID()}`;
   const projectId = `rate-limit-test-project-${randomUUID()}`;
-  const rateLimitKeysPattern = `${RATE_LIMIT_REDIS_KEY_PREFIX}:*:${orgId}`;
+  const rateLimitKeysPattern = `${RATE_LIMIT_REDIS_KEY_PREFIX}:*:${orgId}*`;
   let redis: RedisTestClient;
 
   const createRedisClient = (): RedisTestClient => {
@@ -153,6 +153,58 @@ describe("RateLimitService", () => {
       isFirstInDuration: false,
     });
     expect(result?.isRateLimited()).toBe(false);
+  });
+
+  it("should isolate user buckets within an organization", async () => {
+    const scope = {
+      orgId,
+      plan: "cloud:team" as const,
+      projectId,
+      accessLevel: "project" as const,
+      rateLimitOverrides: [
+        {
+          resource: "in-app-agent-run" as const,
+          points: 4,
+          durationInSec: 60,
+        },
+      ],
+    };
+    const rateLimitService = RateLimitService.getInstance(redis as Redis);
+
+    const firstUserResult = await rateLimitService.rateLimitRequest(
+      asScope(scope),
+      "in-app-agent-run",
+      { type: "user", userId: "user-a", pointsMultiplier: 0.5 },
+    );
+    const secondUserResult = await rateLimitService.rateLimitRequest(
+      asScope(scope),
+      "in-app-agent-run",
+      { type: "user", userId: "user-b", pointsMultiplier: 0.5 },
+    );
+
+    expect(firstUserResult.res).toMatchObject({
+      points: 2,
+      remainingPoints: 1,
+      consumedPoints: 1,
+    });
+    expect(secondUserResult.res).toMatchObject({
+      points: 2,
+      remainingPoints: 1,
+      consumedPoints: 1,
+    });
+    await expect(
+      redis.get(
+        `${RATE_LIMIT_REDIS_KEY_PREFIX}:in-app-agent-run:user:${orgId}:user:user-a`,
+      ),
+    ).resolves.toBeDefined();
+    await expect(
+      redis.get(
+        `${RATE_LIMIT_REDIS_KEY_PREFIX}:in-app-agent-run:user:${orgId}:user:user-b`,
+      ),
+    ).resolves.toBeDefined();
+    await expect(
+      redis.get(`${RATE_LIMIT_REDIS_KEY_PREFIX}:in-app-agent-run:${orgId}`),
+    ).resolves.toBeNull();
   });
 
   it("should reset the rate limit count after the window expires", async () => {

--- a/web/src/__tests__/server/unit/in-app-agent-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-rate-limit.servertest.ts
@@ -1,6 +1,7 @@
 import type { ApiAccessScope } from "@langfuse/shared/src/server";
 
 const rateLimitRequestMock = vi.hoisted(() => vi.fn());
+const refundUserRateLimitMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/src/features/public-api/server/RateLimitService", () => ({
   RateLimitService: {
@@ -69,5 +70,37 @@ describe("checkInAppAgentRateLimit", () => {
       checkInAppAgentRateLimit(scope, "user-a", "in-app-agent-run"),
     ).resolves.toBe(rateLimitResult);
     expect(rateLimitRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refunds the user bucket when the organization bucket rejects", async () => {
+    const organizationRateLimitResult = {
+      resource: "in-app-agent-run" as const,
+      scope,
+      points: 1_000,
+      remainingPoints: 0,
+      msBeforeNext: 60_000,
+      consumedPoints: 1_001,
+      isFirstInDuration: false,
+    };
+    rateLimitRequestMock
+      .mockResolvedValueOnce({
+        isRateLimited: () => false,
+        res: {
+          ...organizationRateLimitResult,
+          points: 500,
+          remainingPoints: 499,
+          consumedPoints: 1,
+        },
+        refund: refundUserRateLimitMock,
+      })
+      .mockResolvedValueOnce({
+        isRateLimited: () => true,
+        res: organizationRateLimitResult,
+      });
+
+    await expect(
+      checkInAppAgentRateLimit(scope, "user-a", "in-app-agent-run"),
+    ).resolves.toBe(organizationRateLimitResult);
+    expect(refundUserRateLimitMock).toHaveBeenCalledOnce();
   });
 });

--- a/web/src/__tests__/server/unit/in-app-agent-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-rate-limit.servertest.ts
@@ -1,0 +1,73 @@
+import type { ApiAccessScope } from "@langfuse/shared/src/server";
+
+const rateLimitRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/src/features/public-api/server/RateLimitService", () => ({
+  RateLimitService: {
+    getInstance: () => ({ rateLimitRequest: rateLimitRequestMock }),
+  },
+}));
+
+import { checkInAppAgentRateLimit } from "@/src/features/in-app-agent/server/rateLimit";
+
+const scope: ApiAccessScope = {
+  orgId: "org-1",
+  plan: "cloud:team",
+  projectId: "project-1",
+  accessLevel: "project",
+  rateLimitOverrides: [],
+  apiKeyId: "in-app-agent-session",
+  publicKey: "in-app-agent-session",
+  isIngestionSuspended: false,
+};
+
+describe("checkInAppAgentRateLimit", () => {
+  beforeEach(() => {
+    rateLimitRequestMock.mockReset();
+    rateLimitRequestMock.mockResolvedValue({
+      isRateLimited: () => false,
+      res: undefined,
+    });
+  });
+
+  it("uses distinct per-user buckets while retaining the organization bucket", async () => {
+    await checkInAppAgentRateLimit(scope, "user-a", "in-app-agent-run");
+    await checkInAppAgentRateLimit(scope, "user-b", "in-app-agent-run");
+
+    expect(rateLimitRequestMock.mock.calls).toEqual([
+      [
+        scope,
+        "in-app-agent-run",
+        { type: "user", userId: "user-a", pointsMultiplier: 0.5 },
+      ],
+      [scope, "in-app-agent-run"],
+      [
+        scope,
+        "in-app-agent-run",
+        { type: "user", userId: "user-b", pointsMultiplier: 0.5 },
+      ],
+      [scope, "in-app-agent-run"],
+    ]);
+  });
+
+  it("does not consume the organization bucket after the user is limited", async () => {
+    const rateLimitResult = {
+      resource: "in-app-agent-run" as const,
+      scope,
+      points: 500,
+      remainingPoints: 0,
+      msBeforeNext: 60_000,
+      consumedPoints: 501,
+      isFirstInDuration: false,
+    };
+    rateLimitRequestMock.mockResolvedValueOnce({
+      isRateLimited: () => true,
+      res: rateLimitResult,
+    });
+
+    await expect(
+      checkInAppAgentRateLimit(scope, "user-a", "in-app-agent-run"),
+    ).resolves.toBe(rateLimitResult);
+    expect(rateLimitRequestMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/__tests__/server/unit/rate-limit-response.servertest.ts
+++ b/web/src/__tests__/server/unit/rate-limit-response.servertest.ts
@@ -83,7 +83,45 @@ vi.mock(
   }),
 );
 
-import { sendRateLimitResponse } from "@/src/features/public-api/server/RateLimitService";
+import {
+  RateLimitHelper,
+  sendRateLimitResponse,
+} from "@/src/features/public-api/server/RateLimitService";
+
+describe("RateLimitHelper", () => {
+  const resultAtLimit = {
+    points: 1,
+    remainingPoints: 0,
+    msBeforeNext: 60_000,
+    resource: "in-app-agent-run",
+    scope: {
+      projectId: "project-1",
+      orgId: "org-1",
+      plan: "cloud:team",
+      accessLevel: "project",
+      rateLimitOverrides: [],
+      apiKeyId: "in-app-agent-session",
+      publicKey: "in-app-agent-session",
+      isIngestionSuspended: false,
+    },
+    consumedPoints: 1,
+    isFirstInDuration: true,
+  } satisfies RateLimitResult;
+
+  it("allows the request that consumes the final available point", () => {
+    expect(new RateLimitHelper(resultAtLimit).isRateLimited()).toBe(false);
+  });
+
+  it("rejects requests consumed beyond the configured points", () => {
+    expect(
+      new RateLimitHelper({
+        ...resultAtLimit,
+        consumedPoints: 2,
+        isFirstInDuration: false,
+      }).isRateLimited(),
+    ).toBe(true);
+  });
+});
 
 describe("sendRateLimitResponse", () => {
   const upgradePath = {

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -237,9 +237,9 @@ export default async function handler(request: Request) {
       plan: rateLimitScope.plan,
     });
 
-    // TODO: Add an additional user-level cap once the rate-limit service supports non-org keys.
     const rateLimitResponse = await rateLimitInAppAgentRequest(
       rateLimitScope,
+      userId,
       "in-app-agent-run",
     );
 
@@ -653,9 +653,10 @@ function getInAppAgentUserAccess(
 
 async function rateLimitInAppAgentRequest(
   scope: ApiAccessScope,
+  userId: string,
   resource: Parameters<RateLimitService["rateLimitRequest"]>[1],
 ): Promise<Response | undefined> {
-  const rateLimitRes = await checkInAppAgentRateLimit(scope, resource);
+  const rateLimitRes = await checkInAppAgentRateLimit(scope, userId, resource);
 
   return rateLimitRes
     ? createInAppAgentRateLimitResponse(rateLimitRes)

--- a/web/src/features/in-app-agent/server/rateLimit.ts
+++ b/web/src/features/in-app-agent/server/rateLimit.ts
@@ -13,13 +13,15 @@ import { RateLimitService } from "@/src/features/public-api/server/RateLimitServ
 
 type SessionUser = NonNullable<Session["user"]>;
 
+// Follow the effective organization limit (including overrides) while
+// reserving at least half of the shared allowance for other users.
+const IN_APP_AGENT_USER_RATE_LIMIT_MULTIPLIER = 0.5;
+
 /**
- * Build the org-scoped rate-limit scope for an in-app agent request.
+ * Build the organization rate-limit scope for an in-app agent request.
  *
  * Shared by the foreground route and the background `startRun` mutation so a
- * user cannot bypass the cap by submitting through the other path.
- *
- * TODO: this is org-scoped only; there is no per-user cap yet.
+ * user cannot bypass the limits by submitting through the other path.
  */
 export function getInAppAgentApiAccessScope(
   user: SessionUser,
@@ -68,22 +70,44 @@ export function getInAppAgentApiAccessScope(
 
 export async function checkInAppAgentRateLimit(
   scope: ApiAccessScope,
+  userId: string,
   resource: Parameters<RateLimitService["rateLimitRequest"]>[1],
 ): Promise<RateLimitResult | undefined> {
-  const rateLimit = await RateLimitService.getInstance().rateLimitRequest(
+  const rateLimitService = RateLimitService.getInstance();
+
+  // Check the user bucket first so repeated rejected requests from one user do
+  // not consume the shared organization allowance.
+  const userRateLimit = await rateLimitService.rateLimitRequest(
+    scope,
+    resource,
+    {
+      type: "user",
+      userId,
+      pointsMultiplier: IN_APP_AGENT_USER_RATE_LIMIT_MULTIPLIER,
+    },
+  );
+
+  if (userRateLimit.isRateLimited()) {
+    return userRateLimit.res ?? undefined;
+  }
+
+  const organizationRateLimit = await rateLimitService.rateLimitRequest(
     scope,
     resource,
   );
 
-  return rateLimit.isRateLimited() ? (rateLimit.res ?? undefined) : undefined;
+  return organizationRateLimit.isRateLimited()
+    ? (organizationRateLimit.res ?? undefined)
+    : undefined;
 }
 
 /** tRPC-shaped variant; BaseErrors bubble to the tRPC error middleware. */
 export async function assertInAppAgentRateLimit(
   scope: ApiAccessScope,
+  userId: string,
   resource: Parameters<RateLimitService["rateLimitRequest"]>[1],
 ): Promise<void> {
-  const rateLimitRes = await checkInAppAgentRateLimit(scope, resource);
+  const rateLimitRes = await checkInAppAgentRateLimit(scope, userId, resource);
 
   if (!rateLimitRes) {
     return;

--- a/web/src/features/in-app-agent/server/rateLimit.ts
+++ b/web/src/features/in-app-agent/server/rateLimit.ts
@@ -96,9 +96,12 @@ export async function checkInAppAgentRateLimit(
     resource,
   );
 
-  return organizationRateLimit.isRateLimited()
-    ? (organizationRateLimit.res ?? undefined)
-    : undefined;
+  if (organizationRateLimit.isRateLimited()) {
+    await userRateLimit.refund();
+    return organizationRateLimit.res ?? undefined;
+  }
+
+  return undefined;
 }
 
 /** tRPC-shaped variant; BaseErrors bubble to the tRPC error middleware. */

--- a/web/src/features/in-app-agent/server/router.ts
+++ b/web/src/features/in-app-agent/server/router.ts
@@ -182,6 +182,7 @@ export const inAppAgentRouter = createTRPCRouter({
           input.projectId,
           projectAvailability,
         ),
+        ctx.session.user.id,
         "in-app-agent-run",
       );
 
@@ -238,6 +239,7 @@ export const inAppAgentRouter = createTRPCRouter({
           input.projectId,
           projectAvailability,
         ),
+        ctx.session.user.id,
         "in-app-agent-run",
       );
 

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -104,8 +104,12 @@ export class RateLimitService {
       return new RateLimitHelper(undefined);
     }
 
+    const result = await this.checkRateLimit(scope, resource, consumptionScope);
     return new RateLimitHelper(
-      await this.checkRateLimit(scope, resource, consumptionScope),
+      result,
+      result && !isRateLimitExceeded(result)
+        ? () => this.refundRateLimitRequest(scope, resource, consumptionScope)
+        : undefined,
     );
   }
 
@@ -114,26 +118,16 @@ export class RateLimitService {
     resource: z.infer<typeof RateLimitResource>,
     consumptionScope: RateLimitConsumptionScope = { type: "organization" },
   ) {
-    const configuredRateLimit = getRateLimitConfig(scope, resource);
-    const effectiveConfig =
-      consumptionScope.type === "user" && configuredRateLimit?.points
-        ? {
-            ...configuredRateLimit,
-            points: Math.max(
-              1,
-              Math.floor(
-                configuredRateLimit.points * consumptionScope.pointsMultiplier,
-              ),
-            ),
-          }
-        : configuredRateLimit;
+    const effectiveConfig = getEffectiveRateLimitConfig(
+      scope,
+      resource,
+      consumptionScope,
+    );
+    const points = effectiveConfig?.points;
+    const durationInSec = effectiveConfig?.durationInSec;
 
     // returning early if no rate limit is set
-    if (
-      !effectiveConfig ||
-      !effectiveConfig.points ||
-      !effectiveConfig.durationInSec
-    ) {
+    if (!points || !durationInSec) {
       return;
     }
 
@@ -146,20 +140,12 @@ export class RateLimitService {
       }
     }
 
-    const rateLimiter = new RateLimiterRedis({
-      // Basic options
-      points: effectiveConfig.points, // Number of points
-      duration: effectiveConfig.durationInSec, // Per second(s)
-
-      keyPrefix: this.rateLimitPrefix(resource, consumptionScope.type), // must be unique for limiters with different purpose
-      storeClient: RateLimitService.redis,
-      rejectIfRedisNotReady: true,
-    });
-
-    const consumptionKey =
-      consumptionScope.type === "user"
-        ? `${scope.orgId}:user:${consumptionScope.userId}`
-        : scope.orgId;
+    const rateLimiter = this.createRateLimiter(
+      resource,
+      consumptionScope.type,
+      { points, durationInSec },
+    );
+    const consumptionKey = this.consumptionKey(scope, consumptionScope);
 
     let res: RateLimitResult | undefined = undefined;
     try {
@@ -167,7 +153,7 @@ export class RateLimitService {
       res = {
         resource,
         scope,
-        points: effectiveConfig.points,
+        points,
         remainingPoints: libRes.remainingPoints,
         msBeforeNext: libRes.msBeforeNext,
         consumedPoints: libRes.consumedPoints,
@@ -179,7 +165,7 @@ export class RateLimitService {
         res = {
           resource,
           scope,
-          points: effectiveConfig.points,
+          points,
           remainingPoints: err.remainingPoints,
           msBeforeNext: err.msBeforeNext,
           consumedPoints: err.consumedPoints,
@@ -192,7 +178,7 @@ export class RateLimitService {
       }
     }
 
-    if (res.remainingPoints < 1) {
+    if (isRateLimitExceeded(res)) {
       recordIncrement("langfuse.rate_limit.exceeded", 1, {
         orgId: scope.orgId,
         plan: scope.plan,
@@ -202,6 +188,57 @@ export class RateLimitService {
     }
 
     return res;
+  }
+
+  private async refundRateLimitRequest(
+    scope: ApiAccessScope,
+    resource: z.infer<typeof RateLimitResource>,
+    consumptionScope: RateLimitConsumptionScope,
+  ): Promise<void> {
+    const effectiveConfig = getEffectiveRateLimitConfig(
+      scope,
+      resource,
+      consumptionScope,
+    );
+    const points = effectiveConfig?.points;
+    const durationInSec = effectiveConfig?.durationInSec;
+    if (!points || !durationInSec || !RateLimitService.redis) {
+      return;
+    }
+
+    try {
+      await this.createRateLimiter(resource, consumptionScope.type, {
+        points,
+        durationInSec,
+      }).reward(this.consumptionKey(scope, consumptionScope));
+    } catch (error) {
+      // A Redis transport failure is already observable server-side. Preserve
+      // the original rate-limit result rather than replacing it with a 500.
+      logger.error("Internal rate limit refund error", error);
+    }
+  }
+
+  private createRateLimiter(
+    resource: string,
+    consumptionScope: RateLimitConsumptionScope["type"],
+    config: { points: number; durationInSec: number },
+  ) {
+    return new RateLimiterRedis({
+      points: config.points,
+      duration: config.durationInSec,
+      keyPrefix: this.rateLimitPrefix(resource, consumptionScope),
+      storeClient: RateLimitService.redis,
+      rejectIfRedisNotReady: true,
+    });
+  }
+
+  private consumptionKey(
+    scope: ApiAccessScope,
+    consumptionScope: RateLimitConsumptionScope,
+  ) {
+    return consumptionScope.type === "user"
+      ? `${scope.orgId}:user:${consumptionScope.userId}`
+      : scope.orgId;
   }
 
   rateLimitPrefix(
@@ -215,13 +252,28 @@ export class RateLimitService {
 
 export class RateLimitHelper {
   res: RateLimitResult | undefined;
+  private readonly refundConsumedPoint?: () => Promise<void>;
+  private isRefunded = false;
 
-  constructor(res: RateLimitResult | undefined) {
+  constructor(
+    res: RateLimitResult | undefined,
+    refundConsumedPoint?: () => Promise<void>,
+  ) {
     this.res = res;
+    this.refundConsumedPoint = refundConsumedPoint;
   }
 
   isRateLimited() {
-    return this.res ? this.res.remainingPoints < 1 : false;
+    return this.res ? isRateLimitExceeded(this.res) : false;
+  }
+
+  async refund() {
+    if (!this.refundConsumedPoint || this.isRefunded) {
+      return;
+    }
+
+    this.isRefunded = true;
+    await this.refundConsumedPoint();
   }
 
   sendRestResponseIfLimited(
@@ -276,6 +328,29 @@ const getRateLimitConfig = (
 
   return customConfig || planBasedConfig;
 };
+
+const getEffectiveRateLimitConfig = (
+  scope: ApiAccessScope,
+  resource: z.infer<typeof RateLimitResource>,
+  consumptionScope: RateLimitConsumptionScope,
+) => {
+  const configuredRateLimit = getRateLimitConfig(scope, resource);
+
+  return consumptionScope.type === "user" && configuredRateLimit?.points
+    ? {
+        ...configuredRateLimit,
+        points: Math.max(
+          1,
+          Math.floor(
+            configuredRateLimit.points * consumptionScope.pointsMultiplier,
+          ),
+        ),
+      }
+    : configuredRateLimit;
+};
+
+const isRateLimitExceeded = (result: RateLimitResult) =>
+  result.consumedPoints > result.points;
 
 const getPlanBasedRateLimitConfig = (
   plan: Plan,

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -35,6 +35,14 @@ export type RateLimitResponseOptionsInput =
   | PublicApiErrorContract
   | RateLimitResponseOptions;
 
+export type RateLimitConsumptionScope =
+  | { type: "organization" }
+  | {
+      type: "user";
+      userId: string;
+      pointsMultiplier: number;
+    };
+
 const normalizeRateLimitResponseOptions = (
   options?: RateLimitResponseOptionsInput,
 ): RateLimitResponseOptions => {
@@ -80,6 +88,7 @@ export class RateLimitService {
   async rateLimitRequest(
     scope: ApiAccessScope,
     resource: z.infer<typeof RateLimitResource>,
+    consumptionScope: RateLimitConsumptionScope = { type: "organization" },
   ) {
     // if cloud config is not present, we don't apply rate limits and just return
     if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
@@ -95,14 +104,29 @@ export class RateLimitService {
       return new RateLimitHelper(undefined);
     }
 
-    return new RateLimitHelper(await this.checkRateLimit(scope, resource));
+    return new RateLimitHelper(
+      await this.checkRateLimit(scope, resource, consumptionScope),
+    );
   }
 
   async checkRateLimit(
     scope: ApiAccessScope,
     resource: z.infer<typeof RateLimitResource>,
+    consumptionScope: RateLimitConsumptionScope = { type: "organization" },
   ) {
-    const effectiveConfig = getRateLimitConfig(scope, resource);
+    const configuredRateLimit = getRateLimitConfig(scope, resource);
+    const effectiveConfig =
+      consumptionScope.type === "user" && configuredRateLimit?.points
+        ? {
+            ...configuredRateLimit,
+            points: Math.max(
+              1,
+              Math.floor(
+                configuredRateLimit.points * consumptionScope.pointsMultiplier,
+              ),
+            ),
+          }
+        : configuredRateLimit;
 
     // returning early if no rate limit is set
     if (
@@ -127,15 +151,19 @@ export class RateLimitService {
       points: effectiveConfig.points, // Number of points
       duration: effectiveConfig.durationInSec, // Per second(s)
 
-      keyPrefix: this.rateLimitPrefix(resource), // must be unique for limiters with different purpose
+      keyPrefix: this.rateLimitPrefix(resource, consumptionScope.type), // must be unique for limiters with different purpose
       storeClient: RateLimitService.redis,
       rejectIfRedisNotReady: true,
     });
 
+    const consumptionKey =
+      consumptionScope.type === "user"
+        ? `${scope.orgId}:user:${consumptionScope.userId}`
+        : scope.orgId;
+
     let res: RateLimitResult | undefined = undefined;
     try {
-      // orgId used as key for different resources
-      const libRes = await rateLimiter.consume(scope.orgId);
+      const libRes = await rateLimiter.consume(consumptionKey);
       res = {
         resource,
         scope,
@@ -169,14 +197,19 @@ export class RateLimitService {
         orgId: scope.orgId,
         plan: scope.plan,
         resource: resource,
+        rateLimitScope: consumptionScope.type,
       });
     }
 
     return res;
   }
 
-  rateLimitPrefix(resource: string) {
-    return `${RATE_LIMIT_REDIS_KEY_PREFIX}:${resource}`;
+  rateLimitPrefix(
+    resource: string,
+    consumptionScope: RateLimitConsumptionScope["type"] = "organization",
+  ) {
+    const basePrefix = `${RATE_LIMIT_REDIS_KEY_PREFIX}:${resource}`;
+    return consumptionScope === "user" ? `${basePrefix}:user` : basePrefix;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a per-user rate-limit bucket to in-app agent runs while preserving the existing organization-wide quota.

Each authenticated user can consume up to 50% of the organization's effective in-app agent allowance per window. The effective allowance continues to come from the organization's plan and any existing `rateLimitOverrides`, so custom Cloud limits automatically scale the user bucket without adding a second configuration surface.

The user bucket is consumed before the organization bucket. Once a user reaches their own limit, further attempts are rejected without consuming the shared organization allowance. Requests that pass the user check still consume the existing organization bucket, so aggregate spend remains capped.

This applies consistently to:

- the foreground in-app agent API route;
- the background `startRun` mutation;
- tool-approval continuation requests; and
- instance administrators as well as project members.

`RateLimitService` now supports an explicit user consumption scope with a separate Redis key namespace. User keys contain both the organization ID and the authenticated server-side user ID, preventing collisions across organizations while leaving all existing organization rate-limit keys unchanged.

Fixes #15736

## Security considerations

- The user key is derived from the authenticated session, not request input.
- The organization ID remains part of every user bucket key, preserving tenant isolation.
- Existing organization quotas and Redis fail-open behavior are unchanged.
- No authorization, secret-handling, outbound-request, or public API contract behavior changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- Added a focused unit regression suite for distinct user buckets, retained organization consumption, and short-circuiting after a user limit is reached.
- Added Redis-backed coverage for per-user key isolation within an organization.
- Updated foreground-route coverage to verify both regular users and instance admins use their authenticated user bucket.
- Confirmed the new unit test failed before the production implementation and passed afterward.
- `Tests  2 passed (2)` — focused in-app agent rate-limit unit suite.
- `Tasks: 7 successful, 7 total` — repository lint.
- Web TypeScript check completed successfully (`tsc --noEmit`, exit 0).
- `All matched files use Prettier code style!`

The Redis-backed server suite could not execute locally because Redis was unavailable at `127.0.0.1:6379`; its setup timed out after repeated `ECONNREFUSED` errors (`Tests 15 skipped (15)`). The test is included for CI, where the service dependency is available. Database-backed route tests were not run locally for the same unavailable local service stack; their mock expectations were updated and are covered by typechecking and CI.

No documentation, schema generation, or browser verification is required because this is a server-only behavior change with no public contract or UI changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a per-user in-app-agent quota layered over the existing organization quota.
- Extends RateLimitService with user-scoped Redis keys and scaled point allowances.
- Applies the user bucket to foreground runs, background starts, and tool-approval continuations.
- Adds unit, route-auth, and Redis-backed coverage for user isolation and short-circuiting.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The quota-consumption and small-override failures need to be fixed before merging.

Organization-level rejections currently consume personal quota, while valid one- or two-point overrides cause the new user bucket to reject every run.

**Files Needing Attention:** web/src/features/in-app-agent/server/rateLimit.ts; web/src/features/public-api/server/RateLimitService.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant Agent as In-app agent endpoint
  participant UserBucket as User Redis bucket
  participant OrgBucket as Organization Redis bucket
  User->>Agent: Start or continue run
  Agent->>UserBucket: Consume one point
  alt User bucket rejects
    UserBucket-->>Agent: Limited
    Agent-->>User: 429
  else User bucket accepts
    UserBucket-->>Agent: Consumed
    Agent->>OrgBucket: Consume one point
    alt Organization bucket rejects
      OrgBucket-->>Agent: Limited
      Agent-->>User: 429 (user point remains consumed)
    else Organization bucket accepts
      OrgBucket-->>Agent: Consumed
      Agent-->>User: Run proceeds
    end
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/in-app-agent/server/rateLimit.ts:94-98
**Organization rejection drains user quota**

When the organization bucket is exhausted while the user still has capacity, the user-scoped consume succeeds before the organization-scoped consume rejects. The run is aborted, but the user's point remains consumed, so repeated organization-limited attempts can exhaust that user's personal allowance without starting any runs.

### Issue 2
web/src/features/public-api/server/RateLimitService.ts:117-128
**One-point buckets reject immediately**

When an `in-app-agent-run` override contains one or two points, scaling produces a one-point user bucket. Its first consume leaves zero remaining points, which `isRateLimited()` immediately classifies as limited, causing every agent run under these valid override values to be rejected.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(in-app-agent): add per-user run rat..."](https://github.com/langfuse/langfuse/commit/25fabbedd184780c52b6367dc344e8f8dcaded6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49784286)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)
- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->