### PR TITLE
feat(in-app-agent): Allow users to start new conversations (or switch) while another one is running 

### DIFF
--- a/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
@@ -244,12 +244,13 @@ describe("in-app agent background runs", () => {
     const { caller, projectId, userId } = await createCaller();
     const conversation = await createConversation({ projectId, userId });
 
-    const { runId } = await caller.startRun({
+    const { conversationId, runId } = await caller.startRun({
       projectId,
       conversationId: conversation.id,
       message: "why did these traces fail?",
       context: [{ description: "current_url", value: "/project/x/traces" }],
     });
+    expect(conversationId).toBe(conversation.id);
 
     const run = await prisma.inAppAgentRun.findFirstOrThrow({
       where: { id: runId, projectId },

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -179,6 +179,7 @@ export function ControlledInAppAgentWindow(
       isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}
       isConversationInteractionDisabled={isConversationInteractionDisabled}
+      isSelectedConversationHydrating={isSelectedConversationHydrating}
       disablePendingToolApprovalActions={selectedConversationIsWriteLocked}
       messages={drawerMessages}
       quickActionContext={quickActionContext}

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -184,6 +184,7 @@ export function ControlledInAppAgentWindow(
       isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}
       isConversationInteractionDisabled={isConversationInteractionDisabled}
+      isSelectedConversationHydrating={isSelectedConversationHydrating}
       disablePendingToolApprovalActions={selectedConversationIsWriteLocked}
       messages={drawerMessages}
       quickActionContext={quickActionContext}

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -191,6 +191,8 @@ export function ControlledInAppAgentWindow(
       quickActionResetKey={quickActionResetKey}
       screenContextDescription={screenContextDescription}
       conversations={conversations}
+      // Only the background driver produces runs that survive leaving them.
+      canLeaveRunningConversation={execution.type === "background"}
       hasMoreConversations={hasMoreConversations}
       isLoadingMoreConversations={isLoadingMoreConversations}
       selectedConversationId={selectedConversationId}

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -1144,9 +1144,12 @@ describe("in-app agent concurrent conversations", () => {
     expect(screen.getByText("Ready")).toBeInTheDocument();
   });
 
-  it("keeps a failed new conversation unqueryable until persistence is acknowledged", async () => {
+  it("keeps a failed new conversation provisional and preserves its messages on retry", async () => {
     providerMocks.getConversation.mockClear();
-    providerMocks.startRun.mockRejectedValueOnce(new Error("Rate limited"));
+    providerMocks.startRun
+      .mockReset()
+      .mockRejectedValueOnce(new Error("Start failed"))
+      .mockImplementationOnce(() => new Promise<never>(() => undefined));
 
     renderExecutionUi();
 
@@ -1169,5 +1172,23 @@ describe("in-app agent concurrent conversations", () => {
       );
     });
     expect(screen.getByText("First question")).toBeVisible();
+
+    fireEvent.change(input, { target: { value: "Retry question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(providerMocks.startRun).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByText("First question")).toBeVisible();
+    expect(screen.getByText("Retry question")).toBeVisible();
+    expect(providerMocks.capture).toHaveBeenCalledWith(
+      "in_app_agent:new_chat_started",
+      { entryPoint: "chat" },
+    );
+    expect(
+      providerMocks.capture.mock.calls.filter(
+        ([event]) => event === "in_app_agent:new_chat_started",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -120,7 +120,10 @@ vi.mock("@/src/utils/api", () => ({
         useInfiniteQuery: () => providerMocks.listQuery,
       },
       getConversation: {
-        useQuery: () => providerMocks.conversationQuery,
+        useQuery: (...args: unknown[]) => {
+          providerMocks.getConversation(...args);
+          return providerMocks.conversationQuery;
+        },
       },
       deleteConversation: {
         useMutation: () => ({ mutateAsync: vi.fn() }),
@@ -998,5 +1001,51 @@ describe("in-app agent concurrent conversations", () => {
     });
     // The first conversation was left running, not cancelled.
     expect(providerMocks.cancelRun).not.toHaveBeenCalled();
+  });
+
+  it("waits for startRun before fetching a new conversation", async () => {
+    providerMocks.backgroundExecutionEnabled = true;
+    providerMocks.getConversation.mockClear();
+    providerMocks.startRun.mockReset();
+
+    let resolveStartRun:
+      | ((result: { runId: string; conversationId: string }) => void)
+      | undefined;
+    providerMocks.startRun.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveStartRun = resolve;
+        }),
+    );
+
+    renderExecutionUi();
+
+    const input = screen.getByRole("textbox", {
+      name: "Message the assistant",
+    });
+    fireEvent.change(input, { target: { value: "First question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(providerMocks.startRun).toHaveBeenCalledOnce();
+    });
+    const conversationId = providerMocks.startRun.mock.calls[0]?.[0]
+      ?.conversationId as string;
+
+    expect(providerMocks.getConversation).toHaveBeenLastCalledWith(
+      expect.objectContaining({ conversationId }),
+      expect.objectContaining({ enabled: false }),
+    );
+
+    await act(async () => {
+      resolveStartRun?.({ runId: "run-1", conversationId });
+    });
+
+    await waitFor(() => {
+      expect(providerMocks.getConversation).toHaveBeenLastCalledWith(
+        expect.objectContaining({ conversationId }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -927,3 +927,76 @@ describe("in-app agent execution", () => {
     });
   });
 });
+
+describe("in-app agent concurrent conversations", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("starts a new conversation while another one is still running", async () => {
+    // The submit guard used to read `isRunning` before resolving the target
+    // conversation, so a running conversation refused a brand-new one --
+    // silently, by returning false. That is the whole feature failing closed.
+    providerMocks.backgroundExecutionEnabled = true;
+    providerMocks.conversationQuery.data = {
+      conversation: { id: "conversation-1", isWriteLocked: false },
+      messages: [],
+      eventCursor: 3,
+      latestRun: {
+        id: "run-1",
+        status: InAppAgentRunStatus.RUNNING,
+        errorCode: null,
+        cancelRequested: false,
+      },
+      pendingToolApprovals: [],
+    };
+    providerMocks.startRun.mockResolvedValue({ runId: "run-2" });
+    window.sessionStorage.setItem(
+      "langfuse:in-app-ai-agent-selected-conversation:project-1",
+      JSON.stringify("conversation-1"),
+    );
+
+    renderExecutionUi();
+
+    // Starting another conversation is reachable while the first one runs.
+    const newConversationButton = await screen.findByRole("button", {
+      name: "Start new conversation",
+    });
+    expect(newConversationButton).toBeEnabled();
+    fireEvent.click(newConversationButton);
+
+    const input = await screen.findByRole("textbox", {
+      name: "Message the assistant",
+    });
+    fireEvent.change(input, { target: { value: "Second question" } });
+    const form = input.closest("form");
+    if (!form) {
+      throw new Error("Expected the assistant composer to render a form");
+    }
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(providerMocks.startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-1",
+          message: "Second question",
+        }),
+      );
+    });
+    // The first conversation was left running, not cancelled.
+    expect(providerMocks.cancelRun).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -926,3 +926,76 @@ describe("in-app agent execution", () => {
     });
   });
 });
+
+describe("in-app agent concurrent conversations", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("starts a new conversation while another one is still running", async () => {
+    // The submit guard used to read `isRunning` before resolving the target
+    // conversation, so a running conversation refused a brand-new one --
+    // silently, by returning false. That is the whole feature failing closed.
+    providerMocks.backgroundExecutionEnabled = true;
+    providerMocks.conversationQuery.data = {
+      conversation: { id: "conversation-1", isWriteLocked: false },
+      messages: [],
+      eventCursor: 3,
+      latestRun: {
+        id: "run-1",
+        status: InAppAgentRunStatus.RUNNING,
+        errorCode: null,
+        cancelRequested: false,
+      },
+      pendingToolApprovals: [],
+    };
+    providerMocks.startRun.mockResolvedValue({ runId: "run-2" });
+    window.sessionStorage.setItem(
+      "langfuse:in-app-ai-agent-selected-conversation:project-1",
+      JSON.stringify("conversation-1"),
+    );
+
+    renderExecutionUi();
+
+    // Starting another conversation is reachable while the first one runs.
+    const newConversationButton = await screen.findByRole("button", {
+      name: "Start new conversation",
+    });
+    expect(newConversationButton).toBeEnabled();
+    fireEvent.click(newConversationButton);
+
+    const input = await screen.findByRole("textbox", {
+      name: "Message the assistant",
+    });
+    fireEvent.change(input, { target: { value: "Second question" } });
+    const form = input.closest("form");
+    if (!form) {
+      throw new Error("Expected the assistant composer to render a form");
+    }
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(providerMocks.startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-1",
+          message: "Second question",
+        }),
+      );
+    });
+    // The first conversation was left running, not cancelled.
+    expect(providerMocks.cancelRun).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -165,6 +165,53 @@ function ReopenAssistantButton() {
   );
 }
 
+function ConcurrentConversationProbe({
+  conversationId,
+}: {
+  conversationId: string | null;
+}) {
+  const { isSubmitting, selectConversation, submit } = useInAppAiAgent();
+
+  return (
+    <>
+      <p>{isSubmitting ? "Submitting" : "Ready"}</p>
+      <button
+        type="button"
+        onClick={() => {
+          submit("First question").catch(() => undefined);
+        }}
+      >
+        Submit
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          selectConversation(null);
+        }}
+      >
+        Leave conversation
+      </button>
+      <button
+        type="button"
+        disabled={!conversationId}
+        onClick={() => {
+          selectConversation(conversationId);
+        }}
+      >
+        Return to conversation
+      </button>
+    </>
+  );
+}
+
+function providerProbe(conversationId: string | null) {
+  return (
+    <InAppAiAgentProvider defaultOpen>
+      <ConcurrentConversationProbe conversationId={conversationId} />
+    </InAppAiAgentProvider>
+  );
+}
+
 function renderExecutionUi({
   defaultOpen = true,
   includeReopenButton = false,
@@ -951,6 +998,11 @@ describe("in-app agent concurrent conversations", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    providerMocks.conversationQuery.data = undefined;
+    providerMocks.conversationQuery.error = null;
+    providerMocks.conversationQuery.isLoading = false;
     window.sessionStorage.clear();
     window.localStorage.clear();
   });
@@ -1056,5 +1108,66 @@ describe("in-app agent concurrent conversations", () => {
         expect.objectContaining({ enabled: true }),
       );
     });
+  });
+
+  it("releases a conversation submit lock when switching away", async () => {
+    providerMocks.startRun.mockImplementation(
+      async (input: { conversationId: string }) => ({
+        conversationId: input.conversationId,
+        runId: "run-1",
+      }),
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+
+    const { rerender } = render(providerProbe(null));
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(providerMocks.startRun).toHaveBeenCalledOnce();
+    });
+    const conversationId = providerMocks.startRun.mock.calls[0]?.[0]
+      ?.conversationId as string;
+    rerender(providerProbe(conversationId));
+
+    fireEvent.click(screen.getByRole("button", { name: "Leave conversation" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Return to conversation" }),
+    );
+
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+  });
+
+  it("keeps a failed new conversation unqueryable until persistence is acknowledged", async () => {
+    providerMocks.getConversation.mockClear();
+    providerMocks.startRun.mockRejectedValueOnce(new Error("Rate limited"));
+
+    renderExecutionUi();
+
+    const input = screen.getByRole("textbox", {
+      name: "Message the assistant",
+    });
+    fireEvent.change(input, { target: { value: "First question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(providerMocks.startRun).toHaveBeenCalledOnce();
+    });
+    const conversationId = providerMocks.startRun.mock.calls[0]?.[0]
+      ?.conversationId as string;
+
+    await waitFor(() => {
+      expect(providerMocks.getConversation).toHaveBeenLastCalledWith(
+        expect.objectContaining({ conversationId }),
+        expect.objectContaining({ enabled: false }),
+      );
+    });
+    expect(screen.getByText("First question")).toBeVisible();
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -789,8 +789,14 @@ describe("in-app agent execution", () => {
       },
     };
     providerMocks.startRun
-      .mockResolvedValueOnce({ runId: "run-1" })
-      .mockResolvedValueOnce({ runId: "run-2" });
+      .mockResolvedValueOnce({
+        conversationId: "conversation-1",
+        runId: "run-1",
+      })
+      .mockResolvedValueOnce({
+        conversationId: "conversation-1",
+        runId: "run-2",
+      });
     providerMocks.cancelRun.mockResolvedValue({
       cancelledImmediately: false,
       status: InAppAgentRunStatus.RUNNING,
@@ -953,7 +959,6 @@ describe("in-app agent concurrent conversations", () => {
     // The submit guard used to read `isRunning` before resolving the target
     // conversation, so a running conversation refused a brand-new one --
     // silently, by returning false. That is the whole feature failing closed.
-    providerMocks.backgroundExecutionEnabled = true;
     providerMocks.conversationQuery.data = {
       conversation: { id: "conversation-1", isWriteLocked: false },
       messages: [],
@@ -966,7 +971,12 @@ describe("in-app agent concurrent conversations", () => {
       },
       pendingToolApprovals: [],
     };
-    providerMocks.startRun.mockResolvedValue({ runId: "run-2" });
+    providerMocks.startRun.mockImplementation(
+      async (input: { conversationId: string }) => ({
+        conversationId: input.conversationId,
+        runId: "run-2",
+      }),
+    );
     window.sessionStorage.setItem(
       "langfuse:in-app-ai-agent-selected-conversation:project-1",
       JSON.stringify("conversation-1"),
@@ -1004,7 +1014,6 @@ describe("in-app agent concurrent conversations", () => {
   });
 
   it("waits for startRun before fetching a new conversation", async () => {
-    providerMocks.backgroundExecutionEnabled = true;
     providerMocks.getConversation.mockClear();
     providerMocks.startRun.mockReset();
 

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -1008,9 +1008,6 @@ describe("in-app agent concurrent conversations", () => {
   });
 
   it("starts a new conversation while another one is still running", async () => {
-    // The submit guard used to read `isRunning` before resolving the target
-    // conversation, so a running conversation refused a brand-new one --
-    // silently, by returning false. That is the whole feature failing closed.
     providerMocks.conversationQuery.data = {
       conversation: { id: "conversation-1", isWriteLocked: false },
       messages: [],
@@ -1036,7 +1033,6 @@ describe("in-app agent concurrent conversations", () => {
 
     renderExecutionUi();
 
-    // Starting another conversation is reachable while the first one runs.
     const newConversationButton = await screen.findByRole("button", {
       name: "Start new conversation",
     });
@@ -1061,7 +1057,6 @@ describe("in-app agent concurrent conversations", () => {
         }),
       );
     });
-    // The first conversation was left running, not cancelled.
     expect(providerMocks.cancelRun).not.toHaveBeenCalled();
   });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWidgetComposer.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWidgetComposer.clienttest.tsx
@@ -2,21 +2,23 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { InAppAgentWidgetComposer } from "./InAppAgentWidgetComposer";
 
-const openAssistant = vi.fn().mockReturnValue(true);
-const submit = vi.fn().mockResolvedValue(true);
+const agentContext = vi.hoisted(() => ({
+  isAvailable: true,
+  isRunning: false,
+  isSubmitting: false,
+  openAssistant: vi.fn().mockReturnValue(true),
+  submit: vi.fn().mockResolvedValue(true),
+}));
+const { openAssistant, submit } = agentContext;
 
 vi.mock("./InAppAiAgentProvider", () => ({
-  useInAppAiAgent: () => ({
-    isAvailable: true,
-    isRunning: false,
-    isSubmitting: false,
-    openAssistant,
-    submit,
-  }),
+  useInAppAiAgent: () => agentContext,
 }));
 
 describe("InAppAgentWidgetComposer", () => {
   beforeEach(() => {
+    agentContext.isRunning = false;
+    agentContext.isSubmitting = false;
     openAssistant.mockClear().mockReturnValue(true);
     submit.mockClear().mockResolvedValue(true);
   });
@@ -52,6 +54,28 @@ describe("InAppAgentWidgetComposer", () => {
     expect(
       screen.getByRole("button", { name: "Add with Langfuse Assistant" }),
     ).toBeDisabled();
+  });
+
+  it("starts a new widget conversation while the selected conversation is busy", async () => {
+    agentContext.isRunning = true;
+    agentContext.isSubmitting = true;
+    const onSubmitted = vi.fn();
+    render(<InAppAgentWidgetComposer onSubmitted={onSubmitted} />);
+
+    fireEvent.change(screen.getByLabelText("Describe the widget you want"), {
+      target: { value: "Show p95 latency" },
+    });
+    const submitButton = screen.getByRole("button", {
+      name: "Add with Langfuse Assistant",
+    });
+
+    expect(submitButton).toBeEnabled();
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledOnce();
+    });
+    expect(onSubmitted).toHaveBeenCalledOnce();
   });
 
   it("keeps the picker open and preserves the request when submit does not start", async () => {

--- a/web/src/features/in-app-agent/components/InAppAgentWidgetComposer.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWidgetComposer.tsx
@@ -26,8 +26,7 @@ export function InAppAgentWidgetComposer({
 }: {
   onSubmitted: () => void;
 }) {
-  const { isAvailable, isRunning, isSubmitting, openAssistant, submit } =
-    useInAppAiAgent();
+  const { isAvailable, openAssistant, submit } = useInAppAiAgent();
   const [request, setRequest] = useState("");
 
   if (!isAvailable) {
@@ -38,7 +37,7 @@ export function InAppAgentWidgetComposer({
     event.preventDefault();
     const trimmedRequest = request.trim();
 
-    if (!trimmedRequest || isRunning || isSubmitting) {
+    if (!trimmedRequest) {
       return;
     }
 
@@ -102,7 +101,7 @@ export function InAppAgentWidgetComposer({
           className="h-8 w-8 shrink-0 rounded-md border"
           variant="outline"
           aria-label="Add with Langfuse Assistant"
-          disabled={!request.trim() || isRunning || isSubmitting}
+          disabled={!request.trim()}
         >
           <SendHorizontal className="h-4 w-4" />
         </Button>

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -79,6 +79,7 @@ function windowElement(
 ) {
   const props: InAppAgentWindowProps = {
     conversations: [],
+    canLeaveRunningConversation: false,
     error: null,
     executionUi: { type: "foreground" },
     hasMoreConversations: false,
@@ -268,10 +269,18 @@ describe("ControlledInAppAgentWindow composer", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("keeps navigation disabled while an approval is pending", () => {
+  it("blocks another turn here but still lets you leave, on the background path", () => {
+    // A parked approval owns this conversation's composer, not the whole
+    // assistant: a background run is durable, so leaving does not abandon it.
     controlledAgent.value.isRunning = false;
     controlledAgent.value.pendingToolApprovals = [{ id: "approval-1" }];
     controlledAgent.value.submit = vi.fn();
+    controlledAgent.value.execution = {
+      type: "background",
+      run: null,
+      isCancelling: false,
+      cancel: vi.fn(),
+    };
 
     render(
       <TooltipProvider>
@@ -288,6 +297,32 @@ describe("ControlledInAppAgentWindow composer", () => {
       screen.getByRole("textbox", { name: "Message the assistant" }),
     ).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Start new conversation" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Conversation history" }),
+    ).toBeEnabled();
+  });
+
+  it("keeps you pinned to the conversation while a foreground turn runs", () => {
+    // A foreground run dies with its request, so navigating away would abandon
+    // it. Enabling these controls made them look clickable and do nothing.
+    controlledAgent.value.isRunning = true;
+    controlledAgent.value.pendingToolApprovals = [];
+    controlledAgent.value.execution = { type: "foreground" };
+
+    render(
+      <TooltipProvider>
+        <ControlledInAppAgentWindow
+          isExpanded={false}
+          onClose={vi.fn()}
+          onDeleteConversation={vi.fn()}
+          onExpandedChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
     expect(
       screen.getByRole("button", { name: "Start new conversation" }),
     ).toBeDisabled();

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -86,6 +86,7 @@ function windowElement(
     isAssistantTurnInProgress: false,
     isExpanded: false,
     isConversationInteractionDisabled: false,
+    isSelectedConversationHydrating: false,
     isLoadingMoreConversations: false,
     messages: [],
     onApproveToolCall: vi.fn(),
@@ -177,6 +178,26 @@ describe("InAppAgentWindow quick actions", () => {
       position: 0,
     });
     expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not offer quick actions while a conversation is still loading", () => {
+    // Switching conversations empties the transcript before the next one
+    // arrives. Showing the welcome screen there flashes the wrong thing and
+    // invites a click that would start a turn in the conversation being left.
+    render(
+      windowElement({
+        messages: [],
+        selectedConversationId: "conversation-1",
+        isSelectedConversationHydrating: true,
+      }),
+    );
+
+    expect(
+      screen.queryByText("Welcome to the Langfuse Assistant"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Create a prompt/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows focused actions on the initial tab and coarse actions elsewhere", () => {

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -176,26 +176,6 @@ describe("InAppAgentWindow quick actions", () => {
     expect(capture).toHaveBeenCalledTimes(1);
   });
 
-  it("does not offer quick actions while a conversation is still loading", () => {
-    // Switching conversations empties the transcript before the next one
-    // arrives. Showing the welcome screen there flashes the wrong thing and
-    // invites a click that would start a turn in the conversation being left.
-    render(
-      windowElement({
-        messages: [],
-        selectedConversationId: "conversation-1",
-        isSelectedConversationHydrating: true,
-      }),
-    );
-
-    expect(
-      screen.queryByText("Welcome to the Langfuse Assistant"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /^Create a prompt/ }),
-    ).not.toBeInTheDocument();
-  });
-
   it("shows focused actions on the initial tab and coarse actions elsewhere", () => {
     render(
       windowElement({
@@ -225,31 +205,13 @@ describe("InAppAgentWindow quick actions", () => {
 });
 
 describe("ControlledInAppAgentWindow composer", () => {
-  it("keeps a draft editable but prevents submitting it while rate limited", () => {
-    const onSubmit = vi.fn().mockResolvedValue(true);
-    render(
-      windowElement({
-        error: { type: "rate_limit", retryAt: Date.now() + 60_000 },
-        onSubmit,
-      }),
-    );
-
-    const input = screen.getByRole("textbox", {
-      name: "Message the assistant",
-    });
-    fireEvent.change(input, { target: { value: "Follow up" } });
-
-    expect(input).toHaveValue("Follow up");
-    expect(input).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
-
-    const form = input.closest("form");
-    if (!form) {
-      throw new Error("Expected the assistant composer to render a form");
-    }
-
-    fireEvent.submit(form);
-    expect(onSubmit).not.toHaveBeenCalled();
+  beforeEach(() => {
+    controlledAgent.value.error = null;
+    controlledAgent.value.isRunning = true;
+    controlledAgent.value.isSelectedConversationHydrating = false;
+    controlledAgent.value.isSubmitting = false;
+    controlledAgent.value.pendingToolApprovals = [];
+    controlledAgent.value.selectedConversationIsWriteLocked = false;
   });
 
   it("keeps a draft editable but prevents submitting it while an assistant turn is active", () => {
@@ -315,6 +277,32 @@ describe("ControlledInAppAgentWindow composer", () => {
       screen.getByRole("button", { name: "Conversation history" }),
     ).toBeEnabled();
   });
+
+  it("lets you leave a read-only conversation", () => {
+    controlledAgent.value.isRunning = false;
+    controlledAgent.value.selectedConversationIsWriteLocked = true;
+
+    render(
+      <TooltipProvider>
+        <ControlledInAppAgentWindow
+          isExpanded={false}
+          onClose={vi.fn()}
+          onDeleteConversation={vi.fn()}
+          onExpandedChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Start new conversation" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Conversation history" }),
+    ).toBeEnabled();
+  });
 });
 
 describe("ControlledInAppAgentWindow stop", () => {
@@ -350,30 +338,5 @@ describe("ControlledInAppAgentWindow stop", () => {
     // buffered block keeps typing out, which reads as "stop did nothing".
     expect(cancel).toHaveBeenCalledOnce();
     expect(finishAnimation).toHaveBeenCalledOnce();
-  });
-});
-
-describe("InAppAgentWindow focus", () => {
-  it("refocuses the composer when an active turn completes", () => {
-    const { rerender } = render(
-      <>
-        <button type="button">Other control</button>
-        {windowElement({ isAssistantTurnInProgress: true })}
-      </>,
-    );
-
-    screen.getByRole("button", { name: "Other control" }).focus();
-    expect(screen.getByRole("button", { name: "Other control" })).toHaveFocus();
-
-    rerender(
-      <>
-        <button type="button">Other control</button>
-        {windowElement({ isAssistantTurnInProgress: false })}
-      </>,
-    );
-
-    expect(
-      screen.getByRole("textbox", { name: "Message the assistant" }),
-    ).toHaveFocus();
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -265,7 +265,9 @@ describe("ControlledInAppAgentWindow composer", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("keeps navigation disabled while an approval is pending", () => {
+  it("blocks another turn here but still lets you leave", () => {
+    // A parked approval owns this conversation's composer, not the whole
+    // assistant: the run is durable, so leaving does not abandon it.
     controlledAgent.value.isRunning = false;
     controlledAgent.value.pendingToolApprovals = [{ id: "approval-1" }];
     controlledAgent.value.submit = vi.fn();
@@ -287,10 +289,10 @@ describe("ControlledInAppAgentWindow composer", () => {
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Start new conversation" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     expect(
       screen.getByRole("button", { name: "Conversation history" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   });
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -82,6 +82,7 @@ function windowElement(
     isAssistantTurnInProgress: false,
     isExpanded: false,
     isConversationInteractionDisabled: false,
+    isSelectedConversationHydrating: false,
     isLoadingMoreConversations: false,
     messages: [],
     onApproveToolCall: vi.fn(),
@@ -173,6 +174,26 @@ describe("InAppAgentWindow quick actions", () => {
       position: 0,
     });
     expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not offer quick actions while a conversation is still loading", () => {
+    // Switching conversations empties the transcript before the next one
+    // arrives. Showing the welcome screen there flashes the wrong thing and
+    // invites a click that would start a turn in the conversation being left.
+    render(
+      windowElement({
+        messages: [],
+        selectedConversationId: "conversation-1",
+        isSelectedConversationHydrating: true,
+      }),
+    );
+
+    expect(
+      screen.queryByText("Welcome to the Langfuse Assistant"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Create a prompt/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows focused actions on the initial tab and coarse actions elsewhere", () => {

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -249,8 +249,6 @@ describe("ControlledInAppAgentWindow composer", () => {
   });
 
   it("blocks another turn here but still lets you leave", () => {
-    // A parked approval owns this conversation's composer, not the whole
-    // assistant: the run is durable, so leaving does not abandon it.
     controlledAgent.value.isRunning = false;
     controlledAgent.value.pendingToolApprovals = [{ id: "approval-1" }];
     controlledAgent.value.submit = vi.fn();

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1182,10 +1182,10 @@ export const RateLimited = meta.story({
     ).toBeDisabled();
     await expect(
       canvas.getByRole("button", { name: "Start new conversation" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     await expect(
       canvas.getByRole("button", { name: "Conversation history" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   },
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -597,6 +597,7 @@ const meta = preview.meta({
     executionUi: { notice: null, stop: null },
     isExpanded: false,
     isConversationInteractionDisabled: false,
+    isSelectedConversationHydrating: false,
     conversations,
     hasMoreConversations: false,
     isLoadingMoreConversations: false,
@@ -665,6 +666,15 @@ export const ToolApprovalRequired = meta.story({
 export const Empty = meta.story({
   args: {
     messages: [],
+  },
+});
+
+/** Mid-switch: no transcript yet, and deliberately no welcome screen either. */
+export const LoadingConversation = meta.story({
+  args: {
+    messages: [],
+    selectedConversationId: "conversation-1",
+    isSelectedConversationHydrating: true,
   },
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -591,6 +591,7 @@ const meta = preview.meta({
     executionUi: { type: "foreground" as const },
     isExpanded: false,
     isConversationInteractionDisabled: false,
+    isSelectedConversationHydrating: false,
     conversations,
     canLeaveRunningConversation: false,
     hasMoreConversations: false,
@@ -659,6 +660,15 @@ export const ToolApprovalRequired = meta.story({
 export const Empty = meta.story({
   args: {
     messages: [],
+  },
+});
+
+/** Mid-switch: no transcript yet, and deliberately no welcome screen either. */
+export const LoadingConversation = meta.story({
+  args: {
+    messages: [],
+    selectedConversationId: "conversation-1",
+    isSelectedConversationHydrating: true,
   },
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -626,7 +626,6 @@ const meta = preview.meta({
 export const ToolApprovalRequired = meta.story({
   args: {
     isAssistantTurnInProgress: true,
-    isConversationInteractionDisabled: true,
     selectedConversationId: "conversation-1",
     messages: [
       {
@@ -666,15 +665,6 @@ export const ToolApprovalRequired = meta.story({
 export const Empty = meta.story({
   args: {
     messages: [],
-  },
-});
-
-/** Mid-switch: no transcript yet, and deliberately no welcome screen either. */
-export const LoadingConversation = meta.story({
-  args: {
-    messages: [],
-    selectedConversationId: "conversation-1",
-    isSelectedConversationHydrating: true,
   },
 });
 
@@ -1120,6 +1110,36 @@ export const BackgroundRunStops = meta.story({
   },
 });
 
+/** Mid-switch: no transcript yet, and deliberately no welcome screen either. */
+export const LoadingConversation = meta.story({
+  name: "(Test) Loading Conversation",
+  args: {
+    isConversationInteractionDisabled: true,
+    messages: [],
+    selectedConversationId: "conversation-1",
+    isSelectedConversationHydrating: true,
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.queryByText("Welcome to the Langfuse Assistant"),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("button", { name: /^Create a prompt/ }),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", { name: "Start new conversation" }),
+    ).toBeEnabled();
+    await expect(
+      canvas.getByRole("button", { name: "Conversation history" }),
+    ).toBeEnabled();
+    await expect(
+      canvas.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeDisabled();
+  },
+});
+
 export const RateLimited = meta.story({
   name: "(Test) Rate Limited",
   args: {
@@ -1158,17 +1178,25 @@ export const RateLimited = meta.story({
       />
     );
   },
-  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     const alert = canvas.getByRole("alert");
+    const textarea = canvas.getByRole("textbox", {
+      name: "Message the assistant",
+    });
 
     await expect(alert).toHaveTextContent(
       "You've reached the assistant request limit",
     );
     await expect(alert).toHaveTextContent("Try again in about");
+    await expect(textarea).toBeEnabled();
+    await userEvent.type(textarea, "Follow up");
+    await expect(textarea).toHaveValue("Follow up");
     await expect(
-      canvas.getByRole("textbox", { name: "Message the assistant" }),
-    ).toBeEnabled();
+      canvas.getByRole("button", { name: "Send message" }),
+    ).toBeDisabled();
+    await userEvent.keyboard("{Enter}");
+    await expect(args.onSubmit).not.toHaveBeenCalled();
     await expect(
       canvas.getByRole("button", { name: "Approve" }),
     ).toBeDisabled();

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -592,6 +592,7 @@ const meta = preview.meta({
     isExpanded: false,
     isConversationInteractionDisabled: false,
     conversations,
+    canLeaveRunningConversation: false,
     hasMoreConversations: false,
     isLoadingMoreConversations: false,
     isAssistantTurnInProgress: false,

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1110,7 +1110,6 @@ export const BackgroundRunStops = meta.story({
   },
 });
 
-/** Mid-switch: no transcript yet, and deliberately no welcome screen either. */
 export const LoadingConversation = meta.story({
   name: "(Test) Loading Conversation",
   args: {

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -274,6 +274,11 @@ export type InAppAgentWindowProps = {
   isHeaderDragHandleEnabled?: boolean;
   isExpanded: boolean;
   isConversationInteractionDisabled: boolean;
+  /**
+   * The selected conversation's transcript is still loading. Distinct from
+   * having no messages: one is "nothing yet", the other is "nothing to say".
+   */
+  isSelectedConversationHydrating: boolean;
   isLoadingMoreConversations: boolean;
   messages: InAppAgentWindowMessage[];
   onExpandedChange: (isExpanded: boolean) => void;
@@ -378,6 +383,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     isExpanded,
     isConversationInteractionDisabled,
     isLoadingMoreConversations,
+    isSelectedConversationHydrating,
     messages,
     onDeleteConversation,
     onExpandedChange,
@@ -737,7 +743,12 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               isExpanded ? "px-0" : "px-3",
             )}
           >
-            {messages.length === 0 ? (
+            {/* An empty transcript that is still loading is not an empty
+                conversation. Offering the welcome screen and its quick actions
+                mid-switch flashes the wrong thing and invites a click that
+                would start a turn in the conversation being left behind. */}
+            {messages.length === 0 &&
+            isSelectedConversationHydrating ? null : messages.length === 0 ? (
               <div className="flex h-full w-full flex-1 flex-col items-center justify-center px-2">
                 <div>
                   <BotMessageSquare className="text-muted-foreground mx-auto h-7 w-7" />

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -269,6 +269,12 @@ export type InAppAgentWindowExecutionUi =
 
 export type InAppAgentWindowProps = {
   conversations: InAppAgentWindowConversation[];
+  /**
+   * Whether leaving a running conversation is possible at all. False on the
+   * foreground path, whose run cannot outlive the request, so navigating away
+   * mid-turn would abandon it — the controls stay disabled there.
+   */
+  canLeaveRunningConversation: boolean;
   disablePendingToolApprovalActions?: boolean;
   error: InAppAgentError | null;
   executionUi: InAppAgentWindowExecutionUi;
@@ -370,6 +376,7 @@ function InAppAgentGenericError({
 
 export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const {
+    canLeaveRunningConversation,
     conversations,
     disablePendingToolApprovalActions = false,
     error,
@@ -405,6 +412,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const isMobile = useIsMobile();
   const isRateLimited = isInAppAgentRateLimited(error);
   const isComposerDisabled = isConversationInteractionDisabled;
+  // Foreground runs die with the request, so the drawer stays pinned to the
+  // conversation until the turn finishes.
+  const isPinnedToTurn =
+    isAssistantTurnInProgress && !canLeaveRunningConversation;
   const isSubmitDisabled =
     isComposerDisabled || isRateLimited || isAssistantTurnInProgress;
   const backgroundNotice =
@@ -563,9 +574,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={
-                  isConversationInteractionDisabled || isAssistantTurnInProgress
-                }
+                // A background turn no longer blocks starting another
+                // conversation: the run is durable, so leaving does not abandon
+                // it. A foreground turn still does.
+                disabled={isConversationInteractionDisabled || isPinnedToTurn}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -592,8 +604,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     size="icon"
                     className="size-6 shrink-0"
                     disabled={
-                      isConversationInteractionDisabled ||
-                      isAssistantTurnInProgress
+                      isConversationInteractionDisabled || isPinnedToTurn
                     }
                     aria-label="Conversation history"
                   >

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -566,7 +566,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={isConversationInteractionDisabled}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -592,7 +591,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     variant="ghost"
                     size="icon"
                     className="size-6 shrink-0"
-                    disabled={isConversationInteractionDisabled}
                     aria-label="Conversation history"
                   >
                     <History className="size-3" />

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -283,6 +283,11 @@ export type InAppAgentWindowProps = {
   isHeaderDragHandleEnabled?: boolean;
   isExpanded: boolean;
   isConversationInteractionDisabled: boolean;
+  /**
+   * The selected conversation's transcript is still loading. Distinct from
+   * having no messages: one is "nothing yet", the other is "nothing to say".
+   */
+  isSelectedConversationHydrating: boolean;
   isLoadingMoreConversations: boolean;
   messages: InAppAgentWindowMessage[];
   onExpandedChange: (isExpanded: boolean) => void;
@@ -387,6 +392,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     isExpanded,
     isConversationInteractionDisabled,
     isLoadingMoreConversations,
+    isSelectedConversationHydrating,
     messages,
     onDeleteConversation,
     onExpandedChange,
@@ -756,7 +762,12 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               isExpanded ? "px-0" : "px-3",
             )}
           >
-            {messages.length === 0 ? (
+            {/* An empty transcript that is still loading is not an empty
+                conversation. Offering the welcome screen and its quick actions
+                mid-switch flashes the wrong thing and invites a click that
+                would start a turn in the conversation being left behind. */}
+            {messages.length === 0 &&
+            isSelectedConversationHydrating ? null : messages.length === 0 ? (
               <div className="flex h-full w-full flex-1 flex-col items-center justify-center px-2">
                 <div>
                   <BotMessageSquare className="text-muted-foreground mx-auto h-7 w-7" />

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -274,10 +274,7 @@ export type InAppAgentWindowProps = {
   isHeaderDragHandleEnabled?: boolean;
   isExpanded: boolean;
   isConversationInteractionDisabled: boolean;
-  /**
-   * The selected conversation's transcript is still loading. Distinct from
-   * having no messages: one is "nothing yet", the other is "nothing to say".
-   */
+  /** Distinguishes a loading transcript from an empty conversation. */
   isSelectedConversationHydrating: boolean;
   isLoadingMoreConversations: boolean;
   messages: InAppAgentWindowMessage[];

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -560,9 +560,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 size="icon"
                 className="size-6 shrink-0"
                 onClick={onNewConversation}
-                disabled={
-                  isConversationInteractionDisabled || isAssistantTurnInProgress
-                }
+                disabled={isConversationInteractionDisabled}
                 aria-label="Start new conversation"
               >
                 <Plus className="size-3" />
@@ -588,10 +586,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     variant="ghost"
                     size="icon"
                     className="size-6 shrink-0"
-                    disabled={
-                      isConversationInteractionDisabled ||
-                      isAssistantTurnInProgress
-                    }
+                    disabled={isConversationInteractionDisabled}
                     aria-label="Conversation history"
                   >
                     <History className="size-3" />

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -379,12 +379,25 @@ function InAppAiAgentProviderInner({
       conversationId: _selectedConversationId ?? "",
     },
     {
-      // Keyed against the raw id because `selectedConversationId` is derived
-      // from this very query's error state.
+      /**
+       * The submit lock suppresses this refetch only on the foreground path,
+       * where the in-flight turn lives in memory and a snapshot would flash the
+       * transcript backwards to before the user's message.
+       *
+       * A background submit commits its user message before the run starts, so
+       * the snapshot is already correct and the suppression would instead be
+       * harmful: the lock is held for the whole run, so returning to a
+       * still-running conversation would find this query disabled, no session
+       * (leaving disposed it) and therefore nothing to render at all.
+       *
+       * Keyed against the raw id because `selectedConversationId` is derived
+       * from this very query's error state.
+       */
       enabled:
         open &&
         Boolean(_selectedConversationId) &&
-        submittingConversationId !== _selectedConversationId,
+        (backgroundExecutionEnabled ||
+          submittingConversationId !== _selectedConversationId),
     },
   );
   const deleteConversationMutation =

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -334,7 +334,17 @@ function InAppAiAgentProviderInner({
   >([]);
   const [isForegroundRunning, setIsForegroundRunning] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  /**
+   * Which conversation has a turn being submitted, not whether one is.
+   *
+   * Keyed because submitting into a *new* conversation resets the agent for the
+   * old one, and an unkeyed release would drop the lock the submit had just
+   * taken. Everything user-facing derives from whether this names the
+   * conversation currently on screen.
+   */
+  const [submittingConversationId, setSubmittingConversationId] = useState<
+    string | null
+  >(null);
   const [loadingEventIds, setLoadingEventIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -349,7 +359,7 @@ function InAppAiAgentProviderInner({
   const backgroundExecutionEnabled =
     useInAppAgentBackgroundExecutionEnabled(projectId);
   const intentionalAbortRef = useRef(false);
-  const submitInFlightRef = useRef(false);
+  const submitInFlightRef = useRef<string | null>(null);
   const runInFlightRef = useRef(false);
   const subscriptionRef = useRef<ReturnType<AbstractAgent["subscribe"]> | null>(
     null,
@@ -369,7 +379,12 @@ function InAppAiAgentProviderInner({
       conversationId: _selectedConversationId ?? "",
     },
     {
-      enabled: open && Boolean(_selectedConversationId) && !isSubmitting,
+      // Keyed against the raw id because `selectedConversationId` is derived
+      // from this very query's error state.
+      enabled:
+        open &&
+        Boolean(_selectedConversationId) &&
+        submittingConversationId !== _selectedConversationId,
     },
   );
   const deleteConversationMutation =
@@ -384,6 +399,10 @@ function InAppAiAgentProviderInner({
   const selectedConversationId = isSelectedConversationNotFound
     ? null
     : _selectedConversationId;
+  // A submit into another conversation must not make this one look busy.
+  const isSubmitting =
+    submittingConversationId !== null &&
+    submittingConversationId === selectedConversationId;
 
   const conversations = useMemo(
     () =>
@@ -959,9 +978,21 @@ function InAppAiAgentProviderInner({
     ],
   );
 
-  const releaseSubmitLock = useCallback(() => {
-    submitInFlightRef.current = false;
-    setIsSubmitting(false);
+  /**
+   * Release the submit lock, but only if it still belongs to the conversation
+   * the caller is finishing. A later submit into another conversation owns the
+   * lock by then and must keep it.
+   */
+  const releaseSubmitLock = useCallback((conversationId: string | null) => {
+    if (
+      conversationId !== null &&
+      submitInFlightRef.current !== conversationId
+    ) {
+      return;
+    }
+
+    submitInFlightRef.current = null;
+    setSubmittingConversationId(null);
   }, []);
 
   const getOrCreateAgent = useCallback(
@@ -1102,7 +1133,7 @@ function InAppAiAgentProviderInner({
               projectId,
               conversationId,
             });
-            releaseSubmitLock();
+            releaseSubmitLock(conversationId);
             activeRunIdRef.current = null;
             intentionalAbortRef.current = false;
           },
@@ -1211,7 +1242,7 @@ function InAppAiAgentProviderInner({
             projectId,
             conversationId,
           });
-          releaseSubmitLock();
+          releaseSubmitLock(conversationId);
           activeRunIdRef.current = null;
           intentionalAbortRef.current = false;
           runInFlightRef.current = false;
@@ -1231,7 +1262,14 @@ function InAppAiAgentProviderInner({
 
   const selectConversation = useCallback(
     (conversationId: string | null) => {
-      if (isRunning || conversationId === _selectedConversationId) {
+      if (conversationId === _selectedConversationId) {
+        return;
+      }
+
+      // Leaving a running conversation is allowed: `resetAgent` only detaches
+      // this browser's observation, and the run itself is durable server-side.
+      // Foreground runs cannot outlive the request, so they still hold on.
+      if (isRunning && !backgroundExecutionEnabled) {
         return;
       }
 
@@ -1242,7 +1280,13 @@ function InAppAiAgentProviderInner({
       setForegroundMessages([]);
       setSelectedConversationId(conversationId);
     },
-    [_selectedConversationId, isRunning, resetAgent, setSelectedConversationId],
+    [
+      _selectedConversationId,
+      backgroundExecutionEnabled,
+      isRunning,
+      resetAgent,
+      setSelectedConversationId,
+    ],
   );
 
   const deleteConversation = useCallback(
@@ -1302,43 +1346,49 @@ function InAppAiAgentProviderInner({
 
   const submit = useCallback(
     async (content: string, options?: InAppAgentSubmitOptions) => {
+      // Resolve the target conversation before guarding on it. `isRunning`,
+      // hydration and the write lock all describe the *selected* conversation,
+      // so testing them against a brand-new conversation would refuse a turn
+      // the user is entitled to start while something else is still running.
+      const isNewConversation =
+        options?.newConversation === true || !selectedConversationId;
+      const conversationId = isNewConversation
+        ? createInAppAgentConversationId()
+        : selectedConversationId;
+
       if (
         !content ||
-        isRunning ||
+        !conversationId ||
         isInAppAgentRateLimited(error) ||
-        (options?.newConversation !== true &&
-          isSelectedConversationHydrating) ||
-        submitInFlightRef.current ||
-        runInFlightRef.current
+        runInFlightRef.current ||
+        // A turn already going into this same conversation is the only
+        // submit-side conflict; one per conversation remains the rule.
+        submitInFlightRef.current === conversationId
       ) {
         return false;
       }
 
-      submitInFlightRef.current = true;
-      setIsSubmitting(true);
+      if (
+        !isNewConversation &&
+        (isRunning || isSelectedConversationHydrating)
+      ) {
+        return false;
+      }
+
+      if (!isNewConversation && selectedConversationIsWriteLocked) {
+        setError({
+          type: "generic",
+          message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+        });
+        return false;
+      }
+
+      submitInFlightRef.current = conversationId;
+      setSubmittingConversationId(conversationId);
       setError(null);
 
       let startedRun = false;
       try {
-        const isNewConversation =
-          options?.newConversation === true || !selectedConversationId;
-
-        if (!isNewConversation && selectedConversationIsWriteLocked) {
-          setError({
-            type: "generic",
-            message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-          });
-          return false;
-        }
-
-        const conversationId = isNewConversation
-          ? createInAppAgentConversationId()
-          : selectedConversationId;
-
-        if (!conversationId) {
-          return false;
-        }
-
         if (isNewConversation) {
           setSelectedConversationId(conversationId);
         }
@@ -1433,7 +1483,7 @@ function InAppAiAgentProviderInner({
         return false;
       } finally {
         if (!startedRun) {
-          releaseSubmitLock();
+          releaseSubmitLock(conversationId);
         }
       }
     },
@@ -1577,7 +1627,7 @@ function InAppAiAgentProviderInner({
 
         if (backgroundExecutionEnabled) {
           backgroundSessionRef.current?.detach();
-          releaseSubmitLock();
+          releaseSubmitLock(selectedConversationId);
         }
       }
 

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -995,11 +995,14 @@ function InAppAiAgentProviderInner({
       // hydration and the write lock all describe the *selected* conversation,
       // so testing them against a brand-new conversation would refuse a turn
       // the user is entitled to start while something else is still running.
-      const isNewConversation =
+      const startsNewConversation =
         options?.newConversation === true || !selectedConversationId;
-      const conversationId = isNewConversation
+      const conversationId = startsNewConversation
         ? createInAppAgentConversationId()
         : selectedConversationId;
+      const shouldRestorePersistedMessages =
+        !startsNewConversation &&
+        !unpersistedConversationIds.has(conversationId ?? "");
 
       if (
         !content ||
@@ -1013,13 +1016,13 @@ function InAppAiAgentProviderInner({
       }
 
       if (
-        !isNewConversation &&
+        !startsNewConversation &&
         (isRunning || isSelectedConversationHydrating)
       ) {
         return false;
       }
 
-      if (!isNewConversation && selectedConversationIsWriteLocked) {
+      if (!startsNewConversation && selectedConversationIsWriteLocked) {
         setError({
           type: "generic",
           message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
@@ -1033,7 +1036,7 @@ function InAppAiAgentProviderInner({
 
       let startedRun = false;
       try {
-        if (isNewConversation) {
+        if (startsNewConversation) {
           setUnpersistedConversationIds((current) =>
             new Set(current).add(conversationId),
           );
@@ -1044,9 +1047,9 @@ function InAppAiAgentProviderInner({
           conversationQuery.data?.conversation.id === conversationId
             ? conversationQuery.data.messages
             : undefined;
-        const initialMessages = isNewConversation
-          ? []
-          : (storedMessages?.filter(isAgentConversationMessage) ?? []);
+        const initialMessages = shouldRestorePersistedMessages
+          ? (storedMessages?.filter(isAgentConversationMessage) ?? [])
+          : [];
         // TODO: Avoid hydrating the full history once the agent client can send
         // only the latest user turn; the server rebuilds history from persistence.
         const agent = getOrCreateAgent(conversationId, initialMessages);
@@ -1056,7 +1059,7 @@ function InAppAiAgentProviderInner({
         }
 
         // Start background turns from the persisted transcript and cursor.
-        if (!isNewConversation) {
+        if (shouldRestorePersistedMessages) {
           agent.setMessages(initialMessages);
         }
 
@@ -1068,7 +1071,7 @@ function InAppAiAgentProviderInner({
 
         agent.addMessage(userMessage);
         const entryPoint = options?.entryPoint ?? "chat";
-        if (isNewConversation) {
+        if (startsNewConversation) {
           capture("in_app_agent:new_chat_started", { entryPoint });
         }
         capture("in_app_agent:new_chat_turn", { entryPoint });
@@ -1110,6 +1113,7 @@ function InAppAiAgentProviderInner({
       selectedConversationId,
       selectedConversationIsWriteLocked,
       setSelectedConversationId,
+      unpersistedConversationIds,
     ],
   );
 

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -295,7 +295,17 @@ function InAppAiAgentProviderInner({
       {},
     );
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  /**
+   * Which conversation has a turn being submitted, not whether one is.
+   *
+   * Keyed because submitting into a *new* conversation resets the agent for the
+   * old one, and an unkeyed release would drop the lock the submit had just
+   * taken. Everything user-facing derives from whether this names the
+   * conversation currently on screen.
+   */
+  const [submittingConversationId, setSubmittingConversationId] = useState<
+    string | null
+  >(null);
   const [loadingEventIds, setLoadingEventIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -306,7 +316,7 @@ function InAppAiAgentProviderInner({
     useState<BackgroundExecutionSession | null>(null);
   const toolCallNamesRef = useRef(new Map<string, string>());
   const handledToolCallIdsRef = useRef(new Set<string>());
-  const submitInFlightRef = useRef(false);
+  const submitInFlightRef = useRef<string | null>(null);
 
   const conversationListQuery =
     api.inAppAgent.listConversations.useInfiniteQuery(
@@ -322,7 +332,12 @@ function InAppAiAgentProviderInner({
       conversationId: _selectedConversationId ?? "",
     },
     {
-      enabled: open && Boolean(_selectedConversationId) && !isSubmitting,
+      // Keyed against the raw id because `selectedConversationId` is derived
+      // from this very query's error state.
+      enabled:
+        open &&
+        Boolean(_selectedConversationId) &&
+        submittingConversationId !== _selectedConversationId,
     },
   );
   const deleteConversationMutation =
@@ -337,6 +352,10 @@ function InAppAiAgentProviderInner({
   const selectedConversationId = isSelectedConversationNotFound
     ? null
     : _selectedConversationId;
+  // A submit into another conversation must not make this one look busy.
+  const isSubmitting =
+    submittingConversationId !== null &&
+    submittingConversationId === selectedConversationId;
 
   const conversations = useMemo(
     () =>
@@ -692,9 +711,21 @@ function InAppAiAgentProviderInner({
     [clearLoadingEvents, updateLoadingEvent, utils],
   );
 
-  const releaseSubmitLock = useCallback(() => {
-    submitInFlightRef.current = false;
-    setIsSubmitting(false);
+  /**
+   * Release the submit lock, but only if it still belongs to the conversation
+   * the caller is finishing. A later submit into another conversation owns the
+   * lock by then and must keep it.
+   */
+  const releaseSubmitLock = useCallback((conversationId: string | null) => {
+    if (
+      conversationId !== null &&
+      submitInFlightRef.current !== conversationId
+    ) {
+      return;
+    }
+
+    submitInFlightRef.current = null;
+    setSubmittingConversationId(null);
   }, []);
 
   const getOrCreateAgent = useCallback(
@@ -812,7 +843,7 @@ function InAppAiAgentProviderInner({
             projectId,
             conversationId,
           });
-          releaseSubmitLock();
+          releaseSubmitLock(conversationId);
         },
       });
       backgroundSessionRef.current = nextBackgroundSession;
@@ -867,7 +898,7 @@ function InAppAiAgentProviderInner({
 
   const selectConversation = useCallback(
     (conversationId: string | null) => {
-      if (isRunning || conversationId === _selectedConversationId) {
+      if (conversationId === _selectedConversationId) {
         return;
       }
 
@@ -877,7 +908,7 @@ function InAppAiAgentProviderInner({
       resetAgent();
       setSelectedConversationId(conversationId);
     },
-    [_selectedConversationId, isRunning, resetAgent, setSelectedConversationId],
+    [_selectedConversationId, resetAgent, setSelectedConversationId],
   );
 
   const deleteConversation = useCallback(
@@ -936,42 +967,48 @@ function InAppAiAgentProviderInner({
 
   const submit = useCallback(
     async (content: string, options?: InAppAgentSubmitOptions) => {
+      // Resolve the target conversation before guarding on it. `isRunning`,
+      // hydration and the write lock all describe the *selected* conversation,
+      // so testing them against a brand-new conversation would refuse a turn
+      // the user is entitled to start while something else is still running.
+      const isNewConversation =
+        options?.newConversation === true || !selectedConversationId;
+      const conversationId = isNewConversation
+        ? createInAppAgentConversationId()
+        : selectedConversationId;
+
       if (
         !content ||
-        isRunning ||
+        !conversationId ||
         isInAppAgentRateLimited(error) ||
-        (options?.newConversation !== true &&
-          isSelectedConversationHydrating) ||
-        submitInFlightRef.current
+        // A turn already going into this same conversation is the only
+        // submit-side conflict; one per conversation remains the rule.
+        submitInFlightRef.current === conversationId
       ) {
         return false;
       }
 
-      submitInFlightRef.current = true;
-      setIsSubmitting(true);
+      if (
+        !isNewConversation &&
+        (isRunning || isSelectedConversationHydrating)
+      ) {
+        return false;
+      }
+
+      if (!isNewConversation && selectedConversationIsWriteLocked) {
+        setError({
+          type: "generic",
+          message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+        });
+        return false;
+      }
+
+      submitInFlightRef.current = conversationId;
+      setSubmittingConversationId(conversationId);
       setError(null);
 
       let startedRun = false;
       try {
-        const isNewConversation =
-          options?.newConversation === true || !selectedConversationId;
-
-        if (!isNewConversation && selectedConversationIsWriteLocked) {
-          setError({
-            type: "generic",
-            message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-          });
-          return false;
-        }
-
-        const conversationId = isNewConversation
-          ? createInAppAgentConversationId()
-          : selectedConversationId;
-
-        if (!conversationId) {
-          return false;
-        }
-
         if (isNewConversation) {
           setSelectedConversationId(conversationId);
         }
@@ -1029,7 +1066,7 @@ function InAppAiAgentProviderInner({
         return false;
       } finally {
         if (!startedRun) {
-          releaseSubmitLock();
+          releaseSubmitLock(conversationId);
         }
       }
     },
@@ -1152,7 +1189,7 @@ function InAppAiAgentProviderInner({
         setIsExpanded(false);
 
         backgroundSessionRef.current?.detach();
-        releaseSubmitLock();
+        releaseSubmitLock(selectedConversationId);
       }
 
       if (nextOpen && selectedConversationId) {

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -295,14 +295,7 @@ function InAppAiAgentProviderInner({
       {},
     );
   const [isExpanded, setIsExpanded] = useState(false);
-  /**
-   * Which conversation has a turn being submitted, not whether one is.
-   *
-   * Keyed because submitting into a *new* conversation resets the agent for the
-   * old one, and an unkeyed release would drop the lock the submit had just
-   * taken. Everything user-facing derives from whether this names the
-   * conversation currently on screen.
-   */
+  // Key by conversation so another conversation cannot release its submit lock.
   const [submittingConversationId, setSubmittingConversationId] = useState<
     string | null
   >(null);
@@ -335,12 +328,7 @@ function InAppAiAgentProviderInner({
       conversationId: _selectedConversationId ?? "",
     },
     {
-      /**
-       * A new id is selected optimistically so its first user message renders
-       * immediately. It becomes fetchable only after `startRun` returns the id,
-       * which confirms the server has persisted the conversation. Existing
-       * conversations stay fetchable for the full lifetime of a background run.
-       */
+      // Provisional ids become fetchable after `startRun` acknowledges persistence.
       enabled:
         open &&
         Boolean(_selectedConversationId) &&
@@ -359,7 +347,6 @@ function InAppAiAgentProviderInner({
   const selectedConversationId = isSelectedConversationNotFound
     ? null
     : _selectedConversationId;
-  // A submit into another conversation must not make this one look busy.
   const isSubmitting =
     submittingConversationId !== null &&
     submittingConversationId === selectedConversationId;
@@ -718,11 +705,7 @@ function InAppAiAgentProviderInner({
     [clearLoadingEvents, updateLoadingEvent, utils],
   );
 
-  /**
-   * Release the submit lock, but only if it still belongs to the conversation
-   * the caller is finishing. A later submit into another conversation owns the
-   * lock by then and must keep it.
-   */
+  // Release only the caller's lock; a newer conversation may own it.
   const releaseSubmitLock = useCallback((conversationId: string | null) => {
     if (
       conversationId !== null &&
@@ -991,10 +974,7 @@ function InAppAiAgentProviderInner({
 
   const submit = useCallback(
     async (content: string, options?: InAppAgentSubmitOptions) => {
-      // Resolve the target conversation before guarding on it. `isRunning`,
-      // hydration and the write lock all describe the *selected* conversation,
-      // so testing them against a brand-new conversation would refuse a turn
-      // the user is entitled to start while something else is still running.
+      // A new conversation must not inherit the selected conversation's guards.
       const startsNewConversation =
         options?.newConversation === true || !selectedConversationId;
       const conversationId = startsNewConversation
@@ -1008,8 +988,6 @@ function InAppAiAgentProviderInner({
         !content ||
         !conversationId ||
         isInAppAgentRateLimited(error) ||
-        // A turn already going into this same conversation is the only
-        // submit-side conflict; one per conversation remains the rule.
         submitInFlightRef.current === conversationId
       ) {
         return false;

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -306,6 +306,9 @@ function InAppAiAgentProviderInner({
   const [submittingConversationId, setSubmittingConversationId] = useState<
     string | null
   >(null);
+  const [unpersistedConversationIds, setUnpersistedConversationIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const [loadingEventIds, setLoadingEventIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -333,24 +336,15 @@ function InAppAiAgentProviderInner({
     },
     {
       /**
-       * The submit lock suppresses this refetch only on the foreground path,
-       * where the in-flight turn lives in memory and a snapshot would flash the
-       * transcript backwards to before the user's message.
-       *
-       * A background submit commits its user message before the run starts, so
-       * the snapshot is already correct and the suppression would instead be
-       * harmful: the lock is held for the whole run, so returning to a
-       * still-running conversation would find this query disabled, no session
-       * (leaving disposed it) and therefore nothing to render at all.
-       *
-       * Keyed against the raw id because `selectedConversationId` is derived
-       * from this very query's error state.
+       * A new id is selected optimistically so its first user message renders
+       * immediately. It becomes fetchable only after `startRun` returns the id,
+       * which confirms the server has persisted the conversation. Existing
+       * conversations stay fetchable for the full lifetime of a background run.
        */
       enabled:
         open &&
         Boolean(_selectedConversationId) &&
-        (backgroundExecutionEnabled ||
-          submittingConversationId !== _selectedConversationId),
+        !unpersistedConversationIds.has(_selectedConversationId ?? ""),
     },
   );
   const deleteConversationMutation =
@@ -770,13 +764,37 @@ function InAppAiAgentProviderInner({
         threadId: conversationId,
         initialMessages,
         cursor: initialCursor,
-        startRun: (params) =>
-          startRunMutation.mutateAsync({
-            projectId,
-            conversationId,
-            message: params.message,
-            context: [...params.context],
-          }),
+        startRun: async (params) => {
+          try {
+            const started = await startRunMutation.mutateAsync({
+              projectId,
+              conversationId,
+              message: params.message,
+              context: [...params.context],
+            });
+            setUnpersistedConversationIds((current) => {
+              if (!current.has(started.conversationId)) {
+                return current;
+              }
+
+              const next = new Set(current);
+              next.delete(started.conversationId);
+              return next;
+            });
+            return started;
+          } catch (error) {
+            setUnpersistedConversationIds((current) => {
+              if (!current.has(conversationId)) {
+                return current;
+              }
+
+              const next = new Set(current);
+              next.delete(conversationId);
+              return next;
+            });
+            throw error;
+          }
+        },
       });
 
       agentRef.current = agent;
@@ -1023,6 +1041,9 @@ function InAppAiAgentProviderInner({
       let startedRun = false;
       try {
         if (isNewConversation) {
+          setUnpersistedConversationIds((current) =>
+            new Set(current).add(conversationId),
+          );
           setSelectedConversationId(conversationId);
         }
 

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -332,12 +332,25 @@ function InAppAiAgentProviderInner({
       conversationId: _selectedConversationId ?? "",
     },
     {
-      // Keyed against the raw id because `selectedConversationId` is derived
-      // from this very query's error state.
+      /**
+       * The submit lock suppresses this refetch only on the foreground path,
+       * where the in-flight turn lives in memory and a snapshot would flash the
+       * transcript backwards to before the user's message.
+       *
+       * A background submit commits its user message before the run starts, so
+       * the snapshot is already correct and the suppression would instead be
+       * harmful: the lock is held for the whole run, so returning to a
+       * still-running conversation would find this query disabled, no session
+       * (leaving disposed it) and therefore nothing to render at all.
+       *
+       * Keyed against the raw id because `selectedConversationId` is derived
+       * from this very query's error state.
+       */
       enabled:
         open &&
         Boolean(_selectedConversationId) &&
-        submittingConversationId !== _selectedConversationId,
+        (backgroundExecutionEnabled ||
+          submittingConversationId !== _selectedConversationId),
     },
   );
   const deleteConversationMutation =

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -765,35 +765,22 @@ function InAppAiAgentProviderInner({
         initialMessages,
         cursor: initialCursor,
         startRun: async (params) => {
-          try {
-            const started = await startRunMutation.mutateAsync({
-              projectId,
-              conversationId,
-              message: params.message,
-              context: [...params.context],
-            });
-            setUnpersistedConversationIds((current) => {
-              if (!current.has(started.conversationId)) {
-                return current;
-              }
+          const started = await startRunMutation.mutateAsync({
+            projectId,
+            conversationId,
+            message: params.message,
+            context: [...params.context],
+          });
+          setUnpersistedConversationIds((current) => {
+            if (!current.has(started.conversationId)) {
+              return current;
+            }
 
-              const next = new Set(current);
-              next.delete(started.conversationId);
-              return next;
-            });
-            return started;
-          } catch (error) {
-            setUnpersistedConversationIds((current) => {
-              if (!current.has(conversationId)) {
-                return current;
-              }
-
-              const next = new Set(current);
-              next.delete(conversationId);
-              return next;
-            });
-            throw error;
-          }
+            const next = new Set(current);
+            next.delete(started.conversationId);
+            return next;
+          });
+          return started;
         },
       });
 
@@ -936,10 +923,16 @@ function InAppAiAgentProviderInner({
       setError((currentError) =>
         isInAppAgentRateLimited(currentError) ? currentError : null,
       );
+      releaseSubmitLock(_selectedConversationId);
       resetAgent();
       setSelectedConversationId(conversationId);
     },
-    [_selectedConversationId, resetAgent, setSelectedConversationId],
+    [
+      _selectedConversationId,
+      releaseSubmitLock,
+      resetAgent,
+      setSelectedConversationId,
+    ],
   );
 
   const deleteConversation = useCallback(

--- a/web/src/features/in-app-agent/server/backgroundRunService.ts
+++ b/web/src/features/in-app-agent/server/backgroundRunService.ts
@@ -259,7 +259,7 @@ export async function startBackgroundRun(params: {
     aiTelemetryEnabled: params.aiTelemetryEnabled,
   });
 
-  return { runId: run.id };
+  return { conversationId: conversation.id, runId: run.id };
 }
 
 /** Soft-delete a conversation and cancel its unsettled runs atomically. */


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15851.preview.langfuse.com](https://pr-15851.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

Background runs are durable, but the drawer still behaved as if one selected conversation owned the whole assistant. A running conversation prevented starting another one, and switching conversations could briefly render the welcome screen or fetch a client-selected conversation id before `startRun` had persisted it.

## How

- Scope running, submitting, hydration, and write-lock guards to the selected conversation. Starting or selecting another conversation detaches local observation without cancelling its background run.
- Release the selected conversation's local submit lock when leaving it. Returning derives the current state from the persisted run instead of retaining a stale client-only busy state.
- Keep the Plus and History navigation available independently of the selected conversation's state, including while it is running, hydrating, rate-limited, or read-only.
- Keep the first user message optimistic for a new conversation, but do not call `getConversation` for its provisional client-generated id until `startRun` returns that persisted `conversationId`. A failed start leaves the id provisional instead of triggering a `NotFound` fetch.
- Reuse a provisional conversation and its optimistic transcript when retrying a failed first start. Server history replaces local messages only after persistence is acknowledged, and retries do not emit another new-conversation event.
- Return `conversationId` together with `runId` from `startRun`, making persistence acknowledgement explicit without adding another endpoint or changing the schema.
- Let the dashboard widget composer start its always-new conversation while the currently selected conversation is busy.

## Test ownership

- Prop-driven `InAppAgentWindow` behavior is covered by Storybook interaction tests.
- Provider, context, query, and background-session transitions remain in client tests.
- Background-run persistence and transaction behavior remains in the server regression suite.

This removes duplicate client coverage for loading, rate-limit, and refocus behavior while retaining focused integration tests for the state translation that Storybook cannot exercise.

## Scope

This PR only establishes safe background conversation switching and startup. It deliberately does not add activity state, badges, notifications, or client-side deletion guards; those remain in the following PRs.

It also does not move conversation creation into a new transaction with run creation. The server already creates a missing client-supplied conversation id, and the acknowledgement above fixes the observable race without expanding this PR into a persistence redesign.

## Verification

| Check | Result |
| --- | --- |
| `pnpm run lint` | `Tasks: 7 successful, 7 total` |
| `pnpm --filter web run typecheck` | clean |
| `pnpm --filter web run test-client src/features/in-app-agent` | `Tests 116 passed (116)` |
| `pnpm --filter web run test-storybook src/features/in-app-agent/components/InAppAgentWindow.stories.tsx` | `Tests 18 passed (18)` |
| `pnpm --filter web run test src/__tests__/server/in-app-agent-background-run.servertest.ts` | `Tests 24 passed (24)` |
| Browser, managed slot 2 Storybook | Loading and rate-limit states keep Plus/History available, suppress the false welcome state during hydration, keep drafts editable where allowed, and block only the affected conversation actions. |

Regression coverage verifies that a new conversation can start while another run continues, switching releases the detached conversation's client-only submit state, failed starts remain unqueryable until persistence is acknowledged, retrying preserves the provisional optimistic transcript without duplicating the new-conversation event, and the widget entry point follows the same background-concurrency model.

## Context

Part B of the background assistant activity and notifications split. Rebased directly onto `main` after the prerequisite cleanup merged.
