### PR TITLE
docs(contributing): replace broken clickhouse binary install with docker shim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Requirements
 - Node.js 24 as specified in the [.nvmrc](.nvmrc)
 - Pnpm v.11.10.0
 - Docker to run the database locally
-- Clickhouse client
+- ClickHouse client access (set up via the Docker shim in step 1)
 
 **Note:** You can also simply run Langfuse in a **GitHub Codespace** via the provided devcontainer. To do this, click on the green "Code" button in the top right corner of the repository and select "Open with Codespaces".
 
@@ -201,7 +201,28 @@ When you change the shared MCP setup:
 
 1. Install development dependencies:
    - [golang-migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#migrate-cli) as CLI
-   - [clickhouse binary](https://clickhouse.com/docs/install) on macOS with brew: `curl https://clickhouse.com/ | sh`
+   - ClickHouse client via the dev container. The official ClickHouse binary
+     installers are currently unreliable on macOS (the Homebrew cask removes
+     itself and leaves a large quarantined binary). Instead, create a small shim
+     that invokes the `clickhouse` client already inside the running Docker
+     container:
+
+     ```bash
+     mkdir -p ~/.local/bin
+     cat > ~/.local/bin/clickhouse <<'EOF'
+     #!/usr/bin/env bash
+     exec docker exec -i "${CLICKHOUSE_CONTAINER_NAME:-langfuse-clickhouse}" clickhouse "$@"
+     EOF
+     chmod +x ~/.local/bin/clickhouse
+     ```
+
+     Make sure `~/.local/bin` is on your `PATH` (or choose another directory that
+     is). The dev containers started later by `pnpm run dx` or
+     `pnpm run infra:dev:up` expose ClickHouse under the default
+     `langfuse-clickhouse` container name. If you override
+     `CLICKHOUSE_CONTAINER_NAME` in `.env`, the shim respects that override, so
+     `pnpm run ch:dev-tables` and other ClickHouse scripts work without
+     installing a separate 800 MB binary.
 
 2. Fork the repository and clone it locally
 


### PR DESCRIPTION
## What does this PR do?

Updates "CONTRIBUTING.md" to document the Docker-based ClickHouse client shim that CI already uses, instead of the broken official binary / Homebrew cask path.

The official "curl https://clickhouse.com/ | sh" / "brew install --cask clickhouse" path currently installs a deprecated cask that removes itself and leaves an 815 MB quarantined binary. The repo's dev container already provides the ClickHouse client binary, so contributors can use a 76-byte shim: "docker exec -i langfuse-clickhouse clickhouse \"\"".

This is the separate CONTRIBUTING.md fix that the reporter of #15751 suggested sending if the skill in #15752 stays focused on ".agents/skills/".

Relates to #15751

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the contributor setup instructions to use the ClickHouse client bundled in the development container instead of an unreliable native macOS installation.
- Adds a small executable shim that forwards ClickHouse commands and standard input through `docker exec`.
- Documents the required `PATH` setup and the development commands that start ClickHouse.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation change is safe to merge, with a non-blocking compatibility issue for contributors who customize the ClickHouse container name.

The shim matches the repository’s working CI setup and correctly forwards arguments and standard input, but hardcoding the default container name makes it inconsistent with the configurable development Compose service.

**Files Needing Attention:** CONTRIBUTING.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
CONTRIBUTING.md:213
**Hardcoded ClickHouse container name**

The shim always targets `langfuse-clickhouse`, while the development Compose configuration supports overriding `CLICKHOUSE_CONTAINER_NAME`; contributors using that override receive a missing-container error when running `pnpm run ch:dev-tables`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(contributing): replace broken click..."](https://github.com/langfuse/langfuse/commit/02ee1c050a5f684b7296f17aed69f59cde200d18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50303616)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->