### PR TITLE
chore(deps): bump fast-uri to 3.1.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7950,8 +7950,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -18019,7 +18019,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -19718,7 +19718,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ minimumReleaseAgeExclude:
   - "eslint-config-next@16.2.11"
   - "next@16.2.11"
   - "ws@8.21.1"
-  - "fast-uri@3.1.4"
+  - "fast-uri@3.1.5"
 allowBuilds:
   "@prisma/client": true
   "@prisma/engines": true


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15776.preview.langfuse.com](https://pr-15776.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the transitive `fast-uri` dependency from 3.1.4 to 3.1.5.
- Updates the package resolution, AJV dependency snapshot, and integrity hash in `pnpm-lock.yaml`.
- Updates the corresponding minimum-release-age exclusion in `pnpm-workspace.yaml`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The transitive patch update is internally consistent across the lockfile and workspace release-age policy, with no stale references or incompatible dependency constraints found.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump fast-uri to 3.1.5"](https://github.com/langfuse/langfuse/commit/ee75058171326c122ffbab9fe4b39ef4556ad57a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50057562)</sub>

<!-- /greptile_comment -->