### PR TITLE
fix(batch-export): stabilize audit logs export pagination with unique id tiebreaker

### DIFF
--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -22,6 +22,7 @@ import {
   DatasetStatus,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
+import { env } from "../env";
 import { getDatabaseReadStreamPaginated } from "../features/database-read-stream/getDatabaseReadStream";
 import { getObservationStream } from "../features/database-read-stream/observation-stream";
 import { getTraceStream } from "../features/database-read-stream/trace-stream";
@@ -1700,6 +1701,62 @@ describe("batch export test suite", () => {
       expect(row.projectId).toBe(projectId);
       expect(row.orgId).toBe(orgId);
     });
+  });
+
+  it("should export audit logs without duplicates or omissions when entries share a creation timestamp", async () => {
+    const { projectId, orgId } = await createOrgProjectAndApiKey();
+
+    // Insert more audit logs than a single export page, all sharing the same
+    // creation timestamp, so the paginated read must resolve ordering ties
+    // deterministically instead of duplicating or omitting rows at page
+    // boundaries.
+    const total = env.BATCH_EXPORT_PAGE_SIZE + 50;
+    const sharedTimestamp = new Date("2024-05-01T12:00:00Z");
+    const auditLogEntries = Array.from({ length: total }, () => ({
+      id: randomUUID(),
+      projectId: projectId,
+      orgId: orgId,
+      type: "API_KEY" as const,
+      apiKeyId: randomUUID(),
+      resourceType: "prompt",
+      resourceId: randomUUID(),
+      action: "CREATE",
+      before: null,
+      after: null,
+      createdAt: sharedTimestamp,
+      updatedAt: sharedTimestamp,
+    }));
+
+    await prisma.auditLog.createMany({
+      data: auditLogEntries,
+    });
+
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId: projectId,
+      tableName: BatchExportTableName.AuditLogs,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+      orderBy: { column: "createdAt", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    // No row may be duplicated or omitted at page boundaries
+    expect(rows).toHaveLength(total);
+    const exportedIds = rows.map((row) => row.id);
+    expect(new Set(exportedIds).size).toBe(total);
+
+    // Ordering must match the deterministic createdAt + id ordering
+    const expectedOrder = await prisma.auditLog.findMany({
+      where: { projectId: projectId },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      select: { id: true },
+    });
+    expect(exportedIds).toEqual(expectedOrder.map((log) => log.id));
   });
 
   it("should export traces with searchQuery and searchType filters applied correctly", async () => {

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -636,9 +636,9 @@ export const getDatabaseReadStreamPaginated = async ({
                 lt: cutoffCreatedAt,
               },
             },
-            orderBy: {
-              createdAt: "desc",
-            },
+            // Order by createdAt plus the unique id so offset-based pagination
+            // is stable even when audit logs share a creation timestamp.
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
             skip: offset,
             take: pageSize,
           });


### PR DESCRIPTION
## What does this PR do?

The audit logs batch export reads rows with offset-based pagination ordered only by the non-unique `createdAt` column. When audit log entries share a creation timestamp, the database is free to return tied rows in any order, so entries can be **duplicated or omitted** when a page boundary falls between tied rows.

This PR appends the unique audit log `id` as a deterministic tiebreaker (`ORDER BY createdAt DESC, id DESC`) in the `audit_logs` case of `getDatabaseReadStreamPaginated`, mirroring the pagination-stability pattern recently applied to other export paths.

## Changes

- `worker/src/features/database-read-stream/getDatabaseReadStream.ts`: order the audit logs query by `[{ createdAt: "desc" }, { id: "desc" }]`.
- `worker/src/__tests__/batchExport.test.ts`: add an integration test that inserts more than one export page of audit logs all sharing the same creation timestamp and asserts the export contains every row exactly once in the deterministic order. The test fails against the previous ordering and passes with this fix.

## Verification

- `tsc --noEmit` (worker) passes
- Prettier check passes
- Integration tests run against local Postgres: both audit logs export tests pass; the new test fails without the fix (verified by temporarily reverting it)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a unique audit-log ID tiebreaker to stabilize offset-based batch-export pagination when multiple records share a creation timestamp.
- Orders audit logs by `createdAt DESC, id DESC`.
- Adds an integration test spanning multiple pages and verifying completeness, uniqueness, and deterministic order.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed pagination logic or its regression coverage.

The unique ID tiebreaker correctly stabilizes equal-timestamp ordering while preserving the existing cutoff, filtering, and descending creation-time behavior, and the test exercises the affected page-boundary condition.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(batch-export): stabilize audit logs ..."](https://github.com/langfuse/langfuse/commit/2158b977de793d24101325cb83e7eddc286170d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50738953)</sub>

**Context used:**

- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)

<!-- /greptile_comment -->