### PR TITLE
fix(agent): hide background run notices

### DIFF
--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -36,14 +36,6 @@ function getBackgroundRunNotice(
     return "Stopping the run…";
   }
 
-  if (run.status === InAppAgentRunStatus.QUEUED) {
-    return "Waiting for a worker to pick this up. You can close this; the run continues in the background.";
-  }
-
-  if (run.status === InAppAgentRunStatus.RUNNING) {
-    return "You can close this; the run continues in the background.";
-  }
-
   if (run.status === InAppAgentRunStatus.FAILED) {
     return getBackgroundRunFailureMessage(run.errorCode ?? null);
   }

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -298,40 +298,6 @@ describe("ControlledInAppAgentWindow composer", () => {
 });
 
 describe("ControlledInAppAgentWindow stop", () => {
-  it("does not show informational background-run status while keeping Stop available", () => {
-    const cancel = vi.fn();
-    controlledAgent.value.isRunning = true;
-    controlledAgent.value.pendingToolApprovals = [];
-    controlledAgent.value.execution = {
-      type: "background",
-      run: {
-        id: "run-1",
-        status: InAppAgentRunStatus.RUNNING,
-        errorCode: null,
-        cancelRequested: false,
-      },
-      isCancelling: false,
-      cancel,
-    };
-
-    render(
-      <TooltipProvider>
-        <ControlledInAppAgentWindow
-          isExpanded={false}
-          onClose={vi.fn()}
-          onDeleteConversation={vi.fn()}
-          onExpandedChange={vi.fn()}
-        />
-      </TooltipProvider>,
-    );
-
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/waiting for a worker|continues in the background/i),
-    ).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Stop run" })).toBeVisible();
-  });
-
   it("flushes the paced reveal and cancels the run from one Stop click", () => {
     const cancel = vi.fn();
     controlledAgent.value.isRunning = true;

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -298,6 +298,40 @@ describe("ControlledInAppAgentWindow composer", () => {
 });
 
 describe("ControlledInAppAgentWindow stop", () => {
+  it("does not show informational background-run status while keeping Stop available", () => {
+    const cancel = vi.fn();
+    controlledAgent.value.isRunning = true;
+    controlledAgent.value.pendingToolApprovals = [];
+    controlledAgent.value.execution = {
+      type: "background",
+      run: {
+        id: "run-1",
+        status: InAppAgentRunStatus.RUNNING,
+        errorCode: null,
+        cancelRequested: false,
+      },
+      isCancelling: false,
+      cancel,
+    };
+
+    render(
+      <TooltipProvider>
+        <ControlledInAppAgentWindow
+          isExpanded={false}
+          onClose={vi.fn()}
+          onDeleteConversation={vi.fn()}
+          onExpandedChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/waiting for a worker|continues in the background/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stop run" })).toBeVisible();
+  });
+
   it("flushes the paced reveal and cancels the run from one Stop click", () => {
     const cancel = vi.fn();
     controlledAgent.value.isRunning = true;

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1091,10 +1091,7 @@ export const BackgroundRunStops = meta.story({
             ? { type: "background", notice: null, stop: null }
             : {
                 type: "background",
-                notice:
-                  phase === "stopping"
-                    ? "Stopping the run…"
-                    : null,
+                notice: phase === "stopping" ? "Stopping the run…" : null,
                 stop: {
                   status: phase === "stopping" ? "stopping" : "available",
                   onStop: () => {

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -999,7 +999,7 @@ export const BackgroundRun = meta.story({
     isAssistantTurnInProgress: true,
     executionUi: {
       type: "background",
-      notice: "You can close this; the run continues in the background.",
+      notice: null,
       stop: { status: "available", onStop: fn() },
     },
     messages: [
@@ -1094,7 +1094,7 @@ export const BackgroundRunStops = meta.story({
                 notice:
                   phase === "stopping"
                     ? "Stopping the run…"
-                    : "You can close this; the run continues in the background.",
+                    : null,
                 stop: {
                   status: phase === "stopping" ? "stopping" : "available",
                   onStop: () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15782.preview.langfuse.com](https://pr-15782.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Remove non-actionable QUEUED and RUNNING background-run notices from the agent drawer.
- Preserve stopping controls and terminal failure feedback.
- Update stories and client coverage.

## Verification
- `git diff --check` passed.
- The focused client test was attempted but the isolated worktree dependency setup was incomplete after install recreation; the PR3 worktree has the full focused suite passing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes informational notices for queued and running background agent runs while retaining stopping and terminal failure feedback.
- Returns no notice for active queued or running background runs.
- Updates background-run stories to represent the notice-free active state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

Active background runs retain their independently rendered stop controls and progress treatment, while stopping and failure notices remain available.
</details>

<sub>Reviews (1): Last reviewed commit: ["style(agent): format background run stor..."](https://github.com/langfuse/langfuse/commit/d6e6b136db10fa9de2099d6e6d1fa4f1fcfd828e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50095742)</sub>

<!-- /greptile_comment -->