### PR TITLE
feat(web): add batch export button to dataset run items table

### DIFF
--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -18,12 +18,16 @@ import {
   DatasetItemIOCell,
   TraceObservationIOCell,
 } from "@/src/features/datasets/components/DatasetIOCells";
-import { datasetRunItemsTableColsWithOptions } from "@langfuse/shared";
+import {
+  datasetRunItemsTableColsWithOptions,
+  BatchExportTableName,
+} from "@langfuse/shared";
 import { convertRunItemToItemsByRunUiTableRow } from "@/src/features/datasets/lib/convertRunItemDataToUiTableRow";
 import { type DatasetRunItemByRunRowData } from "@/src/features/datasets/lib/types";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useDebounce } from "@/src/hooks/useDebounce";
+import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 
 export function DatasetRunItemsByRunTable(props: {
   projectId: string;
@@ -289,6 +293,29 @@ export function DatasetRunItemsByRunTable(props: {
         setColumnOrder={setColumnOrder}
         rowHeight={rowHeight}
         setRowHeight={setRowHeight}
+        actionButtons={
+          <BatchExportTableButton
+            key="batchExport"
+            projectId={projectId}
+            tableName={BatchExportTableName.DatasetRunItems}
+            orderByState={{ column: "createdAt", order: "DESC" }}
+            filterState={[
+              {
+                type: "string",
+                operator: "=",
+                column: "datasetRunId",
+                value: datasetRunId,
+              },
+              {
+                type: "string",
+                operator: "=",
+                column: "datasetId",
+                value: datasetId,
+              },
+              ...userFilterState,
+            ]}
+          />
+        }
       />
       <DataTable
         tableName="datasetRunItems"

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -10,6 +10,8 @@ import {
   createTrace,
   createTracesCh,
   createManyDatasetItems,
+  createDatasetRunItem,
+  createDatasetRunItemsCh,
   applyCommentFilters,
   createEvent,
   createEventsCh,
@@ -5174,5 +5176,92 @@ maybeDescribe("getEventsForBlobStorageExport", () => {
     expect(Object.keys(rows[0]).sort()).toEqual(expectedColumns);
     expect(rows[0].input).toBe("hello");
     expect(rows[0].output).toBe("world");
+  });
+  it("should export dataset run items scoped to a run", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const datasetId = randomUUID();
+    await prisma.dataset.create({
+      data: {
+        id: datasetId,
+        name: "test-dataset-run-items-export",
+        projectId,
+      },
+    });
+
+    const runId1 = randomUUID();
+    const runId2 = randomUUID();
+    const now = Date.now();
+
+    await createDatasetRunItemsCh([
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: runId1,
+        dataset_item_id: randomUUID(),
+        dataset_run_name: "run-1",
+        created_at: now,
+        updated_at: now,
+        event_ts: now,
+      }),
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: runId1,
+        dataset_item_id: randomUUID(),
+        dataset_run_name: "run-1",
+        created_at: now,
+        updated_at: now,
+        event_ts: now,
+      }),
+      // Second run — must be excluded by the datasetRunId filter
+      createDatasetRunItem({
+        project_id: projectId,
+        dataset_id: datasetId,
+        dataset_run_id: runId2,
+        dataset_item_id: randomUUID(),
+        dataset_run_name: "run-2",
+        created_at: now,
+        updated_at: now,
+        event_ts: now,
+      }),
+    ]);
+
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId,
+      tableName: BatchExportTableName.DatasetRunItems,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [
+        {
+          type: "string",
+          operator: "=",
+          column: "datasetRunId",
+          value: runId1,
+        },
+        {
+          type: "string",
+          operator: "=",
+          column: "datasetId",
+          value: datasetId,
+        },
+      ],
+      orderBy: { column: "createdAt", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row).toEqual(
+        expect.objectContaining({
+          datasetName: "test-dataset-run-items-export",
+        }),
+      );
+      expect(row.traceId).toBeTruthy();
+      expect(row.datasetItemId).toBeTruthy();
+    }
   });
 });


### PR DESCRIPTION
Add a batch export button to the run items table on the dataset run detail page.

### Changes
- Add `BatchExportTableButton` to `DatasetRunItemsByRunTable` toolbar
- The button injects `datasetRunId` and `datasetId` filter conditions so only items of the current run are exported
- Reuses the existing `dataset_run_items` worker read stream — zero worker changes
- Integration test verifying the export is scoped by the injected filters

### Testing
- New integration test in `worker/src/__tests__/batchExport.test.ts` (passing against local Postgres + ClickHouse)
- `pnpm run typecheck` passes in shared, worker and web

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a batch-export control to the dataset run-items toolbar, preserving the current run, dataset, and user-selected filters in the export query.
- Reuses the existing dataset-run-items batch-export worker stream.
- Adds an integration test confirming that another run’s items are excluded.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The pull request appears safe to merge, with export scoping and authorization preserved by the existing batch-export path.

The new control forwards valid run, dataset, and user filters to the existing export stream, while the added integration test verifies that items from another run are excluded.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add batch export button to da..."](https://github.com/langfuse/langfuse/commit/59bf929649c31ed5cda999c65b392dfb3fac5eee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50678528)</sub>

**Context used:**

- Knowledge Base — [Datasets, Dataset Runs, and Experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md)
- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)

<!-- /greptile_comment -->