### PR TITLE
fix(mcp): separate agent submissions from tool call limits

### DIFF
--- a/packages/shared/prisma/migrations/20260804000000_add_in_app_agent_mcp_tool_call_count/migration.sql
+++ b/packages/shared/prisma/migrations/20260804000000_add_in_app_agent_mcp_tool_call_count/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "in_app_agent_conversations"
+ADD COLUMN "mcp_tool_call_count" INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX "in_app_agent_runs_project_mcp_key_idx"
+ON "in_app_agent_runs" ("project_id", "mcp_api_key_id");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -239,6 +239,7 @@ model InAppAgentConversation {
   renamedByUserAt   DateTime?                             @map("renamed_by_user_at")
   visibilityScope   InAppAgentConversationVisibilityScope @default(PERSONAL) @map("visibility_scope")
   providerSessionId String?                               @map("provider_session_id")
+  mcpToolCallCount  Int                                   @default(0) @map("mcp_tool_call_count")
   deletedAt         DateTime?                             @map("deleted_at")
   createdAt         DateTime                              @default(now()) @map("created_at")
   updatedAt         DateTime                              @default(now()) @updatedAt @map("updated_at")
@@ -301,6 +302,7 @@ model InAppAgentRun {
   // migration since Prisma cannot express partial uniqueness in the schema DSL.
   @@id([id, projectId])
   @@index([projectId, conversationId, createdAt], map: "in_app_agent_runs_project_conversation_created_idx")
+  @@index([projectId, mcpApiKeyId], map: "in_app_agent_runs_project_mcp_key_idx")
   @@map("in_app_agent_runs")
 }
 

--- a/packages/shared/src/in-app-agent/constants.ts
+++ b/packages/shared/src/in-app-agent/constants.ts
@@ -5,6 +5,11 @@ export const IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE = "tool_call_rejected";
 
 export const IN_APP_AGENT_MCP_USER_AGENT = "langfuse-in-app-agent";
 
+// Hard stop for Langfuse MCP calls across all turns in one conversation. The
+// counter lives on the conversation row so foreground, background, and
+// approval-continuation runs share the same budget.
+export const IN_APP_AGENT_MAX_MCP_TOOL_CALLS_PER_CONVERSATION = 100;
+
 // Header used only by Langfuse's server-side in-app agent when it calls the
 // Langfuse MCP endpoint with a temporary in-app-agent API key and run override.
 export const IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER =

--- a/web/src/__tests__/server/unit/in-app-agent-mcp-tool-call-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-mcp-tool-call-limit.servertest.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { updateMany } = vi.hoisted(() => ({ updateMany: vi.fn() }));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    inAppAgentConversation: {
+      updateMany,
+    },
+  },
+}));
+
+import { consumeInAppAgentMcpToolCall } from "@/src/features/mcp/server/inAppAgentToolCallLimit";
+import { IN_APP_AGENT_MAX_MCP_TOOL_CALLS_PER_CONVERSATION } from "@langfuse/shared/in-app-agent";
+
+describe("consumeInAppAgentMcpToolCall", () => {
+  beforeEach(() => {
+    updateMany.mockReset();
+  });
+
+  it("reserves a call while the conversation budget remains", async () => {
+    updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      consumeInAppAgentMcpToolCall({
+        projectId: "project-1",
+        conversationId: "conversation-1",
+      }),
+    ).resolves.toBe(true);
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "conversation-1",
+        projectId: "project-1",
+        deletedAt: null,
+        mcpToolCallCount: {
+          lt: IN_APP_AGENT_MAX_MCP_TOOL_CALLS_PER_CONVERSATION,
+        },
+      },
+      data: { mcpToolCallCount: { increment: 1 } },
+    });
+  });
+
+  it("rejects a call once the conversation budget is exhausted", async () => {
+    updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      consumeInAppAgentMcpToolCall({
+        projectId: "project-1",
+        conversationId: "conversation-1",
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
@@ -3,7 +3,10 @@ import {
   createInAppAgentMcpRunOverride,
   InAppAgentMcpRunOverrideSchema,
 } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
-import { getInAppAgentContext } from "@/src/pages/api/public/mcp";
+import {
+  getInAppAgentContext,
+  shouldSkipMcpRateLimit,
+} from "@/src/pages/api/public/mcp";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 
@@ -22,6 +25,12 @@ describe("MCP route in-app-agent context", () => {
     return req;
   };
 
+  it("skips the generic request limiter for in-app-agent MCP calls", () => {
+    expect(shouldSkipMcpRateLimit(true)).toBe(true);
+    expect(shouldSkipMcpRateLimit(false)).toBe(false);
+    expect(shouldSkipMcpRateLimit(undefined)).toBe(false);
+  });
+
   it("returns undefined for non in-app-agent keys", () => {
     const req = createRequest('{"toolName":"upsertDataset"}');
 
@@ -33,6 +42,15 @@ describe("MCP route in-app-agent context", () => {
     const req = createRequest();
 
     expect(getInAppAgentContext(req, true)).toEqual({ permissions: "read" });
+  });
+
+  it("preserves the authenticated conversation id for in-app-agent calls", () => {
+    const req = createRequest();
+
+    expect(getInAppAgentContext(req, true, "conversation-1")).toEqual({
+      permissions: "read",
+      conversationId: "conversation-1",
+    });
   });
 
   it("falls back to read permissions for malformed override headers", () => {

--- a/web/src/features/in-app-agent/README.md
+++ b/web/src/features/in-app-agent/README.md
@@ -212,6 +212,14 @@ The in-app agent uses two request-scoped inputs when calling Langfuse MCP:
 - A temporary project-scoped API key marked as an in-app-agent key.
 - An optional server-generated tool override sent with `x-langfuse-in-app-agent-tool-override`.
 
+Normal MCP requests consume the org-scoped `public-api` rate-limit bucket.
+Active in-app-agent MCP requests skip that request-level bucket because agent
+submissions and approval continuations separately consume the org-scoped
+`in-app-agent-run` daily bucket at user-submission boundaries. In addition, the
+Langfuse MCP endpoint enforces a durable limit of 100 Langfuse tool calls per
+conversation, shared by foreground, background, and approval-continuation
+runs.
+
 The API key authenticates the request and scopes it to the project. Without an override, in-app-agent keys are restricted to MCP tools annotated with `readOnlyHint: true`. When the user approves a single Langfuse MCP tool call, `server/handler.ts` creates a JSON override naming that one unprefixed MCP registry tool and passes it to the MCP route through the request header above.
 
 MCP registry behavior:

--- a/web/src/features/mcp/server/inAppAgentToolCallLimit.ts
+++ b/web/src/features/mcp/server/inAppAgentToolCallLimit.ts
@@ -1,0 +1,30 @@
+import { IN_APP_AGENT_MAX_MCP_TOOL_CALLS_PER_CONVERSATION } from "@langfuse/shared/in-app-agent";
+import { prisma } from "@langfuse/shared/src/db";
+
+/**
+ * Atomically reserve one Langfuse MCP tool call for an in-app-agent
+ * conversation. The conditional update makes parallel tool calls safe: once
+ * the budget is exhausted, no caller can reserve another point.
+ */
+export async function consumeInAppAgentMcpToolCall(params: {
+  projectId: string;
+  conversationId: string;
+}): Promise<boolean> {
+  const result = await prisma.inAppAgentConversation.updateMany({
+    where: {
+      id: params.conversationId,
+      projectId: params.projectId,
+      deletedAt: null,
+      mcpToolCallCount: {
+        lt: IN_APP_AGENT_MAX_MCP_TOOL_CALLS_PER_CONVERSATION,
+      },
+    },
+    data: {
+      mcpToolCallCount: {
+        increment: 1,
+      },
+    },
+  });
+
+  return result.count > 0;
+}

--- a/web/src/features/mcp/server/mcpServer.ts
+++ b/web/src/features/mcp/server/mcpServer.ts
@@ -21,6 +21,8 @@ import type { ServerContext } from "../types";
 import { toolRegistry } from "./registry";
 import { contextWithLangfuseProps, logger } from "@langfuse/shared/src/server";
 import { context as otelContext } from "@opentelemetry/api";
+import { IN_APP_AGENT_MAX_MCP_TOOL_CALLS_PER_CONVERSATION } from "@langfuse/shared/in-app-agent";
+import { consumeInAppAgentMcpToolCall } from "./inAppAgentToolCallLimit";
 
 const MCP_SERVER_NAME = "langfuse";
 
@@ -96,6 +98,25 @@ export function createMcpServer(context: ServerContext): Server {
 
     if (!registeredTool) {
       throw new Error(`Unknown tool: ${name}`);
+    }
+
+    if (context.inAppAgent?.conversationId) {
+      const consumed = await consumeInAppAgentMcpToolCall({
+        projectId: context.projectId,
+        conversationId: context.inAppAgent.conversationId,
+      });
+
+      if (!consumed) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `This conversation reached the maximum of ${IN_APP_AGENT_MAX_MCP_TOOL_CALLS_PER_CONVERSATION} Langfuse MCP tool calls. Start a new conversation to continue.`,
+            },
+          ],
+        };
+      }
     }
 
     // Execute handler with context

--- a/web/src/features/mcp/types.ts
+++ b/web/src/features/mcp/types.ts
@@ -73,8 +73,10 @@ export interface ServerContext {
 export type InAppAgentContext =
   | {
       permissions: "read";
+      conversationId?: string;
     }
   | {
       permissions: "single-tool-override";
       allowedToolName: McpToolName;
+      conversationId?: string;
     };

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -120,15 +120,32 @@ export default async function handler(
       );
     }
 
-    // Rate limit MCP requests
-    const rateLimitCheck =
-      await RateLimitService.getInstance().rateLimitRequest(
-        authCheck.scope,
-        "public-api",
-      );
+    // The in-app agent has its own submission-level limiter on the foreground
+    // route and on background start/approval mutations. Its worker-owned MCP
+    // calls must not consume the generic public-api bucket, otherwise a burst
+    // during background execution can surface as a user-facing "assistant
+    // request limit" error even though the user did not submit anything.
+    if (!shouldSkipMcpRateLimit(authCheck.scope.isInAppAgentKey)) {
+      const rateLimitCheck =
+        await RateLimitService.getInstance().rateLimitRequest(
+          authCheck.scope,
+          "public-api",
+        );
 
-    if (rateLimitCheck?.isRateLimited()) {
-      return rateLimitCheck.sendRestResponseIfLimited(res);
+      if (rateLimitCheck?.isRateLimited()) {
+        return rateLimitCheck.sendRestResponseIfLimited(res);
+      }
+    }
+
+    const inAppAgentConversationId = authCheck.scope.isInAppAgentKey
+      ? await getInAppAgentConversationId(
+          authCheck.scope.apiKeyId,
+          authCheck.scope.projectId,
+        )
+      : undefined;
+
+    if (authCheck.scope.isInAppAgentKey && !inAppAgentConversationId) {
+      throw new ForbiddenError("In-app agent session is no longer active");
     }
 
     // Build ServerContext from authenticated scope. In-app-agent keys need a
@@ -144,7 +161,11 @@ export default async function handler(
       plan: authCheck.scope.plan,
       rateLimitOverrides: authCheck.scope.rateLimitOverrides,
       userAgent: req.headers["user-agent"],
-      inAppAgent: getInAppAgentContext(req, authCheck.scope.isInAppAgentKey),
+      inAppAgent: getInAppAgentContext(
+        req,
+        authCheck.scope.isInAppAgentKey,
+        inAppAgentConversationId,
+      ),
     };
 
     logger.debug("MCP request authenticated", {
@@ -190,9 +211,16 @@ export default async function handler(
   }
 }
 
+export function shouldSkipMcpRateLimit(
+  isInAppAgentKey: boolean | undefined,
+): boolean {
+  return isInAppAgentKey === true;
+}
+
 export function getInAppAgentContext(
   req: NextApiRequest,
   isInAppAgentKey: boolean | undefined,
+  conversationId?: string,
 ): ServerContext["inAppAgent"] {
   if (isInAppAgentKey !== true) {
     return undefined;
@@ -201,7 +229,10 @@ export function getInAppAgentContext(
   const headerValue = req.headers[IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER];
 
   if (typeof headerValue !== "string") {
-    return { permissions: "read" };
+    return {
+      permissions: "read",
+      ...(conversationId ? { conversationId } : {}),
+    };
   }
 
   const parsedOverride = InAppAgentMcpRunOverrideSchema.safeParse(
@@ -212,8 +243,28 @@ export function getInAppAgentContext(
     ? {
         permissions: "single-tool-override",
         allowedToolName: parsedOverride.data.toolName,
+        ...(conversationId ? { conversationId } : {}),
       }
-    : { permissions: "read" };
+    : {
+        permissions: "read",
+        ...(conversationId ? { conversationId } : {}),
+      };
+}
+
+async function getInAppAgentConversationId(
+  apiKeyId: string,
+  projectId: string,
+): Promise<string | undefined> {
+  const run = await prisma.inAppAgentRun.findFirst({
+    where: {
+      projectId,
+      mcpApiKeyId: apiKeyId,
+      finishedAt: null,
+    },
+    select: { conversationId: true },
+  });
+
+  return run?.conversationId;
 }
 
 /**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15761.preview.langfuse.com](https://pr-15761.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Keep the existing org-scoped `public-api` limiter for normal MCP clients.
- Stop active in-app-agent MCP HTTP calls from consuming that short request bucket; foreground submits and background `startRun` / approval mutations still consume the org-scoped `in-app-agent-run` limit.
- Add an atomic, project-scoped conversation counter enforcing 100 Langfuse MCP tool calls across foreground, background, and approval-continuation runs.
- Reject stale in-app-agent temporary API keys without an active run and propagate the authenticated conversation id into MCP authorization.

## Existing limits confirmed

- `in-app-agent-run`: 100/day for Hobby and 1,000/day for Core/Pro/Team/Enterprise; unlimited for OSS/self-hosted.
- `public-api`: separate org-scoped MCP request bucket for normal API-key clients.
- `maxSteps`: 10 per agent run; this was not a conversation-level MCP-call limit.

## Verification

- Focused MCP tests: 2 files passed, 8 tests passed.
- Background execution regression: 1 file passed, 17 tests passed.
- Shared and web typechecks passed.
- Changed-file ESLint passed.
- `git diff --check` passed.
- Full repository lint remains blocked by two pre-existing warnings in `web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx`.