### PR TITLE
fix(auth): resolve session with invalid callback-url cookie as unauthenticated

### DIFF
--- a/web/src/__tests__/server/unit/getServerAuthSessionCallbackCookie.servertest.ts
+++ b/web/src/__tests__/server/unit/getServerAuthSessionCallbackCookie.servertest.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { getServerAuthSession } from "@/src/server/auth";
+import { getCookieName } from "@/src/server/utils/cookies";
+
+// getServerSession only reads headers/cookies from the request and writes
+// response headers, so plain doubles are sufficient.
+const makeCtx = (cookies: Record<string, string>) => {
+  const headers: Record<string, unknown> = {};
+  return {
+    req: { cookies, headers: { host: "localhost:3000" } },
+    res: {
+      setHeader: (name: string, value: unknown) => {
+        headers[name] = value;
+      },
+      getHeader: (name: string) => headers[name],
+    },
+  } as unknown as Parameters<typeof getServerAuthSession>[0];
+};
+
+describe("getServerAuthSession callback-url cookie handling", () => {
+  it("resolves to null for an unauthenticated request when the callback-url cookie is fuzzed garbage", async () => {
+    // Payload observed in the 2026-08-03 prod-us/prod-eu scanner sweep.
+    // NextAuth's assertConfig classifies a non-URL callback-url cookie as a
+    // server misconfiguration and rejects the whole request with a 500.
+    const ctx = makeCtx({
+      [getCookieName("next-auth.callback-url")]: " /bin/sleep 0 \r",
+    });
+
+    await expect(getServerAuthSession(ctx)).resolves.toBeNull();
+  });
+
+  it("resolves to null for an unauthenticated request with a valid relative callback-url cookie", async () => {
+    const ctx = makeCtx({
+      [getCookieName("next-auth.callback-url")]: "/project/some-project-id",
+    });
+
+    await expect(getServerAuthSession(ctx)).resolves.toBeNull();
+  });
+});

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -1152,6 +1152,20 @@ export async function getAuthOptions(signupAttribution?: {
 }
 
 /**
+ * Mirrors NextAuth's `isValidHttpUrl` (core/lib/assert.js): relative URLs
+ * resolve against the base URL, absolute ones must parse as http(s).
+ */
+const isValidHttpUrl = (url: string, baseUrl: string) => {
+  try {
+    return /^https?:/.test(
+      new URL(url, url.startsWith("/") ? baseUrl : undefined).protocol,
+    );
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Wrapper for `getServerSession` so that you don't need to import the `authOptions` in every file.
  *
  * @see https://next-auth.js.org/configuration/nextjs
@@ -1161,6 +1175,21 @@ export const getServerAuthSession = async (ctx: {
   res: GetServerSidePropsContext["res"];
 }) => {
   const authOptions = await getAuthOptions();
+
+  // NextAuth's assertConfig treats a malformed callback-url cookie as a server
+  // misconfiguration and rejects the whole request with a 500 — session reads
+  // included, so security scanners fuzzing cookie values turn every tRPC route
+  // into a 5xx (pages the tRPC error-rate monitors, see LFE-10960). The cookie
+  // only preserves a post-login redirect target; drop an invalid value and
+  // resolve the session as if it were absent.
+  const callbackUrlCookieName = getCookieName("next-auth.callback-url");
+  const callbackUrlCookie = ctx.req.cookies[callbackUrlCookieName];
+  if (
+    callbackUrlCookie !== undefined &&
+    !isValidHttpUrl(callbackUrlCookie, env.NEXTAUTH_URL)
+  ) {
+    delete ctx.req.cookies[callbackUrlCookieName];
+  }
   // https://github.com/nextauthjs/next-auth/issues/2408#issuecomment-1382629234
   // for api routes, we need to call the headers in the api route itself
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15754.preview.langfuse.com](https://pr-15754.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Problem

Security scanners (Burp-style sweep, 2026-08-03 on prod-us and prod-eu) replay browser sessions with the `__Secure-next-auth.callback-url.<REGION>` cookie fuzzed to injection payloads (`\x03 /bin/sleep 0 \r`, `WEB-INF/web.xml`, `oastify.com` callbacks, …).

NextAuth's `assertConfig` (`core/lib/assert.js`) validates that cookie on every `getServerSession` call and classifies a non-URL value as a **server misconfiguration**: it logs `INVALID_CALLBACK_URL_ERROR` and rejects the request with a 500 ("There is a problem with the server configuration"). Since `createTRPCContext` resolves the session before any procedure runs, every tRPC route hit with such a cookie returned a 500 — 229 requests across ~10 routes on 2026-08-03 (prod-us 14:04–18:42 UTC), paging `[PROD-US] Other tRPC APIs Error Rate` (monitor 237640603) at 16:14 and 18:42.

## Fix

In `getServerAuthSession`, drop a callback-url cookie that fails NextAuth's own `isValidHttpUrl` check before calling `getServerSession`. The cookie only preserves a post-login redirect target, so an invalid value is safe to treat as absent:

- scanner requests now resolve as unauthenticated → tRPC `UNAUTHORIZED` (401, info-level log, no error span, no page),
- a legitimate user with a corrupted cookie gets their session resolved instead of a 500,
- genuine server misconfigurations (e.g. missing secret) still surface as 500s.

This extends the existing scanner-hardening precedent in the same file (the custom `redirect` callback guarding `/api/auth/callback/*` against malformed callback URLs).

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test src/__tests__/server/unit/getServerAuthSessionCallbackCookie.servertest.ts` — new test reproduces the prod failure (rejects with "There is a problem with the server configuration" from `next-auth/next/index.js:149`) before the fix; after the fix: `Tests  2 passed (2)`.
- `pnpm run lint` — `Tasks: 7 successful, 7 total`.

## Ops context

Root-cause analysis of the 2026-08-03 alert firings lives in the incident-alert KB ticket [LFE-10960](https://linear.app/clickhouse/issue/LFE-10960/prod-eu-other-trpc-apis-error-rate) (covers the EU + US monitor twins). Follow-ups not in this PR: same cookie/query sanitization for direct `/api/auth/*` hits, and mapping superjson's prototype-pollution guard to 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents malformed NextAuth callback-url cookies from turning session resolution into HTTP 500 responses.
- Adds a pre-session callback-cookie validation and deletion step.
- Adds server tests for malformed and valid relative callback cookies.
- The new validation mishandles valid relative callback URLs on Vercel because its configured base lacks a URL scheme.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This needs correction before merging because Vercel deployments will discard valid relative callback destinations.

The new validator passes raw `env.NEXTAUTH_URL` to `new URL`; Vercel intentionally supplies this value without a scheme, causing valid relative callback cookies to fail validation and be deleted.

**Files Needing Attention:** web/src/server/auth.ts and its callback-cookie server test
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Request with callback-url cookie] --> B[getServerAuthSession]
  B --> C{Valid against env.NEXTAUTH_URL?}
  C -->|No| D[Delete callback cookie]
  C -->|Yes| E[Preserve callback cookie]
  D --> F[getServerSession]
  E --> F
  V[Vercel: NEXTAUTH_URL is protocol-less] --> C
  V --> G[Valid relative URL fails parsing]
  G --> D
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/server/auth.ts:1189
**Vercel base rejects relative callbacks**

On Vercel, `env.NEXTAUTH_URL` is populated from the protocol-less `VERCEL_URL`, so validating a legitimate relative callback such as `/project/some-project-id` against it returns false and deletes the cookie, causing users to lose their intended post-login destination.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): resolve session with invalid ..."](https://github.com/langfuse/langfuse/commit/7020fe83c2aa5dde3edbfe404ddadc4cfe1dca9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49941882)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)

<!-- /greptile_comment -->