### PR TITLE
feat(web/worker): add batch export for dataset runs table

### DIFF
--- a/packages/shared/src/interfaces/tableNames.ts
+++ b/packages/shared/src/interfaces/tableNames.ts
@@ -10,6 +10,7 @@ export enum BatchTableNames {
   Observations = "observations",
   Events = "events",
   Datasets = "datasets",
+  DatasetRuns = "dataset_runs",
   DatasetRunItems = "dataset_run_items",
   DatasetItems = "dataset_items",
   AuditLogs = "audit_logs",

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -324,6 +324,15 @@ const getDatasetRunsTableInternal = async <T>(
   if (orderBy) {
     orderByArray.push(orderBy);
   }
+  // Append the unique run id as a tiebreaker so offset-based pagination is
+  // stable when runs share a creation timestamp (e.g. batch exports). The
+  // count query aggregates to a single row, so it must not receive it.
+  if (opts.select !== "count" && orderBy?.column !== "id") {
+    orderByArray.push({
+      column: "id",
+      order: "DESC",
+    });
+  }
 
   const orderByClause = orderByToClickhouseSql(
     orderByArray,

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -66,6 +66,8 @@ import {
 } from "@/src/features/scores/lib/scoreColumns";
 import { getScoreLabelFromKey } from "@/src/features/scores/lib/aggregateScores";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
+import { BatchExportTableName } from "@langfuse/shared";
 
 export type DatasetRunRowData = {
   id: string;
@@ -733,6 +735,21 @@ export function DatasetRunsTable(props: {
                     setRowSelection={setSelectedRows}
                   />
                 ) : null,
+                <BatchExportTableButton
+                  key="batchExport"
+                  projectId={props.projectId}
+                  tableName={BatchExportTableName.DatasetRuns}
+                  orderByState={{ column: "createdAt", order: "DESC" }}
+                  filterState={[
+                    {
+                      type: "string",
+                      operator: "=",
+                      column: "datasetId",
+                      value: props.datasetId,
+                    },
+                    ...userFilterState,
+                  ]}
+                />,
               ]}
             />
             <DataTable
@@ -798,6 +815,21 @@ export function DatasetRunsTable(props: {
                   setRowSelection={setSelectedRows}
                 />
               ) : null,
+              <BatchExportTableButton
+                key="batchExport"
+                projectId={props.projectId}
+                tableName={BatchExportTableName.DatasetRuns}
+                orderByState={{ column: "createdAt", order: "DESC" }}
+                filterState={[
+                  {
+                    type: "string",
+                    operator: "=",
+                    column: "datasetId",
+                    value: props.datasetId,
+                  },
+                  ...userFilterState,
+                ]}
+              />,
             ]}
           />
           <DataTable

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -10,6 +10,8 @@ import {
   createTrace,
   createTracesCh,
   createManyDatasetItems,
+  createDatasetRunItem,
+  createDatasetRunItemsCh,
   applyCommentFilters,
   createEvent,
   createEventsCh,
@@ -5174,5 +5176,148 @@ maybeDescribe("getEventsForBlobStorageExport", () => {
     expect(Object.keys(rows[0]).sort()).toEqual(expectedColumns);
     expect(rows[0].input).toBe("hello");
     expect(rows[0].output).toBe("world");
+  });
+  it("should export dataset runs with aggregated metrics", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create two datasets to verify datasetId scoping of the export
+    const datasetId = randomUUID();
+    await prisma.dataset.create({
+      data: {
+        id: datasetId,
+        name: "test-dataset-runs-export",
+        projectId,
+      },
+    });
+    const datasetId2 = randomUUID();
+    await prisma.dataset.create({
+      data: {
+        id: datasetId2,
+        name: "test-dataset-runs-export-2",
+        projectId,
+      },
+    });
+
+    const runCreatedAt = new Date(Date.now() - 1000 * 60 * 60);
+    const runTimestamp = runCreatedAt.getTime();
+
+    // Observations backing the run items' traces (trace-level metrics:
+    // run items carry observation_id = null). 5s latency and 0.5 cost each.
+    const traceId1 = randomUUID();
+    const traceId2 = randomUUID();
+    await createObservationsCh([
+      createObservation({
+        project_id: projectId,
+        trace_id: traceId1,
+        type: "GENERATION",
+        start_time: runTimestamp,
+        end_time: runTimestamp + 5000,
+        total_cost: 0.5,
+      }),
+      createObservation({
+        project_id: projectId,
+        trace_id: traceId2,
+        type: "GENERATION",
+        start_time: runTimestamp,
+        end_time: runTimestamp + 5000,
+        total_cost: 0.5,
+      }),
+    ]);
+
+    const runId = randomUUID();
+    await createDatasetRunItemsCh([
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: runId,
+        dataset_item_id: randomUUID(),
+        trace_id: traceId1,
+        observation_id: null,
+        dataset_run_name: "test-run",
+        dataset_run_description: "test run description",
+        dataset_run_metadata: { purpose: "testing" },
+        dataset_run_created_at: runTimestamp,
+        created_at: runTimestamp,
+        updated_at: runTimestamp,
+        event_ts: runTimestamp,
+      }),
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: runId,
+        dataset_item_id: randomUUID(),
+        trace_id: traceId2,
+        observation_id: null,
+        dataset_run_name: "test-run",
+        dataset_run_description: "test run description",
+        dataset_run_metadata: { purpose: "testing" },
+        dataset_run_created_at: runTimestamp,
+        created_at: runTimestamp,
+        updated_at: runTimestamp,
+        event_ts: runTimestamp,
+      }),
+      // Run in the other dataset — must not be exported
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId2,
+        dataset_run_id: randomUUID(),
+        dataset_item_id: randomUUID(),
+        trace_id: randomUUID(),
+        observation_id: null,
+        dataset_run_name: "other-run",
+        dataset_run_created_at: runTimestamp,
+        created_at: runTimestamp,
+        updated_at: runTimestamp,
+        event_ts: runTimestamp,
+      }),
+    ]);
+
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId,
+      tableName: BatchExportTableName.DatasetRuns,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [
+        {
+          type: "string",
+          operator: "=",
+          column: "datasetId",
+          value: datasetId,
+        },
+      ],
+      orderBy: { column: "createdAt", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        id: runId,
+        name: "test-run",
+        description: "test run description",
+        metadata: { purpose: "testing" },
+        countRunItems: 2,
+      }),
+    );
+    expect(Number(rows[0].avgLatency)).toBeCloseTo(5);
+    expect(Number(rows[0].avgTotalCost)).toBeCloseTo(0.5);
+    expect(Number(rows[0].totalCost)).toBeCloseTo(1);
+  });
+
+  it("should fail dataset runs export without datasetId filter", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    await expect(
+      getDatabaseReadStreamPaginated({
+        projectId,
+        tableName: BatchExportTableName.DatasetRuns,
+        cutoffCreatedAt: new Date(),
+        filter: [],
+        orderBy: { column: "createdAt", order: "DESC" },
+      }),
+    ).rejects.toThrow("dataset_runs export requires a datasetId filter");
   });
 });

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -25,6 +25,8 @@ import {
   getTracesTableMetrics,
   getTraceIdentifiers,
   getDatasetRunItemsCh,
+  getDatasetRunsTableRowsCh,
+  getDatasetRunsTableMetricsCh,
   getTracesByIds,
   getScoresForTraces,
   getDatasetItems,
@@ -45,6 +47,7 @@ const tableNameToTimeFilterColumn: Record<BatchTableNames, string> = {
   observations: "startTime",
   events: "startTime",
   datasets: "createdAt",
+  dataset_runs: "createdAt",
   dataset_run_items: "createdAt",
   dataset_items: "createdAt", // TODO: flip to validFrom once we write in new format
   audit_logs: "createdAt",
@@ -56,6 +59,7 @@ const tableNameToTimeFilterColumnCh: Record<BatchTableNames, string> = {
   observations: "startTime",
   events: "startTime",
   datasets: "createdAt",
+  dataset_runs: "createdAt",
   dataset_run_items: "createdAt",
   dataset_items: "createdAt",
   audit_logs: "createdAt",
@@ -540,6 +544,89 @@ export const getDatabaseReadStreamPaginated = async ({
             chunkWithComments,
             emptyScoreColumns,
           );
+        },
+        env.BATCH_EXPORT_PAGE_SIZE,
+        rowLimit,
+      );
+    }
+
+    case "dataset_runs": {
+      // Export dataset runs with their aggregated metrics (latency, cost,
+      // run-item count). The datasetId is passed as a filter condition from the
+      // UI so that only runs belonging to the current dataset are exported.
+      // Extract datasetId from the filter array (injected by the UI).
+      const datasetIdFilter = filter?.find((f) => f.column === "datasetId");
+      const datasetId =
+        datasetIdFilter && "value" in datasetIdFilter
+          ? String(datasetIdFilter.value)
+          : undefined;
+
+      if (!datasetId) {
+        // Throw eagerly (not inside the lazy query delegate) so the job
+        // fails fast with a clear error.
+        throw new Error(
+          "dataset_runs export requires a datasetId filter condition",
+        );
+      }
+
+      return new DatabaseReadStream<unknown>(
+        async (pageSize: number, offset: number) => {
+          // Build the filter list for ClickHouse queries, excluding the
+          // synthetic datasetId filter (it's passed as a dedicated param) and
+          // appending the createdAt cutoff.
+          const chFilter = [
+            ...(filter ?? []).filter((f) => f.column !== "datasetId"),
+            createdAtCutoffFilter,
+          ];
+
+          // Phase 1: fetch the run rows (id, name, description, metadata, etc.)
+          const rows = await getDatasetRunsTableRowsCh({
+            projectId,
+            datasetId,
+            filter: chFilter,
+            orderBy,
+            limit: pageSize,
+            offset,
+          });
+
+          if (rows.length === 0) return [];
+
+          // Phase 2: fetch aggregated metrics for the page's run IDs.
+          const runIds = rows.map((r) => r.id);
+          const metrics = await getDatasetRunsTableMetricsCh({
+            projectId,
+            datasetId,
+            runIds,
+            filter: chFilter,
+          });
+
+          // Phase 3: merge rows + metrics into flat export records.
+          return rows.map((row) => {
+            const metric = metrics.find((m) => m.id === row.id);
+
+            // ClickHouse stores run metadata as a JSON string; parse it so
+            // JSON/JSONL exports contain structured data like other tables.
+            let metadata: unknown = row.metadata;
+            if (typeof row.metadata === "string") {
+              try {
+                metadata = JSON.parse(row.metadata);
+              } catch {
+                // keep the raw string if it is not valid JSON
+              }
+            }
+
+            return {
+              id: row.id,
+              name: row.name,
+              description: row.description,
+              createdAt: row.createdAt,
+              metadata,
+              countRunItems: metric?.countRunItems ?? 0,
+              avgLatency: metric?.avgLatency ?? null,
+              avgTotalCost: metric?.avgTotalCost ?? null,
+              totalCost: metric?.totalCost ?? null,
+            };
+          });
         },
         env.BATCH_EXPORT_PAGE_SIZE,
         rowLimit,


### PR DESCRIPTION
Add the ability to export dataset runs as CSV/JSON/JSONL via the existing batch export infrastructure. Closes discussion "Export Dataset Run Table" (51 votes).

### Changes
- Add `DatasetRuns` to `BatchTableNames` enum (shared)
- Implement `dataset_runs` case in `getDatabaseReadStream` (worker): fetches run rows + aggregated metrics (run-item count, avg latency, avg/total cost) from ClickHouse and merges them into flat export records. Run metadata JSON is parsed so exports contain structured data. The required `datasetId` filter is validated eagerly at stream creation.
- Add `BatchExportTableButton` to `DatasetRunsTable` toolbar (web): passes `datasetId` as a filter condition so only runs of the current dataset are exported
- Integration tests covering metrics aggregation, dataset scoping and the missing-datasetId error path

### Testing
- New integration tests in `worker/src/__tests__/batchExport.test.ts` (all passing against local Postgres + ClickHouse)
- `pnpm run typecheck` passes in shared, worker and web

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds dataset-run exports through the existing batch-export infrastructure, including dataset scoping and aggregated ClickHouse metrics.
- Adds the shared `dataset_runs` batch table identifier.
- Adds CSV/JSON/JSONL export controls to both dataset-runs table layouts.
- Streams run records from ClickHouse and merges run-item count, latency, and cost metrics.
- Adds integration coverage for aggregation, dataset scoping, metadata parsing, and missing-filter validation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The dataset-run export should not merge until pagination uses a stable tie-breaker, otherwise sufficiently large exports can omit or duplicate runs with identical creation timestamps.

The new worker path uses offset pagination ordered only by createdAt, so rows tied on that non-unique field are not guaranteed to remain in a consistent position across page queries.

**Files Needing Attention:** worker/src/features/database-read-stream/getDatabaseReadStream.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Dataset Runs Table
  participant API as Batch Export API
  participant Worker as Export Worker
  participant CH as ClickHouse
  participant Blob as Blob Storage
  UI->>API: Create dataset_runs export with datasetId filter
  API->>Worker: Queue export job
  loop Each offset page
    Worker->>CH: Fetch ordered run rows
    CH-->>Worker: Run page
    Worker->>CH: Fetch metrics for page run IDs
    CH-->>Worker: Aggregated metrics
    Worker->>Worker: Parse metadata and merge records
    Worker->>Blob: Append serialized records
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/database-read-stream/getDatabaseReadStream.ts:588-589
**Unstable dataset-run pagination**

If an export spans multiple pages and runs share a creation timestamp, the offset-based query orders them only by `createdAt`, so ClickHouse can place tied runs on different sides of successive page boundaries, causing duplicate or omitted rows in the exported file.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web/worker): add batch export for d..."](https://github.com/langfuse/langfuse/commit/98dd91a55453ec1566cdb670c468b3a4491fce08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50678424)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Datasets, Dataset Runs, and Experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)

<!-- /greptile_comment -->