### PR TITLE
fix: read parts[].content in the Gemini ChatML adapter

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/gemini.ts
+++ b/packages/shared/src/utils/chatml/adapters/gemini.ts
@@ -141,6 +141,19 @@ function extractFromParts(parts: unknown[]): {
       continue;
     }
 
+    // OTel GenAI text parts carry the text under `content` instead of `text`,
+    // e.g. {type: "text", content: "..."}. Read it like the generic adapter
+    // does so the message body is not dropped (#15790). Only a string content
+    // is a text part; object content is a tool result handled elsewhere.
+    if (typeof p.content === "string") {
+      if (p.thought === true) {
+        thinkingParts.push({ content: p.content });
+      } else {
+        textParts.push(p.content);
+      }
+      continue;
+    }
+
     // {function_response: {name, response}} OR {functionResponse: {name, response}}
     const fr = getField(p, "function_response", "functionResponse");
     if (fr && typeof fr === "object") {

--- a/worker/src/__tests__/chatml/adapters/gemini.test.ts
+++ b/worker/src/__tests__/chatml/adapters/gemini.test.ts
@@ -194,6 +194,40 @@ describe("geminiAdapter", () => {
       expect(toolCall.args).toBeUndefined();
     });
 
+    it("should extract text from OTel GenAI parts using the 'content' field (#15790)", () => {
+      // OTel GenAI messages carry the text under parts[].content rather than
+      // parts[].text. The Gemini adapter must read both, like the generic one.
+      const input = [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Hello" }],
+          finish_reason: "stop",
+        },
+      ];
+
+      const result = geminiAdapter.preprocess(input, "input", {}) as any[];
+
+      expect(result.length).toBe(1);
+      expect(result[0].role).toBe("assistant");
+      expect(result[0].content).toBe("Hello");
+      expect(result[0].finish_reason).toBe("stop");
+      // parts is consumed once its text is extracted
+      expect(result[0].parts).toBeUndefined();
+    });
+
+    it("should still prefer parts[].text when both text and content are present (#15790)", () => {
+      const input = [
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "from-text", content: "from-content" }],
+        },
+      ];
+
+      const result = geminiAdapter.preprocess(input, "input", {}) as any[];
+
+      expect(result[0].content).toBe("from-text");
+    });
+
     it("should handle Google ADK format with tool calls and function responses", () => {
       // This is the format from google-adk-2025-08-28.json
       const input = {


### PR DESCRIPTION
## What does this PR do?

When an observation name contains `gemini`, the Gemini ChatML adapter is selected. OTel GenAI messages carry a part's text under `parts[].content` (`{"type": "text", "content": "Hello"}`), but the Gemini adapter only read `parts[].text`. The text was therefore never extracted, and because the adapter deletes `parts` after processing them, the formatted preview ended up with no message body — even though the raw JSON was stored correctly.

Fixes #15790

### Cause

`extractFromParts` in `packages/shared/src/utils/chatml/adapters/gemini.ts` handles `parts[].text` but has no branch for `parts[].content`. The generic adapter (`generic.ts`) already reads both:

```ts
if (p.text) return p.text;
if (p.content && typeof p.content === "string") return p.content;
```

So a part shaped like `{type: "text", content: "Hello"}` falls through every branch and contributes nothing, then `delete normalized.parts` removes the source data.

### Fix

Add a string-`content` branch to `extractFromParts`, right after the existing `text` branch:

- Reads `parts[].content` only when it is a string (an object `content` is a tool result, handled by the existing tool-result logic — left untouched).
- `text` still takes precedence when a part has both.
- Respects Gemini's `thought: true` flag, so thinking content routes the same way it does for `text`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Tests

The failing test was written first and confirmed red before the fix (`expected undefined to be 'Hello'`):

- `worker/src/__tests__/chatml/adapters/gemini.test.ts`:
  - extracts text from an OTel GenAI part using `content` (the issue's exact example) — was failing, now passes.
  - still prefers `parts[].text` when both `text` and `content` are present — guards the precedence.

Local runs: `typecheck` `7 successful, 7 total`; `lint` clean for shared and worker; the Gemini adapter suite `14 passed`; the full chatml suite `124 passed (124)` with no regressions.

This is a pure normalization function, so it is verified through the adapter's unit tests rather than a browser session; a live repro would require a seeded trace with a gemini-named observation carrying OTel `parts`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Gemini ChatML normalization so OTel GenAI text stored in `parts[].content` is preserved in formatted message previews.
- Extracts string-valued `content` while retaining `text` precedence and thought-part routing.
- Adds regression coverage for OTel content extraction and mixed `text`/`content` precedence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the reported Gemini OTel normalization gap fixed by a focused and tested fallback.

String-valued `parts[].content` is now normalized through the same text and thought paths as `parts[].text`, while existing precedence and structured response handling remain intact for supported payload shapes.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: read parts\[\].content in the Gemini ..."](https://github.com/langfuse/langfuse/commit/e02d26ea52cf6207e2ed7cddd811c067541a16d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50210572)</sub>

<!-- /greptile_comment -->