### PR TITLE
fix(otel): reject non-array attributes and events with a 400

### DIFF
--- a/packages/shared/src/server/otel/utils.test.ts
+++ b/packages/shared/src/server/otel/utils.test.ts
@@ -160,6 +160,109 @@ describe("validateOtelSpanIds", () => {
     });
   });
 
+  // The production payload (prod-us, 2026-08-04): a hand-rolled exporter that
+  // serializes span attributes as a JSON object instead of an OTLP KeyValue
+  // list. Every id is valid hex and both collections are arrays, so the id
+  // checks wave it through — and then extractSpanAttributes reduces over the
+  // object in the worker and fails the file through all six attempts.
+  it("rejects span attributes serialized as a JSON object", () => {
+    const result = validateOtelSpanIds([
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "ai-control-plane" } },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: "ai-control-plane.agent", version: "1.0.0" },
+            spans: [
+              {
+                traceId: "631d6c6420ad4a7598b5f496f614c8b5",
+                spanId: "424e9dc6ea864dee",
+                parentSpanId: "f51a5c11ad4f4a96",
+                name: "Capability: document_retrieval",
+                kind: "INTERNAL",
+                startTimeUnixNano: "1785884062122000000",
+                attributes: {
+                  "capability.id": "document_retrieval",
+                  "run.id": "agent-1785884041268-eou2re",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(result).toMatchObject({ totalSpanCount: 1, invalidSpanCount: 1 });
+    expect(result.reasonCounts).toEqual({ "attributes:not_an_array": 1 });
+    expect(result.scopeNames).toEqual(["ai-control-plane.agent"]);
+  });
+
+  // The worker reduces over span attributes and filters over span events, so a
+  // present-but-non-array value in any of them throws there just like a bad id.
+  // Each is attributable to a span, so each counts as an invalid span and keeps
+  // the endpoint's discardedValidSpans invariant exact.
+  it.each([
+    {
+      shape: "object attributes",
+      span: {
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        attributes: { "run.id": "agent-1" },
+      },
+      reason: "attributes:not_an_array",
+    },
+    {
+      shape: "object events",
+      span: { traceId: TRACE_ID, spanId: SPAN_ID, events: {} },
+      reason: "events:not_an_array",
+    },
+    {
+      shape: "object attributes on a span event",
+      span: {
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        events: [{ name: "gen_ai.choice", attributes: { role: "assistant" } }],
+      },
+      reason: "event.attributes:not_an_array",
+    },
+  ])("rejects a span with $shape", ({ span, reason }) => {
+    const result = validateOtelSpanIds(wrap([span]));
+    expect(result).toMatchObject({ totalSpanCount: 1, invalidSpanCount: 1 });
+    expect(result.reasons).toEqual([reason]);
+    expect(result.scopeNames).toEqual(["my-tracer"]);
+  });
+
+  // Resource and scope attributes are reduced before any span is touched, so
+  // they fail the file even when the subtree holds no spans at all. There is no
+  // span to attribute them to, so they land in malformedCollectionCount.
+  it.each([
+    {
+      shape: "the resource",
+      payload: [{ resource: { attributes: {} }, scopeSpans: [] }],
+      reason: "resource.attributes:not_an_array",
+    },
+    {
+      shape: "the instrumentation scope",
+      payload: [
+        {
+          scopeSpans: [
+            { scope: { name: "my-tracer", attributes: {} }, spans: [] },
+          ],
+        },
+      ],
+      reason: "scope.attributes:not_an_array",
+    },
+  ])("rejects non-array attributes on $shape", ({ payload, reason }) => {
+    const result = validateOtelSpanIds(payload);
+    expect(result).toMatchObject({
+      invalidSpanCount: 0,
+      malformedCollectionCount: 1,
+    });
+    expect(result.reasons).toEqual([reason]);
+  });
+
   // Absent and empty collections are legitimate and must stay accepted.
   it.each([
     { shape: "non-array", payload: undefined },
@@ -169,6 +272,29 @@ describe("validateOtelSpanIds", () => {
       payload: [{ scopeSpans: [{ scope: null, spans: null }] }],
     },
     { shape: "empty spans", payload: [{ scopeSpans: [{ spans: [] }] }] },
+    // Over-rejection guard: the overwhelming majority of real exports omit or
+    // empty these, and flagging them would 400 traffic that ingests fine today.
+    {
+      shape: "absent and empty attributes and events",
+      payload: [
+        {
+          resource: {},
+          scopeSpans: [
+            {
+              scope: { name: "my-tracer", attributes: [] },
+              spans: [
+                {
+                  traceId: TRACE_ID,
+                  spanId: SPAN_ID,
+                  attributes: [],
+                  events: [{ name: "gen_ai.choice" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ])("accepts $shape", ({ payload }) => {
     const result = validateOtelSpanIds(payload);
     expect(result.invalidSpanCount).toBe(0);

--- a/packages/shared/src/server/otel/utils.ts
+++ b/packages/shared/src/server/otel/utils.ts
@@ -41,13 +41,25 @@ export function getOtelIdRejectionReason(
   return "not_an_id";
 }
 
+/**
+ * Whether an OTLP field that must hold a list — `attributes`, `events`,
+ * `scopeSpans`, `spans` — is present but not an array. Absent and empty are
+ * legitimate and stay valid; only a present, non-array value is a defect.
+ */
+function isMalformedList(value: unknown): boolean {
+  return value !== null && value !== undefined && !Array.isArray(value);
+}
+
 export interface OtelSpanIdValidationResult {
   totalSpanCount: number;
   invalidSpanCount: number;
   /**
-   * `scopeSpans`/`spans` fields that are present but not arrays. Counted
-   * separately from `invalidSpanCount` because there is no span to attribute
-   * them to — the collection that would hold the spans is itself unusable.
+   * `scopeSpans`/`spans` fields that are present but not arrays, and non-array
+   * `attributes` on a resource or an instrumentation scope. Counted separately
+   * from `invalidSpanCount` because there is no span to attribute them to —
+   * either the collection that would hold the spans is itself unusable, or the
+   * defect sits above the spans and fails the export even when the subtree
+   * holds none.
    */
   malformedCollectionCount: number;
   /**
@@ -56,9 +68,9 @@ export interface OtelSpanIdValidationResult {
    *
    * A span with both a bad traceId and a bad spanId counts once under each, so
    * these can sum above `invalidSpanCount`. The key set is bounded by
-   * construction (the id fields x the reason union, plus the two
-   * `not_an_array` keys), which is what makes it safe to use as a metric tag
-   * and why it is not sampled.
+   * construction (the id fields x the reason union, plus the `not_an_array`
+   * keys), which is what makes it safe to use as a metric tag and why it is not
+   * sampled.
    */
   reasonCounts: Record<string, number>;
   /** Deduped `<field>:<reason>` pairs, e.g. "traceId:absent". */
@@ -70,8 +82,8 @@ export interface OtelSpanIdValidationResult {
 /**
  * Walk a decoded OTLP trace export and report everything that makes it
  * unprocessable downstream: spans whose traceId, spanId or (when present)
- * parentSpanId cannot be converted, and `scopeSpans`/`spans` fields that are
- * present but not arrays.
+ * parentSpanId cannot be converted, and `scopeSpans`, `spans`, `attributes` or
+ * `events` fields that are present but not arrays.
  *
  * An unconvertible id throws ERR_INVALID_ARG_TYPE in parseId, failing the queue
  * job through every retry attempt. The dominant real-world source is an OTLP
@@ -79,11 +91,19 @@ export interface OtelSpanIdValidationResult {
  * share protobuf field numbers, so log records decode into spans that carry a
  * valid instrumentation scope but no ids at all.
  *
- * Non-array collections cannot be converted either: the worker iterates the
- * same fields behind a `?? []` fallback, which does not guard a non-nullish
- * non-array, so `for...of` throws there and the job fails through every retry.
- * Reporting them here lets the endpoint reject the payload instead. Absent and
- * empty collections stay valid — only a present, non-array value is a defect.
+ * Non-array collections cannot be converted either. The worker iterates
+ * `scopeSpans`/`spans` behind a `?? []` fallback, which does not guard a
+ * non-nullish non-array, so `for...of` throws; it reduces over `attributes`
+ * (resource, scope, span and span-event level) and filters over `events`, which
+ * throw on anything without those methods. The observed source is a hand-rolled
+ * OTLP/JSON exporter emitting attributes as a `{key: value}` object instead of a
+ * KeyValue list — only reachable over `application/json`, since a protobuf
+ * decode always materializes repeated fields as arrays.
+ *
+ * Reporting all of it here lets the endpoint reject the payload with a 400
+ * instead of accepting it and losing the whole file six attempts later. Absent
+ * and empty collections stay valid — only a present, non-array value is a
+ * defect.
  */
 export function validateOtelSpanIds(
   resourceSpans: unknown,
@@ -110,7 +130,20 @@ export function validateOtelSpanIds(
     };
   }
 
+  const sampleScopeName = (scopeName: unknown) => {
+    if (scopeName && scopeNames.size < maxSamples) {
+      scopeNames.add(String(scopeName));
+    }
+  };
+
   for (const resourceSpan of resourceSpans) {
+    // extractResourceAttributes reduces this before any span is reached, so a
+    // map-shaped one fails the export even for a resource carrying no spans.
+    if (isMalformedList((resourceSpan as any)?.resource?.attributes)) {
+      malformedCollectionCount++;
+      countReason("resource.attributes:not_an_array");
+    }
+
     // Never hand a non-array to for...of: a `?? []` fallback does not guard a
     // non-nullish non-iterable (`{}`, a number), and this runs on the request
     // path, so throwing here would surface as a 500 rather than a rejection.
@@ -124,15 +157,20 @@ export function validateOtelSpanIds(
     }
 
     for (const scopeSpan of scopeSpans) {
+      // Same as the resource: extractScopeAttributes runs per scopeSpan,
+      // independently of how many spans it holds.
+      if (isMalformedList(scopeSpan?.scope?.attributes)) {
+        malformedCollectionCount++;
+        countReason("scope.attributes:not_an_array");
+        sampleScopeName(scopeSpan?.scope?.name);
+      }
+
       const spans = scopeSpan?.spans;
       if (!Array.isArray(spans)) {
         if (spans !== null && spans !== undefined) {
           malformedCollectionCount++;
           countReason("spans:not_an_array");
-          const malformedScope = scopeSpan?.scope?.name;
-          if (malformedScope && scopeNames.size < maxSamples) {
-            scopeNames.add(String(malformedScope));
-          }
+          sampleScopeName(scopeSpan?.scope?.name);
         }
         continue;
       }
@@ -152,14 +190,30 @@ export function validateOtelSpanIds(
           const reason = getOtelIdRejectionReason(span.parentSpanId);
           if (reason) spanReasons.push(`parentSpanId:${reason}`);
         }
+
+        // Attributed to the span rather than counted as a malformed collection,
+        // so that a span carrying one stays outside the endpoint's
+        // discardedValidSpans invariant — it is genuinely unprocessable, not a
+        // valid span caught by a batch rejection.
+        if (isMalformedList(span?.attributes)) {
+          spanReasons.push("attributes:not_an_array");
+        }
+        if (isMalformedList(span?.events)) {
+          spanReasons.push("events:not_an_array");
+        } else if (Array.isArray(span?.events)) {
+          // One bad event is enough to fail the span, and the reason is the same
+          // for every further one, so stop at the first.
+          if (
+            span.events.some((event: any) => isMalformedList(event?.attributes))
+          )
+            spanReasons.push("event.attributes:not_an_array");
+        }
+
         if (spanReasons.length === 0) continue;
 
         invalidSpanCount++;
         spanReasons.forEach(countReason);
-        const scopeName = scopeSpan?.scope?.name;
-        if (scopeName && scopeNames.size < maxSamples) {
-          scopeNames.add(String(scopeName));
-        }
+        sampleScopeName(scopeSpan?.scope?.name);
       }
     }
   }

--- a/web/src/__tests__/server/otel-api.servertest.ts
+++ b/web/src/__tests__/server/otel-api.servertest.ts
@@ -519,9 +519,55 @@ describe("/api/public/otel/v1/traces API Endpoint", () => {
 
     expect(response.status).toBe(400);
     expect(response.body.error).toContain("2 of 2 span(s)");
-    expect(response.body.error).toContain("1 scopeSpans/spans field(s)");
+    expect(response.body.error).toContain(
+      "1 resource- or scope-level field(s)",
+    );
     expect(response.body.error).toContain("scopeSpans:not_an_array");
     expect(response.body.error).toContain("uvicorn.access");
+  });
+
+  // The prod-us shape: ids are valid hex and every collection is an array
+  // except the span attributes, which a hand-rolled OTLP/JSON exporter emitted
+  // as a {key: value} object. It cleared the id validation and then failed in
+  // the worker on attributes.reduce, losing the file after all six attempts.
+  it("should reject span attributes sent as a JSON object", async () => {
+    const response = await makeAPICall<{ error: string }>(
+      "POST",
+      "/api/public/otel/v1/traces",
+      {
+        resourceSpans: [
+          {
+            resource: {
+              attributes: [
+                {
+                  key: "service.name",
+                  value: { stringValue: "ai-control-plane" },
+                },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "ai-control-plane.agent", version: "1.0.0" },
+                spans: [
+                  {
+                    traceId: randomBytes(16).toString("hex"),
+                    spanId: randomBytes(8).toString("hex"),
+                    name: "Capability: document_retrieval",
+                    attributes: { "capability.id": "document_retrieval" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain("1 of 1 span(s)");
+    expect(response.body.error).toContain("attributes:not_an_array");
+    expect(response.body.error).toContain("not a JSON object");
+    expect(response.body.error).toContain("ai-control-plane.agent");
   });
 
   // An OTLP *logs* export pointed at this endpoint. ResourceLogs and

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -113,16 +113,18 @@ export default withMiddlewares({
       }
 
       // Reject payloads the worker cannot convert: spans whose traceId/spanId is
-      // missing or malformed, and scopeSpans/spans fields that are present but
-      // not arrays. Both fail in the worker — parseId throws
+      // missing or malformed, and scopeSpans/spans/attributes/events fields that
+      // are present but not arrays. All fail in the worker — parseId throws
       // ERR_INVALID_ARG_TYPE or yields a truncated id, and a non-array
-      // collection throws on for...of — so the job burns all six attempts before
-      // being dropped anyway. Failing here returns a non-retryable status
-      // instead.
+      // collection throws on for...of, reduce or filter — so the job burns all
+      // six attempts before being dropped anyway. Failing here returns a
+      // non-retryable status instead.
       //
       // The common source is an OTLP *logs* export pointed at this endpoint.
       // ResourceLogs and ResourceSpans share protobuf field numbers, so log
       // records decode into spans with a valid instrumentation scope but no ids.
+      // The other observed source is a hand-rolled OTLP/JSON exporter writing
+      // attributes as a {key: value} object rather than a KeyValue list.
       //
       // One invalid span means the whole export is almost certainly malformed,
       // so the batch is rejected as a unit and the response says so explicitly
@@ -164,9 +166,17 @@ export default withMiddlewares({
         // totalSpanCount. Any gap means this rejection just discarded spans
         // that would have ingested fine, which is data loss and invalidates
         // the assumption — escalate so it cannot pass unnoticed among warns.
+        //
+        // Only meaningful when every defect was span-attributable. A malformed
+        // resource- or scope-level collection fails its whole subtree in the
+        // worker no matter how sound the individual spans underneath are, so
+        // counting those spans as discarded-but-valid would be a false alarm.
         const discardedValidSpans =
           idValidation.totalSpanCount - idValidation.invalidSpanCount;
-        if (discardedValidSpans > 0) {
+        if (
+          discardedValidSpans > 0 &&
+          idValidation.malformedCollectionCount === 0
+        ) {
           logger.error(
             "Rejected OTEL trace export contained valid spans — batch rejection discarded them",
             { ...rejectionContext, discardedValidSpans },
@@ -177,14 +187,39 @@ export default withMiddlewares({
         if (idValidation.invalidSpanCount > 0) {
           problems.push(
             `${idValidation.invalidSpanCount} of ${idValidation.totalSpanCount} ` +
-              `span(s) are missing a traceId or spanId, or carry one that cannot ` +
-              `be decoded — each must be a string or a byte array`,
+              `span(s) cannot be processed`,
           );
         }
         if (idValidation.malformedCollectionCount > 0) {
           problems.push(
-            `${idValidation.malformedCollectionCount} scopeSpans/spans field(s) ` +
-              `are present but not arrays`,
+            `${idValidation.malformedCollectionCount} resource- or scope-level ` +
+              `field(s) are present but not arrays`,
+          );
+        }
+
+        // Name the contract that was broken, so a hand-rolled exporter can be
+        // corrected from the response alone rather than by guessing at the
+        // reason keys.
+        const hints: string[] = [];
+        if (
+          idValidation.reasons.some(
+            (reason) =>
+              reason.endsWith(":absent") || reason.endsWith(":not_an_id"),
+          )
+        ) {
+          hints.push(
+            `traceId and spanId are required on every span, and each must be a ` +
+              `string or a byte array.`,
+          );
+        }
+        if (
+          idValidation.reasons.some((reason) =>
+            reason.endsWith(":not_an_array"),
+          )
+        ) {
+          hints.push(
+            `scopeSpans, spans, attributes and events must all be arrays — OTLP ` +
+              `attributes are a list of {key, value} entries, not a JSON object.`,
           );
         }
 
@@ -192,8 +227,8 @@ export default withMiddlewares({
         return {
           error:
             `Invalid OTLP trace export: ${problems.join("; ")} ` +
-            `(${idValidation.reasons.join(", ")}). The entire export was rejected ` +
-            `and no spans were ingested. ` +
+            `(${idValidation.reasons.join(", ")}). ${hints.join(" ")} ` +
+            `The entire export was rejected and no spans were ingested. ` +
             `Instrumentation scopes: ${idValidation.scopeNames.join(", ") || "unknown"}. ` +
             `This endpoint accepts OpenTelemetry traces only — if you are exporting ` +
             `OpenTelemetry logs, point your log exporter elsewhere.`,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15793.preview.langfuse.com](https://pr-15793.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Closes the remaining hole in the OTLP validation gate added by #15707, which was live in prod-us and prod-eu on v4.4.0 but only checked ids and non-array `scopeSpans`/`spans`.

A span whose `attributes` is present but **not an array** cleared that gate and then crashed the worker, because `extractSpanAttributes` reduces over the value behind an optional chain that only guards null/undefined:

```
TypeError: span?.attributes?.reduce is not a function
    at OtelIngestionProcessor.extractSpanAttributes (OtelIngestionProcessor.js:823:35)
```

One such span fails the **whole S3 file** on both write paths — `processToIngestionEvents` swallows and writes nothing ([otelIngestionQueue.ts:337](https://github.com/langfuse/langfuse/blob/main/worker/src/queues/otelIngestionQueue.ts#L337)), then `processToEvent` rethrows ([:522](https://github.com/langfuse/langfuse/blob/main/worker/src/queues/otelIngestionQueue.ts#L522)) and burns all six queue attempts — while the client received a success response. Silent data loss.

### Observed in production

prod-us, 2026-08-04 22:20–22:37 UTC: **36 files from one project** (`cmsf5iluj0gqyad0dv35p4sws`), instrumentation scope `ai-control-plane.agent`, `spanCount` 1 each; 2 more files on Jul 25 from another project. Zero occurrences in prod-eu/jp/hipaa over 14 days.

The payload, from a hand-rolled OTLP/JSON exporter (`sdkName` `unknown`, i.e. no `x-langfuse-sdk-name`):

```json
{"spans":[{"traceId":"631d…c8b5","spanId":"424e…4dee","parentSpanId":"f51a…4a96",
  "name":"Capability: document_retrieval",
  "attributes":{"capability.id":"document_retrieval","run.id":"agent-…"}}]}
```

Ids are valid hex and `resource.attributes` is a proper array — which is exactly why it passed the id gate. This is only reachable over `application/json`, since a protobuf decode always materializes repeated fields as arrays.

## What changed

- `validateOtelSpanIds` now also reports present-but-non-array `attributes` at **resource, scope, span and span-event** level, plus a non-array `events`. Each of these is separately confirmed to crash the worker (`reduce` on attributes, `filter` on events).
  - **Span-level** defects are attributed to the span (`invalidSpanCount`), so they stay inside the endpoint's `discardedValidSpans` invariant.
  - **Resource/scope-level** defects are counted as malformed collections, since they fail their whole subtree even when it holds no spans at all.
- The 400 response now names the broken contract: *"OTLP attributes are a list of {key, value} entries, not a JSON object."*
- The `discardedValidSpans` **error** escalation no longer fires when a malformed resource- or scope-level collection is present — that defect fails every span underneath regardless, so calling them valid-but-discarded is a false alarm. This was pre-existing for non-array `scopeSpans`/`spans`.

Absent and empty collections stay valid throughout; only a present, non-array value is a defect. There is an explicit over-rejection regression case for that.

## Reviewer notes

- **No Fern change needed** — `fern/apis/server/definition/opentelemetry.yml` already declares `attributes` as `optional<list<OtelAttribute>>`, so this enforces the published contract rather than narrowing it.
- The metric name `langfuse.ingestion.otel.rejected_invalid_span_ids` is left alone to keep dashboard continuity; the `reason` tag carries the new values (`attributes:not_an_array`, …). The function name is likewise now narrower than its behavior — happy to rename in a follow-up if preferred.
- **Still open, deliberately out of scope:** the worker has no per-span isolation, so one malformed span drops the whole file. That is the shared root cause behind this class, the #15707 class, and the still-live `Cannot read properties of undefined (reading 'stringValue')` class (a KeyValue entry with no `value`, ~30 hits in prod-eu). This PR stops the payload at the door; it does not cap blast radius for the next unknown shape.
- The 38 already-failed S3 files are retained and replayable, but replaying them now would just re-crash — worth doing only after the worker tolerates these shapes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

Red-first: the 6 new validator cases were confirmed failing against the old behavior (`Tests 6 failed | 37 passed (43)`) before the fix.

- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `pnpm --filter @langfuse/shared run test utils.test.ts` → `Tests 43 passed (43)`
- `pnpm --filter worker run test otelConversionFailureLogging.test.ts` → `Tests 3 passed (3)`
- Targeted servertests against a local dev server, incl. the new end-to-end case for this payload → `should reject span attributes sent as a JSON object` and `should reject unprocessable spans and non-array collections` both pass

Not run: the full `otel-api.servertest.ts` file (the ingestion happy-path tests). CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends OTLP request validation to reject present-but-non-array attributes and events before malformed exports reach the worker.

- Validates resource, scope, span, and span-event attributes plus span events.
- Attributes span-local defects to invalid spans and higher-level defects to malformed collections.
- Improves client-facing 400 responses and adds unit and endpoint regression coverage.
- Adjusts discarded-valid-span escalation for higher-level malformed collections.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking observability gap for mixed exports containing a malformed subtree alongside valid spans.

The new validation rejects the targeted worker-crashing shapes before queue publication, but the blanket malformedCollectionCount guard can hide the dedicated valid-span data-loss escalation for unaffected sibling subtrees.

**Files Needing Attention:** web/src/pages/api/public/otel/v1/traces/index.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[OTLP client] --> Decode[Decode JSON or protobuf]
  Decode --> Validate[Validate IDs and list-shaped fields]
  Validate -->|Malformed| Reject[HTTP 400; nothing queued]
  Validate -->|Valid| Stage[Stage raw export in S3]
  Stage --> Queue[OTel ingestion queue]
  Queue --> Worker[Convert spans and write events]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/pages/api/public/otel/v1/traces/index.ts:176-179
**Overbroad escalation suppression**

When one resource or scope subtree is malformed while a sibling subtree contains valid spans, `malformedCollectionCount === 0` suppresses the dedicated `discardedValidSpans` error for the entire rejected export. Those valid sibling spans are still discarded, so this mixed-batch data loss receives only the generic warning and loses the intended operational escalation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): reject non-array attributes a..."](https://github.com/langfuse/langfuse/commit/f59de9689b9257fa02f121e56a8775df2fdd73f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50260584)</sub>

**Context used:**

- Knowledge Base — [Ingestion Pipeline: SDK/OTel Event to ClickHouse](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/ingestion-pipeline.md)
- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->