### PR TITLE
fix(ui): preserve ordered list start numbers

### DIFF
--- a/web/src/components/ui/MarkdownViewer.clienttest.tsx
+++ b/web/src/components/ui/MarkdownViewer.clienttest.tsx
@@ -61,6 +61,14 @@ describe("MarkdownView link rendering", () => {
   });
 });
 
+describe("MarkdownView ordered lists", () => {
+  it("preserves an explicit ordered-list start number", () => {
+    const { container } = renderMarkdown("2.");
+
+    expect(container.querySelector("ol")?.getAttribute("start")).toBe("2");
+  });
+});
+
 describe("prependBasePathToInternalHref", () => {
   // A native <a> loses the NEXT_PUBLIC_BASE_PATH that <Link> used to prepend to
   // root-relative internal hrefs; this helper restores it for subpath deploys.

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -338,8 +338,12 @@ function MarkdownRenderer({
 
               return <ul className="list-inside list-disc">{children}</ul>;
             },
-            ol({ children }) {
-              return <ol className="list-inside list-decimal">{children}</ol>;
+            ol({ children, start }) {
+              return (
+                <ol start={start} className="list-inside list-decimal">
+                  {children}
+                </ol>
+              );
             },
             li({ children }) {
               return (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15828.preview.langfuse.com](https://pr-15828.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- preserve explicit Markdown ordered-list start numbers in the renderer
- add a regression test for a message containing `2.`

## Verification
- Not run per request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves explicit Markdown ordered-list start numbers by forwarding the renderer-provided `start` value to the HTML `<ol>` element.
- Updates the ordered-list renderer to emit the `start` attribute.
- Adds a client regression test for a list beginning with `2.`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or quality issues identified.

The renderer now passes the parser-provided ordered-list start value directly to the corresponding standard HTML attribute, and the focused regression test covers the intended behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): preserve ordered list start num..."](https://github.com/langfuse/langfuse/commit/0b645ace1c7ac3aecc4e5d34864292406d1b664e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50747948)</sub>

<!-- /greptile_comment -->