### PR TITLE
docs(skills): state the HIPAA compliance boundary in the Sentry PII rule

### DIFF
--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -114,11 +114,22 @@ properly (below).
    that only reads the exception value silently never fires on them (the reason
    the original invalid-href filter never worked).
 
-7. **PII — never put user content in a message, `extra`, or tag.** No prompt
-   text, trace content, tokens, share-link secrets, user/session ids. Respect
-   the replay masking already configured for HIPAA/regions in
-   `instrumentation-client.ts`. A message that interpolates user data both leaks
-   and shatters grouping (Rule 5).
+7. **PII / HIPAA — never put user content in a message, `extra`, breadcrumb,
+   or tag.** No prompt text, trace content, tokens, share-link secrets,
+   user/session ids. This is not hygiene — it is the compliance boundary: ALL
+   cloud regions, **including HIPAA**, report to the **same US Sentry org**,
+   and error events are **never masked**, so this discipline is the only thing
+   keeping user content out of them. Session Replay is the one masked channel:
+   [`instrumentation-client.ts`](../../../web/instrumentation-client.ts) gates
+   `maskAllText`/`blockAllMedia` so replays are fully masked everywhere except
+   the EU/US non-HIPAA cloud regions. **Never remove or weaken that gate** — a
+   CI guard
+   ([`instrumentation-client-replay-mask.clienttest.ts`](../../../web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts))
+   fails if you do, and any diff touching `instrumentation-client.ts` or replay
+   config must pass the reviewer checklist in the
+   [reference](references/sentry-capture-contract.md#pii-and-the-hipaa-compliance-boundary).
+   A message that interpolates user data both leaks and shatters grouping
+   (Rule 5).
 
 8. **VERIFY in the environment that actually fires the error.** Router/console
    validations run only in the **real client runtime, not jsdom** — a green unit
@@ -154,6 +165,8 @@ properly (below).
   that reads the wrong event field (Rule 6).
 - Interpolating ids/user data into the message → PII + grouping explosion
   (Rules 5, 7).
+- Removing/weakening the region-gated replay mask, or "fixing" the mask-guard
+  test instead of the diff that tripped it (Rule 7).
 - Trusting a green jsdom test as proof the noise is gone (Rule 8).
 - An ad-hoc inline `beforeSend` check instead of a named, tested predicate in
   `sentryFilters.ts`.
@@ -161,8 +174,10 @@ properly (below).
 ## References
 
 - [references/sentry-capture-contract.md](references/sentry-capture-contract.md)
-  — the capture contract in depth: the shared-helper APIs, the beforeSend /
+  — the capture contract in depth: the shared-helper APIs, the PII/HIPAA
+  compliance boundary (replay mask + reviewer checklist), the beforeSend /
   denylist authoring protocol (field-reading, negative fixtures), fingerprinting
   and `area` tagging, the known noise families, and the shipped-PR case studies
   (#15145 / #15173 / #15174 / #15175 / #15238 / #15243 / #15245). Read when
-  authoring a suppression rule, hardening a capture path, or triaging a family.
+  authoring a suppression rule, hardening a capture path, touching replay/region
+  config, or triaging a family.

--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -122,11 +122,14 @@ properly (below).
    keeping user content out of them. Session Replay is the one masked channel:
    [`instrumentation-client.ts`](../../../web/instrumentation-client.ts) gates
    `maskAllText`/`blockAllMedia` so replays are fully masked everywhere except
-   the EU/US non-HIPAA cloud regions. **Never remove or weaken that gate** — a
-   CI guard
-   ([`instrumentation-client-replay-mask.clienttest.ts`](../../../web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts))
-   fails if you do, and any diff touching `instrumentation-client.ts` or replay
-   config must pass the reviewer checklist in the
+   the EU/US non-HIPAA cloud regions. **Never remove or weaken that gate** —
+   the gate (`isEuOrUsRegionNonHipaa` → the `replayIntegration` options) must
+   be covered by a CI regression test asserting the masked/unmasked regions on
+   the real module (the mask-guard
+   `instrumentation-client-replay-mask.clienttest.ts`; landing with #15802).
+   Reject any diff that touches the gate without that guard passing, and run
+   every diff touching `instrumentation-client.ts` or replay config through
+   the reviewer checklist in the
    [reference](references/sentry-capture-contract.md#pii-and-the-hipaa-compliance-boundary).
    A message that interpolates user data both leaks and shatters grouping
    (Rule 5).

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -45,13 +45,15 @@ cover **different channels**. Do not conflate them.
 1. **Session Replay → the region-gated mask.**
    [`instrumentation-client.ts`](../../../../web/instrumentation-client.ts)
    configures `replayIntegration({ maskAllText, blockAllMedia })` gated on the
-   cloud region: replays are **fully masked everywhere except the EU/US
-   non-HIPAA cloud regions** (HIPAA, JP, STAGING, DEV, and self-hosted/unset
-   all mask — default-deny). The gate must never be removed or weakened. A CI
-   guard,
-   [`instrumentation-client-replay-mask.clienttest.ts`](../../../../web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts),
-   executes the real module per region and fails on any change to the gate, so
-   a diff that trips it is a compliance change, not a broken test.
+   cloud region via `isEuOrUsRegionNonHipaa`: replays are **fully masked
+   everywhere except the EU/US non-HIPAA cloud regions** (HIPAA, JP, STAGING,
+   DEV, and self-hosted/unset all mask — default-deny). The gate must never be
+   removed or weakened, and it must be covered by a CI regression test that
+   executes the real module per region and fails on any change to the gate
+   (the mask-guard `instrumentation-client-replay-mask.clienttest.ts`; landing
+   with #15802). A diff that trips that guard is a compliance change, not a
+   broken test; a diff that touches the gate without the guard passing must be
+   rejected.
 2. **Error events → the capture discipline (SKILL rule 7).** The mask covers
    Session Replay ONLY. Error-event payloads — message, breadcrumbs, `extra`,
    tags — are **not masked in any region**. The rule "no user content in
@@ -65,8 +67,8 @@ replay integration, or region gating:**
 
 - `maskAllText`/`blockAllMedia` still derive from the region gate (masked
   unless the region is exactly `EU` or `US`), and the mask-guard clienttest
-  still asserts against the real module — not a copy of the config or an
-  uncalled predicate.
+  (landing with #15802) asserts against the real module — not a copy of the
+  config or an uncalled predicate.
 - No new replay option weakens masking for masked regions (e.g.
   `maskAllInputs: false`, unmask/unblock selectors).
 - `sendDefaultPii` remains unset/false; no integration starts attaching

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -7,6 +7,7 @@ the detail behind its rules.
 ## Contents
 
 - [Where Sentry is wired](#where-sentry-is-wired)
+- [PII and the HIPAA compliance boundary](#pii-and-the-hipaa-compliance-boundary)
 - [The shared capture helpers](#the-shared-capture-helpers)
 - [beforeSend / denylist authoring protocol](#beforesend--denylist-authoring-protocol)
 - [Fingerprinting, tagging, messages](#fingerprinting-tagging-messages)
@@ -34,6 +35,44 @@ the detail behind its rules.
   PR #15243 drops expected `data.code`s (`NOT_FOUND` / `FORBIDDEN` /
   `UNAUTHORIZED`) there with a breadcrumb and tags the rest
   (`trpc.code` / `trpc.path`).
+
+## PII and the HIPAA compliance boundary
+
+ALL cloud regions — **including HIPAA** — report to the **same US Sentry org**.
+Two mechanisms keep user content (prompts, traces, PII/PHI) out of it, and they
+cover **different channels**. Do not conflate them.
+
+1. **Session Replay → the region-gated mask.**
+   [`instrumentation-client.ts`](../../../../web/instrumentation-client.ts)
+   configures `replayIntegration({ maskAllText, blockAllMedia })` gated on the
+   cloud region: replays are **fully masked everywhere except the EU/US
+   non-HIPAA cloud regions** (HIPAA, JP, STAGING, DEV, and self-hosted/unset
+   all mask — default-deny). The gate must never be removed or weakened. A CI
+   guard,
+   [`instrumentation-client-replay-mask.clienttest.ts`](../../../../web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts),
+   executes the real module per region and fails on any change to the gate, so
+   a diff that trips it is a compliance change, not a broken test.
+2. **Error events → the capture discipline (SKILL rule 7).** The mask covers
+   Session Replay ONLY. Error-event payloads — message, breadcrumbs, `extra`,
+   tags — are **not masked in any region**. The rule "no user content in
+   messages/extra/tags" IS the compliance boundary for error events; there is
+   no downstream scrub to catch a leak. `sendDefaultPii` stays unset (false),
+   so the SDK attaches no cookies, headers, request/response bodies, or user
+   IP.
+
+**Reviewer checklist — any diff touching `instrumentation-client.ts`, the
+replay integration, or region gating:**
+
+- `maskAllText`/`blockAllMedia` still derive from the region gate (masked
+  unless the region is exactly `EU` or `US`), and the mask-guard clienttest
+  still asserts against the real module — not a copy of the config or an
+  uncalled predicate.
+- No new replay option weakens masking for masked regions (e.g.
+  `maskAllInputs: false`, unmask/unblock selectors).
+- `sendDefaultPii` remains unset/false; no integration starts attaching
+  bodies, headers, or cookies.
+- Changes to the mask-guard test itself (skipped cases, loosened assertions,
+  region list edits) are reviewed as compliance changes.
 
 ## The shared capture helpers
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15803.preview.langfuse.com](https://pr-15803.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Docs-only. Hardens the PII rule in the `sentry-instrumentation` skill to state the HIPAA compliance boundary explicitly, and adds a reviewer checklist for any diff touching `instrumentation-client.ts` / replay config. No runtime changes.

## Why

The old rule 7 said "respect the replay masking" — too soft for what it actually protects. The precise facts were written down nowhere an agent or reviewer would reliably load:

- All cloud regions, **including HIPAA**, report to the **same US Sentry org**.
- Session Replay is the only masked channel: `maskAllText`/`blockAllMedia` are region-gated in `instrumentation-client.ts` (masked everywhere except the EU/US non-HIPAA cloud regions).
- Error-event payloads (message, breadcrumbs, extra, tags) are **never masked** — the capture-contract rule "no user content in messages/extra/tags" IS the compliance boundary for error events. There is no downstream scrub.

## What

- `SKILL.md` rule 7 rewritten to state the boundary, the mask gate, its CI guard, and the review requirement; new anti-pattern for weakening the mask or "fixing" the guard test.
- `references/sentry-capture-contract.md`: new "PII and the HIPAA compliance boundary" section separating the two channels (replay mask vs. error-event discipline) plus a concrete reviewer checklist (gate semantics intact, no mask-weakening replay options, `sendDefaultPii` stays unset, guard-test edits reviewed as compliance changes).

## Result

Any agent or reviewer loading the skill before touching capture paths or the Sentry config now sees the compliance constraint stated precisely, with the checklist to enforce it on diffs.

**Merge order:** companion PR #15802 (the CI mask-guard test) should merge first, or together with this one. The docs reference the guard normatively — "must be covered by … (landing with #15802)" — anchored on the gate that exists on main (`isEuOrUsRegionNonHipaa` in `instrumentation-client.ts`), so no present-tense claim depends on an unmerged file. A short equivalent paragraph belongs in `web/OBSERVABILITY.md`'s PII section as a follow-up after #15771 (which introduces that file) lands — deliberately not edited here to avoid a conflicting parallel version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR clarifies that replay masking and error-event capture discipline protect separate Sentry channels.
- Defines the HIPAA/PII boundary and region-gated replay-mask semantics.
- Adds a compliance-focused checklist for instrumentation, replay configuration, and guard-test changes.
- Warns against weakening masking or enabling default PII collection.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it changes documentation only and its technical claims align with the current instrumentation behavior.

The documented replay gate matches the implementation, the error-event path has no downstream PII scrub, and the temporarily absent guard test is explicitly accounted for by the companion PR.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(skills): state the HIPAA compliance..."](https://github.com/langfuse/langfuse/commit/434f73ba3c0708066576edc3b3af14e52f68c1b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50411239)</sub>

<!-- /greptile_comment -->
