### PR TITLE
fix(experiments): remove compare IO cell hover expansion

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentGridCell.tsx
+++ b/web/src/features/experiments/components/table/ExperimentGridCell.tsx
@@ -484,7 +484,6 @@ export const ExperimentGridCell = ({
             data={data.output ?? null}
             className="bg-accent-light-green min-h-8"
             singleLine={singleLine}
-            enableExpandOnHover
           />
         ),
       },

--- a/web/src/features/experiments/components/table/ExperimentGridView.tsx
+++ b/web/src/features/experiments/components/table/ExperimentGridView.tsx
@@ -211,7 +211,6 @@ export const ExperimentGridView = ({
             isLoading={isLoading}
             data={row.original.input ?? null}
             singleLine={singleLine}
-            enableExpandOnHover
           />
         ),
       },
@@ -226,7 +225,6 @@ export const ExperimentGridView = ({
             data={row.original.expectedOutput ?? null}
             singleLine={singleLine}
             className="bg-accent-light-green"
-            enableExpandOnHover
           />
         ),
       },

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -189,7 +189,6 @@ const StackedOutputRow = ({
         data={output}
         singleLine={singleLine}
         className="bg-accent-light-green"
-        enableExpandOnHover
       />
     </div>
   );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15830.preview.langfuse.com](https://pr-15830.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- remove hover expansion from compare-view input, expected output, and actual output cells
- keep all other IO and score hover behavior unchanged

## Verification
- Not run per request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes hover expansion from input, expected-output, and actual-output cells in experiment comparison views while leaving unrelated IO and score-cell behavior unchanged.

- Removes hover expansion from grid comparison input and expected-output cells.
- Removes hover expansion from individual and stacked actual-output cells.
- Relies on the IO cell component’s existing non-expanding default behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the changed call sites are confined to the intended experiment comparison views.

The removed props fall back to the IO cell component’s existing non-expanding behavior, and no changed call site serves a non-compare view whose hover behavior needed to remain intact.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): remove IO cell hover e..."](https://github.com/langfuse/langfuse/commit/ab3c54c8d5ba81d4c243379c97faec2a3300055b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50749706)</sub>

**Context used:**

- Knowledge Base — [Datasets, Dataset Runs, and Experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md)

<!-- /greptile_comment -->