### PR TITLE
docs(agents): add setup-local-dev skill

### DIFF
--- a/.agents/skills/setup-local-dev/SKILL.md
+++ b/.agents/skills/setup-local-dev/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: setup-local-dev
+description: |
+  Bring a Langfuse checkout from scratch to a running local dev stack. Use for
+  first-time setup, a fresh clone or git worktree, day-to-day start/stop, or
+  when web or worker will not start locally.
+---
+
+# Set Up Local Dev
+
+## The mental model
+
+Local Langfuse is **hybrid, not "all in Docker"**:
+
+- **Docker** runs the stateful services only — Postgres, ClickHouse server, Redis, MinIO
+  (`docker-compose.dev.yml`).
+- **The host** runs the app: `web` (:3000) and `worker` (:3030) under `pnpm run dev`, so
+  hot reload works.
+- **Host CLIs** apply schema *to* the containers: `migrate` (golang-migrate) for ClickHouse
+  migrations, `clickhouse client` for dev tables.
+
+That third bullet is why host tools are still needed even though the databases are
+containerised. Assuming otherwise is the most common wrong turn.
+
+Do **not** start with `pnpm run dx`. CONTRIBUTING documents it as failing on the very
+first run, and it wipes existing data. Use the ordered steps below; `dx` is for later.
+
+## 1. Preflight
+
+```bash
+bash .agents/skills/setup-local-dev/scripts/preflight.sh
+```
+
+Prints PASS/WARN/FAIL for repo root, node, pnpm, Docker daemon, `migrate`, `clickhouse`
+and ports, with an exact fix command per failure. Expected versions are read from
+`package.json`, so its output is authoritative over anything written here.
+
+Fix every FAIL, then re-run until it exits 0.
+
+**Node** — install and select the major version, not the `.nvmrc` pin:
+`nvm install 24 && nvm use 24`. A bare `nvm use` reads `.nvmrc`, which pins an exact
+patch version that is often not installed locally, and fails.
+
+**pnpm** — run the command preflight printed (it substitutes the pinned version):
+
+```bash
+corepack enable && corepack prepare pnpm@<pinned version> --activate
+```
+
+**Docker** — `open -a Docker`, then wait until `docker info` succeeds.
+
+**golang-migrate** — `brew install golang-migrate`. No Homebrew: download the darwin
+binary from the golang-migrate GitHub releases, matching the version CI pins.
+
+**ClickHouse client** — install a Docker shim rather than the standalone binary (the trick
+`.github/workflows/pipeline.yml` uses). Do not `brew install --cask clickhouse`: that cask
+is deprecated, self-removes after installing, and leaves an **815 MB** binary behind.
+
+```bash
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/clickhouse <<'SHIM'
+#!/usr/bin/env bash
+exec docker exec -i langfuse-clickhouse clickhouse "$@"
+SHIM
+chmod +x ~/.local/bin/clickhouse
+
+# ~/.local/bin is not on PATH by default on a fresh Mac.
+grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' ~/.zshrc 2>/dev/null \
+  || printf '\nexport PATH="$HOME/.local/bin:$PATH"\n' >> ~/.zshrc
+export PATH="$HOME/.local/bin:$PATH"
+command -v clickhouse
+```
+
+The shim needs the `langfuse-clickhouse` container running — always true at the point it
+is used, but it will fail if invoked before step 3. Inside the container the
+`--host localhost --port 9000` that the scripts pass resolves to the server itself, so it
+works unchanged.
+
+## 2. Environment files
+
+```bash
+cp .env.dev.example .env
+cp .env.test.example .env.test
+```
+
+Keep the dev defaults. `.env*` is gitignored and **per-checkout** — every new worktree
+needs this step again. Skip `.env.test` only if the test suites are not needed; without
+it `db:reset:test` silently does nothing.
+
+## 3. Install and start infrastructure
+
+```bash
+pnpm install
+pnpm run infra:dev:up
+```
+
+Verify: `docker ps` shows `langfuse-postgres`, `langfuse-clickhouse`, `langfuse-redis`,
+`langfuse-minio`. `infra:dev:up` passes `--wait`, so it only returns once healthchecks
+pass.
+
+## 4. Postgres schema and seed data
+
+```bash
+pnpm --filter=shared run db:generate
+pnpm --filter=shared run db:deploy
+pnpm --filter=shared run db:seed:examples
+```
+
+`db:deploy` applies migrations without the interactive reset prompt. `db:seed:examples`
+is a **superset** of the base seed — running it alone is enough. It creates login
+`demo@langfuse.com` / `password` and project `7a88fb47-b4e2-43b8-a06c-a5ce950dc53a`.
+
+## 5. ClickHouse schema and seed data
+
+```bash
+pnpm --filter=shared run ch:up
+pnpm --filter=shared run ch:seed
+pnpm --filter=shared run ch:dev-tables
+```
+
+**Order matters** and mirrors `ch:reset`. `ch:up` needs `migrate`; `ch:dev-tables` needs
+`clickhouse`; `ch:seed` reads projects seeded in step 4, so it must come after it.
+
+## 6. Test database
+
+```bash
+pnpm --filter=shared run db:reset:test
+```
+
+Creates/resets `langfuse_test` using the `.env.test` overrides. Non-interactive.
+
+## 7. Run and verify
+
+```bash
+pnpm run dev
+```
+
+The worker answers on :3030 within seconds, but the **web app's first Turbopack compile
+takes several minutes** during which :3000 refuses connections. That is normal on a cold
+checkout — do not conclude the setup is broken. Keep the process in a background shell and
+do not pipe it through `tail`/`head`, which buffer and hide the startup output.
+
+Then confirm all four:
+
+```bash
+curl -s http://localhost:3000/api/public/ready   # {"status":"OK","version":"..."}
+curl -s http://localhost:3030/api/ready          # {"status":"ok"}  — note: NOT /api/public/ready
+pnpm run seed -- doctor                          # every check PASS
+```
+
+- Both endpoints answer as above.
+- <http://localhost:3000> loads and `demo@langfuse.com` / `password` logs in.
+- `pnpm run seed -- doctor` reports PASS for every check.
+
+`doctor` is the authoritative end-to-end verification. Setup is not done until it is
+clean.
+
+## Daily loop
+
+```bash
+open -a Docker          # only if the daemon is not already running
+pnpm run infra:dev:up   # idempotent, seconds; volumes persist
+pnpm run dev            # web :3000 + worker :3030
+```
+
+Stop with `Ctrl+C`; containers can stay up. `pnpm run infra:dev:down` stops them without
+data loss.
+
+Reach for the slow paths only when needed:
+
+- `pnpm run dx` — wipe, re-migrate, re-seed. Use after pulling schema changes or switching
+  between branches with divergent migrations.
+- `pnpm run infra:dev:prune` — **destroys all volumes**. Confirm with the user first.
+
+## Troubleshooting
+
+**Run `pnpm run seed -- doctor` before debugging anything by hand.** It checks Postgres,
+migrations, the seeded project, ClickHouse, v4 dev tables, Redis and blob storage, and
+prints the exact fix command per failure.
+
+`doctor` cannot run before `pnpm install` and `.env` exist — that layer is what
+`preflight.sh` covers.
+
+| Symptom | Cause and fix |
+| --- | --- |
+| `Module not found: Can't resolve '@langfuse/shared'` under `next dev` | Next.js infers the workspace root from the *outermost* lockfile, so a worktree nested inside another checkout resolves the relative turbopack alias against the wrong root. Pin `turbopack.root` in `web/next.config.mjs`, or use `pnpm run dev:web-webpack`. |
+| `clickhouse: command not found` during `ch:dev-tables` | Shim missing from `PATH`, or the `langfuse-clickhouse` container is not running. |
+| `ERR_PNPM_FETCH_404` on one tarball during `pnpm install` | A corporate npm mirror (check `registry` in `~/.npmrc`) lags behind npmjs and lacks that exact version. Confirm with `curl -o /dev/null -w '%{http_code}' https://registry.npmjs.org/<pkg>/-/<pkg>-<version>.tgz`; if it returns 200, install once against the public registry: `pnpm install --registry https://registry.npmjs.org/`. The lockfile pins versions and integrity hashes, so only the download host changes. Do not edit the user's global `~/.npmrc`. |
+| Port already allocated on `infra:dev:up` | Container names, host ports and volumes are **global**. Two checkouts share one stack — run only one at a time, or set the `*_HOST_PORT` overrides in `.env`. |
+| `open -a Docker` exits 0 but no daemon appears | Docker Desktop is wedged mid-shutdown (`docker desktop status` shows `stopping`) and silently refuses to relaunch. Kill the leftover `com.docker.backend` / `com.docker.build` / `com.docker.dev-envs` PIDs from `ps aux \| grep com.docker`, then `open -a Docker` again. |
+| Migrations or seeds behave oddly after switching branches | The schema moved. Run `pnpm run dx`. |
+
+## Starting over
+
+Destructive — confirm with the user before running:
+
+```bash
+pnpm run infra:dev:prune                  # deletes all Docker volumes
+rm -f .env .env.test
+rm -rf node_modules */node_modules packages/*/node_modules
+```
+
+Prefer this over `pnpm run nuke`, which also runs `pnpm store prune` and forces a full
+dependency re-download.
+
+## Related skills
+
+- `seed-test-data` — richer local data once the stack runs (complex traces, sessions,
+  bulk data). Never write ad-hoc seed scripts.
+- `langfuse-codebase-navigator` — where code lives, once the stack is up.

--- a/.agents/skills/setup-local-dev/agents/openai.yaml
+++ b/.agents/skills/setup-local-dev/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Set Up Local Dev"
+  short_description: "Bootstrap a Langfuse checkout to a running stack"
+  default_prompt: "Use $setup-local-dev to bring this Langfuse checkout to a running local dev stack."

--- a/.agents/skills/setup-local-dev/scripts/preflight.sh
+++ b/.agents/skills/setup-local-dev/scripts/preflight.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Host prerequisite check for local Langfuse development.
+#
+# Complements `pnpm run seed -- doctor`, which can only run *after* `pnpm install`
+# and `.env` exist. This script checks the layer underneath: the host tools needed
+# to get that far.
+#
+# Exit 0 = every required check passed. Exit 1 = at least one FAIL.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+fail_count=0
+warn_count=0
+
+pass() { printf 'PASS  %-22s %s\n' "$1" "$2"; }
+warn() {
+  printf 'WARN  %-22s %s\n' "$1" "$2"
+  printf '      %-22s fix: %s\n' "" "$3"
+  warn_count=$((warn_count + 1))
+}
+fail() {
+  printf 'FAIL  %-22s %s\n' "$1" "$2"
+  printf '      %-22s fix: %s\n' "" "$3"
+  fail_count=$((fail_count + 1))
+}
+
+echo "Langfuse host preflight — $REPO_ROOT"
+echo
+
+# --- repo root ---------------------------------------------------------------
+if [ -f package.json ] && grep -q '"name": *"langfuse"' package.json; then
+  pass "repo-root" "$REPO_ROOT"
+else
+  fail "repo-root" "not a Langfuse checkout" \
+    "run this script from inside a Langfuse checkout"
+  echo
+  echo "Aborting: cannot check anything else without the repo."
+  exit 1
+fi
+
+# Expected versions are read from package.json so this script cannot go stale.
+expected_node="$(sed -n 's/.*"node": *"\([^"]*\)".*/\1/p' package.json | head -1)"
+expected_pnpm="$(sed -n 's/.*"packageManager": *"pnpm@\([^"]*\)".*/\1/p' package.json | head -1)"
+expected_node="${expected_node:-24}"
+expected_pnpm="${expected_pnpm:-latest}"
+
+# --- node --------------------------------------------------------------------
+if command -v node >/dev/null 2>&1; then
+  node_version="$(node --version 2>/dev/null)"
+  node_major="$(printf '%s' "$node_version" | sed 's/^v//' | cut -d. -f1)"
+  if [ "$node_major" = "$expected_node" ]; then
+    pass "node" "$node_version (engines wants $expected_node)"
+  else
+    fail "node" "$node_version, but package.json engines wants $expected_node" \
+      "nvm install $expected_node && nvm use $expected_node"
+  fi
+else
+  fail "node" "not found" \
+    "install Node $expected_node (nvm install $expected_node)"
+fi
+
+# --- pnpm --------------------------------------------------------------------
+# corepack ships with Node and is the supported way to get the pinned pnpm.
+if command -v pnpm >/dev/null 2>&1; then
+  pass "pnpm" "$(pnpm --version 2>/dev/null) (pinned $expected_pnpm)"
+else
+  fail "pnpm" "not found" \
+    "corepack enable && corepack prepare pnpm@$expected_pnpm --activate"
+fi
+
+# --- docker daemon -----------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  fail "docker" "docker CLI not found" \
+    "install Docker Desktop: https://docs.docker.com/desktop/"
+elif docker info >/dev/null 2>&1; then
+  pass "docker" "daemon responding"
+else
+  fail "docker" "CLI present but daemon not responding" \
+    "open -a Docker   # then wait until 'docker info' succeeds"
+fi
+
+# --- golang-migrate ----------------------------------------------------------
+# Runs on the HOST against the ClickHouse container; not bundled in the image.
+if command -v migrate >/dev/null 2>&1; then
+  pass "golang-migrate" "$(command -v migrate)"
+else
+  fail "golang-migrate" "not found (needed by ch:up)" \
+    "brew install golang-migrate"
+fi
+
+# --- clickhouse client -------------------------------------------------------
+# ch:dev-tables shells out to `clickhouse client`. A Docker shim avoids the
+# ~300MB standalone binary; this is the trick .github/workflows/pipeline.yml uses.
+if command -v clickhouse >/dev/null 2>&1; then
+  pass "clickhouse" "$(command -v clickhouse)"
+else
+  fail "clickhouse" "not found (needed by ch:dev-tables)" \
+    "install the Docker shim — see the 'ClickHouse client' step in SKILL.md"
+fi
+
+# --- ports -------------------------------------------------------------------
+# WARN, not FAIL: on a re-run the Langfuse containers legitimately hold these.
+if command -v lsof >/dev/null 2>&1; then
+  busy=""
+  for port in 3000 3030 5432 6379 8123 9000 9090 9091; do
+    if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+      busy="$busy $port"
+    fi
+  done
+  if [ -z "$busy" ]; then
+    pass "ports" "3000 3030 5432 6379 8123 9000 9090 9091 free"
+  else
+    warn "ports" "in use:$busy" \
+      "fine if these are your own Langfuse containers; otherwise free them or set *_HOST_PORT overrides in .env"
+  fi
+else
+  warn "ports" "lsof unavailable, not checked" \
+    "check manually if 'infra:dev:up' reports a port conflict"
+fi
+
+# --- summary -----------------------------------------------------------------
+echo
+if [ "$fail_count" -gt 0 ]; then
+  echo "preflight: $fail_count FAIL, $warn_count WARN — fix the FAILs above, then re-run."
+  exit 1
+fi
+echo "preflight: all required checks passed ($warn_count WARN)."
+exit 0


### PR DESCRIPTION
## What does this PR do?

Adds a repo-owned agent skill that takes a Langfuse checkout from scratch to a running local dev stack.

Implements the proposal in #15751, which carries the full rationale. That issue also asks whether a community-contributed skill is something you want in `.agents/skills/` at all, given every recent skill PR is maintainer-authored — happy to close this if the area should stay maintainer-owned.

### Why

No existing skill covers this. Across the 31 skills in `.agents/skills/`, `infra:dev:up`, `dx` and `corepack` appear in **none** of them; `golang-migrate` and `.env.dev.example` appear only as passing mentions in reference docs, never as a procedure. `seed-test-data` is the nearest neighbour, and its `pnpm run seed -- doctor` is the right tool once the stack exists, but `doctor` structurally cannot run before `pnpm install` and `.env` do, so the bootstrap layer underneath it is uncovered.

The practical consequence is in #15751: an agent asked to set the project up falls back to `CONTRIBUTING.md` and hits the broken ClickHouse cask.

### Scope

Deliberately narrow: **zero to running stack**, then hand off. The skill delegates data seeding to `seed-test-data`, runtime diagnosis to `pnpm run seed -- doctor`, and code orientation to `langfuse-codebase-navigator` rather than restating any of them.

`scripts/preflight.sh` covers only the layer `doctor` cannot: node major, pnpm, Docker daemon, `migrate`, `clickhouse`, and port availability. Expected versions are parsed from `package.json` so the script cannot drift from the repo. Ports are WARN rather than FAIL so re-running against an already-running stack is not blocked.

### Two intentional divergences from CONTRIBUTING, flagged for review

- **The skill says not to start with `pnpm run dx`.** CONTRIBUTING recommends it while also stating it fails on the very first run. The ordered granular path avoids that failure mode.
- **The skill installs the ClickHouse client as a Docker shim**, the same trick `.github/workflows/pipeline.yml` already uses. CONTRIBUTING's binary route is currently broken; see #15751. The shim is 76 bytes versus 815 MB.

I am happy to align `CONTRIBUTING.md` with whichever way you decide, in this PR or a follow-up.

Relates to #15751

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Validation

The skill was executed end to end **three times on a real machine**, with a full teardown between runs: `pnpm run infra:dev:prune`, remove env files, remove `node_modules`, `brew uninstall golang-migrate`, remove the shim, `corepack disable`. Every failure was fixed **in the skill** and the step re-run from the corrected text, never patched by hand.

| Run | Skill edits required |
| --- | --- |
| 1 | 2 |
| 2 | 1 |
| 3 | **0, `doctor` 11/11 PASS** |

Defects that only surfaced by executing it:

- a corporate npm mirror lagging npmjs and 404-ing a single tarball
- the multi-minute silent first web compile, which reads as a hang
- `open -a Docker` exiting 0 while doing nothing when Docker Desktop is wedged mid-shutdown

A separate agent, given only the skill and no other context, then reproduced the sequence and surfaced two more gaps, both since fixed: `.nvmrc` pins a patch version that a bare `nvm use` cannot resolve, and `~/.local/bin` is not on `PATH` by default.

Checks run locally:

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run agents:check` — clean
- `pnpm i` then `git status --porcelain` — empty, so the agent-shim CI gate passes
- `quick_validate.py` — `Skill is valid!`
- prettier — `All matched files use Prettier code style!`
- codespell — clean
- knip — not applicable, `.agents/skills/**` is in knip's ignore list

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a repository-owned agent skill for taking a fresh Langfuse checkout through prerequisite checks, environment setup, database initialization, and local service verification.

- Documents the ordered local-development bootstrap and daily workflow.
- Adds a shell preflight for Node, pnpm, Docker, database CLIs, and ports.
- Adds OpenAI agent metadata for invoking the skill.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking issue where preflight can approve an unpinned pnpm installation.

The setup documentation and prerequisite checks are coherent, but the pnpm branch only tests executable presence despite presenting the package.json pin as the expected version.

**Files Needing Attention:** .agents/skills/setup-local-dev/scripts/preflight.sh
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Run host preflight] --> B[Create environment files]
  B --> C[Install dependencies]
  C --> D[Start Docker infrastructure]
  D --> E[Initialize Postgres]
  E --> F[Initialize ClickHouse]
  F --> G[Reset test database]
  G --> H[Run web and worker]
  H --> I[Verify readiness and run doctor]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.agents/skills/setup-local-dev/scripts/preflight.sh:69-70
**Validate the pinned pnpm version**

When a developer has any pnpm version on `PATH`, this branch reports PASS without comparing it to the repository pin, undermining the preflight guarantee and allowing incompatible install or lockfile behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): add setup-local-dev skill"](https://github.com/langfuse/langfuse/commit/9289914603df6642020de43bb26ab5b06d490481) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49935446)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->