### PR TITLE
fix(observations): use outputUsage/totalUsage in tokensPerSecond cell

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1148,15 +1148,15 @@ export default function ObservationsTable({
           cell: ({ row }) => {
             const latency: number | undefined = row.getValue("latency");
             const usage: {
-              promptTokens: number;
-              completionTokens: number;
-              totalTokens: number;
+              inputUsage: number;
+              outputUsage: number;
+              totalUsage: number;
             } = row.getValue("usage");
             return latency !== undefined &&
-              (usage.completionTokens !== 0 || usage.totalTokens !== 0) ? (
+              (usage.outputUsage !== 0 || usage.totalUsage !== 0) ? (
               <span>
-                {usage.completionTokens && latency
-                  ? Number((usage.completionTokens / latency).toFixed(1))
+                {usage.outputUsage && latency
+                  ? Number((usage.outputUsage / latency).toFixed(1))
                   : undefined}
               </span>
             ) : undefined;


### PR DESCRIPTION
## Summary

The **Tokens per second** column in the Generations/Observations table was permanently blank even when output tokens and latency were both populated.

**Root cause:** The `tokensPerSecond` cell renderer destructured `{ completionTokens, totalTokens }` from the `usage` row value. Those field names were replaced by `{ inputUsage, outputUsage, totalUsage }` when the usage shape was migrated. Because the old names resolved to `undefined`, the conditional `(usage.completionTokens !== 0 || usage.totalTokens !== 0)` always evaluated to false and the cell rendered nothing.

The adjacent **Input Tokens** and **Output Tokens** columns (lines 1178-1201) already use the correct field names — only the `tokensPerSecond` cell was left on the old names.

## Change

Update the type annotation and all three field references in the `tokensPerSecond` cell renderer to use `outputUsage` and `totalUsage`.

Fixes #14913

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes the observations table’s Tokens per second cell after the usage-field migration.

- Replaces stale `completionTokens` and `totalTokens` references with `outputUsage` and `totalUsage`.
- Updates the renderer’s local usage type to match `ObservationsTableRow`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the renderer now reads the usage fields supplied by observation table rows.

The focused field-name correction restores the existing output-token-over-latency calculation without changing the table’s data flow or public contracts.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observations): use outputUsage/total..."](https://github.com/langfuse/langfuse/commit/22ff7dd0bdfedd3e7ea1e09ed82ffccc3a41e59a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50328997)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->