### PR TITLE
feat(migration): enhance experiment instrumentation migration handling

### DIFF
--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -11,7 +11,7 @@ vi.mock("@/src/server/auth", () => ({
 const sharedServerMock = vi.hoisted(() => ({
   queryClickhouse: vi.fn(),
   logger: {
-    error: vi.fn(),
+    warn: vi.fn(),
   },
   INTERNAL_INGESTION_SDK_NAMES: [
     "langfuse-internal-ai-sdk",

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -1506,78 +1506,80 @@ describe("v4TransitionRouter", () => {
   });
 
   it("summarizes outdated SDK usage series by organization project", async () => {
-    mockedQueryClickhouse.mockResolvedValueOnce([
-      {
-        projectId,
-        sdkName: "python",
-        sdkVersion: "3.9.0",
-        publicKey: "pk-lf-python",
-        count: "8",
-        firstSeen: "2026-06-24T01:00:00Z",
-        lastSeen: "2026-06-24T02:00:00Z",
-        hasDelayedOtelEvents: "1",
-      },
-      {
-        projectId,
-        sdkName: "python",
-        sdkVersion: "4.14.1",
-        publicKey: "pk-lf-python",
-        count: "13",
-        firstSeen: "2026-06-24T03:00:00Z",
-        lastSeen: "2026-06-24T04:00:00Z",
-        hasDelayedOtelEvents: "1",
-      },
-      {
-        projectId,
-        sdkName: "python",
-        sdkVersion: "4.6.9",
-        publicKey: "pk-lf-pre-v4-python",
-        count: "5",
-        firstSeen: "2026-06-24T12:00:00Z",
-        lastSeen: "2026-06-24T13:00:00Z",
-        hasDelayedOtelEvents: "1",
-      },
-      {
-        projectId,
-        sdkName: "python",
-        sdkVersion: "4.7.0",
-        publicKey: "pk-lf-current-python",
-        count: "6",
-        firstSeen: "2026-06-24T13:30:00Z",
-        lastSeen: "2026-06-24T14:00:00Z",
-        hasDelayedOtelEvents: "1",
-      },
-      {
-        projectId: secondProjectId,
-        sdkName: "@langfuse/tracing",
-        sdkVersion: "5.3.9",
-        publicKey: "pk-lf-old-js",
-        count: "5",
-        firstSeen: "2026-06-24T01:00:00Z",
-        lastSeen: "2026-06-24T04:00:00Z",
-        hasDelayedOtelEvents: "1",
-      },
-      {
-        projectId: secondProjectId,
-        sdkName: "unknown",
-        sdkVersion: "unknown",
-        publicKey: "pk-lf-otel",
-        count: "3",
-        firstSeen: "2026-06-24T01:00:00Z",
-        lastSeen: "2026-06-24T04:00:00Z",
-        hasDelayedOtelEvents: "0",
-      },
-      {
-        projectId: secondProjectId,
-        sdkName: "custom-otel-writer",
-        sdkVersion: "1.2.3",
-        publicKey: "pk-lf-custom-otel",
-        count: "2",
-        firstSeen: "2026-06-24T02:00:00Z",
-        lastSeen: "2026-06-24T03:00:00Z",
-        hasDelayedOtelEvents: "1",
-      },
-    ]);
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          sdkName: "python",
+          sdkVersion: "3.9.0",
+          publicKey: "pk-lf-python",
+          count: "8",
+          firstSeen: "2026-06-24T01:00:00Z",
+          lastSeen: "2026-06-24T02:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+        {
+          projectId,
+          sdkName: "python",
+          sdkVersion: "4.14.1",
+          publicKey: "pk-lf-python",
+          count: "13",
+          firstSeen: "2026-06-24T03:00:00Z",
+          lastSeen: "2026-06-24T04:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+        {
+          projectId,
+          sdkName: "python",
+          sdkVersion: "4.6.9",
+          publicKey: "pk-lf-pre-v4-python",
+          count: "5",
+          firstSeen: "2026-06-24T12:00:00Z",
+          lastSeen: "2026-06-24T13:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+        {
+          projectId,
+          sdkName: "python",
+          sdkVersion: "4.7.0",
+          publicKey: "pk-lf-current-python",
+          count: "6",
+          firstSeen: "2026-06-24T13:30:00Z",
+          lastSeen: "2026-06-24T14:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+        {
+          projectId: secondProjectId,
+          sdkName: "@langfuse/tracing",
+          sdkVersion: "5.3.9",
+          publicKey: "pk-lf-old-js",
+          count: "5",
+          firstSeen: "2026-06-24T01:00:00Z",
+          lastSeen: "2026-06-24T04:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+        {
+          projectId: secondProjectId,
+          sdkName: "unknown",
+          sdkVersion: "unknown",
+          publicKey: "pk-lf-otel",
+          count: "3",
+          firstSeen: "2026-06-24T01:00:00Z",
+          lastSeen: "2026-06-24T04:00:00Z",
+          hasDelayedOtelEvents: "0",
+        },
+        {
+          projectId: secondProjectId,
+          sdkName: "custom-otel-writer",
+          sdkVersion: "1.2.3",
+          publicKey: "pk-lf-custom-otel",
+          count: "2",
+          firstSeen: "2026-06-24T02:00:00Z",
+          lastSeen: "2026-06-24T03:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+      ])
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
     const mockPrisma = {
       project: {
         findMany: vi
@@ -1598,6 +1600,10 @@ describe("v4TransitionRouter", () => {
         projectId,
         outdatedSdkUsageSeriesCount: 1,
         delayedOtelIngestionSeriesCount: 0,
+        experimentInstrumentationMigration: {
+          status: "sdk_usage_inconclusive",
+          upgradePath: "sdk",
+        },
         sdkUsageSeries: [
           {
             sdkName: "python",
@@ -1657,6 +1663,10 @@ describe("v4TransitionRouter", () => {
         projectId: secondProjectId,
         outdatedSdkUsageSeriesCount: 1,
         delayedOtelIngestionSeriesCount: 1,
+        experimentInstrumentationMigration: {
+          status: "not_required",
+          upgradePath: null,
+        },
         sdkUsageSeries: [
           {
             sdkName: "@langfuse/tracing",
@@ -1711,7 +1721,7 @@ describe("v4TransitionRouter", () => {
         id: true,
       },
     });
-    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(1);
+    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(2);
     const usageQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
     expect(usageQuery?.query).toContain("FROM events_core");
     expect(usageQuery?.query).toContain("UNION ALL");
@@ -1745,6 +1755,127 @@ describe("v4TransitionRouter", () => {
     });
     expect(usageQuery?.tags).toEqual({
       route: "v4-org-sdk-usage-summary",
+    });
+
+    const experimentUsageQuery = mockedQueryClickhouse.mock.calls[1]?.[0];
+    expect(experimentUsageQuery?.query).toContain(
+      "splitByChar('?', JSONExtractString(log_comment, 'route'))[1] = 'POST /api/public/dataset-run-items'",
+    );
+    expect(experimentUsageQuery?.query).toContain(
+      "JSONExtractString(log_comment, 'projectId') IN {projectIds: Array(String)}",
+    );
+    expect(experimentUsageQuery?.query).toContain(
+      "event_date >= toDate({fromTimestamp: DateTime64(3)})",
+    );
+    expect(experimentUsageQuery?.params).toMatchObject({
+      projectIds: [projectId, secondProjectId],
+      fromTimestamp: "2026-06-24 00:00:00.000",
+      toTimestamp: "2026-06-25 00:00:00.000",
+    });
+    expect(experimentUsageQuery?.tags).toEqual({
+      route: "v4-org-experiment-instrumentation-summary",
+    });
+  });
+
+  it("requires removing dataset-run-items POST usage for native OTel instrumentation", async () => {
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          sdkName: "unknown",
+          sdkVersion: "unknown",
+          publicKey: "pk-lf-otel",
+          count: "3",
+          firstSeen: "2026-06-24T01:00:00Z",
+          lastSeen: "2026-06-24T04:00:00Z",
+          hasDelayedOtelEvents: "0",
+        },
+      ])
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
+    const caller = createCaller({
+      project: {
+        findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
+      },
+    });
+
+    const [summary] = await caller.sdkUsageSummaryByProject({
+      orgId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+    });
+
+    expect(summary).toMatchObject({
+      projectId,
+      experimentInstrumentationMigration: {
+        status: "required",
+        upgradePath: "api",
+      },
+    });
+  });
+
+  it("requires an API upgrade when POST usage predates the experiment runner", async () => {
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          sdkName: "python",
+          sdkVersion: "3.3.5",
+          publicKey: "pk-lf-python",
+          count: "3",
+          firstSeen: "2026-06-24T01:00:00Z",
+          lastSeen: "2026-06-24T04:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+      ])
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
+    const caller = createCaller({
+      project: {
+        findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
+      },
+    });
+
+    const [summary] = await caller.sdkUsageSummaryByProject({
+      orgId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+    });
+
+    expect(summary?.experimentInstrumentationMigration).toEqual({
+      status: "required",
+      upgradePath: "api",
+    });
+  });
+
+  it("does not require an upgrade for current experiment instrumentation", async () => {
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          sdkName: "python",
+          sdkVersion: "4.0.0",
+          publicKey: "pk-lf-python",
+          count: "3",
+          firstSeen: "2026-06-24T01:00:00Z",
+          lastSeen: "2026-06-24T04:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+      ])
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
+    const caller = createCaller({
+      project: {
+        findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
+      },
+    });
+
+    const [summary] = await caller.sdkUsageSummaryByProject({
+      orgId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+    });
+
+    expect(summary?.experimentInstrumentationMigration).toEqual({
+      status: "not_required",
+      upgradePath: null,
     });
   });
 

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -10,6 +10,9 @@ vi.mock("@/src/server/auth", () => ({
 
 const sharedServerMock = vi.hoisted(() => ({
   queryClickhouse: vi.fn(),
+  logger: {
+    error: vi.fn(),
+  },
   INTERNAL_INGESTION_SDK_NAMES: [
     "langfuse-internal-ai-sdk",
     "langfuse-internal-otel-writer",
@@ -1810,6 +1813,50 @@ describe("v4TransitionRouter", () => {
         status: "required",
         upgradePath: "api",
       },
+    });
+  });
+
+  it("preserves SDK usage when the experiment instrumentation check fails", async () => {
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          sdkName: "python",
+          sdkVersion: "3.9.0",
+          publicKey: "pk-lf-python",
+          count: "3",
+          firstSeen: "2026-06-24T01:00:00Z",
+          lastSeen: "2026-06-24T04:00:00Z",
+          hasDelayedOtelEvents: "1",
+        },
+      ])
+      .mockRejectedValueOnce(new Error("query_log unavailable"));
+    const caller = createCaller({
+      project: {
+        findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
+      },
+    });
+
+    const [summary] = await caller.sdkUsageSummaryByProject({
+      orgId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+    });
+
+    expect(summary).toMatchObject({
+      projectId,
+      outdatedSdkUsageSeriesCount: 1,
+      experimentInstrumentationMigration: {
+        status: "check_failed",
+        upgradePath: null,
+      },
+      sdkUsageSeries: [
+        {
+          sdkName: "python",
+          sdkVersion: "3.9.0",
+          v4MigrationStatus: "upgrade_required",
+        },
+      ],
     });
   });
 

--- a/web/src/features/sdk-version/lib/sdkVersionCapabilities.clienttest.ts
+++ b/web/src/features/sdk-version/lib/sdkVersionCapabilities.clienttest.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { getSdkVersionCapabilityStatus } from "./sdkVersionCapabilities";
+
+describe("experiment instrumentation SDK capability", () => {
+  it.each([
+    ["python", "3.3.5", "unsupported"],
+    ["python", "3.4.0", "supported"],
+    ["javascript", "4.0.1", "unsupported"],
+    ["javascript", "4.1.0", "supported"],
+  ] as const)(
+    "classifies experiment runner support for %s %s as %s",
+    (language, version, expected) => {
+      expect(
+        getSdkVersionCapabilityStatus(
+          { language, version },
+          "experimentRunner",
+        ),
+      ).toBe(expected);
+    },
+  );
+
+  it.each([
+    ["python", "3.99.0", "unsupported"],
+    ["python", "4.0.0", "supported"],
+    ["javascript", "5.9.9", "unsupported"],
+    ["javascript", "5.10.0", "supported"],
+  ] as const)("classifies %s %s as %s", (language, version, expected) => {
+    expect(
+      getSdkVersionCapabilityStatus(
+        { language, version },
+        "experimentLinkDeprecation",
+      ),
+    ).toBe(expected);
+  });
+});

--- a/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
+++ b/web/src/features/sdk-version/lib/sdkVersionCapabilities.ts
@@ -26,6 +26,14 @@ const SDK_VERSION_CAPABILITIES = {
     javascript: [5, 4, 0],
     python: [4, 7, 0],
   },
+  experimentRunner: {
+    javascript: [4, 1, 0],
+    python: [3, 4, 0],
+  },
+  experimentLinkDeprecation: {
+    javascript: [5, 10, 0],
+    python: [4, 0, 0],
+  },
 } as const;
 
 type SdkVersionCapability = keyof typeof SDK_VERSION_CAPABILITIES;

--- a/web/src/features/v4-migration/V4MigrationBanner.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationBanner.clienttest.tsx
@@ -48,14 +48,21 @@ vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
   },
 }));
 
-const status = (overrides?: Partial<ProjectMigrationStatus>) =>
-  ({
-    sdk: { status: "latest", sdkUsageSeries: [], upgradeRequiredCount: 0 },
-    evals: { status: "loaded", count: 0 },
-    apis: { status: "loaded", count: 0 },
-    exports: { status: "loaded", count: 0 },
-    ...overrides,
-  }) as ProjectMigrationStatus;
+const status = (
+  overrides?: Partial<ProjectMigrationStatus>,
+): ProjectMigrationStatus => ({
+  sdk: {
+    status: "latest",
+    sdkUsageSeries: [],
+    upgradeRequiredCount: 0,
+    delayedOtelIngestionCount: 0,
+  },
+  evals: { status: "loaded", count: 0 },
+  experiments: { status: "loaded", result: "not_required" },
+  apis: { status: "loaded", count: 0 },
+  exports: { status: "loaded", count: 0 },
+  ...overrides,
+});
 
 describe("V4MigrationBanner", () => {
   beforeEach(() => {

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -239,8 +239,9 @@ describe("V4MigrationDetailsContent", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Experiments/ }));
     expect(screen.getByText(/POST \/dataset-run-items/)).toBeInTheDocument();
-    expect(screen.getByText(">=4.7.0")).toBeInTheDocument();
-    expect(screen.getByText(">=5.10.0")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Upgrade the SDK" }),
+    ).toBeInTheDocument();
   });
 
   it("shows inconclusive experiment runner usage as needing review", () => {
@@ -257,7 +258,7 @@ describe("V4MigrationDetailsContent", () => {
     expect(
       screen.getByText(/supports the experiment runner/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/deprecated/)).toBeInTheDocument();
+    expect(screen.getByText(".link()")).toBeInTheDocument();
   });
 
   it("asks direct API users to replace dataset-run-items POST usage", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -11,7 +11,10 @@ import {
   V4MigrationDetailsContent,
   V4MigrationHeaderContent,
 } from "./V4MigrationContent";
-import { type MigrationCountState } from "./migrationData";
+import {
+  type MigrationActionState,
+  type MigrationCountState,
+} from "./migrationData";
 import { type V4MigrationSdkState } from "./sdkVersionStatus";
 
 const mocks = vi.hoisted(() => ({
@@ -32,6 +35,11 @@ const mocks = vi.hoisted(() => ({
       delayedOtelIngestionCount: 0,
     } as V4MigrationSdkState,
     evals: { status: "loaded", count: 0 } as MigrationCountState,
+    experiments: {
+      status: "loaded",
+      result: "not_required",
+    } as MigrationActionState,
+    experimentInstrumentationUpgradePath: null as "sdk" | "api" | null,
     apis: { status: "loaded", count: 1 } as MigrationCountState,
     exports: { status: "loaded", count: 3 } as MigrationCountState,
     apiUsage: [
@@ -136,6 +144,11 @@ describe("V4MigrationDetailsContent", () => {
     mocks.routerPush.mockResolvedValue(true);
     mocks.submitAgentMessage.mockResolvedValue(undefined);
     mocks.migrationData.evals = { status: "loaded", count: 0 };
+    mocks.migrationData.experiments = {
+      status: "loaded",
+      result: "not_required",
+    };
+    mocks.migrationData.experimentInstrumentationUpgradePath = null;
     mocks.canToggleV4 = true;
     mocks.migrationData.sdk.status = "latest";
     mocks.migrationData.apis = { status: "loaded", count: 1 };
@@ -213,6 +226,50 @@ describe("V4MigrationDetailsContent", () => {
     expect(
       screen.getByText("No deprecated evals detected."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("No experiment instrumentation updates detected."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the experiment instrumentation upgrade requirement", () => {
+    mocks.migrationData.experiments = { status: "loaded", result: "required" };
+    mocks.migrationData.experimentInstrumentationUpgradePath = "sdk";
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(screen.getByText("Experiments")).toBeInTheDocument();
+    expect(screen.getByText(/POST \/dataset-run-items/)).toBeInTheDocument();
+    expect(screen.getByText(">=4.0.0")).toBeInTheDocument();
+    expect(screen.getByText(">=5.10.0")).toBeInTheDocument();
+  });
+
+  it("shows inconclusive experiment runner usage as needing review", () => {
+    mocks.migrationData.experiments = {
+      status: "loaded",
+      result: "sdk_usage_inconclusive",
+    };
+    mocks.migrationData.experimentInstrumentationUpgradePath = "sdk";
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+    expect(
+      screen.getByText(/supports the experiment runner but predates/),
+    ).toBeInTheDocument();
+  });
+
+  it("asks direct API users to replace dataset-run-items POST usage", () => {
+    mocks.migrationData.experiments = { status: "loaded", result: "required" };
+    mocks.migrationData.experimentInstrumentationUpgradePath = "api";
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(
+      screen.getByText(/outside a compatible experiment runner/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Replace this direct API call/),
+    ).toBeInTheDocument();
   });
 
   it("shows no detected ingestion data without asking for SDK review", () => {
@@ -289,6 +346,11 @@ describe("V4MigrationDetailsContent", () => {
 describe("V4MigrationHeaderContent", () => {
   beforeEach(() => {
     mocks.migrationData.evals = { status: "loaded", count: 0 };
+    mocks.migrationData.experiments = {
+      status: "loaded",
+      result: "not_required",
+    };
+    mocks.migrationData.experimentInstrumentationUpgradePath = null;
     mocks.migrationData.apis = { status: "loaded", count: 1 };
     mocks.migrationData.exports = { status: "loaded", count: 3 };
     mocks.hasApiKeyCreateAccess = true;

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -227,7 +227,7 @@ describe("V4MigrationDetailsContent", () => {
       screen.getByText("No deprecated evals detected."),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("No experiment instrumentation updates detected."),
+      screen.getByText("No experiment instrumentation updates required."),
     ).toBeInTheDocument();
   });
 
@@ -237,9 +237,9 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
-    expect(screen.getByText("Experiments")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Experiments/ }));
     expect(screen.getByText(/POST \/dataset-run-items/)).toBeInTheDocument();
-    expect(screen.getByText(">=4.0.0")).toBeInTheDocument();
+    expect(screen.getByText(">=4.7.0")).toBeInTheDocument();
     expect(screen.getByText(">=5.10.0")).toBeInTheDocument();
   });
 
@@ -252,10 +252,12 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
+    fireEvent.click(screen.getByRole("button", { name: /Experiments/ }));
     expect(screen.getByText("Needs review")).toBeInTheDocument();
     expect(
-      screen.getByText(/supports the experiment runner but predates/),
+      screen.getByText(/supports the experiment runner/),
     ).toBeInTheDocument();
+    expect(screen.getByText(/deprecated/)).toBeInTheDocument();
   });
 
   it("asks direct API users to replace dataset-run-items POST usage", () => {
@@ -264,11 +266,11 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
+    fireEvent.click(screen.getByRole("button", { name: /Experiments/ }));
     expect(
-      screen.getByText(/outside a compatible experiment runner/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Replace this direct API call/),
+      screen.getByRole("link", {
+        name: "OTel experiment instrumentation guide",
+      }),
     ).toBeInTheDocument();
   });
 

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -695,8 +695,16 @@ export function V4MigrationDetailsContent({
                     This project called{" "}
                     <MonoValue>POST /dataset-run-items</MonoValue> with an SDK
                     version that supports the experiment runner. Review that you
-                    are using the experiment runner SDK and not the deprecated
-                    `.link()` method. This warning will disappear once you
+                    are using the experiment runner SDK and not the deprecated{" "}
+                    <>
+                      <>
+                        <code className="bg-muted px-1 font-mono text-sm">
+                          .link()
+                        </code>{" "}
+                        method. This warning will{" "}
+                      </>
+                      disappear once you{" "}
+                    </>
                     upgrade to latest SDK version.
                   </>
                 ) : (
@@ -707,15 +715,13 @@ export function V4MigrationDetailsContent({
                     <ExternalLink href={SDK_UPGRADE_URL}>
                       Upgrade the SDK
                     </ExternalLink>{" "}
-                    to Python <MonoValue>&gt;=4.7.0</MonoValue> or JS/TS{" "}
-                    <MonoValue>&gt;=5.10.0</MonoValue> and use the experiment
-                    runner method.
+                    and use the experiment runner method.
                   </>
                 )}
               </p>
             ) : (
               <p className="text-muted-foreground text-sm">
-                No experiment instrumentation updates detected.
+                No experiment instrumentation updates required.
               </p>
             )}
           </Section>

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -33,6 +33,7 @@ import { useProjectV4MigrationData } from "@/src/features/v4-migration/hooks/use
 import {
   getProjectMigrationReadiness,
   V4_MIGRATION_LOOKBACK_DAYS,
+  type MigrationActionState,
   type MigrationCountState,
 } from "@/src/features/v4-migration/migrationData";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
@@ -67,6 +68,8 @@ const DEPRECATED_INTEGRATION_MIGRATION_URLS: Record<string, string> = {
   "Blob Storage":
     "https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage#upgrade-path",
 };
+const EXPERIMENT_OTEL_INGESTION_URL =
+  "https://langfuse.com/integrations/native/opentelemetry/experiments";
 
 // Copies the agent migration prompt to the clipboard with toast + analytics;
 // shared by the panel/modal header CTA and the status page.
@@ -196,6 +199,22 @@ function MigrationCountChip({
     <Chip variant="warning">
       {state.count} {affectedLabel}
     </Chip>
+  );
+}
+
+function MigrationActionChip({ state }: { state: MigrationActionState }) {
+  if (state.status === "loading") {
+    return <Chip variant="warning">Checking</Chip>;
+  }
+  if (state.status === "error") {
+    return <Chip variant="warning">Check failed</Chip>;
+  }
+  return state.result === "required" ? (
+    <Chip variant="warning">Update required</Chip>
+  ) : state.result === "sdk_usage_inconclusive" ? (
+    <Chip variant="warning">Needs review</Chip>
+  ) : (
+    <Chip variant="success">Up to date</Chip>
   );
 }
 
@@ -640,6 +659,63 @@ export function V4MigrationDetailsContent({
             ) : (
               <p className="text-muted-foreground text-sm">
                 No deprecated evals detected.
+              </p>
+            )}
+          </Section>
+
+          <Section
+            title="Experiments"
+            chip={<MigrationActionChip state={migrationData.experiments} />}
+          >
+            {migrationData.experiments.status === "loading" ? (
+              <p className="text-muted-foreground text-sm">
+                Checking experiment instrumentation…
+              </p>
+            ) : migrationData.experiments.status === "error" ? (
+              <p className="text-muted-foreground text-sm">
+                We could not check experiment instrumentation. Try again later.
+              </p>
+            ) : migrationData.experiments.result !== "not_required" ? (
+              <p className="text-muted-foreground text-sm">
+                {migrationData.experimentInstrumentationUpgradePath ===
+                "api" ? (
+                  <>
+                    This project called the deprecated{" "}
+                    <MonoValue>POST /dataset-run-items</MonoValue>. Replace this
+                    direct API call with OTel experiment instrumentation. See
+                    the{" "}
+                    <ExternalLink href={EXPERIMENT_OTEL_INGESTION_URL}>
+                      OTel experiment instrumentation guide
+                    </ExternalLink>{" "}
+                    for more details.
+                  </>
+                ) : migrationData.experiments.result ===
+                  "sdk_usage_inconclusive" ? (
+                  <>
+                    This project called{" "}
+                    <MonoValue>POST /dataset-run-items</MonoValue> with an SDK
+                    version that supports the experiment runner. Review that you
+                    are using the experiment runner SDK and not the deprecated
+                    `.link()` method. This warning will disappear once you
+                    upgrade to latest SDK version.
+                  </>
+                ) : (
+                  <>
+                    This project called{" "}
+                    <MonoValue>POST /dataset-run-items</MonoValue> with an
+                    outdated SDK.{" "}
+                    <ExternalLink href={SDK_UPGRADE_URL}>
+                      Upgrade the SDK
+                    </ExternalLink>{" "}
+                    to Python <MonoValue>&gt;=4.7.0</MonoValue> or JS/TS{" "}
+                    <MonoValue>&gt;=5.10.0</MonoValue> and use the experiment
+                    runner method.
+                  </>
+                )}
+              </p>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                No experiment instrumentation updates detected.
               </p>
             )}
           </Section>

--- a/web/src/features/v4-migration/V4MigrationEntryPoints.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationEntryPoints.clienttest.tsx
@@ -58,6 +58,7 @@ const migrationStatus = (
     delayedOtelIngestionCount: 0,
   },
   evals: { status: "loaded", count: 0 },
+  experiments: { status: "loaded", result: "not_required" },
   apis: { status: "loaded", count: 0 },
   exports: { status: "loaded", count: 0 },
   ...overrides,

--- a/web/src/features/v4-migration/V4MigrationNavItem.tsx
+++ b/web/src/features/v4-migration/V4MigrationNavItem.tsx
@@ -25,6 +25,7 @@ export function V4MigrationNavItem() {
   const readiness = getProjectMigrationReadiness({
     sdk: migrationData.sdk,
     evals: migrationData.evals,
+    experiments: migrationData.experiments,
     apis: migrationData.apis,
     exports: migrationData.exports,
   });

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -86,6 +86,7 @@ vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
         {
           sdk: mocks.sdk,
           evals: { status: "loaded", count: 0 },
+          experiments: { status: "loaded", result: "not_required" },
           apis: { status: "loaded", count: 0 },
           exports: { status: "loaded", count: 0 },
         },

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 import {
   getProjectMigrationReadiness,
+  type MigrationActionState,
   type MigrationCountState,
   type ProjectMigrationReadiness,
   type ProjectMigrationStatus,
@@ -65,6 +66,22 @@ function AffectedCell({ count }: { count: MigrationCountState }) {
   return <span>{count.count}</span>;
 }
 
+function MigrationActionCell({ state }: { state: MigrationActionState }) {
+  if (state.status === "loading") {
+    return <span className="text-foreground-tertiary">Checking…</span>;
+  }
+  if (state.status === "error") {
+    return <span className="text-foreground-tertiary">Unavailable</span>;
+  }
+  return state.result === "required" ? (
+    <span>Update required</span>
+  ) : state.result === "sdk_usage_inconclusive" ? (
+    <span>Needs review</span>
+  ) : (
+    <span className="text-foreground-tertiary">Up to date</span>
+  );
+}
+
 function StatusPill({ readiness }: { readiness: ProjectMigrationReadiness }) {
   const label =
     readiness === "ready"
@@ -96,6 +113,7 @@ type SortKey =
   | "status"
   | "sdk"
   | "evals"
+  | "experiments"
   | "apis"
   | "exports"
   | "lastTrace";
@@ -224,6 +242,12 @@ function OrgStatusSection({
                       : 0;
       case "evals":
         return row.status?.evals.count ?? 0;
+      case "experiments":
+        return row.status?.experiments.result === "required"
+          ? 2
+          : row.status?.experiments.result === "sdk_usage_inconclusive"
+            ? 1
+            : 0;
       case "apis":
         return row.status?.apis.count ?? 0;
       case "exports":
@@ -278,6 +302,12 @@ function OrgStatusSection({
                 <SortableHead
                   label="Affected Evals"
                   column="evals"
+                  orderBy={orderBy}
+                  onSort={handleSort}
+                />
+                <SortableHead
+                  label="Affected Experiments"
+                  column="experiments"
                   orderBy={orderBy}
                   onSort={handleSort}
                 />
@@ -369,6 +399,9 @@ function OrgStatusSection({
                     </TableCell>
                     <TableCell density="comfortable">
                       <AffectedCell count={row.status.evals} />
+                    </TableCell>
+                    <TableCell density="comfortable">
+                      <MigrationActionCell state={row.status.experiments} />
                     </TableCell>
                     <TableCell density="comfortable">
                       <AffectedCell count={row.status.apis} />

--- a/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
+++ b/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
@@ -92,6 +92,10 @@ describe("account v4 migration data", () => {
             projectId: "project-1",
             outdatedSdkUsageSeriesCount: 0,
             delayedOtelIngestionSeriesCount: 0,
+            experimentInstrumentationMigration: {
+              status: "sdk_usage_inconclusive" as const,
+              upgradePath: "sdk" as const,
+            },
             sdkUsageSeries: [currentSdkSeries],
           },
         ]),
@@ -135,6 +139,10 @@ describe("account v4 migration data", () => {
         delayedOtelIngestionCount: 0,
       },
       evals: { status: "loaded", count: 2 },
+      experiments: {
+        status: "loaded",
+        result: "sdk_usage_inconclusive",
+      },
       apis: { status: "loaded", count: 2 },
       exports: { status: "loaded", count: 1 },
     });

--- a/web/src/features/v4-migration/hooks/useV4MigrationData.ts
+++ b/web/src/features/v4-migration/hooks/useV4MigrationData.ts
@@ -6,6 +6,7 @@ import {
   aggregateLegacyApiUsage,
   createV4MigrationDetectionRange,
   getLegacyIntegrationLabels,
+  getMigrationActionState,
   getMigrationCountState,
   type ProjectMigrationStatus,
 } from "@/src/features/v4-migration/migrationData";
@@ -109,6 +110,12 @@ export function useAccountV4MigrationData(params: {
               ?.traceLevelEvalCount ?? 0
           );
         }),
+        experiments: getMigrationActionState(
+          sdkQuery,
+          (rows) =>
+            rows.find((row) => row.projectId === project.id)
+              ?.experimentInstrumentationMigration.status ?? "not_required",
+        ),
         apis: getMigrationCountState(apiQuery, (rows) => {
           return countLegacyApiEntrypoints(
             rows.filter((row) => row.projectId === project.id),
@@ -127,7 +134,7 @@ export function useAccountV4MigrationData(params: {
   return statusByProjectId;
 }
 
-export function useProjectV4SdkData(params: {
+function useProjectV4SdkSummary(params: {
   projectId: string | undefined;
   orgId: string | undefined;
   enabled: boolean;
@@ -147,6 +154,16 @@ export function useProjectV4SdkData(params: {
     },
   );
   const summary = sdkQuery.data?.find((row) => row.projectId === projectId);
+
+  return { sdkQuery, summary };
+}
+
+export function useProjectV4SdkData(params: {
+  projectId: string | undefined;
+  orgId: string | undefined;
+  enabled: boolean;
+}) {
+  const { sdkQuery, summary } = useProjectV4SdkSummary(params);
 
   return getV4MigrationSdkState({
     summary,
@@ -177,7 +194,7 @@ export function useProjectV4MigrationData(params: {
   const { projectId, orgId, enabled } = params;
   const queryEnabled = enabled && Boolean(projectId);
   const [detectionRange] = useState(createV4MigrationDetectionRange);
-  const sdk = useProjectV4SdkData({
+  const { sdkQuery, summary: sdkSummary } = useProjectV4SdkSummary({
     projectId,
     orgId,
     enabled,
@@ -209,11 +226,23 @@ export function useProjectV4MigrationData(params: {
   );
 
   return {
-    sdk,
+    sdk: getV4MigrationSdkState({
+      summary: sdkSummary,
+      isLoading: sdkQuery.data === undefined && !sdkQuery.isError,
+      isError: sdkQuery.isError,
+    }),
     evals: getMigrationCountState(
       evalQuery,
       (data) => data.traceLevelEvalCount,
     ),
+    experiments: getMigrationActionState(
+      sdkQuery,
+      (rows) =>
+        rows.find((row) => row.projectId === projectId)
+          ?.experimentInstrumentationMigration.status ?? "not_required",
+    ),
+    experimentInstrumentationUpgradePath:
+      sdkSummary?.experimentInstrumentationMigration.upgradePath ?? null,
     apis: getMigrationCountState(apiQuery, () => apiUsage.length),
     exports: getMigrationCountState(
       integrationQuery,

--- a/web/src/features/v4-migration/migrationData.clienttest.ts
+++ b/web/src/features/v4-migration/migrationData.clienttest.ts
@@ -2,12 +2,16 @@ import {
   aggregateLegacyApiUsage,
   createV4MigrationDetectionRange,
   getLegacyIntegrationLabels,
+  getMigrationActionState,
   getMigrationCountState,
   getProjectMigrationReadiness,
   type ProjectMigrationStatus,
 } from "@/src/features/v4-migration/migrationData";
 
 const loaded = (count: number) => ({ status: "loaded" as const, count });
+const loadedAction = (
+  result: "required" | "not_required" | "sdk_usage_inconclusive",
+) => ({ status: "loaded" as const, result });
 const migrationStatus = (
   overrides: Partial<ProjectMigrationStatus> = {},
 ): ProjectMigrationStatus => ({
@@ -18,6 +22,7 @@ const migrationStatus = (
     delayedOtelIngestionCount: 0,
   },
   evals: loaded(0),
+  experiments: loadedAction("not_required"),
   apis: loaded(0),
   exports: loaded(0),
   ...overrides,
@@ -48,6 +53,16 @@ describe("v4 migration data", () => {
         return data.count;
       }),
     ).toEqual(loaded(0));
+    expect(getMigrationActionState(null, () => "required")).toEqual({
+      status: "loading",
+      result: null,
+    });
+    expect(
+      getMigrationActionState(
+        { data: { result: "required" as const }, isError: false },
+        (data) => data.result,
+      ),
+    ).toEqual(loadedAction("required"));
   });
 
   it("only marks a fully loaded project without affected items as ready", () => {
@@ -74,6 +89,18 @@ describe("v4 migration data", () => {
     ).toBe("ready");
     expect(
       getProjectMigrationReadiness(migrationStatus({ evals: loaded(1) })),
+    ).toBe("action-needed");
+    expect(
+      getProjectMigrationReadiness(
+        migrationStatus({ experiments: loadedAction("required") }),
+      ),
+    ).toBe("action-needed");
+    expect(
+      getProjectMigrationReadiness(
+        migrationStatus({
+          experiments: loadedAction("sdk_usage_inconclusive"),
+        }),
+      ),
     ).toBe("action-needed");
     expect(
       getProjectMigrationReadiness(

--- a/web/src/features/v4-migration/migrationData.clienttest.ts
+++ b/web/src/features/v4-migration/migrationData.clienttest.ts
@@ -63,6 +63,12 @@ describe("v4 migration data", () => {
         (data) => data.result,
       ),
     ).toEqual(loadedAction("required"));
+    expect(
+      getMigrationActionState(
+        { data: { result: "check_failed" as const }, isError: false },
+        (data) => data.result,
+      ),
+    ).toEqual({ status: "error", result: null });
   });
 
   it("only marks a fully loaded project without affected items as ready", () => {

--- a/web/src/features/v4-migration/migrationData.ts
+++ b/web/src/features/v4-migration/migrationData.ts
@@ -23,6 +23,14 @@ export type MigrationCountState =
   | { status: "error"; count: 0 }
   | { status: "loaded"; count: number };
 
+export type MigrationActionState =
+  | { status: "loading"; result: null }
+  | { status: "error"; result: null }
+  | {
+      status: "loaded";
+      result: "required" | "not_required" | "sdk_usage_inconclusive";
+    };
+
 const loadingMigrationCount = {
   status: "loading",
   count: 0,
@@ -51,9 +59,27 @@ export const getMigrationCountState = <T>(
   return query?.isError ? errorMigrationCount : loadingMigrationCount;
 };
 
+export const getMigrationActionState = <T>(
+  query: {
+    data: T | undefined;
+    isError: boolean;
+  } | null,
+  getResult: (
+    data: T,
+  ) => "required" | "not_required" | "sdk_usage_inconclusive",
+): MigrationActionState => {
+  if (query?.data !== undefined) {
+    return { status: "loaded", result: getResult(query.data) };
+  }
+  return query?.isError
+    ? { status: "error", result: null }
+    : { status: "loading", result: null };
+};
+
 export type ProjectMigrationStatus = {
   sdk: V4MigrationSdkState;
   evals: MigrationCountState;
+  experiments: MigrationActionState;
   apis: MigrationCountState;
   exports: MigrationCountState;
 };
@@ -71,12 +97,14 @@ export const getProjectMigrationReadiness = (
 
   if (
     status.sdk.status === "error" ||
+    status.experiments.status === "error" ||
     counts.some((count) => count.status === "error")
   ) {
     return "unavailable";
   }
   if (
     status.sdk.status === "checking" ||
+    status.experiments.status === "loading" ||
     counts.some((count) => count.status === "loading")
   ) {
     return "checking";
@@ -85,6 +113,7 @@ export const getProjectMigrationReadiness = (
     (status.sdk.status === "latest" ||
       status.sdk.status === "otel_realtime" ||
       status.sdk.status === "no_data") &&
+    status.experiments.result === "not_required" &&
     counts.every((count) => count.count === 0)
   ) {
     return "ready";

--- a/web/src/features/v4-migration/migrationData.ts
+++ b/web/src/features/v4-migration/migrationData.ts
@@ -66,10 +66,13 @@ export const getMigrationActionState = <T>(
   } | null,
   getResult: (
     data: T,
-  ) => "required" | "not_required" | "sdk_usage_inconclusive",
+  ) => "required" | "not_required" | "sdk_usage_inconclusive" | "check_failed",
 ): MigrationActionState => {
   if (query?.data !== undefined) {
-    return { status: "loaded", result: getResult(query.data) };
+    const result = getResult(query.data);
+    return result === "check_failed"
+      ? { status: "error", result: null }
+      : { status: "loaded", result };
   }
   return query?.isError
     ? { status: "error", result: null }

--- a/web/src/features/v4-migration/sdkVersionStatus.clienttest.ts
+++ b/web/src/features/v4-migration/sdkVersionStatus.clienttest.ts
@@ -28,6 +28,10 @@ const getLoadedSdkState = (...sdkUsageSeries: ReturnType<typeof sdkSeries>[]) =>
       projectId: "project-1",
       outdatedSdkUsageSeriesCount: 0,
       delayedOtelIngestionSeriesCount: 0,
+      experimentInstrumentationMigration: {
+        status: "not_required",
+        upgradePath: null,
+      },
       sdkUsageSeries,
     },
     isError: false,

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -15,6 +15,7 @@ import {
   classifyIngestionSdkVersion,
   convertDateToClickhouseDateTime,
   INTERNAL_INGESTION_SDK_NAMES,
+  logger,
   queryClickhouse,
   systemTableRef,
   type IngestionSdkAttributionStatus,
@@ -192,7 +193,11 @@ type SdkUsageSummaryByProjectResultRow = {
   outdatedSdkUsageSeriesCount: number;
   delayedOtelIngestionSeriesCount: number;
   experimentInstrumentationMigration: {
-    status: "required" | "not_required" | "sdk_usage_inconclusive";
+    status:
+      | "required"
+      | "not_required"
+      | "sdk_usage_inconclusive"
+      | "check_failed";
     upgradePath: "sdk" | "api" | null;
   };
   sdkUsageSeries: SdkUsageSummaryByProjectSeries[];
@@ -940,7 +945,7 @@ ORDER BY ${bucketTimeSql} ASC, sdk_name ASC, sdk_version ASC, public_key ASC
     AND ingestion_sdk_name NOT IN {internalSdkNames: Array(String)}
     AND is_deleted = 0`;
 
-      const [rows, datasetRunItemsPostUsageRows] = await Promise.all([
+      const [rows, datasetRunItemsPostUsageResult] = await Promise.all([
         queryClickhouse<SdkUsageSummaryByProjectRow>({
           query: `
 WITH selected AS (
@@ -1017,7 +1022,18 @@ SETTINGS skip_unavailable_shards = 1
           clickhouseSettings: {
             skip_unavailable_shards: 1,
           },
-        }),
+        })
+          .then((rows) => ({ status: "success" as const, rows }))
+          .catch((error: unknown) => {
+            logger.warn(
+              "Failed to query dataset-run-items POST usage for v4 migration",
+              error,
+            );
+            return {
+              status: "error" as const,
+              rows: [] as DatasetRunItemsPostUsageByProjectRow[],
+            };
+          }),
       ]);
 
       const rowsByProjectId = new Map<string, SdkUsageSummaryByProjectRow[]>();
@@ -1027,7 +1043,7 @@ SETTINGS skip_unavailable_shards = 1
         rowsByProjectId.set(row.projectId, projectRows);
       }
       const projectsUsingDatasetRunItemsPost = new Set(
-        datasetRunItemsPostUsageRows
+        datasetRunItemsPostUsageResult.rows
           .filter((row) => Number(row.count) > 0)
           .map((row) => row.projectId),
       );
@@ -1139,13 +1155,15 @@ SETTINGS skip_unavailable_shards = 1
           },
         );
         const experimentInstrumentationMigration: SdkUsageSummaryByProjectResultRow["experimentInstrumentationMigration"] =
-          !usesDatasetRunItemsPost
-            ? { status: "not_required", upgradePath: null }
-            : hasCurrentExperimentInstrumentation
+          datasetRunItemsPostUsageResult.status === "error"
+            ? { status: "check_failed", upgradePath: null }
+            : !usesDatasetRunItemsPost
               ? { status: "not_required", upgradePath: null }
-              : hasInconclusiveExperimentSdkUsage
-                ? { status: "sdk_usage_inconclusive", upgradePath: "sdk" }
-                : { status: "required", upgradePath: "api" };
+              : hasCurrentExperimentInstrumentation
+                ? { status: "not_required", upgradePath: null }
+                : hasInconclusiveExperimentSdkUsage
+                  ? { status: "sdk_usage_inconclusive", upgradePath: "sdk" }
+                  : { status: "required", upgradePath: "api" };
 
         return {
           projectId,

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -191,7 +191,16 @@ type SdkUsageSummaryByProjectResultRow = {
   projectId: string;
   outdatedSdkUsageSeriesCount: number;
   delayedOtelIngestionSeriesCount: number;
+  experimentInstrumentationMigration: {
+    status: "required" | "not_required" | "sdk_usage_inconclusive";
+    upgradePath: "sdk" | "api" | null;
+  };
   sdkUsageSeries: SdkUsageSummaryByProjectSeries[];
+};
+
+type DatasetRunItemsPostUsageByProjectRow = {
+  projectId: string;
+  count: string | number;
 };
 
 const getEmptyTimelineBuckets = (
@@ -931,8 +940,9 @@ ORDER BY ${bucketTimeSql} ASC, sdk_name ASC, sdk_version ASC, public_key ASC
     AND ingestion_sdk_name NOT IN {internalSdkNames: Array(String)}
     AND is_deleted = 0`;
 
-      const rows = await queryClickhouse<SdkUsageSummaryByProjectRow>({
-        query: `
+      const [rows, datasetRunItemsPostUsageRows] = await Promise.all([
+        queryClickhouse<SdkUsageSummaryByProjectRow>({
+          query: `
 WITH selected AS (
   SELECT
     project_id,
@@ -964,18 +974,51 @@ SELECT
 FROM selected
 GROUP BY project_id, sdk_name, sdk_version, public_key
 ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
-        `,
-        params: {
-          projectIds,
-          fromTimestamp: convertDateToClickhouseDateTime(input.fromTimestamp),
-          toTimestamp: convertDateToClickhouseDateTime(input.toTimestamp),
-          internalSdkNames: [...INTERNAL_INGESTION_SDK_NAMES],
-        },
-        tags: {
-          route: "v4-org-sdk-usage-summary",
-        },
-        preferredClickhouseService: "EventsReadOnly",
-      });
+          `,
+          params: {
+            projectIds,
+            fromTimestamp: convertDateToClickhouseDateTime(input.fromTimestamp),
+            toTimestamp: convertDateToClickhouseDateTime(input.toTimestamp),
+            internalSdkNames: [...INTERNAL_INGESTION_SDK_NAMES],
+          },
+          tags: {
+            route: "v4-org-sdk-usage-summary",
+          },
+          preferredClickhouseService: "EventsReadOnly",
+        }),
+        queryClickhouse<DatasetRunItemsPostUsageByProjectRow>({
+          query: `
+SELECT
+  JSONExtractString(log_comment, 'projectId') AS projectId,
+  count() AS count
+FROM ${systemTableRef("system.query_log")}
+WHERE
+  event_time >= {fromTimestamp: DateTime64(3)}
+  AND event_time <= {toTimestamp: DateTime64(3)}
+  AND event_date >= toDate({fromTimestamp: DateTime64(3)})
+  AND event_date <= toDate({toTimestamp: DateTime64(3)})
+  AND type = 'QueryFinish'
+  AND JSONExtractString(log_comment, 'tag_schema_version') = '1'
+  AND JSONExtractString(log_comment, 'surface') = 'publicapi'
+  AND JSONExtractString(log_comment, 'projectId') IN {projectIds: Array(String)}
+  AND splitByChar('?', JSONExtractString(log_comment, 'route'))[1] = 'POST /api/public/dataset-run-items'
+GROUP BY projectId
+SETTINGS skip_unavailable_shards = 1
+          `,
+          params: {
+            projectIds,
+            fromTimestamp: convertDateToClickhouseDateTime(input.fromTimestamp),
+            toTimestamp: convertDateToClickhouseDateTime(input.toTimestamp),
+          },
+          tags: {
+            route: "v4-org-experiment-instrumentation-summary",
+          },
+          preferredClickhouseService: "ReadOnly",
+          clickhouseSettings: {
+            skip_unavailable_shards: 1,
+          },
+        }),
+      ]);
 
       const rowsByProjectId = new Map<string, SdkUsageSummaryByProjectRow[]>();
       for (const row of rows) {
@@ -983,6 +1026,11 @@ ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
         projectRows.push(row);
         rowsByProjectId.set(row.projectId, projectRows);
       }
+      const projectsUsingDatasetRunItemsPost = new Set(
+        datasetRunItemsPostUsageRows
+          .filter((row) => Number(row.count) > 0)
+          .map((row) => row.projectId),
+      );
 
       return projectIds.map((projectId): SdkUsageSummaryByProjectResultRow => {
         const projectRows = (rowsByProjectId.get(projectId) ?? []).map(
@@ -1049,6 +1097,55 @@ ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
             };
           },
         );
+        const usesDatasetRunItemsPost =
+          projectsUsingDatasetRunItemsPost.has(projectId);
+        const langfuseSdkUsage = projectRows.filter(
+          (series) => series.canonicalSdkName !== null,
+        );
+        const hasCurrentExperimentInstrumentation =
+          langfuseSdkUsage.length > 0 &&
+          langfuseSdkUsage.every(
+            (series) =>
+              getSdkVersionCapabilityStatus(
+                {
+                  language: series.sdkName,
+                  version: series.sdkVersion,
+                },
+                "experimentLinkDeprecation",
+              ) === "supported",
+          );
+        const hasInconclusiveExperimentSdkUsage = langfuseSdkUsage.some(
+          (series) => {
+            const runnerStatus = getSdkVersionCapabilityStatus(
+              {
+                language: series.sdkName,
+                version: series.sdkVersion,
+              },
+              "experimentRunner",
+            );
+            const currentInstrumentationStatus = getSdkVersionCapabilityStatus(
+              {
+                language: series.sdkName,
+                version: series.sdkVersion,
+              },
+              "experimentLinkDeprecation",
+            );
+
+            return (
+              currentInstrumentationStatus === "unknown" ||
+              (runnerStatus !== "unsupported" &&
+                currentInstrumentationStatus !== "supported")
+            );
+          },
+        );
+        const experimentInstrumentationMigration: SdkUsageSummaryByProjectResultRow["experimentInstrumentationMigration"] =
+          !usesDatasetRunItemsPost
+            ? { status: "not_required", upgradePath: null }
+            : hasCurrentExperimentInstrumentation
+              ? { status: "not_required", upgradePath: null }
+              : hasInconclusiveExperimentSdkUsage
+                ? { status: "sdk_usage_inconclusive", upgradePath: "sdk" }
+                : { status: "required", upgradePath: "api" };
 
         return {
           projectId,
@@ -1064,6 +1161,7 @@ ORDER BY project_id ASC, sdk_name ASC, sdk_version ASC, public_key ASC
               series.hasDelayedOtelEvents === true &&
               series.canonicalSdkName === null,
           ).length,
+          experimentInstrumentationMigration,
           sdkUsageSeries,
         };
       });

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -1013,7 +1013,7 @@ SETTINGS skip_unavailable_shards = 1
           tags: {
             route: "v4-org-experiment-instrumentation-summary",
           },
-          preferredClickhouseService: "ReadOnly",
+          preferredClickhouseService: "EventsReadOnly",
           clickhouseSettings: {
             skip_unavailable_shards: 1,
           },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15757.preview.langfuse.com](https://pr-15757.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends v4 migration reporting with experiment-instrumentation detection, SDK capability thresholds, readiness integration, and corresponding project/org UI states and tests.

- Queries dataset-run-items usage from ClickHouse query logs.
- Classifies experiment migrations as required, inconclusive, or not required.
- Displays experiment status and guidance in migration details and organization tables.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until deprecated dataset-run-items calls can no longer be hidden by unrelated current SDK telemetry from the same project.

The new classifier joins two independently aggregated project-level signals, so a direct deprecated API caller and a current SDK caller are indistinguishable and can incorrectly produce a not-required migration status.

**Files Needing Attention:** web/src/features/v4/server/v4TransitionRouter.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  QL[query_log: project-level dataset-run-items usage] --> C[Migration classifier]
  SDK[events/scores: project-wide SDK versions] --> C
  C -->|required| API[API migration guidance]
  C -->|inconclusive| Review[SDK usage review]
  C -->|not required| Ready[Project marked up to date]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4/server/v4TransitionRouter.ts:1105-1116
**Project-wide SDK attribution hides usage**

When a project calls `POST /api/public/dataset-run-items` through a deprecated direct client while also ingesting through current Langfuse SDKs, the route query records only the project ID and this project-wide SDK check classifies the call as `not_required`, causing the migration UI to hide an experiment integration that still requires migration.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(migration): enhance experiment inst..."](https://github.com/langfuse/langfuse/commit/4c81a17fb48d89c68d63db5bb33fa3fc781d924c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49991334)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->