### PR TITLE
fix(datasets): stop reusing stored remote experiment headers on destination change

### DIFF
--- a/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
+++ b/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
@@ -282,6 +282,63 @@ describe("remote experiment auth headers and signing secret", () => {
     expect(preserved.remoteExperimentRequestHeaders).toEqual(storedHeaders);
   });
 
+  it("does not forward a stored secret header to a new destination URL", async () => {
+    // Same root cause as CVE-2026-41487 (LLM connection secret reused against
+    // an attacker controlled baseURL). Any project member with datasets:CUD,
+    // the same scope needed to configure this feature at all, can repoint an
+    // existing remote experiment config to a URL they control, without
+    // supplying a new secret header. The previously stored, decrypted secret
+    // header must not be sent to that new URL on the next trigger.
+    const { caller, projectId } = await prepare();
+    const datasetId = await createDataset(projectId);
+
+    // A legitimate config pointing at the real endpoint, with a secret
+    // authorization header meant only for that endpoint.
+    await caller.datasets.upsertRemoteExperiment({
+      projectId,
+      datasetId,
+      url: "https://example.com/hook",
+      defaultPayload: "{}",
+      enabled: true,
+      requestHeaders: {
+        authorization: { secret: true, value: "Bearer super-secret-token" },
+      },
+    });
+
+    // The destination is repointed without supplying requestHeaders.
+    await caller.datasets.upsertRemoteExperiment({
+      projectId,
+      datasetId,
+      url: "https://example.org/collect",
+      defaultPayload: "{}",
+      enabled: true,
+    });
+
+    // Trigger the new destination and capture what is actually sent.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await caller.datasets.triggerRemoteExperiment({
+      projectId,
+      datasetId,
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(calledUrl).toBe("https://example.org/collect");
+
+    const sentAuthHeader = new Headers(calledInit.headers).get("authorization");
+
+    expect(sentAuthHeader).not.toBe("Bearer super-secret-token");
+
+    vi.unstubAllGlobals();
+  });
+
   it("excludes secret columns from generic dataset reads via the global Prisma omit", async () => {
     const { caller, projectId } = await prepare();
     const datasetId = await createDataset(projectId);

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -2174,11 +2174,34 @@ export const datasetRouter = createTRPCRouter({
         });
       }
 
+      // A project member with datasets:CUD can repoint url to a host they
+      // control. Stored headers must never carry over to a new host, or a
+      // secret configured for one destination would be decrypted and sent
+      // to a different one on the next trigger. Same fix as the LLM
+      // connection secret reuse issue, applied here to remote experiment
+      // headers.
+      const isDestinationOriginChanged = ((): boolean => {
+        if (!dataset.remoteExperimentUrl) return false;
+        try {
+          return (
+            new URL(input.url).origin !==
+            new URL(dataset.remoteExperimentUrl).origin
+          );
+        } catch {
+          // If the previously stored URL can no longer be parsed, treat the
+          // destination as changed rather than forward a secret to an
+          // origin that was never verified.
+          return true;
+        }
+      })();
+
       const { requestHeaders, displayHeaders } = processRemoteExperimentHeaders(
         input.requestHeaders,
-        parseStoredRemoteExperimentHeaders(
-          dataset.remoteExperimentRequestHeaders,
-        ),
+        isDestinationOriginChanged
+          ? {}
+          : parseStoredRemoteExperimentHeaders(
+              dataset.remoteExperimentRequestHeaders,
+            ),
       );
 
       const signingSecret =


### PR DESCRIPTION
## Summary

`upsertRemoteExperiment` carries previously stored request headers forward whenever the caller omits `requestHeaders`, without checking whether the destination URL changed. Since the stored headers can include secret values, a config whose `url` is repointed at a different host will send those secrets to the new host on the next trigger.

The scope needed to do this is `datasets:CUD`, which is the same scope needed to configure the feature in the first place, and is granted to the `MEMBER` role by default. So a member can repoint a config set up by someone with broader access and receive whatever secret header was attached to it, for example a bearer token for an internal endpoint.

This is the same shape as the LLM connection issue where a stored provider secret could be reused against a caller supplied `baseURL`. That was fixed for connections; remote experiments have the same pattern and were not covered.

## Fix

Compare the origin of the incoming `url` against the currently stored `remoteExperimentUrl` before deciding whether to reuse stored headers. If the origin changed, pass an empty header set into `processRemoteExperimentHeaders` so anything the caller wants to keep has to be supplied again.

Path only changes on the same origin behave exactly as before, so updating `https://example.com/hook` to `https://example.com/hook-v2` still preserves headers. If the stored URL cannot be parsed, the destination is treated as changed rather than trusted.

## Test plan

Added a test that configures a secret `authorization` header against one endpoint, repoints the URL to a different origin without supplying headers, then triggers the webhook and asserts the secret is not in the outgoing request.

Verified it fails on current `main` before the change:

```
AssertionError: expected 'Bearer super-secret-token' not to be 'Bearer super-secret-token'
```

and passes after it.

```
datasets-remote-experiment.servertest.ts   10 passed
datasets-trpc.servertest.ts                 6 passed
remote-experiment-helpers.servertest.ts    15 passed
```

Happy to adjust the approach if you would rather handle this differently, or to move the discussion somewhere private if you prefer.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents remote-experiment secrets from carrying over when a dataset webhook is moved to a different origin.
- Compares the incoming and stored destination origins before reusing encrypted request headers.
- Clears prior headers on cross-origin changes or when the stored URL cannot be parsed.
- Adds a server test proving an authorization secret is not sent after repointing the webhook.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and closes the cross-origin stored-header reuse path without affecting same-origin updates.

The changed mutation validates the destination, discards stored headers whenever the origin changes or the stored URL is unparseable, and preserves existing behavior for same-origin updates; no actionable regressions were identified.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Member
  participant Router as Dataset router
  participant DB as Dataset config
  participant Target as Remote destination
  Member->>Router: Update webhook to another origin
  Router->>DB: Read stored URL and encrypted headers
  Router->>Router: Compare old and new origins
  Router->>DB: Save new URL without prior headers
  Member->>Router: Trigger remote experiment
  Router->>DB: Read updated configuration
  Router->>Target: Send request without prior secret
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): stop reusing stored remot..."](https://github.com/langfuse/langfuse/commit/16af3b1f30d2902d0f5e278d1f1d9ee76a884406) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50793732)</sub>

<!-- /greptile_comment -->