### PR TITLE
refactor(in-app-agent): reconcile on watch attach, not on a timer (LFE-14624)

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -544,11 +544,6 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(15_000),
-  LANGFUSE_IN_APP_AGENT_WATCH_RECONCILE_INTERVAL_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(5_000),
   LANGFUSE_IN_APP_AGENT_WATCH_MAX_CONNECTION_MS: z.coerce
     .number()
     .int()

--- a/packages/shared/src/in-app-agent/server/tunables.ts
+++ b/packages/shared/src/in-app-agent/server/tunables.ts
@@ -31,10 +31,6 @@ export const IN_APP_AGENT_WATCH_TAIL_POLL_MS =
 export const IN_APP_AGENT_WATCH_KEEPALIVE_MS =
   env.LANGFUSE_IN_APP_AGENT_WATCH_KEEPALIVE_MS;
 
-/** Reconcile on attach, then independently from the event polling cadence. */
-export const IN_APP_AGENT_WATCH_RECONCILE_INTERVAL_MS =
-  env.LANGFUSE_IN_APP_AGENT_WATCH_RECONCILE_INTERVAL_MS;
-
 /**
  * Deliberate stream end; the client reconnects with its cursor through the
  * same path as a fresh page load, so route/LB duration limits are never hit

--- a/packages/shared/src/in-app-agent/server/watch.test.ts
+++ b/packages/shared/src/in-app-agent/server/watch.test.ts
@@ -1,5 +1,5 @@
 import { EventType } from "@ag-ui/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { InAppAgentRunStatus } from "../../index";
 import type { PrismaClient } from "../../db";
@@ -23,6 +23,8 @@ type RunRow = {
   status: InAppAgentRunStatus;
   errorCode: string | null;
   cancelRequestedAt?: Date | null;
+  claimedAt?: Date | null;
+  heartbeatAt?: Date | null;
 };
 
 function fakePrisma(polls: Array<{ events: EventRow[]; run: RunRow | null }>) {
@@ -324,5 +326,56 @@ describe("watchConversationFrames", () => {
       EventType.TEXT_MESSAGE_START,
       EventType.RUN_FINISHED,
     ]);
+  });
+
+  it("reconciles once on attach and never again while the run stays healthy", async () => {
+    // The watch used to open a write-capable transaction every few seconds for
+    // every attached viewer. A healthy stream must now be pure reads after the
+    // one reconcile that covers a run dying while nothing watched it.
+    const healthy: RunRow = {
+      id: "run-1",
+      status: InAppAgentRunStatus.RUNNING,
+      errorCode: null,
+      claimedAt: new Date(-5_000),
+      heartbeatAt: new Date(0),
+    };
+    const prisma = fakePrisma([
+      { events: [], run: healthy },
+      { events: [], run: healthy },
+      { events: [], run: { ...succeeded, id: "run-1" } },
+    ]);
+    const reconcileReads = vi.spyOn(prisma.inAppAgentRun, "findMany");
+
+    await collect(prisma, -1);
+
+    expect(reconcileReads).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles again, once, when it observes a heartbeat that already went stale", async () => {
+    // Without this the stream would poll a dead run to the connection cap and
+    // reconnect into the same state, leaving the drawer thinking indefinitely.
+    const abandoned: RunRow = {
+      id: "run-1",
+      status: InAppAgentRunStatus.RUNNING,
+      errorCode: null,
+      claimedAt: new Date(-600_000),
+      heartbeatAt: new Date(-120_000),
+    };
+    const prisma = fakePrisma([
+      { events: [], run: abandoned },
+      { events: [], run: abandoned },
+      { events: [], run: abandoned },
+      {
+        events: [],
+        run: { ...succeeded, id: "run-1", errorCode: "worker_lost" },
+      },
+    ]);
+    const reconcileReads = vi.spyOn(prisma.inAppAgentRun, "findMany");
+
+    await collect(prisma, -1);
+
+    // Attach plus exactly one staleness-triggered reconcile, however many
+    // polls observe the same dead run.
+    expect(reconcileReads).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/shared/src/in-app-agent/server/watch.ts
+++ b/packages/shared/src/in-app-agent/server/watch.ts
@@ -1,6 +1,6 @@
 import { EventType } from "@ag-ui/core";
 
-import { InAppAgentRunStatusSchema } from "../../index";
+import { InAppAgentRunStatus, InAppAgentRunStatusSchema } from "../../index";
 import { Prisma, type PrismaClient } from "../../db";
 import {
   isActiveInAppAgentRunStatus,
@@ -9,9 +9,9 @@ import {
 import type { AgUiEvent } from "../schema";
 import { reconcileConversationRuns } from "./runLifecycle";
 import {
+  IN_APP_AGENT_HEARTBEAT_STALE_MS,
   IN_APP_AGENT_WATCH_KEEPALIVE_MS,
   IN_APP_AGENT_WATCH_MAX_CONNECTION_MS,
-  IN_APP_AGENT_WATCH_RECONCILE_INTERVAL_MS,
   IN_APP_AGENT_WATCH_TAIL_POLL_MS,
 } from "./tunables";
 
@@ -19,6 +19,13 @@ import {
  * Tail persisted events while preserving AG-UI run framing. Synthetic frames
  * never advance beyond the event they frame, so reconnect cannot skip a row.
  * `null` asks the SSE transport to emit a keep-alive comment.
+ *
+ * Reconciliation here is evidence-driven, not periodic. A healthy watch issues
+ * pure reads: the only writes are one reconcile when the stream attaches, and
+ * one more if a poll ever observes a heartbeat that has already gone stale.
+ * Polling a write-capable transaction every few seconds regardless of need was
+ * the previous shape, and it put a transaction on the SSE path for every
+ * attached viewer of every conversation.
  */
 export async function* watchConversationFrames(params: {
   prisma: PrismaClient;
@@ -37,23 +44,23 @@ export async function* watchConversationFrames(params: {
   const startedAt = now();
   let cursor = params.cursor;
   let lastKeepaliveAt = startedAt;
-  let lastReconciledAt: number | null = null;
   let openRunId: string | null = null;
   let lastStatusKey: string | null = null;
+  let reconciledStaleRun = false;
+
+  const reconcile = () =>
+    reconcileConversationRuns({
+      prisma: params.prisma,
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+    });
+
+  // On attach, because the run may have died while nothing was watching. A
+  // reconnect lands here too, which is what bounds recovery for a conversation
+  // whose viewer never closes the drawer.
+  await reconcile();
 
   while (!params.signal?.aborted) {
-    if (
-      lastReconciledAt === null ||
-      now() - lastReconciledAt >= IN_APP_AGENT_WATCH_RECONCILE_INTERVAL_MS
-    ) {
-      await reconcileConversationRuns({
-        prisma: params.prisma,
-        projectId: params.projectId,
-        conversationId: params.conversationId,
-      });
-      lastReconciledAt = now();
-    }
-
     // Read status first: terminal CAS happens after the worker appends events.
     const { latestRun, events } = await params.prisma.$transaction(
       async (tx) => ({
@@ -68,6 +75,10 @@ export async function* watchConversationFrames(params: {
             status: true,
             errorCode: true,
             cancelRequestedAt: true,
+            // Carried on the read we already make, so noticing a dead worker
+            // costs nothing until there is something to notice.
+            claimedAt: true,
+            heartbeatAt: true,
           },
         }),
         events: await tx.inAppAgentEvent.findMany({
@@ -164,6 +175,17 @@ export async function* watchConversationFrames(params: {
       return;
     }
 
+    // The run claims to be active but its worker stopped signalling. Left
+    // alone, this stream would poll a dead run until the connection cap and
+    // then reconnect into the same state, so the drawer would sit thinking
+    // indefinitely. Reconcile once and let the next poll read the outcome; if
+    // the CAS lost a race, the reconnect's attach reconcile tries again.
+    if (!reconciledStaleRun && isStaleClaimedRun(latestRun, now())) {
+      reconciledStaleRun = true;
+      await reconcile();
+      continue;
+    }
+
     if (now() - startedAt >= IN_APP_AGENT_WATCH_MAX_CONNECTION_MS) {
       return;
     }
@@ -175,6 +197,34 @@ export async function* watchConversationFrames(params: {
 
     await sleep(IN_APP_AGENT_WATCH_TAIL_POLL_MS);
   }
+}
+
+/**
+ * Only a claimed run can be judged by its heartbeat. Foreground runs insert as
+ * RUNNING with neither timestamp and are stale-closed by their own 150s rule on
+ * the read path, so they must not be judged here.
+ */
+function isStaleClaimedRun(
+  run: {
+    status: string | null;
+    claimedAt?: Date | null;
+    heartbeatAt?: Date | null;
+  },
+  now: number,
+): boolean {
+  if (run.status !== InAppAgentRunStatus.RUNNING) {
+    return false;
+  }
+
+  const lastSign = run.heartbeatAt ?? run.claimedAt;
+
+  // Nullish rather than `!== null`: a legacy row can carry neither timestamp,
+  // and treating "no signal ever recorded" as stale would kill it.
+  if (!lastSign) {
+    return false;
+  }
+
+  return now - lastSign.getTime() > IN_APP_AGENT_HEARTBEAT_STALE_MS;
 }
 
 /** Match foreground streaming by withholding persisted replay input. */


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15812.preview.langfuse.com](https://pr-15812.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Removes the reconciliation timer from the SSE watch. Nothing else — full browser-independent recovery stays in #15808 pending the observation window.

## Why

The watch opened a write-capable transaction every 5 seconds for every attached viewer of every conversation, whether or not anything was wrong. Reconciliation is not the watch's job, and putting it on a polling loop inside the SSE stream made every viewer a writer.

## What

Reconcile once when the stream attaches, which also covers the deliberate 90s reconnect, and again only if a poll observes a heartbeat that has already gone stale. `claimedAt` and `heartbeatAt` are added to the query the loop already makes, so noticing a dead worker costs no extra round trip and a healthy stream is pure reads.

Attach-only would have been simpler, and was the original intent, but it regresses the case a human is actually present for: a run whose worker dies mid-cycle would be polled as RUNNING to the 90s connection cap, reconnect into the same state, and leave the drawer thinking indefinitely.

Reconciling at the **end** of a cycle was considered instead and rejected. The client reconnects milliseconds later and lands on the attach reconcile anyway, so it would double the writes for no additional coverage. The other two ways a cycle ends are worse candidates: on terminal status there is nothing to reconcile, and on client abort you would be writing from a request that is already tearing down for a user who has left.

Per-watch Postgres statements while healthy:

| | Tail poll | Reconcile | Total |
|---|---|---|---|
| Before | 5.0 | 0.6 | **5.6** |
| After | 5.0 | ~0 | **5.0** |

The remaining 5.0 is the interactive transaction wrapping the 1 Hz event tail. Collapsing that into a single statement — same atomicity, since one statement takes one snapshot even at Read Committed — is the real reduction and belongs to LFE-14629.

Also drops `LANGFUSE_IN_APP_AGENT_WATCH_RECONCILE_INTERVAL_MS`, which now has no reader and appears in no `.env*.example`.

## Behaviour when the sweep from #15808 does not exist

Recovery still has three owners without it: snapshot hydration, `createQueuedRun`, and now watch attach plus the staleness trigger. A run whose worker died is terminalized when the user next looks at the conversation, sends a message, or is already watching it. What remains uncovered is a run nobody ever returns to — which is exactly the case #15808 addresses and the case we agreed to measure first:

```sql
SELECT count(*) FROM in_app_agent_runs
WHERE finished_at IS NULL AND created_at < now() - interval '20 minutes';
```

## Impacted packages

`@langfuse/shared`.

## Verification

```
pnpm run lint                                              Tasks: 7 successful, 7 total
pnpm run typecheck                                         Tasks: 7 successful, 7 total
pnpm --filter @langfuse/shared run test in-app-agent       Tests  12 passed (12)
pnpm --filter worker run test src/features/in-app-agent    Tests  16 passed (16)
pnpm --filter web run test in-app-agent                    Tests  133 passed (133)
```

119 lines added, 25 removed, all in `@langfuse/shared`.

**Tests added: 2**, both in `watch.test.ts`: one reconcile on attach and none thereafter while the run stays healthy, and exactly one extra when a stale heartbeat is observed however many polls see it. The first is the one that protects the property this PR exists for.

The existing watch suite caught a real bug while writing them: `heartbeatAt ?? claimedAt` yields `undefined` for a legacy row carrying neither timestamp, and a `!== null` guard let it through to `.getTime()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces periodic write-capable reconciliation in the in-app-agent SSE watch with reconciliation on stream attachment and a single additional attempt when polling observes a stale worker heartbeat.
- Removes the obsolete watch reconciliation interval environment setting and tunable.
- Extends the existing run poll with claim and heartbeat timestamps.
- Adds attach-time and stale-heartbeat reconciliation coverage.
- Adds tests ensuring healthy watches do not repeatedly reconcile and stale observations trigger only one additional attempt.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The watch retains full reconciliation on every attachment, detects stale claimed workers from timestamps already returned by its polling query, and remains bounded by the deliberate reconnect cycle for lifecycle conditions outside the heartbeat trigger.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client as SSE client
  participant Watch as watchConversationFrames
  participant DB as PostgreSQL
  participant Reconcile as Run reconciliation

  Client->>Watch: Attach or reconnect
  Watch->>Reconcile: Reconcile once
  Reconcile->>DB: Check and CAS stale runs
  loop Until abort, terminal status, or connection cap
    Watch->>DB: Poll latest run and events
    DB-->>Watch: Status, timestamps, events
    alt First observed stale heartbeat
      Watch->>Reconcile: Reconcile once more
      Reconcile->>DB: Check and CAS stale run
    else Healthy or already attempted
      Watch-->>Client: Events or keepalive
    end
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(in-app-agent): reconcile on wat..."](https://github.com/langfuse/langfuse/commit/bbc03452df451013ae3b578a907f64a996fc85cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50447453)</sub>

<!-- /greptile_comment -->