### PR TITLE
chore(ui): remove json beta migration shim

### DIFF
--- a/web/src/components/trace/contexts/ViewPreferencesContext.clienttest.tsx
+++ b/web/src/components/trace/contexts/ViewPreferencesContext.clienttest.tsx
@@ -1,0 +1,43 @@
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import {
+  useViewPreferences,
+  ViewPreferencesProvider,
+} from "./ViewPreferencesContext";
+import { useJsonBetaToggle } from "../hooks/useJsonBetaToggle";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ViewPreferencesProvider>{children}</ViewPreferencesProvider>
+);
+
+describe("JSON beta preference", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("does not enable JSON beta from the expired jsonViewPreference migration", () => {
+    localStorage.setItem("jsonViewPreference", JSON.stringify("json-beta"));
+
+    const preferences = renderHook(() => useViewPreferences(), { wrapper });
+    const toggle = renderHook(() => useJsonBetaToggle("json", vi.fn()));
+
+    expect(preferences.result.current.jsonBetaEnabled).toBe(false);
+    expect(toggle.result.current.jsonBetaEnabled).toBe(false);
+  });
+
+  it("keeps an explicit jsonBetaEnabled preference", () => {
+    localStorage.setItem("jsonViewPreference", JSON.stringify("json-beta"));
+    localStorage.setItem("jsonBetaEnabled", JSON.stringify(true));
+
+    const preferences = renderHook(() => useViewPreferences(), { wrapper });
+    const toggle = renderHook(() => useJsonBetaToggle("json", vi.fn()));
+
+    expect(preferences.result.current.jsonBetaEnabled).toBe(true);
+    expect(toggle.result.current.jsonBetaEnabled).toBe(true);
+  });
+});

--- a/web/src/components/trace/contexts/ViewPreferencesContext.tsx
+++ b/web/src/components/trace/contexts/ViewPreferencesContext.tsx
@@ -136,12 +136,9 @@ export function ViewPreferencesProvider({
     useLocalStorage<LogViewTreeStyle>("logViewTreeStyle", "flat");
   const [jsonViewPreference, setJsonViewPreference] =
     useLocalStorage<JsonViewPreference>("jsonViewPreference", "pretty");
-  // Migration: default to true if user had json-beta selected previously
-  // TODO: Remove migration logic after 2025-01-26 (2 weeks) when user settings are migrated
   const [jsonBetaEnabled, setJsonBetaEnabled] = useLocalStorage<boolean>(
     "jsonBetaEnabled",
-    typeof window !== "undefined" &&
-      localStorage.getItem("jsonViewPreference") === '"json-beta"',
+    false,
   );
   // Shared with the inline expand/collapse toggle on system prompt messages;
   // instances sync via useLocalStorage's localStorageChange events.

--- a/web/src/components/trace/hooks/useJsonBetaToggle.ts
+++ b/web/src/components/trace/hooks/useJsonBetaToggle.ts
@@ -14,12 +14,9 @@ export function useJsonBetaToggle(
   currentView: ViewMode,
   setCurrentView: (view: ViewMode) => void,
 ) {
-  // Migration: default to true if user had json-beta selected previously
-  // TODO: Remove migration logic after 2025-01-26 (2 weeks) when user settings are migrated
   const [jsonBetaEnabled, setJsonBetaEnabled] = useLocalStorage<boolean>(
     "jsonBetaEnabled",
-    typeof window !== "undefined" &&
-      localStorage.getItem("jsonViewPreference") === '"json-beta"',
+    false,
   );
 
   // Derive UI tab selection (2 tabs: pretty or json)


### PR DESCRIPTION
## Summary

Closes #15738.

- removes the expired `jsonViewPreference === "json-beta"` localStorage migration seed from both JSON beta preference owners
- defaults missing `jsonBetaEnabled` to `false` directly while preserving explicit stored `jsonBetaEnabled` values
- adds client coverage for both `ViewPreferencesProvider` and `useJsonBetaToggle`

## Impacted packages

- `web`

## Verification

- Failing test before fix: `Tests  1 failed | 1 passed (2)`
- `DATABASE_URL=... NEXTAUTH_URL=... SALT=... CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=... pnpm --filter web run test-client src/components/trace/contexts/ViewPreferencesContext.clienttest.tsx` -> `Tests  2 passed (2)`
- `DATABASE_URL=... NEXTAUTH_URL=... SALT=... CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=... pnpm run lint` -> `Tasks:    7 successful, 7 total`
- commit hook `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` -> `All matched files use Prettier code style!`
- commit hook `turbo run lint` -> `Tasks:    7 successful, 7 total`
- `DATABASE_URL=... NEXTAUTH_URL=... SALT=... CLICKHOUSE_URL=... CLICKHOUSE_USER=... CLICKHOUSE_PASSWORD=... pnpm --filter web run typecheck` -> `tsc` exited 0

## Browser review

- Not run: no Playwright browser MCP tool was exposed in this Codex session. The changed behavior is covered by the targeted client regression test.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the expired JSON beta migration fallback.
- Defaults a missing `jsonBetaEnabled` preference to `false` in both preference owners.
- Continues to preserve explicitly stored `jsonBetaEnabled` values.
- Adds client tests covering missing and explicitly enabled preferences.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

Explicit stored preferences remain authoritative through the shared localStorage hook, while only users without the dedicated preference key receive the intended false default.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ui): remove json beta migration sh..."](https://github.com/langfuse/langfuse/commit/2299a368835da2b513bee9fb0172c72e999510bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49796098)</sub>

<!-- /greptile_comment -->