### PR TITLE
chore(eslint): keep overlay triggers colocated with siblings

### DIFF
--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -145,6 +145,7 @@ export default [
       },
     },
     rules: {
+      "@repo/no-abstracted-overlay-trigger": "warn",
       "@repo/no-tailwind-overflow-scroll": "warn",
       // Custom rules from old config
       "@typescript-eslint/consistent-type-imports": [

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import { default as noTailwindOverflowScroll } from "./rules/no-tailwind-overflow-scroll.js";
 import { default as noArbitraryColors } from "./rules/no-arbitrary-colors.js";
+import { default as noAbstractedOverlayTrigger } from "./rules/no-abstracted-overlay-trigger.js";
 import { default as noInSourceVitest } from "./rules/no-in-source-vitest.js";
 import { default as noMarginOnRootElements } from "./rules/no-margin-on-root-elements.js";
 import { default as noOverlayZindex } from "./rules/no-overlay-zindex.js";
@@ -11,6 +12,7 @@ import { default as noUnnecessaryCn } from "./rules/no-unnecessary-cn.js";
 
 const plugin = {
   rules: {
+    "no-abstracted-overlay-trigger": noAbstractedOverlayTrigger,
     "no-arbitrary-colors": noArbitraryColors,
     "no-in-source-vitest": noInSourceVitest,
     "no-margin-on-root-elements": noMarginOnRootElements,

--- a/packages/eslint-plugin/src/react-components.ts
+++ b/packages/eslint-plugin/src/react-components.ts
@@ -9,6 +9,10 @@ type RootElementCallbacks = {
   onRootElement: (node: TSESTree.JSXElement) => void;
 };
 
+type ReturnExpressionCallbacks = {
+  onReturnExpression: (node: TSESTree.Expression) => void;
+};
+
 const REACT_COMPONENT_TYPES = new Set([
   "FC",
   "FunctionComponent",
@@ -369,6 +373,154 @@ export function createComponentRootElementVisitors(
         init.type === AST_NODE_TYPES.FunctionExpression
       ) {
         maybeVisitFunctionComponentRoots(init, null);
+      }
+    },
+  };
+}
+
+function visitReturnExpressionsInStatement(
+  statement: TSESTree.Statement | null | undefined,
+  callbacks: ReturnExpressionCallbacks,
+): void {
+  if (!statement) return;
+
+  if (statement.type === AST_NODE_TYPES.ReturnStatement) {
+    if (statement.argument) callbacks.onReturnExpression(statement.argument);
+    return;
+  }
+  if (statement.type === AST_NODE_TYPES.BlockStatement) {
+    for (const child of statement.body) {
+      visitReturnExpressionsInStatement(child, callbacks);
+    }
+    return;
+  }
+  if (statement.type === AST_NODE_TYPES.IfStatement) {
+    visitReturnExpressionsInStatement(statement.consequent, callbacks);
+    visitReturnExpressionsInStatement(statement.alternate, callbacks);
+    return;
+  }
+  if (statement.type === AST_NODE_TYPES.SwitchStatement) {
+    for (const switchCase of statement.cases) {
+      for (const child of switchCase.consequent) {
+        visitReturnExpressionsInStatement(child, callbacks);
+      }
+    }
+    return;
+  }
+  if (statement.type === AST_NODE_TYPES.TryStatement) {
+    visitReturnExpressionsInStatement(statement.block, callbacks);
+    visitReturnExpressionsInStatement(statement.handler?.body, callbacks);
+    visitReturnExpressionsInStatement(statement.finalizer, callbacks);
+  }
+}
+
+/**
+ * Visits complete expressions returned by React components. Unlike the root
+ * element visitor, this preserves fragments and sibling relationships for
+ * rules that need to understand the component's full render boundary.
+ */
+export function createComponentReturnExpressionVisitors(
+  callbacks: ReturnExpressionCallbacks,
+) {
+  function getDirectVariableInitializers(
+    node:
+      | TSESTree.ArrowFunctionExpression
+      | TSESTree.FunctionDeclaration
+      | TSESTree.FunctionExpression,
+  ) {
+    const initializers = new Map<string, TSESTree.Expression>();
+    for (const statement of (node.body as TSESTree.BlockStatement).body) {
+      if (
+        statement.type !== AST_NODE_TYPES.VariableDeclaration ||
+        statement.kind !== "const"
+      ) {
+        continue;
+      }
+      for (const declaration of statement.declarations) {
+        if (
+          declaration.id.type === AST_NODE_TYPES.Identifier &&
+          declaration.init
+        ) {
+          initializers.set(declaration.id.name, declaration.init);
+        }
+      }
+    }
+    return initializers;
+  }
+
+  function resolveDirectVariable(
+    expression: TSESTree.Expression,
+    initializers: Map<string, TSESTree.Expression>,
+  ) {
+    if (expression.type !== AST_NODE_TYPES.Identifier) return expression;
+    return initializers.get(expression.name) ?? expression;
+  }
+
+  function maybeVisitFunctionComponentReturns(
+    node:
+      | TSESTree.ArrowFunctionExpression
+      | TSESTree.FunctionDeclaration
+      | TSESTree.FunctionExpression,
+    name: string | null,
+  ): void {
+    if (name && !isCapitalizedName(name)) return;
+
+    if (
+      node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+      node.expression
+    ) {
+      if (!expressionReturnsJsxOrNull(node.body)) return;
+      callbacks.onReturnExpression(node.body);
+      return;
+    }
+
+    const initializers = getDirectVariableInitializers(node);
+    const returnExpressions: TSESTree.Expression[] = [];
+    for (const statement of (node.body as TSESTree.BlockStatement).body) {
+      if (statement.type === AST_NODE_TYPES.ReturnStatement) {
+        if (statement.argument) {
+          returnExpressions.push(
+            resolveDirectVariable(statement.argument, initializers),
+          );
+        }
+        continue;
+      }
+      visitReturnExpressionsInStatement(statement, {
+        onReturnExpression(expression) {
+          returnExpressions.push(expression);
+        },
+      });
+    }
+    if (!returnExpressions.some(expressionReturnsJsxOrNull)) return;
+    for (const expression of returnExpressions) {
+      callbacks.onReturnExpression(expression);
+    }
+  }
+
+  return {
+    FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+      maybeVisitFunctionComponentReturns(node, node.id?.name ?? null);
+    },
+    VariableDeclarator(node: TSESTree.VariableDeclarator) {
+      if (node.id.type !== AST_NODE_TYPES.Identifier) return;
+      if (!isCapitalizedName(node.id.name)) return;
+      if (!node.init) return;
+
+      const init = unwrapComponentInit(node.init);
+      if (
+        init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        init.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        maybeVisitFunctionComponentReturns(init, node.id.name);
+      }
+    },
+    ExportDefaultDeclaration(node: TSESTree.ExportDefaultDeclaration) {
+      const init = unwrapComponentInit(node.declaration);
+      if (
+        init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        init.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        maybeVisitFunctionComponentReturns(init, null);
       }
     },
   };

--- a/packages/eslint-plugin/src/react-components.ts
+++ b/packages/eslint-plugin/src/react-components.ts
@@ -487,7 +487,9 @@ export function createComponentReturnExpressionVisitors(
       }
       visitReturnExpressionsInStatement(statement, {
         onReturnExpression(expression) {
-          returnExpressions.push(expression);
+          returnExpressions.push(
+            resolveDirectVariable(expression, initializers),
+          );
         },
       });
     }

--- a/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.test.ts
+++ b/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.test.ts
@@ -1,0 +1,509 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as typescriptEslintParser from "@typescript-eslint/parser";
+
+import rule from "./no-abstracted-overlay-trigger.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptEslintParser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("no-abstracted-overlay-trigger", rule, {
+  valid: [
+    `const value = 42;`,
+    `function helper() { return <div />; }`,
+    `const helper = () => <div />;`,
+    `const { Component } = source;`,
+    `const Component = undefined;`,
+    `let Component;`,
+    `function Component({ visible }) { if (visible) return <div />; return; }`,
+    `function Component() { return 42; }`,
+    `const Component = () => 42;`,
+    `function Component({ fallback }) { if (fallback === null) return; if (!fallback) return <main />; return fallback; }`,
+    `export default function () { return <main />; }`,
+    `export default class Component {}`,
+    `
+      import { Dialog, DialogContent } from "@/src/components/ui/dialog";
+
+      export function DialogController({ children }) {
+        return (
+          <Dialog>
+            {children}
+            <DialogContent />
+          </Dialog>
+        );
+      }
+    `,
+    `
+      import { Dialog, DialogTrigger } from "@/src/components/ui/dialog";
+
+      export function Parent() {
+        return (
+          <DialogController>
+            <DialogTrigger />
+          </DialogController>
+        );
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "@/src/components/ui/dialog";
+
+      export function SettingsPage() {
+        return (
+          <main>
+            <h1>Settings</h1>
+            <Dialog>
+              <DialogTrigger />
+              <DialogContent />
+            </Dialog>
+          </main>
+        );
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "@/src/components/ui/dialog";
+
+      export function SettingsPage() {
+        return (
+          <>
+            <Header />
+            <Dialog>
+              <DialogTrigger />
+              <DialogContent />
+            </Dialog>
+          </>
+        );
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "somewhere-else";
+
+      export function UnrelatedComponent() {
+        return (
+          <Dialog>
+            <DialogTrigger />
+            <DialogContent />
+          </Dialog>
+        );
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "@/src/components/ui/dialog";
+
+      export function Conditional({ embedded }) {
+        if (embedded) {
+          return (
+            <main>
+              <Header />
+              <Dialog>
+                <DialogTrigger />
+                <DialogContent />
+              </Dialog>
+            </main>
+          );
+        }
+
+        return <Dialog><DialogContent /></Dialog>;
+      }
+    `,
+    `
+      import Dialog, * as DialogComponents from "@/src/components/ui/dialog";
+      import { "Dialog" as Modal } from "@/src/components/ui/dialog";
+
+      export function MemberRoot() {
+        return <DialogComponents.Dialog />;
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "@/src/components/ui/dialog";
+
+      export function TextWrapper() {
+        return <div>Label<Dialog><DialogTrigger /><DialogContent /></Dialog></div>;
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "@/src/components/ui/dialog";
+
+      export function SpreadWrapper({ children }) {
+        return <div>{...children}<Dialog><DialogTrigger /><DialogContent /></Dialog></div>;
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "@/src/components/ui/dialog";
+
+      export function Incomplete({ visible }) {
+        return visible ? null : <Dialog><DialogTrigger /></Dialog>;
+      }
+    `,
+    `
+      import {
+        Dialog,
+        DialogContent,
+        DialogTrigger,
+      } from "@/src/components/ui/dialog";
+
+      export function TryAndSwitch({ state }) {
+        try {
+          switch (state) {
+            case "content":
+              return <Dialog><DialogContent /></Dialog>;
+            default:
+              return <main />;
+          }
+        } catch {
+          return <aside />;
+        } finally {
+          cleanup();
+        }
+      }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        import {
+          Dialog,
+          DialogContent,
+          DialogTrigger,
+        } from "@/src/components/ui/dialog";
+
+        export function DeleteButton() {
+          return (
+            <Dialog>
+              <DialogTrigger />
+              <DialogContent />
+            </Dialog>
+          );
+        }
+      `,
+      errors: [
+        {
+          messageId: "abstractedTrigger",
+          data: { overlay: "Dialog" },
+        },
+      ],
+    },
+    {
+      code: `
+        import {
+          Dialog,
+          DialogContent,
+          DialogTrigger,
+        } from "@/src/components/ui/dialog";
+
+        export function DeleteButton() {
+          return (
+            <Dialog>
+              <><DialogTrigger /></>
+              <DialogContent />
+            </Dialog>
+          );
+        }
+      `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+        import {
+          Dialog as Modal,
+          DialogContent as ModalContent,
+          DialogTrigger as ModalTrigger,
+        } from "@/src/components/ui/dialog";
+
+        export const DeleteButton = () => (
+          <Modal>
+            <ModalTrigger />
+            <ModalContent />
+          </Modal>
+        );
+      `,
+      errors: [
+        {
+          messageId: "abstractedTrigger",
+          data: { overlay: "Dialog" },
+        },
+      ],
+    },
+    {
+      code: `
+        import {
+          Dialog,
+          DialogContent,
+          DialogTrigger,
+        } from "@/src/components/ui/dialog";
+
+        export function DeleteButton() {
+          return (
+            <div className="wrapper">
+              <Dialog>
+                <DialogTrigger />
+                <DialogContent />
+              </Dialog>
+            </div>
+          );
+        }
+      `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+        import {
+          Dialog,
+          DialogContent,
+          DialogTrigger,
+        } from "@/src/components/ui/dialog";
+
+        export function DeleteButton() {
+          return (
+            <section>
+              <div>
+                <Dialog>
+                  <DialogTrigger />
+                  <DialogContent />
+                </Dialog>
+              </div>
+            </section>
+          );
+        }
+      `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+        import {
+          Dialog,
+          DialogContent,
+          DialogTrigger,
+        } from "@/src/components/ui/dialog";
+
+        export function DeleteButton() {
+          return (
+            <>
+              <Dialog>
+                <DialogTrigger />
+                <DialogContent />
+              </Dialog>
+            </>
+          );
+        }
+      `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+        import {
+          DropdownMenu,
+          DropdownMenuContent,
+          DropdownMenuTrigger,
+        } from "@/src/components/ui/dropdown-menu";
+
+        export const ActionsMenu = forwardRef(() => {
+          return (
+            <DropdownMenu>
+              <DropdownMenuTrigger />
+              <DropdownMenuContent />
+            </DropdownMenu>
+          );
+        });
+      `,
+      errors: [
+        {
+          messageId: "abstractedTrigger",
+          data: { overlay: "DropdownMenu" },
+        },
+      ],
+    },
+    {
+      code: `
+        import {
+          Sheet,
+          SheetContent,
+          SheetTrigger,
+        } from "@/src/components/ui/sheet";
+
+        export function MobileFilters({ loading }) {
+          return loading ? <Spinner /> : (
+            <Sheet>
+              <SheetTrigger />
+              <SheetContent />
+            </Sheet>
+          );
+        }
+      `,
+      errors: [
+        {
+          messageId: "abstractedTrigger",
+          data: { overlay: "Sheet" },
+        },
+      ],
+    },
+    {
+      code: `
+        import {
+          Dialog,
+          DialogContent,
+          DialogTrigger,
+        } from "@/src/components/ui/dialog";
+
+        export default () => (
+          <div>
+            {/* transparent */}
+            {<Dialog>
+              {enabled && <DialogTrigger />}
+              {enabled ? <DialogContent /> : null}
+            </Dialog>}
+          </div>
+        );
+      `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+        import {
+          Popover,
+          PopoverContent,
+          PopoverTrigger,
+        } from "@/src/components/ui/popover";
+
+        export function Picker({ ready }) {
+          return ready && (
+            <Popover>
+              <PopoverTrigger />
+              <PopoverContent />
+            </Popover>
+          );
+        }
+      `,
+      errors: [
+        {
+          messageId: "abstractedTrigger",
+          data: { overlay: "Popover" },
+        },
+      ],
+    },
+    {
+      code: `
+        import {
+          AlertDialog,
+          AlertDialogContent,
+          AlertDialogTrigger,
+        } from "@/src/components/ui/alert-dialog";
+
+        export function Confirm() {
+          return (
+            <AlertDialog>
+              <AlertDialogTrigger />
+              <AlertDialogContent />
+            </AlertDialog>
+          ) as JSX.Element;
+        }
+      `,
+      errors: [
+        {
+          messageId: "abstractedTrigger",
+          data: { overlay: "AlertDialog" },
+        },
+      ],
+    },
+    {
+      code: `
+          import {
+            Dialog,
+            DialogContent,
+            DialogTrigger,
+          } from "@/src/components/ui/dialog";
+
+          export function DeleteButton() {
+            return (
+              <div>
+                <Dialog>
+                  <DialogTrigger />
+                  <DialogContent />
+                </Dialog>
+                {null}
+                {false}
+                {true}
+                {undefined}
+              </div>
+            );
+          }
+        `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+          import {
+            Dialog,
+            DialogContent,
+            DialogTrigger,
+          } from "@/src/components/ui/dialog";
+
+          export function DeleteButton() {
+            let mutableOverlay = null;
+            const { ignored } = source;
+            const overlay = (
+              <Dialog>
+                <DialogTrigger />
+                <DialogContent />
+              </Dialog>
+            );
+            return overlay;
+          }
+        `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+          import {
+            Dialog,
+            DialogContent,
+            DialogTrigger,
+          } from "@/src/components/ui/dialog";
+
+          export default function DeleteButton() {
+            return (
+              <Dialog>
+                <DialogTrigger />
+                <DialogContent />
+              </Dialog>
+            );
+          }
+        `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.test.ts
+++ b/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.test.ts
@@ -195,8 +195,8 @@ ruleTester.run("no-abstracted-overlay-trigger", rule, {
   invalid: [
     {
       code: `
-        import {
-          Dialog,
+            import {
+              Dialog,
           DialogContent,
           DialogTrigger,
         } from "@/src/components/ui/dialog";
@@ -276,13 +276,34 @@ ruleTester.run("no-abstracted-overlay-trigger", rule, {
             </div>
           );
         }
-      `,
+          `,
       errors: [{ messageId: "abstractedTrigger" }],
     },
     {
       code: `
-        import {
-          Dialog,
+            import {
+              Dialog,
+              DialogContent,
+              DialogTrigger,
+            } from "@/src/components/ui/dialog";
+
+            export function DeleteButton({ visible }) {
+              const overlay = (
+                <Dialog>
+                  <DialogTrigger />
+                  <DialogContent />
+                </Dialog>
+              );
+              if (visible) return overlay;
+              return null;
+            }
+          `,
+      errors: [{ messageId: "abstractedTrigger" }],
+    },
+    {
+      code: `
+            import {
+              Dialog,
           DialogContent,
           DialogTrigger,
         } from "@/src/components/ui/dialog";

--- a/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.ts
+++ b/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.ts
@@ -1,0 +1,227 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createComponentReturnExpressionVisitors } from "../react-components.js";
+import { createRule } from "../util.js";
+
+const OVERLAY_FAMILIES = [
+  {
+    module: "@/src/components/ui/dialog",
+    root: "Dialog",
+    trigger: "DialogTrigger",
+    contents: ["DialogContent"],
+  },
+  {
+    module: "@/src/components/ui/alert-dialog",
+    root: "AlertDialog",
+    trigger: "AlertDialogTrigger",
+    contents: ["AlertDialogContent"],
+  },
+  {
+    module: "@/src/components/ui/dropdown-menu",
+    root: "DropdownMenu",
+    trigger: "DropdownMenuTrigger",
+    contents: ["DropdownMenuContent", "DropdownMenuSubContent"],
+  },
+  {
+    module: "@/src/components/ui/popover",
+    root: "Popover",
+    trigger: "PopoverTrigger",
+    contents: ["PopoverContent"],
+  },
+  {
+    module: "@/src/components/ui/sheet",
+    root: "Sheet",
+    trigger: "SheetTrigger",
+    contents: ["SheetContent"],
+  },
+] as const;
+
+type JsxRenderableNode =
+  | TSESTree.Expression
+  | TSESTree.JSXElement
+  | TSESTree.JSXFragment;
+
+function isDefinitelyNonRendering(node: TSESTree.Expression): boolean {
+  if (node.type === AST_NODE_TYPES.Literal) {
+    return node.value === null || typeof node.value === "boolean";
+  }
+  return node.type === AST_NODE_TYPES.Identifier && node.name === "undefined";
+}
+
+function getJsxElementName(node: TSESTree.JSXElement): string | null {
+  const name = node.openingElement.name;
+  if (name.type === AST_NODE_TYPES.JSXIdentifier) return name.name;
+  return null;
+}
+
+function getMeaningfulChild(
+  children: TSESTree.JSXChild[],
+): JsxRenderableNode | null {
+  const meaningful: JsxRenderableNode[] = [];
+
+  for (const child of children) {
+    if (child.type === AST_NODE_TYPES.JSXText) {
+      if (child.value.trim()) return null;
+      continue;
+    }
+    if (child.type === AST_NODE_TYPES.JSXExpressionContainer) {
+      if (
+        child.expression.type !== AST_NODE_TYPES.JSXEmptyExpression &&
+        !isDefinitelyNonRendering(child.expression)
+      ) {
+        meaningful.push(child.expression);
+      }
+      continue;
+    }
+    if (child.type === AST_NODE_TYPES.JSXSpreadChild) return null;
+    meaningful.push(child);
+  }
+
+  return meaningful.length === 1 ? meaningful[0] : null;
+}
+
+function isIntrinsicElement(node: TSESTree.JSXElement): boolean {
+  const name = getJsxElementName(node);
+  return name !== null && /^[a-z]/.test(name);
+}
+
+function getEffectiveRoots(node: JsxRenderableNode): TSESTree.JSXElement[] {
+  if (
+    node.type === AST_NODE_TYPES.TSAsExpression ||
+    node.type === AST_NODE_TYPES.TSNonNullExpression ||
+    node.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    node.type === AST_NODE_TYPES.TSTypeAssertion
+  ) {
+    return getEffectiveRoots(node.expression);
+  }
+  if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+    return [
+      ...getEffectiveRoots(node.consequent),
+      ...getEffectiveRoots(node.alternate),
+    ];
+  }
+  if (node.type === AST_NODE_TYPES.LogicalExpression) {
+    return [...getEffectiveRoots(node.left), ...getEffectiveRoots(node.right)];
+  }
+  if (node.type === AST_NODE_TYPES.JSXFragment) {
+    const child = getMeaningfulChild(node.children);
+    return child ? getEffectiveRoots(child) : [];
+  }
+  if (node.type !== AST_NODE_TYPES.JSXElement) return [];
+  if (!isIntrinsicElement(node)) return [node];
+
+  const child = getMeaningfulChild(node.children);
+  return child ? getEffectiveRoots(child) : [];
+}
+
+function jsxSubtreeContainsName(
+  node: TSESTree.JSXElement | TSESTree.JSXFragment,
+  names: Set<string>,
+): boolean {
+  if (node.type === AST_NODE_TYPES.JSXElement) {
+    const name = getJsxElementName(node);
+    if (name && names.has(name)) return true;
+  }
+
+  for (const child of node.children) {
+    if (
+      child.type === AST_NODE_TYPES.JSXElement ||
+      child.type === AST_NODE_TYPES.JSXFragment
+    ) {
+      if (jsxSubtreeContainsName(child, names)) return true;
+      continue;
+    }
+    if (
+      child.type === AST_NODE_TYPES.JSXExpressionContainer &&
+      child.expression.type !== AST_NODE_TYPES.JSXEmptyExpression
+    ) {
+      for (const root of getEffectiveRoots(child.expression)) {
+        if (jsxSubtreeContainsName(root, names)) return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+const rule = createRule<[], "abstractedTrigger">({
+  name: "no-abstracted-overlay-trigger",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow components that abstract an overlay trigger and its floating content together.",
+    },
+    schema: [],
+    messages: {
+      abstractedTrigger:
+        "Do not abstract `{{overlay}}` trigger and content together. Keep the trigger in the parent tree and expose the overlay behavior through a controller/render prop.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const localImports = new Map<string, string>();
+
+    const returnVisitors = createComponentReturnExpressionVisitors({
+      onReturnExpression(node) {
+        for (const rootNode of getEffectiveRoots(node)) {
+          const localRootName = getJsxElementName(rootNode);
+          if (!localRootName) continue;
+
+          for (const family of OVERLAY_FAMILIES) {
+            if (
+              localImports.get(`${family.module}:${family.root}`) !==
+              localRootName
+            ) {
+              continue;
+            }
+
+            const localTrigger = localImports.get(
+              `${family.module}:${family.trigger}`,
+            );
+            const localContents = family.contents
+              .map((content) => localImports.get(`${family.module}:${content}`))
+              .filter((content): content is string => content !== undefined);
+            if (!localTrigger || localContents.length === 0) continue;
+            if (!jsxSubtreeContainsName(rootNode, new Set([localTrigger]))) {
+              continue;
+            }
+            if (!jsxSubtreeContainsName(rootNode, new Set(localContents))) {
+              continue;
+            }
+
+            context.report({
+              node: rootNode.openingElement,
+              messageId: "abstractedTrigger",
+              data: { overlay: family.root },
+            });
+          }
+        }
+      },
+    });
+
+    return {
+      ImportDeclaration(node) {
+        const family = OVERLAY_FAMILIES.find(
+          ({ module }) => module === node.source.value,
+        );
+        if (!family) return;
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type !== AST_NODE_TYPES.ImportSpecifier) continue;
+          const importedName =
+            specifier.imported.type === AST_NODE_TYPES.Identifier
+              ? specifier.imported.name
+              : String(specifier.imported.value);
+          localImports.set(
+            `${family.module}:${importedName}`,
+            specifier.local.name,
+          );
+        }
+      },
+      ...returnVisitors,
+    };
+  },
+});
+
+export default rule;

--- a/web/src/components/BatchExportTableButton.tsx
+++ b/web/src/components/BatchExportTableButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import { useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import {

--- a/web/src/components/nav/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/nav/topbar-account.tsx
+++ b/web/src/components/nav/topbar-account.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 "use client";
 
 import Link from "next/link";

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { memo, type JSX, useState } from "react";
 import { useRouter } from "next/router";
 import { type Row } from "@tanstack/react-table";

--- a/web/src/components/table/data-table-row-height-switch.tsx
+++ b/web/src/components/table/data-table-row-height-switch.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import {
   DropdownMenu,

--- a/web/src/components/ui/combobox.tsx
+++ b/web/src/components/ui/combobox.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/side-panel.tsx
+++ b/web/src/components/ui/side-panel.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import { useState, useCallback, type ReactNode } from "react";
 import { Button } from "@/src/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";

--- a/web/src/ee/features/billing/components/BillingDiscountCodeButton.tsx
+++ b/web/src/ee/features/billing/components/BillingDiscountCodeButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 // Langfuse Cloud only
 import { useState } from "react";
 import Link from "next/link";

--- a/web/src/ee/features/billing/components/StripeCancellationButton.tsx
+++ b/web/src/ee/features/billing/components/StripeCancellationButton.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,

--- a/web/src/ee/features/billing/components/StripeKeepPlanButton.tsx
+++ b/web/src/ee/features/billing/components/StripeKeepPlanButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/ee/features/billing/components/StripeSwitchPlanButton.tsx
+++ b/web/src/ee/features/billing/components/StripeSwitchPlanButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/ee/features/sso-settings/components/SSOSettings.tsx
+++ b/web/src/ee/features/sso-settings/components/SSOSettings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import {
   AlertDialog,

--- a/web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx
+++ b/web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import {
   AlertDialog,

--- a/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
+++ b/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { Button, type ButtonProps } from "@/src/components/ui/button";
 import {

--- a/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
+++ b/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button, type ButtonProps } from "@/src/components/ui/button";
 import React, { useEffect, useMemo, useState } from "react";
 import {

--- a/web/src/features/auth/components/CloudRegionPicker.tsx
+++ b/web/src/features/auth/components/CloudRegionPicker.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import {
   Dialog,
   DialogBody,

--- a/web/src/features/automations/components/DeleteAutomationButton.tsx
+++ b/web/src/features/automations/components/DeleteAutomationButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Trash } from "lucide-react";

--- a/web/src/features/background-migrations/components/retry-background-migration.tsx
+++ b/web/src/features/background-migrations/components/retry-background-migration.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import { api } from "@/src/utils/api";
 import { useState } from "react";

--- a/web/src/features/comments/ReactionPicker.tsx
+++ b/web/src/features/comments/ReactionPicker.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import {
   Popover,

--- a/web/src/features/dashboard/components/ModelSelector.tsx
+++ b/web/src/features/dashboard/components/ModelSelector.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import {
   InputCommand,

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { EvaluatorStatus } from "@/src/features/evals/types";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";

--- a/web/src/features/evals/components/default-eval-model-setup.tsx
+++ b/web/src/features/evals/components/default-eval-model-setup.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { ModelParameters } from "@/src/components/ModelParameters";
 import { CardContent } from "@/src/components/ui/card";

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import { type EvalTemplate } from "@langfuse/shared";
 
 import {

--- a/web/src/features/events/components/MobileFiltersSheet.tsx
+++ b/web/src/features/events/components/MobileFiltersSheet.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 "use client";
 
 import { type ReactNode } from "react";

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useMemo, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { type FilterState, type QueryType } from "@langfuse/shared";

--- a/web/src/features/experiments/components/ExperimentDisplaySettings.tsx
+++ b/web/src/features/experiments/components/ExperimentDisplaySettings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/web/src/features/filters/components/multi-select.tsx
+++ b/web/src/features/filters/components/multi-select.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import * as React from "react";
 import { Check, ChevronDown } from "lucide-react";
 

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 "use client";
 import {
   ArrowRight,

--- a/web/src/features/models/components/DeleteModelButton.tsx
+++ b/web/src/features/models/components/DeleteModelButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useState } from "react";
 
 import { Button } from "@/src/components/ui/button";

--- a/web/src/features/models/components/PriceUnitSelector.tsx
+++ b/web/src/features/models/components/PriceUnitSelector.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { ChevronDownIcon } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";

--- a/web/src/features/models/components/UpsertModelFormDialog.tsx
+++ b/web/src/features/models/components/UpsertModelFormDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 /* eslint @repo/no-style-props: "off" */
 import Link from "next/link";
 import { useEffect, useState, useMemo } from "react";

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import { type ReactNode, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/web/src/features/monitors/components/MonitorsTable.tsx
+++ b/web/src/features/monitors/components/MonitorsTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { MoreVertical, PauseCircle, PlayCircle, SquarePen } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/web/src/features/organizations/components/DeleteOrganizationButton.tsx
+++ b/web/src/features/organizations/components/DeleteOrganizationButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,

--- a/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import { Terminal, ChevronDown } from "lucide-react";
 import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/router";

--- a/web/src/features/projects/components/DeleteProjectButton.tsx
+++ b/web/src/features/projects/components/DeleteProjectButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,

--- a/web/src/features/projects/components/TransferProjectButton.tsx
+++ b/web/src/features/projects/components/TransferProjectButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,

--- a/web/src/features/prompts/components/NewPromptForm/ReviewPromptDialog.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/ReviewPromptDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React from "react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
+++ b/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React from "react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React, { useEffect, useState, useRef, type ReactNode } from "react";
 import { CircleFadingArrowUp } from "lucide-react";
 import { Button } from "@/src/components/ui/button";

--- a/web/src/features/prompts/components/delete-folder.tsx
+++ b/web/src/features/prompts/components/delete-folder.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";

--- a/web/src/features/prompts/components/delete-prompt-version.tsx
+++ b/web/src/features/prompts/components/delete-prompt-version.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";

--- a/web/src/features/prompts/components/delete-prompt.tsx
+++ b/web/src/features/prompts/components/delete-prompt.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";

--- a/web/src/features/prompts/components/duplicate-folder.tsx
+++ b/web/src/features/prompts/components/duplicate-folder.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";

--- a/web/src/features/prompts/components/duplicate-prompt.tsx
+++ b/web/src/features/prompts/components/duplicate-prompt.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useRouter } from "next/router";
 import { Button } from "@/src/components/ui/button";
 import { api } from "@/src/utils/api";

--- a/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { PlusIcon } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/features/public-api/components/UpdateLLMApiKeyDialog.tsx
+++ b/web/src/features/public-api/components/UpdateLLMApiKeyDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/features/rbac/components/CreateProjectMemberButton.tsx
+++ b/web/src/features/rbac/components/CreateProjectMemberButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import { api } from "@/src/utils/api";
 import { useState } from "react";

--- a/web/src/features/score-configs/components/ArchiveScoreConfigButton.tsx
+++ b/web/src/features/score-configs/components/ArchiveScoreConfigButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { Archive } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
+++ b/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React, { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";

--- a/web/src/features/scores/components/multi-select-key-values.tsx
+++ b/web/src/features/scores/components/multi-select-key-values.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import * as React from "react";
 import { Archive, ChevronDown, Component, Search } from "lucide-react";
 

--- a/web/src/features/slack/components/SlackDisconnectButton.tsx
+++ b/web/src/features/slack/components/SlackDisconnectButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React, { useState } from "react";
 import { Unlink, AlertTriangle } from "lucide-react";
 import { Button } from "@/src/components/ui/button";

--- a/web/src/features/tag/components/TagManager.tsx
+++ b/web/src/features/tag/components/TagManager.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import TagCommandItem from "@/src/features/tag/components/TagCommandItem";
 import TagCreateItem from "@/src/features/tag/components/TagCreateItem";
 import { TagInput } from "@/src/features/tag/components/TagInput";

--- a/web/src/features/traces/components/TraceSettingsDropdown.tsx
+++ b/web/src/features/traces/components/TraceSettingsDropdown.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 /**
  * TraceSettingsDropdown - View preferences dropdown component
  *

--- a/web/src/features/traces/components/_shared/CopyIdsPopover.tsx
+++ b/web/src/features/traces/components/_shared/CopyIdsPopover.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import { Button } from "@/src/components/ui/button";
 import { CopyIcon, CheckIcon } from "lucide-react";
 import { useState } from "react";

--- a/web/src/features/traces/components/_shared/DetailHeaderActionsMenu.tsx
+++ b/web/src/features/traces/components/_shared/DetailHeaderActionsMenu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { useRouter } from "next/router";
 import { CheckIcon, CopyIcon, EllipsisVertical } from "lucide-react";
 import { useState } from "react";

--- a/web/src/features/web-callouts/components/WebCalloutSettingsPage.tsx
+++ b/web/src/features/web-callouts/components/WebCalloutSettingsPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Pencil, Plus, Trash2, Webhook, X } from "lucide-react";
 import type { ReactNode } from "react";

--- a/web/src/pages/account/settings/index.tsx
+++ b/web/src/pages/account/settings/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import { PagedSettingsContainer } from "@/src/components/PagedSettingsContainer";
 import Header from "@/src/components/layouts/header";
 import { Card } from "@/src/components/ui/card";


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15837.preview.langfuse.com](https://pr-15837.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

# Keep overlay triggers colocated with their siblings

## Motivation

[PR #15531](https://github.com/langfuse/langfuse/pull/15531) highlighted a recurring problem: extracted components that own both an overlay trigger and its dialog, dropdown, popover, or sheet.

For example, a component such as `DatasetActionButton` may initially seem reusable. In practice, the trigger belongs to the surrounding UI while the floating content belongs to the operation.

When both are abstracted together, the trigger's styling moves away from its siblings:

```tsx
<HeaderActions>
  <DatasetActionButton mode="create" />
  <Button variant="outline">Import</Button>
</HeaderActions>
```

The parent no longer shows whether the hidden trigger is an icon button, primary button, menu item, or something else. Its size, variant, tooltip, disabled state, and event behavior live in another file. Understanding or changing the layout requires jumping through component boundaries, and sibling styling becomes unpredictable.

The abstraction also makes the floating content less reusable. The same dialog may need to open from:

- a primary page action
- an icon in a table row
- a dropdown item
- an onboarding empty state

If the dialog owns one concrete trigger, every new context requires presentation flags and internal branches. This is especially costly for dialogs, where the form, permissions, analytics, and mutation behavior are valuable to reuse but the trigger presentation almost never is.

## Desired Boundary

The trigger should remain in the parent's tree, colocated with the controls it must visually and behaviorally match. Shared overlay behavior and content should be exposed through a controller or controlled content component.

```tsx
<UpdateDatasetDialogController {...props}>
  {({ disabled, openDialog }) => (
    <DialogTrigger asChild>
      <IconOnlyButton
        disabledReason={disabled?.reason}
        onClick={(event) => {
          event.stopPropagation();
          openDialog();
        }}
      />
    </DialogTrigger>
  )}
</UpdateDatasetDialogController>
```

This keeps ownership clear:

- The parent owns trigger markup, styling, placement, tooltips, and event propagation.
- The controller owns permissions, open state, analytics, and orchestration.
- The content component owns the reusable dialog or floating surface.

The result is easier to read locally and easier to reuse. A caller can see all sibling controls together, while the same dialog behavior can be composed with any trigger without adding `icon`, `size`, `variant`, or `insideDropdown` props.

It also avoids lifecycle problems when opening a dialog from a dropdown. The dialog controller can remain mounted outside the dropdown content while the colocated menu item acts as its trigger. Closing the dropdown therefore does not unmount the dialog it just opened.

## What Should Be Disallowed

An extracted component should not effectively consist of an overlay root containing both its trigger and content:

```tsx
function DeleteProjectButton() {
  return (
    <Dialog>
      <DialogTrigger asChild>
        <Button>Delete project</Button>
      </DialogTrigger>
      <DialogContent>{/* ... */}</DialogContent>
    </Dialog>
  );
}
```

A single wrapping `<div>`, `<span>`, `<section>`, or fragment does not create meaningful colocation and should not bypass the rule.

Complete overlays remain valid when they are genuinely part of a larger component tree with meaningful sibling UI. In that case, the trigger is already colocated with its context.

## ESLint Enforcement

Enable `@repo/no-abstracted-overlay-trigger` for the web application. The rule is import-aware and covers `Dialog`, `AlertDialog`, `DropdownMenu`, `Popover`, and `Sheet`.

It currently reports **66 violations across 63 files**:

| Overlay      | Violations |
| ------------ | ---------: |
| Dialog       |         27 |
| Popover      |         20 |
| DropdownMenu |         15 |
| AlertDialog  |          2 |
| Sheet        |          2 |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces and enables an import-aware ESLint rule intended to keep overlay triggers colocated with their sibling controls. However, existing violations are retained behind module-wide suppressions.

- Adds component-return AST traversal and the `@repo/no-abstracted-overlay-trigger` rule.
- Registers and enables the rule for Next.js TypeScript sources.
- Adds rule tests covering overlay families, aliases, wrappers, fragments, and conditional returns.
- Adds broad suppressions across the affected web modules instead of performing the stated migrations.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge as the completed enforcement feature because broad module-level suppressions leave the targeted abstractions and future regressions invisible to lint.

The rule itself is enabled, but every affected module disables it for the entire file while retaining trigger-and-content overlay components, so the advertised enforcement and migration do not occur.

**Files Needing Attention:** packages/config-eslint/next.js and the web modules adding @repo/no-abstracted-overlay-trigger file-level disables
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config[Enable overlay-trigger rule] --> Lint[Lint web TypeScript modules]
  Lint --> Disable{File-level disable present?}
  Disable -->|Yes| Suppressed[Skip all rule reports in module]
  Disable -->|No| Detect[Inspect component return roots]
  Detect --> Violation{Overlay contains trigger and content?}
  Violation -->|Yes| Warning[Report colocation warning]
  Violation -->|No| Pass[Pass]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/BatchExportTableButton.tsx:1
**File-wide suppression defeats enforcement**

When lint processes this module, the file-level directive suppresses every report from the newly enabled rule while the component retains a `DropdownMenu` containing both its trigger and content. This allows the existing abstraction—and new violations added anywhere in the module—to pass lint without warning; the same broad suppression pattern appears across the other affected web modules.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Enable overlay trigger ESLint rule"](https://github.com/langfuse/langfuse/commit/afe5f054de102586dd0498bf848fb4e7be462de7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50765951)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->