### PR TITLE
fix(otel): keep OpenInference span kind over the SDK's default type

### DIFF
--- a/packages/shared/src/server/otel/ObservationTypeMapper.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.ts
@@ -115,6 +115,26 @@ class CustomAttributeMapper implements ObservationTypeMapper {
   }
 }
 
+const LANGFUSE_SDK_SCOPE_NAME = "langfuse-sdk";
+
+const OPENINFERENCE_SPAN_KIND_ATTRIBUTE = "openinference.span.kind";
+
+// Format:
+// OpenInference Value: Langfuse ObservationType
+const OPENINFERENCE_SPAN_KIND_MAPPINGS: Record<
+  string,
+  LangfuseObservationType
+> = {
+  CHAIN: "CHAIN",
+  RETRIEVER: "RETRIEVER",
+  LLM: "GENERATION",
+  EMBEDDING: "EMBEDDING",
+  AGENT: "AGENT",
+  TOOL: "TOOL",
+  GUARDRAIL: "GUARDRAIL",
+  EVALUATOR: "EVALUATOR",
+};
+
 // value is not null, undefined, empty string, or empty object/array
 function hasMeaningfulValue(value: unknown): boolean {
   if (value === null || value === undefined || value === "") {
@@ -213,6 +233,51 @@ export class ObservationTypeMapperRegistry {
       },
     ),
 
+    // Priority 0: third-party OpenInference spans stamped with the SDK's default type
+    // The Python SDK's update_current_*() helpers resolve the observation type
+    // from langfuse.observation.type alone, fall back to "span" when it is
+    // absent, and then write that fallback onto the current OTel span - even
+    // when the span belongs to a third-party instrumentor. On an OpenInference
+    // span this silently downgrades AGENT/TOOL/... to SPAN, and only for the
+    // spans a hook happened to touch.
+    // Disjoint with PythonSDKv330Override above, which requires the
+    // langfuse-sdk scope that this mapper excludes.
+    new CustomAttributeMapper(
+      "ThirdPartyOpenInferenceSpanKind",
+      0, // Priority
+      // canMap?
+      (attributes, _resourceAttributes, scopeData) => {
+        // Only "span" is ambiguous: it is what the SDK writes when the caller
+        // asked for no type at all. Any other value is a deliberate choice.
+        if (
+          attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] !== "span"
+        ) {
+          return false;
+        }
+
+        // Spans the Langfuse SDK created own their type. Only defer to the
+        // instrumentor when another scope is the identified owner of the span;
+        // an unknown scope keeps the explicit attribute.
+        const scopeName = scopeData?.name;
+        if (
+          typeof scopeName !== "string" ||
+          scopeName === "" ||
+          scopeName === LANGFUSE_SDK_SCOPE_NAME
+        ) {
+          return false;
+        }
+
+        return hasMeaningfulValue(
+          attributes[OPENINFERENCE_SPAN_KIND_ATTRIBUTE],
+        );
+      },
+      // map!
+      (attributes) =>
+        OPENINFERENCE_SPAN_KIND_MAPPINGS[
+          attributes[OPENINFERENCE_SPAN_KIND_ATTRIBUTE] as string
+        ] ?? null,
+    ),
+
     // Priority 1: maps langfuse.observation.type directly
     new SimpleAttributeMapper(
       "LangfuseObservationTypeDirectMapping",
@@ -233,18 +298,12 @@ export class ObservationTypeMapperRegistry {
     ),
 
     // Priority 2: OpenInference span kind
-    new SimpleAttributeMapper("OpenInference", 2, "openinference.span.kind", {
-      // Format:
-      // OpenInference Value: Langfuse ObservationType
-      CHAIN: "CHAIN",
-      RETRIEVER: "RETRIEVER",
-      LLM: "GENERATION",
-      EMBEDDING: "EMBEDDING",
-      AGENT: "AGENT",
-      TOOL: "TOOL",
-      GUARDRAIL: "GUARDRAIL",
-      EVALUATOR: "EVALUATOR",
-    }),
+    new SimpleAttributeMapper(
+      "OpenInference",
+      2,
+      OPENINFERENCE_SPAN_KIND_ATTRIBUTE,
+      OPENINFERENCE_SPAN_KIND_MAPPINGS,
+    ),
 
     // Priority 3: OpenTelemetry GenAI operation
     new SimpleAttributeMapper(

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -2804,6 +2804,177 @@ describe("OTel Resource Span Mapping", () => {
       ).toBe(false);
     });
 
+    // The Python SDK's update_current_span() stamps its default
+    // langfuse.observation.type="span" onto whatever OTel span is current,
+    // including spans owned by third-party instrumentation. On an
+    // OpenInference span that default must not erase the instrumentor's kind.
+    it("should keep the OpenInference kind when the SDK stamped its default span type on a third-party span", async () => {
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            scope: {
+              name: "openinference.instrumentation.agno",
+              version: "1.0.1",
+            },
+            spans: [
+              {
+                ...defaultSpanProps,
+                name: "MyAgent.arun",
+                attributes: [
+                  {
+                    key: "openinference.span.kind",
+                    value: { stringValue: "AGENT" },
+                  },
+                  {
+                    key: "langfuse.observation.type",
+                    value: { stringValue: "span" },
+                  },
+                  {
+                    key: "langfuse.observation.metadata.user_id",
+                    value: { stringValue: "u1" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      expect(
+        langfuseEvents.some((event) => event.type === "agent-create"),
+      ).toBe(true);
+      expect(langfuseEvents.some((event) => event.type === "span-create")).toBe(
+        false,
+      );
+    });
+
+    it("should map the OpenInference kind for every third-party kind the SDK default would have masked", async () => {
+      const cases: Array<[string, string]> = [
+        ["TOOL", "tool-create"],
+        ["LLM", "generation-create"],
+        ["CHAIN", "chain-create"],
+        ["RETRIEVER", "retriever-create"],
+        ["EMBEDDING", "embedding-create"],
+        ["GUARDRAIL", "guardrail-create"],
+        ["EVALUATOR", "evaluator-create"],
+      ];
+
+      for (const [spanKind, expectedEventType] of cases) {
+        const resourceSpan = {
+          scopeSpans: [
+            {
+              scope: { name: "openinference.instrumentation.agno" },
+              spans: [
+                {
+                  ...defaultSpanProps,
+                  attributes: [
+                    {
+                      key: "openinference.span.kind",
+                      value: { stringValue: spanKind },
+                    },
+                    {
+                      key: "langfuse.observation.type",
+                      value: { stringValue: "span" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        const langfuseEvents = await convertOtelSpanToIngestionEvent(
+          resourceSpan,
+          new Set(),
+        );
+
+        expect(
+          langfuseEvents.some((event) => event.type === expectedEventType),
+          `openinference.span.kind=${spanKind} should map to ${expectedEventType}`,
+        ).toBe(true);
+      }
+    });
+
+    it("should still trust an explicit span type on Langfuse SDK spans that carry an OpenInference kind", async () => {
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            scope: { name: "langfuse-sdk", version: "4.14.2" },
+            spans: [
+              {
+                ...defaultSpanProps,
+                attributes: [
+                  {
+                    key: "langfuse.observation.type",
+                    value: { stringValue: "span" },
+                  },
+                  {
+                    key: "openinference.span.kind",
+                    value: { stringValue: "AGENT" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      expect(langfuseEvents.some((event) => event.type === "span-create")).toBe(
+        true,
+      );
+      expect(
+        langfuseEvents.some((event) => event.type === "agent-create"),
+      ).toBe(false);
+    });
+
+    it("should keep an explicit non-default Langfuse type on a third-party span", async () => {
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            scope: { name: "openinference.instrumentation.agno" },
+            spans: [
+              {
+                ...defaultSpanProps,
+                attributes: [
+                  // not the SDK default -> a deliberate type the caller asked for
+                  {
+                    key: "langfuse.observation.type",
+                    value: { stringValue: "generation" },
+                  },
+                  {
+                    key: "openinference.span.kind",
+                    value: { stringValue: "AGENT" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      expect(
+        langfuseEvents.some((event) => event.type === "generation-create"),
+      ).toBe(true);
+      expect(
+        langfuseEvents.some((event) => event.type === "agent-create"),
+      ).toBe(false);
+    });
+
     it("should trust OpenInference over model detection but keep model attributes", async () => {
       const resourceSpan = {
         scopeSpans: [


### PR DESCRIPTION
Fixes #15814

## Problem

The Python SDK's `update_current_span()` / `update_current_generation()` / `update_current_observation()` resolve the observation type from `langfuse.observation.type` alone, fall back to `"span"` when it is absent, and then **write that fallback back onto the current OTel span** — even when the span belongs to a third-party instrumentor.

On an OpenInference span the write is destructive. `openinference.span.kind = AGENT` is still there, but ingestion resolves `langfuse.observation.type` first (priority 1) and the OpenInference mapper (priority 2) never runs, so the observation is stored as `SPAN`.

The effect is silent and order-dependent: only the spans a hook happens to touch are downgraded, so a single trace shows a mix of correctly and incorrectly typed observations — which reads like an instrumentation bug rather than a typing bug.

## Reproduction

Sent the reporter's span shape through the local stack (web + worker + ClickHouse), restarting the stack for each build so the running code matched the tree:

| build | `CleanAgent.arun` (untouched) | `StampedAgent.arun` (after `update_current_span`) |
| --- | --- | --- |
| before | `AGENT` | **`SPAN`** |
| after | `AGENT` | `AGENT` |

## Fix

Adds a mapper ahead of the direct `langfuse.observation.type` mapping that restores the instrumentor's kind, gated on all three of:

1. `langfuse.observation.type` is exactly `"span"` — what the SDK writes when the caller asked for no type. Any other value is a deliberate choice and still wins.
2. The span's scope names an owner other than `langfuse-sdk`. Spans the Langfuse SDK created keep explicit-type-wins.
3. `openinference.span.kind` is set.

Spans with no scope also keep the current precedence, so the existing `should trust Langfuse type over OpenInference or model detection` contract is unchanged.

Handling this at ingestion rather than in the SDK also covers the SDK versions already deployed, which is what makes it a permanent fix for existing users.

`openinference.span.kind` mapping table is now shared between the new mapper and the existing priority-2 mapper so the two cannot drift.

## Impacted packages

- `packages/shared` — `src/server/otel/ObservationTypeMapper.ts`
- `web` — tests only

## Verification

| check | result |
| --- | --- |
| `pnpm run lint` | `Tasks: 7 successful, 7 total` |
| `pnpm run typecheck` | `Tasks: 7 successful, 7 total` |
| `pnpm --filter web run test otelMapping.servertest.ts` | `Tests 227 passed \| 1 skipped (228)` |
| `pnpm --filter web run test otel-api.servertest.ts` | `Tests 16 passed \| 1 skipped (17)` |
| `pnpm --filter @langfuse/shared run test src/server/otel` | `Tests 85 passed (85)` |
| `pnpm --filter worker run test chatml` | `Tests 122 passed (122)` |
| `pnpm --filter worker run test otel` | `Tests 76 passed`, 1 pre-existing failure (see below) |

The four new tests fail before the fix and pass after it.

One unrelated pre-existing failure in `worker/src/queues/__tests__/otelMetadataProcessing.test.ts` (experiment-item-version timestamp normalization) reproduces on an unmodified tree and passes under `TZ=UTC` — a local-timezone artifact, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves OpenInference observation kinds when older Python SDK helpers stamp their default `"span"` type onto third-party spans.
- Adds a priority-0 mapper gated by the default Langfuse type, a known third-party instrumentation scope, and an OpenInference span kind.
- Shares the OpenInference kind mapping table with the existing mapper.
- Adds coverage for every supported OpenInference kind and for explicit Langfuse-type precedence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new precedence behavior narrowly gated and existing fallback behavior preserved.

The mapper only overrides the ambiguous default `"span"` on identified third-party scopes with recognized OpenInference kinds; unsupported kinds continue to the existing direct Langfuse mapping, and tests cover the intended precedence boundaries.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[OTel span attributes] --> B{Langfuse type is span?}
  B -->|No| E[Existing mapper precedence]
  B -->|Yes| C{Nonempty third-party scope?}
  C -->|No| E
  C -->|Yes| D{OpenInference kind mapped?}
  D -->|Yes| F[Use OpenInference observation type]
  D -->|No| E
  E --> G[Use explicit Langfuse type or later fallback]
  F --> H[Create typed ingestion event]
  G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): keep OpenInference span kind ..."](https://github.com/langfuse/langfuse/commit/3ee5cf99d6f5194c8688a12c9a0efb3a191fa99e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50622788)</sub>

<!-- /greptile_comment -->