### PR TITLE
[reference, do not merge] Background assistant activity and notifications — whole feature in one diff

### DIFF
--- a/packages/shared/src/in-app-agent/backgroundWatch.ts
+++ b/packages/shared/src/in-app-agent/backgroundWatch.ts
@@ -93,3 +93,23 @@ export function isActiveInAppAgentRunStatus(
 ): boolean {
   return IN_APP_AGENT_ACTIVE_RUN_STATUSES.includes(status);
 }
+
+/**
+ * Runs the user still has to deal with: executing, or parked on their decision.
+ *
+ * Wider than {@link IN_APP_AGENT_ACTIVE_RUN_STATUSES} on purpose. A parked
+ * approval sets `finishedAt`, so `finishedAt: null` finds executing runs but
+ * silently misses the one state that is literally waiting for the user.
+ */
+export const IN_APP_AGENT_UNSETTLED_RUN_STATUSES: readonly InAppAgentRunStatus[] =
+  [
+    InAppAgentRunStatus.QUEUED,
+    InAppAgentRunStatus.RUNNING,
+    InAppAgentRunStatus.AWAITING_APPROVAL,
+  ];
+
+export function isUnsettledInAppAgentRunStatus(
+  status: InAppAgentRunStatus,
+): boolean {
+  return IN_APP_AGENT_UNSETTLED_RUN_STATUSES.includes(status);
+}

--- a/packages/shared/src/in-app-agent/server/runLifecycle.ts
+++ b/packages/shared/src/in-app-agent/server/runLifecycle.ts
@@ -7,7 +7,10 @@ import {
 import { Prisma } from "../../db";
 import type { InAppAgentRun, PrismaClient } from "../../db";
 import { logger } from "../../server";
-import { buildInAppAgentApprovalDecisionEvent } from "../backgroundWatch";
+import {
+  buildInAppAgentApprovalDecisionEvent,
+  IN_APP_AGENT_UNSETTLED_RUN_STATUSES,
+} from "../backgroundWatch";
 import type { AgUiEvent } from "../schema";
 import {
   InAppAgentRunRequestSchema,
@@ -324,13 +327,7 @@ export async function cancelConversationRunsInTransaction(params: {
       projectId: params.projectId,
       conversationId: params.conversationId,
       // Parked approvals have finishedAt set but remain unsettled.
-      status: {
-        in: [
-          InAppAgentRunStatus.QUEUED,
-          InAppAgentRunStatus.RUNNING,
-          InAppAgentRunStatus.AWAITING_APPROVAL,
-        ],
-      },
+      status: { in: [...IN_APP_AGENT_UNSETTLED_RUN_STATUSES] },
     },
     select: { id: true, status: true },
   });
@@ -561,7 +558,16 @@ async function reconcileConversationRunsInTransaction(params: {
   return reconciled;
 }
 
-function classifyStaleRun(
+/**
+ * Decide whether a non-terminal run has already missed every deadline that
+ * should have failed it. Pure: callers choose whether to act on the verdict.
+ *
+ * Reconciliation writes the verdict; read paths that only need to render a run
+ * may apply it without writing, so a dead worker does not leave a conversation
+ * spinning until someone opens it (`reconcileConversationRuns` is the only
+ * authority that persists the transition).
+ */
+export function classifyStaleRun(
   run: {
     status: string | null;
     createdAt: Date;

--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -1882,3 +1882,204 @@ async function pendingToolApprovalExists(params: {
 
   return Boolean(pendingApproval);
 }
+
+describe("in-app agent activity", () => {
+  it("reports only the caller's runs and classifies a dead worker without writing", async () => {
+    const { getInAppAgentActivity } =
+      await import("@/src/features/in-app-agent/server/backgroundRunService");
+    const { project, userId } = await setupInAppAgentProjectSession();
+
+    const otherUser = await prisma.user.create({
+      data: {
+        id: `user-${randomUUID()}`,
+        email: `${randomUUID()}@example.com`,
+      },
+    });
+
+    const mineId = `conversation-${randomUUID()}`;
+    const theirsId = `conversation-${randomUUID()}`;
+    await prisma.inAppAgentConversation.createMany({
+      data: [
+        {
+          id: mineId,
+          projectId: project.id,
+          createdByUserId: userId,
+          title: "Mine",
+        },
+        {
+          id: theirsId,
+          projectId: project.id,
+          createdByUserId: otherUser.id,
+          title: "Theirs",
+        },
+      ],
+    });
+
+    // Claimed recently enough to be inside the run-duration budget, but the
+    // worker stopped signalling — worker loss, not a run that simply ran long.
+    const deadRun = await prisma.inAppAgentRun.create({
+      data: {
+        id: `run-${randomUUID()}`,
+        projectId: project.id,
+        conversationId: mineId,
+        triggeredByUserId: userId,
+        status: InAppAgentRunStatus.RUNNING,
+        claimedAt: new Date(Date.now() - 5 * 60_000),
+        heartbeatAt: new Date(Date.now() - 5 * 60_000),
+      },
+    });
+    await prisma.inAppAgentRun.create({
+      data: {
+        id: `run-${randomUUID()}`,
+        projectId: project.id,
+        conversationId: theirsId,
+        triggeredByUserId: otherUser.id,
+        status: InAppAgentRunStatus.RUNNING,
+      },
+    });
+
+    const activity = await getInAppAgentActivity({
+      prisma,
+      projectId: project.id,
+      userId,
+      trackedRunIds: [],
+    });
+
+    expect(activity.map((run) => run.conversationId)).toEqual([mineId]);
+    expect(activity[0]).toMatchObject({
+      runId: deadRun.id,
+      status: InAppAgentRunStatus.FAILED,
+      errorCode: InAppAgentRunErrorCode.WORKER_LOST,
+    });
+
+    // The verdict is rendered, never persisted: reconciliation stays the only
+    // authority that writes it.
+    const stored = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: deadRun.id, projectId: project.id },
+    });
+    expect(stored.status).toBe(InAppAgentRunStatus.RUNNING);
+    expect(stored.finishedAt).toBeNull();
+  });
+
+  it("adjudicates a tracked run that finished while the client was away", async () => {
+    const { getInAppAgentActivity } =
+      await import("@/src/features/in-app-agent/server/backgroundRunService");
+    const { project, userId } = await setupInAppAgentProjectSession();
+    const conversationId = `conversation-${randomUUID()}`;
+
+    await prisma.inAppAgentConversation.create({
+      data: {
+        id: conversationId,
+        projectId: project.id,
+        createdByUserId: userId,
+      },
+    });
+    const finishedRun = await prisma.inAppAgentRun.create({
+      data: {
+        id: `run-${randomUUID()}`,
+        projectId: project.id,
+        conversationId,
+        triggeredByUserId: userId,
+        status: InAppAgentRunStatus.SUCCEEDED,
+        finishedAt: new Date(),
+      },
+    });
+
+    // Not in the attention set, so only the tracked-id lookup can find it.
+    expect(
+      await getInAppAgentActivity({
+        prisma,
+        projectId: project.id,
+        userId,
+        trackedRunIds: [],
+      }),
+    ).toEqual([]);
+
+    const activity = await getInAppAgentActivity({
+      prisma,
+      projectId: project.id,
+      userId,
+      trackedRunIds: [finishedRun.id],
+    });
+
+    expect(activity).toHaveLength(1);
+    expect(activity[0]).toMatchObject({
+      runId: finishedRun.id,
+      status: InAppAgentRunStatus.SUCCEEDED,
+    });
+  });
+});
+
+describe("in-app agent conversation deletion", () => {
+  it("cancels whatever the conversation was still doing instead of refusing", async () => {
+    const { deleteBackgroundConversation } =
+      await import("@/src/features/in-app-agent/server/backgroundRunService");
+    const { project, userId } = await setupInAppAgentProjectSession();
+
+    const runningId = `conversation-${randomUUID()}`;
+    const parkedId = `conversation-${randomUUID()}`;
+    await prisma.inAppAgentConversation.createMany({
+      data: [runningId, parkedId].map((id) => ({
+        id,
+        projectId: project.id,
+        createdByUserId: userId,
+      })),
+    });
+
+    const runningRun = await prisma.inAppAgentRun.create({
+      data: {
+        id: `run-${randomUUID()}`,
+        projectId: project.id,
+        conversationId: runningId,
+        triggeredByUserId: userId,
+        status: InAppAgentRunStatus.RUNNING,
+        claimedAt: new Date(),
+        heartbeatAt: new Date(),
+      },
+    });
+    // A parked approval sets `finishedAt`, so a `finishedAt: null` sweep would
+    // miss the one run actually waiting on this user.
+    const parkedRun = await prisma.inAppAgentRun.create({
+      data: {
+        id: `run-${randomUUID()}`,
+        projectId: project.id,
+        conversationId: parkedId,
+        triggeredByUserId: userId,
+        status: InAppAgentRunStatus.AWAITING_APPROVAL,
+        finishedAt: new Date(),
+      },
+    });
+
+    for (const conversationId of [runningId, parkedId]) {
+      await deleteBackgroundConversation({
+        prisma,
+        projectId: project.id,
+        conversationId,
+        userId,
+      });
+
+      expect(
+        (
+          await prisma.inAppAgentConversation.findFirstOrThrow({
+            where: { id: conversationId, projectId: project.id },
+          })
+        ).deletedAt,
+      ).not.toBeNull();
+    }
+
+    // Nothing is executing behind a parked approval, so it ends here.
+    const parked = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: parkedRun.id, projectId: project.id },
+    });
+    expect(parked.status).toBe(InAppAgentRunStatus.CANCELLED);
+    expect(parked.errorCode).toBe(InAppAgentRunErrorCode.APPROVAL_CANCELLED);
+
+    // A claimed run is the worker's to end; it is signalled, not force-closed,
+    // so the run keeps its capacity slot until the worker actually stops.
+    const running = await prisma.inAppAgentRun.findFirstOrThrow({
+      where: { id: runningRun.id, projectId: project.id },
+    });
+    expect(running.status).toBe(InAppAgentRunStatus.RUNNING);
+    expect(running.cancelRequestedAt).not.toBeNull();
+  });
+});

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -23,7 +23,7 @@ export const InAppAiAgentButton = ({
 }: {
   prominent?: boolean;
 } = {}) => {
-  const { open, setOpen, openAssistant } = useInAppAiAgent();
+  const { open, setOpen, openAssistant, attentionCount } = useInAppAiAgent();
   const canUseAssistant = useCanUseInAppAgent();
 
   const toggleAssistant = useCallback(
@@ -88,7 +88,7 @@ export const InAppAiAgentButton = ({
           : undefined
       }
       className={cn(
-        "gap-2",
+        "relative gap-2",
         // Compact icon-only launcher for the top bar.
         prominent && "size-9 shrink-0 px-0",
         !prominent &&
@@ -99,6 +99,16 @@ export const InAppAiAgentButton = ({
       <BotMessageSquare
         className={cn("h-4 w-4", prominent && open && "text-primary-accent")}
       />
+      {/* Conversations still owed a look. Anchored to the button rather than
+          the icon so it survives the prominent (icon-only) variant. */}
+      {attentionCount > 0 && (
+        <span
+          className="bg-primary-accent text-primary-foreground absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold"
+          aria-label={`${attentionCount} assistant ${attentionCount === 1 ? "conversation needs" : "conversations need"} attention`}
+        >
+          {attentionCount > 99 ? "99+" : attentionCount}
+        </span>
+      )}
       {/* The prominent launcher is a fixed 36px square (top bar, below md), so
           it stays strictly icon-only — the `sm:inline` label would otherwise
           reveal in the 640–767px band and overflow the box. */}

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -67,6 +67,7 @@ export function ControlledInAppAgentWindow(
 ) {
   const router = useRouter();
   const {
+    activityByConversationId,
     conversations,
     error,
     hasMoreConversations,
@@ -191,6 +192,7 @@ export function ControlledInAppAgentWindow(
       quickActionResetKey={quickActionResetKey}
       screenContextDescription={screenContextDescription}
       conversations={conversations}
+      activityByConversationId={activityByConversationId}
       // Only the background driver produces runs that survive leaving them.
       canLeaveRunningConversation={execution.type === "background"}
       hasMoreConversations={hasMoreConversations}

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -191,6 +191,8 @@ export function ControlledInAppAgentWindow(
       quickActionResetKey={quickActionResetKey}
       screenContextDescription={screenContextDescription}
       conversations={conversations}
+      // Only the background driver produces runs that survive leaving them.
+      canLeaveRunningConversation={execution.type === "background"}
       hasMoreConversations={hasMoreConversations}
       isLoadingMoreConversations={isLoadingMoreConversations}
       selectedConversationId={selectedConversationId}

--- a/web/src/features/in-app-agent/components/ConversationActivityIndicator.stories.tsx
+++ b/web/src/features/in-app-agent/components/ConversationActivityIndicator.stories.tsx
@@ -1,0 +1,48 @@
+import preview from "../../../../.storybook/preview";
+import { ConversationActivityIndicator } from "./ConversationActivityIndicator";
+import type { InAppAgentActivityState } from "@/src/features/in-app-agent/lib/inAppAgentActivity";
+
+const meta = preview.meta({
+  component: ConversationActivityIndicator,
+});
+
+export const ApprovalRequired = meta.story({
+  args: { state: "approval" },
+});
+
+export const Running = meta.story({
+  args: { state: "running" },
+});
+
+export const UnreadFailure = meta.story({
+  args: { state: "failed-unread" },
+});
+
+export const UnreadSuccess = meta.story({
+  args: { state: "done-unread" },
+});
+
+const STATES: readonly { state: InAppAgentActivityState; label: string }[] = [
+  { state: "approval", label: "Needs your approval" },
+  { state: "running", label: "Queued or running" },
+  { state: "failed-unread", label: "Failed, unread" },
+  { state: "done-unread", label: "Finished, unread" },
+];
+
+/**
+ * Top to bottom is the priority order a conversation row applies: only the
+ * first matching state is ever rendered.
+ */
+export const VariantMatrix = meta.story({
+  args: { state: "approval" },
+  render: () => (
+    <div className="flex flex-col gap-2">
+      {STATES.map(({ state, label }) => (
+        <div key={state} className="flex items-center gap-2 text-sm">
+          <ConversationActivityIndicator state={state} />
+          <span className="text-muted-foreground">{label}</span>
+        </div>
+      ))}
+    </div>
+  ),
+});

--- a/web/src/features/in-app-agent/components/ConversationActivityIndicator.tsx
+++ b/web/src/features/in-app-agent/components/ConversationActivityIndicator.tsx
@@ -1,0 +1,45 @@
+import { CircleAlert, Loader2 } from "lucide-react";
+
+import { cn } from "@/src/utils/tailwind";
+import type { InAppAgentActivityState } from "@/src/features/in-app-agent/lib/inAppAgentActivity";
+
+/**
+ * Trailing state for one recent-conversation row.
+ *
+ * Exactly one indicator can show, so the caller's priority order is the whole
+ * design: what the assistant needs from you beats what it is doing, which beats
+ * what it already did.
+ */
+export function ConversationActivityIndicator({
+  state,
+}: {
+  state: InAppAgentActivityState;
+}) {
+  if (state === "approval") {
+    return (
+      <CircleAlert
+        className="text-primary-accent size-3 shrink-0"
+        aria-label="Needs your approval"
+      />
+    );
+  }
+
+  if (state === "running") {
+    return (
+      <Loader2
+        className="text-muted-foreground size-3 shrink-0 animate-spin"
+        aria-label="Working"
+      />
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "size-1.5 shrink-0 rounded-full",
+        state === "failed-unread" ? "bg-destructive" : "bg-primary-accent",
+      )}
+      aria-label={state === "failed-unread" ? "Failed" : "Finished"}
+    />
+  );
+}

--- a/web/src/features/in-app-agent/components/InAppAgentActivityCards.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentActivityCards.stories.tsx
@@ -1,0 +1,160 @@
+import preview from "../../../../.storybook/preview";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { InAppAgentActivityCards } from "./InAppAgentActivityCards";
+
+const meta = preview.meta({
+  component: InAppAgentActivityCards,
+  args: {
+    onOpen: fn(),
+    onDismiss: fn(),
+  },
+});
+
+export const ApprovalRequired = meta.story({
+  args: {
+    cards: [
+      {
+        conversationId: "conversation-1",
+        runId: "run-1",
+        title: "Create the eval dataset",
+        state: "approval",
+      },
+    ],
+  },
+});
+
+export const Finished = meta.story({
+  args: {
+    cards: [
+      {
+        conversationId: "conversation-1",
+        runId: "run-1",
+        title: "Latency outliers",
+        state: "done-unread",
+      },
+    ],
+  },
+});
+
+export const Failed = meta.story({
+  args: {
+    cards: [
+      {
+        conversationId: "conversation-1",
+        runId: "run-1",
+        title: "Score correlation",
+        state: "failed-unread",
+      },
+    ],
+  },
+});
+
+export const UntitledConversation = meta.story({
+  args: {
+    cards: [
+      {
+        conversationId: "conversation-1",
+        runId: "run-1",
+        title: null,
+        state: "done-unread",
+      },
+    ],
+  },
+});
+
+/** Approvals sort to the top regardless of the order they arrived in. */
+export const Stacked = meta.story({
+  args: {
+    cards: [
+      {
+        conversationId: "conversation-1",
+        runId: "run-1",
+        title: "Finished while away",
+        state: "done-unread",
+      },
+      {
+        conversationId: "conversation-2",
+        runId: "run-2",
+        title: "Needs your approval",
+        state: "approval",
+      },
+      {
+        conversationId: "conversation-3",
+        runId: "run-3",
+        title: "Failed while away",
+        state: "failed-unread",
+      },
+    ],
+  },
+});
+
+export const Empty = meta.story({
+  args: { cards: [] },
+});
+
+export const CapsTheStack = meta.story({
+  name: "(Test) Caps The Stack And Keeps The Approval",
+  args: {
+    cards: [
+      {
+        conversationId: "conversation-1",
+        runId: "run-1",
+        title: "Oldest result",
+        state: "done-unread",
+      },
+      {
+        conversationId: "conversation-2",
+        runId: "run-2",
+        title: "Second result",
+        state: "done-unread",
+      },
+      {
+        conversationId: "conversation-3",
+        runId: "run-3",
+        title: "Third result",
+        state: "done-unread",
+      },
+      {
+        conversationId: "conversation-4",
+        runId: "run-4",
+        title: "Waiting on you",
+        state: "approval",
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Four in, three out — and the approval is never the one dropped.
+    await expect(canvas.getAllByRole("status")).toHaveLength(3);
+    await expect(canvas.getByText("Waiting on you")).toBeVisible();
+    await expect(canvas.queryByText("Third result")).not.toBeInTheDocument();
+  },
+});
+
+export const OpensAndDismisses = meta.story({
+  name: "(Test) Opens And Dismisses",
+  args: {
+    cards: [
+      {
+        conversationId: "conversation-1",
+        runId: "run-1",
+        title: "Latency outliers",
+        state: "done-unread",
+      },
+    ],
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByText("Latency outliers"));
+    await expect(args.onOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conversation-1" }),
+    );
+
+    await userEvent.click(canvas.getByRole("button", { name: "Dismiss" }));
+    await expect(args.onDismiss).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-1" }),
+    );
+  },
+});

--- a/web/src/features/in-app-agent/components/InAppAgentActivityCards.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentActivityCards.tsx
@@ -1,0 +1,120 @@
+import { CircleAlert, CircleCheck, CircleX, X } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import { cn } from "@/src/utils/tailwind";
+import type { InAppAgentActivityState } from "@/src/features/in-app-agent/lib/inAppAgentActivity";
+
+/** Approvals first: a question outranks a result the user can read later. */
+const CARD_PRIORITY: Record<string, number> = {
+  approval: 0,
+  "failed-unread": 1,
+  "done-unread": 2,
+};
+
+const MAX_VISIBLE_CARDS = 3;
+
+export type InAppAgentActivityCard = {
+  conversationId: string;
+  /** Card identity. A later run in the same conversation is a new card. */
+  runId: string;
+  title: string | null;
+  state: InAppAgentActivityState;
+};
+
+function getCardCopy(state: InAppAgentActivityState) {
+  if (state === "approval") {
+    return {
+      label: "Needs your approval",
+      Icon: CircleAlert,
+      tone: "accent" as const,
+    };
+  }
+
+  if (state === "failed-unread") {
+    return { label: "Run failed", Icon: CircleX, tone: "destructive" as const };
+  }
+
+  return { label: "Finished", Icon: CircleCheck, tone: "accent" as const };
+}
+
+/**
+ * The assistant's floating activity stack, as pure presentation.
+ *
+ * Owns which cards win and in what order; owns none of the lifecycle. The
+ * caller decides when a card arrives, expires, or is retired, which keeps the
+ * ordering rules visible in one place and testable without timers.
+ */
+export function InAppAgentActivityCards({
+  cards,
+  onOpen,
+  onDismiss,
+}: {
+  cards: readonly InAppAgentActivityCard[];
+  onOpen: (card: InAppAgentActivityCard) => void;
+  onDismiss: (card: InAppAgentActivityCard) => void;
+}) {
+  const visible = [...cards]
+    .sort(
+      (a, b) => (CARD_PRIORITY[a.state] ?? 9) - (CARD_PRIORITY[b.state] ?? 9),
+    )
+    .slice(0, MAX_VISIBLE_CARDS);
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="top-banner-offset pointer-events-none fixed right-4 flex w-80 flex-col gap-2 pt-4">
+      {visible.map((card) => {
+        const { label, Icon, tone } = getCardCopy(card.state);
+        const conversationTitle = card.title?.trim() || "Untitled conversation";
+
+        return (
+          <div
+            key={card.runId}
+            role="status"
+            className="bg-background pointer-events-auto flex items-start gap-2 rounded-md border p-3 shadow-lg"
+          >
+            <Icon
+              className={cn(
+                "mt-0.5 size-4 shrink-0",
+                tone === "destructive"
+                  ? "text-destructive"
+                  : "text-primary-accent",
+              )}
+            />
+            <button
+              type="button"
+              className="min-w-0 flex-1 text-left"
+              onClick={() => {
+                onOpen(card);
+              }}
+            >
+              <p className="truncate text-sm font-bold" title={label}>
+                {label}
+              </p>
+              <p
+                className="text-muted-foreground truncate text-xs"
+                title={conversationTitle}
+              >
+                {conversationTitle}
+              </p>
+            </button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="text-muted-foreground -mt-1 -mr-1 shrink-0"
+              aria-label="Dismiss"
+              onClick={() => {
+                onDismiss(card);
+              }}
+            >
+              <X className="size-3" />
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/features/in-app-agent/components/InAppAgentActivityNotifications.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentActivityNotifications.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Layer } from "@/src/components/ui/layer";
+import {
+  InAppAgentActivityCards,
+  type InAppAgentActivityCard,
+} from "@/src/features/in-app-agent/components/InAppAgentActivityCards";
+
+/** Results are a glance; an approval is a question and waits to be answered. */
+const RESULT_CARD_TTL_MS = 8_000;
+
+export type InAppAgentActivityNotification = InAppAgentActivityCard;
+
+/**
+ * Lifecycle around the floating activity stack: what is still on screen, when a
+ * result expires, and when a run counts as announced.
+ *
+ * Assistant-owned rather than routed through the app's Sonner toaster, which is
+ * mounted with `visibleToasts={1}`: an approval card lives until it is answered,
+ * and parking it in that single slot would mute every unrelated app alert for
+ * as long as it sits there.
+ */
+export function InAppAgentActivityNotifications({
+  notifications,
+  onOpenConversation,
+  onDelivered,
+}: {
+  notifications: readonly InAppAgentActivityNotification[];
+  onOpenConversation: (conversationId: string) => void;
+  /** Marks these runs as announced; dismissal must not mark them read. */
+  onDelivered: (conversationIds: readonly string[]) => void;
+}) {
+  /**
+   * Keyed by run, not by conversation. Dismissing a result must not silence the
+   * *next* run in the same conversation, which is a different thing to say.
+   */
+  const [dismissedRunIds, setDismissedRunIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const visible = useMemo(
+    () =>
+      notifications.filter(
+        (notification) => !dismissedRunIds.has(notification.runId),
+      ),
+    [dismissedRunIds, notifications],
+  );
+
+  /**
+   * Delivery is recorded when a card *leaves*, not when it appears.
+   *
+   * A card the user never actually got — the tab closed inside the result
+   * window, an approval still sitting unanswered — is therefore still
+   * undelivered on the next load and shows again, which is the whole point of
+   * persisting it. Marking on render would consume the announcement for a card
+   * nobody saw.
+   */
+  const retire = (cards: readonly InAppAgentActivityCard[]) => {
+    if (cards.length === 0) {
+      return;
+    }
+
+    setDismissedRunIds(
+      (current) => new Set([...current, ...cards.map((card) => card.runId)]),
+    );
+    onDelivered(cards.map((card) => card.conversationId));
+  };
+
+  // Both ids travel in the key so the timer closes over stable strings rather
+  // than an array that is rebuilt every render.
+  const expiringKey = visible
+    .filter((card) => card.state !== "approval")
+    .map((card) => `${card.runId} ${card.conversationId}`)
+    .join("|");
+
+  useEffect(() => {
+    if (expiringKey.length === 0) {
+      return;
+    }
+
+    const expiring = expiringKey.split("|").map((pair) => pair.split(" "));
+    const timeout = window.setTimeout(() => {
+      setDismissedRunIds(
+        (current) => new Set([...current, ...expiring.map(([runId]) => runId)]),
+      );
+      onDelivered(expiring.map(([, conversationId]) => conversationId));
+    }, RESULT_CARD_TTL_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [expiringKey, onDelivered]);
+
+  return (
+    <Layer name="toast">
+      <InAppAgentActivityCards
+        cards={visible}
+        onOpen={(card) => {
+          retire([card]);
+          onOpenConversation(card.conversationId);
+        }}
+        onDismiss={(card) => {
+          retire([card]);
+        }}
+      />
+    </Layer>
+  );
+}

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -926,3 +926,76 @@ describe("in-app agent execution", () => {
     });
   });
 });
+
+describe("in-app agent concurrent conversations", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("starts a new conversation while another one is still running", async () => {
+    // The submit guard used to read `isRunning` before resolving the target
+    // conversation, so a running conversation refused a brand-new one --
+    // silently, by returning false. That is the whole feature failing closed.
+    providerMocks.backgroundExecutionEnabled = true;
+    providerMocks.conversationQuery.data = {
+      conversation: { id: "conversation-1", isWriteLocked: false },
+      messages: [],
+      eventCursor: 3,
+      latestRun: {
+        id: "run-1",
+        status: InAppAgentRunStatus.RUNNING,
+        errorCode: null,
+        cancelRequested: false,
+      },
+      pendingToolApprovals: [],
+    };
+    providerMocks.startRun.mockResolvedValue({ runId: "run-2" });
+    window.sessionStorage.setItem(
+      "langfuse:in-app-ai-agent-selected-conversation:project-1",
+      JSON.stringify("conversation-1"),
+    );
+
+    renderExecutionUi();
+
+    // Starting another conversation is reachable while the first one runs.
+    const newConversationButton = await screen.findByRole("button", {
+      name: "Start new conversation",
+    });
+    expect(newConversationButton).toBeEnabled();
+    fireEvent.click(newConversationButton);
+
+    const input = await screen.findByRole("textbox", {
+      name: "Message the assistant",
+    });
+    fireEvent.change(input, { target: { value: "Second question" } });
+    const form = input.closest("form");
+    if (!form) {
+      throw new Error("Expected the assistant composer to render a form");
+    }
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(providerMocks.startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-1",
+          message: "Second question",
+        }),
+      );
+    });
+    // The first conversation was left running, not cancelled.
+    expect(providerMocks.cancelRun).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -32,6 +32,7 @@ const providerMocks = vi.hoisted(() => {
       decideToolApproval: { mutateAsync: decideToolApproval },
     },
     getConversation: vi.fn(),
+    activityQuery: { data: undefined, refetch: vi.fn() },
     listQuery: {
       data: { pages: [{ conversations: [] }] },
       error: null,
@@ -125,6 +126,8 @@ vi.mock("@/src/utils/api", () => ({
     inAppAgent: {
       listConversations: {
         useInfiniteQuery: () => providerMocks.listQuery,
+        // The activity sidecar caller: same procedure, `limit: 1`.
+        useQuery: () => providerMocks.activityQuery,
       },
       getConversation: {
         useQuery: () => providerMocks.conversationQuery,

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -79,6 +79,7 @@ function windowElement(
 ) {
   const props: InAppAgentWindowProps = {
     conversations: [],
+    canLeaveRunningConversation: false,
     error: null,
     executionUi: { type: "foreground" },
     hasMoreConversations: false,
@@ -268,10 +269,18 @@ describe("ControlledInAppAgentWindow composer", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("keeps navigation disabled while an approval is pending", () => {
+  it("blocks another turn here but still lets you leave, on the background path", () => {
+    // A parked approval owns this conversation's composer, not the whole
+    // assistant: a background run is durable, so leaving does not abandon it.
     controlledAgent.value.isRunning = false;
     controlledAgent.value.pendingToolApprovals = [{ id: "approval-1" }];
     controlledAgent.value.submit = vi.fn();
+    controlledAgent.value.execution = {
+      type: "background",
+      run: null,
+      isCancelling: false,
+      cancel: vi.fn(),
+    };
 
     render(
       <TooltipProvider>
@@ -288,6 +297,32 @@ describe("ControlledInAppAgentWindow composer", () => {
       screen.getByRole("textbox", { name: "Message the assistant" }),
     ).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Start new conversation" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Conversation history" }),
+    ).toBeEnabled();
+  });
+
+  it("keeps you pinned to the conversation while a foreground turn runs", () => {
+    // A foreground run dies with its request, so navigating away would abandon
+    // it. Enabling these controls made them look clickable and do nothing.
+    controlledAgent.value.isRunning = true;
+    controlledAgent.value.pendingToolApprovals = [];
+    controlledAgent.value.execution = { type: "foreground" };
+
+    render(
+      <TooltipProvider>
+        <ControlledInAppAgentWindow
+          isExpanded={false}
+          onClose={vi.fn()}
+          onDeleteConversation={vi.fn()}
+          onExpandedChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
     expect(
       screen.getByRole("button", { name: "Start new conversation" }),
     ).toBeDisabled();

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -11,7 +11,10 @@ import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
 const capture = vi.fn();
 const controlledAgent = vi.hoisted(() => ({
   value: {
-    conversations: [],
+    conversations: [] as Array<{ id: string; title: string | null }>,
+    activityByConversationId: new Map<string, { state: string }>(),
+    attentionCount: 0,
+    markActivityDelivered: vi.fn(),
     error: null,
     hasMoreConversations: false,
     isLoadingMoreConversations: false,
@@ -79,6 +82,7 @@ function windowElement(
 ) {
   const props: InAppAgentWindowProps = {
     conversations: [],
+    activityByConversationId: new Map(),
     canLeaveRunningConversation: false,
     error: null,
     executionUi: { type: "foreground" },

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -592,6 +592,7 @@ const meta = preview.meta({
     isExpanded: false,
     isConversationInteractionDisabled: false,
     conversations,
+    activityByConversationId: new Map(),
     canLeaveRunningConversation: false,
     hasMoreConversations: false,
     isLoadingMoreConversations: false,

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -592,6 +592,7 @@ const meta = preview.meta({
     isExpanded: false,
     isConversationInteractionDisabled: false,
     conversations,
+    canLeaveRunningConversation: false,
     hasMoreConversations: false,
     isLoadingMoreConversations: false,
     isAssistantTurnInProgress: false,

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -269,6 +269,12 @@ export type InAppAgentWindowExecutionUi =
 
 export type InAppAgentWindowProps = {
   conversations: InAppAgentWindowConversation[];
+  /**
+   * Whether leaving a running conversation is possible at all. False on the
+   * foreground path, whose run cannot outlive the request, so navigating away
+   * mid-turn would abandon it — the controls stay disabled there.
+   */
+  canLeaveRunningConversation: boolean;
   disablePendingToolApprovalActions?: boolean;
   error: InAppAgentError | null;
   executionUi: InAppAgentWindowExecutionUi;
@@ -370,6 +376,7 @@ function InAppAgentGenericError({
 
 export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const {
+    canLeaveRunningConversation,
     conversations,
     disablePendingToolApprovalActions = false,
     error,
@@ -405,6 +412,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const isMobile = useIsMobile();
   const isRateLimited = isInAppAgentRateLimited(error);
   const isComposerDisabled = isConversationInteractionDisabled;
+  // Foreground runs die with the request, so the drawer stays pinned to the
+  // conversation until the turn finishes.
+  const isPinnedToTurn =
+    isAssistantTurnInProgress && !canLeaveRunningConversation;
   const isSubmitDisabled =
     isComposerDisabled || isRateLimited || isAssistantTurnInProgress;
   const backgroundNotice =
@@ -563,9 +574,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={
-                  isConversationInteractionDisabled || isAssistantTurnInProgress
-                }
+                // A background turn no longer blocks starting another
+                // conversation: the run is durable, so leaving does not abandon
+                // it. A foreground turn still does.
+                disabled={isConversationInteractionDisabled || isPinnedToTurn}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -592,8 +604,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     size="icon"
                     className="size-6 shrink-0"
                     disabled={
-                      isConversationInteractionDisabled ||
-                      isAssistantTurnInProgress
+                      isConversationInteractionDisabled || isPinnedToTurn
                     }
                     aria-label="Conversation history"
                   >

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -44,6 +44,8 @@ import {
 } from "./InAppAgentMessage";
 import type { InAppAgentMessageFeedbackValue } from "@langfuse/shared/in-app-agent";
 import type { InAppAgentScreenContextDescription } from "@/src/features/in-app-agent/context";
+import type { InAppAgentActivityByConversationId } from "@/src/features/in-app-agent/lib/inAppAgentActivity";
+import { ConversationActivityIndicator } from "@/src/features/in-app-agent/components/ConversationActivityIndicator";
 import { InAppAgentToolCallCard } from "@/src/features/in-app-agent/components/InAppAgentToolCallCard";
 import {
   type InAppAgentError,
@@ -269,6 +271,8 @@ export type InAppAgentWindowExecutionUi =
 
 export type InAppAgentWindowProps = {
   conversations: InAppAgentWindowConversation[];
+  /** Per-conversation attention state, for the recent-conversation indicators. */
+  activityByConversationId: InAppAgentActivityByConversationId;
   /**
    * Whether leaving a running conversation is possible at all. False on the
    * foreground path, whose run cannot outlive the request, so navigating away
@@ -376,6 +380,7 @@ function InAppAgentGenericError({
 
 export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const {
+    activityByConversationId,
     canLeaveRunningConversation,
     conversations,
     disablePendingToolApprovalActions = false,
@@ -628,6 +633,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 conversations.map((conversation) => {
                   const conversationTitle =
                     conversation.title?.trim() || "Untitled conversation";
+                  const activityState = activityByConversationId.get(
+                    conversation.id,
+                  )?.state;
 
                   return (
                     <DropdownMenuItem
@@ -647,15 +655,17 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       >
                         {conversationTitle}
                       </span>
+                      {activityState ? (
+                        <ConversationActivityIndicator state={activityState} />
+                      ) : null}
                       <Button
                         type="button"
                         variant="ghost"
                         size="icon-xs"
                         className="text-muted-foreground hover:text-destructive -mr-1.5 shrink-0"
-                        disabled={
-                          isConversationInteractionDisabled ||
-                          isAssistantTurnInProgress
-                        }
+                        // Deleting is always allowed; it cancels whatever the
+                        // conversation was doing rather than refusing.
+                        disabled={isConversationInteractionDisabled}
                         aria-label="Delete conversation"
                         onClick={(event) => {
                           event.preventDefault();

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -334,7 +334,17 @@ function InAppAiAgentProviderInner({
   >([]);
   const [isForegroundRunning, setIsForegroundRunning] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  /**
+   * Which conversation has a turn being submitted, not whether one is.
+   *
+   * Keyed because submitting into a *new* conversation resets the agent for the
+   * old one, and an unkeyed release would drop the lock the submit had just
+   * taken. Everything user-facing derives from whether this names the
+   * conversation currently on screen.
+   */
+  const [submittingConversationId, setSubmittingConversationId] = useState<
+    string | null
+  >(null);
   const [loadingEventIds, setLoadingEventIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -349,7 +359,7 @@ function InAppAiAgentProviderInner({
   const backgroundExecutionEnabled =
     useInAppAgentBackgroundExecutionEnabled(projectId);
   const intentionalAbortRef = useRef(false);
-  const submitInFlightRef = useRef(false);
+  const submitInFlightRef = useRef<string | null>(null);
   const runInFlightRef = useRef(false);
   const subscriptionRef = useRef<ReturnType<AbstractAgent["subscribe"]> | null>(
     null,
@@ -369,7 +379,12 @@ function InAppAiAgentProviderInner({
       conversationId: _selectedConversationId ?? "",
     },
     {
-      enabled: open && Boolean(_selectedConversationId) && !isSubmitting,
+      // Keyed against the raw id because `selectedConversationId` is derived
+      // from this very query's error state.
+      enabled:
+        open &&
+        Boolean(_selectedConversationId) &&
+        submittingConversationId !== _selectedConversationId,
     },
   );
   const deleteConversationMutation =
@@ -384,6 +399,10 @@ function InAppAiAgentProviderInner({
   const selectedConversationId = isSelectedConversationNotFound
     ? null
     : _selectedConversationId;
+  // A submit into another conversation must not make this one look busy.
+  const isSubmitting =
+    submittingConversationId !== null &&
+    submittingConversationId === selectedConversationId;
 
   const conversations = useMemo(
     () =>
@@ -959,9 +978,21 @@ function InAppAiAgentProviderInner({
     ],
   );
 
-  const releaseSubmitLock = useCallback(() => {
-    submitInFlightRef.current = false;
-    setIsSubmitting(false);
+  /**
+   * Release the submit lock, but only if it still belongs to the conversation
+   * the caller is finishing. A later submit into another conversation owns the
+   * lock by then and must keep it.
+   */
+  const releaseSubmitLock = useCallback((conversationId: string | null) => {
+    if (
+      conversationId !== null &&
+      submitInFlightRef.current !== conversationId
+    ) {
+      return;
+    }
+
+    submitInFlightRef.current = null;
+    setSubmittingConversationId(null);
   }, []);
 
   const getOrCreateAgent = useCallback(
@@ -1102,7 +1133,7 @@ function InAppAiAgentProviderInner({
               projectId,
               conversationId,
             });
-            releaseSubmitLock();
+            releaseSubmitLock(conversationId);
             activeRunIdRef.current = null;
             intentionalAbortRef.current = false;
           },
@@ -1211,7 +1242,7 @@ function InAppAiAgentProviderInner({
             projectId,
             conversationId,
           });
-          releaseSubmitLock();
+          releaseSubmitLock(conversationId);
           activeRunIdRef.current = null;
           intentionalAbortRef.current = false;
           runInFlightRef.current = false;
@@ -1231,7 +1262,14 @@ function InAppAiAgentProviderInner({
 
   const selectConversation = useCallback(
     (conversationId: string | null) => {
-      if (isRunning || conversationId === _selectedConversationId) {
+      if (conversationId === _selectedConversationId) {
+        return;
+      }
+
+      // Leaving a running conversation is allowed: `resetAgent` only detaches
+      // this browser's observation, and the run itself is durable server-side.
+      // Foreground runs cannot outlive the request, so they still hold on.
+      if (isRunning && !backgroundExecutionEnabled) {
         return;
       }
 
@@ -1242,7 +1280,13 @@ function InAppAiAgentProviderInner({
       setForegroundMessages([]);
       setSelectedConversationId(conversationId);
     },
-    [_selectedConversationId, isRunning, resetAgent, setSelectedConversationId],
+    [
+      _selectedConversationId,
+      backgroundExecutionEnabled,
+      isRunning,
+      resetAgent,
+      setSelectedConversationId,
+    ],
   );
 
   const deleteConversation = useCallback(
@@ -1302,43 +1346,49 @@ function InAppAiAgentProviderInner({
 
   const submit = useCallback(
     async (content: string, options?: InAppAgentSubmitOptions) => {
+      // Resolve the target conversation before guarding on it. `isRunning`,
+      // hydration and the write lock all describe the *selected* conversation,
+      // so testing them against a brand-new conversation would refuse a turn
+      // the user is entitled to start while something else is still running.
+      const isNewConversation =
+        options?.newConversation === true || !selectedConversationId;
+      const conversationId = isNewConversation
+        ? createInAppAgentConversationId()
+        : selectedConversationId;
+
       if (
         !content ||
-        isRunning ||
+        !conversationId ||
         isInAppAgentRateLimited(error) ||
-        (options?.newConversation !== true &&
-          isSelectedConversationHydrating) ||
-        submitInFlightRef.current ||
-        runInFlightRef.current
+        runInFlightRef.current ||
+        // A turn already going into this same conversation is the only
+        // submit-side conflict; one per conversation remains the rule.
+        submitInFlightRef.current === conversationId
       ) {
         return false;
       }
 
-      submitInFlightRef.current = true;
-      setIsSubmitting(true);
+      if (
+        !isNewConversation &&
+        (isRunning || isSelectedConversationHydrating)
+      ) {
+        return false;
+      }
+
+      if (!isNewConversation && selectedConversationIsWriteLocked) {
+        setError({
+          type: "generic",
+          message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+        });
+        return false;
+      }
+
+      submitInFlightRef.current = conversationId;
+      setSubmittingConversationId(conversationId);
       setError(null);
 
       let startedRun = false;
       try {
-        const isNewConversation =
-          options?.newConversation === true || !selectedConversationId;
-
-        if (!isNewConversation && selectedConversationIsWriteLocked) {
-          setError({
-            type: "generic",
-            message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-          });
-          return false;
-        }
-
-        const conversationId = isNewConversation
-          ? createInAppAgentConversationId()
-          : selectedConversationId;
-
-        if (!conversationId) {
-          return false;
-        }
-
         if (isNewConversation) {
           setSelectedConversationId(conversationId);
         }
@@ -1433,7 +1483,7 @@ function InAppAiAgentProviderInner({
         return false;
       } finally {
         if (!startedRun) {
-          releaseSubmitLock();
+          releaseSubmitLock(conversationId);
         }
       }
     },
@@ -1577,7 +1627,7 @@ function InAppAiAgentProviderInner({
 
         if (backgroundExecutionEnabled) {
           backgroundSessionRef.current?.detach();
-          releaseSubmitLock();
+          releaseSubmitLock(selectedConversationId);
         }
       }
 

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -52,6 +52,7 @@ import type {
   InAppAgentActivityByConversationId,
   InAppAgentActivityRunSummary,
 } from "@/src/features/in-app-agent/lib/inAppAgentActivity";
+import { InAppAgentActivityNotifications } from "@/src/features/in-app-agent/components/InAppAgentActivityNotifications";
 import { InAppAgentBackgroundClient } from "@/src/features/in-app-agent/lib/backgroundAgentClient";
 import { useInAppAgentBackgroundExecutionEnabled } from "@/src/features/in-app-agent/lib/executionMode";
 import {
@@ -1974,6 +1975,39 @@ function InAppAiAgentProviderInner({
     isCancellingRun,
   ]);
 
+  /** Only outcomes and questions surface as cards; a run in progress is not news. */
+  const activityNotifications = useMemo(
+    () =>
+      [...activityByConversationId.entries()].flatMap(
+        ([conversationId, { state, entry }]) =>
+          state === "running" || entry.toastDelivered
+            ? []
+            : [
+                {
+                  conversationId,
+                  runId: entry.runId,
+                  title: entry.title,
+                  state,
+                },
+              ],
+      ),
+    [activityByConversationId],
+  );
+
+  const openConversationFromActivity = useCallback(
+    (conversationId: string) => {
+      const state = activityByConversationId.get(conversationId)?.state;
+
+      capture("in_app_agent:activity_opened", {
+        source: "notification",
+        activityType: state ?? "unknown",
+      });
+      setAgentOpen(true);
+      selectConversation(conversationId);
+    },
+    [activityByConversationId, capture, selectConversation, setAgentOpen],
+  );
+
   const approveToolCall = useCallback(
     (approvalId: string) => resumeToolApproval(approvalId, true),
     [resumeToolApproval],
@@ -2055,6 +2089,13 @@ function InAppAiAgentProviderInner({
   return (
     <InAppAiAgentContext.Provider value={value}>
       {children}
+      {/* Rendered here, not from the window host, which unmounts when the
+          assistant is closed — exactly when a notification matters most. */}
+      <InAppAgentActivityNotifications
+        notifications={activityNotifications}
+        onDelivered={markDelivered}
+        onOpenConversation={openConversationFromActivity}
+      />
       <InAppAgentDisabledDialog
         open={enableDialogOpen}
         onOpenChange={setEnableDialogOpen}

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -47,6 +47,11 @@ import {
   recordInAppAgentToolCallForDisplay,
   type InAppAgentDisplayState,
 } from "@/src/features/in-app-agent/lib/display";
+import { useInAppAgentActivity } from "@/src/features/in-app-agent/lib/useInAppAgentActivity";
+import type {
+  InAppAgentActivityByConversationId,
+  InAppAgentActivityRunSummary,
+} from "@/src/features/in-app-agent/lib/inAppAgentActivity";
 import { InAppAgentBackgroundClient } from "@/src/features/in-app-agent/lib/backgroundAgentClient";
 import { useInAppAgentBackgroundExecutionEnabled } from "@/src/features/in-app-agent/lib/executionMode";
 import {
@@ -155,6 +160,9 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
   conversations: [],
   hasMoreConversations: false,
   isLoadingMoreConversations: false,
+  activityByConversationId: new Map(),
+  attentionCount: 0,
+  markActivityDelivered: () => undefined,
   selectedConversationId: undefined,
   selectedConversationIsWriteLocked: false,
   loadMoreConversations: () => undefined,
@@ -215,6 +223,11 @@ type InAppAiAgentContextType = {
   conversations: InAppAiAgentConversation[];
   hasMoreConversations: boolean;
   isLoadingMoreConversations: boolean;
+  /** Conversations wanting attention, by id. Empty unless background is on. */
+  activityByConversationId: InAppAgentActivityByConversationId;
+  /** Conversations the user still owes a look, for the launcher badge. */
+  attentionCount: number;
+  markActivityDelivered: (conversationIds: readonly string[]) => void;
   selectedConversationId: string | undefined;
   selectedConversationIsWriteLocked: boolean;
   loadMoreConversations: () => void;
@@ -474,6 +487,55 @@ function InAppAiAgentProviderInner({
   const liveMessageVersion = backgroundExecutionEnabled
     ? backgroundExecutionView.liveMessageRevision
     : foregroundLiveMessageVersion;
+
+  /**
+   * The selected conversation's run is known first-hand from the attached
+   * session, so it is folded in directly rather than waited for from a poll
+   * this tab does not need to make.
+   */
+  const localActivityRuns = useMemo<InAppAgentActivityRunSummary[]>(() => {
+    if (!selectedConversationId || !currentBackgroundRun) {
+      return [];
+    }
+
+    return [
+      {
+        conversationId: selectedConversationId,
+        title:
+          conversations.find(
+            (conversation) => conversation.id === selectedConversationId,
+          )?.title ?? null,
+        runId: currentBackgroundRun.id,
+        status: currentBackgroundRun.status,
+        errorCode: currentBackgroundRun.errorCode,
+        cancelRequested: currentBackgroundRun.cancelRequested,
+      },
+    ];
+  }, [conversations, currentBackgroundRun, selectedConversationId]);
+
+  const backgroundAttachmentStatus = backgroundExecutionView.attachment.status;
+  const isCoveredByLiveSession = useCallback(
+    (conversationId: string) =>
+      open &&
+      conversationId === selectedConversationId &&
+      backgroundAttachmentStatus === "attached",
+    [backgroundAttachmentStatus, open, selectedConversationId],
+  );
+
+  const {
+    activityByConversationId,
+    attentionCount,
+    markConversationSeen,
+    markDelivered,
+  } = useInAppAgentActivity({
+    projectId,
+    enabled: backgroundExecutionEnabled,
+    localRuns: localActivityRuns,
+    // Only what the user can actually see counts as looked at; a selected
+    // conversation behind a closed window has not been read.
+    visibleConversationId: open ? selectedConversationId : null,
+    isCoveredByLiveSession,
+  });
 
   const effectivePendingToolApprovals = useMemo(() => {
     if (!backgroundExecutionEnabled) {
@@ -1279,11 +1341,17 @@ function InAppAiAgentProviderInner({
       resetAgent();
       setForegroundMessages([]);
       setSelectedConversationId(conversationId);
+
+      if (conversationId && open) {
+        markConversationSeen(conversationId);
+      }
     },
     [
       _selectedConversationId,
       backgroundExecutionEnabled,
       isRunning,
+      markConversationSeen,
+      open,
       resetAgent,
       setSelectedConversationId,
     ],
@@ -1291,10 +1359,6 @@ function InAppAiAgentProviderInner({
 
   const deleteConversation = useCallback(
     async (conversationId: string) => {
-      if (isRunning) {
-        return;
-      }
-
       try {
         await deleteConversationMutation.mutateAsync({
           projectId,
@@ -1333,7 +1397,6 @@ function InAppAiAgentProviderInner({
     },
     [
       deleteConversationMutation,
-      isRunning,
       projectId,
       resetAgent,
       selectedConversationId,
@@ -1438,7 +1501,15 @@ function InAppAiAgentProviderInner({
         }
         const entryPoint = options?.entryPoint ?? "chat";
         if (isNewConversation) {
-          capture("in_app_agent:new_chat_started", { entryPoint });
+          capture("in_app_agent:new_chat_started", {
+            entryPoint,
+            // Whether starting here means running two conversations at once.
+            hasOtherActiveRun: [...activityByConversationId.entries()].some(
+              ([otherId, activity]) =>
+                otherId !== conversationId &&
+                (activity.state === "running" || activity.state === "approval"),
+            ),
+          });
         }
         capture("in_app_agent:new_chat_turn", {
           entryPoint,
@@ -1488,6 +1559,7 @@ function InAppAiAgentProviderInner({
       }
     },
     [
+      activityByConversationId,
       backgroundExecutionEnabled,
       conversationQuery.data,
       capture,
@@ -1933,6 +2005,9 @@ function InAppAiAgentProviderInner({
       conversations,
       hasMoreConversations,
       isLoadingMoreConversations,
+      activityByConversationId,
+      attentionCount,
+      markActivityDelivered: markDelivered,
       selectedConversationId: selectedConversationId ?? undefined,
       selectedConversationIsWriteLocked,
       loadMoreConversations,
@@ -1945,9 +2020,12 @@ function InAppAiAgentProviderInner({
       submitFeedback,
     }),
     [
+      activityByConversationId,
       approveToolCall,
+      attentionCount,
       isExpanded,
       conversations,
+      markDelivered,
       effectiveError,
       hasMoreConversations,
       isLoadingMoreConversations,

--- a/web/src/features/in-app-agent/lib/inAppAgentActivity.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/inAppAgentActivity.clienttest.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+
+import { InAppAgentRunStatus } from "@langfuse/shared";
+
+import {
+  IN_APP_AGENT_ACTIVITY_TRACKED_RUN_ID_LIMIT,
+  getInAppAgentActivityByConversationId,
+  getInAppAgentAttentionCount,
+  getInAppAgentTrackedRunIds,
+  markInAppAgentActivityDelivered,
+  markInAppAgentConversationSeen,
+  reconcileInAppAgentActivityLedger,
+  type InAppAgentActivityLedger,
+  type InAppAgentActivityRunSummary,
+} from "./inAppAgentActivity";
+
+const run = (
+  overrides: Partial<InAppAgentActivityRunSummary> = {},
+): InAppAgentActivityRunSummary => ({
+  conversationId: "conversation-1",
+  title: "Investigate latency",
+  runId: "run-1",
+  status: InAppAgentRunStatus.RUNNING,
+  errorCode: null,
+  cancelRequested: false,
+  ...overrides,
+});
+
+const sync = (
+  ledger: InAppAgentActivityLedger,
+  runs: InAppAgentActivityRunSummary[],
+  options: {
+    requestedRunIds?: string[];
+    visibleConversationId?: string | null;
+  } = {},
+) => reconcileInAppAgentActivityLedger({ ledger, runs, ...options });
+
+describe("in-app agent activity ledger", () => {
+  it("baselines finished history as seen but never an in-flight run", () => {
+    // First use on this device: an existing backlog must not light up, yet a run
+    // that is still executing has an outcome the user has not been told about.
+    const ledger = sync(null, [
+      run({
+        conversationId: "old",
+        runId: "old-run",
+        status: InAppAgentRunStatus.SUCCEEDED,
+      }),
+      run({
+        conversationId: "live",
+        runId: "live-run",
+        status: InAppAgentRunStatus.RUNNING,
+      }),
+    ]);
+
+    // Retained as an acknowledged tombstone, but never surfaced.
+    expect(
+      getInAppAgentActivityByConversationId(ledger).get("old"),
+    ).toBeUndefined();
+    expect(ledger?.entries.live).toMatchObject({
+      runId: "live-run",
+      seen: false,
+      toastDelivered: false,
+    });
+
+    const afterCompletion = sync(ledger, [
+      run({
+        conversationId: "live",
+        runId: "live-run",
+        status: InAppAgentRunStatus.SUCCEEDED,
+      }),
+    ]);
+
+    expect(
+      getInAppAgentActivityByConversationId(afterCompletion).get("live")?.state,
+    ).toBe("done-unread");
+    expect(getInAppAgentAttentionCount(afterCompletion)).toBe(1);
+  });
+
+  it("discovers a run that finished while the app was closed", () => {
+    // The ledger persists the run id precisely so it can be adjudicated on
+    // return: a terminal run is in neither the attention set nor any in-memory
+    // state that survived the reload.
+    const beforeClose = sync(null, [
+      run({ conversationId: "away", runId: "away-run" }),
+    ]);
+
+    expect(
+      getInAppAgentTrackedRunIds(
+        beforeClose,
+        IN_APP_AGENT_ACTIVITY_TRACKED_RUN_ID_LIMIT,
+      ),
+    ).toEqual(["away-run"]);
+
+    const afterReturn = sync(
+      beforeClose,
+      [
+        run({
+          conversationId: "away",
+          runId: "away-run",
+          status: InAppAgentRunStatus.FAILED,
+        }),
+      ],
+      { requestedRunIds: ["away-run"] },
+    );
+
+    expect(
+      getInAppAgentActivityByConversationId(afterReturn).get("away")?.state,
+    ).toBe("failed-unread");
+  });
+
+  it("acknowledges only what the user can actually see", () => {
+    const ledger = sync(
+      null,
+      [
+        run({
+          conversationId: "watched",
+          runId: "watched-run",
+          status: InAppAgentRunStatus.SUCCEEDED,
+        }),
+        run({
+          conversationId: "hidden",
+          runId: "hidden-run",
+          status: InAppAgentRunStatus.SUCCEEDED,
+        }),
+      ],
+      { visibleConversationId: "watched" },
+    );
+
+    // The visible one is acknowledged on arrival; the hidden one is baselined
+    // as history because this is a first sync. Neither surfaces.
+    expect(getInAppAgentActivityByConversationId(ledger).size).toBe(0);
+
+    const second = sync(ledger, [
+      run({
+        conversationId: "hidden",
+        runId: "hidden-run-2",
+        status: InAppAgentRunStatus.SUCCEEDED,
+      }),
+    ]);
+
+    expect(
+      getInAppAgentActivityByConversationId(second).get("hidden")?.state,
+    ).toBe("done-unread");
+    expect(
+      getInAppAgentActivityByConversationId(
+        markInAppAgentConversationSeen(second, "hidden"),
+      ).size,
+    ).toBe(0);
+  });
+
+  it("keeps an approval counted after it has been read, and never counts mere execution", () => {
+    const parked = sync(null, [
+      run({
+        conversationId: "approve",
+        runId: "approve-run",
+        status: InAppAgentRunStatus.AWAITING_APPROVAL,
+      }),
+    ]);
+    const read = markInAppAgentConversationSeen(parked, "approve");
+
+    expect(
+      getInAppAgentActivityByConversationId(read).get("approve")?.state,
+    ).toBe("approval");
+    expect(getInAppAgentAttentionCount(read)).toBe(1);
+
+    const running = sync(null, [
+      run({ conversationId: "busy", runId: "busy-run" }),
+    ]);
+
+    expect(
+      getInAppAgentActivityByConversationId(running).get("busy")?.state,
+    ).toBe("running");
+    expect(getInAppAgentAttentionCount(running)).toBe(0);
+  });
+
+  it("treats a cancelled run as already known and never surfaces it", () => {
+    const ledger = sync(null, [
+      run({ conversationId: "stopped", runId: "stopped-run" }),
+    ]);
+    const cancelled = sync(ledger, [
+      run({
+        conversationId: "stopped",
+        runId: "stopped-run",
+        status: InAppAgentRunStatus.CANCELLED,
+      }),
+    ]);
+
+    expect(
+      getInAppAgentActivityByConversationId(cancelled).get("stopped"),
+    ).toBeUndefined();
+    expect(getInAppAgentAttentionCount(cancelled)).toBe(0);
+  });
+
+  it("returns the same ledger when a poll changes nothing", () => {
+    const ledger = sync(null, [run()]);
+
+    expect(sync(ledger, [run()])).toBe(ledger);
+  });
+
+  it("ignores a stale report that a finished run is running again", () => {
+    // The tracked-run request is derived from this ledger, so settling a run
+    // switches which query cache entry is read — and that entry can hold a
+    // reply fetched while the run was still executing. Accepting it flipped the
+    // run back, which switched the request back, which read the finished reply
+    // again: an infinite render loop that tore the assistant down.
+    const running = run({
+      runId: "run-1",
+      status: InAppAgentRunStatus.RUNNING,
+    });
+    const finished = run({
+      runId: "run-1",
+      status: InAppAgentRunStatus.SUCCEEDED,
+    });
+
+    const settled = sync(sync(null, [running]), [finished]);
+    expect(settled?.entries["conversation-1"]?.status).toBe(
+      InAppAgentRunStatus.SUCCEEDED,
+    );
+
+    // The stale reply must change nothing at all, reference included.
+    expect(sync(settled, [running])).toBe(settled);
+  });
+
+  it("keeps a run acknowledged when the drawer closes and reopens", () => {
+    // The local session republishes the selected conversation's settled run on
+    // every render. Acknowledgement therefore has to outlive the render that
+    // granted it: deleting the entry once acknowledged let the next
+    // not-visible render resurrect the same run as unread, so the badge ticked
+    // up whenever the drawer closed and dismissed cards came back.
+    const settled = run({
+      conversationId: "watching",
+      runId: "watching-run",
+      status: InAppAgentRunStatus.SUCCEEDED,
+    });
+
+    const whileOpen = sync(null, [settled], {
+      visibleConversationId: "watching",
+    });
+    expect(getInAppAgentAttentionCount(whileOpen)).toBe(0);
+
+    // Drawer closed: nothing is visible, but the run is still republished.
+    const whileClosed = sync(whileOpen, [settled], {
+      visibleConversationId: null,
+    });
+    expect(getInAppAgentAttentionCount(whileClosed)).toBe(0);
+    expect(
+      getInAppAgentActivityByConversationId(whileClosed).get("watching"),
+    ).toBeUndefined();
+
+    // And reopening does not flip it back either.
+    expect(
+      getInAppAgentAttentionCount(
+        sync(whileClosed, [settled], { visibleConversationId: "watching" }),
+      ),
+    ).toBe(0);
+  });
+
+  it("stays stable when a run is acknowledged and republished in the same pass", () => {
+    // The selected conversation's settled run is republished on every render by
+    // the local session. It is acknowledged on arrival (the user is looking at
+    // it) and then pruned as fully acknowledged — a net no-op that must not
+    // report a change, or every render writes localStorage, whose cross-tab
+    // event feeds a fresh object straight back in (React #185).
+    const settledAndVisible = run({
+      conversationId: "watching",
+      runId: "watching-run",
+      status: InAppAgentRunStatus.SUCCEEDED,
+    });
+    const options = { visibleConversationId: "watching" };
+
+    const first = sync(null, [settledAndVisible], options);
+    expect(getInAppAgentActivityByConversationId(first).size).toBe(0);
+
+    expect(sync(first, [settledAndVisible], options)).toBe(first);
+  });
+
+  it("keeps a dismissed card dismissed when its run is republished", () => {
+    // Dismissal records delivery. If a later republish of the same run reset
+    // that flag, the card would reappear and could never be clicked away.
+    const finished = sync(null, [run({ runId: "run-1" })]);
+    const done = sync(finished, [
+      run({ runId: "run-1", status: InAppAgentRunStatus.SUCCEEDED }),
+    ]);
+    const announced = markInAppAgentActivityDelivered(done, ["conversation-1"]);
+
+    const republished = sync(announced, [
+      run({ runId: "run-1", status: InAppAgentRunStatus.SUCCEEDED }),
+    ]);
+
+    expect(republished?.entries["conversation-1"]).toMatchObject({
+      toastDelivered: true,
+      seen: false,
+    });
+    // Still unread — dismissing a card must not mark the conversation read.
+    expect(getInAppAgentAttentionCount(republished)).toBe(1);
+  });
+});

--- a/web/src/features/in-app-agent/lib/inAppAgentActivity.ts
+++ b/web/src/features/in-app-agent/lib/inAppAgentActivity.ts
@@ -1,0 +1,376 @@
+import { InAppAgentRunStatus } from "@langfuse/shared";
+import { isUnsettledInAppAgentRunStatus } from "@langfuse/shared/in-app-agent";
+
+/**
+ * Cross-conversation activity state for the assistant.
+ *
+ * The ledger, not the server, is the source of unread truth. The server answers
+ * only "what is the current status of these runs"; whether the user still owes
+ * a conversation their attention is client state, because it depends on what
+ * this person has actually looked at. That split is what keeps the server query
+ * a pure read and lets it stay silent while nothing is pending.
+ */
+
+export type InAppAgentActivityRunSummary = {
+  conversationId: string;
+  title: string | null;
+  runId: string;
+  status: InAppAgentRunStatus;
+  errorCode: string | null;
+  cancelRequested: boolean;
+};
+
+export type InAppAgentActivityEntry = {
+  runId: string;
+  status: InAppAgentRunStatus;
+  title: string | null;
+  /** The user has looked at this run's conversation since it reached this run. */
+  seen: boolean;
+  /** A notification for this run has been shown (and must not be shown twice). */
+  toastDelivered: boolean;
+};
+
+/**
+ * `null` means "never initialized on this device", which is materially
+ * different from "initialized and currently empty": the first sync baselines
+ * pre-existing history as acknowledged, and doing that twice would swallow
+ * completions.
+ */
+export type InAppAgentActivityLedger = {
+  v: 1;
+  entries: Record<string, InAppAgentActivityEntry>;
+} | null;
+
+export type InAppAgentActivityState =
+  | "running"
+  | "approval"
+  | "failed-unread"
+  | "done-unread";
+
+export const IN_APP_AGENT_ACTIVITY_LEDGER_VERSION = 1;
+
+/**
+ * Upper bound on run ids one activity request may adjudicate. Well above the
+ * per-user concurrency ceiling, and safe to hit: the ledger keeps unread state
+ * itself, so truncating a request defers a verdict rather than losing one.
+ */
+export const IN_APP_AGENT_ACTIVITY_TRACKED_RUN_ID_LIMIT = 20;
+
+/** Bound on retained acknowledgements; only settled, acknowledged ones evict. */
+export const IN_APP_AGENT_ACTIVITY_LEDGER_MAX_ENTRIES = 200;
+
+export function getInAppAgentActivityLedgerStorageKey(projectId: string) {
+  return `langfuse-in-app-agent-activity:v${IN_APP_AGENT_ACTIVITY_LEDGER_VERSION}:${projectId}`;
+}
+
+function isTerminal(status: InAppAgentRunStatus): boolean {
+  return !isUnsettledInAppAgentRunStatus(status);
+}
+
+/**
+ * A cancelled run is the one terminal outcome the user already knows about:
+ * they are the one who stopped it. It never becomes unread and never notifies,
+ * so it is born fully acknowledged and prunes on the next reconcile.
+ */
+function isSelfEvident(status: InAppAgentRunStatus): boolean {
+  return status === InAppAgentRunStatus.CANCELLED;
+}
+
+/**
+ * Fold a batch of run summaries into the ledger.
+ *
+ * Returns the *same reference* when nothing changed. Callers persist to
+ * localStorage on change, and localStorage writes are broadcast to every other
+ * tab, so an unstable identity here would turn a quiet poll into a storm.
+ */
+export function reconcileInAppAgentActivityLedger(params: {
+  ledger: InAppAgentActivityLedger;
+  runs: readonly InAppAgentActivityRunSummary[];
+  /**
+   * Run ids the client asked the server to adjudicate. Any of them missing from
+   * `runs` no longer exists for this user (deleted conversation, revoked
+   * access) and is dropped rather than tracked forever.
+   */
+  requestedRunIds?: readonly string[];
+  /**
+   * The conversation the user is demonstrably looking at right now, if any.
+   * Anything landing here is seen on arrival — the user is watching it happen.
+   */
+  visibleConversationId?: string | null;
+}): InAppAgentActivityLedger {
+  const isFirstSync = params.ledger === null;
+  const previousEntries = params.ledger?.entries ?? {};
+  const nextEntries: Record<string, InAppAgentActivityEntry> = {};
+
+  for (const [conversationId, entry] of Object.entries(previousEntries)) {
+    nextEntries[conversationId] = entry;
+  }
+
+  for (const run of params.runs) {
+    const previous = previousEntries[run.conversationId];
+    // Acknowledgement carries over only within the same run. A newer run in a
+    // conversation the user already read is unread again.
+    const sameRun = previous?.runId === run.runId ? previous : undefined;
+    const isVisible = params.visibleConversationId === run.conversationId;
+
+    /**
+     * A run's outcome is monotonic: once it has finished it can never be
+     * executing again, so a report saying otherwise is stale and is dropped.
+     *
+     * This is load-bearing, not defensive. The tracked-run request is derived
+     * from this ledger, so settling a run changes the request and therefore the
+     * query cache entry it reads from — and the entry it switches to may hold a
+     * reply fetched while that same run was still executing. Accepting it flips
+     * the run back to running, which switches the request back, which reads the
+     * finished reply again: the two caches oscillate forever and React tears
+     * the tree down with "maximum update depth exceeded".
+     */
+    if (sameRun && isTerminal(sameRun.status) && !isTerminal(run.status)) {
+      continue;
+    }
+
+    // A first sync acknowledges history so an existing backlog does not light
+    // up — but only history that is actually finished. Baselining an in-flight
+    // run would silently swallow the completion this feature exists to report.
+    const acknowledgedOnArrival =
+      isVisible ||
+      isSelfEvident(run.status) ||
+      (isFirstSync && !previous && isTerminal(run.status));
+
+    const next: InAppAgentActivityEntry = {
+      runId: run.runId,
+      status: run.status,
+      title: run.title,
+      seen: acknowledgedOnArrival || sameRun?.seen === true,
+      toastDelivered: acknowledgedOnArrival || sameRun?.toastDelivered === true,
+    };
+
+    nextEntries[run.conversationId] = next;
+  }
+
+  const returnedRunIds = new Set(params.runs.map((run) => run.runId));
+
+  /**
+   * An acknowledged entry is kept, not deleted.
+   *
+   * It is the only record that this run was already dealt with, and the local
+   * session republishes the selected conversation's run on every render for as
+   * long as it stays selected. Deleting on acknowledgement therefore erased the
+   * memory and let the very next non-visible render resurrect the same run as
+   * unread — the badge ticking up whenever the drawer closed, and a result card
+   * that came back no matter how often it was dismissed.
+   *
+   * Only entries whose run no longer exists for this user are dropped.
+   */
+  for (const [conversationId, entry] of Object.entries(nextEntries)) {
+    const wasRequestedAndMissing =
+      params.requestedRunIds?.includes(entry.runId) === true &&
+      !returnedRunIds.has(entry.runId);
+
+    if (wasRequestedAndMissing) {
+      delete nextEntries[conversationId];
+    }
+  }
+
+  evictAcknowledgedOverflow(nextEntries);
+
+  /**
+   * Compare the *outcome*, never a "something happened" flag.
+   *
+   * A run can be added and dropped within one pass, which a flag would call a
+   * change forever. Each new object writes to localStorage, whose cross-tab
+   * event re-parses it into yet another object, and the render loop never
+   * settles (React #185).
+   */
+  return isFirstSync || hasLedgerChanged(previousEntries, nextEntries)
+    ? { v: IN_APP_AGENT_ACTIVITY_LEDGER_VERSION, entries: nextEntries }
+    : params.ledger;
+}
+
+/**
+ * Keeping acknowledged entries means the ledger grows with the number of
+ * conversations the user has ever run, so settled-and-acknowledged ones are
+ * evicted oldest-first once it gets large. Anything still owed to the user is
+ * never evicted, however old.
+ */
+function evictAcknowledgedOverflow(
+  entries: Record<string, InAppAgentActivityEntry>,
+): void {
+  const conversationIds = Object.keys(entries);
+  let overflow =
+    conversationIds.length - IN_APP_AGENT_ACTIVITY_LEDGER_MAX_ENTRIES;
+
+  if (overflow <= 0) {
+    return;
+  }
+
+  // Insertion order, so the longest-untouched acknowledged entries go first.
+  for (const conversationId of conversationIds) {
+    const entry = entries[conversationId];
+
+    if (
+      entry &&
+      isTerminal(entry.status) &&
+      entry.seen &&
+      entry.toastDelivered
+    ) {
+      delete entries[conversationId];
+      overflow -= 1;
+
+      if (overflow <= 0) {
+        return;
+      }
+    }
+  }
+}
+
+function hasLedgerChanged(
+  previousEntries: Record<string, InAppAgentActivityEntry>,
+  nextEntries: Record<string, InAppAgentActivityEntry>,
+): boolean {
+  const nextConversationIds = Object.keys(nextEntries);
+
+  if (nextConversationIds.length !== Object.keys(previousEntries).length) {
+    return true;
+  }
+
+  return nextConversationIds.some((conversationId) => {
+    const previous = previousEntries[conversationId];
+    const next = nextEntries[conversationId];
+
+    return (
+      !previous ||
+      !next ||
+      previous.runId !== next.runId ||
+      previous.status !== next.status ||
+      previous.title !== next.title ||
+      previous.seen !== next.seen ||
+      previous.toastDelivered !== next.toastDelivered
+    );
+  });
+}
+
+/** Mark one conversation as looked at. Same-reference on no-op. */
+export function markInAppAgentConversationSeen(
+  ledger: InAppAgentActivityLedger,
+  conversationId: string,
+): InAppAgentActivityLedger {
+  const entry = ledger?.entries[conversationId];
+
+  if (!ledger || !entry || entry.seen) {
+    return ledger;
+  }
+
+  return {
+    ...ledger,
+    entries: { ...ledger.entries, [conversationId]: { ...entry, seen: true } },
+  };
+}
+
+/** Record that a run's notification has been shown. Same-reference on no-op. */
+export function markInAppAgentActivityDelivered(
+  ledger: InAppAgentActivityLedger,
+  conversationIds: readonly string[],
+): InAppAgentActivityLedger {
+  if (!ledger) {
+    return ledger;
+  }
+
+  const undelivered = conversationIds.flatMap((conversationId) => {
+    const entry = ledger.entries[conversationId];
+    return entry && !entry.toastDelivered
+      ? [[conversationId, entry] as const]
+      : [];
+  });
+
+  if (undelivered.length === 0) {
+    return ledger;
+  }
+
+  const entries = { ...ledger.entries };
+  for (const [conversationId, entry] of undelivered) {
+    entries[conversationId] = { ...entry, toastDelivered: true };
+  }
+
+  return { ...ledger, entries };
+}
+
+export function getInAppAgentActivityState(
+  entry: InAppAgentActivityEntry,
+): InAppAgentActivityState | null {
+  if (entry.status === InAppAgentRunStatus.AWAITING_APPROVAL) {
+    return "approval";
+  }
+
+  if (isUnsettledInAppAgentRunStatus(entry.status)) {
+    return "running";
+  }
+
+  if (entry.seen || isSelfEvident(entry.status)) {
+    return null;
+  }
+
+  return entry.status === InAppAgentRunStatus.FAILED
+    ? "failed-unread"
+    : "done-unread";
+}
+
+export type InAppAgentActivityByConversationId = Map<
+  string,
+  { state: InAppAgentActivityState; entry: InAppAgentActivityEntry }
+>;
+
+export function getInAppAgentActivityByConversationId(
+  ledger: InAppAgentActivityLedger,
+): InAppAgentActivityByConversationId {
+  const byConversationId = new Map<
+    string,
+    { state: InAppAgentActivityState; entry: InAppAgentActivityEntry }
+  >();
+
+  for (const [conversationId, entry] of Object.entries(ledger?.entries ?? {})) {
+    const state = getInAppAgentActivityState(entry);
+
+    if (state) {
+      byConversationId.set(conversationId, { state, entry });
+    }
+  }
+
+  return byConversationId;
+}
+
+/**
+ * Conversations still owed the user's attention. A run merely executing does
+ * not count — the spinner on its row already says so, and a badge that ticks up
+ * whenever the assistant is working would train the user to ignore it.
+ */
+export function getInAppAgentAttentionCount(
+  ledger: InAppAgentActivityLedger,
+): number {
+  let count = 0;
+
+  for (const { state } of getInAppAgentActivityByConversationId(
+    ledger,
+  ).values()) {
+    if (state !== "running") {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Runs whose outcome the client cannot know on its own. Only unsettled runs
+ * qualify: a terminal run already has its verdict recorded, so re-asking would
+ * spend the request budget on an answer we have.
+ */
+export function getInAppAgentTrackedRunIds(
+  ledger: InAppAgentActivityLedger,
+  limit: number,
+): string[] {
+  return Object.values(ledger?.entries ?? {})
+    .filter((entry) => isUnsettledInAppAgentRunStatus(entry.status))
+    .map((entry) => entry.runId)
+    .slice(0, limit);
+}

--- a/web/src/features/in-app-agent/lib/useInAppAgentActivity.ts
+++ b/web/src/features/in-app-agent/lib/useInAppAgentActivity.ts
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo } from "react";
+
+import { isUnsettledInAppAgentRunStatus } from "@langfuse/shared/in-app-agent";
+
+import useLocalStorage from "@/src/components/useLocalStorage";
+import {
+  IN_APP_AGENT_ACTIVITY_TRACKED_RUN_ID_LIMIT,
+  getInAppAgentActivityByConversationId,
+  getInAppAgentActivityLedgerStorageKey,
+  getInAppAgentAttentionCount,
+  getInAppAgentTrackedRunIds,
+  markInAppAgentActivityDelivered,
+  markInAppAgentConversationSeen,
+  reconcileInAppAgentActivityLedger,
+  type InAppAgentActivityLedger,
+  type InAppAgentActivityRunSummary,
+} from "@/src/features/in-app-agent/lib/inAppAgentActivity";
+import { api } from "@/src/utils/api";
+
+/** Fast enough that a finished run feels immediate; only ever while pending. */
+const ACTIVITY_POLL_INTERVAL_MS = 4_000;
+
+function useIsDocumentVisible(): () => boolean {
+  return useCallback(
+    () =>
+      typeof document === "undefined" || document.visibilityState === "visible",
+    [],
+  );
+}
+
+/**
+ * Cross-conversation assistant activity: what is running, what needs approval,
+ * and what finished without the user noticing.
+ *
+ * Polls only while something is pending and *not already covered by the live
+ * transcript session*. With nothing running this issues no requests at all —
+ * which is the entire reason this replaces a watch stream per conversation
+ * rather than sitting alongside them.
+ */
+export function useInAppAgentActivity(params: {
+  projectId: string;
+  enabled: boolean;
+  /** Runs this tab knows about first-hand, from the attached session. */
+  localRuns: readonly InAppAgentActivityRunSummary[];
+  /** The conversation the user can actually see right now, if any. */
+  visibleConversationId: string | null;
+  /** Conversations whose live session already reports every transition. */
+  isCoveredByLiveSession: (conversationId: string) => boolean;
+}) {
+  const {
+    projectId,
+    enabled,
+    localRuns,
+    visibleConversationId,
+    isCoveredByLiveSession,
+  } = params;
+  const [ledger, setLedger] = useLocalStorage<InAppAgentActivityLedger>(
+    getInAppAgentActivityLedgerStorageKey(projectId),
+    null,
+  );
+  const getIsDocumentVisible = useIsDocumentVisible();
+
+  const trackedRunIds = useMemo(
+    () =>
+      getInAppAgentTrackedRunIds(
+        ledger,
+        IN_APP_AGENT_ACTIVITY_TRACKED_RUN_ID_LIMIT,
+      ),
+    [ledger],
+  );
+
+  const hasPendingUncoveredRun = useMemo(
+    () =>
+      Object.entries(ledger?.entries ?? {}).some(
+        ([conversationId, entry]) =>
+          isUnsettledInAppAgentRunStatus(entry.status) &&
+          !isCoveredByLiveSession(conversationId),
+      ),
+    [isCoveredByLiveSession, ledger],
+  );
+
+  // `limit: 1` because this caller wants only the `activity` sidecar; the
+  // conversation page it also returns is the cheapest one that can exist. The
+  // drawer's own infinite list is a separate cache entry with its own page size.
+  const activityQuery = api.inAppAgent.listConversations.useQuery(
+    { projectId, limit: 1, trackedRunIds },
+    {
+      enabled,
+      // Two gates, both cheap: no slow idle tick when nothing is pending, and
+      // `refetchIntervalInBackground: false` parks the poll entirely while the
+      // tab is hidden — a background tab with a run in flight costs nothing
+      // until someone looks at it again, which is also when it catches up.
+      refetchInterval: hasPendingUncoveredRun
+        ? ACTIVITY_POLL_INTERVAL_MS
+        : false,
+      refetchIntervalInBackground: false,
+      refetchOnWindowFocus: true,
+    },
+  );
+
+  const runs = useMemo(
+    () => [...(activityQuery.data?.activity ?? []), ...localRuns],
+    [activityQuery.data?.activity, localRuns],
+  );
+
+  /**
+   * localStorage is the external system this synchronizes with, and it is
+   * shared with every other tab, so the reconcile is written only when it
+   * actually changes something — `reconcileInAppAgentActivityLedger` returns
+   * the same reference otherwise.
+   */
+  useEffect(() => {
+    // A disabled query never resolves, so undefined data is also the
+    // feature-off case — no separate guard needed.
+    if (activityQuery.data === undefined) {
+      return;
+    }
+
+    const next = reconcileInAppAgentActivityLedger({
+      ledger,
+      runs,
+      requestedRunIds: trackedRunIds,
+      visibleConversationId: getIsDocumentVisible()
+        ? visibleConversationId
+        : null,
+    });
+
+    // `useLocalStorage` writes and broadcasts on every call, and its own
+    // listener re-parses that broadcast into a fresh object — so an unchanged
+    // reconcile must not reach it at all, or identity churns forever.
+    if (next !== ledger) {
+      setLedger(next);
+    }
+  }, [
+    ledger,
+    activityQuery.data,
+    getIsDocumentVisible,
+    runs,
+    setLedger,
+    trackedRunIds,
+    visibleConversationId,
+  ]);
+
+  const markConversationSeen = useCallback(
+    (conversationId: string) => {
+      setLedger((current) =>
+        markInAppAgentConversationSeen(current, conversationId),
+      );
+    },
+    [setLedger],
+  );
+
+  const markDelivered = useCallback(
+    (conversationIds: readonly string[]) => {
+      setLedger((current) =>
+        markInAppAgentActivityDelivered(current, conversationIds),
+      );
+    },
+    [setLedger],
+  );
+
+  /**
+   * Returning to the tab is the one "the user is looking at it now" signal that
+   * arrives from outside React, so it is the one that needs a listener.
+   */
+  useEffect(() => {
+    if (!visibleConversationId) {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        markConversationSeen(visibleConversationId);
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [markConversationSeen, visibleConversationId]);
+
+  return useMemo(
+    () => ({
+      activityByConversationId: getInAppAgentActivityByConversationId(ledger),
+      attentionCount: getInAppAgentAttentionCount(ledger),
+      markConversationSeen,
+      markDelivered,
+    }),
+    [ledger, markConversationSeen, markDelivered],
+  );
+}

--- a/web/src/features/in-app-agent/server/backgroundRunService.ts
+++ b/web/src/features/in-app-agent/server/backgroundRunService.ts
@@ -5,6 +5,7 @@ import {
   BaseError,
   InAppAgentRunErrorCode,
   InAppAgentRunStatus,
+  InAppAgentRunStatusSchema,
   LangfuseNotFoundError,
   type Plan,
 } from "@langfuse/shared";
@@ -23,6 +24,7 @@ import {
   type AgUiRunAgentInput,
 } from "@langfuse/shared/in-app-agent";
 import { parseInAppAgentInterruptEvent } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
+import { IN_APP_AGENT_UNSETTLED_RUN_STATUSES } from "@langfuse/shared/in-app-agent";
 import {
   ensureOwnedConversation,
   getConversationEvents,
@@ -35,6 +37,7 @@ import {
 import {
   cancelConversationRunsInTransaction,
   cleanupTerminalRunMcpApiKeys,
+  classifyStaleRun,
   createQueuedRun,
   decideToolApproval,
   reconcileConversationRuns,
@@ -146,6 +149,105 @@ export async function getBackgroundConversationSnapshot(params: {
       conversationId: params.conversationId,
     },
   };
+}
+
+export type InAppAgentActivityRun = {
+  conversationId: string;
+  title: string | null;
+  runId: string;
+  status: InAppAgentRunStatus;
+  errorCode: string | null;
+  cancelRequested: boolean;
+};
+
+const IN_APP_AGENT_ACTIVITY_RUN_SELECT = {
+  id: true,
+  conversationId: true,
+  status: true,
+  errorCode: true,
+  cancelRequestedAt: true,
+  // Everything `classifyStaleRun` reads, carried on the row we already fetch.
+  createdAt: true,
+  claimedAt: true,
+  heartbeatAt: true,
+  finishedAt: true,
+  conversation: { select: { title: true } },
+} as const;
+
+/**
+ * Run summaries for the assistant's cross-conversation activity surface.
+ *
+ * Summaries, not transcripts: the caller renders a badge and a row indicator,
+ * so it never needs the event log of a conversation it is not showing. That is
+ * what lets one polled query replace one watch stream per active conversation.
+ *
+ * Two reads, and never a per-conversation loop:
+ * - the attention set, every unsettled run the caller owns in this project;
+ * - the runs the caller is still tracking, by primary key
+ *   (`@@id([id, projectId])`), which is how a run that finished while the app
+ *   was closed is discovered at all — it is in neither the attention set nor
+ *   any in-memory state that survived the reload.
+ *
+ * Stale runs are classified but **not** written. A dead worker leaves a row
+ * RUNNING until something reconciles it, and reconciliation is conversation
+ * scoped, so without this the badge would spin forever on a conversation nobody
+ * opens. Persisting the verdict stays with `reconcileConversationRuns` on the
+ * read paths that already own it; polling must not write.
+ */
+export async function getInAppAgentActivity(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  userId: string;
+  trackedRunIds: readonly string[];
+}): Promise<InAppAgentActivityRun[]> {
+  const ownedByCaller = {
+    projectId: params.projectId,
+    conversation: { createdByUserId: params.userId, deletedAt: null },
+  };
+
+  const [attentionRuns, trackedRuns] = await Promise.all([
+    params.prisma.inAppAgentRun.findMany({
+      where: {
+        ...ownedByCaller,
+        status: { in: [...IN_APP_AGENT_UNSETTLED_RUN_STATUSES] },
+      },
+      select: IN_APP_AGENT_ACTIVITY_RUN_SELECT,
+    }),
+    params.trackedRunIds.length === 0
+      ? []
+      : params.prisma.inAppAgentRun.findMany({
+          where: { ...ownedByCaller, id: { in: [...params.trackedRunIds] } },
+          select: IN_APP_AGENT_ACTIVITY_RUN_SELECT,
+        }),
+  ]);
+
+  const now = Date.now();
+  const byRunId = new Map<string, InAppAgentActivityRun>();
+
+  for (const run of [...attentionRuns, ...trackedRuns]) {
+    if (byRunId.has(run.id)) {
+      continue;
+    }
+
+    // Legacy rows predate the status column and cannot be described.
+    const parsedStatus = InAppAgentRunStatusSchema.safeParse(run.status);
+    if (!parsedStatus.success) {
+      continue;
+    }
+
+    const stale = classifyStaleRun(run, now);
+
+    byRunId.set(run.id, {
+      conversationId: run.conversationId,
+      title: run.conversation.title,
+      runId: run.id,
+      status: stale ? InAppAgentRunStatus.FAILED : parsedStatus.data,
+      errorCode: stale ? stale.errorCode : run.errorCode,
+      cancelRequested: Boolean(run.cancelRequestedAt),
+    });
+  }
+
+  return [...byRunId.values()];
 }
 
 export async function startBackgroundRun(params: {

--- a/web/src/features/in-app-agent/server/router.ts
+++ b/web/src/features/in-app-agent/server/router.ts
@@ -19,6 +19,7 @@ import {
 } from "@langfuse/shared/in-app-agent";
 import { InAppAgentMessageFeedbackValueSchema } from "@langfuse/shared/in-app-agent";
 import { assertInAppAgentAvailable } from "@/src/features/in-app-agent/server/availability";
+import { IN_APP_AGENT_ACTIVITY_TRACKED_RUN_ID_LIMIT } from "@/src/features/in-app-agent/lib/inAppAgentActivity";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
@@ -39,6 +40,7 @@ import {
   decideBackgroundApproval,
   deleteBackgroundConversation,
   getBackgroundConversationSnapshot,
+  getInAppAgentActivity,
   startBackgroundRun,
 } from "@/src/features/in-app-agent/server/backgroundRunService";
 
@@ -98,12 +100,32 @@ export const inAppAgentRouter = createTRPCRouter({
       mode: sharedEnv.LANGFUSE_IN_APP_AGENT_EXECUTION_MODE,
     })),
 
+  /**
+   * The conversation list, plus an `activity` sidecar describing every
+   * conversation that currently wants the user's attention.
+   *
+   * The sidecar is deliberately **not** per-row: it spans the whole project
+   * rather than the requested page, because the caller that needs it most is
+   * the closed-window poller, which asks for `limit: 1` and reads only
+   * `activity`. Keeping it off the rows is also what keeps this free of a
+   * latest-run-per-conversation join.
+   */
   listConversations: protectedProjectProcedure
     .input(
       z.object({
         projectId: z.string(),
         cursor: ConversationListCursorSchema.optional(),
         limit: z.number().int().min(1).max(CONVERSATION_LIST_LIMIT).default(50),
+        /**
+         * Runs the client last saw as active and still needs a verdict on.
+         * Bounded well above the per-user concurrency ceiling; the client keeps
+         * its own unread state, so a truncated request only defers a verdict,
+         * it never loses one.
+         */
+        trackedRunIds: z
+          .array(z.string())
+          .max(IN_APP_AGENT_ACTIVITY_TRACKED_RUN_ID_LIMIT)
+          .default([]),
       }),
     )
     .query(async ({ ctx, input }) => {
@@ -111,6 +133,13 @@ export const inAppAgentRouter = createTRPCRouter({
         prisma: ctx.prisma,
         projectId: input.projectId,
         user: ctx.session.user,
+      });
+
+      const activity = await getInAppAgentActivity({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        userId: ctx.session.user.id,
+        trackedRunIds: input.trackedRunIds,
       });
 
       const conversations = await ctx.prisma.inAppAgentConversation.findMany({
@@ -148,6 +177,7 @@ export const inAppAgentRouter = createTRPCRouter({
                 id: lastConversation.id,
               }
             : undefined,
+        activity,
       };
     }),
 

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -305,6 +305,7 @@ export const events = {
     "community_hours_click",
   ], // also used on landing page for consistency
   in_app_agent: [
+    "activity_opened",
     "entry_point_click",
     "new_chat_started",
     "new_chat_turn",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15842.preview.langfuse.com](https://pr-15842.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

> **Reference only — not a merge candidate.** This is the whole feature in one diff, kept open so the pieces can be judged as a design rather than four disconnected reviews. The mergeable work is split across the PRs below, which carry byte-identical content.
>
> | PR | Scope | Size |
> | --- | --- | --- |
> | #15850 | Cancel a conversation's run when it is deleted (pre-existing bug) | ~200 |
> | #15851 | Let one conversation run while you use another | ~215 |
> | #15852 | Activity sidecar, ledger, badge, row indicators | ~1,355 |
> | #15853 | Floating notification cards | ~430 |
>
> This PR self-empties as those land. Close it when its diff reaches zero.

## Why

Background runs are durable, but the drawer pinned you to one conversation, and nothing told you when a run you walked away from finished, failed, or parked itself waiting on your approval.

## The shape

**One live transcript session, for the selected conversation only.** Everything else is tracked as run *summaries*, not transcripts.

The rejected alternative was a `BackgroundExecutionSessionController` and a `/api/in-app-agent/watch` stream per active conversation. That stream is not push — it polls Postgres every second in a `RepeatableRead` transaction and holds a Node request for 90s *per attached viewer*. Fanning it out would cost N held requests and N tx/s per user to render a badge, against a concurrency ceiling explicitly sized on the assumption it isn't fanned out (`runCapacity.ts:10-12`).

Instead, `listConversations` carries an `activity` sidecar: two indexed reads, no per-conversation loop, no latest-run-per-row join, no raw SQL. It is polled at 4s only while something is pending and is completely idle otherwise.

**Two invariants everything follows from:**

- *The ledger is the source of unread truth.* The server is asked only "what is the current status of these runs", never "what should the user be notified about". Whether a conversation still owes you attention depends on what **you** have looked at.
- *A run is only acknowledged by being looked at.* Nothing marks a conversation seen except viewing it in an open window on a visible tab.

## What review should focus on

Three bugs survived a green unit suite because they only exist in the interaction between the ledger and React Query. Each is now an invariant with a regression test:

1. **Run status is monotonic.** The tracked-run request is derived from the ledger, so settling a run changes which query cache entry is read — and that entry can hold a reply fetched while the run was still executing. Accepting it flipped the run back, which switched the request back: an infinite render loop that tore the assistant down.
2. **Acknowledgement is retained, never deleted.** The local session republishes the selected conversation's run every render, so deleting the entry on acknowledgement erased the only record it had been dealt with, and the next not-visible render resurrected it as unread.
3. **A card is identified by its run, not its conversation.** Keying dismissal by conversation silently suppressed the next run's card in that conversation.

## Verification

`pnpm run lint` and `pnpm run typecheck`: `Tasks: 7 successful, 7 total`. Web client `Tests 122 passed (122)`, Storybook `57 passed (57)`, server `33 passed (33)`, worker `16 passed (16)`.

Browser-verified end to end by driving a run `RUNNING → SUCCEEDED` against a live page: exactly two ledger writes and no render loop (was 53 writes and a dead launcher), badge steady across repeated ⌘I toggles, card auto-expires and dismisses, clicking it opens the conversation and clears the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

