### PR TITLE
fix(prompts): reserve 'metrics' and 'prompt-detail' as prompt names

### DIFF
--- a/packages/shared/src/features/prompts/constants.ts
+++ b/packages/shared/src/features/prompts/constants.ts
@@ -5,6 +5,15 @@ export const COMMIT_MESSAGE_MAX_LENGTH = 500;
 // Prompt name validation
 export const PROMPT_NAME_MAX_LENGTH = 255;
 export const RESERVED_PROMPT_NAME_NEW = "new";
+// Static sibling pages of the /prompts/[[...folder]] catch-all route
+// (web/src/pages/project/[projectId]/prompts/). Next.js resolves static
+// routes before the catch-all, so a prompt with one of these exact names
+// would have every link to it render the static page instead.
+export const RESERVED_PROMPT_NAMES = [
+  RESERVED_PROMPT_NAME_NEW,
+  "metrics",
+  "prompt-detail",
+] as const;
 export const PROMPT_NAME_PIPE_RESTRICTION_REGEX = /^[^|]*$/;
 export const PROMPT_NAME_PIPE_RESTRICTION_ERROR =
   "Prompt name cannot contain '|' character";

--- a/packages/shared/src/features/prompts/validation.test.ts
+++ b/packages/shared/src/features/prompts/validation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { RESERVED_PROMPT_NAMES } from "./constants";
+import { PromptNameSchema } from "./validation";
+
+describe("PromptNameSchema", () => {
+  // The static /prompts/* pages (new, metrics, prompt-detail) beat the
+  // [[...folder]] catch-all in Next.js routing, so a prompt with one of these
+  // exact names would have every link to it resolve to the static page.
+  it.each(RESERVED_PROMPT_NAMES)("rejects the reserved name '%s'", (name) => {
+    const result = PromptNameSchema.safeParse(name);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      `Prompt name cannot be '${name}'`,
+    );
+  });
+
+  it.each(RESERVED_PROMPT_NAMES)(
+    "rejects '%s' with surrounding whitespace (compared after trim)",
+    (name) => {
+      expect(PromptNameSchema.safeParse(` ${name} `).success).toBe(false);
+    },
+  );
+
+  // Only the exact single-segment name collides with the static routes:
+  // "metrics/foo" (folder named metrics) and "foo/new" (leaf named new)
+  // resolve through the catch-all. Deliberately not over-blocked.
+  // Note: "folder/metrics" stays valid here; the catch-all's `/metrics`
+  // URL-suffix handling is a separate, pre-existing quirk documented in
+  // web/src/pages/project/[projectId]/prompts/[[...folder]].tsx.
+  it.each(RESERVED_PROMPT_NAMES)(
+    "allows '%s' as a folder name or leaf segment",
+    (name) => {
+      expect(PromptNameSchema.safeParse(`${name}/foo`).success).toBe(true);
+      expect(PromptNameSchema.safeParse(`folder/${name}`).success).toBe(true);
+    },
+  );
+
+  it("accepts ordinary prompt names", () => {
+    for (const name of [
+      "my-prompt",
+      "metrics-v2",
+      "new-onboarding",
+      "folder/sub-folder/prompt",
+    ]) {
+      const result = PromptNameSchema.safeParse(name);
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(name);
+    }
+  });
+
+  it("still enforces the existing rules (pipe, slashes, emptiness)", () => {
+    expect(PromptNameSchema.safeParse("a|b").success).toBe(false);
+    expect(PromptNameSchema.safeParse("/a").success).toBe(false);
+    expect(PromptNameSchema.safeParse("a/").success).toBe(false);
+    expect(PromptNameSchema.safeParse("a//b").success).toBe(false);
+    expect(PromptNameSchema.safeParse("").success).toBe(false);
+  });
+
+  it("trims surrounding whitespace from valid names", () => {
+    expect(PromptNameSchema.safeParse(" my-prompt ").data).toBe("my-prompt");
+  });
+});

--- a/packages/shared/src/features/prompts/validation.ts
+++ b/packages/shared/src/features/prompts/validation.ts
@@ -3,7 +3,7 @@ import { withFolderPathValidation } from "../folders/validation";
 import {
   PROMPT_NAME_PIPE_RESTRICTION_REGEX,
   PROMPT_NAME_PIPE_RESTRICTION_ERROR,
-  RESERVED_PROMPT_NAME_NEW,
+  RESERVED_PROMPT_NAMES,
 } from "./constants";
 
 /**
@@ -15,8 +15,10 @@ export const PromptNameSchema = withFolderPathValidation(
     // Note: pipe character is used for prompt composition
     PROMPT_NAME_PIPE_RESTRICTION_ERROR,
   ),
-  // Note: we use "new" as a special name for the new prompt form
 ).refine(
-  (name) => name !== RESERVED_PROMPT_NAME_NEW,
-  `Prompt name cannot be '${RESERVED_PROMPT_NAME_NEW}'`,
+  // Reserved: names of the static /prompts/* pages (see RESERVED_PROMPT_NAMES).
+  // Only the exact name collides — "metrics/foo" or "foo/metrics" route
+  // through the [[...folder]] catch-all.
+  (name) => !(RESERVED_PROMPT_NAMES as readonly string[]).includes(name),
+  { error: (issue) => `Prompt name cannot be '${issue.input}'` },
 );

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -20,6 +20,7 @@ import {
   optionalPaginationZod,
   paginationZod,
   PromptLabelSchema,
+  PromptNameSchema,
   promptsTableCols,
   PromptType,
   StringNoHTMLNonEmpty,
@@ -356,7 +357,9 @@ export const promptRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         promptId: z.string(),
-        name: StringNoHTMLNonEmpty,
+        // Same rules as create: a duplicate is a new prompt, so reserved
+        // names / pipes / malformed paths must not slip in through this path.
+        name: PromptNameSchema,
         isSingleVersion: z.boolean(),
       }),
     )


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15775.preview.langfuse.com](https://pr-15775.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

A prompt literally named `metrics` or `prompt-detail` passes validation today, but every link to it resolves to the static page of the same name — Next.js static routes beat the `[[...folder]]` catch-all. This extends the existing `new` reservation to a reserved-names list `{new, metrics, prompt-detail}` and closes the duplicate-prompt path, which bypassed name validation (including the existing `new` reservation) entirely. Existing prompts with these names are unaffected at read time; only creation/duplication is blocked.

## Why

Pre-existing bug surfaced by an automated review finding on #15767 and verified against the routing: `web/src/pages/project/[projectId]/prompts/` contains three static siblings of the `[[...folder]].tsx` catch-all — `new.tsx`, `metrics.tsx`, `prompt-detail.tsx`. `PromptNameSchema` reserved only `new`, so `/prompts/metrics` and `/prompts/prompt-detail` render the wrong page for prompts with those exact names (a metrics table for an undefined prompt, an empty detail view).

**Scope of the collision — exact single-segment names only.** Folder browsing uses the `?folder=` query param, not path segments, and the static pages are leaves: `/prompts/metrics/foo` (a folder named `metrics`) and `/prompts/foo/new` (a leaf named `new` inside a folder) have no static match and route through the catch-all correctly. The reservation therefore blocks only the exact full names, mirroring how `new` was already handled — folder names are deliberately not over-blocked.

## What

- `RESERVED_PROMPT_NAMES = ["new", "metrics", "prompt-detail"]` in `packages/shared/src/features/prompts/constants.ts`; `PromptNameSchema` refines against the list with the same per-name error message pattern (`Prompt name cannot be '<name>'`).
- `prompts.duplicatePrompt` (tRPC) now validates its `name` with `PromptNameSchema` instead of the bare `StringNoHTMLNonEmpty` — previously a duplicate could be named `new`, `metrics`, `prompt-detail`, or even contain `|` / malformed slashes, bypassing every rule the create path enforces.
- Parameterized tests in `packages/shared/src/features/prompts/validation.test.ts`: each reserved name rejected (exact and whitespace-padded), allowed as folder/leaf segment, ordinary names pass, existing pipe/slash/emptiness rules locked.

## Result

Prompts can no longer be created or duplicated under a name whose links would resolve to the wrong page.

**Enforcement surface (disclosure):** `PromptNameSchema` runs at every creation path — public API v2 (`POST /api/public/v2/prompts`), the legacy public API, tRPC create (plus the UI form client-side), the in-app MCP prompt tools, and now tRPC duplicate. API consumers creating prompts named `metrics` / `prompt-detail` will start receiving a 400, matching the long-standing behavior for `new`. Read paths (`GET .../prompts/{name}`, tRPC getters) use plain string schemas — existing prompts with these names keep resolving via the API and can be deleted; they are only un-navigable in the UI, which is the bug this prevents going forward. There is no rename path for prompts.

<details>
<summary>Routing analysis and verification detail</summary>

- Next.js pages-router precedence: predefined (static) routes are matched before dynamic and catch-all routes at the same level, so `/prompts/metrics` always hits `metrics.tsx`, never `[[...folder]].tsx` — regardless of an existing prompt with that name.
- The catch-all interprets path segments as the prompt name (with a trailing `/metrics` segment switching to the metrics view). A known, pre-existing quirk documented in `[[...folder]].tsx` — a prompt named `folder/metrics` renders the metrics view for `folder` — is a URL-suffix ambiguity inside the catch-all, distinct from the static-route collision, and is not addressed (or worsened) here; blocking every `*/metrics` leaf would over-reserve.
- The duplicate-name swap also means duplicate names are now trimmed like create names (the schema's transform).
- Checks: `vitest run src/features/prompts/validation.test.ts` in `packages/shared` (12 tests green); the `prompts.duplicatePrompt` servertests pass except one webhook-execution assertion that fails identically on unmodified `origin/main` (local queue-worker dependency, pre-existing); prettier, eslint, `tsc --noEmit` for both `shared` and `web` green.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes the static-route prompt-name reservations and applies the complete prompt-name schema to single-prompt duplication.
- Adds `new`, `metrics`, and `prompt-detail` to a shared reserved-name list.
- Rejects exact reserved names after whitespace normalization while preserving valid folder paths.
- Adds parameterized validation coverage for reserved names and existing path constraints.
- Aligns the duplicate-prompt tRPC input with prompt creation validation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the reserved-name checks matching the actual static-route collisions and all affected creation paths remaining consistent.

The shared schema rejects only the exact normalized names shadowed by static Next.js routes, while folder-qualified names remain valid and duplicate-prompt creation now follows the same validation contract as ordinary creation.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): reserve &#39;metrics&#39; and &#39;pro..."](https://github.com/langfuse/langfuse/commit/19eadfa138834c1c8ba2c5497a435c8f42bb6a36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50057111)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->