### PR TITLE
test(web): guard region-gated Session Replay masking against regression

### DIFF
--- a/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
+++ b/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
@@ -1,0 +1,114 @@
+/**
+ * HIPAA / non-EU-US Session Replay masking guard.
+ *
+ * All cloud regions (including HIPAA) report to the same US Sentry org.
+ * The compliance safeguard for Session Replay is the region-gated
+ * `maskAllText` / `blockAllMedia` configuration in
+ * `web/instrumentation-client.ts`: replays are masked everywhere EXCEPT the
+ * EU and US non-HIPAA cloud regions. Removing or weakening that gate would
+ * ship unmasked replay of user content (prompts, traces, PII/PHI) from
+ * HIPAA and other regions to Sentry.
+ *
+ * Scope note: the mask covers Session Replay ONLY. Error-event payloads
+ * (message, breadcrumbs, extra, tags) are never masked — for those, the
+ * capture-contract rule "no user content in messages/extra/tags" (skill
+ * rule 7) is the compliance boundary.
+ *
+ * These tests import the REAL `web/instrumentation-client.ts` module (the
+ * file Next.js executes in the browser) with `@sentry/nextjs` mocked, and
+ * assert on the arguments Sentry actually receives. They intentionally do
+ * NOT test a copy of the config or an exported predicate: if the replay
+ * options move, stop flowing into `Sentry.init`, or change values, these
+ * tests fail. If this file fails after an instrumentation change, the
+ * change weakens the compliance mask — fix the change, not the test.
+ */
+
+type ReplayOptions = { maskAllText: boolean; blockAllMedia: boolean };
+
+const { initMock, replayIntegrationMock, replaySentinel } = vi.hoisted(() => {
+  const replaySentinel = { name: "Replay-sentinel" };
+  return {
+    initMock: vi.fn<(options: { integrations: unknown[] }) => void>(),
+    replayIntegrationMock: vi.fn(
+      (_options: { maskAllText: boolean; blockAllMedia: boolean }) =>
+        replaySentinel,
+    ),
+    replaySentinel,
+  };
+});
+
+vi.mock("@sentry/nextjs", () => ({
+  init: initMock,
+  replayIntegration: replayIntegrationMock,
+  browserTracingIntegration: vi.fn(() => ({ name: "BrowserTracing" })),
+  httpClientIntegration: vi.fn(() => ({ name: "HttpClient" })),
+  captureConsoleIntegration: vi.fn(() => ({ name: "CaptureConsole" })),
+  browserProfilingIntegration: vi.fn(() => ({ name: "BrowserProfiling" })),
+  captureRouterTransitionStart: vi.fn(),
+}));
+
+/**
+ * Executes the real instrumentation-client module under the given cloud
+ * region and returns the options `Sentry.replayIntegration` was called with.
+ * Also asserts the resulting integration instance is actually wired into
+ * `Sentry.init` — a replay integration that is configured but never passed
+ * to init would silently disable replay instead of masking it.
+ */
+async function loadReplayOptions(
+  region: string | undefined,
+): Promise<ReplayOptions> {
+  vi.resetModules();
+  initMock.mockClear();
+  replayIntegrationMock.mockClear();
+  vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", region);
+
+  await import("@/instrumentation-client");
+
+  expect(initMock).toHaveBeenCalledTimes(1);
+  expect(replayIntegrationMock).toHaveBeenCalledTimes(1);
+  expect(initMock.mock.calls[0]![0].integrations).toContain(replaySentinel);
+
+  return replayIntegrationMock.mock.calls[0]![0]!;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("Session Replay masking is region-gated (compliance guard)", () => {
+  // Regions that must ALWAYS be fully masked. `toStrictEqual` on the whole
+  // options object is deliberate: any new replay option must be reviewed
+  // here for its compliance impact before it can ship.
+  const alwaysMaskedRegions: [string | undefined, string][] = [
+    ["HIPAA", "the HIPAA cloud region"],
+    ["JP", "a non-EU/US cloud region"],
+    ["STAGING", "the staging environment"],
+    ["DEV", "the dev environment"],
+    [undefined, "self-hosted (region unset)"],
+    ["", "an empty region value"],
+    ["us", "a lowercase region value (gate must be exact-match)"],
+  ];
+
+  it.each(alwaysMaskedRegions)(
+    "region %j (%s) gets maskAllText + blockAllMedia",
+    async (region) => {
+      await expect(loadReplayOptions(region)).resolves.toStrictEqual({
+        maskAllText: true,
+        blockAllMedia: true,
+      });
+    },
+  );
+
+  // The ONLY regions where unmasked replay is permitted. If this case starts
+  // failing because masking became unconditional, that is a deliberate
+  // product decision to confirm — not a bug in this test.
+  it.each(["EU", "US"])(
+    "only the %s cloud region may run unmasked replay",
+    async (region) => {
+      await expect(loadReplayOptions(region)).resolves.toStrictEqual({
+        maskAllText: false,
+        blockAllMedia: false,
+      });
+    },
+  );
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15802.preview.langfuse.com](https://pr-15802.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Adds a CI regression test that fails if anyone removes or weakens the region-gated Session Replay masking (`maskAllText` / `blockAllMedia`) in `web/instrumentation-client.ts`. Zero runtime changes — the shipped Sentry config is byte-identical.

## Why

All cloud regions, including HIPAA, report to the same US Sentry org. The compliance safeguard for Session Replay is the region gate in `instrumentation-client.ts`: replays are fully masked everywhere except the EU/US non-HIPAA cloud regions. Today nothing stops a well-meaning refactor from silently dropping that gate — it is one boolean expression in an untested file.

Scope note: the mask covers Session Replay only. Error-event payloads (message, breadcrumbs, extra, tags) are never masked; for those, the capture-contract rule "no user content in messages/extra/tags" is the compliance boundary (a companion docs PR hardens that wording).

## What

One new test file, `web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts`, running in the existing `client` vitest project (already in the CI pipeline). It imports the **real** `web/instrumentation-client.ts` with `@sentry/nextjs` mocked and asserts, per region, the exact options `Sentry.replayIntegration` receives **and** that the resulting integration instance is actually passed into `Sentry.init`.

## Result

- HIPAA / JP / STAGING / DEV / unset (self-hosted) / empty / lowercase region → must get `{ maskAllText: true, blockAllMedia: true }`.
- Only `EU` and `US` may run unmasked replay.
- Removing the gate, unmasking HIPAA, or renaming the env var read all fail CI (mutation-tested below).

<details>
<summary>Mechanism, refactor-evasion resistance, verification</summary>

**Why this shape:** the test deliberately does not test a copy of the config or an exported predicate nobody calls. It executes the actual module Next.js runs in the browser (`vi.resetModules()` + `vi.stubEnv` per region) and asserts on the arguments Sentry receives. If the replay options move to another call site, stop flowing into `Sentry.init`, or change values, the test fails. The `toStrictEqual` on the whole options object means any new replay option must be consciously reviewed here for compliance impact.

**Mutation testing** (each mutation applied to `instrumentation-client.ts`, suite re-run, then reverted — the file in this PR is byte-identical to `origin/main`):

| Mutation | Result |
|---|---|
| `maskAllText: false` hardcoded | 7/9 tests fail |
| `["EU", "US", "HIPAA"]` in the gate | 1/9 fails (the HIPAA case) |
| env var read renamed | 2/9 fail (EU/US cases — fails in the safe, masked-everywhere direction) |

**Fail-safe direction:** unknown/lowercase/empty/unset regions all assert masked, matching the current `!isEuOrUsRegionNonHipaa` default-deny semantics.

**Verification:** 9/9 tests pass locally (`vitest run --project client`); tsc, eslint, prettier, codespell clean. CI runs the `client` project in `pipeline.yml` ("run test-client"), so the guard is enforced on every PR.

</details>

<details>
<summary>Follow-up considered: region-gated beforeSend scrub for error events (recommendation: not now)</summary>

We evaluated adding a `beforeSend` field-scrub (dropping/truncating `extra`/breadcrumbs beyond an allowlist) for masked regions as defense-in-depth on the error-event side. Recommendation is **no general scrub for now**:

- The SDK config is already conservative: `sendDefaultPii` is unset (false) — no cookies, headers, request/response bodies, or user IP are attached; fetch/XHR breadcrumbs carry method/URL/status only.
- The capture contract (shared helpers + review gate) bans user content in messages/extra/tags at the source; a scrub cannot distinguish user content from diagnostic context and would degrade exactly the events that are hardest to reproduce region-locally.
- Cheaper, safer levers exist if technical enforcement is later required: Sentry org-level server-side data scrubbing (config, uniform across payload paths), or a narrow region-gated `beforeBreadcrumb` that drops/truncates `console`-category breadcrumbs — the one auto-attached channel that can carry free-form logged content.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a client-side regression suite protecting Session Replay’s region-dependent masking configuration without changing runtime code.
- Imports the production instrumentation module under nine cloud-region values.
- Verifies masking remains enabled outside the exact `EU` and `US` regions.
- Confirms the configured replay integration is passed to `Sentry.init`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the added regression test.

The test resets import state between region cases, supplies the complete Sentry API surface used during initialization, and directly verifies both replay options and integration wiring.
</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): guard region-gated Session Re..."](https://github.com/langfuse/langfuse/commit/988f4a2953e84cc67faaa6c58bb4429ee0d41c26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50410513)</sub>

<!-- /greptile_comment -->