### PR TITLE
fix(web): classify tRPC response JSON-parse failures as transport noise

### DIFF
--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -1,12 +1,24 @@
 import { TRPCClientError } from "@trpc/client";
+import { vi } from "vitest";
 import {
   EXPECTED_TRPC_ERROR_CODES,
+  fetchWithParseErrorStatus,
   getTrpcErrorCode,
   getTrpcErrorPath,
   isExpectedTrpcClientError,
   isNetworkConnectivityError,
   isTrpcResponseParseError,
 } from "@/src/utils/api";
+
+/** A JSON.parse SyntaxError annotated with the HTTP status it was parsed
+ * from, as produced by `fetchWithParseErrorStatus`. */
+const parseErrorWithStatus = (message: string, status: number) => {
+  const cause: SyntaxError & { responseStatus?: number } = new SyntaxError(
+    message,
+  );
+  cause.responseStatus = status;
+  return cause;
+};
 
 /** Builds a TRPCClientError with the given server error shape (code/path). */
 const trpcServerError = (opts: {
@@ -136,6 +148,69 @@ describe("isTrpcResponseParseError", () => {
     ).toBe(false);
     expect(isTrpcResponseParseError(null)).toBe(false);
     expect(isTrpcResponseParseError(undefined)).toBe(false);
+  });
+
+  // Request-too-large (414/431) parse failures are the app-owned
+  // oversized-GET-URL bug class (see sendAsPostOption) and MUST keep
+  // flowing to Sentry.
+  it.each([414, 431])(
+    "does not match a parse failure annotated with HTTP %i",
+    (status) => {
+      const error = TRPCClientError.from(
+        parseErrorWithStatus("Unexpected end of JSON input", status),
+      );
+
+      expect(isTrpcResponseParseError(error)).toBe(false);
+    },
+  );
+
+  it("does not match a parse failure whose link meta shows HTTP 431", () => {
+    const error = TRPCClientError.from(
+      new SyntaxError("Unexpected end of JSON input"),
+      { meta: { response: new Response("", { status: 431 }) } },
+    );
+
+    expect(isTrpcResponseParseError(error)).toBe(false);
+  });
+
+  it("matches a parse failure annotated with a non-request-too-large status", () => {
+    const error = TRPCClientError.from(
+      parseErrorWithStatus(
+        "JSON.parse: unexpected character at line 1 column 1 of the JSON data",
+        200,
+      ),
+    );
+
+    expect(isTrpcResponseParseError(error)).toBe(true);
+  });
+});
+
+describe("fetchWithParseErrorStatus", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("annotates the parse SyntaxError with the response HTTP status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 431 })),
+    );
+
+    const response = await fetchWithParseErrorStatus("http://localhost/x");
+    await expect(response.json()).rejects.toMatchObject({
+      name: "SyntaxError",
+      responseStatus: 431,
+    });
+  });
+
+  it("returns parsed JSON unchanged when the body is valid", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response('{"ok":true}', { status: 200 })),
+    );
+
+    const response = await fetchWithParseErrorStatus("http://localhost/x");
+    await expect(response.json()).resolves.toEqual({ ok: true });
   });
 });
 

--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -5,6 +5,7 @@ import {
   getTrpcErrorPath,
   isExpectedTrpcClientError,
   isNetworkConnectivityError,
+  isTrpcResponseParseError,
 } from "@/src/utils/api";
 
 /** Builds a TRPCClientError with the given server error shape (code/path). */
@@ -77,6 +78,64 @@ describe("isNetworkConnectivityError", () => {
     expect(isNetworkConnectivityError(new TypeError("Failed to fetch"))).toBe(
       false,
     );
+  });
+});
+
+describe("isTrpcResponseParseError", () => {
+  it("detects a JSON.parse failure on the response body (Firefox message)", () => {
+    const error = TRPCClientError.from(
+      new SyntaxError(
+        "JSON.parse: unexpected character at line 1 column 1 of the JSON data",
+      ),
+      {
+        meta: { response: new Response("<html></html>", { status: 200 }) },
+      },
+    );
+
+    expect(isTrpcResponseParseError(error)).toBe(true);
+  });
+
+  it("detects a truncated response body (Chromium message)", () => {
+    const error = TRPCClientError.from(
+      new SyntaxError("Unexpected end of JSON input"),
+    );
+
+    expect(isTrpcResponseParseError(error)).toBe(true);
+  });
+
+  // Negative fixtures: real errors MUST still flow to Sentry. If any of these
+  // start returning true, the suppression rule has grown a hole that hides a
+  // genuine bug.
+  it("does not match tRPC server errors (a parsed error envelope)", () => {
+    const error = trpcServerError({
+      code: "INTERNAL_SERVER_ERROR",
+      httpStatus: 500,
+      path: "events.all",
+    });
+
+    expect(isTrpcResponseParseError(error)).toBe(false);
+  });
+
+  it("does not match network connectivity failures", () => {
+    const error = TRPCClientError.from(new TypeError("Failed to fetch"));
+
+    expect(isTrpcResponseParseError(error)).toBe(false);
+  });
+
+  it("does not match a TRPCClientError with a non-SyntaxError cause", () => {
+    const error = TRPCClientError.from(new Error("boom"));
+
+    expect(isTrpcResponseParseError(error)).toBe(false);
+  });
+
+  it("does not match a raw JSON.parse SyntaxError thrown by app code", () => {
+    // Not wrapped by the tRPC client — in handleTrpcError it takes the
+    // non-TRPC branch and is captured unchanged.
+    expect(
+      isTrpcResponseParseError(new SyntaxError("Unexpected end of JSON input")),
+    ).toBe(false);
+    expect(isTrpcResponseParseError(null)).toBe(false);
+    expect(isTrpcResponseParseError(undefined)).toBe(false);
   });
 });
 

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -162,6 +162,25 @@ export const isExpectedTrpcClientError = (error: unknown): boolean => {
 };
 
 /**
+ * True when `error` is a TRPCClientError caused by the tRPC client failing to
+ * JSON-parse the HTTP response body (a `SyntaxError` cause, e.g. "JSON.parse:
+ * unexpected character at line 1 column 1 of the JSON data" / "Unexpected end
+ * of JSON input").
+ *
+ * Our tRPC handler always returns JSON, so a non-JSON body means something
+ * between server and client replaced or truncated it (a proxy/LB error page,
+ * an interrupted connection, an intercepting proxy). That is transport state,
+ * not an app bug — the server owns the real signal. A parsed tRPC error
+ * envelope (`error.data`) means the server DID answer with a real error
+ * shape; those keep flowing to Sentry unchanged.
+ */
+export const isTrpcResponseParseError = (error: unknown): boolean => {
+  if (!(error instanceof TRPCClientError)) return false;
+  if (error.data) return false;
+  return getCause(error) instanceof SyntaxError;
+};
+
+/**
  * tRPC serializes query input into the GET URL. For reads whose input scales with
  * the number of rows (the `*.batchIO` I/O fetches), that URL grows large (~6KB at
  * 50 rows, ~12KB at 100) and — together with per-user cookies (NextAuth session
@@ -255,6 +274,23 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
           code: getTrpcErrorCode(error),
           path: getTrpcErrorPath(error),
           httpStatus,
+        },
+      });
+    } else if (isTrpcResponseParseError(error)) {
+      // The response body was not JSON (proxy error page, truncated body) —
+      // transport state, not an app bug. Breadcrumb instead of capture; the
+      // toast below still renders. See `isTrpcResponseParseError`.
+      addBreadcrumb({
+        category: "trpc",
+        type: "http",
+        level: "warning",
+        message: "Suppressed tRPC response parse error (not sent to Sentry)",
+        data: {
+          message: error.message,
+          status:
+            error.meta?.response instanceof Response
+              ? error.meta.response.status
+              : undefined,
         },
       });
     } else {

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -420,10 +420,9 @@ const requestTooLargeDiagnosticsLink = (): TRPCLink<AppRouter> => () => {
         error(err) {
           const sentAsGet =
             op.type === "query" && op.context.sendAsPost !== true;
-          const status =
-            err.meta?.response instanceof Response
-              ? err.meta.response.status
-              : undefined;
+          // Annotation-first (meta is dropped on JSON-parse failures — the
+          // common shape of a real 414/431, whose body is empty/HTML).
+          const status = getResponseStatus(err);
 
           if (
             sentAsGet &&

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -161,6 +161,53 @@ export const isExpectedTrpcClientError = (error: unknown): boolean => {
   );
 };
 
+// HTTP statuses returned when a request's URL/headers are too large for the
+// browser or an upstream proxy. The response body is usually not a tRPC
+// envelope, so these are otherwise hard to diagnose.
+const REQUEST_TOO_LARGE_STATUSES = [414, 431];
+
+type SyntaxErrorWithResponseStatus = SyntaxError & { responseStatus?: number };
+
+/**
+ * `@trpc/client` (11.13.4) rejects with the bare `SyntaxError` when
+ * JSON-parsing a response body fails — the link only records the response
+ * meta (and so the HTTP status) for fulfilled requests. This fetch wrapper
+ * re-attaches the status to the parse `SyntaxError` so error classification
+ * can tell an app-owned 414/431 failure from transport garbage.
+ * Exported for tests.
+ */
+export const fetchWithParseErrorStatus: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init);
+  const originalJson = response.json.bind(response);
+  response.json = async () => {
+    try {
+      return await originalJson();
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        (error as SyntaxErrorWithResponseStatus).responseStatus =
+          response.status;
+      }
+      throw error;
+    }
+  };
+  return response;
+};
+
+/** HTTP status of a failed tRPC response: from the annotated parse error
+ * (`fetchWithParseErrorStatus`) or, when a link attached it, the response meta. */
+const getResponseStatus = (error: TRPCClientError<any>): number | undefined => {
+  const cause = getCause(error);
+  if (
+    cause instanceof SyntaxError &&
+    typeof (cause as SyntaxErrorWithResponseStatus).responseStatus === "number"
+  ) {
+    return (cause as SyntaxErrorWithResponseStatus).responseStatus;
+  }
+  return error.meta?.response instanceof Response
+    ? error.meta.response.status
+    : undefined;
+};
+
 /**
  * True when `error` is a TRPCClientError caused by the tRPC client failing to
  * JSON-parse the HTTP response body (a `SyntaxError` cause, e.g. "JSON.parse:
@@ -173,11 +220,19 @@ export const isExpectedTrpcClientError = (error: unknown): boolean => {
  * not an app bug — the server owns the real signal. A parsed tRPC error
  * envelope (`error.data`) means the server DID answer with a real error
  * shape; those keep flowing to Sentry unchanged.
+ *
+ * Deliberately NOT matched: a parse failure on HTTP 414/431. That is the
+ * app-owned oversized-GET-URL bug class (see `sendAsPostOption`) and must
+ * keep capturing. Unknown status (no annotation, no meta) stays classified
+ * as transport — the live client drops the response meta on parse failures,
+ * which is why `fetchWithParseErrorStatus` exists.
  */
 export const isTrpcResponseParseError = (error: unknown): boolean => {
   if (!(error instanceof TRPCClientError)) return false;
   if (error.data) return false;
-  return getCause(error) instanceof SyntaxError;
+  if (!(getCause(error) instanceof SyntaxError)) return false;
+  const status = getResponseStatus(error);
+  return status === undefined || !REQUEST_TOO_LARGE_STATUSES.includes(status);
 };
 
 /**
@@ -287,10 +342,7 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
         message: "Suppressed tRPC response parse error (not sent to Sentry)",
         data: {
           message: error.message,
-          status:
-            error.meta?.response instanceof Response
-              ? error.meta.response.status
-              : undefined,
+          status: getResponseStatus(error),
         },
       });
     } else {
@@ -350,11 +402,6 @@ const buildIdLink = (): TRPCLink<AppRouter> => () => {
     });
   };
 };
-
-// HTTP statuses returned when a request's URL/headers are too large for the
-// browser or an upstream proxy. The response body is usually not a tRPC
-// envelope, so these are otherwise hard to diagnose.
-const REQUEST_TOO_LARGE_STATUSES = [414, 431];
 
 // Logs request-size context to the console when a GET-routed query fails because
 // its URL was too large. tRPC serializes query input into the GET URL, so an
@@ -473,10 +520,12 @@ export const api = createTRPCNext<AppRouter>({
               url: `${getBaseUrl()}/api/trpc`,
               transformer: superjson,
               methodOverride: "POST",
+              fetch: fetchWithParseErrorStatus,
             }),
             false: httpLink({
               url: `${getBaseUrl()}/api/trpc`,
               transformer: superjson,
+              fetch: fetchWithParseErrorStatus,
             }),
           }),
           // when condition is false, use batching
@@ -484,6 +533,7 @@ export const api = createTRPCNext<AppRouter>({
             url: `${getBaseUrl()}/api/trpc`,
             transformer: superjson,
             maxURLLength: 2083, // avoid too large batches
+            fetch: fetchWithParseErrorStatus,
           }),
         }),
       ],

--- a/web/src/utils/trpcErrorToast.tsx
+++ b/web/src/utils/trpcErrorToast.tsx
@@ -86,7 +86,7 @@ export const trpcErrorToast = (error: unknown) => {
     if (isResponseParseError(error)) {
       showErrorToast(
         "Unexpected Response",
-        "The request could not be completed. We've been notified and are looking into it. Please try again or contact support if this persists.",
+        "The request could not be completed. Please try again or contact support if this persists.",
         "WARNING",
       );
       return;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15772.preview.langfuse.com](https://pr-15772.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

`TRPCClientError: JSON.parse: unexpected character…` / `Unexpected end of JSON input` events are transport noise (a non-JSON response body reached the tRPC client), not app bugs. This classifies them at the existing `handleTrpcError` seam: breadcrumb instead of Sentry capture, error toast unchanged. Negative fixtures prove real errors still capture.

## Why

Sentry issues LANGFUSE-5V0 (12 events / 6 users since 2026-07-24) and LANGFUSE-5VS (2 events / 1 user): the tRPC client throws a `TRPCClientError` wrapping a raw `SyntaxError` from `JSON.parse` on the response body. Evidence this is transport-shaped, not an app bug:

- The events carry **no tRPC error envelope** (`error.data` is absent — no `trpc.code`/`trpc.path` tags): the server never answered with a tRPC error shape.
- In the captured replay breadcrumbs, the failing fetch returned **HTTP 200 with an unparseable body** — something between the server and the `JSON.parse` call replaced or truncated the body.
- The 5V0 events all come from Firefox sessions belonging to security researchers (bug-bounty / disposable-mail accounts) probing auth and settings pages — the signature of an intercepting proxy rewriting responses. 5VS is two events 11 ms apart from one user — a truncated body on a flaky connection.

Our tRPC handler always serializes JSON, so a body that fails `JSON.parse` was corrupted in transit. The client-side event is an amplified, lower-fidelity copy of a signal the server already owns.

## What

- New named predicate `isTrpcResponseParseError` in `web/src/utils/api.ts`: a `TRPCClientError` whose `cause` is a `SyntaxError` **and** that has no parsed tRPC error envelope (`error.data`) **and** whose response status is not 414/431 — a parse failure on a request-too-large response is the app-owned oversized-GET-URL bug class (the `sendAsPostOption` machinery) and keeps capturing.
- Because `@trpc/client` drops the response meta when body parsing fails (verified against 11.13.4: the link records meta only for fulfilled requests), a small `fetch` wrapper on the links re-attaches the HTTP status to the parse `SyntaxError` so the 414/431 exclusion actually works in the live flow.
- `handleTrpcError` (the established seam from #15243) drops the transport-shaped ones from Sentry with a breadcrumb (message + response status), exactly like the expected-code suppression next to it.
- The parse-error toast copy in `trpcErrorToast.tsx` no longer claims "We've been notified" (no longer true for the suppressed class); it now reads "The request could not be completed. Please try again or contact support if this persists."

## Result

The two JSON-parse issue families stop minting Sentry events; a breadcrumb keeps the trail in any later real event from the same session.

**Does this rule hide a real error?** No — locked by negative fixtures in `api.clienttest.ts`:

- a tRPC server error envelope (e.g. `INTERNAL_SERVER_ERROR`, 500) still captures (`error.data` present → predicate is false),
- a parse failure on HTTP 414/431 (request too large — an actionable app bug) still captures, via the status annotation or link meta,
- a raw `SyntaxError` thrown by app code (not wrapped by the tRPC client) still captures via the non-TRPC branch,
- network connectivity failures and other causes are untouched.

A systemic outage where a proxy serves error pages for every response surfaces server-side (5xx/LB metrics), not through browser JSON.parse copies.

<details>
<summary>Mechanism and verification detail</summary>

- `TRPCClientError.from(cause)` (trpc client v11) wraps a thrown `SyntaxError` as `new TRPCClientError(cause.message, { cause })`, leaving `shape`/`data` undefined — verified against the installed `@trpc/client@11.13.4`. A server error response goes through the `isTRPCErrorResponse` branch instead and always carries `result.error.data`.
- The predicate reads `error.data` first, so any response that parsed into an error envelope can never be classified as a parse failure, regardless of cause.
- **Why the fetch wrapper:** empirically probed the installed client — for a 431 empty body, a 200 HTML body, and a 502 HTML body alike, the thrown `TRPCClientError` has `meta: undefined` (the link's `meta` closure is assigned in the fulfilled branch only, `httpLink` → `.catch((cause) => TRPCClientError.from(cause, { meta }))`). A status check on `error.meta.response` alone would therefore never fire in the live flow; the wrapper re-attaches the status at the only place that still has both the `Response` and the parse error. The predicate also reads `error.meta.response.status` as a fallback for links that do attach meta.
- Suppression follows the sentry-instrumentation contract: named, documented predicate + breadcrumb trail + negative fixtures (the #15243 seam-classification pattern, same file).
- Checks: `vitest --project client src/utils/api.clienttest.ts` (28 tests green, incl. wrapper tests), prettier, eslint, `tsc --noEmit` all green.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
