### PR TITLE
feat(automations): remove API version dropdown from webhook actions

### DIFF
--- a/web/src/features/automations/components/actions/BaseActionHandler.ts
+++ b/web/src/features/automations/components/actions/BaseActionHandler.ts
@@ -24,8 +24,13 @@ export interface BaseActionHandler<
     errors?: string[];
   };
 
-  // Build the action config for API submission
-  buildActionConfig(formData: TFormData): ActionCreate;
+  // Build the action config for API submission. `eventSource` is passed for
+  // action types whose config depends on the trigger (webhooks derive their
+  // payload apiVersion from it); other handlers ignore it.
+  buildActionConfig(
+    formData: TFormData,
+    eventSource?: TriggerEventSource,
+  ): ActionCreate;
 
   // Render the action form UI - using any for form to allow flexibility
   renderForm(props: {

--- a/web/src/features/automations/components/actions/WebhookActionForm.tsx
+++ b/web/src/features/automations/components/actions/WebhookActionForm.tsx
@@ -8,20 +8,12 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/src/components/ui/select";
 import { X, Plus, RefreshCw, Lock, LockOpen } from "lucide-react";
 import { useFieldArray, type UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 import {
   type ActionDomain,
   type ActionDomainWithSecrets,
-  AvailableWebhookApiSchema,
   type SafeWebhookActionConfig,
   WebhookDefaultHeaders,
   WebhookProtectedHeaders,
@@ -66,7 +58,6 @@ export const webhookSchema = z.object({
       wasSecret: z.boolean(),
     }),
   ),
-  apiVersion: AvailableWebhookApiSchema,
 });
 
 export type WebhookFormValues = z.infer<typeof webhookSchema>;
@@ -137,35 +128,6 @@ export const WebhookActionForm: React.FC<WebhookActionFormProps> = ({
             <FormDescription>
               The HTTP URL to call when the trigger fires. We will send a POST
               request to this URL. Only HTTPS URLs are allowed for security.
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <FormField
-        control={form.control}
-        name="webhook.apiVersion.prompt"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>API Version</FormLabel>
-            <Select
-              onValueChange={field.onChange}
-              value={field.value}
-              disabled={disabled}
-            >
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select API version" />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                <SelectItem value="v1">v1</SelectItem>
-              </SelectContent>
-            </Select>
-            <FormDescription>
-              The API version to use for the webhook payload format when prompt
-              events are triggered.
             </FormDescription>
             <FormMessage />
           </FormItem>

--- a/web/src/features/automations/components/actions/WebhookActionHandler.clienttest.ts
+++ b/web/src/features/automations/components/actions/WebhookActionHandler.clienttest.ts
@@ -1,62 +1,43 @@
 import { describe, expect, it } from "vitest";
 
-import { type AutomationDomain, TriggerEventSource } from "@langfuse/shared";
+import { TriggerEventSource } from "@langfuse/shared";
 import { WebhookActionHandler } from "./WebhookActionHandler";
 
 const handler = new WebhookActionHandler();
 
-const webhookAutomation = (
-  apiVersion: Record<string, "v1">,
-): AutomationDomain =>
-  ({
-    id: "automation-1",
-    name: "test",
-    trigger: {
-      id: "trigger-1",
-      eventSource: TriggerEventSource.Monitor,
-      eventActions: ["created"],
-      filter: [],
-      status: "ACTIVE",
-    },
-    action: {
-      id: "action-1",
-      type: "WEBHOOK",
-      config: {
-        type: "WEBHOOK",
-        url: "https://example.com",
-        apiVersion,
-        displaySecretKey: "sk_...abcd",
-      },
-    },
-  }) as unknown as AutomationDomain;
+const formData = {
+  webhook: {
+    url: "https://example.com/hook",
+    headers: [],
+  },
+};
 
-describe("WebhookActionHandler.getDefaultValues", () => {
-  it("monitor-source new automation: seeds apiVersion { monitor: v1 }", () => {
-    expect(
-      handler.getDefaultValues(undefined, TriggerEventSource.Monitor).webhook
-        .apiVersion,
-    ).toEqual({ monitor: "v1" });
-  });
+const apiVersionFor = (eventSource?: TriggerEventSource) => {
+  const config = handler.buildActionConfig(formData, eventSource);
+  if (config.type !== "WEBHOOK") throw new Error("expected webhook config");
+  return config.apiVersion;
+};
 
-  it("prompt-source new automation: seeds apiVersion { prompt: v1 }", () => {
-    expect(
-      handler.getDefaultValues(undefined, TriggerEventSource.Prompt).webhook
-        .apiVersion,
-    ).toEqual({ prompt: "v1" });
-  });
-
-  it("no eventSource: seeds apiVersion { prompt: v1 }", () => {
-    expect(handler.getDefaultValues(undefined).webhook.apiVersion).toEqual({
-      prompt: "v1",
+// apiVersion is not user-editable; it is derived from the trigger's event
+// source at submit time so it cannot drift when the source changes.
+describe("WebhookActionHandler.buildActionConfig apiVersion", () => {
+  it("monitor source: derives { monitor: v1 }", () => {
+    expect(apiVersionFor(TriggerEventSource.Monitor)).toEqual({
+      monitor: "v1",
     });
   });
 
-  it("editing existing config: stored apiVersion wins over eventSource", () => {
-    expect(
-      handler.getDefaultValues(
-        webhookAutomation({ monitor: "v1" }),
-        TriggerEventSource.Prompt,
-      ).webhook.apiVersion,
-    ).toEqual({ monitor: "v1" });
+  it("prompt source: derives { prompt: v1 }", () => {
+    expect(apiVersionFor(TriggerEventSource.Prompt)).toEqual({ prompt: "v1" });
+  });
+
+  it("project-notification source: derives { project-notification: v1 }", () => {
+    expect(apiVersionFor(TriggerEventSource.ProjectNotification)).toEqual({
+      "project-notification": "v1",
+    });
+  });
+
+  it("no eventSource: falls back to { prompt: v1 }", () => {
+    expect(apiVersionFor(undefined)).toEqual({ prompt: "v1" });
   });
 });

--- a/web/src/features/automations/components/actions/WebhookActionHandler.tsx
+++ b/web/src/features/automations/components/actions/WebhookActionHandler.tsx
@@ -4,7 +4,7 @@ import { type BaseActionHandler } from "./BaseActionHandler";
 import { WebhookActionForm, formatWebhookHeaders } from "./WebhookActionForm";
 import {
   type AutomationDomain,
-  AvailableWebhookApiSchema,
+  type AvailableWebhookApiSchema,
   WebhookProtectedHeaders,
   TriggerEventSource,
   type ActionCreate,
@@ -29,11 +29,29 @@ export const WebhookActionFormSchema = z.object({
         }),
       )
       .default([]),
-    apiVersion: AvailableWebhookApiSchema.default({ prompt: "v1" }),
   }),
 });
 
 type WebhookActionFormData = z.infer<typeof WebhookActionFormSchema>;
+
+/**
+ * apiVersionForEventSource derives the stored webhook payload version from the
+ * trigger's event source. There is only one version per source today, so this
+ * is not user-editable and is deliberately not part of the form state — keeping
+ * it derived is what stops it from drifting when the event source changes.
+ */
+const apiVersionForEventSource = (
+  eventSource?: TriggerEventSource,
+): z.infer<typeof AvailableWebhookApiSchema> => {
+  switch (eventSource) {
+    case TriggerEventSource.Monitor:
+      return { monitor: "v1" };
+    case TriggerEventSource.ProjectNotification:
+      return { "project-notification": "v1" };
+    default:
+      return { prompt: "v1" };
+  }
+};
 
 // Define a type for header pairs
 type HeaderPair = {
@@ -73,26 +91,7 @@ export class WebhookActionHandler implements BaseActionHandler<WebhookActionForm
     return [];
   }
 
-  getDefaultValues(
-    automation?: AutomationDomain,
-    eventSource?: TriggerEventSource,
-  ): WebhookActionFormData {
-    // Extract apiVersion from existing config
-    let apiVersion: z.infer<typeof AvailableWebhookApiSchema> =
-      eventSource === TriggerEventSource.Monitor
-        ? { monitor: "v1" }
-        : eventSource === TriggerEventSource.ProjectNotification
-          ? { "project-notification": "v1" }
-          : { prompt: "v1" };
-    if (
-      automation?.action?.type === "WEBHOOK" &&
-      automation?.action?.config &&
-      "apiVersion" in automation.action.config &&
-      automation.action.config.apiVersion
-    ) {
-      apiVersion = automation.action.config.apiVersion;
-    }
-
+  getDefaultValues(automation?: AutomationDomain): WebhookActionFormData {
     return {
       webhook: {
         url:
@@ -102,7 +101,6 @@ export class WebhookActionHandler implements BaseActionHandler<WebhookActionForm
             automation.action.config.url) ||
           "",
         headers: this.parseHeaders(automation),
-        apiVersion,
       },
     };
   }
@@ -166,7 +164,10 @@ export class WebhookActionHandler implements BaseActionHandler<WebhookActionForm
     };
   }
 
-  buildActionConfig(formData: WebhookActionFormData): ActionCreate {
+  buildActionConfig(
+    formData: WebhookActionFormData,
+    eventSource?: TriggerEventSource,
+  ): ActionCreate {
     // Convert headers array to requestHeaders format
     let headersObject: Record<string, { secret: boolean; value: string }> = {};
 
@@ -178,7 +179,7 @@ export class WebhookActionHandler implements BaseActionHandler<WebhookActionForm
       type: "WEBHOOK",
       url: formData.webhook?.url || "",
       requestHeaders: headersObject,
-      apiVersion: formData.webhook?.apiVersion || { prompt: "v1" },
+      apiVersion: apiVersionForEventSource(eventSource),
     };
   }
 

--- a/web/src/features/automations/components/automationForm.clienttest.tsx
+++ b/web/src/features/automations/components/automationForm.clienttest.tsx
@@ -25,11 +25,25 @@ vi.mock("@/src/utils/api", () => ({
         useQuery: () => ({ data: undefined }),
       },
     },
+    // Pulled in by the prompt-source filter builder.
+    projects: { byId: { useQuery: () => ({ data: undefined }) } },
+    naturalLanguageFilters: {
+      createCompletion: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
   },
 }));
 
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: undefined, status: "unauthenticated" }),
+}));
+
 vi.mock("next/router", () => ({
-  useRouter: () => ({ asPath: "/", push: vi.fn() }),
+  // query.projectId is read by the prompt-source filter builder.
+  useRouter: () => ({
+    asPath: "/",
+    push: vi.fn(),
+    query: { projectId: "p1" },
+  }),
 }));
 
 vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
@@ -38,6 +52,11 @@ vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
 
 vi.mock("@/src/features/feature-flags/hooks/useIsFeatureEnabled", () => ({
   default: () => true,
+}));
+
+// Cloud-only: the Monitor option in the event-source picker is gated on this.
+vi.mock("@/src/features/organizations/hooks", () => ({
+  useLangfuseCloudRegion: () => ({ isLangfuseCloud: true, region: "US" }),
 }));
 
 import { AutomationForm } from "./automationForm";
@@ -73,7 +92,7 @@ describe("AutomationForm handleActionTypeChange", () => {
       />,
     );
 
-    // comboboxes: [0] eventSource, [1] actionType, [2] webhook apiVersion.
+    // comboboxes: [0] eventSource, [1] actionType.
     fireEvent.click(screen.getAllByRole("combobox")[1]);
     fireEvent.click(await screen.findByRole("option", { name: "Slack" }));
 
@@ -95,5 +114,48 @@ describe("AutomationForm handleActionTypeChange", () => {
 
     const payload = createAutomationMutateAsync.mock.calls[0][0];
     expect(payload.actionConfig.apiVersion).toEqual({ monitor: "v1" });
+  });
+
+  it("switching event source from prompt to monitor derives apiVersion monitor", async () => {
+    render(
+      <AutomationForm
+        projectId="p1"
+        isEditing={true}
+        prefill={{ actionType: "WEBHOOK" }}
+      />,
+    );
+
+    // comboboxes: [0] eventSource, [1] actionType.
+    fireEvent.click(screen.getAllByRole("combobox")[0]);
+    fireEvent.click(await screen.findByRole("option", { name: "Monitor" }));
+
+    fireEvent.change(screen.getByPlaceholderText(/automation name/i), {
+      target: { value: "My automation" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/https/i), {
+      target: { value: "https://example.com/hook" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save automation/i }));
+
+    await waitFor(() => {
+      expect(createAutomationMutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = createAutomationMutateAsync.mock.calls[0][0];
+    expect(payload.actionConfig.apiVersion).toEqual({ monitor: "v1" });
+  });
+
+  it("does not render an API version control for webhook actions", () => {
+    render(
+      <AutomationForm
+        projectId="p1"
+        isEditing={true}
+        prefill={{ actionType: "WEBHOOK" }}
+      />,
+    );
+
+    expect(screen.queryByText("API Version")).toBeNull();
+    expect(screen.queryByText("Select API version")).toBeNull();
   });
 });

--- a/web/src/features/automations/components/automationForm.tsx
+++ b/web/src/features/automations/components/automationForm.tsx
@@ -464,19 +464,13 @@ export const AutomationForm = ({
     if (actionType === "WEBHOOK") {
       // Use action handler to get default values with proper typing
       const handler = ActionHandlerRegistry.getHandler("WEBHOOK");
-      const webhookDefaults = handler.getDefaultValues(
-        automation,
-        resolvedEventSource,
-      );
+      const webhookDefaults = handler.getDefaultValues(automation);
       return {
         ...baseValues,
         actionType: "WEBHOOK" as const,
         webhook: {
           url: webhookDefaults.webhook.url || "",
           headers: webhookDefaults.webhook.headers || [],
-          apiVersion: webhookDefaults.webhook.apiVersion || {
-            prompt: "v1" as const,
-          },
         },
       };
     } else if (actionType === "SLACK") {
@@ -539,7 +533,10 @@ export const AutomationForm = ({
       return;
     }
 
-    const actionConfig = handler.buildActionConfig(data);
+    const actionConfig = handler.buildActionConfig(
+      data,
+      data.eventSource as TriggerEventSource,
+    );
 
     // Project-notification names are auto-generated from the destination (the
     // name field is hidden for this source; regenerated on every save so the
@@ -605,10 +602,7 @@ export const AutomationForm = ({
 
     if (value === "WEBHOOK") {
       const handler = ActionHandlerRegistry.getHandler("WEBHOOK");
-      const defaultValues = handler.getDefaultValues(
-        undefined,
-        form.getValues("eventSource") as TriggerEventSource,
-      );
+      const defaultValues = handler.getDefaultValues();
       form.setValue("webhook", defaultValues.webhook);
     } else if (value === "SLACK") {
       const handler = ActionHandlerRegistry.getHandler("SLACK");


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15755.preview.langfuse.com](https://pr-15755.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The webhook action form showed an "API Version" select whose only option was `v1`, asking the user to make a choice that does not exist yet. This removes the control and derives the stored `apiVersion` from the trigger's event source at submit time instead.

The persisted contract is unchanged: `AvailableWebhookApiSchema` and `WebhookActionConfigSchema` in `packages/shared` are untouched, and the JSON written to `Action.config` is identical for prompt-source webhooks. Only the two web-local zod *form* schemas lose the field.

Deriving the value also fixes a latent bug. The select was bound to a fixed `webhook.apiVersion.prompt` key even though `apiVersion` is a partial record keyed by event source (`prompt` | `monitor` | `project-notification`), and `handleEventSourceChange` never re-seeded the field. Switching the event source from Prompt to Monitor therefore saved `{ prompt: "v1" }` instead of `{ monitor: "v1" }`. Nothing reads the stored value today — the outbound `apiVersion` in the webhook body is hardcoded at dispatch — so the wrong key was inert, but it would become a real dispatch bug once versioning is used. `apiVersion` is now a pure function of the event source with no form state to drift.

Fixes LFE-14546

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Changes

- `WebhookActionForm.tsx` — drop the `API Version` `FormField` and its now-unused `Select*` imports; drop `apiVersion` from `webhookSchema`.
- `WebhookActionHandler.tsx` — add `apiVersionForEventSource`; `buildActionConfig` derives the value; delete the seeding block in `getDefaultValues`, including its "stored value wins over event source" special case.
- `BaseActionHandler.ts` — `buildActionConfig` takes an optional `eventSource`. The Slack and GitHub handlers are unchanged; they simply ignore it.
- `automationForm.tsx` — drop `apiVersion` from the webhook form defaults, pass the event source at submit. `handleEventSourceChange` needs no re-seed because there is no longer mirrored state to sync.

One behavioral note for reviewers: saving an existing automation now recomputes `apiVersion` from its current event source, so a legacy row carrying a mismatched key self-heals on next save.

## Verification

- `pnpm run lint` (pre-commit, full repo): `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-client src/features/automations`: `Tests 7 passed (7)`
- Both `apiVersion` assertions were confirmed to fail when the derivation is stubbed back to the old fixed-key behavior, so they are load-bearing rather than tautological.
- `pnpm --filter web run typecheck`: identical error set before and after this change (198 errors both ways, empty diff). Those are pre-existing in this environment and stem from Prisma client type resolution, not from this PR.
- Browser review against a local stack, signed in as the seeded demo user: the create form renders 2 comboboxes (Event Source, Action Type) where it previously rendered 3, no "API Version" text remains, and Webhook URL flows into Headers with no layout gap. Saving a prompt-source webhook persisted `{"prompt": "v1"}`; switching the source to Monitor and saving persisted `{"monitor": "v1"}` — verified directly in Postgres, and the latter is the case that was broken before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrXsZZsC2xqaVs4986JY9d)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes the single-option webhook API-version control and derives the persisted version from the selected trigger source during submission.

- Removes `apiVersion` from webhook form schemas, defaults, and rendered controls.
- Extends action-config construction with trigger-source context while leaving non-webhook handlers unchanged.
- Adds coverage for all supported trigger sources, event-source changes, action-type changes, and control removal.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete regressions identified in the changed submission or form-state paths.

The sole webhook submission path derives the required API-version record from current event-source state before server validation, while action-source transitions and non-webhook handlers remain behaviorally intact.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): remove API version dr..."](https://github.com/langfuse/langfuse/commit/ed5bf4ecd736113a92d1307d279ea13fe8a7727c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49968223)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->