### PR TITLE
fix(web): stop Sentry capture of expected query-guardrail tRPC errors

### DIFF
--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -108,17 +108,47 @@ describe("getTrpcErrorCode / getTrpcErrorPath", () => {
 });
 
 describe("isExpectedTrpcClientError", () => {
+  const httpStatusByCode: Record<string, number> = {
+    NOT_FOUND: 404,
+    FORBIDDEN: 403,
+    UNAUTHORIZED: 401,
+    UNPROCESSABLE_CONTENT: 422,
+  };
+
   // Expected, user-facing states — must be suppressed (not captured to Sentry).
   it.each(EXPECTED_TRPC_ERROR_CODES)(
     "treats %s as an expected client error",
     (code) => {
-      const httpStatus =
-        code === "NOT_FOUND" ? 404 : code === "FORBIDDEN" ? 403 : 401;
-      const error = trpcServerError({ code, httpStatus, path: "traces.byId" });
+      const error = trpcServerError({
+        code,
+        httpStatus: httpStatusByCode[code],
+        path: "traces.byId",
+      });
 
       expect(isExpectedTrpcClientError(error)).toBe(true);
     },
   );
+
+  it("treats the ClickHouse query-guardrail advice as expected", () => {
+    // Mirrors the production shape: `withErrorHandling` (web/src/server/api/
+    // trpc.ts) maps ClickHouseResourceError to UNPROCESSABLE_CONTENT with the
+    // RESOURCE_LIMIT_ERROR_MESSAGE advice; the UI renders it as toast/inline.
+    const error = TRPCClientError.from({
+      error: {
+        code: -32600,
+        message:
+          "Your query could not be completed. Please narrow your request by adding more specific filters (e.g., a shorter date range).",
+        data: {
+          code: "UNPROCESSABLE_CONTENT",
+          httpStatus: 422,
+          path: "traces.metrics",
+          errorName: "ClickHouseResourceError",
+        },
+      },
+    });
+
+    expect(isExpectedTrpcClientError(error)).toBe(true);
+  });
 
   // Negative fixtures: real errors MUST still flow to Sentry. If any of these
   // start returning true, the suppression rule has grown a hole that hides a

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -104,20 +104,28 @@ export const isNetworkConnectivityError = (error: unknown): boolean => {
  *  - FORBIDDEN     — the signed-in user may not access this resource (a trace in
  *                    another org, a project they are not a member of)
  *  - UNAUTHORIZED  — the session expired or the user is not signed in
+ *  - UNPROCESSABLE_CONTENT — a resource guardrail rejected the request with
+ *                    user-facing advice. The server mints this code only for
+ *                    query resource limits (`ClickHouseResourceError` → "narrow
+ *                    your request…", see `withErrorHandling` in
+ *                    `web/src/server/api/trpc.ts`) and oversized payloads
+ *                    (`PayloadTooLargeError`, httpCode 422)
  *
  * The UI already renders each of these as an error page or toast — it is the
  * product working as designed, not a regression a human should act on. Sending
  * them to Sentry turns the error tracker into a log of ordinary navigation
  * (`Trace not found` alone is the #2 issue by volume, ~30k events / ~3.3k
- * users) and drowns real signal.
+ * users; the query-guardrail advice minted ~2.3k events / ~600 users in two
+ * weeks) and drowns real signal.
  *
  * Suppressing capture here does NOT blind us to real authz/lookup regressions:
  * the server owns that signal — a genuine regression surfaces as a 4xx-rate
  * anomaly server-side and as user reports, whereas the client Sentry event is
  * only an amplified, lower-fidelity copy. The server itself already logs
- * NOT_FOUND / UNAUTHORIZED as non-errors (`web/src/server/api/trpc.ts`), and
- * `handleTrpcError` leaves a breadcrumb for each suppressed error so its path +
- * code stay in the trail of any real event captured later in the session.
+ * NOT_FOUND / UNAUTHORIZED as non-errors and every guardrail hit as a warning
+ * (`web/src/server/api/trpc.ts`), and `handleTrpcError` leaves a breadcrumb
+ * for each suppressed error so its path + code stay in the trail of any real
+ * event captured later in the session.
  *
  * Deliberately narrow: only these codes on an actual `TRPCClientError`. A 5xx
  * (`INTERNAL_SERVER_ERROR`), a `BAD_REQUEST`, an unrecognized code, or any
@@ -127,6 +135,7 @@ export const EXPECTED_TRPC_ERROR_CODES = [
   "NOT_FOUND",
   "FORBIDDEN",
   "UNAUTHORIZED",
+  "UNPROCESSABLE_CONTENT",
 ] as const;
 
 const getTrpcErrorData = (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15765.preview.langfuse.com](https://pr-15765.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The client tRPC seam (`handleTrpcError`) now classifies `UNPROCESSABLE_CONTENT` as an expected user-facing outcome — Sentry breadcrumb instead of an event — exactly like `NOT_FOUND`/`FORBIDDEN`/`UNAUTHORIZED` since #15243. This removes the dominant remaining Sentry noise family: the query-guardrail advice ("Your query could not be completed. Please narrow your request…"), ~2.3k events / ~600 users in the last two weeks. Users still see the toast; real errors (5xx, `BAD_REQUEST`, unknown codes, non-tRPC) still capture. One line of behavior change + docs + tests.

## Why

Six sibling Sentry issues with the same guardrail title dominate the current inflow (largest two: 1,045 events / 383 users and 917 events / 221 users, still firing daily). Every one of these is the product working as designed: a query hit a resource guardrail, the server replied 422 with advice, and the UI rendered it as a toast/inline state. An event in Sentry is a promise a human should act — nobody acts on these, and at this volume they drown real signal.

## What

Verified the capture mechanism first: the latest events on all six issues carry `mechanism: generic`, `handled: yes`, and `trpc.code=UNPROCESSABLE_CONTENT` / `trpc.path` tags — set only by `handleTrpcError`'s `captureException`. So the fix belongs at that one classification seam, not in `beforeSend`: added `UNPROCESSABLE_CONTENT` to `EXPECTED_TRPC_ERROR_CODES`.

The server mints this code in exactly two places, both designed guardrails with user-facing advice:
- `withErrorHandling` (`web/src/server/api/trpc.ts`) wraps `ClickHouseResourceError` (query memory limit / overcommit / timeout) into 422 + the "narrow your request" message, and logs each hit server-side as a warning with `errorType` and query tags.
- `PayloadTooLargeError` (httpCode 422) for oversized trace observations.

## Result

The guardrail family stops minting Sentry events while staying fully visible to users (toast unchanged), to the session trail (breadcrumb with code + path), and to server-side logs (per-hit warning). Genuine unexpected tRPC failures keep flowing to Sentry with `trpc.code`/`trpc.path` tags.

<details>
<summary>Mechanism, suppression-safety review, and verification</summary>

### Does this hide a real error?

- Exhaustive search: no other `UNPROCESSABLE_CONTENT` throw sites in `web/`, `worker/`, `packages/shared/`, `ee/`. Zod input validation maps to `BAD_REQUEST` (still captured). tRPC internals emit this code only in the WebSocket and app-dir adapters, neither of which is used here.
- Matching requires a real `TRPCClientError` with `data.code` from a tRPC envelope — infra/proxy error bodies have no envelope and keep capturing via the non-expected path.
- Negative fixtures assert `INTERNAL_SERVER_ERROR` (500), `BAD_REQUEST`, `CONFLICT`, an unrecognized code, and non-tRPC errors are NOT suppressed.
- An independent skeptical review of the diff hunted for masked-real-error scenarios and found no blocker. Its one substantive note: a ClickHouse socket-level timeout during cluster degradation is wrapped by the message-based classifier as a "resource error", so it also stops producing client Sentry events — that signal lives in the server-side warning rate (split by `errorType`), which is the higher-fidelity detector; see follow-ups.

### Verified capture mechanism

Latest events on all six sibling issues: exception-type, `mechanism: generic`, `handled: yes`, tagged `trpc.code=UNPROCESSABLE_CONTENT` + `trpc.path` (`traces.metrics`, `events.filterOptions`, `scores.getScoreColumns`, `events.all`). Those tags exist only in `handleTrpcError`'s `captureException` call, ruling out the console-capture path (the tRPC `loggerLink` is dev-only).

### Follow-ups (not in this PR)

- A PostHog counter for guardrail-hit rate: hundreds of users hitting query limits weekly is a product signal (query UX / limits tuning), not an error signal.
- A log-based monitor on the server-side "ClickHouse resource limit exceeded" warning rate, split by `errorType` — a TIMEOUT-rate spike is the cluster-degradation / guardrail-regression detector.

### Verification

- `web` client vitest suite: 2,851 passed (incl. `api.clienttest.ts` 18/18: new positive fixtures for `UNPROCESSABLE_CONTENT` + the exact production error shape; existing negative fixtures unchanged and green).
- `pnpm --filter=web run typecheck`: green.
- Prettier + lint (pre-commit turbo run across packages): green.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR classifies tRPC `UNPROCESSABLE_CONTENT` responses as expected user-facing errors, preserving breadcrumbs and UI feedback while avoiding Sentry event capture.
- Adds `UNPROCESSABLE_CONTENT` to the expected tRPC error-code list.
- Adds coverage for the generic 422 classification and the production ClickHouse guardrail response shape.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The only current tRPC source of `UNPROCESSABLE_CONTENT` is the intentionally user-facing ClickHouse resource guardrail, which retains server-side warning logs, client breadcrumbs, and UI feedback; unrelated errors continue through existing capture paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): classify tRPC UNPROCESSABLE\_CO..."](https://github.com/langfuse/langfuse/commit/cfc239682914038cdb30089a9b3b9c06f065f694) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50038558)</sub>

<!-- /greptile_comment -->