### PR TITLE
feat(web/worker): add batch export for prompts

### DIFF
--- a/packages/shared/src/interfaces/tableNames.ts
+++ b/packages/shared/src/interfaces/tableNames.ts
@@ -13,4 +13,5 @@ export enum BatchTableNames {
   DatasetRunItems = "dataset_run_items",
   DatasetItems = "dataset_items",
   AuditLogs = "audit_logs",
+  Prompts = "prompts",
 }

--- a/web/src/components/BatchExportTableButton.tsx
+++ b/web/src/components/BatchExportTableButton.tsx
@@ -86,6 +86,8 @@ export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
         return "Note: Filters on Comments are not included in session exports. You may receive more data than expected.";
       case BatchTableNames.AuditLogs:
         return "Note: Filters are not applied to audit log exports. All audit logs for this project will be exported.";
+      case BatchTableNames.Prompts:
+        return "Note: Filters and search are not applied to prompt exports. All prompt versions for this project will be exported.";
       default:
         // Note: for Scores, DatasetRunItems, DatasetItems, filters should work as expected
         return null;

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -29,6 +29,8 @@ import { useFolderPagination } from "@/src/features/folders/hooks/useFolderPagin
 import { buildFullPath } from "@/src/features/folders/utils";
 import { FolderBreadcrumb } from "@/src/features/folders/components/FolderBreadcrumb";
 import { FolderBreadcrumbLink } from "@/src/features/folders/components/FolderBreadcrumbLink";
+import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
+import { BatchExportTableName } from "@langfuse/shared";
 
 type PromptTableRow = {
   id: string;
@@ -419,6 +421,15 @@ export function PromptTable() {
           columns={promptColumns}
           filterState={queryFilter.filterState}
           columnsWithCustomSelect={["labels", "tags"]}
+          actionButtons={
+            <BatchExportTableButton
+              key="batchExport"
+              projectId={projectId}
+              tableName={BatchExportTableName.Prompts}
+              orderByState={orderByState}
+              filterState={queryFilter.filterState}
+            />
+          }
           searchConfig={{
             metadataSearchFields: ["Name", "Tags", "Content"],
             updateQuery: useDebounce(setSearchQuery, 300),

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -5175,4 +5175,99 @@ maybeDescribe("getEventsForBlobStorageExport", () => {
     expect(rows[0].input).toBe("hello");
     expect(rows[0].output).toBe("world");
   });
+  it("should export prompts with all versions", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    await prisma.prompt.createMany({
+      data: [
+        {
+          projectId,
+          name: "prompt-a",
+          version: 1,
+          type: "text",
+          prompt: "Hello {{name}} v1",
+          labels: [],
+          tags: ["tag1"],
+          config: {},
+          createdBy: "test-user",
+        },
+        {
+          projectId,
+          name: "prompt-a",
+          version: 2,
+          type: "text",
+          prompt: "Hello {{name}} v2",
+          labels: ["production"],
+          tags: ["tag1"],
+          config: { temperature: 0.7 },
+          createdBy: "test-user",
+          commitMessage: "improve greeting",
+        },
+        {
+          projectId,
+          name: "prompt-b",
+          version: 1,
+          type: "chat",
+          prompt: [{ role: "system", content: "You are helpful." }],
+          labels: ["latest"],
+          tags: [],
+          config: {},
+          createdBy: "test-user",
+        },
+        {
+          projectId,
+          name: "prompt-future",
+          version: 1,
+          type: "text",
+          prompt: "created after the export cutoff",
+          labels: [],
+          tags: [],
+          config: {},
+          createdBy: "test-user",
+          // Created after the export cutoff — must be excluded
+          createdAt: new Date(Date.now() + 1000 * 60 * 60 * 48),
+        },
+      ],
+    });
+
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId,
+      tableName: BatchExportTableName.Prompts,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+      orderBy: { column: "createdAt", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    expect(rows).toHaveLength(3);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "prompt-a",
+          version: 1,
+          prompt: "Hello {{name}} v1",
+          tags: ["tag1"],
+          createdBy: "test-user",
+        }),
+        expect.objectContaining({
+          name: "prompt-a",
+          version: 2,
+          labels: ["production"],
+          commitMessage: "improve greeting",
+        }),
+        expect.objectContaining({
+          name: "prompt-b",
+          version: 1,
+          type: "chat",
+          labels: ["latest"],
+        }),
+      ]),
+    );
+    // The future prompt must be excluded by the cutoff
+    expect(rows.map((r) => r.name)).not.toContain("prompt-future");
+  });
 });

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -48,6 +48,7 @@ const tableNameToTimeFilterColumn: Record<BatchTableNames, string> = {
   dataset_run_items: "createdAt",
   dataset_items: "createdAt", // TODO: flip to validFrom once we write in new format
   audit_logs: "createdAt",
+  prompts: "createdAt",
 };
 const tableNameToTimeFilterColumnCh: Record<BatchTableNames, string> = {
   scores: "timestamp",
@@ -59,6 +60,7 @@ const tableNameToTimeFilterColumnCh: Record<BatchTableNames, string> = {
   dataset_run_items: "createdAt",
   dataset_items: "createdAt",
   audit_logs: "createdAt",
+  prompts: "createdAt",
 };
 const isGenerationTimestampFilter = (
   filter: FilterCondition,
@@ -659,6 +661,44 @@ export const getDatabaseReadStreamPaginated = async ({
             action: log.action,
             before: log.before,
             after: log.after,
+          }));
+        },
+        env.BATCH_EXPORT_PAGE_SIZE,
+        rowLimit,
+      );
+    }
+    case "prompts": {
+      // Export all prompt versions of the project. Filters are not applied
+      // (consistent with audit_logs); the UI warns users accordingly.
+      return new DatabaseReadStream<unknown>(
+        async (pageSize: number, offset: number) => {
+          const prompts = await prisma.prompt.findMany({
+            where: {
+              projectId: projectId,
+              createdAt: {
+                lt: cutoffCreatedAt,
+              },
+            },
+            // Order by createdAt plus the unique id so offset-based pagination
+            // is stable even when prompts share a creation timestamp.
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+            skip: offset,
+            take: pageSize,
+          });
+
+          return prompts.map((prompt) => ({
+            id: prompt.id,
+            name: prompt.name,
+            version: prompt.version,
+            type: prompt.type,
+            prompt: prompt.prompt,
+            labels: prompt.labels,
+            tags: prompt.tags,
+            config: prompt.config,
+            commitMessage: prompt.commitMessage,
+            createdAt: prompt.createdAt,
+            updatedAt: prompt.updatedAt,
+            createdBy: prompt.createdBy,
           }));
         },
         env.BATCH_EXPORT_PAGE_SIZE,


### PR DESCRIPTION
Add the ability to export all prompt versions of a project as CSV/JSON/JSONL.

### Changes
- Add `Prompts` to `BatchTableNames` enum (shared)
- Implement `prompts` case in `getDatabaseReadStream` (worker): prisma-paginated read of all prompt versions (id, name, version, type, prompt, labels, tags, config, commitMessage, timestamps, author), respecting the `createdAt` cutoff. Filters/search are not applied, consistent with the `audit_logs` export.
- Add `BatchExportTableButton` to the prompts table toolbar (web) with a warning that filters/search are not applied
- Integration test verifying all versions are exported with fields intact and the createdAt cutoff respected

### Design notes
- Follows the `audit_logs` prisma pagination pattern (skip/take with `BATCH_EXPORT_PAGE_SIZE`)
- Exports every version of every prompt so users can reconstruct full prompt history

### Testing
- New integration test in `worker/src/__tests__/batchExport.test.ts` (passing against local Postgres + ClickHouse)
- `pnpm run typecheck` passes in shared, worker and web

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds project-wide batch export of every prompt version in CSV, JSON, and JSONL formats.
- Extends the shared batch-export table enum with prompts.
- Adds the prompt-table export action and warns that filters and search are ignored.
- Streams prompt versions from Postgres using the export creation time as a cutoff.
- Adds integration coverage for exported fields, versions, and cutoff behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The prompt export should not merge until pagination is made deterministic so every version is exported exactly once.

Prompt versions can share createdAt timestamps, but the new stream orders only by that field while advancing offsets, allowing versions at page boundaries to be silently omitted or duplicated.

**Files Needing Attention:** worker/src/features/database-read-stream/getDatabaseReadStream.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant W as Web
  participant Q as Batch Export Queue
  participant P as Worker
  participant DB as Postgres
  participant S3 as Export Storage
  U->>W: Export prompts
  W->>Q: Enqueue persisted export query
  Q->>P: Process export job
  loop Paginated prompt reads
    P->>DB: findMany(projectId, createdAt cutoff)
    DB-->>P: Prompt versions
  end
  P->>S3: Upload CSV / JSON / JSONL
  S3-->>U: Signed download URL
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/database-read-stream/getDatabaseReadStream.ts:682-687
**Non-deterministic prompt pagination**

When prompt rows sharing the same `createdAt` cross a page boundary, ordering solely by that non-unique field makes offset-based pages unstable, causing prompt versions to be omitted or duplicated while the export still completes successfully.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web/worker): add batch export for p..."](https://github.com/langfuse/langfuse/commit/3562744e5306c0a8a4212222dbf5bace378ab8e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50678761)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)
- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->