### PR TITLE
fix(ui): guard null item refs in Radix roving-focus focusFirst

### DIFF
--- a/patches/@radix-ui__react-roving-focus@1.1.11.patch
+++ b/patches/@radix-ui__react-roving-focus@1.1.11.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/index.js b/dist/index.js
+index b49982f5a62521aaf0be8831ad7c86d661ab04a0..be7e8833cc63f8f6b6f2c8c2ef88999bb13e5652 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -250,6 +250,7 @@ function getFocusIntent(event, orientation, dir) {
+ function focusFirst(candidates, preventScroll = false) {
+   const PREVIOUSLY_FOCUSED_ELEMENT = document.activeElement;
+   for (const candidate of candidates) {
++    if (!candidate) continue;
+     if (candidate === PREVIOUSLY_FOCUSED_ELEMENT) return;
+     candidate.focus({ preventScroll });
+     if (document.activeElement !== PREVIOUSLY_FOCUSED_ELEMENT) return;
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 08aaabcdb5402c74bcbd935a34e2b7f4a50fdfc0..497b7f08f6a8bce319148ab43bf7e660ff4fe1db 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -211,6 +211,7 @@ function getFocusIntent(event, orientation, dir) {
+ function focusFirst(candidates, preventScroll = false) {
+   const PREVIOUSLY_FOCUSED_ELEMENT = document.activeElement;
+   for (const candidate of candidates) {
++    if (!candidate) continue;
+     if (candidate === PREVIOUSLY_FOCUSED_ELEMENT) return;
+     candidate.focus({ preventScroll });
+     if (document.activeElement !== PREVIOUSLY_FOCUSED_ELEMENT) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,7 @@ overrides:
   next-auth>nodemailer: ^9.0.3
 
 patchedDependencies:
+  '@radix-ui/react-roving-focus@1.1.11': fb2bc2e96ad2c31dcb5860e509374a512fa08b1fade5805e3ae2dc72dcd68a0b
   next-auth@4.24.15: 298683aaa31566643f1899990a065b342ad777d8613f50a25ddc44dd46fb5b4d
 
 importers:
@@ -15578,7 +15579,7 @@ snapshots:
       '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(patch_hash=fb2bc2e96ad2c31dcb5860e509374a512fa08b1fade5805e3ae2dc72dcd68a0b)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
@@ -15686,7 +15687,7 @@ snapshots:
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(patch_hash=fb2bc2e96ad2c31dcb5860e509374a512fa08b1fade5805e3ae2dc72dcd68a0b)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
@@ -15696,7 +15697,7 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-roving-focus@1.1.11(patch_hash=fb2bc2e96ad2c31dcb5860e509374a512fa08b1fade5805e3ae2dc72dcd68a0b)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -15824,7 +15825,7 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(patch_hash=fb2bc2e96ad2c31dcb5860e509374a512fa08b1fade5805e3ae2dc72dcd68a0b)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -15838,7 +15839,7 @@ snapshots:
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(patch_hash=fb2bc2e96ad2c31dcb5860e509374a512fa08b1fade5805e3ae2dc72dcd68a0b)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,6 +104,10 @@ overrides:
   # Remove once next-auth allows nodemailer ^9.
   "next-auth>nodemailer": "^9.0.3"
 patchedDependencies:
+  # focusFirst crashes on null item refs (items unmounting while entry focus
+  # runs), e.g. opening a row-actions dropdown while a table re-renders.
+  # Still unfixed upstream as of 1.1.19; remove once Radix guards focusFirst.
+  '@radix-ui/react-roving-focus@1.1.11': patches/@radix-ui__react-roving-focus@1.1.11.patch
   next-auth@4.24.15: patches/next-auth@4.24.15.patch
 publicHoistPattern:
   - "*prisma*"


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15764.preview.langfuse.com](https://pr-15764.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Opening a dropdown menu (or tabbing into a tab list / toggle group) while the surrounding list re-renders crashes with an unhandled `TypeError: Cannot read properties of null (reading 'focus')` inside Radix's roving-focus primitive. This PR adds a one-line pnpm patch so the focus loop skips items whose DOM node is already gone. No behavior change otherwise.

## Why

Sentry shows this as a recurring unhandled crash family, still firing daily:

- LANGFUSE-5TZ — 26 events / 10 users since 2026-07-24, prompts page
- LANGFUSE-5FE — 67 events / 26 users since May, prompts page (same minified frame)
- LANGFUSE-5QA — 11 events / 3 users, prompts page
- LANGFUSE-5T5 — 3 events / 2 users, prompts page
- LANGFUSE-5VE — 1 event / 1 user, dataset items page

All symbolicated stacks converge on the same third-party frame: `@radix-ui/react-roving-focus` `focusFirst()` calling `candidate.focus()` where `candidate` is `null`.

## What

`RovingFocusGroup` builds its focus candidates with `items.map((item) => item.ref.current)` — without filtering nulls. When an item unmounts between collection registration and the entry-focus event (e.g. a row-actions `DropdownMenu` opens while the table re-renders), its ref is `null` and `focusFirst` throws.

Fixed via `pnpm patch` (same mechanism as the existing `next-auth` patch): `focusFirst` now skips null candidates and moves on to the next live item. The bug is still present in the latest upstream release (1.1.19, 2026-07-24), so upgrading is not an option yet; the patch is annotated in `pnpm-workspace.yaml` for removal once Radix fixes it.

## Result

The whole `null (reading 'focus')` crash family stops firing; focus lands on the first still-mounted item, which is the primitive's intended behavior.

<details>
<summary>Engineering detail</summary>

### Crash mechanism

`roving-focus-group.tsx` group `onFocus` (entry focus, src line 185):

```ts
const candidateNodes = candidateItems.map((item) => item.ref.current); // may contain null
focusFirst(candidateNodes, preventScrollOnEntryFocus);
```

`focusFirst` (src line 332):

```ts
for (const candidate of candidates) {
  if (candidate === PREVIOUSLY_FOCUSED_ELEMENT) return;
  candidate.focus({ preventScroll }); // throws when candidate is null
  ...
}
```

Radix's collection registry keeps an item registered for a beat after its DOM node unmounts, so `ref.current` can be `null` inside the entry-focus handler. The Sentry stacks show the trigger is `react-menu`'s `onMountAutoFocus` (opening a `DropdownMenu`) dispatching entry focus into the group mid-re-render.

### Why a guard, not a timing fix

The null item is one that no longer exists in the DOM — focusing it was never possible; before this patch the crash simply pre-empted focusing the next live item. Skipping nulls is exactly what the loop's own "try the next candidate" design intends, so this does not mask a behavioral bug. The arrow-key navigation path funnels through the same `focusFirst`, so a single guard covers both entry focus and keyboard navigation without touching index arithmetic (`indexOf(event.currentTarget)` never matches `null`).

### Patch scope

- `patches/@radix-ui__react-roving-focus@1.1.11.patch` — `if (!candidate) continue;` in `focusFirst`, applied to both `dist/index.js` and `dist/index.mjs`.
- Single version of the package in the lockfile (pulled in by `react-menu`/`react-dropdown-menu`, `react-tabs`, `react-toggle-group`, `react-radio-group`), so one patch covers every consumer.
- Verified the patched build loads and exports correctly; prettier + turbo lint green via pre-commit.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a pnpm patch for Radix roving focus to prevent stale null item references from crashing focus traversal.
- Guards null candidates in both CommonJS and ESM distributions.
- Registers the patch in the pnpm workspace configuration.
- Updates lockfile snapshots to apply the patch consistently to all consumers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the guard skips only absent DOM nodes and the patch is consistently registered across package formats and lockfile consumers.

The changed focus loop retains its existing behavior for live candidates while avoiding the null dereference, and the dependency metadata applies the patch without changing package versions or unrelated dependency paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): guard null item refs in roving-..."](https://github.com/langfuse/langfuse/commit/4f7db924369c4cad2bdcb79d8a9419d70fc9d8a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50037217)</sub>

<!-- /greptile_comment -->