### PR TITLE
docs(agents): add Cursor Cloud native dev-environment setup notes

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -151,3 +151,48 @@ regenerated outputs. Never hand-edit `generated/**`.
 - Generated provider config and shim outputs under `.claude/`, `.cursor/`,
   `.codex/`, `.vscode/`, or `.mcp.json` are local artifacts, not source of
   truth files.
+
+## Cursor Cloud specific instructions
+
+This section is for Cursor Cloud agents. The VM has no Docker, so the standard
+`pnpm run infra:dev:up` / `pnpm run dx*` scripts (which use `docker compose`)
+do NOT work here. Local infra runs as native processes instead. The startup
+update script only refreshes JS deps (`pnpm install` + `pnpm run db:generate`);
+it does not start services. Datastore data, native binaries, and built
+`dist/` folders persist in the VM snapshot, so migrations/seed usually do not
+need re-running — but the datastores and dev servers are NOT auto-started and
+must be started each session as below.
+
+- Toolchain: Node 24 (via `nvm`, set as the default alias) and pnpm (via
+  corepack) resolve automatically in login/interactive shells. `/exec-daemon`
+  ships an older Node on `PATH`; if a bare non-login shell picks Node 22 or
+  cannot find `pnpm`, run commands through a login shell (`bash -lc '…'`).
+- Start datastores (run once per session, from the repo root):
+  - Postgres, Redis, MinIO (run as the current user, data under
+    `.codex/services/`):
+    `source scripts/codex/cloud_services.sh && ensure_postgres_running && ensure_redis_running && ensure_minio_running`
+  - ClickHouse: the helper's `ensure_clickhouse_running` only works as root, so
+    start it as the `clickhouse` system user with default paths instead:
+    `sudo -u clickhouse clickhouse-server --daemon --config-file=/etc/clickhouse-server/config.xml --pid-file=/run/clickhouse-server/clickhouse-server.pid`
+    (data lives in `/var/lib/clickhouse`; the app user `clickhouse`/`clickhouse`
+    already exists in the persisted CH data). Verify with
+    `curl -s localhost:8123/ping`.
+- Start the app: `pnpm run dev` (web on `:3000`, worker on `:3030`). The worker
+  imports `@langfuse/shared` from its built `dist/`, so on a truly fresh tree
+  (no `dist/`) it crashes with `MODULE_NOT_FOUND` until you build the libs once:
+  `pnpm --filter=@langfuse/shared run build && pnpm --filter=@langfuse/ee run build`,
+  then `pnpm run dev`. `dist/` persists in the snapshot, so this is usually a
+  one-time step.
+- First-time DB init (only if the databases are empty): use
+  `pnpm --filter=shared run db:deploy` for Postgres — do NOT use
+  `prisma migrate reset` / `pnpm --filter=shared run db:reset`, because Prisma
+  blocks destructive resets when invoked by an AI agent. Then
+  `pnpm --filter=shared run db:seed`, and for ClickHouse
+  `pnpm --filter=shared run ch:up && pnpm --filter=shared run ch:seed && pnpm --filter=shared run ch:dev-tables`.
+- Local login (from the default seed): `demo@langfuse.com` / `password`.
+- Seeded ingestion API keys (project `llm-app`): public `pk-lf-1234567890`,
+  secret `sk-lf-1234567890` — usable to POST traces to
+  `http://localhost:3000/api/public/ingestion` (Basic auth) for full-pipeline
+  (web → Redis → worker → ClickHouse) testing.
+- Service ports: web `3000`, worker `3030`, Postgres `5432`, ClickHouse
+  `8123`/`9000`, Redis `6379`, MinIO API `9090` / console `9091`.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15778.preview.langfuse.com](https://pr-15778.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Sets up and verifies the Langfuse development environment on a Cursor Cloud VM (no Docker available), and documents the durable, non-obvious startup gotchas for future cloud agents. The only code change is an appended `## Cursor Cloud specific instructions` section in `.agents/AGENTS.md` (synced to the generated `CLAUDE.md` shims via `pnpm run agents:sync`).

Because the VM has no Docker, the standard `pnpm run infra:dev:up` / `pnpm run dx*` scripts don't apply. Instead the four datastores run as native processes and the web + worker dev servers run on the host. The new AGENTS.md section captures:

- Toolchain: Node 24 via nvm (default alias) + pnpm via corepack; `/exec-daemon` ships an older Node, so use a login shell if a bare shell picks Node 22.
- How to start Postgres/Redis/MinIO (repo helper) and ClickHouse (must run as the `clickhouse` system user; the helper's root-only path and CLI `--path` override don't work as a non-root user).
- Worker needs `@langfuse/shared` + `@langfuse/ee` `dist/` built once or it crashes with `MODULE_NOT_FOUND`.
- First-time DB init uses `db:deploy` (not `prisma migrate reset`, which Prisma blocks for AI agents).
- Local login (`demo@langfuse.com` / `password`), seeded ingestion API keys, and service ports.

## Verification performed

- `pnpm install --frozen-lockfile` and `pnpm run db:generate` — OK
- Postgres migrations (`db:deploy`), ClickHouse migrations (`ch:up`), and seed (`db:seed`, `db:seed:examples`, `ch:seed`, `ch:dev-tables`) — OK (2 orgs/projects/users, ~100k observations per project)
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- Targeted test `pnpm --filter @langfuse/shared run test src/utils/json.test.ts` — `Tests 5 passed (5)`
- `pnpm run dev` — web on `:3000`, worker on `:3030` (health endpoints `200`, `{"status":"OK","version":"4.3.1"}`)
- Full-pipeline hello-world: ingested a trace via `POST /api/public/ingestion` (web → Redis → worker → ClickHouse), confirmed queryable via the public API and present in ClickHouse, then signed into the UI and bookmarked the trace.

[langfuse_login_and_bookmark_trace.mp4](https://cursor.com/agents/bc-1d0647f2-8fe9-418c-86e8-70190f76b0a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flangfuse_login_and_bookmark_trace.mp4)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d0647f2-8fe9-418c-86e8-70190f76b0a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d0647f2-8fe9-418c-86e8-70190f76b0a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

