### PR TITLE
docs(web): design-system rules pages

### DIFF
--- a/web/storybook/docs/TokenArchitecture.mdx
+++ b/web/storybook/docs/TokenArchitecture.mdx
@@ -1,0 +1,30 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Token Architecture" />
+
+# Token Architecture
+
+Rules for the token system. The values live on the Palette and Semantic
+tokens pages; component rules live on Writing Good Components.
+
+- Components consume semantic tokens only, never primitives. No raw palette
+  classes (`text-red-700`), no hex values.
+- Themes flip inside the token. A component never carries `dark:` color
+  overrides; if a variant breaks in dark mode, fix the token values, not the
+  component.
+- Tokens are scoped to their property family. Background tokens only work on
+  `bg-*` and gradients, text tokens only on `text-*`. If you need an ink
+  color as a fill, mint a background token (`--bg-inverse`), do not reuse a
+  text token.
+- Sizes are tokens too. Icon dimensions come from `--icon-size-md`, not from
+  ad hoc `size-*` utilities.
+- Every new token goes on the Semantic tokens page in the same change. That
+  page is the registry; an undocumented token does not exist.
+- Token tables sort by the underlying scale: shade/luminance for colors,
+  size for dimensions. Ordinal names (1/2/3/4, sm/md/lg) are just a proxy for
+  that scale, so sorting by name is the same sort.
+- Light and dark values start from the ramp mirror (neutral-N with
+  stone-(1000-N): 700/300, 600/400) but do not need to mirror perfectly.
+  The eye perceives color differently on dark and light backgrounds, and
+  differently across hue groups, so every pair is tuned by eye in both
+  themes (border-default is 200/700, status-error is red-800/red-400).

--- a/web/storybook/docs/WritingGoodComponents.mdx
+++ b/web/storybook/docs/WritingGoodComponents.mdx
@@ -1,0 +1,44 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Writing Good Components" />
+
+# Writing Good Components
+
+Lessons from building the design-system Button. Each rule exists because we
+got it wrong first. Token rules live on Token Architecture.
+
+## Copying a reference
+
+- Measure the reference, do not approximate. The langfuse.com button is 26px,
+  not 32px; its default size is its `small`.
+- Question every borrowed detail. The docs site's icon chip and hover
+  crop-marks came along for the ride and both got cut. Port the essentials,
+  ask about the flourishes.
+
+## Variants and API
+
+- Only ship variants the design actually has. The five-status axis became a
+  single danger type; unused combinations are API surface to maintain.
+- Prefer flat enums over crossed props once the matrix collapses. `type:
+primary | secondary | borderless | danger` beats `type` x `status` with
+  holes in it.
+
+## States
+
+- Check both themes for every state. Dark mode surfaced an unreadable hover
+  fill, an invisible border and a vanishing disabled state that light mode
+  never showed.
+- Hover colors are tokens like every other color, no filters.
+- The rest and hover fills must be far enough apart to notice at a glance.
+  A 4% brightness shift on a white fill is invisible; one real elevation
+  step (bg-elevation-1 to bg-elevation-4) is not.
+- The variant matrix story renders the full cross product, including icon
+  modes, and lists each variant's token routing. If a combination is not in
+  the matrix, it is not reviewed.
+- Every new prop or variant lands in the matrix in the same change,
+  no exceptions.
+
+## Copy
+
+- Curt and minimal everywhere: page ledes, purpose columns, story names.
+- No em dashes in user-facing copy.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15848.preview.langfuse.com](https://pr-15848.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Two Storybook pages under **Design**, split out of #15838:

- **Token Architecture**: semantic-only consumption, themes flip inside tokens, namespace scoping, the Semantic tokens page as registry, scale-sorted tables, ramp mirror as first guess with by-eye tuning per theme.
- **Writing Good Components**: measure the reference, question borrowed details, only ship real variants, token-routed hovers with noticeable rest/hover contrast, full-cross-product variant matrix kept current, curt copy.

Prose only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)