### PR TITLE
fix: trim whitespace from email in auth forms and on the server

### DIFF
--- a/web/src/__tests__/server/credentials-server-utils.servertest.ts
+++ b/web/src/__tests__/server/credentials-server-utils.servertest.ts
@@ -1,0 +1,49 @@
+import { prisma } from "@langfuse/shared/src/db";
+import { createUserEmailPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
+import { v4 } from "uuid";
+
+describe("createUserEmailPassword", () => {
+  const createdUserIds: string[] = [];
+
+  afterAll(async () => {
+    if (createdUserIds.length === 0) return;
+    // Memberships are only created when default orgs/projects are configured;
+    // clear them defensively so the user row can be deleted regardless.
+    await prisma.organizationMembership.deleteMany({
+      where: { userId: { in: createdUserIds } },
+    });
+    await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
+  });
+
+  it("trims and lowercases the email before storing it (#15780)", async () => {
+    const unique = v4().slice(0, 8);
+    const rawEmail = `  Whitespace.${unique}@Example.com  `;
+    const expected = `whitespace.${unique}@example.com`;
+
+    const userId = await createUserEmailPassword(
+      rawEmail,
+      "password123",
+      "Test User",
+    );
+    createdUserIds.push(userId);
+
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    expect(user?.email).toBe(expected);
+  });
+
+  it("treats a whitespace-padded duplicate as the same existing user (#15780)", async () => {
+    const unique = v4().slice(0, 8);
+    const email = `dup.${unique}@example.com`;
+
+    const userId = await createUserEmailPassword(
+      email,
+      "password123",
+      "Test User",
+    );
+    createdUserIds.push(userId);
+
+    await expect(
+      createUserEmailPassword(`  ${email}  `, "password123", "Test User"),
+    ).rejects.toThrow(/already exists/i);
+  });
+});

--- a/web/src/__tests__/server/signup-schema-unicode-name.servertest.ts
+++ b/web/src/__tests__/server/signup-schema-unicode-name.servertest.ts
@@ -95,6 +95,25 @@ describe("signupSchema name validation", () => {
     expect(result.success).toBe(false);
   });
 
+  it("trims surrounding whitespace from the email before validating (#15780)", () => {
+    for (const email of [
+      "test@example.com ",
+      " test@example.com",
+      "\ttest@example.com\t",
+    ]) {
+      const result = signupSchema.safeParse({
+        ...validBaseInput,
+        name: "André",
+        email,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.email).toBe("test@example.com");
+      }
+    }
+  });
+
   it("rejects names with disallowed punctuation", () => {
     const result = signupSchema.safeParse({
       ...validBaseInput,

--- a/web/src/__tests__/server/unit/email-schema.servertest.ts
+++ b/web/src/__tests__/server/unit/email-schema.servertest.ts
@@ -1,0 +1,50 @@
+import {
+  emailSchema,
+  normalizeEmail,
+} from "@/src/features/auth/lib/emailSchema";
+
+describe("emailSchema", () => {
+  it("trims leading, trailing and tab whitespace before validating (#15780)", () => {
+    for (const input of [
+      "user@example.com ",
+      " user@example.com",
+      "\tuser@example.com\t",
+      "  user@example.com  ",
+    ]) {
+      const result = emailSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("user@example.com");
+      }
+    }
+  });
+
+  it("accepts a clean email unchanged", () => {
+    const result = emailSchema.safeParse("user@example.com");
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe("user@example.com");
+  });
+
+  it("preserves case (the server lowercases on lookup)", () => {
+    const result = emailSchema.safeParse("User@Example.com ");
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe("User@Example.com");
+  });
+
+  it("still rejects a value that is not an email", () => {
+    for (const input of ["not-an-email ", "   ", "user@", "@example.com"]) {
+      expect(emailSchema.safeParse(input).success).toBe(false);
+    }
+  });
+});
+
+describe("normalizeEmail", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeEmail("  User@Example.COM ")).toBe("user@example.com");
+    expect(normalizeEmail("\tuser@example.com\n")).toBe("user@example.com");
+  });
+
+  it("leaves an already-normalized email unchanged", () => {
+    expect(normalizeEmail("user@example.com")).toBe("user@example.com");
+  });
+});

--- a/web/src/__tests__/server/unit/signup-verify-email-normalization.servertest.ts
+++ b/web/src/__tests__/server/unit/signup-verify-email-normalization.servertest.ts
@@ -1,0 +1,126 @@
+const mockEnv = vi.hoisted(() => ({
+  env: {
+    LANGFUSE_NEW_USER_SIGNUP_WEBHOOK: undefined as string | undefined,
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined as string | undefined,
+  },
+}));
+
+vi.mock("@/src/env.mjs", () => mockEnv);
+
+const {
+  isEmailVerificationRequiredMock,
+  validateSignupEligibilityMock,
+  createProjectMembershipsOnSignupMock,
+  findUniqueMock,
+  createMock,
+} = vi.hoisted(() => ({
+  isEmailVerificationRequiredMock: vi.fn(),
+  validateSignupEligibilityMock: vi.fn(),
+  createProjectMembershipsOnSignupMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+  createMock: vi.fn(),
+}));
+
+vi.mock("@/src/features/auth-credentials/lib/credentialsUtils", () => ({
+  isEmailVerificationRequired: isEmailVerificationRequiredMock,
+}));
+
+vi.mock("@/src/features/auth-credentials/server/signupApiHandler", () => ({
+  validateSignupEligibility: validateSignupEligibilityMock,
+}));
+
+vi.mock("@/src/features/auth/lib/createProjectMembershipsOnSignup", () => ({
+  createProjectMembershipsOnSignup: createProjectMembershipsOnSignupMock,
+}));
+
+vi.mock("@/src/features/auth/lib/signupAttribution", () => ({
+  getGclidFromRequest: vi.fn(() => undefined),
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: { user: { findUnique: findUniqueMock, create: createMock } },
+}));
+
+import handler from "@/src/pages/api/auth/signup-verify";
+import { type NextApiRequest, type NextApiResponse } from "next";
+
+const makeReqRes = (body: unknown) => {
+  const json = vi.fn();
+  const end = vi.fn();
+  const status = vi.fn().mockReturnValue({ json, end });
+  const req = {
+    method: "POST",
+    body,
+    headers: {},
+    cookies: {},
+  } as unknown as NextApiRequest;
+  const res = {
+    status,
+    setHeader: vi.fn(),
+  } as unknown as NextApiResponse;
+  return { req, res, status, json };
+};
+
+describe("POST /api/auth/signup-verify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isEmailVerificationRequiredMock.mockReturnValue(true);
+    validateSignupEligibilityMock.mockResolvedValue(null);
+    findUniqueMock.mockResolvedValue(null);
+    createMock.mockResolvedValue({ id: "user-1" });
+    createProjectMembershipsOnSignupMock.mockResolvedValue(undefined);
+  });
+
+  it("accepts a whitespace-padded email and normalizes it once (#15780)", async () => {
+    const { req, res, status } = makeReqRes({
+      email: "  User@Example.COM  ",
+      name: "Jane Doe",
+    });
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(200);
+    // The SSO-eligibility check, the duplicate lookup and the write must all
+    // read the same normalized value, otherwise a trailing space could skip
+    // domain-based SSO enforcement while still matching an account.
+    expect(validateSignupEligibilityMock).toHaveBeenCalledWith({
+      email: "user@example.com",
+    });
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { email: "user@example.com" },
+    });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ email: "user@example.com" }),
+      }),
+    );
+  });
+
+  it("treats a whitespace-padded duplicate as the same existing user (#15780)", async () => {
+    findUniqueMock.mockResolvedValue({ id: "user-1", password: "hashed" });
+    const { req, res, status, json } = makeReqRes({
+      email: " existing@example.com ",
+      name: "Jane Doe",
+    });
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(422);
+    expect(json).toHaveBeenCalledWith({
+      message: "User with email already exists. Please sign in.",
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("still rejects a value that is not an email", async () => {
+    const { req, res, status } = makeReqRes({
+      email: "not-an-email",
+      name: "Jane Doe",
+    });
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(422);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
@@ -3,8 +3,8 @@ import { signIn, useSession } from "next-auth/react";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import { useState } from "react";
-import { z } from "zod";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { emailSchema } from "@/src/features/auth/lib/emailSchema";
 import { env } from "@/src/env.mjs";
 
 export function RequestResetPasswordEmailButton({
@@ -24,10 +24,13 @@ export function RequestResetPasswordEmailButton({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const session = useSession();
   const capture = usePostHogClientCapture();
-  const isValidEmail = z.email().safeParse(email).success;
+  // Trim before validating so a pasted email with a stray space still passes
+  // the guard, and send the trimmed value to the reset request (#15780).
+  const parsedEmail = emailSchema.safeParse(email);
+  const isValidEmail = parsedEmail.success;
 
   const handleResetPassword = async () => {
-    if (!isValidEmail) return;
+    if (!parsedEmail.success) return;
     capture("auth:reset_password_email_requested");
     setIsLoading(true);
     setErrorMessage(null);
@@ -36,7 +39,7 @@ export function RequestResetPasswordEmailButton({
         ? `${env.NEXT_PUBLIC_BASE_PATH ?? ""}${callbackUrl}`
         : `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/reset-password`;
       const res = await signIn("email", {
-        email: email,
+        email: parsedEmail.data,
         callbackUrl: targetCallbackUrl,
         redirect: false,
       });

--- a/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
@@ -4,7 +4,10 @@ import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import { useState } from "react";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { emailSchema } from "@/src/features/auth/lib/emailSchema";
+import {
+  emailSchema,
+  normalizeEmail,
+} from "@/src/features/auth/lib/emailSchema";
 import { env } from "@/src/env.mjs";
 
 export function RequestResetPasswordEmailButton({
@@ -65,7 +68,7 @@ export function RequestResetPasswordEmailButton({
     setIsLoading(true);
     setErrorMessage(null);
     try {
-      const formattedEmail = encodeURIComponent(email.toLowerCase().trim());
+      const formattedEmail = encodeURIComponent(normalizeEmail(email));
       const formattedCode = encodeURIComponent(code.trim());
       const targetCb = callbackUrl
         ? `${env.NEXT_PUBLIC_BASE_PATH ?? ""}${callbackUrl}`

--- a/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
@@ -26,11 +26,12 @@ import Link from "next/link";
 import { ErrorPage } from "@/src/components/error-page";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { passwordSchema } from "@/src/features/auth/lib/signupSchema";
+import { emailSchema } from "@/src/features/auth/lib/emailSchema";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 
 const resetPasswordSchema = z
   .object({
-    email: z.email(),
+    email: emailSchema,
     password: passwordSchema,
     confirmPassword: passwordSchema,
   })
@@ -169,6 +170,7 @@ export function ResetPasswordPage({
                       <FormControl>
                         <div className="relative">
                           <Input
+                            type="email"
                             placeholder="jsdoe@example.com"
                             disabled={session.status === "authenticated"}
                             allowPasswordManager

--- a/web/src/features/auth-credentials/lib/credentialsServerUtils.ts
+++ b/web/src/features/auth-credentials/lib/credentialsServerUtils.ts
@@ -1,4 +1,5 @@
 import { createProjectMembershipsOnSignup } from "@/src/features/auth/lib/createProjectMembershipsOnSignup";
+import { normalizeEmail } from "@/src/features/auth/lib/emailSchema";
 import { prisma } from "@langfuse/shared/src/db";
 import { compare, hash } from "bcryptjs";
 
@@ -23,11 +24,15 @@ export async function createUserEmailPassword(
   if (!isValidPassword(password))
     throw new Error("Password needs to be at least 8 characters long.");
 
+  // Normalize once so the duplicate check and the write agree, and so a stray
+  // trailing space never gets persisted as part of the address (#15780).
+  const normalizedEmail = normalizeEmail(email);
+
   const hashedPassword = await hashPassword(password);
   // check that no user exists with this email
   const user = await prisma.user.findUnique({
     where: {
-      email: email.toLowerCase(),
+      email: normalizedEmail,
     },
   });
   if (user !== null) {
@@ -40,7 +45,7 @@ export async function createUserEmailPassword(
 
   const newUser = await prisma.user.create({
     data: {
-      email: email.toLowerCase(),
+      email: normalizedEmail,
       password: hashedPassword,
       name,
     },

--- a/web/src/features/auth/lib/emailSchema.ts
+++ b/web/src/features/auth/lib/emailSchema.ts
@@ -1,0 +1,23 @@
+import * as z from "zod";
+
+/**
+ * Email field schema for the auth forms.
+ *
+ * Strips leading/trailing whitespace before validating, so an address pasted
+ * with a stray space or entered on a mobile keyboard that appends one is
+ * accepted instead of failing with "Invalid email address" (issue #15780).
+ * Case is preserved here for display; the server lowercases on lookup/write
+ * via {@link normalizeEmail}.
+ */
+export const emailSchema = z.string().trim().pipe(z.email());
+
+/**
+ * Normalize an email for storage and lookup: strip surrounding whitespace and
+ * lowercase. Use this once, up front, wherever an email is turned into a
+ * database key — both the user lookup and any domain-derived SSO checks must
+ * read the same normalized value, otherwise a trailing space could skip SSO
+ * enforcement while still matching a user (issue #15780).
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}

--- a/web/src/features/auth/lib/signupSchema.ts
+++ b/web/src/features/auth/lib/signupSchema.ts
@@ -1,5 +1,6 @@
 import { noUrlCheck, StringNoHTMLNonEmpty } from "@langfuse/shared";
 import * as z from "zod";
+import { emailSchema } from "@/src/features/auth/lib/emailSchema";
 
 export const passwordSchema = z
   .string()
@@ -32,7 +33,7 @@ export const nameSchema = StringNoHTMLNonEmpty.max(
 
 export const signupSchema = z.object({
   name: nameSchema,
-  email: z.email(),
+  email: emailSchema,
   password: passwordSchema,
   referralSource: z.string().optional(),
 });

--- a/web/src/pages/api/auth/signup-verify.ts
+++ b/web/src/pages/api/auth/signup-verify.ts
@@ -2,6 +2,10 @@ import { env } from "@/src/env.mjs";
 import { isEmailVerificationRequired } from "@/src/features/auth-credentials/lib/credentialsUtils";
 import { validateSignupEligibility } from "@/src/features/auth-credentials/server/signupApiHandler";
 import { createProjectMembershipsOnSignup } from "@/src/features/auth/lib/createProjectMembershipsOnSignup";
+import {
+  emailSchema,
+  normalizeEmail,
+} from "@/src/features/auth/lib/emailSchema";
 import { getGclidFromRequest } from "@/src/features/auth/lib/signupAttribution";
 import { prisma } from "@langfuse/shared/src/db";
 import { logger } from "@langfuse/shared/src/server";
@@ -10,7 +14,7 @@ import { z } from "zod/v4";
 import { noUrlCheck, StringNoHTMLNonEmpty } from "@langfuse/shared";
 
 const signupVerifySchema = z.object({
-  email: z.email(),
+  email: emailSchema,
   name: StringNoHTMLNonEmpty.refine((value) => noUrlCheck(value), {
     message: "Input should not contain a URL",
   }).refine((value) => /^[a-zA-Z0-9\s]+$/.test(value), {
@@ -44,7 +48,7 @@ export default async function handler(
   }
 
   const { email, name } = parsed.data;
-  const normalizedEmail = email.toLowerCase();
+  const normalizedEmail = normalizeEmail(email);
 
   // Run eligibility checks (signup disabled, SSO enforcement, etc.)
   const eligibilityError = await validateSignupEligibility({

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -17,11 +17,12 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
+import { emailSchema } from "@/src/features/auth/lib/emailSchema";
 import { env } from "@/src/env.mjs";
 import { captureUnknownError } from "@/src/utils/captureUnknownError";
 
 const enterpriseSsoFormSchema = z.object({
-  email: z.email(),
+  email: emailSchema,
 });
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -166,6 +167,7 @@ export default function EnterpriseSsoRequiredPage() {
                     <FormLabel>Email</FormLabel>
                     <FormControl>
                       <Input
+                        type="email"
                         placeholder="jsdoe@example.com"
                         allowPasswordManager
                         autoComplete="email"

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -31,6 +31,7 @@ import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
+import { emailSchema } from "@/src/features/auth/lib/emailSchema";
 import { CloudPrivacyNotice } from "@/src/features/auth/components/AuthCloudPrivacyNotice";
 import { CloudRegionSwitch } from "@/src/features/auth/components/AuthCloudRegionSwitch";
 import { PasswordInput } from "@/src/components/ui/password-input";
@@ -56,7 +57,7 @@ const PREVIEW_DEMO_USER_EMAIL = "demo@langfuse.com";
 const PREVIEW_DEMO_USER_PASSWORD = "password";
 
 const credentialAuthForm = z.object({
-  email: z.email(),
+  email: emailSchema,
   password: z.string().min(8, {
     message: "Password must be at least 8 characters long",
   }),
@@ -721,8 +722,8 @@ export default function SignIn({
     setCredentialsFormError(null);
     credentialsForm.clearErrors();
 
-    // Ensure email is valid before hitting the API
-    const emailSchema = z.email();
+    // Ensure email is valid before hitting the API. emailSchema trims, so the
+    // domain we derive below matches what the server will normalize to.
     const email = emailSchema.safeParse(credentialsForm.getValues("email"));
     if (!email.success) {
       credentialsForm.setError("email", {
@@ -848,6 +849,7 @@ export default function SignIn({
                           <FormLabel>Email</FormLabel>
                           <FormControl>
                             <Input
+                              type="email"
                               placeholder="jsdoe@example.com"
                               allowPasswordManager
                               autoComplete="email"

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { signupSchema } from "@/src/features/auth/lib/signupSchema";
+import { emailSchema } from "@/src/features/auth/lib/emailSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { signIn } from "next-auth/react";
 import Head from "next/head";
@@ -46,7 +47,7 @@ const signupVerifyFormSchema = z.object({
   }).refine((value) => /^[a-zA-Z0-9\s]+$/.test(value), {
     message: "Name can only contain letters, numbers, and spaces",
   }),
-  email: z.email(),
+  email: emailSchema,
 });
 
 type SignupPhase = "form" | "otp";
@@ -119,19 +120,11 @@ function StandardSignupFlow({
     setFormError(null);
     form.clearErrors();
 
-    // Ensure email is valid before hitting the API
-    // We use z.email() manually because we don't use the full schema resolver in the first step
-    // or we could just trigger validation for the email field only
+    // Ensure email is valid before hitting the API. We validate the email field
+    // on its own here because this first step does not run the full signup
+    // schema resolver (name/password are not filled yet). emailSchema trims, so
+    // the domain we derive below matches what the server will normalize to.
     const emailValue = form.getValues("email");
-    // Basic check using zod directly or trigger
-    // Using trigger("email") might validate against the full schema if we don't be careful,
-    // but since we conditionally set the resolver, it might be tricky.
-    // Simplest is manual check here matching what sign-in does.
-    // Note: signupSchema has name and password as required, so trigger() would fail on those if using full schema.
-
-    // Manual email validation to match sign-in behavior
-    // Although signupSchema.shape.email is ZodString, let's just use a new Zod check for simplicity and robustness
-    const emailSchema = z.email();
     const emailResult = emailSchema.safeParse(emailValue);
 
     if (!emailResult.success) {
@@ -259,6 +252,7 @@ function StandardSignupFlow({
                 <FormLabel>Email</FormLabel>
                 <FormControl>
                   <Input
+                    type="email"
                     placeholder="jsdoe@example.com"
                     allowPasswordManager
                     autoComplete="email"
@@ -504,6 +498,7 @@ function VerifiedSignupFlow({
                 <FormLabel>Email</FormLabel>
                 <FormControl>
                   <Input
+                    type="email"
                     placeholder="jsdoe@example.com"
                     allowPasswordManager
                     autoComplete="email"

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -9,7 +9,10 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { signupSchema } from "@/src/features/auth/lib/signupSchema";
-import { emailSchema } from "@/src/features/auth/lib/emailSchema";
+import {
+  emailSchema,
+  normalizeEmail,
+} from "@/src/features/auth/lib/emailSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { signIn } from "next-auth/react";
 import Head from "next/head";
@@ -385,7 +388,7 @@ function VerifiedSignupFlow({
     setOtpLoading(true);
     setOtpError(null);
 
-    const formattedEmail = encodeURIComponent(otpEmail.toLowerCase().trim());
+    const formattedEmail = encodeURIComponent(normalizeEmail(otpEmail));
     const formattedCode = encodeURIComponent(otpCode.trim());
     const callback = encodeURIComponent(
       `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/setup-password`,

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -13,6 +13,7 @@ import {
 import { parseFlags } from "@/src/features/feature-flags/utils";
 import { env } from "@/src/env.mjs";
 import { createProjectMembershipsOnSignup } from "@/src/features/auth/lib/createProjectMembershipsOnSignup";
+import { normalizeEmail } from "@/src/features/auth/lib/emailSchema";
 import {
   type AdapterUser,
   type Adapter,
@@ -87,8 +88,14 @@ const staticProviders: Provider[] = [
           "Sign in with email and password is disabled for this instance. Please use SSO.",
         );
 
+      // Normalize once so the SSO-enforcement checks and the user lookup all
+      // read the same value. Trimming only the lookup would let a trailing
+      // space skip domain-based SSO enforcement while still matching a user
+      // (#15780).
+      const email = normalizeEmail(credentials.email);
+
       const blockedDomains = getSSOBlockedDomains();
-      const domain = credentials.email.split("@")[1]?.toLowerCase();
+      const domain = email.split("@")[1];
       if (domain && blockedDomains.includes(domain)) {
         throw new Error(
           "Sign in with email and password is disabled for this domain. Please use SSO.",
@@ -104,7 +111,7 @@ const staticProviders: Provider[] = [
 
       const dbUser = await prisma.user.findUnique({
         where: {
-          email: credentials.email.toLowerCase(),
+          email,
         },
       });
 


### PR DESCRIPTION
## What does this PR do?

Signing in with email/password fails when the email has a leading or trailing space (from a paste, or a mobile keyboard that appends one): the form rejects it with "Invalid email address" even though the address is correct. The whitespace is invisible, so it's hard to diagnose. The same gap exists on sign-up, password reset, and the enterprise-SSO-required page.

Fixes langfuse/langfuse#15780

### Cause

* The email inputs are not `type="email"`, so the browser's value-sanitization (which strips surrounding whitespace for `type=email`) never runs — they render as `type="text"`.
* The form schemas use bare `z.email()`, which rejects any leading/trailing whitespace with no `.trim()` first:

  ```
  z.email().safeParse("user@example.com ")                         -> invalid
  z.string().trim().pipe(z.email()).safeParse("user@example.com ") -> valid
  ```
* The server doesn't trim either. `authorize()` and `createUserEmailPassword()` `.toLowerCase()` but never `.trim()`, so a request that bypasses the client fails the user lookup.

### Fix

* **Shared schema.** New `web/src/features/auth/lib/emailSchema.ts` exports `emailSchema` (`z.string().trim().pipe(z.email())`) and a `normalizeEmail(email)` helper (trim + lowercase). Adopted in sign-in, sign-up, `signupSchema`, password-reset and enterprise-SSO, including the two-step SSO handlers that validate `getValues("email")` directly.
* `type="email"` **on the email inputs**, so the browser strips whitespace as a second layer.
* **Server normalization, once, up front.** `authorize()` computes `normalizeEmail(credentials.email)` once and uses it for both the SSO-enforcement domain extraction and the user lookup; `createUserEmailPassword()` does the same for the duplicate check and the write.

### Why normalize once (security)

`authorize()` derives the SSO-enforcement domain from the email (`email.split("@")[1]`). Trimming only the user lookup would let `user@corp.com ` skip domain-based SSO enforcement while still matching the account — a bypass. Normalizing up front keeps the domain check and the lookup reading the same value, so this can't drift.

### Scope note

The NextAuth `signIn` callback (`auth.ts`, another bare `z.email()`) is intentionally left unchanged: it only ever sees provider-supplied OAuth emails or the already-normalized value returned by `authorize()`, never user-typed whitespace.

### Design choice

The shared schema lives in `web/src/features/auth/lib/` (next to `signupSchema.ts`) rather than `packages/shared`, since it's only consumed by web auth today. Happy to move it if a maintainer prefers.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code.

## Tests

The failing test was written first and confirmed red before the fix:

* `web/src/__tests__/server/unit/email-schema.servertest.ts` (new): `emailSchema` trims leading/trailing/tab whitespace, preserves case, still rejects non-emails; `normalizeEmail` trims and lowercases.
* `web/src/__tests__/server/signup-schema-unicode-name.servertest.ts`: added a case asserting `signupSchema` trims surrounding whitespace from the email (was failing before the schema change).
* `web/src/__tests__/server/credentials-server-utils.servertest.ts` (new): `createUserEmailPassword` stores a trimmed, lowercased email, and treats a whitespace-padded duplicate as the same existing user.

Local runs: `typecheck` and `lint` both `7 successful, 7 total`; the three test files `22 passed (22)`.

Also verified end to end in a browser: on `/auth/sign-in`, entering `demo@langfuse.com ` (trailing space) plus the correct password now signs in and lands on the app, where before it showed "Invalid email address" and never submitted.

<details><summary>Greptile Summary</summary>

The PR consistently trims user-entered email addresses across credential authentication forms and server-side credential lookup and creation, while lowercasing database keys. It also keeps SSO domain enforcement and user lookup on the same normalized value.

* Adds a shared email schema and normalization helper.
* Applies trimmed email validation and native email input types across sign-in, sign-up, password-reset, and enterprise SSO forms.
* Normalizes credential sign-in and account creation before SSO checks, duplicate checks, lookup, and persistence.
* Adds focused schema and credential-creation tests.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge with no actionable changed-code defects identified.

Email normalization is applied consistently at the form and credential-server boundaries, and the SSO domain check and database operations consume the same normalized identity.

</details>

Reviews (1): Last reviewed commit: ["fix: trim whitespace from email in auth ..."](<https://github.com/langfuse/langfuse/commit/6a4e02c9a1c3e3e0f00361266524ba10df2994d6>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=50207095>)

**Context used:**

* Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md>)