### PR TITLE
feat(in-app-agent): improve tool failure instrumentation

### DIFF
--- a/packages/shared/src/in-app-agent/server/agent.ts
+++ b/packages/shared/src/in-app-agent/server/agent.ts
@@ -14,11 +14,12 @@ import {
   type ResumeForwardedProps,
 } from "../schema";
 import { createManualToolApprovalRunInput } from "./human-in-the-loop";
-import type {
-  InAppAgentPromptMetadata,
-  InAppAgentTracingConfig,
+import {
+  createInAppAgentInstrumentation,
+  type InAppAgentPromptMetadata,
+  type InAppAgentTracingConfig,
 } from "./instrumentation";
-import { createInAppAgentInstrumentation } from "./instrumentation";
+import { getToolFailureMessage } from "./toolErrors";
 import {
   createSandboxTools,
   createRedirectActionTool,
@@ -1104,6 +1105,14 @@ function normalizeAdapterEvent(
         ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
       },
     ];
+  }
+
+  if (event.type === EventType.TOOL_CALL_RESULT) {
+    const failureMessage = getToolFailureMessage(event.error, event.content);
+
+    if (failureMessage && event.error !== failureMessage) {
+      return [{ ...event, error: failureMessage }];
+    }
   }
 
   return [event];

--- a/packages/shared/src/in-app-agent/server/instrumentation.ts
+++ b/packages/shared/src/in-app-agent/server/instrumentation.ts
@@ -9,6 +9,7 @@ import type { AgUiEvent, AgUiMessage, AgUiRunAgentInput } from "../schema";
 import { compactTextMessageChunks } from "./eventCompaction";
 import type { InAppAgentUserAccess } from "./tools";
 import { assertUnreachable } from "../../utils/typeChecks";
+import { getToolFailureMessage, normalizeToolOutput } from "./toolErrors";
 
 export type InAppAgentTracingConfig = {
   environment: string;
@@ -35,6 +36,19 @@ export type InAppAgentPromptMetadata = {
   name: string;
   version: number;
 };
+
+export type InAppAgentExecutionRuntime = "foreground" | "worker";
+
+export function getInAppAgentRunLineageMetadata(
+  input: AgUiRunAgentInput,
+  executionRuntime: InAppAgentExecutionRuntime,
+) {
+  return {
+    execution_runtime: executionRuntime,
+    run_kind: input.parentRunId ? "approval_continuation" : "user_turn",
+    ...(input.parentRunId ? { parent_run_id: input.parentRunId } : {}),
+  };
+}
 
 const IN_APP_AGENT_TURN_NAME = "agent-turn";
 type InternalTracingHandler = ReturnType<typeof getInternalTracingHandler>;
@@ -91,6 +105,15 @@ type ToolObservationBody = {
   metadata?: Record<string, unknown>;
 };
 type ToolCallApprovalStatus = "approved" | "rejected";
+type AgentRunToolSpan = {
+  name: string;
+  startTime: Date;
+  args: string;
+  argsComplete: boolean;
+  output?: unknown;
+  failureMessage?: string;
+  parentMessageId?: string;
+};
 
 export function createInAppAgentInstrumentation({
   input,
@@ -128,17 +151,7 @@ export class InAppAgentInstrumentation {
   private readonly agentRun: InAppAgentGeneration;
   private agentRunInput: unknown;
   private readonly prompt?: InAppAgentPromptMetadata;
-  private readonly toolSpans = new Map<
-    string,
-    {
-      name: string;
-      startTime: Date;
-      args: string;
-      argsComplete: boolean;
-      output?: unknown;
-      parentMessageId?: string;
-    }
-  >();
+  private readonly toolSpans = new Map<string, AgentRunToolSpan>();
   private readonly toolCallApprovals = new Map<
     string,
     ToolCallApprovalStatus
@@ -541,6 +554,7 @@ export class InAppAgentInstrumentation {
     const tool = this.toolSpans.get(event.toolCallId);
     if (tool) {
       tool.output = event.content;
+      tool.failureMessage = getToolFailureMessage(event.error, event.content);
       this.endToolSpanIfComplete(event.toolCallId, tool);
     }
   }
@@ -580,14 +594,7 @@ export class InAppAgentInstrumentation {
 
   private createToolObservation(
     toolCallId: string,
-    tool: {
-      name: string;
-      startTime: Date;
-      args: string;
-      argsComplete: boolean;
-      output?: unknown;
-      parentMessageId?: string;
-    },
+    tool: AgentRunToolSpan,
     options?: {
       metadata?: Record<string, unknown>;
       statusMessage?: string;
@@ -596,7 +603,7 @@ export class InAppAgentInstrumentation {
     const input = parseJsonOrUndefined(tool.args);
     const output =
       tool.output === undefined ? undefined : normalizeToolOutput(tool.output);
-    const isError = options?.statusMessage !== undefined || isToolError(output);
+    const statusMessage = options?.statusMessage ?? tool.failureMessage;
     const toolCallApproval = this.toolCallApprovals.get(toolCallId);
     const body: ToolObservationBody = {
       id: toolCallId,
@@ -608,10 +615,8 @@ export class InAppAgentInstrumentation {
       completionStartTime: tool.startTime,
       input,
       output,
-      ...(isError ? { level: "ERROR" } : {}),
-      ...(options?.statusMessage
-        ? { statusMessage: options.statusMessage }
-        : {}),
+      ...(statusMessage !== undefined ? { level: "ERROR" } : {}),
+      ...(statusMessage ? { statusMessage } : {}),
       metadata: {
         ...(options?.metadata ?? {}),
         toolCallId,
@@ -971,32 +976,6 @@ function parseContextValue(description: string, value: string): unknown {
   }
 
   return parsed;
-}
-
-function normalizeToolOutput(output: unknown): unknown {
-  const parsedOutput =
-    typeof output === "string" ? parseJsonOrString(output) : output;
-
-  if (!isRecord(parsedOutput) || !Array.isArray(parsedOutput.content)) {
-    return parsedOutput;
-  }
-
-  const firstContent: unknown = parsedOutput.content[0];
-
-  if (
-    parsedOutput.content.length !== 1 ||
-    !isRecord(firstContent) ||
-    firstContent.type !== "text" ||
-    typeof firstContent.text !== "string"
-  ) {
-    return parsedOutput;
-  }
-
-  return parseJsonOrString(firstContent.text);
-}
-
-function isToolError(output: unknown): boolean {
-  return isRecord(output) && output.error === true;
 }
 
 function getFiniteNumber(value: unknown): number | undefined {

--- a/packages/shared/src/in-app-agent/server/toolErrors.ts
+++ b/packages/shared/src/in-app-agent/server/toolErrors.ts
@@ -1,0 +1,73 @@
+export function getToolFailureMessage(
+  eventError: unknown,
+  output: unknown,
+): string | undefined {
+  const explicitError = getStringValue(eventError);
+  if (explicitError) {
+    return explicitError;
+  }
+
+  const normalizedOutput = normalizeToolOutput(output);
+
+  if (typeof normalizedOutput === "string") {
+    const message = normalizedOutput.trim();
+    return /^MCP error\b/i.test(message) ? message : undefined;
+  }
+
+  if (!isRecord(normalizedOutput)) {
+    return undefined;
+  }
+
+  const structuredError = getStringValue(normalizedOutput.error);
+  if (structuredError) {
+    return structuredError;
+  }
+
+  if (normalizedOutput.error === true || normalizedOutput.isError === true) {
+    return getStringValue(normalizedOutput.message) ?? "Tool returned an error";
+  }
+
+  return undefined;
+}
+
+export function normalizeToolOutput(output: unknown): unknown {
+  const parsedOutput =
+    typeof output === "string" ? parseJsonOrString(output) : output;
+
+  if (!isRecord(parsedOutput) || !Array.isArray(parsedOutput.content)) {
+    return parsedOutput;
+  }
+
+  const firstContent: unknown = parsedOutput.content[0];
+
+  if (
+    parsedOutput.content.length !== 1 ||
+    !isRecord(firstContent) ||
+    firstContent.type !== "text" ||
+    typeof firstContent.text !== "string"
+  ) {
+    return parsedOutput;
+  }
+
+  return parseJsonOrString(firstContent.text);
+}
+
+function parseJsonOrString(value: string): unknown {
+  if (!value) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getStringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -302,6 +302,7 @@ describe("in-app agent public API route auth", () => {
           input: expect.objectContaining({
             messages: [],
             forwardedProps,
+            parentRunId: "suspended-run-1",
           }),
           options: expect.objectContaining({
             langfuseMcp: expect.objectContaining({

--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -865,6 +865,94 @@ describe("createAgUiStream", () => {
     expect(agentConfig?.defaultOptions).not.toHaveProperty("providerOptions");
   });
 
+  it("propagates structured tool failures to persisted stream events", async () => {
+    const { createAgUiStream } =
+      await import("@langfuse/shared/in-app-agent/server/agent");
+    const input = {
+      threadId: "conversation-1",
+      runId: "run-1",
+      messages: [
+        { id: "user-message-1", role: "user" as const, content: "hello" },
+      ],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    };
+    const failureMessage = "MCP error: invalid score config";
+    const persistedEvents: AgUiEvent[] = [];
+    const langfuseClient = {
+      getPrompt: promptMocks.getPrompt,
+    } as unknown as Langfuse;
+
+    adapterEvents.items = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tool-call-1",
+        toolCallName: "createScoreConfig",
+      },
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tool-call-1",
+        delta: "{}",
+      },
+      {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: "tool-call-1",
+      },
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: "tool-result-1",
+        toolCallId: "tool-call-1",
+        content: JSON.stringify({ error: failureMessage }),
+        role: "tool",
+      },
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    ];
+
+    const stream = await createAgUiStream({
+      input,
+      signal: new AbortController().signal,
+      options: {
+        onEvent: (event) => {
+          persistedEvents.push(event);
+        },
+        awsBedrock: { modelId: "test-model" },
+        langfuseMcp: {
+          url: "https://example.com/api/public/mcp",
+          publicKey: "pk",
+          secretKey: "sk",
+          userAccess: defaultInAppAgentUserAccess,
+        },
+        redirectAction: {
+          projectId: "project-1",
+          isV4Enabled: false,
+        },
+        langfuseClient,
+        useLocalPrompt: false,
+      },
+    });
+
+    await readStream(stream);
+
+    expect(persistedEvents).toContainEqual({
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "tool-result-1",
+      toolCallId: "tool-call-1",
+      content: JSON.stringify({ error: failureMessage }),
+      role: "tool",
+      error: failureMessage,
+    });
+  });
+
   it("executes approved tools manually and continues with tool result history", async () => {
     const { createAgUiStream } =
       await import("@langfuse/shared/in-app-agent/server/agent");

--- a/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
@@ -5,7 +5,10 @@ import {
   getInAppAgentInstrumentationTraceId,
 } from "@langfuse/shared/in-app-agent";
 import type { AgUiRunAgentInput } from "@langfuse/shared/in-app-agent";
-import { InAppAgentInstrumentation } from "@langfuse/shared/in-app-agent/server/instrumentation";
+import {
+  getInAppAgentRunLineageMetadata,
+  InAppAgentInstrumentation,
+} from "@langfuse/shared/in-app-agent/server/instrumentation";
 
 const runId = "run-1";
 const traceId = getInAppAgentInstrumentationTraceId(runId);
@@ -72,6 +75,26 @@ const expectedAgentRunInput = {
 describe("InAppAgentInstrumentation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("labels foreground user turns without a parent run", () => {
+    expect(getInAppAgentRunLineageMetadata(input, "foreground")).toEqual({
+      execution_runtime: "foreground",
+      run_kind: "user_turn",
+    });
+  });
+
+  it("labels worker approval continuations with their parent run", () => {
+    expect(
+      getInAppAgentRunLineageMetadata(
+        { ...input, parentRunId: "parent-run-1" },
+        "worker",
+      ),
+    ).toEqual({
+      execution_runtime: "worker",
+      run_kind: "approval_continuation",
+      parent_run_id: "parent-run-1",
+    });
   });
 
   it("records agent output and tool calls as tool observations", () => {
@@ -453,9 +476,106 @@ describe("InAppAgentInstrumentation", () => {
           message: "Tool input validation failed",
         },
         level: "ERROR",
+        statusMessage: "Tool input validation failed",
       }),
     );
-    expect(toolCreateBody).not.toHaveProperty("statusMessage");
+  });
+
+  it.each([
+    {
+      name: "top-level event errors",
+      content: "Tool input validation failed",
+      error: "Tool input validation failed",
+      expectedOutput: "Tool input validation failed",
+      expectedMessage: "Tool input validation failed",
+    },
+    {
+      name: "structured error strings",
+      content: JSON.stringify({ error: "Tool input validation failed" }),
+      expectedOutput: { error: "Tool input validation failed" },
+      expectedMessage: "Tool input validation failed",
+    },
+    {
+      name: "MCP error strings",
+      content: "MCP error: invalid score config",
+      expectedOutput: "MCP error: invalid score config",
+      expectedMessage: "MCP error: invalid score config",
+    },
+  ])(
+    "marks $name as failed",
+    ({ content, error, expectedOutput, expectedMessage }) => {
+      const instrumentation = createInstrumentation();
+
+      instrumentation.recordEvents([
+        {
+          type: EventType.TOOL_CALL_START,
+          toolCallId: "tool-1",
+          toolCallName: "createScoreConfig",
+        },
+        {
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: "tool-1",
+          delta: "{}",
+        },
+        {
+          type: EventType.TOOL_CALL_END,
+          toolCallId: "tool-1",
+        },
+        {
+          type: EventType.TOOL_CALL_RESULT,
+          toolCallId: "tool-1",
+          content,
+          ...(error ? { error } : {}),
+        },
+      ]);
+
+      expect(mocks.handler.langfuse.enqueue).toHaveBeenCalledWith(
+        "tool-create",
+        expect.objectContaining({
+          output: expectedOutput,
+          level: "ERROR",
+          statusMessage: expectedMessage,
+        }),
+      );
+    },
+  );
+
+  it("does not classify valid output containing the word error as a failure", () => {
+    const instrumentation = createInstrumentation();
+
+    instrumentation.recordEvents([
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tool-1",
+        toolCallName: "search",
+      },
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tool-1",
+        delta: "{}",
+      },
+      {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: "tool-1",
+      },
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: "tool-1",
+        content: JSON.stringify({
+          message: "This record describes an error handling policy",
+        }),
+      },
+    ]);
+
+    const toolCreateBody = mocks.handler.langfuse.enqueue.mock.calls[0]?.[1];
+    expect(toolCreateBody).toEqual(
+      expect.objectContaining({
+        output: {
+          message: "This record describes an error handling policy",
+        },
+      }),
+    );
+    expect(toolCreateBody).not.toHaveProperty("level");
   });
 
   it("sets static prompt metadata on the trace and agent generation", () => {

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -79,6 +79,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import {
   getInAppAgentError,
   isInAppAgentRateLimited,
+  preserveToolCallResultError,
   type InAppAiAgentMessage,
 } from "@/src/features/in-app-agent/components/utils/utils";
 import { evaluateSetStateAction } from "@/src/utils/evaluate-set-state-action";
@@ -865,7 +866,7 @@ function InAppAiAgentProviderInner({
             clearLoadingEvents();
           }
         },
-        onToolCallResultEvent: ({ event }) => {
+        onToolCallResultEvent: ({ event, messages }) => {
           const toolCallId = String(event.toolCallId);
           const toolName = toolCallNamesRef.current.get(toolCallId);
           toolCallNamesRef.current.delete(toolCallId);
@@ -881,6 +882,8 @@ function InAppAiAgentProviderInner({
               );
             });
           }
+
+          return preserveToolCallResultError(messages, event);
         },
         onRunErrorEvent: ({ event }) => {
           if (intentionalAbortRef.current) {
@@ -935,13 +938,14 @@ function InAppAiAgentProviderInner({
           });
         },
         onToolCallResultEvent: (params) => {
-          sharedSubscriber.onToolCallResultEvent(params);
+          const mutation = sharedSubscriber.onToolCallResultEvent(params);
           updatePendingToolApprovals((currentApprovals) =>
             currentApprovals.filter(
               (approval) =>
                 approval.approvalRequest.toolCallId !== params.event.toolCallId,
             ),
           );
+          return mutation;
         },
         onMessagesChanged: ({ messages }) => {
           publishAgentMessages(messages);

--- a/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -4,8 +4,78 @@ import {
   getDrawerMessages,
   getInAppAgentError,
   isInAppAgentRateLimited,
+  preserveToolCallResultError,
   type InAppAiAgentMessage,
 } from "./utils";
+
+describe("preserveToolCallResultError", () => {
+  it("keeps an errored tool result in the live message state", () => {
+    const result = preserveToolCallResultError(
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool-1",
+              type: "function",
+              function: { name: "createScoreConfig", arguments: "{}" },
+            },
+          ],
+        },
+      ],
+      {
+        type: "TOOL_CALL_RESULT",
+        messageId: "tool-result-1",
+        toolCallId: "tool-1",
+        role: "tool",
+        content: "MCP error: invalid score config",
+        error: "MCP error: invalid score config",
+      },
+    );
+
+    expect(result).toEqual({
+      stopPropagation: true,
+      messages: [
+        expect.objectContaining({ id: "assistant-1", role: "assistant" }),
+        {
+          id: "tool-result-1",
+          role: "tool",
+          toolCallId: "tool-1",
+          content: "MCP error: invalid score config",
+          error: "MCP error: invalid score config",
+        },
+      ],
+    });
+  });
+
+  it("replaces an existing result instead of adding a duplicate", () => {
+    const existingResult = {
+      id: "tool-result-1",
+      role: "tool" as const,
+      toolCallId: "tool-1",
+      content: "MCP error: invalid score config",
+    };
+
+    const result = preserveToolCallResultError([existingResult], {
+      type: "TOOL_CALL_RESULT",
+      messageId: "tool-result-1",
+      toolCallId: "tool-1",
+      role: "tool",
+      content: "MCP error: invalid score config",
+      error: "MCP error: invalid score config",
+    });
+
+    expect(result?.messages).toEqual([
+      {
+        ...existingResult,
+        error: "MCP error: invalid score config",
+      },
+    ]);
+  });
+});
+
 describe("getInAppAgentError", () => {
   const now = new Date("2026-07-08T20:00:54.997Z").getTime();
   const rateLimitError = {

--- a/web/src/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.ts
@@ -43,6 +43,63 @@ export type InAppAgentToolCallContent = {
   };
 };
 
+const ToolCallResultWithErrorSchema = z.object({
+  messageId: z.string().optional(),
+  toolCallId: z.string(),
+  content: z.string(),
+  error: z.string().optional(),
+});
+
+export function preserveToolCallResultError(
+  messages: readonly unknown[],
+  event: unknown,
+) {
+  const parsedEvent = ToolCallResultWithErrorSchema.safeParse(event);
+  if (!parsedEvent.success) {
+    return undefined;
+  }
+
+  const {
+    content,
+    error: eventError,
+    messageId,
+    toolCallId,
+  } = parsedEvent.data;
+  const error = eventError?.trim();
+  if (!error) {
+    return undefined;
+  }
+
+  const toolMessage: Extract<AgUiMessage, { role: "tool" }> = {
+    id: messageId ?? toolCallId,
+    role: "tool",
+    toolCallId,
+    content,
+    error,
+  };
+  const existingMessageIndex = messages.findIndex((message) => {
+    const parsedMessage = AgUiMessageSchema.safeParse(message);
+    return (
+      parsedMessage.success &&
+      (parsedMessage.data.id === toolMessage.id ||
+        (parsedMessage.data.role === "tool" &&
+          parsedMessage.data.toolCallId === toolCallId))
+    );
+  });
+  const nextMessages = messages.concat();
+
+  if (existingMessageIndex === -1) {
+    nextMessages.push(toolMessage);
+  } else {
+    nextMessages[existingMessageIndex] = toolMessage;
+  }
+
+  return {
+    messages: nextMessages,
+    stopPropagation: true as const,
+  };
+}
+
 const InAppAgentToolRejectionErrorSchema = z.object({
   code: z.literal(IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE),
   message: z.string(),

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -26,6 +26,7 @@ import {
   type ResumeForwardedProps,
 } from "@langfuse/shared/in-app-agent";
 import { createAgUiStream } from "@langfuse/shared/in-app-agent/server/agent";
+import { getInAppAgentRunLineageMetadata } from "@langfuse/shared/in-app-agent/server/instrumentation";
 import {
   consumeAndValidatePendingToolApproval,
   createInAppAgentMcpRunOverride,
@@ -541,6 +542,10 @@ export default async function handler(request: Request) {
                     thread_id: sanitizedInput.threadId,
                     run_id: sanitizedInput.runId,
                     cloud_region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+                    ...getInAppAgentRunLineageMetadata(
+                      sanitizedInput,
+                      "foreground",
+                    ),
                     agent_session_type:
                       parsedState.data.type === "existingConversation"
                         ? "existing"
@@ -833,10 +838,14 @@ async function prepareAgentInput(
       throw new InvalidRequestError("Invalid forwarded props");
     }
 
+    const parentRunId =
+      input.parentRunId ??
+      resumeForwardedProps.data.command.resume.approvalRequest.runId;
+
     return {
       threadId: input.threadId,
       runId: createInAppAgentRunId(),
-      ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
+      ...(parentRunId ? { parentRunId } : {}),
       state: null,
       messages: [],
       tools: [],

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
@@ -29,6 +29,7 @@ type AgentScenario = (ctx: {
   input: {
     threadId: string;
     runId: string;
+    parentRunId?: string;
     context: Array<{ description: string; value: string }>;
     forwardedProps: unknown;
   };
@@ -229,7 +230,7 @@ async function seedApprovedContinuation(opts?: {
     },
   });
 
-  return seeded;
+  return { ...seeded, parentRun };
 }
 
 describe("executeInAppAgentRun", () => {
@@ -241,9 +242,12 @@ describe("executeInAppAgentRun", () => {
       },
       { description: "browser_languages", value: '["de-DE"]' },
     ];
-    const { projectId, run } = await seedApprovedContinuation({ context });
+    const { projectId, run, parentRun } = await seedApprovedContinuation({
+      context,
+    });
 
     scenarioRef.current = async ({ input, options }) => {
+      expect(input.parentRunId).toBe(parentRun.id);
       expect(input.context).toEqual(context);
       await options.onComplete();
       await options.onFinish();

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -22,6 +22,7 @@ import {
   type AgUiRunAgentInput,
   type InAppAgentToolApprovalRequest,
 } from "@langfuse/shared/in-app-agent";
+import { getInAppAgentRunLineageMetadata } from "@langfuse/shared/in-app-agent/server/instrumentation";
 import {
   claimQueuedRun,
   clearRunMcpApiKeyPointer,
@@ -261,6 +262,9 @@ export async function executeInAppAgentRun(params: {
       messages: [...replayMessages],
       tools: [],
       context: request.context,
+      ...(request.kind === "approvalDecision"
+        ? { parentRunId: request.parentRunId }
+        : {}),
       forwardedProps:
         request.kind === "approvalDecision" && approvalRequest
           ? {
@@ -518,6 +522,10 @@ export async function executeInAppAgentRun(params: {
           projectId,
           conversationId: conversation.id,
           runId,
+          lineageMetadata: getInAppAgentRunLineageMetadata(
+            agentInput,
+            "worker",
+          ),
           user: {
             id: run.triggeredByUserId,
             email: access.email,
@@ -667,6 +675,7 @@ function buildTracingConfig(params: {
   projectId: string;
   conversationId: string;
   runId: string;
+  lineageMetadata: Record<string, unknown>;
   user: {
     id: string;
     email: string | null;
@@ -692,7 +701,7 @@ function buildTracingConfig(params: {
       conversation_id: params.conversationId,
       run_id: params.runId,
       cloud_region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-      execution_runtime: "worker",
+      ...params.lineageMetadata,
     },
   });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15831.preview.langfuse.com](https://pr-15831.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Classify top-level tool errors, structured error payloads, and narrow `MCP error` strings as failed tool observations with `ERROR` level and status messages.
- Preserve tool failures through adapter normalization, persisted streams, and live client messages without duplicate tool results.
- Add foreground/worker execution lineage metadata and parent run IDs for approval continuations.

## Why

Tool failures were present in tool output but were not consistently visible as failed Langfuse observations or in the live transcript. Approval continuations also lacked enough metadata to distinguish their execution runtime and parent run.

## Verification

- Web server tests: 68 passed.
- Client tests: 24 passed.
- Worker tests: 16 passed.
- Web/worker/shared typechecks and lint passed.
- Tests added: 9.
- Browser smoke review was attempted but blocked by the local slot's auth endpoints returning 404.

Linear: [LFE-14780](https://linear.app/clickhouse/issue/LFE-14780/instrument-tool-failures-in-langfuse-in-app-agent)