### PR TITLE
fix(web): stop storage-quota write failures from minting Sentry events

### DIFF
--- a/web/src/components/useLocalStorage.clienttest.tsx
+++ b/web/src/components/useLocalStorage.clienttest.tsx
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import useLocalStorage from "@/src/components/useLocalStorage";
+
+// Seam contract for preference persistence: a localStorage write that throws
+// (quota exceeded, Safari private mode) must not propagate an exception and
+// must not log at error level — the Sentry console integration turns
+// console.error into events (the QuotaExceededError issue family).
+describe("useLocalStorage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("persists the value when the write succeeds", () => {
+    const { result } = renderHook(() =>
+      useLocalStorage("test-pref-key", "initial"),
+    );
+
+    act(() => {
+      result.current[1]("updated");
+    });
+
+    expect(result.current[0]).toBe("updated");
+    expect(localStorage.getItem("test-pref-key")).toBe(
+      JSON.stringify("updated"),
+    );
+  });
+
+  it("does not throw and warns (not errors) when the write fails", () => {
+    const { result } = renderHook(() =>
+      useLocalStorage("test-pref-key", "initial"),
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException(
+        "Failed to execute 'setItem' on 'Storage'",
+        "QuotaExceededError",
+      );
+    });
+
+    expect(() => {
+      act(() => {
+        result.current[1]("updated");
+      });
+    }).not.toThrow();
+
+    // The in-memory state still updates; only persistence is skipped.
+    expect(result.current[0]).toBe("updated");
+    expect(warnSpy).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/useLocalStorage.tsx
+++ b/web/src/components/useLocalStorage.tsx
@@ -40,7 +40,7 @@ function useLocalStorage<T>(
       // Parse stored value if it exists, otherwise use initial value
       return stored ? (JSON.parse(stored) as T) : initialValue;
     } catch (error) {
-      console.error("Error reading from local storage", error);
+      console.warn("Error reading from local storage", error);
       return initialValue;
     }
   });
@@ -55,7 +55,7 @@ function useLocalStorage<T>(
           localStorage.setItem(localStorageKey, stringified);
           return stringified;
         } catch (error) {
-          console.error("Error writing to local storage", error);
+          console.warn("Error writing to local storage", error);
           return null;
         }
       },
@@ -63,7 +63,7 @@ function useLocalStorage<T>(
         try {
           localStorage.removeItem(localStorageKey);
         } catch (error) {
-          console.error("Error clearing local storage", error);
+          console.warn("Error clearing local storage", error);
         }
       },
     }),
@@ -93,7 +93,7 @@ function useLocalStorage<T>(
         try {
           setValue(e.newValue ? (JSON.parse(e.newValue) as T) : initialValue);
         } catch (error) {
-          console.error("Error parsing storage change", error);
+          console.warn("Error parsing storage change", error);
         }
       }
     };
@@ -110,7 +110,7 @@ function useLocalStorage<T>(
               : initialValue,
           );
         } catch (error) {
-          console.error("Error parsing custom event", error);
+          console.warn("Error parsing custom event", error);
         }
       }
     };

--- a/web/src/components/useSessionStorage.tsx
+++ b/web/src/components/useSessionStorage.tsx
@@ -30,7 +30,7 @@ function useSessionStorage<T>(
       const storedValue = sessionStorage.getItem(sessionStorageKey);
       return storedValue ? (JSON.parse(storedValue) as T) : initialValue;
     } catch (error) {
-      console.error("Error reading from session storage", error);
+      console.warn("Error reading from session storage", error);
       return initialValue;
     }
   });
@@ -40,7 +40,7 @@ function useSessionStorage<T>(
       sessionStorage.removeItem(sessionStorageKey);
       setValue(initialValue);
     } catch (error) {
-      console.error("Error clearing session storage", error);
+      console.warn("Error clearing session storage", error);
     }
   };
 
@@ -49,7 +49,7 @@ function useSessionStorage<T>(
     try {
       sessionStorage.setItem(sessionStorageKey, JSON.stringify(value));
     } catch (error) {
-      console.error("Error writing to session storage", error);
+      console.warn("Error writing to session storage", error);
     }
   }, [sessionStorageKey, value]);
 

--- a/web/src/features/column-visibility/hooks/useColumnOrder.ts
+++ b/web/src/features/column-visibility/hooks/useColumnOrder.ts
@@ -11,7 +11,7 @@ const readStoredColumnOrder = (localStorageKey: string): string[] => {
     const storedValue = localStorage.getItem(localStorageKey);
     return storedValue ? JSON.parse(storedValue) : [];
   } catch (error) {
-    console.error("Error reading from local storage", error);
+    console.warn("Error reading from local storage", error);
     return [];
   }
 };
@@ -49,7 +49,7 @@ const hasRunMigration = (versionKey: string): boolean => {
   try {
     return localStorage.getItem(versionKey) !== null;
   } catch (error) {
-    console.error("Error reading migration flag from local storage", error);
+    console.warn("Error reading migration flag from local storage", error);
     return true;
   }
 };
@@ -61,7 +61,7 @@ const markMigrationRun = (versionKey: string): void => {
   try {
     localStorage.setItem(versionKey, "1");
   } catch (error) {
-    console.error("Error writing migration flag to local storage", error);
+    console.warn("Error writing migration flag to local storage", error);
   }
 };
 

--- a/web/src/features/filters/hooks/useKeyedSessionStorageState.ts
+++ b/web/src/features/filters/hooks/useKeyedSessionStorageState.ts
@@ -11,7 +11,7 @@ function readSessionStorageValue<T>(params: {
     const storedValue = sessionStorage.getItem(storageKey);
     return storedValue ? (JSON.parse(storedValue) as T) : fallback;
   } catch (error) {
-    console.error("Error reading from session storage", error);
+    console.warn("Error reading from session storage", error);
     return fallback;
   }
 }
@@ -48,7 +48,7 @@ export function useKeyedSessionStorageState<T>(
     try {
       sessionStorage.setItem(storageKey, JSON.stringify(state.value));
     } catch (error) {
-      console.error("Error writing to session storage", error);
+      console.warn("Error writing to session storage", error);
     }
   }, [state.key, state.value, storageKey]);
 
@@ -76,7 +76,7 @@ export function useKeyedSessionStorageState<T>(
       try {
         sessionStorage.removeItem(storageKey);
       } catch (error) {
-        console.error("Error clearing session storage", error);
+        console.warn("Error clearing session storage", error);
       }
     }
 

--- a/web/src/features/search-bar/store/observedMetadataStore.clienttest.ts
+++ b/web/src/features/search-bar/store/observedMetadataStore.clienttest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   mergeIntoProject,
@@ -239,5 +239,41 @@ describe("useObservedMetadataStore", () => {
     expect(useObservedMetadataStore.getState().byProject.proj?.paths).toEqual({
       "routing.queue": { type: "string", values: ["billing"] },
     });
+  });
+
+  // The persisted map is a best-effort cache: a full/blocked localStorage
+  // (quota exceeded, Safari private mode) must not throw into the React
+  // effect that records paths, and must not log at error level (the console
+  // integration turns console.error into Sentry events).
+  it("does not throw or console.error when the localStorage write fails", () => {
+    useObservedMetadataStore.setState({ byProject: {} });
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException(
+          "Failed to execute 'setItem' on 'Storage'",
+          "QuotaExceededError",
+        );
+      });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(() =>
+        useObservedMetadataStore
+          .getState()
+          .actions.recordPaths("proj-quota", paths({ a: { type: "number" } })),
+      ).not.toThrow();
+      // The in-memory state still updates; only persistence is skipped.
+      expect(
+        useObservedMetadataStore.getState().byProject["proj-quota"]?.paths,
+      ).toEqual({ a: { type: "number" } });
+      expect(warnSpy).toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      setItemSpy.mockRestore();
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/web/src/features/search-bar/store/observedMetadataStore.ts
+++ b/web/src/features/search-bar/store/observedMetadataStore.ts
@@ -43,6 +43,35 @@ const noopStorage: StateStorage = {
   removeItem: () => {},
 };
 
+// localStorage can throw (quota exceeded, Safari private mode). This map is a
+// best-effort cache, so a failed write must not throw into the React effect
+// that recorded the paths. console.warn, not console.error — error-level logs
+// become Sentry events via the console integration.
+const safeLocalStorage: StateStorage = {
+  getItem: (name) => {
+    try {
+      return window.localStorage.getItem(name);
+    } catch (error) {
+      console.warn("Error reading from local storage", error);
+      return null;
+    }
+  },
+  setItem: (name, value) => {
+    try {
+      window.localStorage.setItem(name, value);
+    } catch (error) {
+      console.warn("Error writing to local storage", error);
+    }
+  },
+  removeItem: (name) => {
+    try {
+      window.localStorage.removeItem(name);
+    } catch (error) {
+      console.warn("Error clearing local storage", error);
+    }
+  },
+};
+
 type ProjectMetadataPaths = {
   /** Observed top-level key → stored type + sample values (see StoredKeyInfo). */
   paths: Record<string, StoredKeyInfo>;
@@ -159,7 +188,7 @@ export const useObservedMetadataStore = create<ObservedMetadataState>()(
       version: 2,
       // Hydrates from localStorage on the client; no-op during SSR.
       storage: createJSONStorage(() =>
-        typeof window !== "undefined" ? window.localStorage : noopStorage,
+        typeof window !== "undefined" ? safeLocalStorage : noopStorage,
       ),
       // Persist only data, never the actions object.
       partialize: (state) => ({ byProject: state.byProject }),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15774.preview.langfuse.com](https://pr-15774.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Users with a full or blocked localStorage (quota exceeded, Safari private mode) mint one Sentry issue per preference key they touch. The writes were already caught — but logged with `console.error`, which the Sentry console integration turns into events. This switches the storage seams to `console.warn` and makes the one store that could actually throw into React (zustand persist) non-throwing. Seam tests lock the contract: write succeeds normally; a throwing write propagates no exception and logs warn, never error.

## Why

Sentry: `QuotaExceededError: Failed to execute 'setItem' on 'Storage'` — ~46 events across four fingerprints (one per storage key: `data-table-controls-…` 25 ev, `eventsColumnVisibility-…` 13 ev, `langfuse-observed-metadata` 7 ev, `langfuse-environment-options-cache-v1` 1 ev), all `mechanism: auto.core.capture_console`. Nothing is crashing for these users; a storage-full browser just turns every preference write into an error-level log, and every error-level log into a Sentry event. These writes are best-effort preferences/caches — a failed write is a degradation the app already tolerates, not something a human acts on.

One of the four (`langfuse-observed-metadata`) is different: the zustand `persist` store wrote through raw `window.localStorage`, so the `QuotaExceededError` actually threw out of the store action into the calling React effect and only surfaced as a console capture after React handled it.

## What

- `useLocalStorage` / `useSessionStorage` / `useKeyedSessionStorageState` / `useColumnOrder`: the existing catch blocks log with `console.warn` instead of `console.error` (the non-actionable-log level per the repo's Sentry capture contract).
- `observedMetadataStore`: the persist storage is now a non-throwing `localStorage` wrapper — a failed write warns and skips persistence; in-memory state still updates.
- New seam tests: `useLocalStorage.clienttest.tsx` (write succeeds / write throws → no exception, warn not error) and an equivalent case in `observedMetadataStore.clienttest.ts`.

## Result

Storage-full/private-mode users stop generating Sentry noise on every preference write, and the observed-metadata store can no longer throw a quota error into a React effect. UX is unchanged — these writes were already best-effort.

**Does this hide a real failure someone relies on?** No. Every touched path already swallowed the failure (the app keeps working from in-memory state); the only change to behavior is the log level and, for the zustand store, no longer throwing into the component tree. A real storage-related app bug (e.g. corrupted persisted JSON crashing a component) still surfaces as its own exception — nothing here catches new error classes, and reads still fall back to defaults exactly as before.

<details>
<summary>Evidence and mechanism detail</summary>

- All four Sentry fingerprints carry `mechanism: auto.core.capture_console, handled: yes` — they enter Sentry through `captureConsoleIntegration({ levels: ["error"] })` in `web/instrumentation-client.ts`, not as crashes.
- The `data-table-controls-…`, `eventsColumnVisibility-…`, and `langfuse-environment-options-cache-v1` keys all write through the shared `useLocalStorage` hook (stack: `Object.set` → the hook's `safeLocalStorage.set` catch → `console.error`).
- The `langfuse-observed-metadata` event stack shows `recordPaths → setItem` — zustand v5 `persist` calls `storage.setItem` synchronously inside `set`, so with raw `window.localStorage` the DOMException propagated to the caller.
- Audited every `localStorage.setItem` / `sessionStorage.setItem` under `web/src/`: the remaining call sites either already warn/stay silent in their catch (`recent-searches`, `peekPanelStore`, `useJsonViewPreferences`, `useMonospaceCharWidth`, `JsonExpansionContext`, `useFormPersistence`, `useCollapsibleSystemPrompt`) or write without a catch in flows with no Sentry evidence of firing (playground `windowStorage`/`usePlaygroundCache`, `sdkVersionStorage`, `useV4Beta`, `useHistoryEntryRevisit`) — left untouched to keep this change tight to the evidenced seams.
- Checks: client vitest on the two seam test files (13 tests) + the hook consumers (`data-table-controls`, sidebar filter persistence, saved-view regression — 42 tests), prettier, eslint, `tsc --noEmit` all green.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents expected browser-storage failures from generating error-level Sentry events and makes observed-metadata persistence non-throwing.
- Downgrades storage-operation logging from error to warning across shared local/session-storage hooks.
- Wraps the observed-metadata Zustand persistence adapter with non-throwing storage operations.
- Adds client tests covering successful writes and quota-failure behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking observability concern around suppressing malformed persisted-data diagnostics along with quota failures.

The non-throwing write behavior matches the best-effort persistence contract, but broad read catches now route JSON parsing failures exclusively to console.warn even though production Sentry captures only console.error.

**Files Needing Attention:** web/src/components/useLocalStorage.tsx and the analogous storage-read hooks
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/useLocalStorage.tsx:43
**Preserve parse-failure diagnostics**

Malformed persisted JSON reaches this broad catch just like storage-access failures, so changing it to `console.warn` removes the only Sentry diagnostic and leaves repeated storage-format regressions visible only in the browser console. Please limit warning-only handling to expected storage-access failures or retain error reporting for parsing failures.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop storage-quota write failu..."](https://github.com/langfuse/langfuse/commit/660cea000b5212b137d649f8f7e0c2c2a8eafaff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50055234)</sub>

<!-- /greptile_comment -->