### PR TITLE
fix(web): stop residual expected-error noise from batch deletes and evaluator form

### DIFF
--- a/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-batch-delete-trpc.servertest.ts
@@ -334,10 +334,45 @@ describe("traces.deleteMany batch action", () => {
     ).resolves.toBeNull();
   });
 
-  it("rejects deletes with an empty traceIds array even for batch actions", async () => {
-    // An empty selection while select-all is armed signals a client-side
-    // consistency issue; the server contract requires at least one traceId
-    // for every delete and must fail loudly rather than absorb it.
+  it("dispatches a batch action even when traceIds drained to empty", async () => {
+    // Paging or a background refetch can drain the visible-page selection
+    // while select-all is armed; the batch path deletes by query and ignores
+    // traceIds, so the dispatch must proceed instead of failing on a phantom
+    // id precondition.
+    const { projectId, caller } = await createCaller();
+    const batchActionId = `${projectId}-traces-trace-delete`;
+    const query = traceDeleteQuery(`delete-user-${randomUUID()}`);
+
+    await caller.traces.deleteMany({
+      projectId,
+      traceIds: [],
+      isBatchAction: true,
+      query,
+    });
+
+    const batchAction = await prisma.batchAction.findUniqueOrThrow({
+      where: { id: batchActionId },
+    });
+    expect(batchAction.status).toBe(BatchActionStatus.Queued);
+    expect(batchAction.query).toMatchObject(query);
+  });
+
+  it("still rejects id-based deletes with an empty traceIds array", async () => {
+    const { projectId, caller } = await createCaller();
+
+    await expect(
+      caller.traces.deleteMany({
+        projectId,
+        traceIds: [],
+        isBatchAction: false,
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Minimum 1 traceId is required."),
+    });
+  });
+
+  it("rejects batch actions without a query", async () => {
     const { projectId, caller } = await createCaller();
     const batchActionId = `${projectId}-traces-trace-delete`;
 
@@ -346,11 +381,10 @@ describe("traces.deleteMany batch action", () => {
         projectId,
         traceIds: [],
         isBatchAction: true,
-        query: traceDeleteQuery(`delete-user-${randomUUID()}`),
       }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message: expect.stringContaining("Minimum 1 traceId is required."),
+      message: expect.stringContaining("Batch actions require a query."),
     });
 
     await expect(

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -37,7 +37,8 @@ import {
   observationVariableMapping,
 } from "@langfuse/shared";
 import { useRouter } from "next/router";
-import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
+import { TRPCClientError } from "@trpc/client";
+import { reportError } from "@/src/utils/reportError";
 import { Slider } from "@/src/components/ui/slider";
 import { Card } from "@/src/components/ui/card";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -532,15 +533,13 @@ export const InnerEvaluatorForm = (props: {
   ]);
 
   const utils = api.useUtils();
+  // No onError override: the react-query default (handleTrpcError) owns
+  // classification, Sentry capture, and the standard error toast.
   const createJobMutation = api.evals.createJob.useMutation({
     onSuccess: () => utils.models.invalidate(),
-    // Defining onError replaces the react-query default that shows the
-    // standard error toast, so trigger it explicitly.
-    onError: trpcErrorToast,
   });
   const updateJobMutation = api.evals.updateEvalJob.useMutation({
     onSuccess: () => utils.evals.invalidate(),
-    onError: trpcErrorToast,
   });
   const [availableVariables, setAvailableVariables] = useState<
     typeof availableTraceEvalVariables | typeof availableDatasetEvalVariables
@@ -720,10 +719,17 @@ export const InnerEvaluatorForm = (props: {
         }
       })
       .catch((error) => {
-        // Mutation failures are surfaced via the onError toast; this catch
-        // also swallows post-success errors (onFormSuccess, router.push),
-        // so keep a console trace for those.
-        console.error("Evaluator form submission failed", error);
+        // Mutation failures were already classified + toasted by the
+        // react-query default onError; only post-success errors
+        // (onFormSuccess, router.push) need reporting here. reportError
+        // captures with an area tag and warns — console.error would mint a
+        // second, unclassified Sentry event via captureConsoleIntegration.
+        if (!(error instanceof TRPCClientError)) {
+          reportError(error, {
+            area: "evals",
+            extra: { context: "evaluator-form-post-submit" },
+          });
+        }
       });
   }
 

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -951,11 +951,10 @@ export default function ObservationsEventsTable({
   }, [observations.rows, selectedRows]);
 
   const handleDeleteTraces = async ({ projectId }: { projectId: string }) => {
-    // Select-all deletes are dispatched even if a background refetch drained
-    // the visible-page selection to [] while the dialog was open: the server
-    // requires at least one traceId regardless, so such a dispatch fails
-    // loudly (as in the v3 traces table) — an empty selection while
-    // select-all is armed signals a consistency issue, not a no-op.
+    // Select-all deletes are dispatched even if paging or a background
+    // refetch drained the visible-page selection to []: the batch path
+    // deletes by query server-side and ignores traceIds. Only an id-based
+    // delete with nothing resolvable is a no-op.
     if (!selectAll && selectedTraceIds.length === 0) return;
 
     await traceDeleteMutation.mutateAsync({
@@ -1018,10 +1017,9 @@ export default function ObservationsEventsTable({
             type: BatchActionType.Delete,
             label: "Delete Traces",
             description: `${itemCountDisplay} ${selectedItemCount === 1 ? "item is" : "items are"} selected, spanning ${traceCountDisplay} unique ${selectedUniqueTraceCount === 1 ? "trace" : "traces"}. A trace is always deleted as a whole — if at least one of its observations is selected, all of its observations are deleted with it. This action cannot be undone. Trace deletion happens asynchronously and may take up to 24 hours.`,
-            // Select-all is not gated on the visible-page selection; if that
-            // selection drained to empty, dispatch fails loudly with the
-            // server's min-1 traceIds rejection (as in the v3 traces table).
-            // Page selection needs concrete trace IDs.
+            // Select-all is not gated on the visible-page selection: the
+            // batch path deletes by query and ignores traceIds. Page
+            // selection needs concrete trace IDs.
             disabled: selectAll
               ? hasCommentFilter
               : selectedTraceIds.length === 0,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -462,12 +462,24 @@ export const traceRouter = createTRPCRouter({
     }),
   deleteMany: protectedProjectProcedure
     .input(
-      z.object({
-        traceIds: z.array(z.string()).min(1, "Minimum 1 traceId is required."),
-        projectId: z.string(),
-        query: BatchActionQuerySchema.optional(),
-        isBatchAction: z.boolean().default(false),
-      }),
+      z
+        .object({
+          traceIds: z.array(z.string()),
+          projectId: z.string(),
+          query: BatchActionQuerySchema.optional(),
+          isBatchAction: z.boolean().default(false),
+        })
+        // Batch actions delete by query and ignore traceIds, so an empty list
+        // is valid there (paging/refetch can drain the visible selection while
+        // select-all is armed); only id-based deletes need at least one id.
+        .refine((input) => input.isBatchAction || input.traceIds.length > 0, {
+          message: "Minimum 1 traceId is required.",
+          path: ["traceIds"],
+        })
+        .refine((input) => !input.isBatchAction || input.query !== undefined, {
+          message: "Batch actions require a query.",
+          path: ["query"],
+        }),
     )
     .mutation(async ({ input, ctx }) => {
       throwIfNoProjectAccess({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15806.preview.langfuse.com](https://pr-15806.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Follow-up to #15765. Two residual variants kept feeding the same Sentry fingerprint on the fixed release; both are fixed at the mint. (1) Select-all batch trace deletes failed on a phantom server precondition (`traceIds` min-1) after paging drained the visible selection — the batch path deletes by query and never reads `traceIds`; the input contract is now conditional, so the user's delete succeeds instead of failing with a raw validation-JSON toast plus a Sentry event. (2) The evaluator form bypassed the shared tRPC error seam with an `onError` override and a `console.error` that minted an unclassified Sentry event for every failure, including expected user-facing outcomes; it now uses the default seam and reports only genuine post-success errors.

## Why

Effect-watch after #15765 showed the suppression working (zero `UNPROCESSABLE_CONTENT` events on the fixed release) but the same issue fingerprint still collecting: `BAD_REQUEST` events from `traces.deleteMany` (exception value: the raw Zod issue array for empty `traceIds`) and console-captured events with no tRPC tags (mechanism `auto.core.capture_console`, e.g. the expected "No matching observation found to test this code evaluator" preflight outcome the user already sees as a toast). Each `BAD_REQUEST` event is also a real failed delete for the user.

## What

- `web/src/server/api/routers/traces.ts` — `deleteMany` input: batch actions require a `query` and accept an empty `traceIds` list (they delete by query and ignore ids); id-based deletes keep requiring at least one id with the same message. The prior loud-fail contract assumed an empty selection under select-all signals a client consistency bug; production shows it is a normal state (pagination or a background refetch drains the visible page while select-all stays armed).
- `web/src/features/evals/components/inner-evaluator-form.tsx` — removed the `onError: trpcErrorToast` overrides so the react-query default (`handleTrpcError`) owns classification, tagged capture, and the standard toast; the `.catch` now routes only non-tRPC (post-success) errors through the shared `reportError` seam instead of `console.error`.
- `web/src/features/events/components/EventsTable.tsx` — comment updates only (dispatch guard unchanged).
- Servertest rewritten to the new contract with positive and negative fixtures.

## Result

The residual inflow stops at both mints. Select-all deletes work after paging. Real `evals.createJob` / `updateEvalJob` failures (5xx and other unexpected codes) now reach Sentry classified and tagged (they previously bypassed capture entirely); expected outcomes stay out of the console-capture path.

<details>
<summary>Mechanism, suppression-safety review, and verification</summary>

### Evidence (read-only, from the issue's recent events)

- `BAD_REQUEST` events: `trpc.path=traces.deleteMany`, transaction `/project/[projectId]/observations`, exception value = Zod `too_small` on `traceIds`. The only dispatch path with empty `traceIds` is select-all (the id-based path is guarded client-side), and the server's batch branch never reads `traceIds`.
- No-tag events: mechanism `auto.core.capture_console`, `logger: console`, message "Evaluator form submission failed … No matching observation found to test this code evaluator" with a 412 response breadcrumb — an expected preflight outcome, double-reported through the console integration and never classified because the mutation's `onError` override replaced the seam default.

### Does this hide a real error or enable unintended deletion?

An independent skeptical review hunted for masked-error and unintended-deletion scenarios; verdict: no blocker.

- Deletion safety: the batch job's scope (delete by persisted query, cutoff snapshotted at dispatch, audit-logged) is unchanged; the same scope was already reachable on main with one row checked (its ids passed min-1 and were then ignored). The confirm dialog shows the full match count behind an explicit destructive confirm. Unchecking any row disarms select-all; only paging/refetch/reload drains the visible selection.
- All three `deleteMany` callers always pass `query` when select-all can be armed, so the new "Batch actions require a query" refine breaks no caller.
- Real mutation failures now capture BETTER: the removed overrides had been suppressing seam capture for these mutations entirely.
- Negative fixtures: id-based deletes with empty `traceIds` still rejected; batch without query rejected; unexpected tRPC codes still captured at the seam (covered in `api.clienttest.ts` from #15765).
- Known trade-offs (deliberate): evals preflight failures now surface as classified `PRECONDITION_FAILED` events rather than unclassified console strings — a candidate for a future classification pass once the tag data shows the volume (28 mint-sites across billing/SSO/evals would need an audit before blanket-suppressing the code); the standard toast debounce now applies to the evaluator form like every other form.

### Follow-ups (not in this PR)

- Disarm the persisted select-all state when the page selection fully drains (defense-in-depth for the armed-after-reload edge).
- The v3 traces table lacks the events table's id-based empty-selection guard; add symmetry.
- Classification decision for `PRECONDITION_FAILED` once tagged volume data exists.

### Verification

- `traces-batch-delete-trpc.servertest.ts`: 15/15 pass against the local data tier (rewritten contract tests included), independently re-run by the skeptical reviewer.
- Full web client vitest suite: 2,903 passed.
- `pnpm --filter=web run typecheck`: green. Prettier + turbo lint (pre-commit): green. codespell on touched files: clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes two sources of expected-error noise while preserving user-visible error handling and allowing query-based trace deletion after visible selections drain.

- Makes `traceIds` optional in practice only for query-backed batch trace deletions, while retaining validation for ID-based deletion and requiring batch queries.
- Routes evaluator mutation failures through the shared tRPC error seam and reports only non-tRPC post-submit failures separately.
- Updates server tests for the conditional deletion contract and clarifies unchanged event-table behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the revised validation and evaluator error flow aligned with their existing runtime branches and callers.

Current batch-delete callers provide scoped query objects, ID-based deletion remains protected against empty input, and evaluator mutation errors continue through the shared classification and toast handler.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop residual expected-error n..."](https://github.com/langfuse/langfuse/commit/7da7a4c4c09b2fba2f0aeb8542796260093b9de9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50418530)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)
- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)
</details>

<!-- /greptile_comment -->