### PR TITLE
fix: enable full-text search for EventsReadOnly ClickHouse clients

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -29,17 +29,6 @@ const CLICKHOUSE_CLIENT_DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const CLICKHOUSE_SERVER_TIMEOUT_GRACE_SECONDS = 5;
 
 /**
- * Remove these once we remove corresponding variables
- */
-const EVENTS_TABLE_READ_PATH_ENV_KEYS = [
-  "LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS",
-  "LANGFUSE_ENABLE_EVENTS_TABLE_UI",
-  "LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS",
-  "LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS",
-  "LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN",
-] as const;
-
-/**
  * ClickHouseClientManager provides a singleton pattern for managing ClickHouse clients.
  * It creates and reuses clients based on their configuration to avoid creating
  * a new connection for each query.
@@ -104,8 +93,7 @@ export class ClickHouseClientManager {
     preferredClickhouseService: PreferredClickhouseService,
   ): ServiceClickhouseSettings {
     const eventROSettings: ServiceClickhouseSettings =
-      preferredClickhouseService === "EventsReadOnly" &&
-      this.isEventsTableReadPathEnabled()
+      preferredClickhouseService === "EventsReadOnly"
         ? { enable_full_text_index: 1 }
         : {};
 
@@ -113,12 +101,6 @@ export class ClickHouseClientManager {
       ...getClickHouseCompatibilitySettings(),
       ...eventROSettings,
     };
-  }
-
-  private isEventsTableReadPathEnabled(): boolean {
-    return EVENTS_TABLE_READ_PATH_ENV_KEYS.some(
-      (key) => process.env[key] === "true",
-    );
   }
 
   private getRequestTimeoutClickHouseSettings(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15773.preview.langfuse.com](https://pr-15773.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Addresses https://github.com/langfuse/langfuse/issues/15750 

## Summary

- Always enable the ClickHouse full-text index for `EventsReadOnly` clients.
- Remove the obsolete feature-flag checks controlling this setting.
- Add regression coverage and clean up stubbed environment variables between tests.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR ensures every `EventsReadOnly` ClickHouse client enables full-text-index query support, independent of obsolete events-table feature flags.

- Removes the environment-flag gate from service-specific ClickHouse settings.
- Adds regression coverage for disabled feature flags.
- Restores stubbed environment variables after each client test.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The service-specific setting is consistently included in both client creation and cache-key generation, explicit caller settings can still override it, and the supported ClickHouse baseline provides the required full-text-index capability.
</details>

<sub>Reviews (1): Last reviewed commit: [a628a78](https://github.com/langfuse/langfuse/commit/a628a78d08cd1496c2ba63d8c4a2a86e7837f5ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50054200)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->