### PR TITLE
fix(version-update): only prompt reload when the frontend is 48+ hours stale

### DIFF
--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -5,17 +5,15 @@ import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
 import {
   createVersionUpdateStore,
   VERSION_UPDATE_MIN_STALENESS_MS,
-  VERSION_UPDATE_SHOW_THROTTLE_MS,
   VERSION_UPDATE_DISMISS_SUPPRESSION_MS,
-  VERSION_UPDATE_LAST_SHOWN_AT_KEY,
   VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
   type VersionUpdateStore,
 } from "./versionUpdateStore";
 import type * as versionUpdateStoreModule from "./versionUpdateStore";
 
-// Shared mutable mock state (hoisted above the vi.mock factories). When
-// `h.store` is set, the mocked singleton + availability hook delegate to that
-// REAL store instance (integration tests); otherwise the plain stubs apply.
+// Hoisted mock state. With `h.store` set, the mocked singleton and the
+// availability hook delegate to that REAL store (integration tests); otherwise
+// the plain stubs apply.
 const h = vi.hoisted(() => ({
   capture: vi.fn(),
   dismiss: vi.fn(),
@@ -25,8 +23,7 @@ const h = vi.hoisted(() => ({
   store: null as VersionUpdateStore | null,
 }));
 
-// The connected banner portals into the top-most overlay layer, whose DOM
-// container only exists via _document.tsx; render children inline for the test.
+// The banner portals into an overlay layer that only exists via _document.tsx.
 vi.mock("@/src/components/ui/layer", () => ({
   Layer: ({ children }: { children?: unknown }) => children,
 }));
@@ -60,54 +57,51 @@ vi.mock("./useAppSettled", () => ({
   useAppSettled: () => h.settled,
 }));
 
-describe("VersionUpdateBannerView", () => {
-  it("renders a reload and a dismiss control", () => {
-    render(
-      <VersionUpdateBannerView onReload={() => {}} onDismiss={() => {}} />,
-    );
-    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
-  });
+const createFakeStorage = () => {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+};
 
-  it("invokes the callbacks when the controls are clicked", () => {
-    const onReload = vi.fn();
-    const onDismiss = vi.fn();
-    render(
-      <VersionUpdateBannerView onReload={onReload} onDismiss={onDismiss} />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
-    expect(onReload).toHaveBeenCalledTimes(1);
-
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
-    expect(onDismiss).toHaveBeenCalledTimes(1);
+beforeEach(() => {
+  h.capture.mockClear();
+  h.dismiss.mockClear();
+  h.markShownReported.mockClear();
+  h.markShownReported.mockReturnValue(true);
+  h.available = true;
+  h.settled = true;
+  h.store = null;
+  // Reload is invoked on the Reload click; stub it for jsdom.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { reload: vi.fn() },
   });
 });
 
+afterEach(() => {
+  h.store = null;
+  vi.restoreAllMocks();
+});
+
+it("VersionUpdateBannerView renders both controls and invokes their callbacks", () => {
+  const onReload = vi.fn();
+  const onDismiss = vi.fn();
+  render(<VersionUpdateBannerView onReload={onReload} onDismiss={onDismiss} />);
+
+  fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+  expect(onReload).toHaveBeenCalledTimes(1);
+  fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+  expect(onDismiss).toHaveBeenCalledTimes(1);
+});
+
 describe("VersionUpdateBanner (connected)", () => {
-  beforeEach(() => {
-    h.capture.mockClear();
-    h.dismiss.mockClear();
-    h.markShownReported.mockClear();
-    h.markShownReported.mockReturnValue(true);
-    h.available = true;
-    h.settled = true;
-    h.store = null;
-    // Reload is invoked on the Reload click; stub it so jsdom doesn't complain.
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: { reload: vi.fn() },
-    });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("shows and reports banner_shown when an update is available and the app has settled", () => {
+  it("shows and reports banner_shown exactly once when available and settled", () => {
     render(<VersionUpdateBanner />);
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
-    expect(h.capture).toHaveBeenCalledWith("version_update:banner_shown");
     expect(
       h.capture.mock.calls.filter(
         (c) => c[0] === "version_update:banner_shown",
@@ -115,25 +109,15 @@ describe("VersionUpdateBanner (connected)", () => {
     ).toHaveLength(1);
   });
 
-  it("delegates the once-per-appearance guard to the store (no banner_shown when it returns false)", () => {
-    // Simulates a remount for an appearance the store already reported.
-    h.markShownReported.mockReturnValue(false);
-    render(<VersionUpdateBanner />);
-    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
-    expect(h.capture).not.toHaveBeenCalledWith("version_update:banner_shown");
-  });
-
-  it("stays hidden until the app has settled", () => {
+  it("renders nothing (and captures nothing) while unsettled or without an update", () => {
     h.settled = false;
-    render(<VersionUpdateBanner />);
+    const unsettled = render(<VersionUpdateBanner />);
     expect(
       screen.queryByRole("button", { name: "Reload" }),
     ).not.toBeInTheDocument();
-    expect(h.capture).not.toHaveBeenCalled();
-    expect(h.markShownReported).not.toHaveBeenCalled();
-  });
+    unsettled.unmount();
 
-  it("renders nothing when no update is available", () => {
+    h.settled = true;
     h.available = false;
     render(<VersionUpdateBanner />);
     expect(
@@ -148,45 +132,9 @@ describe("VersionUpdateBanner (connected)", () => {
     expect(h.capture).toHaveBeenCalledWith("version_update:reload_clicked");
     expect(window.location.reload).toHaveBeenCalledTimes(1);
   });
-
-  it("captures dismissed and calls the store on Dismiss", () => {
-    render(<VersionUpdateBanner />);
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
-    expect(h.capture).toHaveBeenCalledWith("version_update:dismissed");
-    expect(h.dismiss).toHaveBeenCalledTimes(1);
-  });
 });
 
-// End-to-end through a REAL store (fake storage + injected clock): the 48 h
-// staleness gate and the persisted suppression windows (LFE-14765) must keep
-// the banner — and its `banner_shown` analytics — quiet, and dismiss must
-// persist its window. Suppression tests disable the staleness gate
-// (`minStalenessMs: 0`) so each test pins one behavior.
 describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
-  const createFakeStorage = () => {
-    const data = new Map<string, string>();
-    return {
-      getItem: (key: string) => data.get(key) ?? null,
-      setItem: (key: string, value: string) => {
-        data.set(key, value);
-      },
-    };
-  };
-
-  beforeEach(() => {
-    h.capture.mockClear();
-    h.settled = true;
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: { reload: vi.fn() },
-    });
-  });
-
-  afterEach(() => {
-    h.store = null;
-    vi.restoreAllMocks();
-  });
-
   it("renders nothing and fires no banner_shown until the frontend is 48 h stale", () => {
     const storage = createFakeStorage();
     let now = 0;
@@ -206,8 +154,7 @@ describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
     ).not.toBeInTheDocument();
     expect(h.capture).not.toHaveBeenCalled();
 
-    // 48 h of supersession later, the next response surfaces the banner and
-    // banner_shown fires exactly once.
+    // 48 h later the next response surfaces it; banner_shown fires once.
     act(() => {
       now = VERSION_UPDATE_MIN_STALENESS_MS;
       store.reportObservedBuildId("deployed");
@@ -220,47 +167,7 @@ describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
     ).toHaveLength(1);
   });
 
-  it("stays hidden and fires no banner_shown while the show throttle is active; shows once it expires", () => {
-    const storage = createFakeStorage();
-    // A banner appearance was recorded just before this simulated reload.
-    storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, "0");
-    let now = 0;
-    const store = createVersionUpdateStore(() => "running", {
-      debounceMs: 0,
-      minStalenessMs: 0,
-      now: () => now,
-      getStorage: () => storage,
-    });
-    h.store = store;
-
-    render(<VersionUpdateBanner />);
-    act(() => {
-      now = 60 * 1000;
-      store.reportObservedBuildId("deployed");
-    });
-    expect(
-      screen.queryByRole("button", { name: "Reload" }),
-    ).not.toBeInTheDocument();
-    expect(h.capture).not.toHaveBeenCalled();
-
-    // Throttle expiry: the next observed response surfaces the pending update;
-    // banner_shown fires once and the appearance re-arms the throttle.
-    act(() => {
-      now = VERSION_UPDATE_SHOW_THROTTLE_MS + 1;
-      store.reportObservedBuildId("deployed");
-    });
-    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
-    expect(
-      h.capture.mock.calls.filter(
-        (c) => c[0] === "version_update:banner_shown",
-      ),
-    ).toHaveLength(1);
-    expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBe(
-      String(VERSION_UPDATE_SHOW_THROTTLE_MS + 1),
-    );
-  });
-
-  it("persists the 24 h suppression window on dismiss and keeps new builds quiet", () => {
+  it("dismiss captures, hides, persists the 24 h window, and keeps new builds quiet", () => {
     const storage = createFakeStorage();
     let now = 1_000;
     const store = createVersionUpdateStore(() => "running", {
@@ -286,10 +193,9 @@ describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
       String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
     );
 
-    // A genuinely new build inside the window must not re-show the banner.
     act(() => {
       now = 2_000;
-      store.reportObservedBuildId("deployed-2");
+      store.reportObservedBuildId("deployed-2"); // genuinely new — still quiet
     });
     expect(
       screen.queryByRole("button", { name: "Reload" }),

--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -4,6 +4,7 @@ import { VersionUpdateBanner } from "./VersionUpdateBanner";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
 import {
   createVersionUpdateStore,
+  VERSION_UPDATE_MIN_STALENESS_MS,
   VERSION_UPDATE_SHOW_THROTTLE_MS,
   VERSION_UPDATE_DISMISS_SUPPRESSION_MS,
   VERSION_UPDATE_LAST_SHOWN_AT_KEY,
@@ -156,9 +157,11 @@ describe("VersionUpdateBanner (connected)", () => {
   });
 });
 
-// End-to-end through a REAL store (fake storage + injected clock): the
-// persisted suppression windows (LFE-14765) must keep the banner — and its
-// `banner_shown` analytics — quiet, and dismiss must persist its window.
+// End-to-end through a REAL store (fake storage + injected clock): the 48 h
+// staleness gate and the persisted suppression windows (LFE-14765) must keep
+// the banner — and its `banner_shown` analytics — quiet, and dismiss must
+// persist its window. Suppression tests disable the staleness gate
+// (`minStalenessMs: 0`) so each test pins one behavior.
 describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
   const createFakeStorage = () => {
     const data = new Map<string, string>();
@@ -184,17 +187,50 @@ describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
     vi.restoreAllMocks();
   });
 
+  it("renders nothing and fires no banner_shown until the frontend is 48 h stale", () => {
+    const storage = createFakeStorage();
+    let now = 0;
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
+    h.store = store;
+
+    render(<VersionUpdateBanner />);
+    act(() => {
+      store.reportObservedBuildId("deployed");
+    });
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
+    expect(h.capture).not.toHaveBeenCalled();
+
+    // 48 h of supersession later, the next response surfaces the banner and
+    // banner_shown fires exactly once.
+    act(() => {
+      now = VERSION_UPDATE_MIN_STALENESS_MS;
+      store.reportObservedBuildId("deployed");
+    });
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(
+      h.capture.mock.calls.filter(
+        (c) => c[0] === "version_update:banner_shown",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("stays hidden and fires no banner_shown while the show throttle is active; shows once it expires", () => {
     const storage = createFakeStorage();
     // A banner appearance was recorded just before this simulated reload.
     storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, "0");
     let now = 0;
-    const store = createVersionUpdateStore(
-      () => "running",
-      0,
-      () => now,
-      () => storage,
-    );
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
     h.store = store;
 
     render(<VersionUpdateBanner />);
@@ -227,12 +263,12 @@ describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
   it("persists the 24 h suppression window on dismiss and keeps new builds quiet", () => {
     const storage = createFakeStorage();
     let now = 1_000;
-    const store = createVersionUpdateStore(
-      () => "running",
-      0,
-      () => now,
-      () => storage,
-    );
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
     h.store = store;
 
     render(<VersionUpdateBanner />);

--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -1,15 +1,27 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VersionUpdateBanner } from "./VersionUpdateBanner";
 import { VersionUpdateBannerView } from "./VersionUpdateBannerView";
+import {
+  createVersionUpdateStore,
+  VERSION_UPDATE_SHOW_THROTTLE_MS,
+  VERSION_UPDATE_DISMISS_SUPPRESSION_MS,
+  VERSION_UPDATE_LAST_SHOWN_AT_KEY,
+  VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
+  type VersionUpdateStore,
+} from "./versionUpdateStore";
+import type * as versionUpdateStoreModule from "./versionUpdateStore";
 
-// Shared mutable mock state (hoisted above the vi.mock factories).
+// Shared mutable mock state (hoisted above the vi.mock factories). When
+// `h.store` is set, the mocked singleton + availability hook delegate to that
+// REAL store instance (integration tests); otherwise the plain stubs apply.
 const h = vi.hoisted(() => ({
   capture: vi.fn(),
   dismiss: vi.fn(),
   markShownReported: vi.fn(() => true),
   available: true,
   settled: true,
+  store: null as VersionUpdateStore | null,
 }));
 
 // The connected banner portals into the top-most overlay layer, whose DOM
@@ -20,15 +32,29 @@ vi.mock("@/src/components/ui/layer", () => ({
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
   usePostHogClientCapture: () => h.capture,
 }));
-vi.mock("./versionUpdateStore", () => ({
-  versionUpdateStore: {
-    dismiss: h.dismiss,
-    markShownReported: h.markShownReported,
-  },
-}));
-vi.mock("./useVersionUpdateAvailable", () => ({
-  useVersionUpdateAvailable: () => h.available,
-}));
+vi.mock("./versionUpdateStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof versionUpdateStoreModule>();
+  return {
+    ...actual,
+    versionUpdateStore: {
+      dismiss: () => (h.store ? h.store.dismiss() : h.dismiss()),
+      markShownReported: () =>
+        h.store ? h.store.markShownReported() : h.markShownReported(),
+    },
+  };
+});
+vi.mock("./useVersionUpdateAvailable", async () => {
+  const { useSyncExternalStore } = await import("react");
+  const subscribeNoop = () => () => {};
+  return {
+    useVersionUpdateAvailable: () =>
+      useSyncExternalStore(
+        h.store ? h.store.subscribe : subscribeNoop,
+        h.store ? h.store.getSnapshot : () => h.available,
+        () => false,
+      ),
+  };
+});
 vi.mock("./useAppSettled", () => ({
   useAppSettled: () => h.settled,
 }));
@@ -65,6 +91,7 @@ describe("VersionUpdateBanner (connected)", () => {
     h.markShownReported.mockReturnValue(true);
     h.available = true;
     h.settled = true;
+    h.store = null;
     // Reload is invoked on the Reload click; stub it so jsdom doesn't complain.
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -126,5 +153,110 @@ describe("VersionUpdateBanner (connected)", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
     expect(h.capture).toHaveBeenCalledWith("version_update:dismissed");
     expect(h.dismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+// End-to-end through a REAL store (fake storage + injected clock): the
+// persisted suppression windows (LFE-14765) must keep the banner — and its
+// `banner_shown` analytics — quiet, and dismiss must persist its window.
+describe("VersionUpdateBanner (integration: real store + fake storage)", () => {
+  const createFakeStorage = () => {
+    const data = new Map<string, string>();
+    return {
+      getItem: (key: string) => data.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        data.set(key, value);
+      },
+    };
+  };
+
+  beforeEach(() => {
+    h.capture.mockClear();
+    h.settled = true;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: vi.fn() },
+    });
+  });
+
+  afterEach(() => {
+    h.store = null;
+    vi.restoreAllMocks();
+  });
+
+  it("stays hidden and fires no banner_shown while the show throttle is active; shows once it expires", () => {
+    const storage = createFakeStorage();
+    // A banner appearance was recorded just before this simulated reload.
+    storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, "0");
+    let now = 0;
+    const store = createVersionUpdateStore(
+      () => "running",
+      0,
+      () => now,
+      () => storage,
+    );
+    h.store = store;
+
+    render(<VersionUpdateBanner />);
+    act(() => {
+      now = 60 * 1000;
+      store.reportObservedBuildId("deployed");
+    });
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
+    expect(h.capture).not.toHaveBeenCalled();
+
+    // Throttle expiry: the next observed response surfaces the pending update;
+    // banner_shown fires once and the appearance re-arms the throttle.
+    act(() => {
+      now = VERSION_UPDATE_SHOW_THROTTLE_MS + 1;
+      store.reportObservedBuildId("deployed");
+    });
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(
+      h.capture.mock.calls.filter(
+        (c) => c[0] === "version_update:banner_shown",
+      ),
+    ).toHaveLength(1);
+    expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBe(
+      String(VERSION_UPDATE_SHOW_THROTTLE_MS + 1),
+    );
+  });
+
+  it("persists the 24 h suppression window on dismiss and keeps new builds quiet", () => {
+    const storage = createFakeStorage();
+    let now = 1_000;
+    const store = createVersionUpdateStore(
+      () => "running",
+      0,
+      () => now,
+      () => storage,
+    );
+    h.store = store;
+
+    render(<VersionUpdateBanner />);
+    act(() => {
+      store.reportObservedBuildId("deployed");
+    });
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(h.capture).toHaveBeenCalledWith("version_update:dismissed");
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
+    expect(storage.getItem(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY)).toBe(
+      String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
+    );
+
+    // A genuinely new build inside the window must not re-show the banner.
+    act(() => {
+      now = 2_000;
+      store.reportObservedBuildId("deployed-2");
+    });
+    expect(
+      screen.queryByRole("button", { name: "Reload" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -1,8 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   createVersionUpdateStore,
   isVersionMismatch,
-  VERSION_UPDATE_DEBOUNCE_MS,
   VERSION_UPDATE_MIN_STALENESS_MS,
   VERSION_UPDATE_SHOW_THROTTLE_MS,
   VERSION_UPDATE_DISMISS_SUPPRESSION_MS,
@@ -11,12 +10,9 @@ import {
   VERSION_UPDATE_STALE_SINCE_KEY,
 } from "./versionUpdateStore";
 
-// No persistence → the store's pure in-memory semantics. Used where the test
-// pins behavior that persisted suppression (LFE-14765) would otherwise mask.
 const noStorage = () => undefined;
 
-// Minimal Map-backed Storage double — deterministic, shareable across store
-// instances to simulate reloads and tabs.
+// Map-backed Storage double, shareable across stores to simulate reloads/tabs.
 const createFakeStorage = () => {
   const data = new Map<string, string>();
   return {
@@ -27,747 +23,262 @@ const createFakeStorage = () => {
   };
 };
 
-describe("isVersionMismatch", () => {
-  it("is true only when both ids are present and differ", () => {
-    expect(isVersionMismatch("build-a", "build-b")).toBe(true);
-  });
-
-  it("is false when the ids are equal", () => {
-    expect(isVersionMismatch("build-a", "build-a")).toBe(false);
-  });
-
-  it("is false when either id is missing", () => {
-    // running missing
-    expect(isVersionMismatch(null, "build-b")).toBe(false);
-    expect(isVersionMismatch(undefined, "build-b")).toBe(false);
-    expect(isVersionMismatch("", "build-b")).toBe(false);
-    // observed missing
-    expect(isVersionMismatch("build-a", null)).toBe(false);
-    expect(isVersionMismatch("build-a", undefined)).toBe(false);
-    expect(isVersionMismatch("build-a", "")).toBe(false);
-    // both missing
-    expect(isVersionMismatch(null, null)).toBe(false);
-    expect(isVersionMismatch(undefined, undefined)).toBe(false);
-  });
+it("isVersionMismatch is true only when both ids are present and differ", () => {
+  expect(isVersionMismatch("build-a", "build-b")).toBe(true);
+  expect(isVersionMismatch("build-a", "build-a")).toBe(false);
+  expect(isVersionMismatch(null, "build-b")).toBe(false);
+  expect(isVersionMismatch(undefined, "build-b")).toBe(false);
+  expect(isVersionMismatch("", "build-b")).toBe(false);
+  expect(isVersionMismatch("build-a", null)).toBe(false);
+  expect(isVersionMismatch("build-a", "")).toBe(false);
+  expect(isVersionMismatch(null, null)).toBe(false);
 });
 
 describe("versionUpdateStore", () => {
-  beforeEach(() => {
-    // Stores built without an injected accessor use the factory default —
-    // jsdom's real localStorage — which is shared across tests; isolate them.
-    window.localStorage.clear();
+  // Mechanics tests disable the staleness gate and storage so each pins one behavior.
+  const mechanics = { debounceMs: 0, minStalenessMs: 0, getStorage: noStorage };
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  // Mechanics tests disable the 48 h staleness gate (`minStalenessMs: 0`) so
-  // each pins exactly one behavior; the gate itself is covered in its own
-  // describe below.
-
-  it("starts with no update available", () => {
-    const store = createVersionUpdateStore(() => "running", {
-      debounceMs: 0,
-      minStalenessMs: 0,
-    });
+  it("arms only on a real mismatch", () => {
+    const store = createVersionUpdateStore(() => "running", mechanics);
     expect(store.getSnapshot()).toBe(false);
-  });
-
-  it("stays silent when the observed build matches the running build", () => {
-    const store = createVersionUpdateStore(() => "running", {
-      debounceMs: 0,
-      minStalenessMs: 0,
-    });
     store.reportObservedBuildId("running");
+    store.reportObservedBuildId(null);
+    store.reportObservedBuildId("");
     expect(store.getSnapshot()).toBe(false);
+    store.reportObservedBuildId("deployed");
+    expect(store.getSnapshot()).toBe(true);
+
+    // Unknown running build (self-hosted without a build id) proves nothing.
+    const unknown = createVersionUpdateStore(() => undefined, mechanics);
+    unknown.reportObservedBuildId("deployed");
+    expect(unknown.getSnapshot()).toBe(false);
   });
 
-  it("becomes available when a differing build id is observed", () => {
-    const store = createVersionUpdateStore(() => "running", {
-      debounceMs: 0,
-      minStalenessMs: 0,
-    });
-    store.reportObservedBuildId("deployed");
+  it("is sticky and flap-free while rolling-deploy pods serve mixed responses", () => {
+    const store = createVersionUpdateStore(() => "running", mechanics);
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.reportObservedBuildId("deployed"); // false→true
+    store.reportObservedBuildId("running"); // old pod — cannot clear it
+    store.reportObservedBuildId("deployed"); // re-observation — no flap
+    expect(store.getSnapshot()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.getServerSnapshot()).toBe(false);
+
+    unsubscribe();
+    store.dismiss();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismiss hides the visible banner; only a never-seen build re-shows (in-memory)", () => {
+    const store = createVersionUpdateStore(() => "running", mechanics);
+    store.reportObservedBuildId("deployed-1");
+    expect(store.getSnapshot()).toBe(true);
+    store.dismiss();
+    expect(store.getSnapshot()).toBe(false);
+    store.reportObservedBuildId("deployed-1"); // already seen
+    expect(store.getSnapshot()).toBe(false);
+    store.reportObservedBuildId("deployed-2"); // genuinely new
     expect(store.getSnapshot()).toBe(true);
   });
 
-  it("stays silent when the running build id is unknown", () => {
-    const store = createVersionUpdateStore(() => undefined, {
-      debounceMs: 0,
-      minStalenessMs: 0,
-    });
-    store.reportObservedBuildId("deployed");
-    expect(store.getSnapshot()).toBe(false);
+  it("markShownReported is true once per appearance and re-arms on a new build", () => {
+    const store = createVersionUpdateStore(() => "running", mechanics);
+    store.reportObservedBuildId("deployed-1");
+    expect(store.markShownReported()).toBe(true);
+    expect(store.markShownReported()).toBe(false); // remount/StrictMode replay
+    store.reportObservedBuildId("deployed-1"); // re-observation — no reset
+    expect(store.markShownReported()).toBe(false);
+    store.reportObservedBuildId("deployed-2"); // fresh appearance
+    expect(store.markShownReported()).toBe(true);
   });
 
-  it("ignores empty/absent observed build ids", () => {
+  it("debounces from the FIRST sighting; a second new build does not extend the wait", () => {
+    vi.useFakeTimers();
     const store = createVersionUpdateStore(() => "running", {
-      debounceMs: 0,
-      minStalenessMs: 0,
-    });
-    store.reportObservedBuildId(null);
-    store.reportObservedBuildId(undefined);
-    store.reportObservedBuildId("");
-    expect(store.getSnapshot()).toBe(false);
-  });
-
-  // Pure in-memory dismiss semantics (`noStorage`) — with storage present the
-  // persisted 24 h dismiss suppression additionally holds back the new build
-  // (see "persisted suppression" below).
-  it("hides after dismiss and re-shows only when a not-yet-seen build arrives (in-memory fallback)", () => {
-    const store = createVersionUpdateStore(() => "running", {
-      debounceMs: 0,
+      debounceMs: 180_000,
       minStalenessMs: 0,
       getStorage: noStorage,
     });
-
     store.reportObservedBuildId("deployed-1");
+    vi.advanceTimersByTime(100_000);
+    store.reportObservedBuildId("deployed-2");
+    vi.advanceTimersByTime(79_999);
+    expect(store.getSnapshot()).toBe(false);
+    vi.advanceTimersByTime(1); // 180_000 since the first sighting
     expect(store.getSnapshot()).toBe(true);
+  });
 
-    store.dismiss();
+  it("shows only once the running build has been superseded for 48 h", () => {
+    const storage = createFakeStorage();
+    let now = 0;
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
+    store.reportObservedBuildId("deployed");
+    expect(store.getSnapshot()).toBe(false); // superseded, but not stale yet
+    now = VERSION_UPDATE_MIN_STALENESS_MS - 1;
+    store.reportObservedBuildId("deployed");
     expect(store.getSnapshot()).toBe(false);
+    now = VERSION_UPDATE_MIN_STALENESS_MS;
+    store.reportObservedBuildId("deployed"); // responses are the clock ticks
+    expect(store.getSnapshot()).toBe(true);
+  });
 
-    // The same build id must not re-trigger the banner after dismissal.
+  it("keeps stale-since across a reload of the SAME running build", () => {
+    const storage = createFakeStorage();
+    let now = 0;
+    createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    }).reportObservedBuildId("deployed"); // stale-since recorded at t=0
+
+    now = VERSION_UPDATE_MIN_STALENESS_MS;
+    const reloaded = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
+    reloaded.reportObservedBuildId("deployed");
+    expect(reloaded.getSnapshot()).toBe(true); // 48 h since the FIRST sighting
+  });
+
+  it("restarts stale-since when the tab reloads onto a NEW running build", () => {
+    const storage = createFakeStorage();
+    let now = 0;
+    createVersionUpdateStore(() => "build-1", {
+      debounceMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    }).reportObservedBuildId("build-2"); // { buildId: build-1, ts: 0 }
+
+    now = VERSION_UPDATE_MIN_STALENESS_MS;
+    const after = createVersionUpdateStore(() => "build-2", {
+      debounceMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
+    after.reportObservedBuildId("build-3");
+    expect(after.getSnapshot()).toBe(false); // clock restarted for build-2
+    expect(storage.getItem(VERSION_UPDATE_STALE_SINCE_KEY)).toBe(
+      JSON.stringify({ buildId: "build-2", ts: now }),
+    );
+    now = 2 * VERSION_UPDATE_MIN_STALENESS_MS;
+    after.reportObservedBuildId("build-3");
+    expect(after.getSnapshot()).toBe(true);
+  });
+
+  it("throttles a second appearance within 2 h across a reload; never hides a visible banner", () => {
+    const storage = createFakeStorage();
+    let now = 0;
+    const before = createVersionUpdateStore(() => "build-1", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
+    before.reportObservedBuildId("build-2");
+    expect(before.markShownReported()).toBe(true); // actual appearance …
+    expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBe("0"); // … recorded
+
+    // The windows gate new appearances only — a new build must not hide it.
+    before.reportObservedBuildId("build-2b");
+    expect(before.getSnapshot()).toBe(true);
+
+    // Reload onto build-2; another release lands 30 min later → throttled.
+    now = 30 * 60 * 1000;
+    const after = createVersionUpdateStore(() => "build-2", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
+    after.reportObservedBuildId("build-3");
+    expect(after.getSnapshot()).toBe(false);
+
+    now = VERSION_UPDATE_SHOW_THROTTLE_MS + 1; // expiry re-allows
+    after.reportObservedBuildId("build-3");
+    expect(after.getSnapshot()).toBe(true);
+  });
+
+  it("dismiss suppresses even genuinely new builds for 24 h, across reloads", () => {
+    const storage = createFakeStorage();
+    let now = 0;
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
     store.reportObservedBuildId("deployed-1");
+    store.dismiss();
+    expect(storage.getItem(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY)).toBe(
+      String(VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
+    );
+
+    now = 3 * 60 * 60 * 1000; // inside the window: even a new build stays quiet
+    store.reportObservedBuildId("deployed-2");
     expect(store.getSnapshot()).toBe(false);
 
-    // A build id the user has not seen re-shows it.
+    const reloaded = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      now: () => now,
+      getStorage: () => storage,
+    });
+    reloaded.reportObservedBuildId("deployed-2");
+    expect(reloaded.getSnapshot()).toBe(false);
+
+    now = VERSION_UPDATE_DISMISS_SUPPRESSION_MS + 1; // expiry re-allows
     store.reportObservedBuildId("deployed-2");
     expect(store.getSnapshot()).toBe(true);
   });
 
-  // Rolling deploy: one tab sees responses from BOTH old and new pods, in any
-  // order, and build ids are opaque (no orderable newer/older). These guard the
-  // three failure modes flagged in review.
-  describe("rolling deploy robustness", () => {
-    it("stays available once a differing build is seen — a later old-pod response cannot suppress it", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-      });
-
-      store.reportObservedBuildId("deployed"); // new pod
-      expect(store.getSnapshot()).toBe(true);
-
-      // Old pod still serving the running build id — must NOT clear the banner.
-      store.reportObservedBuildId("running");
-      expect(store.getSnapshot()).toBe(true);
-
-      // Alternating pods likewise keep it sticky.
-      store.reportObservedBuildId("deployed");
-      store.reportObservedBuildId("running");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("does not reopen a dismissed banner when an already-seen build re-appears (old pod)", () => {
-      // `noStorage` so the seen-set invariant is pinned on its own, not via
-      // the persisted dismiss suppression.
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        getStorage: noStorage,
-      });
-
-      store.reportObservedBuildId("deployed");
-      store.dismiss();
-      expect(store.getSnapshot()).toBe(false);
-
-      // Old pods keep alternating: re-observing the running id or the
-      // already-seen deployed id must not reopen the dismissed banner.
-      store.reportObservedBuildId("running");
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(false);
-    });
-
-    it("re-observing an already-seen build never flaps the snapshot (no extra notifications)", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-      });
-      const listener = vi.fn();
-      store.subscribe(listener);
-
-      store.reportObservedBuildId("deployed"); // 1 change: false→true
-      store.reportObservedBuildId("deployed"); // seen → no-op
-      store.reportObservedBuildId("running"); // matches running → no-op
-      store.reportObservedBuildId("deployed"); // seen → no-op
-      expect(listener).toHaveBeenCalledTimes(1);
-      expect(store.getSnapshot()).toBe(true);
-    });
-  });
-
-  it("notifies subscribers when the snapshot changes and after unsubscribe stops", () => {
-    // `noStorage` so the post-unsubscribe report really changes the snapshot
-    // (a persisted dismiss suppression would keep it false and mask a broken
-    // unsubscribe).
+  it("degrades to in-memory behavior on throwing storage; future-dated stamps are ignored", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    };
     const store = createVersionUpdateStore(() => "running", {
       debounceMs: 0,
       minStalenessMs: 0,
-      getStorage: noStorage,
+      now: () => 0,
+      getStorage: () => throwing,
     });
-    const listener = vi.fn();
-    const unsubscribe = store.subscribe(listener);
-
-    store.reportObservedBuildId("deployed");
-    expect(listener).toHaveBeenCalledTimes(1);
-
-    // No snapshot change → no extra notification.
-    store.reportObservedBuildId("deployed");
-    expect(listener).toHaveBeenCalledTimes(1);
-
+    store.reportObservedBuildId("deployed-1");
+    expect(store.getSnapshot()).toBe(true); // read errors don't block showing
+    expect(store.markShownReported()).toBe(true); // write error swallowed
     store.dismiss();
-    expect(listener).toHaveBeenCalledTimes(2);
+    expect(store.getSnapshot()).toBe(false);
+    store.reportObservedBuildId("deployed-2"); // in-memory: new build re-prompts
+    expect(store.getSnapshot()).toBe(true);
 
-    unsubscribe();
-    store.reportObservedBuildId("deployed-next");
-    expect(listener).toHaveBeenCalledTimes(2);
-  });
-
-  it("has a server snapshot that is always false", () => {
-    const store = createVersionUpdateStore(() => "running", {
+    // Clock skew: a last-shown-at ahead of now must be ignored, not clamped —
+    // a clamp floats with now and would suppress until the clock caught up.
+    const skewed = createFakeStorage();
+    skewed.setItem(
+      VERSION_UPDATE_LAST_SHOWN_AT_KEY,
+      String(5 * 60 * 60 * 1000),
+    );
+    const skewStore = createVersionUpdateStore(() => "running", {
       debounceMs: 0,
       minStalenessMs: 0,
+      now: () => 1_000,
+      getStorage: () => skewed,
     });
-    store.reportObservedBuildId("deployed");
-    expect(store.getServerSnapshot()).toBe(false);
-  });
-
-  // `banner_shown` fires once per appearance; the guard lives here (not in
-  // component state) so a banner remount cannot double-count one appearance.
-  describe("markShownReported (banner_shown once-per-appearance guard)", () => {
-    it("returns true once per appearance, then false", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-      });
-      store.reportObservedBuildId("deployed");
-
-      expect(store.markShownReported()).toBe(true);
-      // A remount / StrictMode-double-invoked effect calls it again for the same
-      // appearance — must not count twice.
-      expect(store.markShownReported()).toBe(false);
-      expect(store.markShownReported()).toBe(false);
-    });
-
-    it("resets for a genuinely new build id (a fresh appearance)", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-      });
-
-      store.reportObservedBuildId("deployed-1");
-      expect(store.markShownReported()).toBe(true);
-      expect(store.markShownReported()).toBe(false);
-
-      // A new, never-seen build id is a new appearance → report again.
-      store.reportObservedBuildId("deployed-2");
-      expect(store.markShownReported()).toBe(true);
-      expect(store.markShownReported()).toBe(false);
-    });
-
-    it("does not reset when an already-seen build id is re-observed", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-      });
-
-      store.reportObservedBuildId("deployed");
-      expect(store.markShownReported()).toBe(true);
-
-      // Re-observing the same (or the running) id is a no-op — no new appearance.
-      store.reportObservedBuildId("deployed");
-      store.reportObservedBuildId("running");
-      expect(store.markShownReported()).toBe(false);
-    });
-  });
-
-  // A page loaded mid-deploy sees the new build id immediately; prompting a
-  // reload right then reloads into a still-switching pod (LFE-14537). The
-  // snapshot must stay false until the settling window elapses.
-  describe("new-version debounce (LFE-14537)", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("stays hidden until the debounce elapses after the first new build id", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 180_000,
-        minStalenessMs: 0,
-      });
-
-      store.reportObservedBuildId("deployed");
-      // Available, but within the settling window → still not shown.
-      expect(store.getSnapshot()).toBe(false);
-
-      vi.advanceTimersByTime(179_999);
-      expect(store.getSnapshot()).toBe(false);
-
-      vi.advanceTimersByTime(1);
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("notifies subscribers exactly once, when the window elapses (not on detection)", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 180_000,
-        minStalenessMs: 0,
-      });
-      const listener = vi.fn();
-      store.subscribe(listener);
-
-      store.reportObservedBuildId("deployed");
-      expect(listener).not.toHaveBeenCalled(); // hidden → snapshot unchanged
-
-      vi.advanceTimersByTime(180_000);
-      expect(listener).toHaveBeenCalledTimes(1);
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("keys the window to the FIRST sighting — a second new build within it does not extend the wait", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 180_000,
-        minStalenessMs: 0,
-      });
-
-      store.reportObservedBuildId("deployed-1");
-      vi.advanceTimersByTime(100_000);
-      // A second genuinely-new build mid-window must not re-arm the timer.
-      store.reportObservedBuildId("deployed-2");
-      vi.advanceTimersByTime(79_999);
-      expect(store.getSnapshot()).toBe(false);
-
-      vi.advanceTimersByTime(1); // 180_000 total since the first sighting
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("re-prompts immediately for a new build once the window has already passed", () => {
-      // `noStorage`: this pins the debounce being satisfied, without the
-      // persisted 24 h dismiss suppression on top.
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 180_000,
-        minStalenessMs: 0,
-        getStorage: noStorage,
-      });
-
-      store.reportObservedBuildId("deployed-1");
-      vi.advanceTimersByTime(180_000);
-      expect(store.getSnapshot()).toBe(true);
-
-      store.dismiss();
-      expect(store.getSnapshot()).toBe(false);
-
-      // The settling window is already satisfied → a later new build shows at once.
-      store.reportObservedBuildId("deployed-2");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("arms no timer when only the running build id is observed", () => {
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 180_000,
-        minStalenessMs: 0,
-      });
-
-      store.reportObservedBuildId("running"); // matches → no new-version signal
-      vi.advanceTimersByTime(180_000);
-      expect(store.getSnapshot()).toBe(false);
-    });
-
-    it("defaults the debounce window to three minutes", () => {
-      expect(VERSION_UPDATE_DEBOUNCE_MS).toBe(3 * 60 * 1000);
-
-      const store = createVersionUpdateStore(() => "running", {
-        minStalenessMs: 0,
-      });
-      store.reportObservedBuildId("deployed");
-      vi.advanceTimersByTime(VERSION_UPDATE_DEBOUNCE_MS - 1);
-      expect(store.getSnapshot()).toBe(false);
-      vi.advanceTimersByTime(1);
-      expect(store.getSnapshot()).toBe(true);
-    });
-  });
-
-  // The primary gate (LFE-14765): the banner exists so long-lived stale tabs
-  // don't 404 on code-split chunks — a prompt minutes after each deploy doesn't
-  // serve that. It may only appear once the RUNNING build has been superseded
-  // for 48 h, measured from the first observed differing build id and persisted
-  // (per running build) across reloads and tabs.
-  describe("48 h staleness gate (LFE-14765)", () => {
-    it("holds the banner until the running build has been superseded for 48 h", () => {
-      const storage = createFakeStorage();
-      let now = 0;
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(false); // superseded, but not stale yet
-
-      now = VERSION_UPDATE_MIN_STALENESS_MS - 1;
-      store.reportObservedBuildId("deployed"); // routine response = clock tick
-      expect(store.getSnapshot()).toBe(false);
-
-      now = VERSION_UPDATE_MIN_STALENESS_MS;
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("keeps the persisted stale-since across a reload of the SAME running build", () => {
-      const storage = createFakeStorage();
-      let now = 0;
-      const first = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-      first.reportObservedBuildId("deployed"); // stale-since recorded at t=0
-
-      // Reloading without picking up a new bundle (or a second tab of the same
-      // bundle) must NOT restart the staleness clock.
-      now = VERSION_UPDATE_MIN_STALENESS_MS;
-      const reloaded = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-      reloaded.reportObservedBuildId("deployed");
-      expect(reloaded.getSnapshot()).toBe(true); // 48 h since the FIRST sighting
-    });
-
-    it("restarts the staleness clock when the tab reloads onto a NEW running build", () => {
-      const storage = createFakeStorage();
-      let now = 0;
-      const before = createVersionUpdateStore(() => "build-1", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-      before.reportObservedBuildId("build-2"); // { buildId: build-1, ts: 0 }
-
-      // The user reloads onto build-2; build-3 supersedes it 48 h later.
-      now = VERSION_UPDATE_MIN_STALENESS_MS;
-      const after = createVersionUpdateStore(() => "build-2", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-      after.reportObservedBuildId("build-3");
-      expect(after.getSnapshot()).toBe(false); // clock restarted for build-2
-      expect(storage.getItem(VERSION_UPDATE_STALE_SINCE_KEY)).toBe(
-        JSON.stringify({ buildId: "build-2", ts: now }),
-      );
-
-      now = 2 * VERSION_UPDATE_MIN_STALENESS_MS;
-      after.reportObservedBuildId("build-3");
-      expect(after.getSnapshot()).toBe(true);
-    });
-
-    it("restarts a future-dated stale-since at now (clock moved backward)", () => {
-      const storage = createFakeStorage();
-      storage.setItem(
-        VERSION_UPDATE_STALE_SINCE_KEY,
-        JSON.stringify({ buildId: "running", ts: 10_000 }),
-      );
-      let now = 1_000;
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(false);
-      expect(storage.getItem(VERSION_UPDATE_STALE_SINCE_KEY)).toBe(
-        JSON.stringify({ buildId: "running", ts: 1_000 }),
-      );
-
-      now = 1_000 + VERSION_UPDATE_MIN_STALENESS_MS;
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("treats garbage stale-since JSON as absent and overwrites it", () => {
-      const storage = createFakeStorage();
-      storage.setItem(VERSION_UPDATE_STALE_SINCE_KEY, "{not json");
-      let now = 0;
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-
-      store.reportObservedBuildId("deployed"); // must not throw
-      expect(store.getSnapshot()).toBe(false);
-      expect(storage.getItem(VERSION_UPDATE_STALE_SINCE_KEY)).toBe(
-        JSON.stringify({ buildId: "running", ts: 0 }),
-      );
-
-      now = VERSION_UPDATE_MIN_STALENESS_MS;
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("gates in memory when storage is unavailable — a tab open 48 h past its first mismatch still prompts", () => {
-      let now = 0;
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: noStorage,
-      });
-
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(false);
-
-      now = VERSION_UPDATE_MIN_STALENESS_MS;
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("defaults the minimum staleness to 48 hours", () => {
-      expect(VERSION_UPDATE_MIN_STALENESS_MS).toBe(48 * 60 * 60 * 1000);
-    });
-
-    it("layers with the show throttle — a stale frontend shown recently is still throttled", () => {
-      const storage = createFakeStorage();
-      let now = VERSION_UPDATE_MIN_STALENESS_MS;
-      storage.setItem(
-        VERSION_UPDATE_STALE_SINCE_KEY,
-        JSON.stringify({ buildId: "running", ts: 0 }),
-      );
-      storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, String(now - 1));
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(false); // stale, but shown < 2 h ago
-
-      now += VERSION_UPDATE_SHOW_THROTTLE_MS;
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(true);
-    });
-  });
-
-  // Secondary suppressions (LFE-14765), tested with the staleness gate disabled
-  // so each pins one behavior: two localStorage-persisted windows gate NEW
-  // appearances — shown at most once per VERSION_UPDATE_SHOW_THROTTLE_MS, and
-  // an explicit dismiss suppresses for VERSION_UPDATE_DISMISS_SUPPRESSION_MS.
-  describe("persisted suppression (LFE-14765)", () => {
-    it("records the last-shown timestamp when the banner actually shows", () => {
-      const storage = createFakeStorage();
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => 1_000,
-        getStorage: () => storage,
-      });
-
-      store.reportObservedBuildId("deployed");
-      expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBeNull();
-
-      // The write happens on the actual appearance (markShownReported), not on
-      // mere eligibility — a banner held back by `useAppSettled` records nothing.
-      expect(store.markShownReported()).toBe(true);
-      expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBe("1000");
-    });
-
-    it("throttles a second appearance within 2 h — across a reload (new store, same storage)", () => {
-      const storage = createFakeStorage();
-      let now = 0;
-
-      // The banner shows for build-2 …
-      const before = createVersionUpdateStore(() => "build-1", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-      before.reportObservedBuildId("build-2");
-      expect(before.getSnapshot()).toBe(true);
-      expect(before.markShownReported()).toBe(true);
-
-      // … the user reloads onto build-2, and another release lands 30 min later.
-      now = 30 * 60 * 1000;
-      const after = createVersionUpdateStore(() => "build-2", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-      after.reportObservedBuildId("build-3");
-      expect(after.getSnapshot()).toBe(false); // shown < 2 h ago → throttled
-
-      // Expiry re-allows: a routine re-observation (every tRPC response) is the
-      // clock tick that surfaces the pending update — no dedicated timer.
-      now = VERSION_UPDATE_SHOW_THROTTLE_MS + 1;
-      after.reportObservedBuildId("build-3");
-      expect(after.getSnapshot()).toBe(true);
-    });
-
-    it("never hides a banner that is already visible (windows gate new appearances only)", () => {
-      const storage = createFakeStorage();
-      let now = 0;
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-
-      store.reportObservedBuildId("deployed-1");
-      expect(store.getSnapshot()).toBe(true);
-      expect(store.markShownReported()).toBe(true); // throttle armed at t=0
-
-      // Inside the throttle window, routine ticks and even a genuinely new
-      // build must not hide (or blink) the banner already on screen.
-      now = 60 * 1000;
-      store.reportObservedBuildId("deployed-1");
-      store.reportObservedBuildId("deployed-2");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("dismiss suppresses even genuinely new builds for 24 h — across a reload", () => {
-      const storage = createFakeStorage();
-      let now = 0;
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-
-      store.reportObservedBuildId("deployed-1");
-      store.dismiss();
-      expect(storage.getItem(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY)).toBe(
-        String(VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
-      );
-
-      // A genuinely new build inside the window stays quiet — unlike the
-      // in-memory fallback, where it would re-prompt immediately.
-      now = 3 * 60 * 60 * 1000; // past the show throttle, inside the dismiss window
-      store.reportObservedBuildId("deployed-2");
-      expect(store.getSnapshot()).toBe(false);
-
-      // … and so does a reloaded tab (new store, same storage).
-      const reloaded = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => now,
-        getStorage: () => storage,
-      });
-      reloaded.reportObservedBuildId("deployed-2");
-      expect(reloaded.getSnapshot()).toBe(false);
-
-      // Expiry re-allows: the pending update surfaces on the next response.
-      now = VERSION_UPDATE_DISMISS_SUPPRESSION_MS + 1;
-      store.reportObservedBuildId("deployed-2");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("falls back to in-memory behavior when storage methods throw", () => {
-      const throwingStorage: Pick<Storage, "getItem" | "setItem"> = {
-        getItem: () => {
-          throw new Error("denied");
-        },
-        setItem: () => {
-          throw new Error("denied");
-        },
-      };
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => 0,
-        getStorage: () => throwingStorage,
-      });
-
-      store.reportObservedBuildId("deployed-1");
-      expect(store.getSnapshot()).toBe(true); // read errors don't block showing
-      expect(store.markShownReported()).toBe(true); // write error swallowed
-
-      store.dismiss(); // write error swallowed; in-memory dismiss still works
-      expect(store.getSnapshot()).toBe(false);
-
-      // In-memory semantics: a genuinely new build re-prompts immediately.
-      store.reportObservedBuildId("deployed-2");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("treats a throwing storage accessor and garbage values as absent", () => {
-      const accessorThrows = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => 0,
-        getStorage: () => {
-          throw new Error("no storage");
-        },
-      });
-      accessorThrows.reportObservedBuildId("deployed");
-      expect(accessorThrows.getSnapshot()).toBe(true);
-      expect(accessorThrows.markShownReported()).toBe(true);
-
-      const storage = createFakeStorage();
-      storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, "not-a-number");
-      storage.setItem(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY, "NaN");
-      const garbage = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => 0,
-        getStorage: () => storage,
-      });
-      garbage.reportObservedBuildId("deployed");
-      expect(garbage.getSnapshot()).toBe(true);
-    });
-
-    // Clock skew: a timestamp persisted before the wall clock moved backward
-    // (correction, restored VM) is finite — the garbage-value guard passes it —
-    // but future-dated. Honoring it would suppress until the clock catches up.
-    it("ignores a future-dated last-shown timestamp (clock moved backward)", () => {
-      const storage = createFakeStorage();
-      storage.setItem(
-        VERSION_UPDATE_LAST_SHOWN_AT_KEY,
-        String(5 * 60 * 60 * 1000), // "shown" five hours in the future
-      );
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => 1_000,
-        getStorage: () => storage,
-      });
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(true);
-    });
-
-    it("ignores a suppressed-until further than one dismiss window ahead", () => {
-      const bogus = createFakeStorage();
-      bogus.setItem(
-        VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
-        String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS + 1),
-      );
-      const store = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => 1_000,
-        getStorage: () => bogus,
-      });
-      store.reportObservedBuildId("deployed");
-      expect(store.getSnapshot()).toBe(true);
-
-      // Exactly one window ahead is what a fresh dismiss writes — still honored.
-      const valid = createFakeStorage();
-      valid.setItem(
-        VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
-        String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
-      );
-      const suppressed = createVersionUpdateStore(() => "running", {
-        debounceMs: 0,
-        minStalenessMs: 0,
-        now: () => 1_000,
-        getStorage: () => valid,
-      });
-      suppressed.reportObservedBuildId("deployed");
-      expect(suppressed.getSnapshot()).toBe(false);
-    });
+    skewStore.reportObservedBuildId("deployed");
+    expect(skewStore.getSnapshot()).toBe(true);
   });
 });

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -506,5 +506,55 @@ describe("versionUpdateStore", () => {
       garbage.reportObservedBuildId("deployed");
       expect(garbage.getSnapshot()).toBe(true);
     });
+
+    // Clock skew: a timestamp persisted before the wall clock moved backward
+    // (correction, restored VM) is finite — the garbage-value guard passes it —
+    // but future-dated. Honoring it would suppress until the clock catches up.
+    it("ignores a future-dated last-shown timestamp (clock moved backward)", () => {
+      const storage = createFakeStorage();
+      storage.setItem(
+        VERSION_UPDATE_LAST_SHOWN_AT_KEY,
+        String(5 * 60 * 60 * 1000), // "shown" five hours in the future
+      );
+      const store = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => 1_000,
+        () => storage,
+      );
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("ignores a suppressed-until further than one dismiss window ahead", () => {
+      const bogus = createFakeStorage();
+      bogus.setItem(
+        VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
+        String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS + 1),
+      );
+      const store = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => 1_000,
+        () => bogus,
+      );
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(true);
+
+      // Exactly one window ahead is what a fresh dismiss writes — still honored.
+      const valid = createFakeStorage();
+      valid.setItem(
+        VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
+        String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
+      );
+      const suppressed = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => 1_000,
+        () => valid,
+      );
+      suppressed.reportObservedBuildId("deployed");
+      expect(suppressed.getSnapshot()).toBe(false);
+    });
   });
 });

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -3,10 +3,12 @@ import {
   createVersionUpdateStore,
   isVersionMismatch,
   VERSION_UPDATE_DEBOUNCE_MS,
+  VERSION_UPDATE_MIN_STALENESS_MS,
   VERSION_UPDATE_SHOW_THROTTLE_MS,
   VERSION_UPDATE_DISMISS_SUPPRESSION_MS,
   VERSION_UPDATE_LAST_SHOWN_AT_KEY,
   VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
+  VERSION_UPDATE_STALE_SINCE_KEY,
 } from "./versionUpdateStore";
 
 // No persistence → the store's pure in-memory semantics. Used where the test
@@ -56,31 +58,50 @@ describe("versionUpdateStore", () => {
     window.localStorage.clear();
   });
 
+  // Mechanics tests disable the 48 h staleness gate (`minStalenessMs: 0`) so
+  // each pins exactly one behavior; the gate itself is covered in its own
+  // describe below.
+
   it("starts with no update available", () => {
-    const store = createVersionUpdateStore(() => "running", 0);
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+    });
     expect(store.getSnapshot()).toBe(false);
   });
 
   it("stays silent when the observed build matches the running build", () => {
-    const store = createVersionUpdateStore(() => "running", 0);
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+    });
     store.reportObservedBuildId("running");
     expect(store.getSnapshot()).toBe(false);
   });
 
   it("becomes available when a differing build id is observed", () => {
-    const store = createVersionUpdateStore(() => "running", 0);
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+    });
     store.reportObservedBuildId("deployed");
     expect(store.getSnapshot()).toBe(true);
   });
 
   it("stays silent when the running build id is unknown", () => {
-    const store = createVersionUpdateStore(() => undefined, 0);
+    const store = createVersionUpdateStore(() => undefined, {
+      debounceMs: 0,
+      minStalenessMs: 0,
+    });
     store.reportObservedBuildId("deployed");
     expect(store.getSnapshot()).toBe(false);
   });
 
   it("ignores empty/absent observed build ids", () => {
-    const store = createVersionUpdateStore(() => "running", 0);
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+    });
     store.reportObservedBuildId(null);
     store.reportObservedBuildId(undefined);
     store.reportObservedBuildId("");
@@ -91,12 +112,11 @@ describe("versionUpdateStore", () => {
   // persisted 24 h dismiss suppression additionally holds back the new build
   // (see "persisted suppression" below).
   it("hides after dismiss and re-shows only when a not-yet-seen build arrives (in-memory fallback)", () => {
-    const store = createVersionUpdateStore(
-      () => "running",
-      0,
-      undefined,
-      noStorage,
-    );
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      getStorage: noStorage,
+    });
 
     store.reportObservedBuildId("deployed-1");
     expect(store.getSnapshot()).toBe(true);
@@ -118,7 +138,10 @@ describe("versionUpdateStore", () => {
   // three failure modes flagged in review.
   describe("rolling deploy robustness", () => {
     it("stays available once a differing build is seen — a later old-pod response cannot suppress it", () => {
-      const store = createVersionUpdateStore(() => "running", 0);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+      });
 
       store.reportObservedBuildId("deployed"); // new pod
       expect(store.getSnapshot()).toBe(true);
@@ -136,12 +159,11 @@ describe("versionUpdateStore", () => {
     it("does not reopen a dismissed banner when an already-seen build re-appears (old pod)", () => {
       // `noStorage` so the seen-set invariant is pinned on its own, not via
       // the persisted dismiss suppression.
-      const store = createVersionUpdateStore(
-        () => "running",
-        0,
-        undefined,
-        noStorage,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        getStorage: noStorage,
+      });
 
       store.reportObservedBuildId("deployed");
       store.dismiss();
@@ -155,7 +177,10 @@ describe("versionUpdateStore", () => {
     });
 
     it("re-observing an already-seen build never flaps the snapshot (no extra notifications)", () => {
-      const store = createVersionUpdateStore(() => "running", 0);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+      });
       const listener = vi.fn();
       store.subscribe(listener);
 
@@ -172,12 +197,11 @@ describe("versionUpdateStore", () => {
     // `noStorage` so the post-unsubscribe report really changes the snapshot
     // (a persisted dismiss suppression would keep it false and mask a broken
     // unsubscribe).
-    const store = createVersionUpdateStore(
-      () => "running",
-      0,
-      undefined,
-      noStorage,
-    );
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+      getStorage: noStorage,
+    });
     const listener = vi.fn();
     const unsubscribe = store.subscribe(listener);
 
@@ -197,7 +221,10 @@ describe("versionUpdateStore", () => {
   });
 
   it("has a server snapshot that is always false", () => {
-    const store = createVersionUpdateStore(() => "running", 0);
+    const store = createVersionUpdateStore(() => "running", {
+      debounceMs: 0,
+      minStalenessMs: 0,
+    });
     store.reportObservedBuildId("deployed");
     expect(store.getServerSnapshot()).toBe(false);
   });
@@ -206,7 +233,10 @@ describe("versionUpdateStore", () => {
   // component state) so a banner remount cannot double-count one appearance.
   describe("markShownReported (banner_shown once-per-appearance guard)", () => {
     it("returns true once per appearance, then false", () => {
-      const store = createVersionUpdateStore(() => "running", 0);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+      });
       store.reportObservedBuildId("deployed");
 
       expect(store.markShownReported()).toBe(true);
@@ -217,7 +247,10 @@ describe("versionUpdateStore", () => {
     });
 
     it("resets for a genuinely new build id (a fresh appearance)", () => {
-      const store = createVersionUpdateStore(() => "running", 0);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+      });
 
       store.reportObservedBuildId("deployed-1");
       expect(store.markShownReported()).toBe(true);
@@ -230,7 +263,10 @@ describe("versionUpdateStore", () => {
     });
 
     it("does not reset when an already-seen build id is re-observed", () => {
-      const store = createVersionUpdateStore(() => "running", 0);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+      });
 
       store.reportObservedBuildId("deployed");
       expect(store.markShownReported()).toBe(true);
@@ -254,7 +290,10 @@ describe("versionUpdateStore", () => {
     });
 
     it("stays hidden until the debounce elapses after the first new build id", () => {
-      const store = createVersionUpdateStore(() => "running", 180_000);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 180_000,
+        minStalenessMs: 0,
+      });
 
       store.reportObservedBuildId("deployed");
       // Available, but within the settling window → still not shown.
@@ -268,7 +307,10 @@ describe("versionUpdateStore", () => {
     });
 
     it("notifies subscribers exactly once, when the window elapses (not on detection)", () => {
-      const store = createVersionUpdateStore(() => "running", 180_000);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 180_000,
+        minStalenessMs: 0,
+      });
       const listener = vi.fn();
       store.subscribe(listener);
 
@@ -281,7 +323,10 @@ describe("versionUpdateStore", () => {
     });
 
     it("keys the window to the FIRST sighting — a second new build within it does not extend the wait", () => {
-      const store = createVersionUpdateStore(() => "running", 180_000);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 180_000,
+        minStalenessMs: 0,
+      });
 
       store.reportObservedBuildId("deployed-1");
       vi.advanceTimersByTime(100_000);
@@ -297,12 +342,11 @@ describe("versionUpdateStore", () => {
     it("re-prompts immediately for a new build once the window has already passed", () => {
       // `noStorage`: this pins the debounce being satisfied, without the
       // persisted 24 h dismiss suppression on top.
-      const store = createVersionUpdateStore(
-        () => "running",
-        180_000,
-        undefined,
-        noStorage,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 180_000,
+        minStalenessMs: 0,
+        getStorage: noStorage,
+      });
 
       store.reportObservedBuildId("deployed-1");
       vi.advanceTimersByTime(180_000);
@@ -317,7 +361,10 @@ describe("versionUpdateStore", () => {
     });
 
     it("arms no timer when only the running build id is observed", () => {
-      const store = createVersionUpdateStore(() => "running", 180_000);
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 180_000,
+        minStalenessMs: 0,
+      });
 
       store.reportObservedBuildId("running"); // matches → no new-version signal
       vi.advanceTimersByTime(180_000);
@@ -327,7 +374,9 @@ describe("versionUpdateStore", () => {
     it("defaults the debounce window to three minutes", () => {
       expect(VERSION_UPDATE_DEBOUNCE_MS).toBe(3 * 60 * 1000);
 
-      const store = createVersionUpdateStore(() => "running");
+      const store = createVersionUpdateStore(() => "running", {
+        minStalenessMs: 0,
+      });
       store.reportObservedBuildId("deployed");
       vi.advanceTimersByTime(VERSION_UPDATE_DEBOUNCE_MS - 1);
       expect(store.getSnapshot()).toBe(false);
@@ -336,20 +385,184 @@ describe("versionUpdateStore", () => {
     });
   });
 
-  // Back-to-back releases re-armed the banner on every deploy, and dismiss was
-  // per-tab and per-build — a customer saw the banner after every reload
-  // (LFE-14765). Two localStorage-persisted windows gate NEW appearances:
-  // shown at most once per VERSION_UPDATE_SHOW_THROTTLE_MS, and an explicit
-  // dismiss suppresses for VERSION_UPDATE_DISMISS_SUPPRESSION_MS.
+  // The primary gate (LFE-14765): the banner exists so long-lived stale tabs
+  // don't 404 on code-split chunks — a prompt minutes after each deploy doesn't
+  // serve that. It may only appear once the RUNNING build has been superseded
+  // for 48 h, measured from the first observed differing build id and persisted
+  // (per running build) across reloads and tabs.
+  describe("48 h staleness gate (LFE-14765)", () => {
+    it("holds the banner until the running build has been superseded for 48 h", () => {
+      const storage = createFakeStorage();
+      let now = 0;
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(false); // superseded, but not stale yet
+
+      now = VERSION_UPDATE_MIN_STALENESS_MS - 1;
+      store.reportObservedBuildId("deployed"); // routine response = clock tick
+      expect(store.getSnapshot()).toBe(false);
+
+      now = VERSION_UPDATE_MIN_STALENESS_MS;
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("keeps the persisted stale-since across a reload of the SAME running build", () => {
+      const storage = createFakeStorage();
+      let now = 0;
+      const first = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+      first.reportObservedBuildId("deployed"); // stale-since recorded at t=0
+
+      // Reloading without picking up a new bundle (or a second tab of the same
+      // bundle) must NOT restart the staleness clock.
+      now = VERSION_UPDATE_MIN_STALENESS_MS;
+      const reloaded = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+      reloaded.reportObservedBuildId("deployed");
+      expect(reloaded.getSnapshot()).toBe(true); // 48 h since the FIRST sighting
+    });
+
+    it("restarts the staleness clock when the tab reloads onto a NEW running build", () => {
+      const storage = createFakeStorage();
+      let now = 0;
+      const before = createVersionUpdateStore(() => "build-1", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+      before.reportObservedBuildId("build-2"); // { buildId: build-1, ts: 0 }
+
+      // The user reloads onto build-2; build-3 supersedes it 48 h later.
+      now = VERSION_UPDATE_MIN_STALENESS_MS;
+      const after = createVersionUpdateStore(() => "build-2", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+      after.reportObservedBuildId("build-3");
+      expect(after.getSnapshot()).toBe(false); // clock restarted for build-2
+      expect(storage.getItem(VERSION_UPDATE_STALE_SINCE_KEY)).toBe(
+        JSON.stringify({ buildId: "build-2", ts: now }),
+      );
+
+      now = 2 * VERSION_UPDATE_MIN_STALENESS_MS;
+      after.reportObservedBuildId("build-3");
+      expect(after.getSnapshot()).toBe(true);
+    });
+
+    it("restarts a future-dated stale-since at now (clock moved backward)", () => {
+      const storage = createFakeStorage();
+      storage.setItem(
+        VERSION_UPDATE_STALE_SINCE_KEY,
+        JSON.stringify({ buildId: "running", ts: 10_000 }),
+      );
+      let now = 1_000;
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(false);
+      expect(storage.getItem(VERSION_UPDATE_STALE_SINCE_KEY)).toBe(
+        JSON.stringify({ buildId: "running", ts: 1_000 }),
+      );
+
+      now = 1_000 + VERSION_UPDATE_MIN_STALENESS_MS;
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("treats garbage stale-since JSON as absent and overwrites it", () => {
+      const storage = createFakeStorage();
+      storage.setItem(VERSION_UPDATE_STALE_SINCE_KEY, "{not json");
+      let now = 0;
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+
+      store.reportObservedBuildId("deployed"); // must not throw
+      expect(store.getSnapshot()).toBe(false);
+      expect(storage.getItem(VERSION_UPDATE_STALE_SINCE_KEY)).toBe(
+        JSON.stringify({ buildId: "running", ts: 0 }),
+      );
+
+      now = VERSION_UPDATE_MIN_STALENESS_MS;
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("gates in memory when storage is unavailable — a tab open 48 h past its first mismatch still prompts", () => {
+      let now = 0;
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: noStorage,
+      });
+
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(false);
+
+      now = VERSION_UPDATE_MIN_STALENESS_MS;
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("defaults the minimum staleness to 48 hours", () => {
+      expect(VERSION_UPDATE_MIN_STALENESS_MS).toBe(48 * 60 * 60 * 1000);
+    });
+
+    it("layers with the show throttle — a stale frontend shown recently is still throttled", () => {
+      const storage = createFakeStorage();
+      let now = VERSION_UPDATE_MIN_STALENESS_MS;
+      storage.setItem(
+        VERSION_UPDATE_STALE_SINCE_KEY,
+        JSON.stringify({ buildId: "running", ts: 0 }),
+      );
+      storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, String(now - 1));
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
+
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(false); // stale, but shown < 2 h ago
+
+      now += VERSION_UPDATE_SHOW_THROTTLE_MS;
+      store.reportObservedBuildId("deployed");
+      expect(store.getSnapshot()).toBe(true);
+    });
+  });
+
+  // Secondary suppressions (LFE-14765), tested with the staleness gate disabled
+  // so each pins one behavior: two localStorage-persisted windows gate NEW
+  // appearances — shown at most once per VERSION_UPDATE_SHOW_THROTTLE_MS, and
+  // an explicit dismiss suppresses for VERSION_UPDATE_DISMISS_SUPPRESSION_MS.
   describe("persisted suppression (LFE-14765)", () => {
     it("records the last-shown timestamp when the banner actually shows", () => {
       const storage = createFakeStorage();
-      const store = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => 1_000,
-        () => storage,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => 1_000,
+        getStorage: () => storage,
+      });
 
       store.reportObservedBuildId("deployed");
       expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBeNull();
@@ -365,24 +578,24 @@ describe("versionUpdateStore", () => {
       let now = 0;
 
       // The banner shows for build-2 …
-      const before = createVersionUpdateStore(
-        () => "build-1",
-        0,
-        () => now,
-        () => storage,
-      );
+      const before = createVersionUpdateStore(() => "build-1", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
       before.reportObservedBuildId("build-2");
       expect(before.getSnapshot()).toBe(true);
       expect(before.markShownReported()).toBe(true);
 
       // … the user reloads onto build-2, and another release lands 30 min later.
       now = 30 * 60 * 1000;
-      const after = createVersionUpdateStore(
-        () => "build-2",
-        0,
-        () => now,
-        () => storage,
-      );
+      const after = createVersionUpdateStore(() => "build-2", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
       after.reportObservedBuildId("build-3");
       expect(after.getSnapshot()).toBe(false); // shown < 2 h ago → throttled
 
@@ -396,12 +609,12 @@ describe("versionUpdateStore", () => {
     it("never hides a banner that is already visible (windows gate new appearances only)", () => {
       const storage = createFakeStorage();
       let now = 0;
-      const store = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => now,
-        () => storage,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
 
       store.reportObservedBuildId("deployed-1");
       expect(store.getSnapshot()).toBe(true);
@@ -418,12 +631,12 @@ describe("versionUpdateStore", () => {
     it("dismiss suppresses even genuinely new builds for 24 h — across a reload", () => {
       const storage = createFakeStorage();
       let now = 0;
-      const store = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => now,
-        () => storage,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
 
       store.reportObservedBuildId("deployed-1");
       store.dismiss();
@@ -438,12 +651,12 @@ describe("versionUpdateStore", () => {
       expect(store.getSnapshot()).toBe(false);
 
       // … and so does a reloaded tab (new store, same storage).
-      const reloaded = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => now,
-        () => storage,
-      );
+      const reloaded = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => now,
+        getStorage: () => storage,
+      });
       reloaded.reportObservedBuildId("deployed-2");
       expect(reloaded.getSnapshot()).toBe(false);
 
@@ -462,12 +675,12 @@ describe("versionUpdateStore", () => {
           throw new Error("denied");
         },
       };
-      const store = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => 0,
-        () => throwingStorage,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => 0,
+        getStorage: () => throwingStorage,
+      });
 
       store.reportObservedBuildId("deployed-1");
       expect(store.getSnapshot()).toBe(true); // read errors don't block showing
@@ -482,14 +695,14 @@ describe("versionUpdateStore", () => {
     });
 
     it("treats a throwing storage accessor and garbage values as absent", () => {
-      const accessorThrows = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => 0,
-        () => {
+      const accessorThrows = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => 0,
+        getStorage: () => {
           throw new Error("no storage");
         },
-      );
+      });
       accessorThrows.reportObservedBuildId("deployed");
       expect(accessorThrows.getSnapshot()).toBe(true);
       expect(accessorThrows.markShownReported()).toBe(true);
@@ -497,12 +710,12 @@ describe("versionUpdateStore", () => {
       const storage = createFakeStorage();
       storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, "not-a-number");
       storage.setItem(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY, "NaN");
-      const garbage = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => 0,
-        () => storage,
-      );
+      const garbage = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => 0,
+        getStorage: () => storage,
+      });
       garbage.reportObservedBuildId("deployed");
       expect(garbage.getSnapshot()).toBe(true);
     });
@@ -516,12 +729,12 @@ describe("versionUpdateStore", () => {
         VERSION_UPDATE_LAST_SHOWN_AT_KEY,
         String(5 * 60 * 60 * 1000), // "shown" five hours in the future
       );
-      const store = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => 1_000,
-        () => storage,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => 1_000,
+        getStorage: () => storage,
+      });
       store.reportObservedBuildId("deployed");
       expect(store.getSnapshot()).toBe(true);
     });
@@ -532,12 +745,12 @@ describe("versionUpdateStore", () => {
         VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
         String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS + 1),
       );
-      const store = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => 1_000,
-        () => bogus,
-      );
+      const store = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => 1_000,
+        getStorage: () => bogus,
+      });
       store.reportObservedBuildId("deployed");
       expect(store.getSnapshot()).toBe(true);
 
@@ -547,12 +760,12 @@ describe("versionUpdateStore", () => {
         VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
         String(1_000 + VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
       );
-      const suppressed = createVersionUpdateStore(
-        () => "running",
-        0,
-        () => 1_000,
-        () => valid,
-      );
+      const suppressed = createVersionUpdateStore(() => "running", {
+        debounceMs: 0,
+        minStalenessMs: 0,
+        now: () => 1_000,
+        getStorage: () => valid,
+      });
       suppressed.reportObservedBuildId("deployed");
       expect(suppressed.getSnapshot()).toBe(false);
     });

--- a/web/src/features/version-update/versionUpdateStore.clienttest.ts
+++ b/web/src/features/version-update/versionUpdateStore.clienttest.ts
@@ -3,7 +3,27 @@ import {
   createVersionUpdateStore,
   isVersionMismatch,
   VERSION_UPDATE_DEBOUNCE_MS,
+  VERSION_UPDATE_SHOW_THROTTLE_MS,
+  VERSION_UPDATE_DISMISS_SUPPRESSION_MS,
+  VERSION_UPDATE_LAST_SHOWN_AT_KEY,
+  VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
 } from "./versionUpdateStore";
+
+// No persistence → the store's pure in-memory semantics. Used where the test
+// pins behavior that persisted suppression (LFE-14765) would otherwise mask.
+const noStorage = () => undefined;
+
+// Minimal Map-backed Storage double — deterministic, shareable across store
+// instances to simulate reloads and tabs.
+const createFakeStorage = () => {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+};
 
 describe("isVersionMismatch", () => {
   it("is true only when both ids are present and differ", () => {
@@ -30,6 +50,12 @@ describe("isVersionMismatch", () => {
 });
 
 describe("versionUpdateStore", () => {
+  beforeEach(() => {
+    // Stores built without an injected accessor use the factory default —
+    // jsdom's real localStorage — which is shared across tests; isolate them.
+    window.localStorage.clear();
+  });
+
   it("starts with no update available", () => {
     const store = createVersionUpdateStore(() => "running", 0);
     expect(store.getSnapshot()).toBe(false);
@@ -61,8 +87,16 @@ describe("versionUpdateStore", () => {
     expect(store.getSnapshot()).toBe(false);
   });
 
-  it("hides after dismiss and re-shows only when a not-yet-seen build arrives", () => {
-    const store = createVersionUpdateStore(() => "running", 0);
+  // Pure in-memory dismiss semantics (`noStorage`) — with storage present the
+  // persisted 24 h dismiss suppression additionally holds back the new build
+  // (see "persisted suppression" below).
+  it("hides after dismiss and re-shows only when a not-yet-seen build arrives (in-memory fallback)", () => {
+    const store = createVersionUpdateStore(
+      () => "running",
+      0,
+      undefined,
+      noStorage,
+    );
 
     store.reportObservedBuildId("deployed-1");
     expect(store.getSnapshot()).toBe(true);
@@ -100,7 +134,14 @@ describe("versionUpdateStore", () => {
     });
 
     it("does not reopen a dismissed banner when an already-seen build re-appears (old pod)", () => {
-      const store = createVersionUpdateStore(() => "running", 0);
+      // `noStorage` so the seen-set invariant is pinned on its own, not via
+      // the persisted dismiss suppression.
+      const store = createVersionUpdateStore(
+        () => "running",
+        0,
+        undefined,
+        noStorage,
+      );
 
       store.reportObservedBuildId("deployed");
       store.dismiss();
@@ -128,7 +169,15 @@ describe("versionUpdateStore", () => {
   });
 
   it("notifies subscribers when the snapshot changes and after unsubscribe stops", () => {
-    const store = createVersionUpdateStore(() => "running", 0);
+    // `noStorage` so the post-unsubscribe report really changes the snapshot
+    // (a persisted dismiss suppression would keep it false and mask a broken
+    // unsubscribe).
+    const store = createVersionUpdateStore(
+      () => "running",
+      0,
+      undefined,
+      noStorage,
+    );
     const listener = vi.fn();
     const unsubscribe = store.subscribe(listener);
 
@@ -246,7 +295,14 @@ describe("versionUpdateStore", () => {
     });
 
     it("re-prompts immediately for a new build once the window has already passed", () => {
-      const store = createVersionUpdateStore(() => "running", 180_000);
+      // `noStorage`: this pins the debounce being satisfied, without the
+      // persisted 24 h dismiss suppression on top.
+      const store = createVersionUpdateStore(
+        () => "running",
+        180_000,
+        undefined,
+        noStorage,
+      );
 
       store.reportObservedBuildId("deployed-1");
       vi.advanceTimersByTime(180_000);
@@ -277,6 +333,178 @@ describe("versionUpdateStore", () => {
       expect(store.getSnapshot()).toBe(false);
       vi.advanceTimersByTime(1);
       expect(store.getSnapshot()).toBe(true);
+    });
+  });
+
+  // Back-to-back releases re-armed the banner on every deploy, and dismiss was
+  // per-tab and per-build — a customer saw the banner after every reload
+  // (LFE-14765). Two localStorage-persisted windows gate NEW appearances:
+  // shown at most once per VERSION_UPDATE_SHOW_THROTTLE_MS, and an explicit
+  // dismiss suppresses for VERSION_UPDATE_DISMISS_SUPPRESSION_MS.
+  describe("persisted suppression (LFE-14765)", () => {
+    it("records the last-shown timestamp when the banner actually shows", () => {
+      const storage = createFakeStorage();
+      const store = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => 1_000,
+        () => storage,
+      );
+
+      store.reportObservedBuildId("deployed");
+      expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBeNull();
+
+      // The write happens on the actual appearance (markShownReported), not on
+      // mere eligibility — a banner held back by `useAppSettled` records nothing.
+      expect(store.markShownReported()).toBe(true);
+      expect(storage.getItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY)).toBe("1000");
+    });
+
+    it("throttles a second appearance within 2 h — across a reload (new store, same storage)", () => {
+      const storage = createFakeStorage();
+      let now = 0;
+
+      // The banner shows for build-2 …
+      const before = createVersionUpdateStore(
+        () => "build-1",
+        0,
+        () => now,
+        () => storage,
+      );
+      before.reportObservedBuildId("build-2");
+      expect(before.getSnapshot()).toBe(true);
+      expect(before.markShownReported()).toBe(true);
+
+      // … the user reloads onto build-2, and another release lands 30 min later.
+      now = 30 * 60 * 1000;
+      const after = createVersionUpdateStore(
+        () => "build-2",
+        0,
+        () => now,
+        () => storage,
+      );
+      after.reportObservedBuildId("build-3");
+      expect(after.getSnapshot()).toBe(false); // shown < 2 h ago → throttled
+
+      // Expiry re-allows: a routine re-observation (every tRPC response) is the
+      // clock tick that surfaces the pending update — no dedicated timer.
+      now = VERSION_UPDATE_SHOW_THROTTLE_MS + 1;
+      after.reportObservedBuildId("build-3");
+      expect(after.getSnapshot()).toBe(true);
+    });
+
+    it("never hides a banner that is already visible (windows gate new appearances only)", () => {
+      const storage = createFakeStorage();
+      let now = 0;
+      const store = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => now,
+        () => storage,
+      );
+
+      store.reportObservedBuildId("deployed-1");
+      expect(store.getSnapshot()).toBe(true);
+      expect(store.markShownReported()).toBe(true); // throttle armed at t=0
+
+      // Inside the throttle window, routine ticks and even a genuinely new
+      // build must not hide (or blink) the banner already on screen.
+      now = 60 * 1000;
+      store.reportObservedBuildId("deployed-1");
+      store.reportObservedBuildId("deployed-2");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("dismiss suppresses even genuinely new builds for 24 h — across a reload", () => {
+      const storage = createFakeStorage();
+      let now = 0;
+      const store = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => now,
+        () => storage,
+      );
+
+      store.reportObservedBuildId("deployed-1");
+      store.dismiss();
+      expect(storage.getItem(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY)).toBe(
+        String(VERSION_UPDATE_DISMISS_SUPPRESSION_MS),
+      );
+
+      // A genuinely new build inside the window stays quiet — unlike the
+      // in-memory fallback, where it would re-prompt immediately.
+      now = 3 * 60 * 60 * 1000; // past the show throttle, inside the dismiss window
+      store.reportObservedBuildId("deployed-2");
+      expect(store.getSnapshot()).toBe(false);
+
+      // … and so does a reloaded tab (new store, same storage).
+      const reloaded = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => now,
+        () => storage,
+      );
+      reloaded.reportObservedBuildId("deployed-2");
+      expect(reloaded.getSnapshot()).toBe(false);
+
+      // Expiry re-allows: the pending update surfaces on the next response.
+      now = VERSION_UPDATE_DISMISS_SUPPRESSION_MS + 1;
+      store.reportObservedBuildId("deployed-2");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("falls back to in-memory behavior when storage methods throw", () => {
+      const throwingStorage: Pick<Storage, "getItem" | "setItem"> = {
+        getItem: () => {
+          throw new Error("denied");
+        },
+        setItem: () => {
+          throw new Error("denied");
+        },
+      };
+      const store = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => 0,
+        () => throwingStorage,
+      );
+
+      store.reportObservedBuildId("deployed-1");
+      expect(store.getSnapshot()).toBe(true); // read errors don't block showing
+      expect(store.markShownReported()).toBe(true); // write error swallowed
+
+      store.dismiss(); // write error swallowed; in-memory dismiss still works
+      expect(store.getSnapshot()).toBe(false);
+
+      // In-memory semantics: a genuinely new build re-prompts immediately.
+      store.reportObservedBuildId("deployed-2");
+      expect(store.getSnapshot()).toBe(true);
+    });
+
+    it("treats a throwing storage accessor and garbage values as absent", () => {
+      const accessorThrows = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => 0,
+        () => {
+          throw new Error("no storage");
+        },
+      );
+      accessorThrows.reportObservedBuildId("deployed");
+      expect(accessorThrows.getSnapshot()).toBe(true);
+      expect(accessorThrows.markShownReported()).toBe(true);
+
+      const storage = createFakeStorage();
+      storage.setItem(VERSION_UPDATE_LAST_SHOWN_AT_KEY, "not-a-number");
+      storage.setItem(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY, "NaN");
+      const garbage = createVersionUpdateStore(
+        () => "running",
+        0,
+        () => 0,
+        () => storage,
+      );
+      garbage.reportObservedBuildId("deployed");
+      expect(garbage.getSnapshot()).toBe(true);
     });
   });
 });

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -1,50 +1,14 @@
 /**
- * External store tracking whether a newer app build has been deployed while the
- * current tab stayed open.
- *
- * Frequent deploys + long-lived tabs leave a tab running a stale JS bundle,
- * which then 404s on code-split chunks and mints stale-fingerprint Sentry noise
- * (LFE-10978, §4.9). This store powers a persistent "reload to update" banner so
- * the user can refresh on their own terms — we NEVER auto-reload (that would
- * throw away unsaved work: open annotations, editors, ...).
- *
- * It is fed imperatively from the tRPC `buildIdLink` (see `src/utils/api.ts`),
- * which captures the `x-build-id` response header on every tRPC response. React
- * reads it via {@link useVersionUpdateAvailable} (a `useSyncExternalStore` hook)
- * — no polling, no effect-driven state sync.
- *
- * New-version debounce (LFE-14537): a page loaded while the web container is
- * mid-deploy can see the new build id immediately, and prompting a reload right
- * then reloads the tab into the still-switching pod (a broken loading state). So
- * "update available" only flips the snapshot to `true` once at least
- * {@link VERSION_UPDATE_DEBOUNCE_MS} has elapsed since the FIRST new build id was
- * seen — a settling window for the deploy to finish. This gate is combined at the
- * banner with a post-load grace (see `useAppSettled`); both must pass.
- *
- * Staleness gate + persisted suppression (LFE-14765): the banner exists so a
- * long-lived stale tab does not 404 on code-split chunks — but dismiss and the
- * seen-build set lived in memory, so back-to-back deploys re-prompted every tab
- * on every release (a customer reported the banner reappearing after every
- * reload). Prompting minutes after each deploy adds work for thousands of users
- * without addressing chunk breakage, so the banner only appears at all once the
- * running bundle has been superseded for at least
- * {@link VERSION_UPDATE_MIN_STALENESS_MS} — measured from the FIRST observed
- * differing build id for the running build, persisted across reloads and tabs.
- * On top of that, two persisted suppression windows apply: at most one
- * appearance per {@link VERSION_UPDATE_SHOW_THROTTLE_MS}, and an explicit
- * dismiss stays quiet for {@link VERSION_UPDATE_DISMISS_SUPPRESSION_MS}, even
- * for genuinely new build ids. All three gate only the hidden→shown transition
- * (a banner already on screen never hides itself) and degrade to in-memory
- * behavior when storage is unavailable. Keeping old bundles servable — the root
- * cause of chunk 404s — is tracked separately.
+ * External store behind the "reload to update" banner (LFE-10978): long-lived
+ * tabs on a superseded bundle 404 on code-split chunks, so we offer (never
+ * force) a reload. Fed by the tRPC `buildIdLink` (`x-build-id` header on every
+ * response); read via `useSyncExternalStore`. Gate chain (LFE-14537, LFE-14765):
+ * superseded ≥ 48 h → 3 min deploy debounce → not shown in the last 2 h → not
+ * dismissed in the last 24 h. Windows persist in localStorage (shared across
+ * tabs/reloads) and degrade to in-memory behavior without storage.
  */
 
-/**
- * True only when both build ids are present and they differ. When either id is
- * missing we cannot conclude anything (a self-hosted build without
- * `NEXT_PUBLIC_BUILD_ID`, or a response that carried no `x-build-id`), so we
- * stay silent rather than nag on a false positive.
- */
+/** True only when both build ids are known and differ; unknown ids prove nothing. */
 export function isVersionMismatch(
   runningBuildId: string | null | undefined,
   observedBuildId: string | null | undefined,
@@ -54,145 +18,59 @@ export function isVersionMismatch(
   );
 }
 
-/**
- * How long after the FIRST new build id is observed before the banner is allowed
- * to appear — a debounce so a deploy that's still switching pods doesn't
- * immediately prompt a reload into a half-deployed state (LFE-14537). Keyed on
- * the first sighting, not re-armed per response, so it can't be starved by a
- * rolling deploy re-serving build ids.
- */
+/** Settling window after the FIRST differing build id, so we don't prompt a reload into a mid-rollout deploy (LFE-14537). */
 export const VERSION_UPDATE_DEBOUNCE_MS = 3 * 60 * 1000;
 
-/**
- * Show throttle (LFE-14765): once the banner has actually appeared, a NEW
- * appearance is blocked until this much time has passed since that appearance —
- * persisted, so it spans reloads and tabs. Sized so a burst of releases (three
- * deploys in an hour) prompts each user once, not once per release.
- */
+/** At most one banner appearance per window, across tabs and reloads. */
 export const VERSION_UPDATE_SHOW_THROTTLE_MS = 2 * 60 * 60 * 1000;
 
-/**
- * Dismiss suppression (LFE-14765): an explicit dismiss (X) means "not now" —
- * suppress the banner for this long, including for build ids never seen before.
- * Persisted, so a dismiss survives reloads and covers all tabs.
- */
+/** An explicit dismiss silences the banner this long, even for new build ids. */
 export const VERSION_UPDATE_DISMISS_SUPPRESSION_MS = 24 * 60 * 60 * 1000;
 
-/**
- * Minimum staleness (LFE-14765): the banner only appears at all once the
- * running bundle has been superseded for at least this long. Measured from the
- * first observed differing build id for the running build — "how long has this
- * frontend been superseded", which is what actually breaks code-split chunks —
- * not from a build timestamp (which would need deploy-pipeline support and
- * measures age, not supersession).
- */
+/** The running build must have been superseded this long before any prompt. */
 export const VERSION_UPDATE_MIN_STALENESS_MS = 48 * 60 * 60 * 1000;
 
 /** localStorage key: epoch ms of the banner's last actual appearance. */
 export const VERSION_UPDATE_LAST_SHOWN_AT_KEY = "version-update-last-shown-at";
-/** localStorage key: epoch ms until which an explicit dismiss suppresses the banner. */
+/** localStorage key: epoch ms until which a dismiss suppresses the banner. */
 export const VERSION_UPDATE_SUPPRESSED_UNTIL_KEY =
   "version-update-suppressed-until";
-/**
- * localStorage key: JSON `{ buildId, ts }` — when the RUNNING build (`buildId`)
- * was first observed superseded. A single overwritten entry, not one key per
- * build, so storage never accumulates.
- */
+/** localStorage key: JSON `{ buildId, ts }` — when the running build was first seen superseded (single overwritten entry). */
 export const VERSION_UPDATE_STALE_SINCE_KEY = "version-update-stale-since";
 
 export type VersionUpdateStore = {
-  /** Subscribe to snapshot changes (for `useSyncExternalStore`). */
+  /** Subscribe to snapshot changes (`useSyncExternalStore`). */
   subscribe: (listener: () => void) => () => void;
-  /**
-   * Current snapshot: is an update available, not yet dismissed, AND has the
-   * new-version debounce ({@link VERSION_UPDATE_DEBOUNCE_MS}) elapsed? A
-   * hidden→shown transition additionally requires the running build to have
-   * been superseded for at least {@link VERSION_UPDATE_MIN_STALENESS_MS} and
-   * the persisted suppression windows (show throttle / dismiss suppression,
-   * LFE-14765) to have expired.
-   */
+  /** Should the banner render right now? */
   getSnapshot: () => boolean;
-  /** SSR snapshot — always `false`; the mismatch only exists in a live tab. */
+  /** Always false — the mismatch only exists in a live tab. */
   getServerSnapshot: () => boolean;
-  /**
-   * Record a build id observed from a server response. Safe to call on every
-   * tRPC response with any value. Once a build id different from the running one
-   * has been seen, "update available" is STICKY — later responses (including an
-   * old pod still serving the running build during a rolling deploy) can never
-   * clear it.
-   */
+  /** Feed a build id from a server response; safe on every response, any value. */
   reportObservedBuildId: (observedBuildId: string | null | undefined) => void;
-  /**
-   * Dismiss the banner for the current session. It re-shows only when a build id
-   * that has NOT been seen before arrives — never on a re-observation of an
-   * already-seen build (an old pod during a rolling deploy). Also persists a
-   * {@link VERSION_UPDATE_DISMISS_SUPPRESSION_MS} suppression window
-   * (LFE-14765), so even genuinely new builds stay quiet for that long.
-   */
+  /** Hide until a never-seen build id arrives; persists the 24 h suppression. */
   dismiss: () => void;
   /**
-   * Returns `true` exactly once per appearance, `false` afterwards; the flag
-   * resets when a genuinely new build id arrives (a fresh appearance). Kept in
-   * the store — not in component state — so the `banner_shown` analytics event
-   * fires once per logical appearance even if the banner component unmounts and
-   * remounts in between (e.g. AppLayout switching between AuthenticatedLayout
-   * and MinimalLayout), and once (not twice) under a StrictMode double-invoked
-   * effect. A `true` return is the store's "the banner actually showed" signal,
-   * so it also records the persisted last-shown timestamp for the show throttle
-   * (LFE-14765).
+   * True exactly once per appearance — store-held so remounts/StrictMode can't
+   * double-fire `banner_shown`. A `true` also records the show-throttle stamp.
    */
   markShownReported: () => boolean;
 };
 
-/**
- * Injection points for {@link createVersionUpdateStore} — everything
- * time/persistence-related, so tests are deterministic. The app singleton uses
- * the defaults.
- */
+/** Injection points for deterministic tests; the app singleton uses the defaults. */
 export type VersionUpdateStoreOptions = {
-  /**
-   * New-version settling window (default {@link VERSION_UPDATE_DEBOUNCE_MS}).
-   * A value ≤ 0 disables the debounce (the update is eligible as soon as it is
-   * available) and stays synchronous — no timer — which keeps the
-   * detection/stickiness tests free of fake timers.
-   */
+  /** Settling window; ≤ 0 elapses synchronously (no timer). */
   debounceMs?: number;
-  /**
-   * How long the running build must have been superseded before the banner may
-   * appear (default {@link VERSION_UPDATE_MIN_STALENESS_MS}); ≤ 0 disables the
-   * staleness gate.
-   */
+  /** Required supersession age before the banner may appear; ≤ 0 disables. */
   minStalenessMs?: number;
-  /** Clock backing the persisted gates (default `Date.now`). */
   now?: () => number;
-  /**
-   * Lazy storage accessor — lazy because module scope must not touch `window`
-   * (SSR). May return `undefined` or throw (private mode, hardened contexts,
-   * quota): every access is guarded, degrading to in-memory behavior.
-   */
+  /** Lazy (SSR-safe); may return undefined or throw — every access is guarded. */
   getStorage?: () => Pick<Storage, "getItem" | "setItem"> | undefined;
 };
 
 /**
- * Builds a version-update store. `getRunningBuildId` returns the build id of the
- * bundle this tab is running; injecting it (rather than reading the module-level
- * env directly) keeps the store deterministic and testable.
- *
- * Rolling-deploy correctness: during a rollout, one tab sees responses from
- * BOTH the old and new pods, in any order, and build ids are opaque hashes with
- * no orderable "newer/older". So the store cannot ask "is the observed build
- * newer?" — it asks only "have we ever seen a build id ≠ ours?". That makes the
- * signal:
- *  - **sticky** — a subsequent old-pod response carrying the running build id
- *    cannot flip the banner back off; and
- *  - **flap-free** — re-observing an already-seen build id does nothing, so the
- *    banner does not blink or reopen as responses alternate between pods.
- * Reloading always converges the tab to whatever build is currently served, so
- * "a build ≠ yours exists → offer reload" is the right action even though we
- * can't prove the other build is strictly newer.
- *
- * All time/persistence inputs are injected via {@link VersionUpdateStoreOptions}
- * for deterministic testing; the app singleton uses the defaults.
+ * Build ids are opaque and unorderable, so "update available" is simply "ever
+ * saw a build id ≠ ours" — sticky and flap-free while rolling-deploy pods serve
+ * mixed responses; reloading converges the tab to whatever is currently served.
  */
 export function createVersionUpdateStore(
   getRunningBuildId: () => string | null | undefined,
@@ -205,29 +83,19 @@ export function createVersionUpdateStore(
   }: VersionUpdateStoreOptions = {},
 ): VersionUpdateStore {
   const listeners = new Set<() => void>();
-  // Every build id observed that differs from the running one. Membership is
-  // what makes re-observation a no-op (no flapping) and dismiss durable.
+  // Membership makes re-observation a no-op (no flapping, no dismiss reopen).
   const seenDifferingBuildIds = new Set<string>();
-  // Sticky: set true the first time a differing build id is seen, never unset.
-  let updateAvailable = false;
+  let updateAvailable = false; // sticky
   let dismissed = false;
-  // `banner_shown` analytics guard — true once the current appearance has been
-  // reported. Reset when a genuinely new build id arrives (new appearance).
+  // `banner_shown` once-guard; reset when a genuinely new build id arrives.
   let shownReported = false;
-  // New-version debounce (LFE-14537). `debounceStarted` guards the one-shot
-  // timer so it is armed exactly once — on the FIRST new build id, keyed to that
-  // sighting (never re-armed by later responses, so a rolling deploy can't
-  // starve it). `debounceElapsed` is sticky: once the window passes the update
-  // is eligible forever, and a later genuinely-new build re-prompts immediately.
+  // One-shot, keyed to the FIRST new build id; `debounceElapsed` stays true.
   let debounceStarted = false;
   let debounceElapsed = false;
-  // When the RUNNING build was first observed superseded (epoch ms). Resolved
-  // once, on the first mismatch (see resolveStaleSince); later new builds do
-  // not move it — they don't make this tab any less stale.
+  // First-superseded-at for the running build; resolved once, then in-memory.
   let staleSince: number | null = null;
 
-  // Guarded storage access: `getStorage` and Storage methods may throw. On any
-  // failure reads yield null and writes are dropped — in-memory behavior only.
+  // Storage may be absent or throw: failed reads → null, writes are dropped.
   const readTimestamp = (key: string): number | null => {
     try {
       const raw = getStorage()?.getItem(key);
@@ -242,16 +110,12 @@ export function createVersionUpdateStore(
     try {
       getStorage()?.setItem(key, String(value));
     } catch {
-      // best-effort persistence; the in-memory gates still apply
+      // best-effort; in-memory gates still apply
     }
   };
 
-  // The staleness clock for the running build, shared across tabs/reloads via
-  // one JSON `{ buildId, ts }` entry. An entry for a DIFFERENT running build
-  // means the tab has since reloaded onto a new bundle → restart at now (and
-  // overwrite). A future-dated `ts` (clock moved backward since the write) is
-  // likewise restarted rather than honored. Unreadable/garbage → treat as
-  // absent; unwritable → the in-memory value still gates this tab.
+  // Adopt a persisted stale-since for the SAME running build; otherwise (other
+  // build, future-dated ts, garbage) restart at now and overwrite the entry.
   const resolveStaleSince = (): number => {
     const t = now();
     const runningBuildId = getRunningBuildId();
@@ -270,7 +134,7 @@ export function createVersionUpdateStore(
         }
       }
     } catch {
-      // fall through to a fresh entry
+      // unreadable → treat as absent
     }
     try {
       getStorage()?.setItem(
@@ -278,27 +142,22 @@ export function createVersionUpdateStore(
         JSON.stringify({ buildId: runningBuildId, ts: t }),
       );
     } catch {
-      // best-effort persistence; the in-memory value still applies
+      // best-effort; in-memory value still applies
     }
     return t;
   };
 
-  // Primary gate (LFE-14765): only a frontend superseded at least
-  // `minStalenessMs` ago may prompt at all.
   const isStaleEnough = (): boolean =>
     staleSince !== null && now() - staleSince >= minStalenessMs;
 
-  // Persisted suppression (LFE-14765). Checked only on the hidden→shown
-  // transition — never hides a banner already on screen. Values written by a
-  // clock that has since moved backward (correction, restored VM) are ignored
-  // rather than honored — a future-dated timestamp could otherwise suppress
-  // until the wall clock catches up, potentially far beyond the window.
+  // Future-dated stamps are ignored, not clamped — a clamp floats with `now`
+  // and would suppress until the wall clock caught up.
   const isSuppressed = (): boolean => {
     const t = now();
     const lastShownAt = readTimestamp(VERSION_UPDATE_LAST_SHOWN_AT_KEY);
     if (
       lastShownAt !== null &&
-      lastShownAt <= t && // ignore future-dated
+      lastShownAt <= t &&
       t < lastShownAt + VERSION_UPDATE_SHOW_THROTTLE_MS
     ) {
       return true;
@@ -315,16 +174,12 @@ export function createVersionUpdateStore(
   const computeEligible = (): boolean =>
     updateAvailable && !dismissed && debounceElapsed;
 
-  // Cache the snapshot so `getSnapshot` returns a referentially stable value
-  // between changes — `useSyncExternalStore` requires this to avoid re-render
-  // loops (it compares snapshots with `Object.is`). Starts hidden; every state
-  // change funnels through `emitChange`.
+  // Cached: `useSyncExternalStore` needs a referentially stable snapshot.
   let snapshot = false;
 
   const emitChange = () => {
-    // A visible banner stays visible while eligible (`snapshot ||` — the
-    // staleness gate and suppression windows govern new appearances, not the
-    // current one).
+    // Staleness/suppression gate the hidden→shown transition only — a banner
+    // already on screen is never hidden by them.
     const next =
       computeEligible() && (snapshot || (isStaleEnough() && !isSuppressed()));
     if (next === snapshot) return;
@@ -332,11 +187,7 @@ export function createVersionUpdateStore(
     for (const listener of listeners) listener();
   };
 
-  // Arm the new-version debounce once, on the first new build id. When it
-  // elapses the update becomes eligible; the timer emits so a tab that has been
-  // sitting on a settling deploy re-renders the banner in without any further
-  // response. A non-positive window elapses synchronously (no timer left
-  // running). One-shot and self-completing — nothing to clean up.
+  // Armed once, on the first new build id; ≤ 0 elapses synchronously.
   const startDebounce = () => {
     if (debounceStarted) return;
     debounceStarted = true;
@@ -367,27 +218,17 @@ export function createVersionUpdateStore(
       if (
         observedBuildId &&
         isVersionMismatch(getRunningBuildId(), observedBuildId) &&
-        // Already-seen differing build (old pod re-serving it) mutates nothing —
-        // re-observation must not flap or reopen a dismiss.
-        !seenDifferingBuildIds.has(observedBuildId)
+        !seenDifferingBuildIds.has(observedBuildId) // re-observation = no-op
       ) {
         seenDifferingBuildIds.add(observedBuildId);
-        updateAvailable = true; // sticky
-        // First supersession of the running build → start the staleness clock.
+        updateAvailable = true;
         if (staleSince === null) staleSince = resolveStaleSince();
-        // A genuinely new (never-seen) differing build → worth re-prompting even
-        // if the user dismissed an earlier one, and worth counting as a fresh
-        // appearance for analytics.
+        // A never-seen build is a fresh appearance: undo dismiss, re-arm analytics.
         dismissed = false;
         shownReported = false;
-        // Arm the settling window on the first new build; a no-op on later ones
-        // (the debounce is keyed to the first sighting, not re-armed per build).
         startDebounce();
       }
-      // Re-evaluate on EVERY report (not only on new builds): responses are the
-      // store's clock ticks, so maturing staleness and expired suppression
-      // windows surface a pending update without a dedicated timer. No-op when
-      // nothing changed.
+      // Responses are the clock ticks that mature staleness / expire windows.
       emitChange();
     },
     dismiss() {
@@ -401,18 +242,13 @@ export function createVersionUpdateStore(
     markShownReported() {
       if (shownReported) return false;
       shownReported = true;
-      // The banner actually showed → start the persisted show throttle.
-      writeTimestamp(VERSION_UPDATE_LAST_SHOWN_AT_KEY, now());
+      writeTimestamp(VERSION_UPDATE_LAST_SHOWN_AT_KEY, now()); // arm the throttle
       return true;
     },
   };
 }
 
-/**
- * App-wide singleton, wired to the running build id. `NEXT_PUBLIC_BUILD_ID` is
- * inlined into the client bundle at build time, so this reflects the exact
- * bundle the tab loaded.
- */
+/** App singleton; `NEXT_PUBLIC_BUILD_ID` is inlined at build time. */
 export const versionUpdateStore = createVersionUpdateStore(
   () => process.env.NEXT_PUBLIC_BUILD_ID,
 );

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -20,6 +20,17 @@
  * {@link VERSION_UPDATE_DEBOUNCE_MS} has elapsed since the FIRST new build id was
  * seen — a settling window for the deploy to finish. This gate is combined at the
  * banner with a post-load grace (see `useAppSettled`); both must pass.
+ *
+ * Persisted suppression (LFE-14765): dismiss and the seen-build set live in
+ * memory, so back-to-back deploys re-prompted every tab on every release — a
+ * customer reported the banner reappearing after every reload. Two
+ * localStorage-persisted gates (shared across reloads AND tabs) sit on top of
+ * the gates above: the banner may APPEAR at most once per
+ * {@link VERSION_UPDATE_SHOW_THROTTLE_MS}, and an explicit dismiss suppresses it
+ * for {@link VERSION_UPDATE_DISMISS_SUPPRESSION_MS} — even for genuinely new
+ * build ids. Both gate only the hidden→shown transition (a banner already on
+ * screen never hides itself), and both degrade to the in-memory behavior when
+ * storage is unavailable.
  */
 
 /**
@@ -46,12 +57,35 @@ export function isVersionMismatch(
  */
 export const VERSION_UPDATE_DEBOUNCE_MS = 3 * 60 * 1000;
 
+/**
+ * Show throttle (LFE-14765): once the banner has actually appeared, a NEW
+ * appearance is blocked until this much time has passed since that appearance —
+ * persisted, so it spans reloads and tabs. Sized so a burst of releases (three
+ * deploys in an hour) prompts each user once, not once per release.
+ */
+export const VERSION_UPDATE_SHOW_THROTTLE_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Dismiss suppression (LFE-14765): an explicit dismiss (X) means "not now" —
+ * suppress the banner for this long, including for build ids never seen before.
+ * Persisted, so a dismiss survives reloads and covers all tabs.
+ */
+export const VERSION_UPDATE_DISMISS_SUPPRESSION_MS = 24 * 60 * 60 * 1000;
+
+/** localStorage key: epoch ms of the banner's last actual appearance. */
+export const VERSION_UPDATE_LAST_SHOWN_AT_KEY = "version-update-last-shown-at";
+/** localStorage key: epoch ms until which an explicit dismiss suppresses the banner. */
+export const VERSION_UPDATE_SUPPRESSED_UNTIL_KEY =
+  "version-update-suppressed-until";
+
 export type VersionUpdateStore = {
   /** Subscribe to snapshot changes (for `useSyncExternalStore`). */
   subscribe: (listener: () => void) => () => void;
   /**
    * Current snapshot: is an update available, not yet dismissed, AND has the
-   * new-version debounce ({@link VERSION_UPDATE_DEBOUNCE_MS}) elapsed?
+   * new-version debounce ({@link VERSION_UPDATE_DEBOUNCE_MS}) elapsed? A
+   * hidden→shown transition additionally requires the persisted suppression
+   * windows (show throttle / dismiss suppression, LFE-14765) to have expired.
    */
   getSnapshot: () => boolean;
   /** SSR snapshot — always `false`; the mismatch only exists in a live tab. */
@@ -67,7 +101,9 @@ export type VersionUpdateStore = {
   /**
    * Dismiss the banner for the current session. It re-shows only when a build id
    * that has NOT been seen before arrives — never on a re-observation of an
-   * already-seen build (an old pod during a rolling deploy).
+   * already-seen build (an old pod during a rolling deploy). Also persists a
+   * {@link VERSION_UPDATE_DISMISS_SUPPRESSION_MS} suppression window
+   * (LFE-14765), so even genuinely new builds stay quiet for that long.
    */
   dismiss: () => void;
   /**
@@ -77,7 +113,9 @@ export type VersionUpdateStore = {
    * fires once per logical appearance even if the banner component unmounts and
    * remounts in between (e.g. AppLayout switching between AuthenticatedLayout
    * and MinimalLayout), and once (not twice) under a StrictMode double-invoked
-   * effect.
+   * effect. A `true` return is the store's "the banner actually showed" signal,
+   * so it also records the persisted last-shown timestamp for the show throttle
+   * (LFE-14765).
    */
   markShownReported: () => boolean;
 };
@@ -105,10 +143,19 @@ export type VersionUpdateStore = {
  * value ≤ 0 disables the debounce (the update shows as soon as it is available)
  * and stays synchronous — no timer — which keeps the detection/stickiness tests
  * free of fake timers.
+ *
+ * `now` and `getStorage` back the persisted suppression gates (LFE-14765);
+ * injected for deterministic testing, like the parameters above. `getStorage`
+ * is lazy (module scope must not touch `window` — SSR) and may return
+ * `undefined` or throw (private mode, hardened contexts, quota): every access
+ * is guarded, degrading to the pre-existing in-memory behavior.
  */
 export function createVersionUpdateStore(
   getRunningBuildId: () => string | null | undefined,
   debounceMs: number = VERSION_UPDATE_DEBOUNCE_MS,
+  now: () => number = () => Date.now(),
+  getStorage: () => Pick<Storage, "getItem" | "setItem"> | undefined = () =>
+    typeof window === "undefined" ? undefined : window.localStorage,
 ): VersionUpdateStore {
   const listeners = new Set<() => void>();
   // Every build id observed that differs from the running one. Membership is
@@ -128,16 +175,54 @@ export function createVersionUpdateStore(
   let debounceStarted = false;
   let debounceElapsed = false;
 
-  const compute = (): boolean =>
+  // Guarded storage access: `getStorage` and Storage methods may throw. On any
+  // failure reads yield null and writes are dropped — in-memory behavior only.
+  const readTimestamp = (key: string): number | null => {
+    try {
+      const raw = getStorage()?.getItem(key);
+      if (!raw) return null;
+      const parsed = Number(raw);
+      return Number.isFinite(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  };
+  const writeTimestamp = (key: string, value: number) => {
+    try {
+      getStorage()?.setItem(key, String(value));
+    } catch {
+      // best-effort persistence; the in-memory gates still apply
+    }
+  };
+
+  // Persisted suppression (LFE-14765). Checked only on the hidden→shown
+  // transition — never hides a banner already on screen.
+  const isSuppressed = (): boolean => {
+    const t = now();
+    const lastShownAt = readTimestamp(VERSION_UPDATE_LAST_SHOWN_AT_KEY);
+    if (
+      lastShownAt !== null &&
+      t < lastShownAt + VERSION_UPDATE_SHOW_THROTTLE_MS
+    ) {
+      return true;
+    }
+    const suppressedUntil = readTimestamp(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY);
+    return suppressedUntil !== null && t < suppressedUntil;
+  };
+
+  const computeEligible = (): boolean =>
     updateAvailable && !dismissed && debounceElapsed;
 
   // Cache the snapshot so `getSnapshot` returns a referentially stable value
   // between changes — `useSyncExternalStore` requires this to avoid re-render
-  // loops (it compares snapshots with `Object.is`).
-  let snapshot = compute();
+  // loops (it compares snapshots with `Object.is`). Starts hidden; every state
+  // change funnels through `emitChange`.
+  let snapshot = false;
 
   const emitChange = () => {
-    const next = compute();
+    // A visible banner stays visible while eligible (`snapshot ||` — the
+    // suppression windows gate new appearances, not the current one).
+    const next = computeEligible() && (snapshot || !isSuppressed());
     if (next === snapshot) return;
     snapshot = next;
     for (const listener of listeners) listener();
@@ -175,30 +260,42 @@ export function createVersionUpdateStore(
       return false;
     },
     reportObservedBuildId(observedBuildId) {
-      if (!observedBuildId) return;
-      if (!isVersionMismatch(getRunningBuildId(), observedBuildId)) return;
-      // A differing build id. If we've already seen this exact one, do nothing —
-      // re-observation (old pod re-serving it) must not flap or reopen a dismiss.
-      if (seenDifferingBuildIds.has(observedBuildId)) return;
-      seenDifferingBuildIds.add(observedBuildId);
-      updateAvailable = true; // sticky
-      // A genuinely new (never-seen) differing build → worth re-prompting even
-      // if the user dismissed an earlier one, and worth counting as a fresh
-      // appearance for analytics.
-      dismissed = false;
-      shownReported = false;
-      // Arm the settling window on the first new build; a no-op on later ones
-      // (the debounce is keyed to the first sighting, not re-armed per build).
-      startDebounce();
+      if (
+        observedBuildId &&
+        isVersionMismatch(getRunningBuildId(), observedBuildId) &&
+        // Already-seen differing build (old pod re-serving it) mutates nothing —
+        // re-observation must not flap or reopen a dismiss.
+        !seenDifferingBuildIds.has(observedBuildId)
+      ) {
+        seenDifferingBuildIds.add(observedBuildId);
+        updateAvailable = true; // sticky
+        // A genuinely new (never-seen) differing build → worth re-prompting even
+        // if the user dismissed an earlier one, and worth counting as a fresh
+        // appearance for analytics.
+        dismissed = false;
+        shownReported = false;
+        // Arm the settling window on the first new build; a no-op on later ones
+        // (the debounce is keyed to the first sighting, not re-armed per build).
+        startDebounce();
+      }
+      // Re-evaluate on EVERY report (not only on new builds): responses are the
+      // store's clock ticks, so an expired suppression window lets a pending
+      // update surface without a dedicated timer. No-op when nothing changed.
       emitChange();
     },
     dismiss() {
       dismissed = true;
+      writeTimestamp(
+        VERSION_UPDATE_SUPPRESSED_UNTIL_KEY,
+        now() + VERSION_UPDATE_DISMISS_SUPPRESSION_MS,
+      );
       emitChange();
     },
     markShownReported() {
       if (shownReported) return false;
       shownReported = true;
+      // The banner actually showed → start the persisted show throttle.
+      writeTimestamp(VERSION_UPDATE_LAST_SHOWN_AT_KEY, now());
       return true;
     },
   };

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -196,18 +196,27 @@ export function createVersionUpdateStore(
   };
 
   // Persisted suppression (LFE-14765). Checked only on the hidden→shown
-  // transition — never hides a banner already on screen.
+  // transition — never hides a banner already on screen. Values written by a
+  // clock that has since moved backward (correction, restored VM) are ignored
+  // rather than honored — a future-dated timestamp could otherwise suppress
+  // until the wall clock catches up, potentially far beyond the window.
   const isSuppressed = (): boolean => {
     const t = now();
     const lastShownAt = readTimestamp(VERSION_UPDATE_LAST_SHOWN_AT_KEY);
     if (
       lastShownAt !== null &&
+      lastShownAt <= t && // ignore future-dated
       t < lastShownAt + VERSION_UPDATE_SHOW_THROTTLE_MS
     ) {
       return true;
     }
     const suppressedUntil = readTimestamp(VERSION_UPDATE_SUPPRESSED_UNTIL_KEY);
-    return suppressedUntil !== null && t < suppressedUntil;
+    return (
+      suppressedUntil !== null &&
+      t < suppressedUntil &&
+      // A valid write is at most one dismiss window ahead of now.
+      suppressedUntil <= t + VERSION_UPDATE_DISMISS_SUPPRESSION_MS
+    );
   };
 
   const computeEligible = (): boolean =>

--- a/web/src/features/version-update/versionUpdateStore.ts
+++ b/web/src/features/version-update/versionUpdateStore.ts
@@ -21,16 +21,22 @@
  * seen — a settling window for the deploy to finish. This gate is combined at the
  * banner with a post-load grace (see `useAppSettled`); both must pass.
  *
- * Persisted suppression (LFE-14765): dismiss and the seen-build set live in
- * memory, so back-to-back deploys re-prompted every tab on every release — a
- * customer reported the banner reappearing after every reload. Two
- * localStorage-persisted gates (shared across reloads AND tabs) sit on top of
- * the gates above: the banner may APPEAR at most once per
- * {@link VERSION_UPDATE_SHOW_THROTTLE_MS}, and an explicit dismiss suppresses it
- * for {@link VERSION_UPDATE_DISMISS_SUPPRESSION_MS} — even for genuinely new
- * build ids. Both gate only the hidden→shown transition (a banner already on
- * screen never hides itself), and both degrade to the in-memory behavior when
- * storage is unavailable.
+ * Staleness gate + persisted suppression (LFE-14765): the banner exists so a
+ * long-lived stale tab does not 404 on code-split chunks — but dismiss and the
+ * seen-build set lived in memory, so back-to-back deploys re-prompted every tab
+ * on every release (a customer reported the banner reappearing after every
+ * reload). Prompting minutes after each deploy adds work for thousands of users
+ * without addressing chunk breakage, so the banner only appears at all once the
+ * running bundle has been superseded for at least
+ * {@link VERSION_UPDATE_MIN_STALENESS_MS} — measured from the FIRST observed
+ * differing build id for the running build, persisted across reloads and tabs.
+ * On top of that, two persisted suppression windows apply: at most one
+ * appearance per {@link VERSION_UPDATE_SHOW_THROTTLE_MS}, and an explicit
+ * dismiss stays quiet for {@link VERSION_UPDATE_DISMISS_SUPPRESSION_MS}, even
+ * for genuinely new build ids. All three gate only the hidden→shown transition
+ * (a banner already on screen never hides itself) and degrade to in-memory
+ * behavior when storage is unavailable. Keeping old bundles servable — the root
+ * cause of chunk 404s — is tracked separately.
  */
 
 /**
@@ -72,11 +78,27 @@ export const VERSION_UPDATE_SHOW_THROTTLE_MS = 2 * 60 * 60 * 1000;
  */
 export const VERSION_UPDATE_DISMISS_SUPPRESSION_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Minimum staleness (LFE-14765): the banner only appears at all once the
+ * running bundle has been superseded for at least this long. Measured from the
+ * first observed differing build id for the running build — "how long has this
+ * frontend been superseded", which is what actually breaks code-split chunks —
+ * not from a build timestamp (which would need deploy-pipeline support and
+ * measures age, not supersession).
+ */
+export const VERSION_UPDATE_MIN_STALENESS_MS = 48 * 60 * 60 * 1000;
+
 /** localStorage key: epoch ms of the banner's last actual appearance. */
 export const VERSION_UPDATE_LAST_SHOWN_AT_KEY = "version-update-last-shown-at";
 /** localStorage key: epoch ms until which an explicit dismiss suppresses the banner. */
 export const VERSION_UPDATE_SUPPRESSED_UNTIL_KEY =
   "version-update-suppressed-until";
+/**
+ * localStorage key: JSON `{ buildId, ts }` — when the RUNNING build (`buildId`)
+ * was first observed superseded. A single overwritten entry, not one key per
+ * build, so storage never accumulates.
+ */
+export const VERSION_UPDATE_STALE_SINCE_KEY = "version-update-stale-since";
 
 export type VersionUpdateStore = {
   /** Subscribe to snapshot changes (for `useSyncExternalStore`). */
@@ -84,8 +106,10 @@ export type VersionUpdateStore = {
   /**
    * Current snapshot: is an update available, not yet dismissed, AND has the
    * new-version debounce ({@link VERSION_UPDATE_DEBOUNCE_MS}) elapsed? A
-   * hidden→shown transition additionally requires the persisted suppression
-   * windows (show throttle / dismiss suppression, LFE-14765) to have expired.
+   * hidden→shown transition additionally requires the running build to have
+   * been superseded for at least {@link VERSION_UPDATE_MIN_STALENESS_MS} and
+   * the persisted suppression windows (show throttle / dismiss suppression,
+   * LFE-14765) to have expired.
    */
   getSnapshot: () => boolean;
   /** SSR snapshot — always `false`; the mismatch only exists in a live tab. */
@@ -121,6 +145,35 @@ export type VersionUpdateStore = {
 };
 
 /**
+ * Injection points for {@link createVersionUpdateStore} — everything
+ * time/persistence-related, so tests are deterministic. The app singleton uses
+ * the defaults.
+ */
+export type VersionUpdateStoreOptions = {
+  /**
+   * New-version settling window (default {@link VERSION_UPDATE_DEBOUNCE_MS}).
+   * A value ≤ 0 disables the debounce (the update is eligible as soon as it is
+   * available) and stays synchronous — no timer — which keeps the
+   * detection/stickiness tests free of fake timers.
+   */
+  debounceMs?: number;
+  /**
+   * How long the running build must have been superseded before the banner may
+   * appear (default {@link VERSION_UPDATE_MIN_STALENESS_MS}); ≤ 0 disables the
+   * staleness gate.
+   */
+  minStalenessMs?: number;
+  /** Clock backing the persisted gates (default `Date.now`). */
+  now?: () => number;
+  /**
+   * Lazy storage accessor — lazy because module scope must not touch `window`
+   * (SSR). May return `undefined` or throw (private mode, hardened contexts,
+   * quota): every access is guarded, degrading to in-memory behavior.
+   */
+  getStorage?: () => Pick<Storage, "getItem" | "setItem"> | undefined;
+};
+
+/**
  * Builds a version-update store. `getRunningBuildId` returns the build id of the
  * bundle this tab is running; injecting it (rather than reading the module-level
  * env directly) keeps the store deterministic and testable.
@@ -138,24 +191,18 @@ export type VersionUpdateStore = {
  * "a build ≠ yours exists → offer reload" is the right action even though we
  * can't prove the other build is strictly newer.
  *
- * `debounceMs` is the new-version settling window (default
- * {@link VERSION_UPDATE_DEBOUNCE_MS}); injected for deterministic testing. A
- * value ≤ 0 disables the debounce (the update shows as soon as it is available)
- * and stays synchronous — no timer — which keeps the detection/stickiness tests
- * free of fake timers.
- *
- * `now` and `getStorage` back the persisted suppression gates (LFE-14765);
- * injected for deterministic testing, like the parameters above. `getStorage`
- * is lazy (module scope must not touch `window` — SSR) and may return
- * `undefined` or throw (private mode, hardened contexts, quota): every access
- * is guarded, degrading to the pre-existing in-memory behavior.
+ * All time/persistence inputs are injected via {@link VersionUpdateStoreOptions}
+ * for deterministic testing; the app singleton uses the defaults.
  */
 export function createVersionUpdateStore(
   getRunningBuildId: () => string | null | undefined,
-  debounceMs: number = VERSION_UPDATE_DEBOUNCE_MS,
-  now: () => number = () => Date.now(),
-  getStorage: () => Pick<Storage, "getItem" | "setItem"> | undefined = () =>
-    typeof window === "undefined" ? undefined : window.localStorage,
+  {
+    debounceMs = VERSION_UPDATE_DEBOUNCE_MS,
+    minStalenessMs = VERSION_UPDATE_MIN_STALENESS_MS,
+    now = () => Date.now(),
+    getStorage = () =>
+      typeof window === "undefined" ? undefined : window.localStorage,
+  }: VersionUpdateStoreOptions = {},
 ): VersionUpdateStore {
   const listeners = new Set<() => void>();
   // Every build id observed that differs from the running one. Membership is
@@ -174,6 +221,10 @@ export function createVersionUpdateStore(
   // is eligible forever, and a later genuinely-new build re-prompts immediately.
   let debounceStarted = false;
   let debounceElapsed = false;
+  // When the RUNNING build was first observed superseded (epoch ms). Resolved
+  // once, on the first mismatch (see resolveStaleSince); later new builds do
+  // not move it — they don't make this tab any less stale.
+  let staleSince: number | null = null;
 
   // Guarded storage access: `getStorage` and Storage methods may throw. On any
   // failure reads yield null and writes are dropped — in-memory behavior only.
@@ -194,6 +245,48 @@ export function createVersionUpdateStore(
       // best-effort persistence; the in-memory gates still apply
     }
   };
+
+  // The staleness clock for the running build, shared across tabs/reloads via
+  // one JSON `{ buildId, ts }` entry. An entry for a DIFFERENT running build
+  // means the tab has since reloaded onto a new bundle → restart at now (and
+  // overwrite). A future-dated `ts` (clock moved backward since the write) is
+  // likewise restarted rather than honored. Unreadable/garbage → treat as
+  // absent; unwritable → the in-memory value still gates this tab.
+  const resolveStaleSince = (): number => {
+    const t = now();
+    const runningBuildId = getRunningBuildId();
+    try {
+      const raw = getStorage()?.getItem(VERSION_UPDATE_STALE_SINCE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as { buildId?: unknown; ts?: unknown };
+        if (
+          parsed &&
+          parsed.buildId === runningBuildId &&
+          typeof parsed.ts === "number" &&
+          Number.isFinite(parsed.ts) &&
+          parsed.ts <= t
+        ) {
+          return parsed.ts;
+        }
+      }
+    } catch {
+      // fall through to a fresh entry
+    }
+    try {
+      getStorage()?.setItem(
+        VERSION_UPDATE_STALE_SINCE_KEY,
+        JSON.stringify({ buildId: runningBuildId, ts: t }),
+      );
+    } catch {
+      // best-effort persistence; the in-memory value still applies
+    }
+    return t;
+  };
+
+  // Primary gate (LFE-14765): only a frontend superseded at least
+  // `minStalenessMs` ago may prompt at all.
+  const isStaleEnough = (): boolean =>
+    staleSince !== null && now() - staleSince >= minStalenessMs;
 
   // Persisted suppression (LFE-14765). Checked only on the hidden→shown
   // transition — never hides a banner already on screen. Values written by a
@@ -230,8 +323,10 @@ export function createVersionUpdateStore(
 
   const emitChange = () => {
     // A visible banner stays visible while eligible (`snapshot ||` — the
-    // suppression windows gate new appearances, not the current one).
-    const next = computeEligible() && (snapshot || !isSuppressed());
+    // staleness gate and suppression windows govern new appearances, not the
+    // current one).
+    const next =
+      computeEligible() && (snapshot || (isStaleEnough() && !isSuppressed()));
     if (next === snapshot) return;
     snapshot = next;
     for (const listener of listeners) listener();
@@ -278,6 +373,8 @@ export function createVersionUpdateStore(
       ) {
         seenDifferingBuildIds.add(observedBuildId);
         updateAvailable = true; // sticky
+        // First supersession of the running build → start the staleness clock.
+        if (staleSince === null) staleSince = resolveStaleSince();
         // A genuinely new (never-seen) differing build → worth re-prompting even
         // if the user dismissed an earlier one, and worth counting as a fresh
         // appearance for analytics.
@@ -288,8 +385,9 @@ export function createVersionUpdateStore(
         startDebounce();
       }
       // Re-evaluate on EVERY report (not only on new builds): responses are the
-      // store's clock ticks, so an expired suppression window lets a pending
-      // update surface without a dedicated timer. No-op when nothing changed.
+      // store's clock ticks, so maturing staleness and expired suppression
+      // windows surface a pending update without a dedicated timer. No-op when
+      // nothing changed.
       emitChange();
     },
     dismiss() {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15785.preview.langfuse.com](https://pr-15785.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The "new version" reload banner now only appears when the user's frontend is at least **48 hours stale** — i.e. the bundle the tab is running was first superseded by another build at least 48 h ago (persisted per running build, across reloads and tabs). On top of that primary gate, two secondary suppressions apply: the banner shows at most **once per 2 hours**, and an explicit dismiss silences it for **24 hours**, even for newer builds. A burst of releases no longer prompts anyone at all until their frontend has actually been stale for two days.

## Why

The banner exists so long-lived stale tabs don't 404 on code-split chunks. But dismissal and the seen-build set lived in memory, per tab, per build id — so on a day with three cloud releases in about an hour, every release re-armed the banner in every open tab, and a reload (the action the banner itself asks for) reset nothing. A customer reported the banner reappearing after every reload, and PostHog showed `version_update:banner_shown` spiking to ~1,600 events for ~1,300 users in two hours against a ~40–60/hour baseline.

Prompting thousands of users minutes after each deploy adds work without solving chunk breakage — a tab that reloads on release N is broken again by release N+1 either way. So the prompt is now reserved for frontends that have been superseded long enough to plausibly hit stale-chunk failures. Keeping old bundles servable — the actual root cause of chunk 404s — is tracked separately as an infra follow-up in LFE-14767.

Closes [LFE-14765](https://linear.app/clickhouse/issue/LFE-14765). Builds on the banner introduced in LFE-10978 and the new-version debounce from LFE-14537.

## What

**Primary gate — 48 h staleness.** "Stale" means: a build id different from the running one was FIRST observed at least `VERSION_UPDATE_MIN_STALENESS_MS` (48 h) ago, for the current running build id. The first-superseded-at timestamp is persisted as a single `{buildId, ts}` localStorage entry keyed to the running build: after a reload onto a new bundle the stored entry no longer matches, so the clock restarts correctly (and one overwritten entry means no unbounded key growth). This measures supersession — the thing that actually breaks chunks — rather than bundle age, needs no CI/deploy-pipeline changes, and works self-hosted.

**Secondary suppressions**, layered on the existing gates (3-min new-version debounce, 60-s post-load settle, sticky mismatch detection, and per-build dismiss semantics are all unchanged):

- **Show throttle** — when the banner actually appears, the timestamp is recorded; a new appearance is blocked until 2 h have passed. Shared across tabs and reloads.
- **Dismiss suppression** — clicking X suppresses the banner for 24 h, including for genuinely new build ids arriving in that window.

All three gate only the hidden→shown transition (a banner already on screen never hides itself), and all degrade gracefully to in-memory behavior when localStorage is unavailable or throwing (SSR, private mode, quota) — a storage-less tab that stays open 48 h past its first observed mismatch still prompts.

## Result

Release bursts stop prompting users whose frontend is hours old; only genuinely stale frontends (48 h+ superseded) are asked to reload, at most once per 2 h, and "not now" means a full day of quiet. `banner_shown` analytics keep firing exactly once per real appearance, so the change is directly measurable against the baseline.

<details>
<summary>Mechanism, design constraints, and test matrix</summary>

**Mechanism**

- The store factory injects a clock (`now`) and a lazy storage accessor via an options object (`debounceMs`, `minStalenessMs`, `now`, `getStorage`), keeping it deterministic for tests; nothing touches `window` at module scope.
- The stale-since entry is resolved once, on the first observed mismatch: a stored entry for the same running build id is adopted (older timestamp wins — that tab was already stale); an entry for a different running build, a future-dated `ts`, or garbage is overwritten with `{buildId: runningBuildId, ts: now}`. Later new build ids never move it — they don't make the tab less stale.
- The last-shown timestamp is written in `markShownReported()` — the existing once-per-appearance guard the banner component calls when it really renders — so the throttle and the `banner_shown` event share one definition of "appeared".
- Gate maturity and expiry need no timer: `reportObservedBuildId` re-evaluates the snapshot on every tRPC response (each response carries `x-build-id`), so maturing staleness and expired suppression windows surface the pending update on the next response. In a fully idle tab that means the banner surfaces when the user next touches the tab (React Query refetch-on-focus triggers a response) — an intended trade-off, and with a 48 h horizon a non-issue: any active tab receives responses constantly. The steady no-update state performs zero storage reads.
- `getSnapshot` remains a cached primitive, preserving the `useSyncExternalStore` referential-stability contract; visibility transitions are computed as `eligible && (alreadyVisible || (staleEnough && !suppressed))`.
- All storage access is wrapped in try/catch; unreadable or garbage values are treated as absent. Future-dated timestamps (a clock that has since moved backward — correction, restored VM) are ignored or restarted at now, so skew fails open (the banner may show once more) instead of suppressing until the wall clock catches up.

**Tests** (all client-side, deterministic: fake storage + injected clock; mechanics tests disable the staleness gate so each pins one behavior — 12 store tests + 6 banner tests)

- Staleness: no banner on first mismatch even with the other gates open, surfaces on the next response after 48 h; a reload of the SAME running build keeps the original stale-since; a reload onto a NEW running build restarts the clock and overwrites the entry.
- Throttle: a second appearance within 2 h is blocked across a simulated reload (new store instance, same storage) and allowed after expiry; the stamp is recorded on the actual appearance; a visible banner is never hidden by the windows.
- Dismiss: hides the visible banner; suppresses genuinely new builds for 24 h across reloads; expiry re-allows; storage-less dismissal keeps the legacy per-build re-show semantics.
- Legacy pins: mismatch detection, sticky/flap-free signal across rolling-deploy pods, debounce keyed to the first sighting, `banner_shown` once per appearance.
- Degrade: throwing storage falls back to the exact in-memory behavior; a future-dated last-shown stamp is ignored, not clamped.
- Banner integration through a real store instance: no render and no `banner_shown` before 48 h of staleness, exactly one `banner_shown` on appearance; dismiss captures, hides, and persists its window.

Verified with the full web client test project (2871 passed), typecheck, and lint.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
