### PR TITLE
fix(blob-storage-export): keep millisecond precision in export object keys

### DIFF
--- a/worker/src/__tests__/blobExportManifest.unit.test.ts
+++ b/worker/src/__tests__/blobExportManifest.unit.test.ts
@@ -22,10 +22,36 @@ const file = (
 });
 
 describe("blob export manifest builders (LFE-10843)", () => {
-  it("strips colons from the timestamp stem and truncates to seconds", () => {
+  it("strips colons and dots from the timestamp stem and keeps milliseconds", () => {
     expect(
       formatBlobExportTimestamp(new Date("2026-07-10T10:20:30.123Z")),
-    ).toBe("2026-07-10T10-20-30");
+    ).toBe("2026-07-10T10-20-30-123");
+  });
+
+  it("produces distinct keys for timestamps within the same wall-clock second", () => {
+    // A caught-up run can emit a full-interval chunk and a sub-second
+    // remainder chunk back-to-back; their keys must never collide or the
+    // remainder silently overwrites the full window's files.
+    const first = formatBlobExportTimestamp(
+      new Date("2026-07-10T10:20:30.058Z"),
+    );
+    const second = formatBlobExportTimestamp(
+      new Date("2026-07-10T10:20:30.447Z"),
+    );
+    expect(first).not.toBe(second);
+    expect(
+      buildBlobExportManifestKey({
+        projectId: "proj",
+        maxTimestamp: new Date("2026-07-10T10:20:30.058Z"),
+      }),
+    ).not.toBe(
+      buildBlobExportManifestKey({
+        projectId: "proj",
+        maxTimestamp: new Date("2026-07-10T10:20:30.447Z"),
+      }),
+    );
+    // Fixed-width stems must preserve chronological lexicographic order.
+    expect(first < second).toBe(true);
   });
 
   it("builds the manifest key under the project's manifests/ prefix", () => {
@@ -35,7 +61,7 @@ describe("blob export manifest builders (LFE-10843)", () => {
         projectId: "proj",
         maxTimestamp: new Date("2026-07-10T10:20:30Z"),
       }),
-    ).toBe("team/proj/manifests/2026-07-10T10-20-30.json");
+    ).toBe("team/proj/manifests/2026-07-10T10-20-30-000.json");
   });
 
   it("treats an absent prefix as empty", () => {
@@ -44,7 +70,7 @@ describe("blob export manifest builders (LFE-10843)", () => {
         projectId: "proj",
         maxTimestamp: new Date("2026-07-10T10:20:30Z"),
       }),
-    ).toBe("proj/manifests/2026-07-10T10-20-30.json");
+    ).toBe("proj/manifests/2026-07-10T10-20-30-000.json");
   });
 
   it("assembles the manifest payload with version, window, and distinct tables", () => {

--- a/worker/src/features/blobstorage/manifest.ts
+++ b/worker/src/features/blobstorage/manifest.ts
@@ -35,9 +35,15 @@ export type BlobExportManifest = {
   files: BlobExportManifestFile[];
 };
 
-/** Shared with table file names so a run's files and manifest sort together. */
+/**
+ * Shared with table file names so a run's files and manifest sort together.
+ * Keeps millisecond precision so consecutive chunks whose maxTimestamps fall
+ * into the same wall-clock second (e.g. a caught-up full-interval chunk
+ * immediately followed by a remainder chunk) never resolve to the same
+ * object key and silently overwrite each other.
+ */
 export const formatBlobExportTimestamp = (date: Date): string =>
-  date.toISOString().replace(/:/g, "-").substring(0, 19);
+  date.toISOString().replace(/[:.]/g, "-").substring(0, 23);
 
 /** `{prefix}{projectId}/manifests/{maxTimestamp}.json` — prefix-filterable per run. */
 export const buildBlobExportManifestKey = (params: {


### PR DESCRIPTION
## What does this PR do?

Fixes #15617

The blob storage export object key stem is built with `formatBlobExportTimestamp`, which truncated the chunk `maxTimestamp` to whole seconds (`.substring(0, 19)`). A caught-up run can emit two chunks back-to-back — a full-interval chunk and a sub-second remainder chunk — whose `maxTimestamps` fall in the same wall-clock second. Both then resolve to the same object key, so the near-empty remainder chunk silently overwrites the full window's files and manifest. On buckets without versioning that window's data is unrecoverable; the reporter observed ~7–8 silently lost windows/day on an hourly integration.

## Changes

- `worker/src/features/blobstorage/manifest.ts`: keep millisecond precision in `formatBlobExportTimestamp` (`substring(0, 23)`) and replace the dot alongside colons so the stem stays key-friendly (`2026-07-28T11-40-00-058`). Both the table file names and the manifest key derive from this one function, so the change is self-consistent.
- `worker/src/__tests__/blobExportManifest.unit.test.ts`: update the existing assertions and add a regression test covering the exact collision scenario from the issue: two timestamps within the same wall-clock second must produce distinct keys, and the fixed-width stems must preserve chronological lexicographic ordering.

## Compatibility notes

- The key stem is a naming convention only — nothing in the repo parses it back, so no consumer breaks.
- Stems remain fixed-width and zero-padded, so lexicographic ordering stays chronological; the "files and manifest sort together" contract is preserved. Old second-precision keys (`...T10-20-30.json`) sort immediately adjacent to new millisecond keys (`...T10-20-30-000.json`).
- The same job already uses full-precision timestamps for its self-requeue `jobId`; this closes the inconsistency.

## Verification

- `tsc --noEmit` (worker) passes
- Prettier check passes
- Unit tests: 6/6 pass with the fix; reverting only the `manifest.ts` change makes 4 of them fail (verified), including the new collision test

Note to maintainers: I noticed this issue is assigned to @nsemmler — happy to close this if the fix is already in flight internally.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves millisecond precision in blob-storage export object keys to prevent distinct chunks within one wall-clock second from overwriting each other.

- Updates the shared timestamp formatter to emit fixed-width, key-friendly millisecond stems.
- Adds regression coverage for uniqueness and chronological lexicographic ordering.
- Updates manifest-key expectations to the new format.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed timestamp formatting or its tests.

The shared formatter is used consistently for table and manifest keys, retains fixed-width chronological ordering, and no internal consumer parses or assumes the former seconds-only key shape.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-storage-export): keep milliseco..."](https://github.com/langfuse/langfuse/commit/5f5509425c9987c81a1bbc22c5952f7e3d9019f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50748081)</sub>

**Context used:**

- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)

<!-- /greptile_comment -->