### PR TITLE
feat: add ClickHouse writer time distribution metrics

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -6,12 +6,13 @@ import { env } from "../../env";
 import { logger } from "@langfuse/shared/src/server";
 import { ClickhouseWriter, TableName } from "../ClickhouseWriter";
 
-// Mock recordHistogram, recordCount, recordGauge
+// Mock recordHistogram, recordDistribution, recordCount, recordGauge
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   const original = (await importOriginal()) as {};
   return {
     ...original,
     recordHistogram: vi.fn(),
+    recordDistribution: vi.fn(),
     recordIncrement: vi.fn(),
     recordCount: vi.fn(),
     recordGauge: vi.fn(),
@@ -319,7 +320,8 @@ describe("ClickhouseWriter", () => {
   });
 
   it("should report wait time and processing time metrics correctly", async () => {
-    const metricsDistributionSpy = vi.spyOn(serverExports, "recordHistogram");
+    const histogramSpy = vi.spyOn(serverExports, "recordHistogram");
+    const distributionSpy = vi.spyOn(serverExports, "recordDistribution");
     const mockInsert = vi
       .spyOn(clickhouseClientMock, "insert")
       .mockResolvedValue();
@@ -328,16 +330,36 @@ describe("ClickhouseWriter", () => {
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
-    expect(metricsDistributionSpy).toHaveBeenCalledWith(
+    expect(histogramSpy).toHaveBeenCalledWith(
       "langfuse.queue.clickhouse_writer.wait_time",
       expect.any(Number),
       { unit: "milliseconds" },
     );
 
-    expect(metricsDistributionSpy).toHaveBeenCalledWith(
+    expect(histogramSpy).toHaveBeenCalledWith(
       "langfuse.queue.clickhouse_writer.processing_time",
       expect.any(Number),
       { unit: "milliseconds" },
+    );
+
+    expect(distributionSpy).toHaveBeenCalledWith(
+      "langfuse.queue.clickhouse_writer.time_distribution",
+      expect.any(Number),
+      {
+        entity_type: TableName.Traces,
+        type: "wait",
+        unit: "milliseconds",
+      },
+    );
+
+    expect(distributionSpy).toHaveBeenCalledWith(
+      "langfuse.queue.clickhouse_writer.time_distribution",
+      expect.any(Number),
+      {
+        entity_type: TableName.Traces,
+        type: "processing",
+        unit: "milliseconds",
+      },
     );
   });
 

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -5,6 +5,7 @@ import {
   getCurrentSpan,
   ObservationRecordInsertType,
   ObservationBatchStagingRecordInsertType,
+  recordDistribution,
   recordGauge,
   recordHistogram,
   recordIncrement,
@@ -375,6 +376,15 @@ export class ClickhouseWriter {
       recordHistogram("langfuse.queue.clickhouse_writer.wait_time", waitTime, {
         unit: "milliseconds",
       });
+      recordDistribution(
+        "langfuse.queue.clickhouse_writer.time_distribution",
+        waitTime,
+        {
+          entity_type: tableName,
+          type: "wait",
+          unit: "milliseconds",
+        },
+      );
     });
 
     const currentSpan = getCurrentSpan();
@@ -488,10 +498,21 @@ export class ClickhouseWriter {
       );
 
       // Log processing time
+      const processingTime = Date.now() - processingStartTime;
+
       recordHistogram(
         "langfuse.queue.clickhouse_writer.processing_time",
-        Date.now() - processingStartTime,
+        processingTime,
         {
+          unit: "milliseconds",
+        },
+      );
+      recordDistribution(
+        "langfuse.queue.clickhouse_writer.time_distribution",
+        processingTime,
+        {
+          entity_type: tableName,
+          type: "processing",
           unit: "milliseconds",
         },
       );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15779.preview.langfuse.com](https://pr-15779.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Add dimensional distribution metrics for ClickHouse writer wait and processing times.
- Preserve existing histogram metrics for backwards compatibility.
- Extend unit tests to verify metric names, values, and dimensions.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds per-entity ClickHouse writer timing distributions while preserving the existing histogram metrics.
- Records wait and processing durations under a shared distribution metric with operation type, entity type, and unit dimensions.
- Extends unit coverage to verify both legacy histograms and new dimensional distributions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new telemetry uses an existing exported distribution API, bounded table-name dimensions, and established timing tag conventions while retaining the previous histogram emissions.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add ClickHouse writer time distribution ..."](https://github.com/langfuse/langfuse/commit/a7d1bb137c8f1cfbc46a832ea1da87a7281ba268) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50061871)</sub>

<!-- /greptile_comment -->