### PR TITLE
fix(web): drop query-param writes issued before the Next.js router is ready

### DIFF
--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -13,7 +13,7 @@ import { CommandMenuProvider } from "@/src/features/command-k-menu/CommandMenuPr
 
 import { api } from "@/src/utils/api";
 
-import NextAdapterPages from "next-query-params/pages";
+import { NextAdapterPagesWithReadyGuard } from "@/src/utils/nextAdapterPagesWithReadyGuard";
 import { QueryParamProvider } from "use-query-params";
 
 import "@/src/styles/globals.css";
@@ -145,7 +145,7 @@ const MyApp: AppType<{ session: Session | null }> = ({
 
   return (
     <QueryParamProvider
-      adapter={NextAdapterPages}
+      adapter={NextAdapterPagesWithReadyGuard}
       options={{ enableBatching: true }}
     >
       <TooltipProvider>

--- a/web/src/utils/nextAdapterPagesWithReadyGuard.clienttest.tsx
+++ b/web/src/utils/nextAdapterPagesWithReadyGuard.clienttest.tsx
@@ -1,0 +1,105 @@
+import type { Mock } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { useRouter } from "next/router";
+import type { QueryParamAdapter } from "use-query-params";
+
+import { NextAdapterPagesWithReadyGuard } from "@/src/utils/nextAdapterPagesWithReadyGuard";
+
+vi.mock("next/router", () => ({
+  useRouter: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+const ROUTE_PATTERN = "/project/[projectId]/prompts/[[...folder]]";
+
+// Minimal router stand-in: before hydration of a statically-optimized dynamic
+// route, `asPath` is still the raw pattern and `isReady` is false.
+function makeRouter(isReady: boolean) {
+  return {
+    isReady,
+    pathname: ROUTE_PATTERN,
+    asPath: isReady ? "/project/p1/prompts" : ROUTE_PATTERN,
+    push: vi.fn(),
+    replace: vi.fn(),
+  };
+}
+
+function renderGuardedAdapter(router: ReturnType<typeof makeRouter>) {
+  (useRouter as Mock).mockReturnValue(router);
+  let adapter: QueryParamAdapter | undefined;
+  render(
+    <NextAdapterPagesWithReadyGuard>
+      {(a) => {
+        adapter = a;
+        return null;
+      }}
+    </NextAdapterPagesWithReadyGuard>,
+  );
+  if (!adapter) throw new Error("adapter was not provided to children");
+  return adapter;
+}
+
+describe("NextAdapterPagesWithReadyGuard", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("drops replace issued before the router is ready and warns", () => {
+    const router = makeRouter(false);
+    const adapter = renderGuardedAdapter(router);
+
+    adapter.replace({ search: "?filter=a" });
+
+    expect(router.replace).not.toHaveBeenCalled();
+    expect(router.push).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("drops push issued before the router is ready and warns", () => {
+    const router = makeRouter(false);
+    const adapter = renderGuardedAdapter(router);
+
+    adapter.push({ search: "?filter=a" });
+
+    expect(router.push).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes writes through unchanged once the router is ready", () => {
+    const router = makeRouter(true);
+    const adapter = renderGuardedAdapter(router);
+
+    adapter.replace({ search: "?filter=a", hash: "" });
+    adapter.push({ search: "?page=2", hash: "" });
+
+    expect(router.replace).toHaveBeenCalledTimes(1);
+    expect(router.replace).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: ROUTE_PATTERN, search: "?filter=a" }),
+      expect.anything(),
+      expect.objectContaining({ shallow: true }),
+    );
+    expect(router.push).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("reads readiness at call time: a write after the isReady flip passes even without a re-render", () => {
+    const router = makeRouter(false);
+    const adapter = renderGuardedAdapter(router);
+
+    // The pages router is a singleton mutated in place; flip readiness on the
+    // same object without re-rendering.
+    router.isReady = true;
+    adapter.replace({ search: "?filter=a" });
+
+    expect(router.replace).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/utils/nextAdapterPagesWithReadyGuard.clienttest.tsx
+++ b/web/src/utils/nextAdapterPagesWithReadyGuard.clienttest.tsx
@@ -77,8 +77,8 @@ describe("NextAdapterPagesWithReadyGuard", () => {
     const router = makeRouter(true);
     const adapter = renderGuardedAdapter(router);
 
-    adapter.replace({ search: "?filter=a", hash: "" });
-    adapter.push({ search: "?page=2", hash: "" });
+    adapter.replace({ search: "?filter=a" });
+    adapter.push({ search: "?page=2" });
 
     expect(router.replace).toHaveBeenCalledTimes(1);
     expect(router.replace).toHaveBeenCalledWith(

--- a/web/src/utils/nextAdapterPagesWithReadyGuard.tsx
+++ b/web/src/utils/nextAdapterPagesWithReadyGuard.tsx
@@ -35,7 +35,8 @@ export const NextAdapterPagesWithReadyGuard: QueryParamAdapterComponent = ({
       // flip and the next render is not incorrectly dropped.
       if (!router.isReady) {
         console.warn(
-          `[use-query-params] Dropped query param ${method} issued before the Next.js router was ready (dynamic route params are not hydrated yet):`,
+          "[use-query-params] Dropped query param write issued before the Next.js router was ready (dynamic route params are not hydrated yet):",
+          method,
           location.search,
         );
         return;

--- a/web/src/utils/nextAdapterPagesWithReadyGuard.tsx
+++ b/web/src/utils/nextAdapterPagesWithReadyGuard.tsx
@@ -1,0 +1,57 @@
+import NextAdapterPages from "next-query-params/pages";
+import { useRouter } from "next/router";
+import type {
+  PartialLocation,
+  QueryParamAdapterComponent,
+} from "use-query-params";
+
+/**
+ * Wraps the next-query-params pages adapter to drop query-param writes issued
+ * before `router.isReady` (Sentry LANGFUSE-5V5 / LANGFUSE-5EM).
+ *
+ * Before hydration of a statically-optimized dynamic route, `router.asPath`
+ * is still the raw pattern (e.g. `/project/[projectId]/prompts/[[...folder]]`)
+ * and the query is empty, so a write makes `router.replace`/`push` throw
+ * "The provided `href` ... is missing query values" as an unhandled rejection.
+ *
+ * Dropping (rather than deferring) is deliberate: a pre-ready write computes
+ * its new search string against the adapter's pre-ready location, which is
+ * `{ search: "" }` — replaying it after hydration would clobber real URL
+ * params from deep links. Today such writes never land anyway (the router
+ * throws before navigating), so dropping preserves behavior minus the error.
+ * Reads are untouched: the adapter's `location` already handles pre-ready
+ * state, and post-ready writes pass through unchanged.
+ */
+export const NextAdapterPagesWithReadyGuard: QueryParamAdapterComponent = ({
+  children,
+}) => {
+  const router = useRouter();
+
+  const guardWrite =
+    (method: "push" | "replace", write: (location: PartialLocation) => void) =>
+    (location: PartialLocation) => {
+      // Read `isReady` at call time, not render time: the pages router is a
+      // singleton mutated in place, so a write issued between the readiness
+      // flip and the next render is not incorrectly dropped.
+      if (!router.isReady) {
+        console.warn(
+          `[use-query-params] Dropped query param ${method} issued before the Next.js router was ready (dynamic route params are not hydrated yet):`,
+          location.search,
+        );
+        return;
+      }
+      write(location);
+    };
+
+  return (
+    <NextAdapterPages>
+      {(adapter) =>
+        children({
+          ...adapter,
+          push: guardWrite("push", adapter.push),
+          replace: guardWrite("replace", adapter.replace),
+        })
+      }
+    </NextAdapterPages>
+  );
+};

--- a/web/vitest.config.mts
+++ b/web/vitest.config.mts
@@ -143,6 +143,17 @@ export default defineConfig({
           "../packages/shared/src/index.ts",
         ),
       },
+      // next-query-params ships a CJS `pages` entry whose default-export
+      // interop breaks when the package is inlined (server.deps.inline
+      // below, needed so vi.mock("next/router") intercepts the adapter's
+      // own router import). Point at the ESM bundle instead.
+      {
+        find: /^next-query-params\/pages$/,
+        replacement: join(
+          import.meta.dirname,
+          "node_modules/next-query-params/dist/pages.esm.js",
+        ),
+      },
     ],
     // The runtime source resolves Mastra/AG-UI/Bedrock through shared's
     // node_modules symlinks — a different module id than the test files'
@@ -172,7 +183,9 @@ export default defineConfig({
     testTimeout: 30_000,
     server: {
       deps: {
-        inline: [/@langfuse\//],
+        // next-query-params is inlined so vi.mock("next/router") also
+        // intercepts the adapter's own router import in clienttests.
+        inline: [/@langfuse\//, "next-query-params"],
       },
     },
     projects: [


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15804.preview.langfuse.com](https://pr-15804.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Query-param writes issued before `router.isReady` crash with an unhandled `href-interpolation-failed` rejection ([Sentry LANGFUSE-5V5](https://langfuse.sentry.io/issues/7631078587/), 31 events, + [LANGFUSE-5EM](https://langfuse.sentry.io/issues/7473082418/), 127 events). This PR guards the `next-query-params` adapter seam: pre-ready writes are dropped with a `console.warn`; everything else passes through unchanged.

## Why

On a statically-optimized dynamic route (e.g. `/project/[projectId]/prompts/[[...folder]]`), `router.asPath` is still the **raw route pattern** and the query is empty until hydration completes (`router.isReady`). If any mount effect writes a query param in that window, the adapter calls `router.replace({ pathname: router.pathname, search }, { pathname: asPath, ... })` — Next sees `as === route`, tries to interpolate the pattern from an empty query, and throws:

> `The provided href (/project/[projectId]/prompts/[[...folder]]?) value is missing query values (projectId) to be interpolated properly.`

This surfaces as an unhandled promise rejection in Sentry, and the write never lands.

## What

- `NextAdapterPagesWithReadyGuard` wraps `next-query-params/pages`: `push`/`replace` issued while `!router.isReady` are dropped with a warning; post-ready writes pass through with identical arguments.
- `_app.tsx` uses the wrapped adapter.
- Unit tests for the seam (pre-ready write dropped + warned, post-ready write passes through, readiness read at call time).

## Result

No more unhandled rejections from pre-ready query writes. User-visible behavior is unchanged: those writes never took effect before either (the router threw before navigating).

<details>
<summary>Design notes, safety analysis, verification</summary>

### Why drop instead of defer

A pre-ready write computes its new search string against the adapter's pre-ready location, which `next-query-params` reports as `{ search: "" }`. Replaying that stale payload after hydration would **clobber real URL params from deep links** (the merged search was built on an empty query). Dropping preserves today's observable behavior minus the error, which makes it strictly non-regressive. The `console.warn` includes the dropped search string so the triggering mount effect can be identified if it ever matters.

### What is not affected

- **Deep links / URL restore**: the read path (`adapter.location`) is untouched; `next-query-params` already defers to `{ search: "" }` pre-ready and hooks re-render once ready.
- **Shallow replaces**: the wrapper does not change the adapter's `shallow` default (true), matching the previous direct usage.
- **Batching**: `enableBatching` stays at the provider level, unchanged.

### Readiness is read at call time

The pages router is a singleton mutated in place, so the guard reads `router.isReady` when the write happens, not when the adapter rendered — a write issued between the readiness flip and the next render is not incorrectly dropped. Covered by a dedicated test.

### Root cause verification

The exact throw site is `Router.change` (`next/dist/esm/shared/lib/router/router.js`, `shouldInterpolate = route === asPathname` branch): pre-ready `asPath` equals the route pattern, so Next attempts interpolation with an empty query and throws with the `?` suffix from the empty formatted search — matching the Sentry title byte for byte. Reproduction requires losing a mount-effect race against hydration on a production build, so verification is by adapter-contract analysis plus unit tests rather than a live repro.

### Test infra note

`vi.mock("next/router")` previously could not intercept the adapter's own router import (externalized CJS dep). The vitest config now inlines `next-query-params` and aliases its `pages` entry to the ESM bundle so the real adapter is exercised in tests. Full client suite: 2906 passed (one pre-existing flaky perf-timing test in `json-utils.clienttest.ts` fails under full-suite load and passes in isolation; unrelated).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR globally wraps the Pages Router query-parameter adapter so writes made before router hydration are dropped instead of reaching Next.js interpolation with incomplete dynamic-route parameters.

- Replaces the global `next-query-params/pages` adapter with a readiness-guarded wrapper.
- Preserves post-ready `push` and `replace` behavior while warning about dropped pre-ready writes.
- Adds client tests for both guarded and pass-through behavior, including readiness changes without rerendering.
- Adjusts Vitest resolution so the adapter’s router import can be mocked.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect established.

The guard is narrowly applied at the adapter write seam, reads router readiness at call time, leaves reads unchanged, and passes ready-state writes through to the original adapter.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  W[Query-param write] --> R{router.isReady?}
  R -->|No| D[Drop write and warn]
  R -->|Yes| A[next-query-params Pages adapter]
  A --> N[Next.js router push or replace]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): drop query-param writes issued..."](https://github.com/langfuse/langfuse/commit/22ac5daae309ad7dc7627cda0114a9c340099021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50417233)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->