### PR TITLE
chore(mcp): mention reply email in feedback tool description

### DIFF
--- a/web/src/features/mcp/features/feedback/tools/submitFeedback.ts
+++ b/web/src/features/mcp/features/feedback/tools/submitFeedback.ts
@@ -8,7 +8,8 @@ export const [submitFeedbackTool, handleSubmitFeedback] = defineTool({
   description: [
     "Submit explicit user-approved feedback to the Langfuse team about Langfuse skills, MCP tools, CLI, docs, or public API.",
     "Before calling, ask the user for permission and show the exact feedback payload, including any optional goal/use-case context.",
-    "Do not include secrets, credentials, customer data, trace payloads, or unrelated context.",
+    "If the user wants a reply, ask them to include their email address in the feedback text; only use an address they explicitly provide and show it in the exact payload preview.",
+    "Do not include secrets, credentials, customer/project data, trace payloads, or unrelated context; the only contact detail to include is an explicitly provided reply email.",
   ].join("\n"),
   baseSchema: PostFeedbackBody,
   inputSchema: PostFeedbackBody,

--- a/web/src/features/mcp/server/mcpServer.ts
+++ b/web/src/features/mcp/server/mcpServer.ts
@@ -32,7 +32,7 @@ const MCP_SERVER_INSTRUCTIONS = [
   "Use this server for project-scoped Langfuse data and actions such as prompts, datasets, scores, comments, metrics, observations etc.",
   "Inspect the available tools and their schemas dynamically; do not assume a fixed tool list.",
   "For conceptual Langfuse product guidance, SDK/API documentation, instrumentation help, or prompt-migration guidance, prefer the Langfuse docs MCP server or installed Langfuse agent skills when they are available.",
-  "To send feedback about Langfuse skills, MCP tools, CLI, docs, or public API, ask the user for permission, show the exact feedback payload, avoid secrets/customer data/trace payloads, then call submitFeedback.",
+  "To send feedback about Langfuse skills, MCP tools, CLI, docs, or public API, ask the user for permission and show the exact feedback payload; if they want a reply, include only an email address they explicitly provide in the feedback text; exclude secrets, customer/project data, trace payloads, and unrelated context, then call submitFeedback.",
 ].join("\n");
 
 /**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15756.preview.langfuse.com](https://pr-15756.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Tell users to include an explicitly provided email in the feedback text when they want a reply.
- Keep the exact-payload preview and sensitive-data safeguards explicit in the tool and server instructions.

## Verification

- `pnpm --filter web run lint`
- `pnpm --filter web run test src/__tests__/server/unit/feedback-api.servertest.ts`
- `git diff --check`

Tests added: 0 — instruction-only change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR clarifies how users can provide a reply email when submitting MCP feedback while preserving explicit payload approval and sensitive-data safeguards.
- Directs the feedback tool to include only an explicitly provided reply email in the feedback text.
- Aligns server-level MCP instructions with the tool description.
- Expands exclusions to cover customer/project data and unrelated context.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The instruction-only changes consistently direct clients to use the existing feedback text field and preserve explicit approval and sensitive-data exclusions without changing runtime behavior or payload contracts.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(mcp): mention reply email in feedba..."](https://github.com/langfuse/langfuse/commit/b117654060f8375b75ec5760387656da6fdbacee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49989300)</sub>

<!-- /greptile_comment -->