### PR TITLE
refactor(web): one seam owns error capture — migrate raw captureException sites to reportError + lint enforcement

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -5,6 +5,49 @@ import eslintPluginTailwindcss from "eslint-plugin-tailwindcss";
 
 import nextConfig from "@repo/eslint-config/next";
 
+// Restricted import patterns that apply everywhere. Flat config replaces (not
+// merges) a rule that is configured twice, so every block that configures
+// no-restricted-imports must spread the full pattern list it wants.
+const restrictedImportPatterns = [
+  {
+    regex: "^react-icons$",
+    message:
+      "Only react-icons/si and react-icons/tb are allowed. Please use lucide-react for other icons.",
+  },
+  {
+    regex: "^react-icons/(?!si(?:/|$)|tb(?:/|$)).*",
+    message:
+      "Only react-icons/si and react-icons/tb are allowed. Please use lucide-react for other icons.",
+  },
+  {
+    // Relative paths escaping web/ bypass @langfuse/shared's exports
+    // map (which points at dist/) and pull shared *source* into the
+    // Next.js typecheck program, where web's next-auth augmentation
+    // breaks it — this failed production deploys (PR #15031).
+    // Note: only static imports are checked. Dynamic import() is not
+    // covered by this rule, which also leaves room for the one
+    // legitimate use: tests that need a Vite-transformed source copy
+    // of a shared module to observe env mutations (vitest loads the
+    // CJS dist through Node's require cache as a second instance —
+    // see blob-storage-integration-trpc.servertest.ts).
+    regex: "^(\\.\\./)+(packages|ee|worker)/",
+    message:
+      "Do not import other workspace packages via relative paths. Use the package entrypoints instead (e.g. @langfuse/shared/src/db, @langfuse/shared/src/server).",
+  },
+];
+
+// One seam owns error capture: raw Sentry capture APIs are restricted to the
+// reportError seam (src/utils/reportError.ts) so classification (`expected`),
+// `area` tagging, and non-Error coercion live in exactly one place. See
+// web/OBSERVABILITY.md. Exempted files re-declare the rule below without this
+// pattern — never via inline eslint-disable.
+const sentryCapturePattern = {
+  regex: "^@sentry/nextjs$",
+  importNames: ["captureException", "captureMessage"],
+  message:
+    "Do not capture directly — route through the reportError seam (@/src/utils/reportError) or a helper that wraps it (captureUnknownError, reportParserWorkerError), so one seam owns error classification. See web/OBSERVABILITY.md.",
+};
+
 // eslint-plugin-tailwindcss types this as Config | ConfigArray, but the
 // recommended export is a single flat config object with rules at runtime.
 const tailwindcssRecommendedConfig =
@@ -207,42 +250,31 @@ export default [
     },
   },
 
-  // Restricted import paths. Flat config replaces (not merges) a rule that is
-  // configured twice, so all no-restricted-imports patterns live in this one
-  // block.
+  // Restricted import paths (patterns defined at the top of this file).
   {
     name: "langfuse/web/restricted-imports",
     rules: {
       "no-restricted-imports": [
         "error",
         {
-          patterns: [
-            {
-              regex: "^react-icons$",
-              message:
-                "Only react-icons/si and react-icons/tb are allowed. Please use lucide-react for other icons.",
-            },
-            {
-              regex: "^react-icons/(?!si(?:/|$)|tb(?:/|$)).*",
-              message:
-                "Only react-icons/si and react-icons/tb are allowed. Please use lucide-react for other icons.",
-            },
-            {
-              // Relative paths escaping web/ bypass @langfuse/shared's exports
-              // map (which points at dist/) and pull shared *source* into the
-              // Next.js typecheck program, where web's next-auth augmentation
-              // breaks it — this failed production deploys (PR #15031).
-              // Note: only static imports are checked. Dynamic import() is not
-              // covered by this rule, which also leaves room for the one
-              // legitimate use: tests that need a Vite-transformed source copy
-              // of a shared module to observe env mutations (vitest loads the
-              // CJS dist through Node's require cache as a second instance —
-              // see blob-storage-integration-trpc.servertest.ts).
-              regex: "^(\\.\\./)+(packages|ee|worker)/",
-              message:
-                "Do not import other workspace packages via relative paths. Use the package entrypoints instead (e.g. @langfuse/shared/src/db, @langfuse/shared/src/server).",
-            },
-          ],
+          patterns: [...restrictedImportPatterns, sentryCapturePattern],
+        },
+      ],
+    },
+  },
+
+  // Sanctioned homes for raw Sentry capture APIs: the reportError seam itself
+  // and the SDK init (`import * as Sentry` would otherwise trip the
+  // importNames restriction). Last-match wins in flat config, so these files
+  // get the shared restrictions without the Sentry capture pattern.
+  {
+    name: "langfuse/web/restricted-imports-sentry-seam",
+    files: ["src/utils/reportError.ts", "instrumentation-client.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: restrictedImportPatterns,
         },
       ],
     },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -38,14 +38,16 @@ const restrictedImportPatterns = [
 
 // One seam owns error capture: raw Sentry capture APIs are restricted to the
 // reportError seam (src/utils/reportError.ts) so classification (`expected`),
-// `area` tagging, and non-Error coercion live in exactly one place. See
-// web/OBSERVABILITY.md. Exempted files re-declare the rule below without this
-// pattern — never via inline eslint-disable.
+// `area` tagging, and non-Error coercion live in exactly one place. The
+// capture contract lives in the seam's doc comment and in
+// .agents/skills/sentry-instrumentation/SKILL.md (human-facing version:
+// web/OBSERVABILITY.md, landing separately). Exempted files get a dedicated
+// config block below without this pattern — never an inline eslint-disable.
 const sentryCapturePattern = {
   regex: "^@sentry/nextjs$",
   importNames: ["captureException", "captureMessage"],
   message:
-    "Do not capture directly — route through the reportError seam (@/src/utils/reportError) or a helper that wraps it (captureUnknownError, reportParserWorkerError), so one seam owns error classification. See web/OBSERVABILITY.md.",
+    "Do not capture directly — route through the reportError seam (@/src/utils/reportError) or a helper that wraps it (captureUnknownError, reportParserWorkerError), so one seam owns error classification. See the reportError doc comment and .agents/skills/sentry-instrumentation/SKILL.md.",
 };
 
 // eslint-plugin-tailwindcss types this as Config | ConfigArray, but the

--- a/web/src/components/error-page.tsx
+++ b/web/src/components/error-page.tsx
@@ -4,7 +4,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import Link from "next/link";
-import { captureException } from "@sentry/nextjs";
+import { reportError } from "@/src/utils/reportError";
 import { stripBasePath } from "@/src/utils/redirect";
 
 export const ErrorPage = ({
@@ -82,8 +82,9 @@ export const ErrorPageWithSentry = ({
   useEffect(() => {
     // Capture the error with Sentry
     if (window !== undefined)
-      captureException(
+      reportError(
         new Error(`ErrorPageWithSentry rendered: ${title}, ${message}`),
+        { area: "error-page" },
       );
   }, [title, message]); // Empty dependency array means this effect runs once on mount
 

--- a/web/src/hooks/parserWorkerError.clienttest.ts
+++ b/web/src/hooks/parserWorkerError.clienttest.ts
@@ -1,11 +1,13 @@
 import { reportParserWorkerError } from "@/src/hooks/parserWorkerError";
-import { captureException } from "@sentry/nextjs";
 
-vi.mock("@sentry/nextjs", () => ({
-  captureException: vi.fn(),
+const { mockCaptureException } = vi.hoisted(() => ({
+  mockCaptureException: vi.fn(),
 }));
 
-const mockCaptureException = vi.mocked(captureException);
+vi.mock("@sentry/nextjs", () => ({
+  captureException: mockCaptureException,
+  addBreadcrumb: vi.fn(),
+}));
 
 /**
  * Observability contract for the JSON-parser Web Worker `onerror` path
@@ -37,7 +39,7 @@ describe("reportParserWorkerError", () => {
     reportParserWorkerError("useParsedTrace", event);
 
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
-    const [err, opts] = mockCaptureException.mock.calls[0];
+    const [err, opts] = mockCaptureException.mock.calls[0]!;
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toContain(
       "[useParsedTrace] worker failed to load",
@@ -65,7 +67,7 @@ describe("reportParserWorkerError", () => {
     );
 
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
-    expect(mockCaptureException.mock.calls[0][0]).toBe(real);
+    expect(mockCaptureException.mock.calls[0]![0]).toBe(real);
   });
 
   it("logs a readable string via console.warn, not console.error (no double-capture)", () => {
@@ -77,8 +79,8 @@ describe("reportParserWorkerError", () => {
     // console.error would be re-captured by captureConsoleIntegration.
     expect(error).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledTimes(1);
-    const logged = String(warn.mock.calls[0][0]);
-    expect(logged).toContain("[useParsedTrace] Worker failed to load");
+    const logged = String(warn.mock.calls[0]![0]);
+    expect(logged).toContain("[useParsedTrace] worker failed to load");
     expect(logged).not.toContain("[object ErrorEvent]");
 
     warn.mockRestore();
@@ -91,7 +93,7 @@ describe("reportParserWorkerError", () => {
       makeErrorEvent({ message: "", filename: "" }),
     );
 
-    const [err] = mockCaptureException.mock.calls[0];
+    const [err] = mockCaptureException.mock.calls[0]!;
     expect((err as Error).message).toContain("unknown");
     expect((err as Error).message).toContain("?");
   });

--- a/web/src/hooks/parserWorkerError.clienttest.ts
+++ b/web/src/hooks/parserWorkerError.clienttest.ts
@@ -74,17 +74,39 @@ describe("reportParserWorkerError", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    reportParserWorkerError("useParsedTrace", makeErrorEvent());
+    const event = makeErrorEvent();
+    reportParserWorkerError("useParsedTrace", event);
 
     // console.error would be re-captured by captureConsoleIntegration.
     expect(error).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledTimes(1);
     const logged = String(warn.mock.calls[0]![0]);
-    expect(logged).toContain("[useParsedTrace] worker failed to load");
+    // hookName + location details appear exactly once, prefixed by the area.
+    expect(logged).toContain(
+      "[io-parse-worker] useParsedTrace worker failed to load",
+    );
+    expect(logged).toContain(event.filename);
+    expect(logged).not.toContain("[useParsedTrace]"); // no double-bracketed hook
     expect(logged).not.toContain("[object ErrorEvent]");
 
     warn.mockRestore();
     error.mockRestore();
+  });
+
+  it("keeps hookName + details on the console line when a real event.error passes through", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const event = makeErrorEvent({ error: new Error("worker init threw") });
+    reportParserWorkerError("useParsedObservation", event);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const logged = String(warn.mock.calls[0]![0]);
+    expect(logged).toContain(
+      "[io-parse-worker] useParsedObservation worker failed to load",
+    );
+    expect(logged).toContain(event.filename);
+
+    warn.mockRestore();
   });
 
   it("degrades gracefully when ErrorEvent fields are empty", () => {

--- a/web/src/hooks/parserWorkerError.ts
+++ b/web/src/hooks/parserWorkerError.ts
@@ -43,5 +43,10 @@ export function reportParserWorkerError(
       lineno: event.lineno,
       colno: event.colno,
     },
+    // Companion console line: carry hookName + location details exactly once
+    // in both branches — the pass-through Error's message lacks them, the
+    // synthesized one already embeds them. Console-only; the captured event
+    // is the Error above.
+    warnMessage: `${hookName} worker failed to load: ${details}`,
   });
 }

--- a/web/src/hooks/parserWorkerError.ts
+++ b/web/src/hooks/parserWorkerError.ts
@@ -1,4 +1,4 @@
-import { captureException } from "@sentry/nextjs";
+import { reportError } from "@/src/utils/reportError";
 
 /**
  * Turn a JSON-parser Web Worker `onerror` ErrorEvent into a legible,
@@ -11,9 +11,10 @@ import { captureException } from "@sentry/nextjs";
  * "[object ErrorEvent]", discarding message/filename/lineno and making the
  * resulting issues undiagnosable.
  *
- * This extracts the real fields, captures one proper Error with structured
- * context, and logs a readable string via `console.warn` (NOT `console.error`,
- * so captureConsoleIntegration — which captures the "error" level — does not
+ * This extracts the real fields and reports one proper Error with structured
+ * context through the {@link reportError} seam, which tags `area` and logs the
+ * companion line via `console.warn` (NOT `console.error`, so
+ * captureConsoleIntegration — which captures the "error" level — does not
  * double-capture a second, opaque event for the same failure).
  *
  * Note: in-worker parse failures are a separate, already-legible path — they
@@ -33,7 +34,8 @@ export function reportParserWorkerError(
       ? event.error
       : new Error(`[${hookName}] worker failed to load: ${details}`);
 
-  captureException(realError, {
+  reportError(realError, {
+    area: "io-parse-worker",
     extra: {
       workerHook: hookName,
       message: event.message,
@@ -41,10 +43,5 @@ export function reportParserWorkerError(
       lineno: event.lineno,
       colno: event.colno,
     },
-    tags: { area: "io-parse-worker" },
   });
-
-  // console.warn (not console.error) keeps the console legible without
-  // triggering a duplicate capture via captureConsoleIntegration.
-  console.warn(`[${hookName}] Worker failed to load: ${details}`);
 }

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -38,7 +38,7 @@ import { isAnySsoConfigured } from "@/src/ee/features/multi-tenant-sso/utils";
 import { isEmailVerificationRequired } from "@/src/features/auth-credentials/lib/credentialsUtils";
 import { Code, Key } from "lucide-react";
 import { useRouter } from "next/router";
-import { captureException } from "@sentry/nextjs";
+import { reportError } from "@/src/utils/reportError";
 import { captureUnknownError } from "@/src/utils/captureUnknownError";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import useLocalStorage from "@/src/components/useLocalStorage";
@@ -572,7 +572,9 @@ export default function SignIn({
       !nextAuthErrorDescription &&
       !signInErrors.find((e) => e.code === nextAuthError)
     ) {
-      captureException(new Error(`Sign in error: ${nextAuthError}`));
+      reportError(new Error(`Sign in error: ${nextAuthError}`), {
+        area: "auth.signIn",
+      });
     }
   }, [nextAuthError, nextAuthErrorDescription]);
 
@@ -635,13 +637,16 @@ export default function SignIn({
       });
       if (result === undefined) {
         setCredentialsFormError("An unexpected error occurred.");
-        captureException(new Error("Sign in result is undefined"));
+        reportError(new Error("Sign in result is undefined"), {
+          area: "auth.signIn.credentials",
+        });
       } else if (!result.ok) {
         if (!result.error) {
-          captureException(
+          reportError(
             new Error(
               `Sign in result error is falsy, result: ${JSON.stringify(result)}`,
             ),
+            { area: "auth.signIn.credentials" },
           );
         }
         setCredentialsFormError(

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -5,7 +5,7 @@
  * We also create a few inference helpers for input and output types.
  */
 
-import { addBreadcrumb, captureException } from "@sentry/nextjs";
+import { addBreadcrumb } from "@sentry/nextjs";
 import {
   createTRPCProxyClient,
   httpBatchLink,
@@ -26,6 +26,7 @@ import { env } from "@/src/env.mjs";
 import { showVersionUpdateToast } from "@/src/features/notifications/showVersionUpdateToast";
 import { versionUpdateStore } from "@/src/features/version-update/versionUpdateStore";
 import { type AppRouter } from "@/src/server/api/root";
+import { reportError } from "@/src/utils/reportError";
 import { setUpSuperjson } from "@/src/utils/superjson";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 
@@ -258,9 +259,10 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
         },
       });
     } else {
-      // Real tRPC errors keep flowing to Sentry, now tagged by procedure/code
+      // Real tRPC errors keep flowing to Sentry, tagged by procedure/code
       // so they group and route instead of collapsing into one opaque bucket.
-      captureException(error, {
+      reportError(error, {
+        area: "trpc",
         tags: {
           "trpc.code": getTrpcErrorCode(error),
           "trpc.path": getTrpcErrorPath(error),
@@ -268,8 +270,8 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
       });
     }
   } else {
-    // For non-TRPC errors, still send to Sentry
-    captureException(error);
+    // For non-TRPC errors, still send to Sentry (coerced to a real Error).
+    reportError(error, { area: "trpc" });
   }
 
   if (!shouldSilenceError && shouldShowToast(error)) {
@@ -414,7 +416,7 @@ export const api = createTRPCNext<AppRouter>({
         requestTooLargeDiagnosticsLink(),
         loggerLink({
           // Only enable in development - production logs would be captured by Sentry
-          // in an unreadable format. We handle 5xx errors via captureException() in
+          // in an unreadable format. We handle 5xx errors via reportError in
           // handleTrpcError and use DataDog for additional server-side logging.
           enabled: () => process.env.NODE_ENV === "development",
         }),
@@ -499,7 +501,7 @@ export const directApi = createTRPCProxyClient<AppRouter>({
   links: [
     loggerLink({
       // Only enable in development - production logs would be captured by Sentry
-      // in an unreadable format. We handle 5xx errors via captureException() in
+      // in an unreadable format. We handle 5xx errors via reportError in
       // handleTrpcError and use DataDog for additional server-side logging.
       enabled: () => process.env.NODE_ENV === "development",
     }),

--- a/web/src/utils/reportError.clienttest.ts
+++ b/web/src/utils/reportError.clienttest.ts
@@ -133,5 +133,29 @@ describe("reportError", () => {
       const [, options] = captureExceptionMock.mock.calls[0]!;
       expect(options.tags.area).toBe("trpc");
     });
+
+    it("warnMessage overrides the console line body, prefixed with the area", () => {
+      reportError(new Error("boom"), {
+        area: "io-parse-worker",
+        warnMessage: "useParsedTrace worker failed to load: details",
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]![0]).toBe(
+        "[io-parse-worker] useParsedTrace worker failed to load: details",
+      );
+    });
+
+    it("warnMessage never affects what is captured", () => {
+      const original = new Error("boom");
+      reportError(original, {
+        area: "io-parse-worker",
+        warnMessage: "console-only text",
+      });
+
+      const [err] = captureExceptionMock.mock.calls[0]!;
+      expect(err).toBe(original);
+      expect(err.message).toBe("boom");
+    });
   });
 });

--- a/web/src/utils/reportError.clienttest.ts
+++ b/web/src/utils/reportError.clienttest.ts
@@ -106,5 +106,32 @@ describe("reportError", () => {
       expect(options.tags.area).toBe("io.parse");
       expect(options.extra).toBeUndefined();
     });
+
+    it("merges caller tags alongside the area tag", () => {
+      reportError(new Error("boom"), {
+        area: "trpc",
+        tags: {
+          "trpc.code": "INTERNAL_SERVER_ERROR",
+          "trpc.path": "traces.all",
+        },
+      });
+
+      const [, options] = captureExceptionMock.mock.calls[0]!;
+      expect(options.tags).toEqual({
+        "trpc.code": "INTERNAL_SERVER_ERROR",
+        "trpc.path": "traces.all",
+        area: "trpc",
+      });
+    });
+
+    it("the seam's area tag wins over a conflicting caller tag", () => {
+      reportError(new Error("boom"), {
+        area: "trpc",
+        tags: { area: "spoofed" },
+      });
+
+      const [, options] = captureExceptionMock.mock.calls[0]!;
+      expect(options.tags.area).toBe("trpc");
+    });
   });
 });

--- a/web/src/utils/reportError.ts
+++ b/web/src/utils/reportError.ts
@@ -67,6 +67,8 @@ export function coerceToError(area: string, value: unknown): Error {
  * - otherwise — coerce to a real `Error` (see {@link coerceToError}),
  *   `captureException` with an `area` tag (so issues route/group by surface) and
  *   the caller's structured `extra`, then log a companion `console.warn`.
+ *   Optional `tags` add further Sentry tags (e.g. `trpc.code`); on a key
+ *   conflict the seam's `area` tag wins.
  *
  * `console.warn`, never `console.error`: `instrumentation-client.ts` enables
  * `captureConsoleIntegration({ levels: ["error"] })`, so a `console.error` here
@@ -79,7 +81,12 @@ export function coerceToError(area: string, value: unknown): Error {
  */
 export function reportError(
   error: unknown,
-  opts: { area: string; expected?: boolean; extra?: Record<string, unknown> },
+  opts: {
+    area: string;
+    expected?: boolean;
+    extra?: Record<string, unknown>;
+    tags?: Record<string, string | undefined>;
+  },
 ): void {
   if (opts.expected === true) {
     addBreadcrumb({
@@ -94,7 +101,7 @@ export function reportError(
 
   const err = coerceToError(opts.area, error);
   captureException(err, {
-    tags: { area: opts.area },
+    tags: { ...opts.tags, area: opts.area },
     extra: opts.extra,
   });
   // warn, not error → captureConsoleIntegration only captures console.error, so

--- a/web/src/utils/reportError.ts
+++ b/web/src/utils/reportError.ts
@@ -68,7 +68,11 @@ export function coerceToError(area: string, value: unknown): Error {
  *   `captureException` with an `area` tag (so issues route/group by surface) and
  *   the caller's structured `extra`, then log a companion `console.warn`.
  *   Optional `tags` add further Sentry tags (e.g. `trpc.code`); on a key
- *   conflict the seam's `area` tag wins.
+ *   conflict the seam's `area` tag wins. Optional `warnMessage` overrides the
+ *   companion console line's body (always prefixed with `[area]`) for callers
+ *   whose legible console text differs from the captured Error's message —
+ *   e.g. a pass-through Error that lacks the caller's context. It never
+ *   affects what is captured.
  *
  * `console.warn`, never `console.error`: `instrumentation-client.ts` enables
  * `captureConsoleIntegration({ levels: ["error"] })`, so a `console.error` here
@@ -86,6 +90,7 @@ export function reportError(
     expected?: boolean;
     extra?: Record<string, unknown>;
     tags?: Record<string, string | undefined>;
+    warnMessage?: string;
   },
 ): void {
   if (opts.expected === true) {
@@ -106,10 +111,15 @@ export function reportError(
   });
   // warn, not error → captureConsoleIntegration only captures console.error, so
   // this line does not create a second, opaque event. Show the `area` exactly
-  // once: a synthesized error already embeds `[area]` in its message
-  // (coerceToError), a pass-through real Error does not — so prefix only that
-  // branch to keep the surface legible in the console without duplicating it.
+  // once: a `warnMessage` body gets the prefix; without one, a synthesized
+  // error already embeds `[area]` in its message (coerceToError) while a
+  // pass-through real Error does not — so prefix only that branch to keep the
+  // surface legible in the console without duplicating it.
   console.warn(
-    error instanceof Error ? `[${opts.area}] ${err.message}` : err.message,
+    opts.warnMessage !== undefined
+      ? `[${opts.area}] ${opts.warnMessage}`
+      : error instanceof Error
+        ? `[${opts.area}] ${err.message}`
+        : err.message,
   );
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15781.preview.langfuse.com](https://pr-15781.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

One seam now owns client-side error capture: every remaining direct `captureException` call site in `web/src` routes through `reportError` (#15278), and a lint restriction prevents new raw capture calls from being minted. Nothing changes about **whether** an event is sent — this is a mechanical seam migration, not a classification change.

## Why

#15278 introduced `reportError` as the single capture seam (classification, `area` tagging, non-Error coercion in one place), but a handful of call sites still imported `captureException` directly — each one a place where future error handling could drift away from the capture contract (see `web/OBSERVABILITY.md`, #15771). Migrating them and enforcing the seam with lint ends new-noise minting at the source.

## What

- **6 call sites migrated** across 4 files (`handleTrpcError` in `api.ts`, `ErrorPageWithSentry`, 3 sites in `sign-in.tsx`) plus `reportParserWorkerError`, which now wraps the seam the same way `captureUnknownError` already does.
- **Seam extension:** `reportError` accepts an optional `tags` record (merged under the seam's `area` tag, which wins on conflict) so the tRPC `trpc.code` / `trpc.path` tags are preserved exactly. Covered by new unit tests.
- **Lint enforcement:** a `no-restricted-imports` pattern (the repo's established mechanism for import restrictions in `web/eslint.config.mjs`) bans `captureException` / `captureMessage` imports from `@sentry/nextjs`. The only sanctioned files — the seam itself and `instrumentation-client.ts` (the SDK init's `import * as Sentry`) — get a targeted config-block exemption, no inline eslint-disables. Namespace imports are flagged too, so the rule can't be side-stepped via `import * as`.

## Result

Raw capture calls outside the seam: **0**. A new `captureException` import now fails `pnpm lint` (`--max-warnings 0`) with a message pointing at the seam and `OBSERVABILITY.md`. Full web client test suite, typecheck, lint, prettier: all green.

<details>
<summary>Per-site migration table and behavior notes</summary>

| File | Site | Before | After | Event delta |
|---|---|---|---|---|
| `web/src/utils/api.ts` | `handleTrpcError`, tRPC branch | `captureException(error, { tags: { "trpc.code", "trpc.path" } })` | `reportError(error, { area: "trpc", tags: { … } })` | Same Error instance, same tags, adds `area: trpc` tag |
| `web/src/utils/api.ts` | `handleTrpcError`, non-tRPC branch | `captureException(error)` (raw unknown) | `reportError(error, { area: "trpc" })` | Non-Error values now coerced to a legible real `Error` instead of an opaque `[object Object]` capture; real Errors pass through unchanged |
| `web/src/components/error-page.tsx` | `ErrorPageWithSentry` mount effect | `captureException(new Error(…))` | `reportError(new Error(…), { area: "error-page" })` | Same message/fingerprint, adds `area` tag |
| `web/src/pages/auth/sign-in.tsx` | unexpected NextAuth error | `captureException(new Error(…))` | `reportError(…, { area: "auth.signIn" })` | Same message, adds `area` tag |
| `web/src/pages/auth/sign-in.tsx` | `signIn` result undefined | `captureException(new Error(…))` | `reportError(…, { area: "auth.signIn.credentials" })` | Same message, adds `area` tag |
| `web/src/pages/auth/sign-in.tsx` | `signIn` result error falsy | `captureException(new Error(…))` | `reportError(…, { area: "auth.signIn.credentials" })` | Same message, adds `area` tag |
| `web/src/hooks/parserWorkerError.ts` | worker `onerror` helper | direct `captureException` + local `console.warn` | wraps `reportError` (like `captureUnknownError` already does) | Identical event (same Error, same `area`/`extra`); companion console.warn text shape changes slightly |

**Behavior-preservation notes**

- No site changes whether an event is sent: `reportError` without `expected` always captures. No site passes `expected` — classification stays exactly as it was.
- No site loses tags, extra, or severity. The additive changes: an `area` tag on sites that had none (routing/grouping aid, per the capture contract), and a companion `console.warn` line (deliberately `warn`, so `captureConsoleIntegration` cannot double-capture).
- The one intentional event-content improvement: a non-Error thrown value reaching the non-tRPC branch of `handleTrpcError` previously produced an opaque no-stack capture; it now arrives as a legible synthesized `Error` (`coerceToError`). Whether it is sent is unchanged.
- The expected-tRPC-error breadcrumb path in `handleTrpcError` is intentionally untouched (`addBreadcrumb` is not a capture API).

**Lint mechanism**

The existing `langfuse/web/restricted-imports` block gains a pattern (`regex: "^@sentry/nextjs$"`, `importNames: ["captureException", "captureMessage"]`). Because flat config replaces rather than merges a rule configured twice, the shared patterns are extracted to a module-level const and the two sanctioned files re-declare the rule without the Sentry pattern in a dedicated `langfuse/web/restricted-imports-sentry-seam` block. Verified: a probe file importing `captureException` (named and via `import * as Sentry`) fails lint; the sanctioned files pass.

**Follow-up candidates (not changed here): `console.error(errorObject)` sites**

`captureConsoleIntegration` turns every `console.error` into a Sentry event, so these are de-facto capture sites logging objects (opaque fingerprints). Migrating them is a separate, riskier lever — flagging representative ones found during the sweep:

- `web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx` (7 sites, e.g. "Failed to load in-app agent conversations")
- `web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx:166` ("Graph layout failed:", error)
- `web/src/features/evals/hooks/useExtractVariables.ts:169,210`
- `web/src/features/auth-credentials/components/ResetPasswordButton.tsx:53,74`
- `web/src/features/filters/hooks/useKeyedSessionStorageState.ts:14,51,79` (likely expected/storage-unavailable states — candidates for `console.warn` or `expected: true` instead)

**Verification**

- Full `pnpm --filter=web run test-client`: 231 files passed / 1 skipped, 2855 tests passed / 79 skipped.
- Targeted seam contract tests (`reportError`, `parserWorkerError`, `captureUnknownError`, `sentryFilters`): 72/72.
- `pnpm --filter=web run typecheck`, `pnpm --filter=web run lint` (`--max-warnings 0`), prettier: green.

</details>

Seed PRs: #15278 (the seam), #15771 (the capture contract doc), #15243 (tRPC seam classification).

Note: the `web/OBSERVABILITY.md` referenced alongside the lint rule lands in #15771; merge order is flexible since the rule's comment and message also cite in-repo sources (the `reportError` doc comment and the sentry-instrumentation skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
