### PR TITLE
fix(in-app-agent): preserve context across approval continuations

### DIFF
--- a/packages/shared/src/features/inAppAgent/types.ts
+++ b/packages/shared/src/features/inAppAgent/types.ts
@@ -83,6 +83,8 @@ export const InAppAgentRunRequestSchema = z.discriminatedUnion("kind", [
     parentRunId: z.string(),
     toolCallId: z.string(),
     approved: z.boolean(),
+    /** Inherited sanitized context; defaults for legacy continuation rows. */
+    context: z.array(AgUiContextSchema).default([]),
   }),
 ]);
 

--- a/packages/shared/src/in-app-agent/server/runLifecycle.ts
+++ b/packages/shared/src/in-app-agent/server/runLifecycle.ts
@@ -9,7 +9,10 @@ import type { InAppAgentRun, PrismaClient } from "../../db";
 import { logger } from "../../server";
 import { buildInAppAgentApprovalDecisionEvent } from "../backgroundWatch";
 import type { AgUiEvent } from "../schema";
-import type { InAppAgentRunRequest } from "../../features/inAppAgent/types";
+import {
+  InAppAgentRunRequestSchema,
+  type InAppAgentRunRequest,
+} from "../../features/inAppAgent/types";
 import {
   ACTIVE_RUN_CONFLICT_MESSAGE,
   FOREGROUND_RUN_STALE_AFTER_MS,
@@ -212,7 +215,7 @@ export async function decideToolApproval(params: {
         projectId: params.projectId,
         conversationId: params.conversationId,
       },
-      select: { status: true, finishedAt: true },
+      select: { status: true, finishedAt: true, request: true },
     });
 
     if (
@@ -261,6 +264,10 @@ export async function decideToolApproval(params: {
       );
     }
 
+    const parentRequest = InAppAgentRunRequestSchema.safeParse(
+      parentRun.request,
+    );
+
     await appendConversationEventInTransaction({
       tx,
       projectId: params.projectId,
@@ -286,6 +293,7 @@ export async function decideToolApproval(params: {
           parentRunId: params.parentRunId,
           toolCallId: params.toolCallId,
           approved: params.approved,
+          context: parentRequest.success ? parentRequest.data.context : [],
         },
       }),
     };

--- a/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
@@ -168,6 +168,7 @@ describe("in-app agent background runs", () => {
     conversationId: string;
     userId: string;
     toolCallId: string;
+    context?: Array<{ description: string; value: string }>;
     parkedAt?: Date;
   }) => {
     const runId = createInAppAgentRunId();
@@ -180,7 +181,10 @@ describe("in-app agent background runs", () => {
         triggeredByUserId: params.userId,
         status: InAppAgentRunStatus.AWAITING_APPROVAL,
         finishedAt: params.parkedAt ?? new Date(),
-        request: { kind: "userMessage", context: [] },
+        request: {
+          kind: "userMessage",
+          context: params.context ?? [],
+        },
       },
     });
 
@@ -320,11 +324,19 @@ describe("in-app agent background runs", () => {
   it("decides an approval exactly once and reads the tool args server-side", async () => {
     const { caller, projectId, userId } = await createCaller();
     const conversation = await createConversation({ projectId, userId });
+    const context = [
+      {
+        description: "current_url",
+        value: '{"pathname":"/project/project-1/traces"}',
+      },
+      { description: "user_name", value: "Agent User" },
+    ];
     const parkedRunId = await parkRunForApproval({
       projectId,
       conversationId: conversation.id,
       userId,
       toolCallId: "tool-call-1",
+      context,
     });
 
     const { runId: continuationRunId } = await caller.decideToolApproval({
@@ -351,6 +363,7 @@ describe("in-app agent background runs", () => {
       parentRunId: parkedRunId,
       toolCallId: "tool-call-1",
       approved: true,
+      context,
     });
 
     const decisionEvent = await prisma.inAppAgentEvent.findFirstOrThrow({
@@ -385,6 +398,83 @@ describe("in-app agent background runs", () => {
         },
       }),
     ).toBe(1);
+  });
+
+  it("preserves context through an approved then rejected chained continuation", async () => {
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({ projectId, userId });
+    const context = [
+      {
+        description: "current_url",
+        value:
+          '{"pathname":"/project/project-1/traces","search":"?filter=error"}',
+      },
+      { description: "current_timezone", value: "Europe/Berlin" },
+    ];
+    const initialRunId = await parkRunForApproval({
+      projectId,
+      conversationId: conversation.id,
+      userId,
+      toolCallId: "tool-call-1",
+      context,
+    });
+
+    const { runId: approvedContinuationId } = await caller.decideToolApproval({
+      projectId,
+      conversationId: conversation.id,
+      runId: initialRunId,
+      toolCallId: "tool-call-1",
+      approved: true,
+    });
+
+    await prisma.inAppAgentRun.update({
+      where: {
+        id_projectId: { id: approvedContinuationId, projectId },
+      },
+      data: {
+        status: InAppAgentRunStatus.AWAITING_APPROVAL,
+        finishedAt: new Date(),
+      },
+    });
+    await prisma.inAppAgentEvent.create({
+      data: {
+        projectId,
+        conversationId: conversation.id,
+        runId: approvedContinuationId,
+        sequenceNumber: 2,
+        type: EventType.CUSTOM,
+        event: {
+          type: EventType.CUSTOM,
+          name: "on_interrupt",
+          value: {
+            type: "mastra_suspend",
+            toolCallId: "tool-call-2",
+            toolName: "langfuse_createTextPrompt",
+            args: { name: "second-tool" },
+            runId: approvedContinuationId,
+          },
+        },
+      },
+    });
+
+    const { runId: rejectedContinuationId } = await caller.decideToolApproval({
+      projectId,
+      conversationId: conversation.id,
+      runId: approvedContinuationId,
+      toolCallId: "tool-call-2",
+      approved: false,
+    });
+
+    const rejectedContinuation = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: rejectedContinuationId, projectId },
+    });
+    expect(rejectedContinuation.request).toMatchObject({
+      kind: "approvalDecision",
+      parentRunId: approvedContinuationId,
+      toolCallId: "tool-call-2",
+      approved: false,
+      context,
+    });
   });
 
   it("rate-limits approval continuations before persisting or enqueueing them", async () => {

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
@@ -22,7 +22,12 @@ vi.hoisted(() => {
  * MCP-key lifecycle, event persistence — runs against the real database.
  */
 type AgentScenario = (ctx: {
-  input: { threadId: string; runId: string; forwardedProps: unknown };
+  input: {
+    threadId: string;
+    runId: string;
+    context: Array<{ description: string; value: string }>;
+    forwardedProps: unknown;
+  };
   signal: AbortSignal;
   options: {
     onEvent: (event: unknown) => Promise<void> | void;
@@ -182,7 +187,9 @@ const getInAppAgentApiKeys = (projectId: string) =>
   prisma.apiKey.findMany({ where: { projectId, isInAppAgentKey: true } });
 
 /** A run resuming an approved tool call whose interrupt event is persisted on a parked parent run. */
-async function seedApprovedContinuation() {
+async function seedApprovedContinuation(opts?: {
+  context?: Array<{ description: string; value: string }>;
+}) {
   const seeded = await seedBackgroundRun();
   const { projectId, conversation, run, user } = seeded;
   const parentRun = await prisma.inAppAgentRun.create({
@@ -213,6 +220,7 @@ async function seedApprovedContinuation() {
         parentRunId: parentRun.id,
         toolCallId: "tc-1",
         approved: true,
+        ...(opts?.context ? { context: opts.context } : {}),
       },
     },
   });
@@ -221,6 +229,38 @@ async function seedApprovedContinuation() {
 }
 
 describe("executeInAppAgentRun", () => {
+  it("passes persisted continuation context to the agent input", async () => {
+    const context = [
+      {
+        description: "current_url",
+        value: '{"pathname":"/project/project-1/traces"}',
+      },
+      { description: "browser_languages", value: '["de-DE"]' },
+    ];
+    const { projectId, run } = await seedApprovedContinuation({ context });
+
+    scenarioRef.current = async ({ input, options }) => {
+      expect(input.context).toEqual(context);
+      await options.onComplete();
+      await options.onFinish();
+    };
+
+    await executeInAppAgentRun({ projectId, runId: run.id });
+  });
+
+  it("defaults legacy continuation context to an empty array", async () => {
+    const { projectId, run } = await seedApprovedContinuation();
+
+    scenarioRef.current = async ({ input, options }) => {
+      expect(input.context).toEqual([]);
+      await options.onComplete();
+      await options.onFinish();
+    };
+
+    await executeInAppAgentRun({ projectId, runId: run.id });
+    expect((await getRun(projectId, run.id)).status).toBe("SUCCEEDED");
+  });
+
   it("executes a queued run to SUCCEEDED with persisted events and full MCP-key lifecycle", async () => {
     const { projectId, conversation, run } = await seedBackgroundRun();
 

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -260,7 +260,7 @@ export async function executeInAppAgentRun(params: {
       state: null,
       messages: [...replayMessages],
       tools: [],
-      context: request.kind === "userMessage" ? request.context : [],
+      context: request.context,
       forwardedProps:
         request.kind === "approvalDecision" && approvalRequest
           ? {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15799.preview.langfuse.com](https://pr-15799.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Persist sanitized page and user context on approval-decision requests, defaulting legacy rows to an empty context.
- Copy the parent context into every approval continuation, including chained approvals and rejections.
- Pass persisted continuation context to the worker and add regression coverage.

## Why

Background approval continuations were always executed with `context: []`, which removed the screen and user context blocks from the agent prompt after the first tool approval. Foreground resumes are unchanged: they continue to recompute context from the browser.

## Verification

- `pnpm --filter web run test src/__tests__/server/in-app-agent-background-run.servertest.ts` — Test Files 1 passed (1), Tests 18 passed (18)
- `pnpm --filter worker run test src/features/in-app-agent/executeInAppAgentRun.test.ts` — Test Files 1 passed (1), Tests 16 passed (16)
- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm tc` — Tasks: 7 successful, 7 total
- `git diff --check`

Related: LFE-14646

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves sanitized page and user context when background in-app-agent runs continue after tool-approval decisions.

- Adds backward-compatible context storage to approval-decision requests.
- Copies context from each parent run into approved and rejected continuations.
- Passes persisted continuation context to worker execution.
- Adds regression coverage for chained approvals and legacy rows.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with context propagation and legacy-row behavior handled consistently across persistence and worker execution.

The shared schema applies the intended legacy default, approval continuations inherit validated parent context, and the worker consumes the parsed context without an established contract or authorization failure.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Browser
  participant Web
  participant DB
  participant Worker
  Browser->>Web: Start background run with page/user context
  Web->>Web: Sanitize and resolve context
  Web->>DB: Persist userMessage request
  Worker->>DB: Park run awaiting approval
  Browser->>Web: Submit approval decision
  Web->>DB: Read parent request context
  Web->>DB: Persist approvalDecision with inherited context
  Worker->>DB: Load and parse continuation request
  Worker->>Worker: Execute agent with persisted context
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): preserve context acro..."](https://github.com/langfuse/langfuse/commit/4c7db05ebc3c1b19b0423f753f25419cba9b0fcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50384587)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)

<!-- /greptile_comment -->