### PR TITLE
fix(web): stop unrelated tRPC client errors from grouping into one Sentry issue

### DIFF
--- a/web/src/components/table/data-table-ai-filters.tsx
+++ b/web/src/components/table/data-table-ai-filters.tsx
@@ -11,7 +11,7 @@ import { Info } from "lucide-react";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { AIFeaturesDisabledNotice } from "@/src/features/organizations/components/AIFeaturesDisabledNotice";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { type FilterState } from "@langfuse/shared";
 
 interface DataTableAIFiltersProps {
@@ -55,7 +55,7 @@ export function DataTableAIFilters({
           setAiError("Invalid response format from API");
         }
       } catch (error) {
-        console.error("Error calling tRPC API:", error);
+        reportNonTrpcError(error, "ai-filters");
         setAiError(
           error instanceof Error ? error.message : "Failed to generate filters",
         );

--- a/web/src/ee/features/billing/components/SpendAlerts/DeleteSpendAlertDialog.tsx
+++ b/web/src/ee/features/billing/components/SpendAlerts/DeleteSpendAlertDialog.tsx
@@ -8,7 +8,7 @@ import {
   DialogTitle,
 } from "@/src/components/ui/dialog";
 import { Button } from "@/src/components/ui/button";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { toast } from "sonner";
 
@@ -46,7 +46,7 @@ export function DeleteSpendAlertDialog({
       toast.success("Spend alert deleted successfully");
       onSuccess();
     } catch (error) {
-      console.error("Failed to delete spend alert:", error);
+      reportNonTrpcError(error, "billing");
       toast.error("Failed to delete spend alert. Please try again.");
     } finally {
       setIsDeleting(false);

--- a/web/src/ee/features/billing/components/SpendAlerts/SpendAlertDialog.tsx
+++ b/web/src/ee/features/billing/components/SpendAlerts/SpendAlertDialog.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { Button } from "@/src/components/ui/button";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { toast } from "sonner";
 import { Info } from "lucide-react";
@@ -102,7 +102,7 @@ export function SpendAlertDialog({
       }
       onSuccess();
     } catch (error) {
-      console.error("Failed to save spend alert:", error);
+      reportNonTrpcError(error, "billing");
       toast.error(
         `Failed to ${alert ? "update" : "create"} spend alert. Please try again.`,
       );

--- a/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
+++ b/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuLabel,
 } from "@/src/components/ui/dropdown-menu";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { type AnnotationQueueObjectType } from "@langfuse/shared";
 import { ChevronDown, ExternalLink, ListPlus } from "lucide-react";
 import { useSession } from "next-auth/react";
@@ -85,7 +85,7 @@ export const CreateNewAnnotationQueueItem = ({
           objectType,
         });
       } catch (error) {
-        console.error("Error toggling queue item:", error);
+        reportNonTrpcError(error, "annotation-queues");
       }
     },
     [

--- a/web/src/features/automations/components/actions/WebhookActionForm.tsx
+++ b/web/src/features/automations/components/actions/WebhookActionForm.tsx
@@ -26,7 +26,7 @@ import {
   WebhookDefaultHeaders,
   WebhookProtectedHeaders,
 } from "@langfuse/shared";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { useState } from "react";
 import {
   Dialog,
@@ -383,7 +383,7 @@ export const RegenerateWebhookSecretButton = ({
       });
       setShowConfirmPopover(false);
     } catch (error) {
-      console.error("Failed to regenerate webhook secret:", error);
+      reportNonTrpcError(error, "automations");
     }
   };
 

--- a/web/src/features/datasets/components/DatasetForm.tsx
+++ b/web/src/features/datasets/components/DatasetForm.tsx
@@ -12,7 +12,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import {
   useMemo,
   useState,
@@ -287,7 +287,7 @@ export const DatasetForm = forwardRef<DatasetFormRef, DatasetFormProps>(
             // System error (not validation)
             setFormError(error.message);
             setServerSideSchemaValidationErrors(null);
-            console.error(error);
+            reportNonTrpcError(error, "datasets");
           });
       } else if (props.mode === "update") {
         capture("datasets:update_form_submit");
@@ -313,7 +313,7 @@ export const DatasetForm = forwardRef<DatasetFormRef, DatasetFormProps>(
             // System error (not validation)
             setFormError(error.message);
             setServerSideSchemaValidationErrors(null);
-            console.error(error);
+            reportNonTrpcError(error, "datasets");
           });
       }
     }

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -12,7 +12,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import {
   useState,
   useMemo,
@@ -334,9 +334,7 @@ export const NewDatasetItemForm = (props: {
           `Item does not match dataset schema. Errors: ${JSON.stringify(result.validationErrors, null, 2)}`,
         );
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
 
   return (

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -334,7 +334,7 @@ export const NewDatasetItemForm = (props: {
           `Item does not match dataset schema. Errors: ${JSON.stringify(result.validationErrors, null, 2)}`,
         );
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "datasets"));
   }
 
   return (

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -442,7 +442,7 @@ export const InnerEvalTemplateForm = (props: {
       .catch((error) => {
         // The mutation's local onError owns the form UX; this owns
         // classification + Sentry capture.
-        reportTrpcErrorWithoutToast(error);
+        reportTrpcErrorWithoutToast(error, "evals");
         if ("message" in error && typeof error.message === "string") {
           setFormError(error.message as string);
           return;

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -13,7 +13,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   createBooleanEvalOutputDefinition,
@@ -440,12 +440,14 @@ export const InnerEvalTemplateForm = (props: {
         );
       })
       .catch((error) => {
+        // The mutation's local onError owns the form UX; this owns
+        // classification + Sentry capture.
+        reportTrpcErrorWithoutToast(error);
         if ("message" in error && typeof error.message === "string") {
           setFormError(error.message as string);
           return;
         }
         setFormError(JSON.stringify(error));
-        console.error(error);
       });
   }
 

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -131,7 +131,7 @@ export default function RemapEvaluatorPage() {
       }
     } catch (err) {
       // The mutations' local onError owns the UX; this owns classification + capture.
-      reportTrpcErrorWithoutToast(err);
+      reportTrpcErrorWithoutToast(err, "evals");
     }
   };
 

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useRouter } from "next/router";
 import Page from "@/src/components/layouts/page";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import { InnerEvaluatorForm } from "@/src/features/evals/components/inner-evaluator-form";
 import {
   mapLegacyToModernTarget,
@@ -130,8 +130,8 @@ export default function RemapEvaluatorPage() {
           break;
       }
     } catch (err) {
-      // Error already handled in mutation onError
-      console.error(`Failed to ${legacyAction} old eval:`, err);
+      // The mutations' local onError owns the UX; this owns classification + capture.
+      reportTrpcErrorWithoutToast(err);
     }
   };
 

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -18,7 +18,7 @@ import {
   type SetStateAction,
 } from "react";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import {
   Check,
   ChevronDown,
@@ -603,7 +603,7 @@ function FilterBuilderForm({
           setAiError("Invalid response format from API");
         }
       } catch (error) {
-        console.error("Error calling tRPC API:", error);
+        reportNonTrpcError(error, "ai-filters");
         setAiError(
           error instanceof Error ? error.message : "Failed to generate filters",
         );

--- a/web/src/features/organizations/components/DeleteOrganizationButton.tsx
+++ b/web/src/features/organizations/components/DeleteOrganizationButton.tsx
@@ -17,7 +17,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import * as z from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -69,7 +69,9 @@ export function DeleteOrganizationButton() {
       await new Promise((resolve) => setTimeout(resolve, 5000)); // Delay for 5 seconds
       window.location.href = env.NEXT_PUBLIC_BASE_PATH ?? "/"; // Browser reload to refresh jwt
     } catch (error) {
-      console.error(error);
+      // tRPC failures were already classified + toasted by the react-query
+      // default onError; only report failures of the post-success work here.
+      reportNonTrpcError(error, "organizations");
     }
   };
 

--- a/web/src/features/organizations/components/NewOrganizationForm.tsx
+++ b/web/src/features/organizations/components/NewOrganizationForm.tsx
@@ -48,7 +48,7 @@ export const NewOrganizationForm = ({
         await onSuccess(org.id);
         form.reset();
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "organizations"));
   }
 
   return (

--- a/web/src/features/organizations/components/NewOrganizationForm.tsx
+++ b/web/src/features/organizations/components/NewOrganizationForm.tsx
@@ -11,7 +11,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import { useSession } from "next-auth/react";
 import { organizationFormSchema } from "@/src/features/organizations/utils/organizationNameSchema";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -48,9 +48,7 @@ export const NewOrganizationForm = ({
         await onSuccess(org.id);
         form.reset();
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
 
   return (

--- a/web/src/features/organizations/components/RenameOrganization.tsx
+++ b/web/src/features/organizations/components/RenameOrganization.tsx
@@ -60,7 +60,7 @@ export default function RenameOrganization() {
       .then(() => {
         form.reset();
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "organizations"));
   }
 
   return (

--- a/web/src/features/organizations/components/RenameOrganization.tsx
+++ b/web/src/features/organizations/components/RenameOrganization.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import type * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -60,9 +60,7 @@ export default function RenameOrganization() {
       .then(() => {
         form.reset();
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
 
   return (

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -59,7 +59,7 @@ export default function ConfigureRetention() {
       .then(() => {
         form.reset();
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "projects"));
   }
 
   return (

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -1,6 +1,6 @@
 import { Card } from "@/src/components/ui/card";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import type * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -59,9 +59,7 @@ export default function ConfigureRetention() {
       .then(() => {
         form.reset();
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
 
   return (

--- a/web/src/features/projects/components/DeleteProjectButton.tsx
+++ b/web/src/features/projects/components/DeleteProjectButton.tsx
@@ -17,7 +17,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import * as z from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -66,9 +66,7 @@ export function DeleteProjectButton() {
       .then(() => {
         window.location.href = env.NEXT_PUBLIC_BASE_PATH ?? "/"; // browser reload to refresh jwt
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch((error) => reportNonTrpcError(error, "projects"));
   };
 
   return (

--- a/web/src/features/projects/components/NewProjectForm.tsx
+++ b/web/src/features/projects/components/NewProjectForm.tsx
@@ -50,7 +50,7 @@ export const NewProjectForm = ({
         onSuccess(project.id);
         form.reset();
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "projects"));
   }
   return (
     <Form {...form}>

--- a/web/src/features/projects/components/NewProjectForm.tsx
+++ b/web/src/features/projects/components/NewProjectForm.tsx
@@ -11,7 +11,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import { useSession } from "next-auth/react";
 import { projectNameSchema } from "@/src/features/auth/lib/projectNameSchema";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -50,9 +50,7 @@ export const NewProjectForm = ({
         onSuccess(project.id);
         form.reset();
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
   return (
     <Form {...form}>

--- a/web/src/features/projects/components/RenameProject.tsx
+++ b/web/src/features/projects/components/RenameProject.tsx
@@ -57,7 +57,7 @@ export default function RenameProject() {
       .then(() => {
         form.reset();
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "projects"));
   }
 
   return (

--- a/web/src/features/projects/components/RenameProject.tsx
+++ b/web/src/features/projects/components/RenameProject.tsx
@@ -1,7 +1,7 @@
 import { Card } from "@/src/components/ui/card";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import type * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -57,9 +57,7 @@ export default function RenameProject() {
       .then(() => {
         form.reset();
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
 
   return (

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/src/components/ui/tabs";
 import { Textarea } from "@/src/components/ui/textarea";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   type CreatePromptTRPCType,
@@ -174,9 +174,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
           router.push(getPromptDetailHref(projectId, newPrompt.name));
         }
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
 
   const hasInitializedMessages = useRef(false);

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -174,7 +174,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
           router.push(getPromptDetailHref(projectId, newPrompt.name));
         }
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "prompts"));
   }
 
   const hasInitializedMessages = useRef(false);

--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/src/components/ui/popover";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import {
   PRODUCTION_LABEL,
   PromptLabelSchema,
@@ -111,7 +111,7 @@ export function SetPromptVersionLabels({
       capture("prompt_detail:apply_labels", { labels: selectedLabels });
       setIsOpen(false);
     } catch (err) {
-      console.error(err);
+      reportNonTrpcError(err, "prompts");
     }
   };
 

--- a/web/src/features/prompts/components/duplicate-prompt.tsx
+++ b/web/src/features/prompts/components/duplicate-prompt.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { Button } from "@/src/components/ui/button";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { Copy } from "lucide-react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -82,9 +82,7 @@ const DuplicatePromptForm: React.FC<{
         onFormSuccess();
         form.reset();
       })
-      .catch((error: Error) => {
-        console.error(error);
-      });
+      .catch((error) => reportNonTrpcError(error, "prompts"));
   }
 
   const allPrompts = api.prompts.filterOptions.useQuery(

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -17,7 +17,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { CreateApiKeyButton } from "@/src/features/public-api/components/CreateApiKeyButton";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { TrashIcon } from "lucide-react";
 import { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
@@ -228,9 +228,7 @@ function DeleteApiKeyButton(props: {
           capture(`${scope}_settings:api_key_delete`);
           setOpen(false);
         })
-        .catch((error) => {
-          console.error(error);
-        });
+        .catch((error) => reportNonTrpcError(error, "api-keys"));
     } else {
       mutDeleteOrgApiKey
         .mutateAsync({
@@ -241,9 +239,7 @@ function DeleteApiKeyButton(props: {
           capture(`${scope}_settings:api_key_delete`);
           setOpen(false);
         })
-        .catch((error) => {
-          console.error(error);
-        });
+        .catch((error) => reportNonTrpcError(error, "api-keys"));
     }
   };
 

--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/src/components/ui/button";
 import { Dialog, DialogTrigger } from "@/src/components/ui/dialog";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { useState } from "react";
 import { PlusIcon } from "lucide-react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -68,9 +68,7 @@ export function CreateApiKeyButton(props: {
           });
           capture(`${props.scope}_settings:api_key_create`);
         })
-        .catch((error) => {
-          console.error(error);
-        });
+        .catch((error) => reportNonTrpcError(error, "api-keys"));
     } else {
       mutCreateOrgApiKey
         .mutateAsync({
@@ -84,9 +82,7 @@ export function CreateApiKeyButton(props: {
           });
           capture(`${props.scope}_settings:api_key_create`);
         })
-        .catch((error) => {
-          console.error(error);
-        });
+        .catch((error) => reportNonTrpcError(error, "api-keys"));
     }
   };
 

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/src/components/ui/select";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
-import { api, type RouterOutputs } from "@/src/utils/api";
+import { api, reportNonTrpcError, type RouterOutputs } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { type useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
@@ -659,9 +659,7 @@ export function CreateLLMApiKeyForm({
         form.reset();
         onSuccess();
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch((error) => reportNonTrpcError(error, "llm-api-keys"));
   }
 
   return (

--- a/web/src/features/public-api/components/LLMApiKeyList.tsx
+++ b/web/src/features/public-api/components/LLMApiKeyList.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/src/components/ui/table";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { CreateLLMApiKeyDialog } from "./CreateLLMApiKeyDialog";
 import { UpdateLLMApiKeyDialog } from "./UpdateLLMApiKeyDialog";
@@ -194,9 +194,7 @@ function DeleteApiKeyButton(props: { projectId: string; apiKeyId: string }) {
             capture("project_settings:llm_api_key_delete");
             setOpen(false);
           })
-          .catch((error) => {
-            console.error(error);
-          });
+          .catch((error) => reportNonTrpcError(error, "llm-api-keys"));
       }}
     />
   );

--- a/web/src/features/rbac/components/CreateProjectMemberButton.tsx
+++ b/web/src/features/rbac/components/CreateProjectMemberButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/src/components/ui/button";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import { useState } from "react";
 import { PlusIcon } from "lucide-react";
 import * as z from "zod";
@@ -129,9 +129,7 @@ export function CreateProjectMemberButton(props: {
         form.reset();
         setOpen(false);
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch(reportTrpcErrorWithoutToast);
   }
 
   return (

--- a/web/src/features/rbac/components/CreateProjectMemberButton.tsx
+++ b/web/src/features/rbac/components/CreateProjectMemberButton.tsx
@@ -129,7 +129,7 @@ export function CreateProjectMemberButton(props: {
         form.reset();
         setOpen(false);
       })
-      .catch(reportTrpcErrorWithoutToast);
+      .catch((error) => reportTrpcErrorWithoutToast(error, "members"));
   }
 
   return (

--- a/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
+++ b/web/src/features/setup/components/TracesSetupOnboardingCard.tsx
@@ -6,7 +6,7 @@ import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { ApiKeyDetailContent } from "@/src/features/public-api/components/ApiKeyDetailContent";
 import { useLangfuseBaseUrl } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Check, Copy, LockIcon, Sparkles } from "lucide-react";
@@ -85,7 +85,7 @@ export function TracesSetupOnboardingCard({
     try {
       await mutCreateApiKey.mutateAsync({ projectId });
     } catch (error) {
-      console.error("Error creating API key:", error);
+      reportNonTrpcError(error, "setup");
       toast.error("Failed to create API key");
     }
   };

--- a/web/src/features/slack/components/ChannelSelector.tsx
+++ b/web/src/features/slack/components/ChannelSelector.tsx
@@ -16,7 +16,7 @@ import {
   CommandList,
 } from "@/src/components/ui/command";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { env } from "@/src/env.mjs";
 import { type SlackChannel } from "@langfuse/shared/src/server";
 
@@ -90,9 +90,9 @@ const useSlackChannels = (projectId: string) => {
   useEffect(() => {
     if (error || !hasNextPage || isFetchingNextPage) return;
 
-    fetchNextPage().catch((error) => {
-      console.error("Failed to load next Slack channels page", error);
-    });
+    // Query failures are classified + captured by the QueryCache seam; only
+    // report non-tRPC failures of the fetch dispatch itself.
+    fetchNextPage().catch((error) => reportNonTrpcError(error, "slack"));
   }, [error, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   return {

--- a/web/src/features/slack/components/SlackDisconnectButton.tsx
+++ b/web/src/features/slack/components/SlackDisconnectButton.tsx
@@ -118,7 +118,7 @@ export const SlackDisconnectButton: React.FC<SlackDisconnectButtonProps> = ({
       await disconnectMutation.mutateAsync({ projectId });
     } catch (error) {
       // The mutation's local onError owns the UX; this owns classification + capture.
-      reportTrpcErrorWithoutToast(error);
+      reportTrpcErrorWithoutToast(error, "slack");
     }
   };
 

--- a/web/src/features/slack/components/SlackDisconnectButton.tsx
+++ b/web/src/features/slack/components/SlackDisconnectButton.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/src/components/ui/dialog";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { api } from "@/src/utils/api";
+import { api, reportTrpcErrorWithoutToast } from "@/src/utils/api";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
 
 /**
@@ -117,8 +117,8 @@ export const SlackDisconnectButton: React.FC<SlackDisconnectButtonProps> = ({
     try {
       await disconnectMutation.mutateAsync({ projectId });
     } catch (error) {
-      // Error handling is done in the mutation callbacks
-      console.error("Disconnect error:", error);
+      // The mutation's local onError owns the UX; this owns classification + capture.
+      reportTrpcErrorWithoutToast(error);
     }
   };
 

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -15,7 +15,7 @@ import {
   isSeverityAllowedForPlan,
 } from "./formConstants";
 
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 
 import { Button } from "@/src/components/ui/button";
 import {
@@ -360,7 +360,7 @@ export function SupportFormSection({
         pylonAttachmentUrls,
       });
     } catch (err: any) {
-      console.error(err);
+      reportNonTrpcError(err, "support");
       setIsSubmittingLocal(false);
       form.setError("message", {
         type: "manual",

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -46,7 +46,7 @@ import {
   V4_CODING_AGENT_PROMPT,
 } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 
 // Single source of truth for the v4-migration copy and content. Both surfaces
 // (side panel and modal) render these components — edit copy here only.
@@ -399,9 +399,7 @@ export function V4MigrationHeaderContent({
         });
         capture(`project_settings:api_key_create`);
       })
-      .catch((error) => {
-        console.error(error);
-      });
+      .catch((error) => reportNonTrpcError(error, "v4-migration"));
   };
 
   return (

--- a/web/src/pages/account/settings/index.tsx
+++ b/web/src/pages/account/settings/index.tsx
@@ -3,7 +3,7 @@ import Header from "@/src/components/layouts/header";
 import { Card } from "@/src/components/ui/card";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -154,7 +154,7 @@ function DeleteAccountButton() {
       await new Promise((resolve) => setTimeout(resolve, 2000));
       await signOut();
     } catch (error) {
-      console.error(error);
+      reportNonTrpcError(error, "account");
       showErrorToast(
         "Failed to Delete Account",
         error instanceof Error ? error.message : "An unexpected error occurred",

--- a/web/src/pages/project/[projectId]/traces/setup.tsx
+++ b/web/src/pages/project/[projectId]/traces/setup.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useRouter } from "next/router";
-import { api } from "@/src/utils/api";
+import { api, reportNonTrpcError } from "@/src/utils/api";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import ContainerPage from "@/src/components/layouts/container-page";
 import { ActionButton } from "@/src/components/ActionButton";
@@ -35,7 +35,7 @@ export const TracingSetup = ({
     try {
       await mutCreateApiKey.mutateAsync({ projectId });
     } catch (error) {
-      console.error("Error creating API key:", error);
+      reportNonTrpcError(error, "setup");
     }
   };
 

--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -4,11 +4,30 @@ import {
   EXPECTED_TRPC_ERROR_CODES,
   fetchWithParseErrorStatus,
   getTrpcErrorCode,
+  getTrpcErrorFingerprint,
   getTrpcErrorPath,
   isExpectedTrpcClientError,
   isNetworkConnectivityError,
   isTrpcResponseParseError,
+  reportNonTrpcError,
+  reportTrpcErrorWithoutToast,
 } from "@/src/utils/api";
+
+const { captureExceptionMock, addBreadcrumbMock, trpcErrorToastMock } =
+  vi.hoisted(() => ({
+    captureExceptionMock: vi.fn(),
+    addBreadcrumbMock: vi.fn(),
+    trpcErrorToastMock: vi.fn(),
+  }));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: captureExceptionMock,
+  addBreadcrumb: addBreadcrumbMock,
+}));
+
+vi.mock("@/src/utils/trpcErrorToast", () => ({
+  trpcErrorToast: trpcErrorToastMock,
+}));
 
 /** A JSON.parse SyntaxError annotated with the HTTP status it was parsed
  * from, as produced by `fetchWithParseErrorStatus`. */
@@ -329,5 +348,213 @@ describe("isExpectedTrpcClientError", () => {
     );
     expect(isExpectedTrpcClientError(null)).toBe(false);
     expect(isExpectedTrpcClientError(undefined)).toBe(false);
+  });
+});
+
+describe("getTrpcErrorFingerprint", () => {
+  // The whole point of the fingerprint: unrelated tRPC failures must STOP
+  // grouping into one issue, while retries of the same failure class must
+  // keep grouping together.
+  it("groups the same code + path together even when messages differ", () => {
+    const first = trpcServerError({
+      code: "FORBIDDEN",
+      httpStatus: 403,
+      path: "organizations.delete",
+      message: "Deletion of your projects is still being processed",
+    });
+    const second = trpcServerError({
+      code: "FORBIDDEN",
+      httpStatus: 403,
+      path: "organizations.delete",
+      message: "some other server-minted advice",
+    });
+
+    expect(getTrpcErrorFingerprint(first)).toEqual(
+      getTrpcErrorFingerprint(second),
+    );
+  });
+
+  it("splits different codes on the same path", () => {
+    const forbidden = trpcServerError({
+      code: "FORBIDDEN",
+      httpStatus: 403,
+      path: "traces.deleteMany",
+    });
+    const internal = trpcServerError({
+      code: "INTERNAL_SERVER_ERROR",
+      httpStatus: 500,
+      path: "traces.deleteMany",
+    });
+
+    expect(getTrpcErrorFingerprint(forbidden)).not.toEqual(
+      getTrpcErrorFingerprint(internal),
+    );
+  });
+
+  it("splits the same code on different paths", () => {
+    const evals = trpcServerError({
+      code: "BAD_REQUEST",
+      httpStatus: 400,
+      path: "evals.createJob",
+    });
+    const traces = trpcServerError({
+      code: "BAD_REQUEST",
+      httpStatus: 400,
+      path: "traces.deleteMany",
+    });
+
+    expect(getTrpcErrorFingerprint(evals)).not.toEqual(
+      getTrpcErrorFingerprint(traces),
+    );
+  });
+
+  it("uses a stable placeholder when the server shape omits the path", () => {
+    const error = trpcServerError({ code: "FORBIDDEN", httpStatus: 403 });
+
+    expect(getTrpcErrorFingerprint(error)).toEqual([
+      "trpc-client-error",
+      "FORBIDDEN",
+      "unknown",
+    ]);
+  });
+
+  it("never leaks the error message into the fingerprint (bounded cardinality)", () => {
+    const message = "user-specific advice with dynamic content 12345";
+    const error = trpcServerError({
+      code: "UNPROCESSABLE_CONTENT",
+      httpStatus: 422,
+      path: "traces.metrics",
+      message,
+    });
+
+    const fingerprint = getTrpcErrorFingerprint(error);
+    expect(fingerprint).toEqual([
+      "trpc-client-error",
+      "UNPROCESSABLE_CONTENT",
+      "traces.metrics",
+    ]);
+    expect(fingerprint.join()).not.toContain("12345");
+  });
+});
+
+describe("reportTrpcErrorWithoutToast", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+    addBreadcrumbMock.mockClear();
+    trpcErrorToastMock.mockClear();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("suppresses expected codes (breadcrumb, no capture) — same policy as the seam", () => {
+    // The organizations.delete FORBIDDEN advice: previously console.error'd by
+    // the component (one Sentry event per retry), now classified as expected.
+    const error = trpcServerError({
+      code: "FORBIDDEN",
+      httpStatus: 403,
+      path: "organizations.delete",
+      message:
+        "Deletion of your projects is still being processed, please try deleting the organization later",
+    });
+
+    reportTrpcErrorWithoutToast(error);
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+    expect(addBreadcrumbMock).toHaveBeenCalledTimes(1);
+    expect(addBreadcrumbMock.mock.calls[0]![0].data).toMatchObject({
+      code: "FORBIDDEN",
+      path: "organizations.delete",
+    });
+  });
+
+  // Negative fixture: real errors MUST still be captured, with the
+  // procedure/code fingerprint and tags.
+  it("captures a real (5xx) tRPC error with fingerprint and tags", () => {
+    const error = trpcServerError({
+      code: "INTERNAL_SERVER_ERROR",
+      httpStatus: 500,
+      path: "projects.create",
+    });
+
+    reportTrpcErrorWithoutToast(error);
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [, options] = captureExceptionMock.mock.calls[0]!;
+    expect(options.fingerprint).toEqual([
+      "trpc-client-error",
+      "INTERNAL_SERVER_ERROR",
+      "projects.create",
+    ]);
+    expect(options.tags).toMatchObject({
+      area: "trpc",
+      "trpc.code": "INTERNAL_SERVER_ERROR",
+      "trpc.path": "projects.create",
+    });
+  });
+
+  it("captures non-tRPC errors unchanged", () => {
+    reportTrpcErrorWithoutToast(new Error("post-success work failed"));
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never shows the standard error toast (the local onError owns the UX)", () => {
+    reportTrpcErrorWithoutToast(
+      trpcServerError({
+        code: "INTERNAL_SERVER_ERROR",
+        httpStatus: 500,
+        path: "projects.create",
+      }),
+    );
+    reportTrpcErrorWithoutToast(new Error("boom"));
+
+    expect(trpcErrorToastMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("reportNonTrpcError", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+    addBreadcrumbMock.mockClear();
+    trpcErrorToastMock.mockClear();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("swallows TRPCClientErrors (already classified by the react-query default onError)", () => {
+    reportNonTrpcError(
+      trpcServerError({
+        code: "INTERNAL_SERVER_ERROR",
+        httpStatus: 500,
+        path: "projects.create",
+      }),
+      "projects",
+    );
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+    expect(trpcErrorToastMock).not.toHaveBeenCalled();
+  });
+
+  // Negative fixture: a genuine non-tRPC failure (post-success callback,
+  // router.push, ...) MUST still be captured.
+  it("reports non-tRPC errors with the caller's area", () => {
+    reportNonTrpcError(new Error("router.push failed"), "organizations", {
+      context: "delete-organization",
+    });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [, options] = captureExceptionMock.mock.calls[0]!;
+    expect(options.tags.area).toBe("organizations");
+    expect(options.extra).toEqual({ context: "delete-organization" });
   });
 });

--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -462,7 +462,7 @@ describe("reportTrpcErrorWithoutToast", () => {
         "Deletion of your projects is still being processed, please try deleting the organization later",
     });
 
-    reportTrpcErrorWithoutToast(error);
+    reportTrpcErrorWithoutToast(error, "organizations");
 
     expect(captureExceptionMock).not.toHaveBeenCalled();
     expect(addBreadcrumbMock).toHaveBeenCalledTimes(1);
@@ -481,7 +481,7 @@ describe("reportTrpcErrorWithoutToast", () => {
       path: "projects.create",
     });
 
-    reportTrpcErrorWithoutToast(error);
+    reportTrpcErrorWithoutToast(error, "projects");
 
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     const [, options] = captureExceptionMock.mock.calls[0]!;
@@ -490,6 +490,7 @@ describe("reportTrpcErrorWithoutToast", () => {
       "INTERNAL_SERVER_ERROR",
       "projects.create",
     ]);
+    // tRPC failures keep the seam's own area regardless of the caller's.
     expect(options.tags).toMatchObject({
       area: "trpc",
       "trpc.code": "INTERNAL_SERVER_ERROR",
@@ -497,10 +498,12 @@ describe("reportTrpcErrorWithoutToast", () => {
     });
   });
 
-  it("captures non-tRPC errors unchanged", () => {
-    reportTrpcErrorWithoutToast(new Error("post-success work failed"));
+  it("captures non-tRPC errors with the caller's area (not the seam's `trpc`)", () => {
+    reportTrpcErrorWithoutToast(new Error("post-success work failed"), "evals");
 
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [, options] = captureExceptionMock.mock.calls[0]!;
+    expect(options.tags.area).toBe("evals");
   });
 
   it("never shows the standard error toast (the local onError owns the UX)", () => {
@@ -510,8 +513,9 @@ describe("reportTrpcErrorWithoutToast", () => {
         httpStatus: 500,
         path: "projects.create",
       }),
+      "projects",
     );
-    reportTrpcErrorWithoutToast(new Error("boom"));
+    reportTrpcErrorWithoutToast(new Error("boom"), "projects");
 
     expect(trpcErrorToastMock).not.toHaveBeenCalled();
   });

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -159,6 +159,24 @@ export const getTrpcErrorPath = (error: unknown): string | undefined => {
 };
 
 /**
+ * Sentry fingerprint for a captured tRPC client error.
+ *
+ * Sentry's default grouping keys on the stack trace, and every
+ * `TRPCClientError` throws from the same client-link frames — so unrelated
+ * failures (different procedures, different codes, different messages)
+ * collapse into one mega-issue. Grouping by code + procedure path gives each
+ * distinct failure class its own issue with bounded cardinality
+ * (procedures × codes) and no user data: `data.path` is the static procedure
+ * name from the router definition (e.g. `traces.deleteMany`) — query input,
+ * ids, and messages are never part of it.
+ */
+export const getTrpcErrorFingerprint = (error: unknown): string[] => [
+  "trpc-client-error",
+  getTrpcErrorCode(error) ?? "unknown",
+  getTrpcErrorPath(error) ?? "unknown",
+];
+
+/**
  * True when `error` is a TRPCClientError whose code is an EXPECTED, user-facing
  * state that should not be captured to Sentry.
  * See {@link EXPECTED_TRPC_ERROR_CODES}.
@@ -356,10 +374,12 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
         },
       });
     } else {
-      // Real tRPC errors keep flowing to Sentry, tagged by procedure/code
-      // so they group and route instead of collapsing into one opaque bucket.
+      // Real tRPC errors keep flowing to Sentry, tagged and fingerprinted by
+      // procedure/code so each failure class gets its own issue instead of
+      // collapsing into one opaque bucket (see getTrpcErrorFingerprint).
       reportError(error, {
         area: "trpc",
+        fingerprint: getTrpcErrorFingerprint(error),
         tags: {
           "trpc.code": getTrpcErrorCode(error),
           "trpc.path": getTrpcErrorPath(error),
@@ -374,6 +394,36 @@ const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
   if (!shouldSilenceError && shouldShowToast(error)) {
     trpcErrorToast(error);
   }
+};
+
+/**
+ * Error handler for `mutateAsync` catch blocks whose mutation KEEPS the
+ * react-query default `onError`: the seam (`handleTrpcError`) already
+ * classified, captured, and toasted the tRPC failure, so the catch only needs
+ * to swallow the rejection — a `console.error` there would mint a second,
+ * unclassified Sentry event via `captureConsoleIntegration`. Non-tRPC errors
+ * (thrown by the catch's own post-success work: callbacks, router.push, ...)
+ * were NOT seen by the seam and are reported with the caller's `area`.
+ */
+export const reportNonTrpcError = (
+  error: unknown,
+  area: string,
+  extra?: Record<string, unknown>,
+): void => {
+  if (error instanceof TRPCClientError) return;
+  reportError(error, { area, extra });
+};
+
+/**
+ * Error handler for `mutateAsync` catch blocks whose mutation defines a local
+ * `onError` (which REPLACES the react-query default): nothing classified or
+ * captured the failure, so route it through the seam here — with the standard
+ * error toast silenced, since the local `onError` owns the UX (form errors,
+ * custom toasts). Replaces the `console.error(error)` anti-pattern, which
+ * minted unclassified Sentry events via `captureConsoleIntegration`.
+ */
+export const reportTrpcErrorWithoutToast = (error: unknown): void => {
+  handleTrpcError(error, true);
 };
 
 // Reads the `x-build-id` response header (the build id serving this response)

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -421,9 +421,19 @@ export const reportNonTrpcError = (
  * error toast silenced, since the local `onError` owns the UX (form errors,
  * custom toasts). Replaces the `console.error(error)` anti-pattern, which
  * minted unclassified Sentry events via `captureConsoleIntegration`.
+ * Non-tRPC errors (thrown by the catch's own post-success work) were never a
+ * tRPC failure, so they are reported with the caller's `area` — mirroring
+ * `reportNonTrpcError` — instead of the seam's generic `trpc` area.
  */
-export const reportTrpcErrorWithoutToast = (error: unknown): void => {
-  handleTrpcError(error, true);
+export const reportTrpcErrorWithoutToast = (
+  error: unknown,
+  area: string,
+): void => {
+  if (error instanceof TRPCClientError) {
+    handleTrpcError(error, true);
+    return;
+  }
+  reportError(error, { area });
 };
 
 // Reads the `x-build-id` response header (the build id serving this response)

--- a/web/src/utils/reportError.clienttest.ts
+++ b/web/src/utils/reportError.clienttest.ts
@@ -124,6 +124,31 @@ describe("reportError", () => {
       });
     });
 
+    it("passes a caller fingerprint through to captureException", () => {
+      reportError(new Error("boom"), {
+        area: "trpc",
+        fingerprint: [
+          "trpc-client-error",
+          "INTERNAL_SERVER_ERROR",
+          "traces.all",
+        ],
+      });
+
+      const [, options] = captureExceptionMock.mock.calls[0]!;
+      expect(options.fingerprint).toEqual([
+        "trpc-client-error",
+        "INTERNAL_SERVER_ERROR",
+        "traces.all",
+      ]);
+    });
+
+    it("omits the fingerprint key entirely when not provided (Sentry default grouping)", () => {
+      reportError(new Error("boom"), { area: "io.parse" });
+
+      const [, options] = captureExceptionMock.mock.calls[0]!;
+      expect("fingerprint" in options).toBe(false);
+    });
+
     it("the seam's area tag wins over a conflicting caller tag", () => {
       reportError(new Error("boom"), {
         area: "trpc",

--- a/web/src/utils/reportError.ts
+++ b/web/src/utils/reportError.ts
@@ -68,7 +68,10 @@ export function coerceToError(area: string, value: unknown): Error {
  *   `captureException` with an `area` tag (so issues route/group by surface) and
  *   the caller's structured `extra`, then log a companion `console.warn`.
  *   Optional `tags` add further Sentry tags (e.g. `trpc.code`); on a key
- *   conflict the seam's `area` tag wins. Optional `warnMessage` overrides the
+ *   conflict the seam's `area` tag wins. Optional `fingerprint` overrides
+ *   Sentry's default grouping for callers whose errors would otherwise
+ *   collapse into one issue (all TRPCClientErrors share the same throw-site
+ *   stack) — values must be bounded and static, never user data. Optional `warnMessage` overrides the
  *   companion console line's body (always prefixed with `[area]`) for callers
  *   whose legible console text differs from the captured Error's message —
  *   e.g. a pass-through Error that lacks the caller's context. It never
@@ -89,6 +92,7 @@ export function reportError(
     area: string;
     expected?: boolean;
     extra?: Record<string, unknown>;
+    fingerprint?: string[];
     tags?: Record<string, string | undefined>;
     warnMessage?: string;
   },
@@ -108,6 +112,7 @@ export function reportError(
   captureException(err, {
     tags: { ...opts.tags, area: opts.area },
     extra: opts.extra,
+    ...(opts.fingerprint !== undefined && { fingerprint: opts.fingerprint }),
   });
   // warn, not error → captureConsoleIntegration only captures console.error, so
   // this line does not create a second, opaque event. Show the `area` exactly


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15818.preview.langfuse.com](https://pr-15818.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

One Sentry issue (LANGFUSE-5W1, 1.1k+ events / 277 users) currently absorbs **every tRPC client error in the app**: its subheader talks about org deletion while its session replays show trace deletion, evaluation model popups, and trace loading — at least 7 unrelated error classes under one title. This PR makes each failure class its own issue by (1) fingerprinting seam-captured tRPC errors by `procedure path + code`, and (2) routing the `console.error(error)` leaks in mutation catch blocks — which minted untagged duplicate events via `captureConsoleIntegration` — through the capture seam instead.

## Why

Two compounding causes, measured on the issue's last 100 events:

1. **Default grouping collapses all TRPCClientErrors** (16/100 events). Sentry groups by stack trace, and every `TRPCClientError` throws from the same tRPC client-link frames — so a 500 on `traces.byId` and a 400 on `evals.createJob` land in the same issue, making it untriageable and burying new regressions in an issue everyone ignores.
2. **`console.error(error)` in mutation catch blocks** (84/100 events). `captureConsoleIntegration` turns each of those into a second, untagged Sentry event. 75 of the 84 were a single user retrying org deletion for ~an hour, each attempt re-minting an event for a server response (`FORBIDDEN`: "deletion of your projects is still being processed") that the seam already classifies as an expected user-facing state (#15765). This is the same anti-pattern #15806 removed from the evaluator form.

## What

- **`reportError` seam** (#15781): accepts an optional `fingerprint`, passed through to `captureException`.
- **`handleTrpcError`** (`web/src/utils/api.ts`): captured tRPC errors now carry `fingerprint: ["trpc-client-error", <code>, <path>]`. Cardinality is bounded (procedures × ~20 codes) and stable: `data.path` is the static procedure name from the router definition — never input, ids, or user data. Non-tRPC errors keep Sentry default grouping (forcing them into one bucket would recreate the mega-issue).
- **31 catch-block migrations across 30 files**, via two new helpers matching each site's semantics (see table in details):
  - `reportNonTrpcError(error, area)` — mutation kept the react-query default `onError`, so the seam already classified + captured + toasted; the catch only swallows the rejection and reports genuine post-success failures.
  - `reportTrpcErrorWithoutToast(error)` — mutation defines a local `onError` (which *replaces* the default, so nothing captured the failure); routes it through the seam with the standard toast silenced because the local handler owns the UX.
- **No new suppression**: `EXPECTED_TRPC_ERROR_CODES`, `beforeSend`, and all filters are untouched. Expected codes that were previously double-reported via `console.error` now follow the seam's pre-existing policy (breadcrumb, no event). Real errors (5xx, unknown codes) that previously *only* surfaced as opaque console events are now properly captured with tags + fingerprint.

## Result

- Each tRPC failure class gets its own correctly-titled issue with `trpc.code` / `trpc.path` tags — regressions become visible and routable instead of drowning in one bucket.
- The org-deletion retry flood (and its siblings) stops minting events; user-facing toasts and form errors are unchanged at every migrated site.
- **Heads-up:** as existing error classes re-key, expect a one-time burst of ~15–25 new (properly-named) Sentry issues over the first days; first-seen alert rules will notify once per new issue. The old issue only drains fully once the listed follow-ups land.

Related: #15806 (evaluator-form precedent), #15781 (the `reportError` seam), #15765 / #15243 (seam classification of expected codes).

<details>
<summary>Site-by-site inventory, mechanism, and verification</summary>

### Why two helpers (react-query semantics)

`defaultOptions.mutations.onError` (→ `handleTrpcError`: classify, capture, toast) applies **only when a mutation does not define its own `onError`** — a local `onError` replaces it (per-key shallow merge in query-core; a local `onSuccess` does *not* displace the default `onError`). So the same `console.error(error)` in a catch block meant two different things:

| Mutation defines local `onError`? | What the console.error was | Fix |
|---|---|---|
| No — default kept | a **duplicate** of the seam capture | `reportNonTrpcError`: swallow `TRPCClientError`, report non-tRPC post-success failures |
| Yes — default replaced | the **only** capture, untagged | `reportTrpcErrorWithoutToast`: full seam classification + fingerprint, toast silenced (local `onError` owns the UX) |

### Migrated — default `onError` kept (duplicate console event removed)

`DeleteOrganizationButton` (the flood source), `DeleteProjectButton`, `ApiKeyList` (×2), `CreateApiKeyButton` (×2), `LLMApiKeyList`, `CreateLLMApiKeyForm`, `duplicate-prompt`, `SetPromptVersionLabels`, `V4MigrationContent`, `WebhookActionForm`, `SpendAlertDialog`, `DeleteSpendAlertDialog`, `TracesSetupOnboardingCard`, `traces/setup` page, `CreateNewAnnotationQueueItem`, `SupportFormSection`, `account/settings` page, `data-table-ai-filters`, `filter-builder`, `DatasetForm` (×2), `ChannelSelector` (query variant: the QueryCache seam owns classification).

### Migrated — local `onError` overrides (previously uncaptured by the seam)

`RenameOrganization`, `NewOrganizationForm`, `CreateProjectMemberButton`, `NewProjectForm`, `RenameProject`, `ConfigureRetention`, `NewPromptForm`, `NewDatasetItemForm`, `remap-evaluator` (2 mutations, both with local `onError`), `template-form`, `SlackDisconnectButton`. Form-error / custom-toast UX at these sites is unchanged; the standard toast stays silenced exactly as before.

### Listed follow-ups (judgment calls, not migrated here)

- `features/in-app-agent/InAppAiAgentProvider.tsx` — ~11 `console.error` sites mixing tRPC mutations with stream-event handling; the feature has its own error model and toasts, so migration needs owner judgment. Until then the old issue keeps receiving residual events at reduced volume.
- `features/slack/SlackConnectionCard.tsx` `onError` props — log a synthesized `Error` from child callbacks; redundant with the now-classified child captures (event count unchanged vs before).
- String-only `console.error` invariant logs (e.g. "invalid response format", "Project ID is missing" guards) — not tRPC error objects; a separate noise class.

### Fingerprint safety

- `@trpc/server` sets `data.path` from server-side procedure resolution and `data.code` from the error-code enum; the app's `errorFormatter` passes both through untouched. No ids, no input, no messages → no PII and bounded cardinality.
- Tests pin the contract (negative fixtures): same code+path groups together even with different messages; a different code *or* path splits; missing path falls back to a stable `"unknown"`; the message can never leak into the fingerprint. Plus: expected codes still produce breadcrumbs (not events), real 5xx still captures with fingerprint + tags, `reportTrpcErrorWithoutToast` never toasts, `reportNonTrpcError` still reports genuine non-tRPC failures.

### Alert/monitor impact

No Sentry alert rule keys on the old issue's identity (issue alerts are first-seen/frequency/replay-based; metric alerts are latency/throughput/event-count). Event volume only goes down. The one-time re-keying burst triggers first-seen notifications once per new issue.

### Verification

- Fresh non-incremental `tsc`: clean.
- Full client vitest suite: 243 files, 2985 tests passed.
- Full web ESLint (`--max-warnings 0`, includes the #15781 seam-enforcement rule): clean.
- Prettier + codespell on all changed files: clean.
- Independent adversarial review of every migrated site's group classification (local-`onError`-ness verified per mutation, multi-mutation catch blocks included) against react-query v5 option-merge semantics: no misclassifications found.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR routes client-side tRPC failures through the shared reporting seam and fingerprints captured events by procedure path and error code.

- Adds optional Sentry fingerprint support to `reportError`.
- Adds helpers for catches with default versus local React Query error handling.
- Replaces duplicate `console.error` captures across mutation and query call sites.
- Adds tests for grouping, suppression, capture, tagging, and toast behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the migrated error paths preserving user-facing handling while improving Sentry classification.

The shared seam now fingerprints actionable tRPC errors, expected errors remain breadcrumbs, and migrated catches consistently avoid duplicate console captures without dropping their existing form or toast behavior.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[tRPC operation fails] --> B{Local onError?}
  B -->|No| C[Default React Query handler]
  C --> D[handleTrpcError]
  D --> E{Expected or transport error?}
  E -->|Yes| F[Breadcrumb only]
  E -->|No| G[Capture with code + path fingerprint]
  C --> H[Catch receives rejected promise]
  H --> I[reportNonTrpcError]
  I --> J[Ignore already-handled TRPCClientError]
  I --> K[Capture post-success non-tRPC error]
  B -->|Yes| L[Local handler owns form or toast UX]
  L --> M[Catch calls reportTrpcErrorWithoutToast]
  M --> D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop unrelated tRPC client err..."](https://github.com/langfuse/langfuse/commit/9a1683dd283d31776746b999891297a48a331a79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50642448)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->