### PR TITLE
fix(trace): decode unicode escapes in client-side trace downloads and copies

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -44,6 +44,10 @@ Use root [AGENTS.md](../../AGENTS.md) for monorepo-level rules.
 - `@langfuse/shared` via `src/index.ts`: default shared surface for
   cross-runtime types, zod schemas, table definitions, domain models, prompt
   helpers, eval/model-pricing helpers, and other frontend-safe utilities.
+  Includes the unicode-decoding JSON serialization helpers (`stringify`,
+  `stringifyForCsv` in `src/utils/stringify.ts`) used by both the server
+  trace-download route and client-side download/copy paths; the server barrel
+  re-exports them for compatibility.
 - `@langfuse/shared/src/server` via `src/server/index.ts`: server-only barrel
   for shared backend services, repositories, queue helpers/contracts, Redis and
   ClickHouse helpers, auth helpers, logger/instrumentation, ingestion helpers,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./constants";
 export { decodeUnicodeEscapesOnly } from "./utils/unicode";
+export { stringify, stringifyForCsv } from "./utils/stringify";
 export * from "./interfaces/filters";
 export * from "./interfaces/orderBy";
 export * from "./interfaces/cloudConfigSchema";

--- a/packages/shared/src/server/utils/transforms/index.ts
+++ b/packages/shared/src/server/utils/transforms/index.ts
@@ -5,7 +5,10 @@ import { transformStreamToCsv } from "./transformStreamToCsv";
 import { transformStreamToJson } from "./transformStreamToJson";
 import { transformStreamToJsonl } from "./transformStreamToJsonl";
 
-export { stringify, stringifyForCsv } from "./stringify";
+// stringify lives in the client-safe utils so the web client (legacy trace
+// download, log view copy/download) serializes through the exact same helper
+// as the server-side trace download route.
+export { stringify, stringifyForCsv } from "../../../utils/stringify";
 
 export const streamTransformations: Record<
   BatchExportFileFormat,

--- a/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
@@ -1,5 +1,5 @@
 import { Transform, type TransformCallback } from "stream";
-import { stringifyForCsv } from "./stringify";
+import { stringifyForCsv } from "../../../utils/stringify";
 
 const DELIMITER = ",";
 const CSV_DOUBLE_QUOTE = /"/g;

--- a/packages/shared/src/server/utils/transforms/transformStreamToJson.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToJson.ts
@@ -1,5 +1,5 @@
 import { Transform, type TransformCallback } from "stream";
-import { stringify } from "./stringify";
+import { stringify } from "../../../utils/stringify";
 
 export function transformStreamToJson(): Transform {
   let isFirstElement = true;

--- a/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
@@ -1,5 +1,5 @@
 import { Transform, type TransformCallback } from "stream";
-import { stringify } from "./stringify";
+import { stringify } from "../../../utils/stringify";
 
 export function transformStreamToJsonl(): Transform {
   return new Transform({

--- a/packages/shared/src/utils/stringify.test.ts
+++ b/packages/shared/src/utils/stringify.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  stringify,
-  stringifyForCsv,
-} from "../../../packages/shared/src/server/utils/transforms/stringify";
+import { stringify, stringifyForCsv } from "./stringify";
 
 describe("stringify", () => {
   it("serializes bigint values as numbers", () => {

--- a/packages/shared/src/utils/stringify.ts
+++ b/packages/shared/src/utils/stringify.ts
@@ -1,4 +1,4 @@
-import { decodeUnicodeEscapesOnly } from "../../../utils/unicode";
+import { decodeUnicodeEscapesOnly } from "./unicode";
 
 // Replacer that keeps bigints JSON-serializable and decodes \uXXXX escapes so
 // that non-ASCII content (e.g. Japanese ingested with Python ensure_ascii=True)

--- a/web/src/components/trace/components/IOPreview/components/ChatMessage.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessage.clienttest.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
+const { copyTextToClipboard } = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(),
+}));
+
+vi.mock("@/src/utils/clipboard", () => ({ copyTextToClipboard }));
+
 import { ChatMessage } from "./ChatMessage";
 import { type ChatMlMessage } from "./chat-message-utils";
 import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
@@ -268,5 +274,34 @@ describe("ChatMessage system prompt collapse", () => {
 
     expect(expandButton()).not.toBeInTheDocument();
     expect(collapseButton()).not.toBeInTheDocument();
+  });
+});
+
+describe("ChatMessage copy", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+    vi.stubGlobal("sessionStorage", createMemoryStorage());
+    copyTextToClipboard.mockClear();
+  });
+
+  it("decodes \\uXXXX escapes when copying a tool-call-only message", () => {
+    // Escaped Japanese as ingested via the Python SDK's ensure_ascii=True.
+    renderChatMessage({
+      role: "assistant",
+      tool_calls: [
+        {
+          id: "call-1",
+          name: "search_traces",
+          arguments: '{"question":"\\u3053\\u3093\\u306b\\u3061\\u306f"}',
+        },
+      ],
+    } as unknown as ChatMlMessage);
+
+    fireEvent.click(screen.getAllByTitle("Copy to clipboard")[0]);
+
+    expect(copyTextToClipboard).toHaveBeenCalledTimes(1);
+    const copied = copyTextToClipboard.mock.calls[0][0] as string;
+    expect(copied).toContain("こんにちは");
+    expect(copied).not.toContain("\\u3053");
   });
 });

--- a/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/src/components/ui/MarkdownJsonView";
 import { ToolCallInvocationsView } from "@/src/components/trace/components/ToolCallInvocationsView";
 import { ListChevronsDownUp, ListChevronsUpDown } from "lucide-react";
+import { stringify } from "@langfuse/shared";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import {
   type ChatMlMessage,
@@ -146,7 +147,10 @@ export function ChatMessage({
           title={title}
           handleOnValueChange={() => {}}
           handleOnCopy={() => {
-            const rawText = JSON.stringify(message, null, 2);
+            // Shared stringify (not raw JSON.stringify) so \uXXXX escapes in
+            // string fields are copied as real characters, like the rendered
+            // view shows them.
+            const rawText = stringify(message, undefined, 2);
             copyTextToClipboard(rawText);
           }}
           controlButtons={passthroughToggleButton}

--- a/web/src/components/trace/components/TraceLogView/useLogViewDownload.clienttest.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewDownload.clienttest.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLogViewDownload } from "./useLogViewDownload";
+import { type ObservationIOData } from "./useLogViewAllObservationsIO";
+
+const { copyTextToClipboard } = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(),
+}));
+
+vi.mock("@/src/utils/clipboard", () => ({ copyTextToClipboard }));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+// jsdom implements neither URL.createObjectURL nor Blob#text.
+const createObjectURL = vi.fn<(blob: Blob) => string>();
+const revokeObjectURL = vi.fn();
+let lastBlob: Blob | undefined;
+
+function readBlobAsText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+// Escaped Japanese as ingested via the Python SDK's ensure_ascii=True.
+const observations: ObservationIOData[] = [
+  {
+    id: "obs-1",
+    type: "GENERATION",
+    name: "generation",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    depth: 0,
+    input: '{"question":"\\u3053\\u3093\\u306b\\u3061\\u306f"}',
+    output: "\\u3042\\u308a\\u304c\\u3068\\u3046",
+  },
+];
+
+function renderDownloadHook() {
+  return renderHook(() =>
+    useLogViewDownload({
+      traceId: "trace-1",
+      isCacheOnly: false,
+      allObservationsData: observations,
+      isLoadingAllData: false,
+      failedObservationIds: [],
+      loadAllData: async () => observations,
+      buildDataFromCache: () => observations,
+    }),
+  );
+}
+
+// jsdom ships no URL.createObjectURL, so capture whatever is (not) there and
+// restore it — Object.assign alone would leak the stub past this file if the
+// client project ever ran with a shared context.
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+describe("useLogViewDownload", () => {
+  beforeEach(() => {
+    lastBlob = undefined;
+    copyTextToClipboard.mockClear();
+    createObjectURL.mockImplementation((blob: Blob) => {
+      lastBlob = blob;
+      return "blob:mock";
+    });
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.assign(URL, {
+      createObjectURL: originalCreateObjectURL,
+      revokeObjectURL: originalRevokeObjectURL,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("decodes \\uXXXX escapes in the copied JSON", async () => {
+    const { result } = renderDownloadHook();
+
+    await act(async () => {
+      await result.current.handleCopyJson();
+    });
+
+    expect(copyTextToClipboard).toHaveBeenCalledTimes(1);
+    const copied = copyTextToClipboard.mock.calls[0][0] as string;
+    expect(copied).toContain("こんにちは");
+    expect(copied).toContain("ありがとう");
+    expect(copied).not.toContain("\\u3053");
+  });
+
+  it("decodes \\uXXXX escapes in the downloaded JSON", async () => {
+    const { result } = renderDownloadHook();
+
+    await act(async () => {
+      await result.current.handleDownloadJson();
+    });
+
+    expect(lastBlob).toBeDefined();
+    const content = await readBlobAsText(lastBlob!);
+    expect(content).toContain("こんにちは");
+    expect(content).toContain("ありがとう");
+    expect(content).not.toContain("\\u3053");
+  });
+});

--- a/web/src/components/trace/components/TraceLogView/useLogViewDownload.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewDownload.ts
@@ -9,6 +9,7 @@
 
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
+import { stringify } from "@langfuse/shared";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { type ObservationIOData } from "./useLogViewAllObservationsIO";
 
@@ -43,10 +44,13 @@ export function useLogViewDownload({
 }: UseLogViewDownloadParams) {
   const [isActionLoading, setIsActionLoading] = useState(false);
 
-  // Helper to download JSON data
+  // Helper to download JSON data. Serializes through the shared stringify
+  // helper (not the raw JSON.stringify) so \uXXXX escapes in string fields
+  // (e.g. Japanese ingested with Python ensure_ascii=True) are decoded to
+  // real characters, matching the server-side trace download route.
   const downloadJsonData = useCallback(
     (data: unknown) => {
-      const blob = new Blob([JSON.stringify(data, null, 2)], {
+      const blob = new Blob([stringify(data, undefined, 2)], {
         type: "application/json",
       });
       const url = URL.createObjectURL(blob);
@@ -67,7 +71,7 @@ export function useLogViewDownload({
       setTimeout(() => {
         try {
           const data = buildDataFromCache();
-          copyTextToClipboard(JSON.stringify(data, null, 2));
+          copyTextToClipboard(stringify(data, undefined, 2));
           toast.success("Copied to clipboard (cache only)");
         } finally {
           setIsActionLoading(false);
@@ -76,7 +80,7 @@ export function useLogViewDownload({
     } else {
       // Load all mode: fetch all data if needed
       if (allObservationsData) {
-        copyTextToClipboard(JSON.stringify(allObservationsData, null, 2));
+        copyTextToClipboard(stringify(allObservationsData, undefined, 2));
         // Show warning if some observations failed to load
         if (failedObservationIds.length > 0) {
           toast.warning(
@@ -89,7 +93,7 @@ export function useLogViewDownload({
         setIsActionLoading(true);
         try {
           const data = await loadAllData();
-          copyTextToClipboard(JSON.stringify(data, null, 2));
+          copyTextToClipboard(stringify(data, undefined, 2));
           // Check for failures after loading
           if (failedObservationIds.length > 0) {
             toast.warning(

--- a/web/src/components/trace/lib/download-trace.clienttest.ts
+++ b/web/src/components/trace/lib/download-trace.clienttest.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadLegacyTraceAsJson } from "./download-trace";
+
+// jsdom does not implement URL.createObjectURL, so we install our own to
+// capture the Blob the download helper builds instead of hitting navigation.
+const createObjectURL = vi.fn<(blob: Blob) => string>();
+const revokeObjectURL = vi.fn();
+
+let lastBlob: Blob | undefined;
+
+// jsdom's Blob has no text(); read it through FileReader instead.
+function readBlobAsText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+// jsdom ships no URL.createObjectURL, so capture whatever is (not) there and
+// restore it — Object.assign alone would leak the stub past this file if the
+// client project ever ran with a shared context.
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+describe("downloadLegacyTraceAsJson", () => {
+  beforeEach(() => {
+    lastBlob = undefined;
+    createObjectURL.mockImplementation((blob: Blob) => {
+      lastBlob = blob;
+      return "blob:mock";
+    });
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.assign(URL, {
+      createObjectURL: originalCreateObjectURL,
+      revokeObjectURL: originalRevokeObjectURL,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("decodes \\uXXXX escapes so non-ASCII content is downloaded as real characters", async () => {
+    downloadLegacyTraceAsJson({
+      trace: {
+        id: "trace-1",
+        input: '{"question":"\\u3053\\u3093\\u306b\\u3061\\u306f"}',
+      },
+      observations: [
+        { id: "obs-1", output: "\\u3042\\u308a\\u304c\\u3068\\u3046" },
+      ],
+    });
+
+    expect(lastBlob).toBeDefined();
+    const content = await readBlobAsText(lastBlob!);
+
+    expect(content).toContain("こんにちは");
+    expect(content).toContain("ありがとう");
+    expect(content).not.toContain("\\u3053");
+  });
+});

--- a/web/src/components/trace/lib/download-trace.ts
+++ b/web/src/components/trace/lib/download-trace.ts
@@ -1,3 +1,5 @@
+import { stringify } from "@langfuse/shared";
+
 export interface ServerTraceDownloadParams {
   traceId: string;
   projectId: string;
@@ -77,7 +79,11 @@ export function downloadLegacyTraceAsJson(params: LegacyTraceDownloadParams) {
   };
 
   downloadBlob({
-    blob: new Blob([JSON.stringify(exportData, null, 2)], {
+    // Use the shared stringify helper (not the raw JSON.stringify) so that
+    // \uXXXX escapes in string fields (e.g. Japanese ingested with Python
+    // ensure_ascii=True) are decoded to real characters, matching the
+    // server-side download route in /api/traces/[traceId]/download.
+    blob: new Blob([stringify(exportData, undefined, 2)], {
       type: "application/json; charset=utf-8",
     }),
     filename: filename || `trace-${trace.id}.json`,


### PR DESCRIPTION
Cherry picks https://github.com/langfuse/langfuse/pull/15698 to v3

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns client-side trace copies and downloads with server-side export behavior by moving the shared serializer to a browser-safe module and decoding Unicode escape sequences consistently.
- Exports `stringify` and `stringifyForCsv` from the shared package’s client-safe surface.
- Uses the shared serializer for legacy trace downloads, log-view copies/downloads, and tool-call message copies.
- Relocates serializer tests and adds client tests for decoded non-ASCII output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the intentional loss of literal Unicode-escape representation already documented by the changed tests.

The relocated serializer is browser-safe, its server compatibility exports remain intact, and the changed client paths consistently produce the intended decoded output without introducing an accepted actionable failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): decode unicode escapes in cl..."](https://github.com/langfuse/langfuse/commit/5a2b9d68fe4e2d26d7eadd7a57e7fdbddd1475e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50404640)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->