### PR TITLE
fix(sentry): stop three noise families from minting a fingerprint per occurrence

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -58,7 +58,7 @@ Sentry.init({
 
     // Stale-deploy / truncated chunk parse errors: collapse into ONE issue
     // instead of one per content-hashed chunk filename. Deliberately grouped,
-    // NOT dropped — a deploy that ships a genuinely unparseable chunk still
+    // NOT dropped — a deploy that ships a genuinely unparsable chunk still
     // surfaces as a spike on the single grouped issue. See
     // isStaleChunkParseErrorEvent for the rationale.
     if (isStaleChunkParseErrorEvent(event)) {

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -2,7 +2,10 @@ import * as Sentry from "@sentry/nextjs";
 import {
   isDenylistedNoiseEvent,
   isNoisyHttpClientPollEvent,
+  isPosthogRecorderInternalEvent,
   isReactDevtoolsInternalEvent,
+  isStaleChunkParseErrorEvent,
+  STALE_CHUNK_PARSE_FINGERPRINT,
 } from "@/src/utils/sentryFilters";
 
 const isEuOrUsRegionNonHipaa =
@@ -43,6 +46,23 @@ Sentry.init({
     // to Sentry. See isDenylistedNoiseEvent for the per-rule rationale.
     if (isDenylistedNoiseEvent(event)) {
       return null;
+    }
+
+    // Drop errors thrown wholly inside PostHog's session-replay recorder
+    // script (rrweb DOM serialization failing on exotic page content). No app
+    // frame is ever present in these stacks; anything touching our code is
+    // kept. See isPosthogRecorderInternalEvent for the rationale.
+    if (isPosthogRecorderInternalEvent(event)) {
+      return null;
+    }
+
+    // Stale-deploy / truncated chunk parse errors: collapse into ONE issue
+    // instead of one per content-hashed chunk filename. Deliberately grouped,
+    // NOT dropped — a deploy that ships a genuinely unparseable chunk still
+    // surfaces as a spike on the single grouped issue. See
+    // isStaleChunkParseErrorEvent for the rationale.
+    if (isStaleChunkParseErrorEvent(event)) {
+      event.fingerprint = [STALE_CHUNK_PARSE_FINGERPRINT];
     }
 
     return event;

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -3,7 +3,9 @@ import { type ErrorEvent } from "@sentry/nextjs";
 import {
   isDenylistedNoiseEvent,
   isNoisyHttpClientPollEvent,
+  isPosthogRecorderInternalEvent,
   isReactDevtoolsInternalEvent,
+  isStaleChunkParseErrorEvent,
 } from "@/src/utils/sentryFilters";
 
 /**
@@ -351,6 +353,78 @@ describe("isDenylistedNoiseEvent", () => {
     });
   });
 
+  describe("D. drops known-benign non-Error promise rejections (exact value denylist)", () => {
+    // Real shape (LANGFUSE-5T9/5TA): SDK-synthesized `UnhandledRejection` type,
+    // `onunhandledrejection` mechanism, NO stack — grouping falls back to the
+    // stringified value, so every new value minted a new fingerprint.
+    const nonErrorRejectionEvent = (rejectionValue: string): ErrorEvent =>
+      ({
+        exception: {
+          values: [
+            {
+              type: "UnhandledRejection",
+              value: `Non-Error promise rejection captured with value: ${rejectionValue}`,
+              mechanism: {
+                type: "auto.browser.global_handlers.onunhandledrejection",
+                handled: false,
+              },
+            },
+          ],
+        },
+      }) as ErrorEvent;
+
+    it("drops the wallet/extension shim rejection (LANGFUSE-5T9)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          nonErrorRejectionEvent("Not implemented on this platform"),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the empty `Promise.reject(undefined)` rejection (LANGFUSE-5TA)", () => {
+      expect(isDenylistedNoiseEvent(nonErrorRejectionEvent("undefined"))).toBe(
+        true,
+      );
+    });
+
+    it("drops the Outlook SafeLinks scanner artifact (LANGFUSE-11Z, variable tail)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          nonErrorRejectionEvent(
+            "Object Not Found Matching Id:2, MethodName:update, ParamCount:4",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("E. drops environmental storage-access SecurityError", () => {
+    it("drops the localStorage access denial (LANGFUSE-5TC/5TD/5TE/5TF)", () => {
+      // Real shape: our useLocalStorage catch logs the DOMException via
+      // console.error → captureConsoleIntegration re-captures it as an
+      // exception event with the browser-generated message.
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Failed to read the 'localStorage' property from 'Window': Access is denied for this document.",
+            "SecurityError",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("drops the sessionStorage variant of the same browser artifact", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.",
+            "SecurityError",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
   describe("A. transport failures also drop when they arrive as message events", () => {
     it("drops a message-event 'Failed to fetch'", () => {
       expect(isDenylistedNoiseEvent(messageEvent("Failed to fetch"))).toBe(
@@ -524,6 +598,90 @@ describe("isDenylistedNoiseEvent", () => {
       ).toBe(false);
     });
 
+    it("keeps a non-Error rejection with an UNKNOWN value (could be app code)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "UnhandledRejection",
+              value:
+                "Non-Error promise rejection captured with value: Something went wrong loading traces",
+              mechanism: {
+                type: "auto.browser.global_handlers.onunhandledrejection",
+                handled: false,
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isDenylistedNoiseEvent(event)).toBe(false);
+    });
+
+    it("keeps the object-shaped rejection variant (has carried real failures)", () => {
+      // LANGFUSE-1BB: `code, message, stack` payloads — a serialized error.
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Object captured as promise rejection with keys: code, message, stack",
+            "UnhandledRejection",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a real unhandled rejection carrying an Error object", () => {
+      // A rejected real Error keeps its own type — never `UnhandledRejection`.
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: "Cannot read properties of undefined (reading 'map')",
+              mechanism: {
+                type: "auto.browser.global_handlers.onunhandledrejection",
+                handled: false,
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isDenylistedNoiseEvent(event)).toBe(false);
+    });
+
+    it("keeps a benign-looking rejection value with extra text (exact match only)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Non-Error promise rejection captured with value: undefined is not a function",
+            "UnhandledRejection",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a real SecurityError from app-adjacent logic (cross-origin frame access)", () => {
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            'Blocked a frame with origin "https://cloud.langfuse.com" from accessing a cross-origin frame.',
+            "SecurityError",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps the storage-denial message when the type is NOT SecurityError", () => {
+      // Proves the type guard: an app error merely quoting the message survives.
+      expect(
+        isDenylistedNoiseEvent(
+          exceptionEvent(
+            "Failed to read the 'localStorage' property from 'Window': Access is denied for this document.",
+            "Error",
+          ),
+        ),
+      ).toBe(false);
+    });
+
     it("keeps an event with no exception values", () => {
       expect(
         isDenylistedNoiseEvent({ message: "some message" } as ErrorEvent),
@@ -601,6 +759,339 @@ describe("isReactDevtoolsInternalEvent", () => {
 
     it("keeps an event with no exception/message/logentry text", () => {
       expect(isReactDevtoolsInternalEvent({} as ErrorEvent)).toBe(false);
+    });
+  });
+});
+
+/**
+ * Build the exact shape browsers produce for a chunk PARSE failure
+ * (LANGFUSE-5WH/5WG/5WD/5S7): global `onerror` mechanism, `SyntaxError`, and a
+ * single anonymous frame at the chunk URL.
+ */
+function chunkParseErrorEvent(
+  value: string,
+  filename = "app:///_next/static/chunks/0_w4b6l3mpyep.js",
+): ErrorEvent {
+  return {
+    exception: {
+      values: [
+        {
+          type: "SyntaxError",
+          value,
+          mechanism: {
+            type: "auto.browser.global_handlers.onerror",
+            handled: false,
+          },
+          stacktrace: { frames: [{ filename, function: undefined }] },
+        },
+      ],
+    },
+  } as ErrorEvent;
+}
+
+describe("isStaleChunkParseErrorEvent", () => {
+  describe("matches stale/truncated chunk parse failures (grouped, not dropped)", () => {
+    it.each([
+      ["Unexpected end of input"], // Chrome, LANGFUSE-5WH
+      ['"" literal not terminated before end of script'], // Firefox, LANGFUSE-5WG
+      ["missing } after property list"], // Firefox, LANGFUSE-5WD
+      ["Invalid or unexpected token"], // Chrome, LANGFUSE-5S7
+      ["expected expression, got end of script"], // Firefox, LANGFUSE-5WN
+    ])("matches the real parse message %j", (value) => {
+      expect(isStaleChunkParseErrorEvent(chunkParseErrorEvent(value))).toBe(
+        true,
+      );
+    });
+
+    it("matches regardless of the (per-deploy hashed) chunk filename", () => {
+      expect(
+        isStaleChunkParseErrorEvent(
+          chunkParseErrorEvent(
+            "Unexpected end of input",
+            "app:///_next/static/chunks/3g9a8ojcqetek.js",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("is grouped by beforeSend, NOT dropped by the denylist", () => {
+      expect(
+        isDenylistedNoiseEvent(chunkParseErrorEvent("Unexpected end of input")),
+      ).toBe(false);
+    });
+  });
+
+  describe("NEVER matches a user-authored or app-code SyntaxError", () => {
+    it("keeps the evals editor's user-code SyntaxError (LANGFUSE-5W3 shape)", () => {
+      // Real shape: console.error capture with app + vendor formatter frames.
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SyntaxError",
+              value: "Unexpected token (1:38)",
+              mechanism: { type: "auto.core.capture_console", handled: true },
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      "web/src/features/evals/components/code-eval-template-form-body.tsx",
+                    function: "P",
+                  },
+                  {
+                    filename:
+                      "node_modules/.pnpm/prettier@3.8.3/node_modules/prettier/standalone.mjs",
+                    function: "Jn",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isStaleChunkParseErrorEvent(event)).toBe(false);
+    });
+
+    it("keeps the evals editor's user-code lint error (LANGFUSE-5W2 shape, type Error)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "Error",
+              value:
+                "Expected class, function definition or async function definition after decorator at byte range 477..481",
+              mechanism: { type: "auto.core.capture_console", handled: true },
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      "web/src/features/evals/utils/code-eval-template-validation.ts",
+                    function: "aa",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isStaleChunkParseErrorEvent(event)).toBe(false);
+    });
+
+    it("keeps a runtime SyntaxError thrown by app code (JSON.parse — multi-frame)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SyntaxError",
+              value: "Unexpected end of JSON input",
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  {
+                    filename: "app:///_next/static/chunks/0r47ep231kqhy.js",
+                    function: "loadSavedFilters",
+                  },
+                  {
+                    filename: "app:///_next/static/chunks/0r47ep231kqhy.js",
+                    function: "JSON.parse",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isStaleChunkParseErrorEvent(event)).toBe(false);
+    });
+
+    it("keeps a single-frame SyntaxError with a NAMED function (runtime throw)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SyntaxError",
+              value: "Unexpected end of JSON input",
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  {
+                    filename: "app:///_next/static/chunks/0r47ep231kqhy.js",
+                    function: "parseStoredView",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isStaleChunkParseErrorEvent(event)).toBe(false);
+    });
+
+    it("keeps a parse error in a non-chunk script", () => {
+      expect(
+        isStaleChunkParseErrorEvent(
+          chunkParseErrorEvent(
+            "Unexpected end of input",
+            "app:///some-other-script.js",
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps a SyntaxError with no stacktrace and a non-SyntaxError parse-like event", () => {
+      expect(
+        isStaleChunkParseErrorEvent(
+          exceptionEvent("Unexpected end of input", "SyntaxError"),
+        ),
+      ).toBe(false);
+      expect(
+        isStaleChunkParseErrorEvent(
+          chunkParseErrorEvent("Unexpected end of input"),
+        ),
+      ).toBe(true); // sanity: same builder matches when shape is complete
+    });
+  });
+});
+
+/** Frame helper for recorder-stack fixtures. */
+function frame(filename: string, fn?: string) {
+  return { filename, function: fn };
+}
+
+describe("isPosthogRecorderInternalEvent", () => {
+  const RECORDER = "app:///static/posthog-recorder.js";
+
+  describe("drops errors thrown wholly inside the PostHog session recorder", () => {
+    it("drops the rrweb mutation-processing SyntaxError (LANGFUSE-5VX shape)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SyntaxError",
+              value: "Invalid or unexpected token",
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  frame(RECORDER, "Ut.processMutations"),
+                  frame(RECORDER, "Ut.emit"),
+                  frame(RECORDER, "Ws.onRRwebEmit"),
+                  frame("<anonymous>", "Array.forEach"),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isPosthogRecorderInternalEvent(event)).toBe(true);
+    });
+
+    it("drops the addEventListener-wrapped variant with a Sentry SDK frame (LANGFUSE-5VY shape)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SyntaxError",
+              value: "Invalid or unexpected token",
+              mechanism: {
+                type: "auto.browser.browserapierrors.addEventListener",
+                handled: false,
+              },
+              stacktrace: {
+                frames: [
+                  frame(
+                    "node_modules/.pnpm/@sentry+browser@10.64.0/node_modules/@sentry/browser/src/helpers.ts",
+                    "r",
+                  ),
+                  frame(RECORDER, "l"),
+                  frame(RECORDER, "Se"),
+                  frame(RECORDER, "Ws.Hd"),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isPosthogRecorderInternalEvent(event)).toBe(true);
+    });
+  });
+
+  describe("KEEPS any error that touches app code", () => {
+    it("keeps a stack that mixes recorder frames with an app chunk frame", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: "Cannot read properties of undefined (reading 'map')",
+              stacktrace: {
+                frames: [
+                  frame(RECORDER, "Ws.onRRwebEmit"),
+                  frame(
+                    "app:///_next/static/chunks/0r47ep231kqhy.js",
+                    "onMutation",
+                  ),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isPosthogRecorderInternalEvent(event)).toBe(false);
+    });
+
+    it("keeps an app-only stack (no recorder frame at all)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: "boom",
+              stacktrace: {
+                frames: [
+                  frame("app:///_next/static/chunks/0r47ep231kqhy.js", "fn"),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isPosthogRecorderInternalEvent(event)).toBe(false);
+    });
+
+    it("keeps an all-opaque stack (<anonymous>/[native code] only — no recorder attribution)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "TypeError",
+              value: "boom",
+              stacktrace: {
+                frames: [
+                  frame("<anonymous>", "Array.forEach"),
+                  frame("[native code]"),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isPosthogRecorderInternalEvent(event)).toBe(false);
+    });
+
+    it("keeps events with no stacktrace", () => {
+      expect(
+        isPosthogRecorderInternalEvent(exceptionEvent("boom", "TypeError")),
+      ).toBe(false);
+      expect(isPosthogRecorderInternalEvent(messageEvent("boom"))).toBe(false);
     });
   });
 });

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -802,12 +802,14 @@ describe("isReactDevtoolsInternalEvent", () => {
  * failure (LANGFUSE-5WH/5WG/5WD/5S7): global `onerror` mechanism,
  * `SyntaxError`, and a single frame at the chunk URL whose function is the
  * SDK's UNKNOWN_FUNCTION placeholder `"?"` (server-side normalization later
- * turns that into `null` — the shape stored events show).
+ * strips that — the shape stored events show). Pass `fn: null` to build the
+ * normalized shape with the `function` key genuinely absent (an explicit
+ * `undefined` would be swallowed by the default parameter).
  */
 function chunkParseErrorEvent(
   value: string,
   filename = "app:///_next/static/chunks/0_w4b6l3mpyep.js",
-  fn: string | undefined = "?",
+  fn: string | null = "?",
 ): ErrorEvent {
   return {
     exception: {
@@ -819,7 +821,9 @@ function chunkParseErrorEvent(
             type: "auto.browser.global_handlers.onerror",
             handled: false,
           },
-          stacktrace: { frames: [{ filename, function: fn }] },
+          stacktrace: {
+            frames: [fn === null ? { filename } : { filename, function: fn }],
+          },
         },
       ],
     },
@@ -851,16 +855,17 @@ describe("isStaleChunkParseErrorEvent", () => {
       ).toBe(true);
     });
 
-    it("matches the normalized stored shape too (function absent instead of '?')", () => {
+    it("matches the normalized stored shape too (function key absent instead of '?')", () => {
+      const event = chunkParseErrorEvent(
+        "Unexpected end of input",
+        "app:///_next/static/chunks/3g9a8ojcqetek.js",
+        null,
+      );
+      // Guard the fixture itself: the frame must NOT carry a function key.
       expect(
-        isStaleChunkParseErrorEvent(
-          chunkParseErrorEvent(
-            "Unexpected end of input",
-            "app:///_next/static/chunks/3g9a8ojcqetek.js",
-            undefined,
-          ),
-        ),
-      ).toBe(true);
+        event.exception?.values?.[0]?.stacktrace?.frames?.[0],
+      ).not.toHaveProperty("function");
+      expect(isStaleChunkParseErrorEvent(event)).toBe(true);
     });
 
     it("is grouped by beforeSend, NOT dropped by the denylist", () => {

--- a/web/src/utils/sentryFilters.clienttest.ts
+++ b/web/src/utils/sentryFilters.clienttest.ts
@@ -398,16 +398,29 @@ describe("isDenylistedNoiseEvent", () => {
     });
   });
 
-  describe("E. drops environmental storage-access SecurityError", () => {
+  describe("E. drops environmental storage-access SecurityError (console-captured only)", () => {
+    // Real shape (LANGFUSE-5TC/5TD/5TE/5TF): our useLocalStorage catch logs the
+    // DOMException via console.error → captureConsoleIntegration re-captures it
+    // as an exception event (mechanism `auto.core.capture_console`) carrying
+    // the browser-generated message.
+    const consoleCapturedStorageDenial = (value: string): ErrorEvent =>
+      ({
+        exception: {
+          values: [
+            {
+              type: "SecurityError",
+              value,
+              mechanism: { type: "auto.core.capture_console", handled: true },
+            },
+          ],
+        },
+      }) as ErrorEvent;
+
     it("drops the localStorage access denial (LANGFUSE-5TC/5TD/5TE/5TF)", () => {
-      // Real shape: our useLocalStorage catch logs the DOMException via
-      // console.error → captureConsoleIntegration re-captures it as an
-      // exception event with the browser-generated message.
       expect(
         isDenylistedNoiseEvent(
-          exceptionEvent(
+          consoleCapturedStorageDenial(
             "Failed to read the 'localStorage' property from 'Window': Access is denied for this document.",
-            "SecurityError",
           ),
         ),
       ).toBe(true);
@@ -416,12 +429,33 @@ describe("isDenylistedNoiseEvent", () => {
     it("drops the sessionStorage variant of the same browser artifact", () => {
       expect(
         isDenylistedNoiseEvent(
-          exceptionEvent(
+          consoleCapturedStorageDenial(
             "Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.",
-            "SecurityError",
           ),
         ),
       ).toBe(true);
+    });
+
+    it("KEEPS an UNCAUGHT storage SecurityError (page crash via global onerror)", () => {
+      // A bare storage read during render that crashes the page arrives via the
+      // global handler, not capture_console — that is a real diagnostic and
+      // must survive.
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SecurityError",
+              value:
+                "Failed to read the 'localStorage' property from 'Window': Access is denied for this document.",
+              mechanism: {
+                type: "auto.browser.global_handlers.onerror",
+                handled: false,
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isDenylistedNoiseEvent(event)).toBe(false);
     });
   });
 
@@ -764,13 +798,16 @@ describe("isReactDevtoolsInternalEvent", () => {
 });
 
 /**
- * Build the exact shape browsers produce for a chunk PARSE failure
- * (LANGFUSE-5WH/5WG/5WD/5S7): global `onerror` mechanism, `SyntaxError`, and a
- * single anonymous frame at the chunk URL.
+ * Build the exact WIRE shape the SDK hands `beforeSend` for a chunk PARSE
+ * failure (LANGFUSE-5WH/5WG/5WD/5S7): global `onerror` mechanism,
+ * `SyntaxError`, and a single frame at the chunk URL whose function is the
+ * SDK's UNKNOWN_FUNCTION placeholder `"?"` (server-side normalization later
+ * turns that into `null` — the shape stored events show).
  */
 function chunkParseErrorEvent(
   value: string,
   filename = "app:///_next/static/chunks/0_w4b6l3mpyep.js",
+  fn: string | undefined = "?",
 ): ErrorEvent {
   return {
     exception: {
@@ -782,7 +819,7 @@ function chunkParseErrorEvent(
             type: "auto.browser.global_handlers.onerror",
             handled: false,
           },
-          stacktrace: { frames: [{ filename, function: undefined }] },
+          stacktrace: { frames: [{ filename, function: fn }] },
         },
       ],
     },
@@ -809,6 +846,18 @@ describe("isStaleChunkParseErrorEvent", () => {
           chunkParseErrorEvent(
             "Unexpected end of input",
             "app:///_next/static/chunks/3g9a8ojcqetek.js",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("matches the normalized stored shape too (function absent instead of '?')", () => {
+      expect(
+        isStaleChunkParseErrorEvent(
+          chunkParseErrorEvent(
+            "Unexpected end of input",
+            "app:///_next/static/chunks/3g9a8ojcqetek.js",
+            undefined,
           ),
         ),
       ).toBe(true);
@@ -965,7 +1014,9 @@ function frame(filename: string, fn?: string) {
 }
 
 describe("isPosthogRecorderInternalEvent", () => {
-  const RECORDER = "app:///static/posthog-recorder.js";
+  // Wire shape: the recorder loads with a version query that survives into
+  // frame filenames handed to beforeSend (stored events show it on abs_path).
+  const RECORDER = "app:///static/posthog-recorder.js?v=1.390.2";
 
   describe("drops errors thrown wholly inside the PostHog session recorder", () => {
     it("drops the rrweb mutation-processing SyntaxError (LANGFUSE-5VX shape)", () => {
@@ -994,7 +1045,29 @@ describe("isPosthogRecorderInternalEvent", () => {
       expect(isPosthogRecorderInternalEvent(event)).toBe(true);
     });
 
-    it("drops the addEventListener-wrapped variant with a Sentry SDK frame (LANGFUSE-5VY shape)", () => {
+    it("drops the same shape without the version query (normalized stored filename)", () => {
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SyntaxError",
+              value: "Invalid or unexpected token",
+              stacktrace: {
+                frames: [
+                  frame(
+                    "app:///static/posthog-recorder.js",
+                    "Ut.processMutations",
+                  ),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isPosthogRecorderInternalEvent(event)).toBe(true);
+    });
+
+    it("drops the addEventListener-wrapped variant with a source-mapped Sentry SDK frame (LANGFUSE-5VY stored shape)", () => {
       const event = {
         exception: {
           values: [
@@ -1039,6 +1112,30 @@ describe("isPosthogRecorderInternalEvent", () => {
                     "app:///_next/static/chunks/0r47ep231kqhy.js",
                     "onMutation",
                   ),
+                ],
+              },
+            },
+          ],
+        },
+      } as ErrorEvent;
+      expect(isPosthogRecorderInternalEvent(event)).toBe(false);
+    });
+
+    it("keeps the wrapped-listener variant when the SDK wrapper is bundled into an app chunk (prod wire shape — deliberate coverage gap)", () => {
+      // In a prod bundle the Sentry wrap() frame is an app-chunk filename;
+      // allowing chunk frames could mask real app listener errors, so this
+      // shape stays kept even though it is recorder noise (LANGFUSE-5VY).
+      const event = {
+        exception: {
+          values: [
+            {
+              type: "SyntaxError",
+              value: "Invalid or unexpected token",
+              stacktrace: {
+                frames: [
+                  frame("app:///_next/static/chunks/2-jdgbtsa7jx3.js", "r"),
+                  frame(RECORDER, "l"),
+                  frame(RECORDER, "Ws.Hd"),
                 ],
               },
             },

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -116,6 +116,44 @@ const NOISE_MESSAGE_PREFIXES: readonly string[] = [
 ];
 
 /**
+ * The Sentry SDK synthesizes this exact prefix (global `onunhandledrejection`
+ * handler) when a promise rejects with a non-`Error` value. These events carry
+ * NO stack, so Sentry groups them by the stringified value — every new value
+ * mints a new fingerprint.
+ */
+const NON_ERROR_REJECTION_PREFIX =
+  "Non-Error promise rejection captured with value: ";
+
+/**
+ * Known-benign non-Error rejection values, each traced to a non-app source
+ * from real events. ONLY these exact values (plus the prefixes below) are
+ * dropped — an unknown value could be a real rejection from our code or a
+ * bundled dependency and is KEPT, as is the object-shaped
+ * `Object captured as promise rejection with keys: …` variant, which has
+ * carried real failures (e.g. `code, message, stack` payloads).
+ */
+const BENIGN_NON_ERROR_REJECTION_VALUES: readonly string[] = [
+  // Browser-extension shim (wallet/provider extensions no-op on unsupported
+  // platforms and reject with this bare string). Observed with no stack and no
+  // app frames (LANGFUSE-5T9).
+  "Not implemented on this platform",
+  // `Promise.reject()` / `reject(undefined)`: zero diagnostic content — no
+  // stack, no message, no value. Nobody can act on it (LANGFUSE-5TA).
+  "undefined",
+];
+
+/**
+ * Prefix-matched benign rejection values whose tail varies per occurrence
+ * (which is exactly what shatters grouping).
+ */
+const BENIGN_NON_ERROR_REJECTION_VALUE_PREFIXES: readonly string[] = [
+  // Microsoft Outlook SafeLinks / email-scanner artifact: the crawler injects
+  // scripts that reject with `Object Not Found Matching Id:<n>, MethodName:…`.
+  // Industry-known scanner noise, never a browser session (LANGFUSE-11Z).
+  "Object Not Found Matching Id:",
+];
+
+/**
  * A `TRPCClientError` re-wraps its cause's message. Depending on capture path
  * the Sentry `value` may be the bare cause message (`Failed to fetch`) or carry
  * the wrapper prefix (`TRPCClientError: Failed to fetch`). We strip ONLY this
@@ -204,10 +242,12 @@ export function isReactDevtoolsInternalEvent(event: ErrorEvent): boolean {
  *    occurred` — it aggregates real exceptions with no stack; hard-dropping it
  *    could blind us if the underlying exceptions are not captured separately.
  *  - `OAuthCallback` sign-in errors — could be a genuine auth-config break.
- *  - auth/permission (`UNAUTHORIZED`, not-a-member), query-timeout,
- *    chunk-load / stale-deploy `SyntaxError`, and Sentry perf detectors /
- *    third-party scripts — handled as UX or in Sentry project settings, not by a
- *    blind client-side drop.
+ *  - auth/permission (`UNAUTHORIZED`, not-a-member), query-timeout, and Sentry
+ *    perf detectors / third-party scripts — handled as UX or in Sentry project
+ *    settings, not by a blind client-side drop.
+ *  - the chunk-load / stale-deploy `SyntaxError` family — GROUPED (not dropped)
+ *    via {@link isStaleChunkParseErrorEvent} so a genuinely broken deploy still
+ *    surfaces as a spike on one issue.
  */
 export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
   const exception = event.exception?.values?.[0];
@@ -268,7 +308,150 @@ export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
     ) {
       return true;
     }
+
+    // Known-benign non-Error promise rejections. The `UnhandledRejection`
+    // exception type is SDK-synthesized (a real `Error` rejection keeps its own
+    // type, e.g. `TypeError`), and the value denylist is exact/prefix-anchored:
+    // an unknown rejection value still flows to Sentry. See
+    // BENIGN_NON_ERROR_REJECTION_VALUES for per-value provenance.
+    if (
+      exceptionType === "UnhandledRejection" &&
+      exceptionValue.startsWith(NON_ERROR_REJECTION_PREFIX)
+    ) {
+      const rejectionValue = exceptionValue.slice(
+        NON_ERROR_REJECTION_PREFIX.length,
+      );
+      if (
+        BENIGN_NON_ERROR_REJECTION_VALUES.includes(rejectionValue) ||
+        BENIGN_NON_ERROR_REJECTION_VALUE_PREFIXES.some((prefix) =>
+          rejectionValue.startsWith(prefix),
+        )
+      ) {
+        return true;
+      }
+    }
+
+    // Environmental storage-access denial: browsers throw a `SecurityError`
+    // DOMException on the `window.localStorage` property GETTER itself when
+    // storage is blocked (third-party iframe, privacy mode). The message is
+    // browser-generated — app logic cannot produce it — and every storage read
+    // in the app already falls back to its initial value (see useLocalStorage /
+    // useSessionStorage). Stacks point at per-deploy hashed chunks, so each
+    // occurrence minted a new fingerprint (LANGFUSE-5TC/5TD/5TE/5TF). Other
+    // `SecurityError`s (e.g. cross-origin frame access) are KEPT.
+    if (
+      exceptionType === "SecurityError" &&
+      /^Failed to read the '(localStorage|sessionStorage)' property from 'Window':/.test(
+        exceptionValue,
+      )
+    ) {
+      return true;
+    }
   }
 
   return false;
+}
+
+/**
+ * Fingerprint used to collapse all stale-chunk parse errors into ONE Sentry
+ * issue (see {@link isStaleChunkParseErrorEvent}).
+ */
+export const STALE_CHUNK_PARSE_FINGERPRINT = "stale-chunk-parse-error";
+
+/**
+ * True for a browser-level parse failure of a Next.js chunk: the global
+ * `onerror` handler caught a `SyntaxError` whose entire stack is ONE anonymous
+ * frame at a `/_next/static/chunks/…` script — the shape a browser produces
+ * when a script's CONTENT fails to parse (truncated download, or a stale
+ * client fetching a chunk that no longer exists and receiving garbage after a
+ * deploy). Chunk filenames are content-hashed, so Sentry minted a new
+ * fingerprint per chunk per deploy (LANGFUSE-5WH/5WG/5WD/5S7 and the 1-event
+ * long tail). The reload banner (#15279) is the mitigation for the cause.
+ *
+ * These events are GROUPED under {@link STALE_CHUNK_PARSE_FINGERPRINT} in
+ * `beforeSend`, NOT dropped: if a deploy ever ships a genuinely unparseable
+ * chunk to everyone, the single grouped issue spikes and stays visible.
+ *
+ * Cannot catch a user-authored or app-code `SyntaxError`:
+ *  - the evals code editor reports user-code syntax errors via
+ *    `console.error` (mechanism `auto.core.capture_console`) with app frames
+ *    (`web/src/features/evals/…`) — different mechanism, multi-frame stack;
+ *  - a runtime `SyntaxError` thrown by app code (e.g. `JSON.parse`) carries
+ *    its throwing function and callers — more than one frame / a named
+ *    function.
+ */
+export function isStaleChunkParseErrorEvent(event: ErrorEvent): boolean {
+  const exception = event.exception?.values?.[0];
+  if (exception?.type !== "SyntaxError") return false;
+  if (exception.mechanism?.type !== "auto.browser.global_handlers.onerror") {
+    return false;
+  }
+
+  const frames = exception.stacktrace?.frames;
+  if (!frames || frames.length !== 1) return false;
+
+  const frame = frames[0];
+  // Parse errors carry no function — a named function means runtime code threw.
+  if (frame?.function) return false;
+
+  return (
+    typeof frame?.filename === "string" &&
+    frame.filename.includes("/_next/static/chunks/")
+  );
+}
+
+/**
+ * PostHog's lazily-loaded session-replay recorder script (served as
+ * `/static/posthog-recorder.js?v=<posthog-js version>`).
+ */
+const POSTHOG_RECORDER_SCRIPT_SUFFIX = "/static/posthog-recorder.js";
+
+/**
+ * Frames that carry no attribution: browser-native/eval frames, and the Sentry
+ * SDK's own wrapper frames (its `wrap()` helper sits at the outer edge of
+ * every instrumented listener stack).
+ */
+function isOpaqueOrSdkFrame(filename: string): boolean {
+  return (
+    filename === "<anonymous>" ||
+    filename === "[native code]" ||
+    (filename.includes("node_modules") && filename.includes("@sentry"))
+  );
+}
+
+/**
+ * True for errors thrown wholly INSIDE PostHog's session-replay recorder:
+ * every attributable stack frame lives in the recorder script (plus at most
+ * browser-native and Sentry-SDK wrapper frames). rrweb's DOM serialization
+ * throws on exotic page content (observed: `SyntaxError: Invalid or unexpected
+ * token` from `processMutations` / `onRRwebEmit`, LANGFUSE-5VY/5VX), and each
+ * throw site mints a new fingerprint per recorder version.
+ *
+ * Safe to drop: an error thrown by OUR code always carries at least one app
+ * chunk frame (the throwing frame), which fails this check. Errors with no
+ * app frame are the vendor recorder failing internally — not a Langfuse app
+ * bug, and not actionable in Sentry (session replay is best-effort telemetry;
+ * a broken recorder shows up as missing recordings in PostHog, not here).
+ * Same posture as the browser-extension `denyUrls` entries, expressed as a
+ * testable predicate because the crash frame is often `<anonymous>`, which
+ * `denyUrls` skips inconsistently.
+ */
+export function isPosthogRecorderInternalEvent(event: ErrorEvent): boolean {
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames;
+  if (!frames || frames.length === 0) return false;
+
+  let sawRecorderFrame = false;
+  for (const frame of frames) {
+    const filename = frame?.filename;
+    // A frame with no filename has no attribution — treat like <anonymous>.
+    if (typeof filename !== "string" || filename.length === 0) continue;
+    if (filename.endsWith(POSTHOG_RECORDER_SCRIPT_SUFFIX)) {
+      sawRecorderFrame = true;
+      continue;
+    }
+    if (isOpaqueOrSdkFrame(filename)) continue;
+    // Any other frame (app chunk, other vendor) → not recorder-internal.
+    return false;
+  }
+  return sawRecorderFrame;
 }

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -334,13 +334,19 @@ export function isDenylistedNoiseEvent(event: ErrorEvent): boolean {
     // Environmental storage-access denial: browsers throw a `SecurityError`
     // DOMException on the `window.localStorage` property GETTER itself when
     // storage is blocked (third-party iframe, privacy mode). The message is
-    // browser-generated — app logic cannot produce it — and every storage read
-    // in the app already falls back to its initial value (see useLocalStorage /
-    // useSessionStorage). Stacks point at per-deploy hashed chunks, so each
-    // occurrence minted a new fingerprint (LANGFUSE-5TC/5TD/5TE/5TF). Other
-    // `SecurityError`s (e.g. cross-origin frame access) are KEPT.
+    // browser-generated — app logic cannot produce it. Stacks point at
+    // per-deploy hashed chunks, so each occurrence minted a new fingerprint
+    // (LANGFUSE-5TC/5TD/5TE/5TF).
+    //
+    // Guarded to the `capture_console` mechanism: only instances our own code
+    // already CAUGHT and logged (e.g. the useLocalStorage / useSessionStorage
+    // fallback paths) are dropped. An UNCAUGHT storage SecurityError — e.g. a
+    // bare storage read during render crashing the page — arrives via the
+    // global `onerror` handler and is KEPT, as are other `SecurityError`s
+    // (e.g. cross-origin frame access).
     if (
       exceptionType === "SecurityError" &&
+      exception?.mechanism?.type === "auto.core.capture_console" &&
       /^Failed to read the '(localStorage|sessionStorage)' property from 'Window':/.test(
         exceptionValue,
       )
@@ -391,8 +397,11 @@ export function isStaleChunkParseErrorEvent(event: ErrorEvent): boolean {
   if (!frames || frames.length !== 1) return false;
 
   const frame = frames[0];
-  // Parse errors carry no function — a named function means runtime code threw.
-  if (frame?.function) return false;
+  // Parse errors carry no function name — the SDK synthesizes the frame with
+  // its UNKNOWN_FUNCTION placeholder `"?"` on the wire (`beforeSend` runs
+  // BEFORE server-side normalization turns that into `null`). A real function
+  // name means runtime code threw.
+  if (frame?.function && frame.function !== "?") return false;
 
   return (
     typeof frame?.filename === "string" &&
@@ -409,7 +418,10 @@ const POSTHOG_RECORDER_SCRIPT_SUFFIX = "/static/posthog-recorder.js";
 /**
  * Frames that carry no attribution: browser-native/eval frames, and the Sentry
  * SDK's own wrapper frames (its `wrap()` helper sits at the outer edge of
- * every instrumented listener stack).
+ * every instrumented listener stack). The `@sentry` path shape only occurs in
+ * dev / source-mapped stacks — in a prod bundle the wrapper lives in an app
+ * chunk, which this predicate deliberately does NOT allow (see the coverage
+ * gap note on {@link isPosthogRecorderInternalEvent}).
  */
 function isOpaqueOrSdkFrame(filename: string): boolean {
   return (
@@ -435,6 +447,12 @@ function isOpaqueOrSdkFrame(filename: string): boolean {
  * Same posture as the browser-extension `denyUrls` entries, expressed as a
  * testable predicate because the crash frame is often `<anonymous>`, which
  * `denyUrls` skips inconsistently.
+ *
+ * Known coverage gap (deliberate): the `addEventListener`-wrapped variant
+ * (LANGFUSE-5VY) carries the Sentry SDK's `wrap()` frame, which in a prod
+ * bundle is an app-chunk filename indistinguishable from app code — those
+ * events are KEPT. Allowing chunk frames here would risk masking real app
+ * listener errors, so only the all-recorder shape (LANGFUSE-5VX) is dropped.
  */
 export function isPosthogRecorderInternalEvent(event: ErrorEvent): boolean {
   const frames = event.exception?.values?.[0]?.stacktrace?.frames;
@@ -445,7 +463,11 @@ export function isPosthogRecorderInternalEvent(event: ErrorEvent): boolean {
     const filename = frame?.filename;
     // A frame with no filename has no attribution — treat like <anonymous>.
     if (typeof filename !== "string" || filename.length === 0) continue;
-    if (filename.endsWith(POSTHOG_RECORDER_SCRIPT_SUFFIX)) {
+    // The recorder loads with a version query (`?v=<posthog-js version>`) that
+    // survives into wire-format frame filenames — strip query/fragment before
+    // matching the path suffix.
+    const path = filename.split(/[?#]/)[0];
+    if (path.endsWith(POSTHOG_RECORDER_SCRIPT_SUFFIX)) {
       sawRecorderFrame = true;
       continue;
     }

--- a/web/src/utils/sentryFilters.ts
+++ b/web/src/utils/sentryFilters.ts
@@ -375,7 +375,7 @@ export const STALE_CHUNK_PARSE_FINGERPRINT = "stale-chunk-parse-error";
  * long tail). The reload banner (#15279) is the mitigation for the cause.
  *
  * These events are GROUPED under {@link STALE_CHUNK_PARSE_FINGERPRINT} in
- * `beforeSend`, NOT dropped: if a deploy ever ships a genuinely unparseable
+ * `beforeSend`, NOT dropped: if a deploy ever ships a genuinely unparsable
  * chunk to everyone, the single grouped issue spikes and stays visible.
  *
  * Cannot catch a user-authored or app-code `SyntaxError`:


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15770.preview.langfuse.com](https://pr-15770.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Three browser-noise families mint a **new Sentry fingerprint per occurrence** (~40 junk issues/week on the board). This adds four narrow, unit-tested rules to the established filter module (`sentryFilters.ts`, pattern from #15145/#15238): two drops keyed on exact signatures that cannot represent an app bug, one **fingerprint grouping** (kept, not dropped) for stale-chunk parse errors, and one drop for errors thrown wholly inside PostHog's session-replay recorder script. Every rule was designed from pulled production events and ships positive + negative fixtures proving real errors still pass.

## Why

- **Non-Error promise rejections** (`Non-Error promise rejection captured with value: …`): no stack, so Sentry groups by the stringified value — every new value is a new issue (LANGFUSE-5T9, 5TA). Sources: browser-extension shims, `Promise.reject(undefined)`, email-scanner artifacts.
- **Storage-access `SecurityError`** (`Failed to read the 'localStorage' property from 'Window': Access is denied…`): iframe/privacy-mode environments; our `useLocalStorage`/`useSessionStorage` hooks already catch and fall back, but the `console.error` in the catch re-captures the DOMException with a per-deploy hashed-chunk stack — four fingerprints in 14 days for one message (LANGFUSE-5TC/5TD/5TE/5TF).
- **Chunk parse `SyntaxError`s**: a stale client fetching a chunk that no longer exists after a deploy parses garbage; chunk filenames are content-hashed, so it's **one fingerprint per chunk per deploy** (LANGFUSE-5WH 15 ev, 5S7 7, 5WG 5, 5WD 3, 5WN + a long 1-event tail). The reload banner (#15279) mitigates the cause; the events themselves are non-actionable.
- **PostHog recorder internals**: rrweb DOM serialization throwing inside `/static/posthog-recorder.js` (LANGFUSE-5VY 21 ev, 5VX 19) — vendor code, no app frame in the stack.

## What

| Family | Mechanism | Signature (all conditions required) |
|---|---|---|
| Non-Error rejections | **drop** | type `UnhandledRejection` + SDK-synthesized prefix + value in an **exact denylist** (`Not implemented on this platform`, `undefined`, `Object Not Found Matching Id:…`) |
| Storage SecurityError | **drop** | type `SecurityError` + mechanism `auto.core.capture_console` (already caught by our hooks) + browser-generated getter-denial message |
| Chunk parse errors | **group** | mechanism `onerror` + type `SyntaxError` + exactly one function-less frame in `/_next/static/chunks/` → single fingerprint `stale-chunk-parse-error` |
| Recorder internals | **drop** | every attributable frame in `/static/posthog-recorder.js` (any app frame ⇒ kept) |

**What still passes (negative fixtures in `sentryFilters.clienttest.ts`):** unknown rejection values and the object-shaped rejection variant; real unhandled rejections carrying an `Error`; an **uncaught** storage `SecurityError` crashing a render (global `onerror`); cross-origin-frame `SecurityError`s; the evals editor's user-code `SyntaxError`s (`/evals/new`, `capture_console` + app frames); runtime `JSON.parse` errors; any stack mixing recorder frames with app frames.

## Result

The three families stop minting fingerprints: two families disappear as known-benign environment noise, chunk-parse errors collapse into **one** issue that would still spike visibly if a deploy ever shipped a genuinely broken chunk, and recorder-internal errors are gone. 82/82 filter tests green; lint + typecheck green.

<details>
<summary>Engineering detail: evidence, skeptic review, and deliberate limits</summary>

### Designed from wire-shape events, not stored JSON
An independent adversarial review of the first draft caught that `beforeSend` sees the **client wire shape**, not the normalized stored event:

- Parse-error frames carry the SDK's `UNKNOWN_FUNCTION` placeholder `"?"` (`_enhanceEventWithInitialFrame`); stored events show `null` only after server-side normalization. The chunk-parse predicate accepts both.
- The recorder script loads as `/static/posthog-recorder.js?v=<posthog-js version>` and the query survives into frame filenames; the predicate strips query/fragment before suffix-matching.

### Masking-risk analysis (per rule)
- **Rejections:** exact-value matching only. The codebase has no `Promise.reject(<non-Error>)`/bare `reject()` sites; a rejected real `Error` keeps its own type and never matches. The object-shaped variant (`Object captured as promise rejection with keys: …`) has carried real failures and is explicitly kept. `undefined` rejections carry zero diagnostic content (no stack, no value) — nothing actionable is lost.
- **Storage SecurityError:** the review found unguarded storage reads (e.g. a `sessionStorage.getItem` in a render-path `useMemo`) that could crash a page in storage-blocked contexts. The rule is therefore **mechanism-guarded**: only `capture_console` instances (already caught + fallen back by our hooks) are dropped; an uncaught crash arrives via `onerror` and is kept.
- **Chunk parse:** grouped, not dropped, precisely so a bad deploy stays visible as a spike on one issue. Recommended follow-up: keep the grouped issue on "archive until escalating", never archive-forever.
- **Recorder:** any stack touching an app chunk is kept. Deliberate coverage gap: the `addEventListener`-wrapped variant carries the Sentry `wrap()` frame, which in a prod bundle is an app-chunk filename — those events remain (dropping chunk-frame stacks could mask real listener errors).

### Test coverage
82 tests: each rule has fixtures replicating the pulled production event shapes (wire + normalized variants) and KEEPS-fixtures for every adjacent real-error shape listed above.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR narrows browser-side Sentry noise without changing application behavior.
- Drops selected non-Error promise rejections and caught storage-access denials.
- Groups anonymous Next.js chunk parse failures under one stable fingerprint.
- Drops errors attributable solely to PostHog’s session-replay recorder.
- Adds positive and adjacent negative fixtures for each filtering rule.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new filters are narrowly constrained and no concrete reachable loss of actionable telemetry was identified.

The filtering rules retain adjacent app-error shapes through mechanism, exception-type, stack-attribution, and frame-shape guards, while stale chunk failures remain visible under a stable fingerprint.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sentry): harden filters against wire..."](https://github.com/langfuse/langfuse/commit/55aa86b358a0fc0a9ce4c9ae7341cf848dcee2f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50043069)</sub>

<!-- /greptile_comment -->