### PR TITLE
fix(prompts): encode prompt name in detail hrefs to avoid invalid routes

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -49,6 +49,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import usePlaygroundCache from "@/src/features/playground/page/hooks/usePlaygroundCache";
 import { useQueryParam } from "use-query-params";
 import { usePromptNameValidation } from "@/src/features/prompts/hooks/usePromptNameValidation";
+import { getPromptDetailHref } from "@/src/features/prompts/utils";
 import { useFormPersistence } from "@/src/hooks/useFormPersistence";
 
 type NewPromptFormProps = {
@@ -170,9 +171,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
         onFormSuccess?.();
         form.reset();
         if ("name" in newPrompt) {
-          router.push(
-            `/project/${projectId}/prompts/${encodeURIComponent(newPrompt.name)}`,
-          );
+          router.push(getPromptDetailHref(projectId, newPrompt.name));
         }
       })
       .catch((error) => {
@@ -262,9 +261,13 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                         <p className="text-destructive text-sm font-bold">
                           {errorMessage}
                         </p>
-                        {errorMessage?.includes("already exist") ? (
+                        {errorMessage?.includes("already exist") &&
+                        projectId ? (
                           <Link
-                            href={`/project/${projectId}/prompts/${currentName.trim()}`}
+                            href={getPromptDetailHref(
+                              projectId,
+                              currentName.trim(),
+                            )}
                             className="flex flex-row items-center"
                           >
                             Create a new version for it here.

--- a/web/src/features/prompts/components/PromptSelectionDialog.tsx
+++ b/web/src/features/prompts/components/PromptSelectionDialog.tsx
@@ -20,6 +20,7 @@ import { Label } from "@/src/components/ui/label";
 import { api } from "@/src/utils/api";
 import { CopyIcon, ExternalLinkIcon } from "lucide-react";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { getPromptDetailHref } from "@/src/features/prompts/utils";
 
 type PromptSelectionDialogProps = {
   isOpen: boolean;
@@ -196,7 +197,7 @@ export function PromptSelectionDialog({
                   </Select>
                   {selectedVersionOrLabel && (
                     <Link
-                      href={`/project/${projectId}/prompts/${selectedPromptName}?${selectionType}=${selectedVersionOrLabel}`}
+                      href={`${getPromptDetailHref(projectId, selectedPromptName)}?${selectionType}=${encodeURIComponent(selectedVersionOrLabel)}`}
                       target="_blank"
                       passHref
                     >

--- a/web/src/features/prompts/utils.clienttest.ts
+++ b/web/src/features/prompts/utils.clienttest.ts
@@ -1,0 +1,33 @@
+import { getPromptDetailHref } from "@/src/features/prompts/utils";
+
+describe("getPromptDetailHref", () => {
+  it("builds the detail href for a plain prompt name", () => {
+    expect(getPromptDetailHref("project-1", "my-prompt")).toBe(
+      "/project/project-1/prompts/my-prompt",
+    );
+  });
+
+  it("encodes slash-grouped (folder) names as a single path segment", () => {
+    expect(getPromptDetailHref("project-1", "folder/sub/prompt")).toBe(
+      "/project/project-1/prompts/folder%2Fsub%2Fprompt",
+    );
+  });
+
+  it("never emits an empty path segment for leading-slash names", () => {
+    const href = getPromptDetailHref("project-1", "/prompt");
+    expect(href).toBe("/project/project-1/prompts/%2Fprompt");
+    expect(href).not.toContain("//");
+  });
+
+  it("never emits an empty path segment for names with empty segments", () => {
+    const href = getPromptDetailHref("project-1", "a//b");
+    expect(href).toBe("/project/project-1/prompts/a%2F%2Fb");
+    expect(href).not.toContain("//");
+  });
+
+  it("encodes characters that would break the path or query", () => {
+    expect(getPromptDetailHref("project-1", "a?b#c d")).toBe(
+      "/project/project-1/prompts/a%3Fb%23c%20d",
+    );
+  });
+});

--- a/web/src/features/prompts/utils.ts
+++ b/web/src/features/prompts/utils.ts
@@ -3,3 +3,17 @@ import { LATEST_PROMPT_LABEL, PRODUCTION_LABEL } from "@langfuse/shared";
 export const isReservedPromptLabel = (label: string) => {
   return [PRODUCTION_LABEL, LATEST_PROMPT_LABEL].includes(label);
 };
+
+/**
+ * Href for a prompt's detail page.
+ *
+ * Prompt names can contain slashes (folder grouping, e.g. "folder/name") and
+ * even empty or leading segments ("a//b", "/name"). The whole name is encoded
+ * as a single path segment so the href never contains empty segments ("//" is
+ * rejected by next/router); the catch-all detail route decodes it and joins
+ * the segments back into the full name, so folder semantics are unchanged.
+ */
+export const getPromptDetailHref = (
+  projectId: string,
+  promptName: string,
+): string => `/project/${projectId}/prompts/${encodeURIComponent(promptName)}`;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15767.preview.langfuse.com](https://pr-15767.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Prompt names can contain slashes (folder grouping), including leading slashes and empty segments (`/name`, `a//b`). Two links interpolated the raw name into the URL path, producing hrefs like `/prompts//name` that next/router rejects with an unhandled runtime error. This PR adds a small `getPromptDetailHref` builder that encodes the whole name as one path segment, uses it at the broken sites, and covers it with unit tests.

## Why

Sentry shows unhandled `Invalid href ... passed to next/router` errors on the New Prompt page:

- LANGFUSE-5T6 — `/prompts//<name>` from a leading-slash prompt name
- LANGFUSE-5T1 — `/prompts//` from a name of just `/`
- LANGFUSE-5WE — invalid href from a pasted multi-line name

All three come from the "prompt already exists — create a new version for it here" link, which used the raw form value: `href={`/project/${projectId}/prompts/${currentName.trim()}`}` (`web/src/features/prompts/components/NewPromptForm/index.tsx`). `PromptSelectionDialog` had the same unencoded pattern.

## What

- New `getPromptDetailHref(projectId, promptName)` in `web/src/features/prompts/utils.ts`: encodes the full name with `encodeURIComponent` as a single path segment, so no `//` can ever appear and folder-grouping semantics stay intact (the `[[...folder]]` catch-all joins its decoded segments back into the full name — same convention every other prompt link in the codebase already uses).
- Adopted at the two unencoded sites (NewPromptForm error link + submit redirect, PromptSelectionDialog external link; the dialog's query value is now encoded too).
- Unit tests for the builder: plain name, slash-grouped name, leading-slash name, empty-segment name, special characters.

## Result

Clicking "Create a new version for it here" (and the prompt-selection external link) now navigates correctly for every legal prompt name instead of crashing the router; the Sentry family above stops firing.

<details>
<summary>Engineering detail</summary>

### Why encoding beats filtering empty segments

Filtering `//` out of the path would silently link to a *different* prompt (`/name` → `name`). Encoding preserves the exact name: `/prompts/%2Fname` decodes to one catch-all segment `"/name"`, which is the prompt's real name. It also fixes the pre-existing ambiguity noted in `[[...folder]].tsx` where an unencoded name ending in `/metrics` would render the metrics page for the wrong prompt.

### Behavior equivalence for valid names

Unencoded `folder/name` and encoded `folder%2Fname` resolve to the same detail page — the catch-all route joins segments with `/` — so existing deep links and navigation are unchanged.

### Not addressed here (different root cause)

Sentry also groups a superficially similar error on the same page: `The provided href (/project/[projectId]/prompts/[[...folder]]?) value is missing query values (projectId)` (LANGFUSE-5V5, LANGFUSE-5EM). That one is not produced by any link builder: the href in the message is the raw route *pattern*, which only the `next-query-params` pages adapter passes (`router.replace({ pathname: router.pathname, search })`). It fires when a query-param write lands before `router.isReady`, while `asPath` still equals the pattern (event URLs literally show the uninterpolated pattern). Fixing that means gating pre-ready query writes and deserves its own change.

### Checks

- `vitest --project client src/features/prompts/utils.clienttest.ts` — 5/5 green
- `tsc --noEmit` (web) — clean
- eslint + prettier on touched files — clean

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes prompt-detail URL construction so prompt names are encoded as one path segment, then adopts it in prompt creation and selection flows.
- Adds `getPromptDetailHref` with focused coverage for slash-grouped, leading-slash, empty-segment, and reserved-character names.
- Uses the helper for post-create navigation, duplicate-name recovery, and prompt-selection links.
- Encodes selected prompt version or label query values.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed links matching the prompt catch-all route and query-decoding contracts.

Whole-name encoding preserves prompt identity through the catch-all route, and the version and label query values remain compatible with the detail page’s existing parameter decoders.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): encode prompt name in deta..."](https://github.com/langfuse/langfuse/commit/b0a3b44b037aa88a9bd40ad87f4872f144bfe890) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50039931)</sub>

**Context used:**

- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->