### PR TITLE
feat(self-hosting): instance usage page (LFE-14708)

### DIFF
--- a/web/src/__tests__/server/unit/instance-usage-router.servertest.ts
+++ b/web/src/__tests__/server/unit/instance-usage-router.servertest.ts
@@ -78,11 +78,13 @@ describe("instanceUsage.get", () => {
   const envRecord = env as unknown as Record<string, string | undefined>;
   const originalCloudRegion = envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
   const originalWriteMode = envRecord.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+  const originalPreviewPrUrl = envRecord.NEXT_PUBLIC_PREVIEW_PR_URL;
 
   beforeEach(() => {
     // The page is self-host only; the local dev .env marks the test process as
     // cloud ("DEV"), which would trip the cloud guard.
     envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    envRecord.NEXT_PUBLIC_PREVIEW_PR_URL = undefined;
     envRecord.LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
     queryClickhouseMock.mockReset();
     queryClickhouseMock.mockResolvedValue([]);
@@ -90,11 +92,43 @@ describe("instanceUsage.get", () => {
 
   afterEach(() => {
     envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    envRecord.NEXT_PUBLIC_PREVIEW_PR_URL = originalPreviewPrUrl;
     envRecord.LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
   });
 
   it("rejects the request on Langfuse Cloud", async () => {
     envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "EU";
+    const caller = createCaller(buildSession({ role: Role.OWNER }));
+
+    await expect(caller.get()).rejects.toThrow(
+      /not available in Langfuse Cloud/,
+    );
+  });
+
+  it("serves PR previews, which build with the DEV cloud region", async () => {
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
+    envRecord.NEXT_PUBLIC_PREVIEW_PR_URL =
+      "https://github.com/langfuse/langfuse/pull/1";
+    const caller = createCaller(buildSession({ role: Role.OWNER }));
+
+    await expect(caller.get()).resolves.toMatchObject({
+      instance: { organizations: 3 },
+    });
+  });
+
+  it("still rejects a real Cloud region that carries a stray preview URL", async () => {
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "EU";
+    envRecord.NEXT_PUBLIC_PREVIEW_PR_URL =
+      "https://github.com/langfuse/langfuse/pull/1";
+    const caller = createCaller(buildSession({ role: Role.OWNER }));
+
+    await expect(caller.get()).rejects.toThrow(
+      /not available in Langfuse Cloud/,
+    );
+  });
+
+  it("rejects the DEV region outside a preview, ie local dev pointed at cloud config", async () => {
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
     const caller = createCaller(buildSession({ role: Role.OWNER }));
 
     await expect(caller.get()).rejects.toThrow(

--- a/web/src/__tests__/server/unit/instance-usage-router.servertest.ts
+++ b/web/src/__tests__/server/unit/instance-usage-router.servertest.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from "node:crypto";
+import type { Session } from "next-auth";
+
+import { env } from "@/src/env.mjs";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { Role } from "@langfuse/shared/src/db";
+import type * as SharedServer from "@langfuse/shared/src/server";
+
+type SessionOrganization = NonNullable<
+  Session["user"]
+>["organizations"][number];
+
+const { queryClickhouseMock } = vi.hoisted(() => ({
+  queryClickhouseMock: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
+  ...(await importOriginal<typeof SharedServer>()),
+  queryClickhouse: queryClickhouseMock,
+}));
+
+const { instanceUsageRouter } =
+  await import("@/src/features/instance-usage/server/instanceUsageRouter");
+
+const buildSession = ({
+  role,
+  admin = false,
+}: {
+  role?: Role;
+  admin?: boolean;
+}): Session => ({
+  expires: "1",
+  user: {
+    id: `instance-usage-user-${randomUUID()}`,
+    canCreateOrganizations: true,
+    name: "Instance Usage Test User",
+    organizations: role
+      ? [
+          {
+            id: "org-1",
+            name: "Org 1",
+            role,
+            projects: [],
+            metadata: {},
+          } as unknown as SessionOrganization,
+        ]
+      : [],
+    featureFlags: {
+      searchBar: false,
+      excludeClickhouseRead: false,
+      templateFlag: true,
+      v4BetaToggleVisible: false,
+      observationEvals: false,
+      experimentsV4Enabled: false,
+    },
+    admin,
+  },
+  environment: {
+    enableExperimentalFeatures: false,
+    selfHostedInstancePlan: "oss",
+  },
+});
+
+const createCaller = (session: Session) => {
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  return instanceUsageRouter.createCaller({
+    ...ctx,
+    prisma: {
+      organization: { count: async () => 3 },
+      project: { count: async () => 5 },
+      user: { count: async () => 9 },
+      $queryRaw: async () => [{ size: BigInt(4096) }],
+    } as unknown as typeof ctx.prisma,
+  });
+};
+
+describe("instanceUsage.get", () => {
+  const envRecord = env as unknown as Record<string, string | undefined>;
+  const originalCloudRegion = envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+  const originalWriteMode = envRecord.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+  beforeEach(() => {
+    // The page is self-host only; the local dev .env marks the test process as
+    // cloud ("DEV"), which would trip the cloud guard.
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    envRecord.LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+    queryClickhouseMock.mockReset();
+    queryClickhouseMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    envRecord.LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+  });
+
+  it("rejects the request on Langfuse Cloud", async () => {
+    envRecord.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "EU";
+    const caller = createCaller(buildSession({ role: Role.OWNER }));
+
+    await expect(caller.get()).rejects.toThrow(
+      /not available in Langfuse Cloud/,
+    );
+  });
+
+  it("rejects members and viewers, who should not see instance-wide numbers", async () => {
+    for (const role of [Role.MEMBER, Role.VIEWER]) {
+      const caller = createCaller(buildSession({ role }));
+      await expect(caller.get()).rejects.toThrow(/Owner or Admin role/);
+    }
+  });
+
+  it.each([Role.OWNER, Role.ADMIN])("allows org-level %s", async (role) => {
+    const caller = createCaller(buildSession({ role }));
+    await expect(caller.get()).resolves.toMatchObject({
+      instance: { organizations: 3, projects: 5, users: 9 },
+    });
+  });
+
+  it("allows a Langfuse admin without any org membership", async () => {
+    const caller = createCaller(buildSession({ admin: true }));
+
+    await expect(caller.get()).resolves.toMatchObject({
+      instance: { postgresBytes: 4096 },
+    });
+  });
+
+  it("turns partition rows into the monthly pivot", async () => {
+    queryClickhouseMock.mockResolvedValue([
+      {
+        table: "traces",
+        partition_id: "202607",
+        rows: "10",
+        bytes_on_disk: "100",
+        data_uncompressed_bytes: "900",
+        part_count: "2",
+      },
+      {
+        table: "observations",
+        partition_id: "202607",
+        rows: "40",
+        bytes_on_disk: "400",
+        data_uncompressed_bytes: "3600",
+        part_count: "3",
+      },
+    ]);
+
+    const result = await createCaller(buildSession({ role: Role.OWNER })).get();
+
+    expect(result.months).toEqual([
+      expect.objectContaining({
+        month: "2026-07",
+        tracingUnits: 50,
+        onDiskBytes: 500,
+        counts: { traces: 10, observations: 40, scores: 0 },
+      }),
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("degrades to an empty table with a warning when system.parts is unreadable", async () => {
+    queryClickhouseMock.mockRejectedValue(new Error("access denied"));
+
+    const result = await createCaller(buildSession({ role: Role.OWNER })).get();
+
+    expect(result.months).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/system\.parts/);
+  });
+});

--- a/web/src/components/nav/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.tsx
@@ -66,6 +66,7 @@ import {
 import { OrganizationDropdownMenu } from "@/src/components/OrganizationDropdownMenu/OrganizationDropdownMenu";
 import { ProjectDropdownMenu } from "@/src/components/ProjectDropdownMenu/ProjectDropdownMenu";
 import { assertUnreachable } from "@/src/utils/types";
+import { isInstanceUsageAvailable } from "@/src/features/instance-usage/lib/availability";
 import { SIDEBAR_NOTIFICATIONS, type SidebarNotification } from "./utils";
 import { useOrgProjectSwitchPaths } from "@/src/features/projects/hooks";
 
@@ -647,7 +648,7 @@ const VersionLabel = ({ state }: { state: SidebarVersionState }) => {
             Releases
           </Link>
         </DropdownMenuItem>
-        {state.deployment === "self-hosted" && (
+        {isInstanceUsageAvailable() && (
           <DropdownMenuItem asChild>
             <Link href="/instance-usage">
               <ChartColumn size={16} className="mr-2" />

--- a/web/src/components/nav/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.tsx
@@ -23,6 +23,7 @@ import {
   ArrowUp,
   ArrowUp10,
   BadgeCheck,
+  ChartColumn,
   ChevronsUpDown,
   ChevronDownIcon,
   ExternalLink,
@@ -646,6 +647,14 @@ const VersionLabel = ({ state }: { state: SidebarVersionState }) => {
             Releases
           </Link>
         </DropdownMenuItem>
+        {state.deployment === "self-hosted" && (
+          <DropdownMenuItem asChild>
+            <Link href="/instance-usage">
+              <ChartColumn size={16} className="mr-2" />
+              Usage
+            </Link>
+          </DropdownMenuItem>
+        )}
         {state.deployment === "self-hosted" && (
           <DropdownMenuItem asChild>
             <Link href="/background-migrations">

--- a/web/src/features/instance-usage/components/instance-usage.tsx
+++ b/web/src/features/instance-usage/components/instance-usage.tsx
@@ -1,0 +1,373 @@
+import { Download } from "lucide-react";
+
+import Page from "@/src/components/layouts/page";
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { Button } from "@/src/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
+import { VERSION } from "@/src/constants";
+import {
+  buildInstanceUsageCsv,
+  daysElapsedInMonth,
+  instanceUsageCsvFilename,
+  type InstanceDataModel,
+  type InstanceUsageResponse,
+} from "@/src/features/instance-usage/lib/instanceUsage";
+import { api } from "@/src/utils/api";
+import { numberFormatter } from "@/src/utils/numbers";
+
+const dataModelLabels: Record<InstanceDataModel, string> = {
+  legacy: "Legacy tables (v3)",
+  dual: "Dual write (v3 and v4)",
+  events_only: "Events tables (v4)",
+};
+
+const formatBytes = (bytes: number | null): string => {
+  if (bytes === null) return "n/a";
+  if (bytes === 0) return "0 B";
+
+  const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
+  const value = bytes / Math.pow(1024, exponent);
+  return `${value.toFixed(value >= 100 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const downloadCsv = (data: InstanceUsageResponse) => {
+  const now = new Date();
+  const blob = new Blob(
+    [buildInstanceUsageCsv({ data, version: VERSION, now })],
+    { type: "text/csv;charset=utf-8" },
+  );
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = instanceUsageCsvFilename(now);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const SummaryItem = ({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) => (
+  <div className="flex flex-col gap-1">
+    <span className="text-muted-foreground text-xs">{label}</span>
+    <span className="text-sm">{value}</span>
+    {hint && <span className="text-muted-foreground text-xs">{hint}</span>}
+  </div>
+);
+
+const InstanceSummary = ({ data }: { data: InstanceUsageResponse }) => {
+  const totalOnDisk = data.storage.reduce(
+    (sum, table) => sum + table.onDiskBytes,
+    0,
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Instance</CardTitle>
+        <CardDescription>
+          Configuration and scope of this deployment.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <SummaryItem label="Version" value={VERSION} />
+        <SummaryItem
+          label="Data model"
+          value={dataModelLabels[data.instance.dataModel]}
+        />
+        <SummaryItem
+          label="Organizations"
+          value={numberFormatter(data.instance.organizations, 0)}
+        />
+        <SummaryItem
+          label="Projects"
+          value={numberFormatter(data.instance.projects, 0)}
+          hint={`${numberFormatter(data.instance.projectsWithRetention, 0)} with data retention configured`}
+        />
+        <SummaryItem
+          label="Users"
+          value={numberFormatter(data.instance.users, 0)}
+        />
+        <SummaryItem
+          label="ClickHouse on disk"
+          value={formatBytes(totalOnDisk)}
+          hint="Tracing tables, one replica"
+        />
+        <SummaryItem
+          label="Postgres size"
+          value={formatBytes(data.instance.postgresBytes)}
+        />
+        <SummaryItem
+          label="Data range"
+          value={
+            data.months.length > 0
+              ? `${data.months[data.months.length - 1].month} to ${data.months[0].month}`
+              : "no data"
+          }
+        />
+      </CardContent>
+    </Card>
+  );
+};
+
+const MonthlyUsageTable = ({ data }: { data: InstanceUsageResponse }) => {
+  const now = new Date();
+  const totals = data.months.reduce(
+    (sum, month) => ({
+      tracingUnits: sum.tracingUnits + month.tracingUnits,
+      onDiskBytes: sum.onDiskBytes + month.onDiskBytes,
+      counts: Object.fromEntries(
+        data.entities.map((entity) => [
+          entity.key,
+          (sum.counts[entity.key] ?? 0) + (month.counts[entity.key] ?? 0),
+        ]),
+      ),
+    }),
+    {
+      tracingUnits: 0,
+      onDiskBytes: 0,
+      counts: {} as Record<string, number>,
+    },
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Usage by month</CardTitle>
+        <CardDescription>
+          Tracing units are the sum of the entities below, counted from{" "}
+          {data.entities.map((entity) => entity.table).join(", ")}. Months are
+          bucketed by event timestamp, in UTC.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Month</TableHead>
+              {data.entities.map((entity) => (
+                <TableHead key={entity.key} className="text-right">
+                  {entity.label}
+                </TableHead>
+              ))}
+              <TableHead className="text-right">Tracing units</TableHead>
+              <TableHead className="text-right">Units / day</TableHead>
+              <TableHead className="text-right">On disk</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.months.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={data.entities.length + 4}
+                  className="text-muted-foreground"
+                >
+                  No tracing data on this instance yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              data.months.map((month) => {
+                const days = daysElapsedInMonth(month.month, now);
+                return (
+                  <TableRow key={month.month}>
+                    <TableCell>
+                      {month.month}
+                      {month.isPartial && (
+                        <span className="text-muted-foreground ml-2 text-xs font-normal">
+                          month to date
+                        </span>
+                      )}
+                    </TableCell>
+                    {data.entities.map((entity) => (
+                      <TableCell key={entity.key} className="text-right">
+                        {numberFormatter(month.counts[entity.key] ?? 0, 0)}
+                      </TableCell>
+                    ))}
+                    <TableCell className="text-right font-bold">
+                      {numberFormatter(month.tracingUnits, 0)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-right">
+                      {days > 0
+                        ? numberFormatter(month.tracingUnits / days, 0)
+                        : "-"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatBytes(month.onDiskBytes)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+          {data.months.length > 0 && (
+            <TableFooter>
+              <TableRow>
+                <TableCell className="font-bold">Total</TableCell>
+                {data.entities.map((entity) => (
+                  <TableCell key={entity.key} className="text-right">
+                    {numberFormatter(totals.counts[entity.key] ?? 0, 0)}
+                  </TableCell>
+                ))}
+                <TableCell className="text-right font-bold">
+                  {numberFormatter(totals.tracingUnits, 0)}
+                </TableCell>
+                <TableCell />
+                <TableCell className="text-right">
+                  {formatBytes(totals.onDiskBytes)}
+                </TableCell>
+              </TableRow>
+            </TableFooter>
+          )}
+        </Table>
+      </CardContent>
+    </Card>
+  );
+};
+
+const StorageTable = ({ data }: { data: InstanceUsageResponse }) => (
+  <Card>
+    <CardHeader>
+      <CardTitle>Storage by table</CardTitle>
+      <CardDescription>
+        ClickHouse footprint of one replica. Uncompressed size and the resulting
+        compression ratio help estimate how the instance scales with retention.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Table</TableHead>
+            <TableHead className="text-right">Rows</TableHead>
+            <TableHead className="text-right">On disk</TableHead>
+            <TableHead className="text-right">Uncompressed</TableHead>
+            <TableHead className="text-right">Ratio</TableHead>
+            <TableHead className="text-right">Months</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.storage.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={6} className="text-muted-foreground">
+                No partitions found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            data.storage.map((table) => (
+              <TableRow key={table.table}>
+                <TableCell className="font-mono text-xs">
+                  {table.table}
+                </TableCell>
+                <TableCell className="text-right">
+                  {numberFormatter(table.rows, 0)}
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatBytes(table.onDiskBytes)}
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatBytes(table.uncompressedBytes)}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-right">
+                  {table.onDiskBytes > 0
+                    ? `${(table.uncompressedBytes / table.onDiskBytes).toFixed(1)}x`
+                    : "-"}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-right">
+                  {numberFormatter(table.partitions, 0)}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </CardContent>
+  </Card>
+);
+
+export default function InstanceUsage() {
+  const usage = api.instanceUsage.get.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  return (
+    <Page
+      scrollable
+      withPadding
+      headerProps={{
+        title: "Instance Usage",
+        help: {
+          description:
+            "Volume and storage footprint of this Langfuse instance, aggregated across all organizations. Useful when sizing a deployment.",
+        },
+        actionButtonsRight: (
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={!usage.data}
+            onClick={() => usage.data && downloadCsv(usage.data)}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            Download CSV
+          </Button>
+        ),
+      }}
+    >
+      <div className="flex flex-col gap-4">
+        {usage.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>{usage.error.message}</AlertDescription>
+          </Alert>
+        )}
+        {usage.data?.warnings.map((warning) => (
+          <Alert key={warning}>
+            <AlertDescription>{warning}</AlertDescription>
+          </Alert>
+        ))}
+        {usage.isPending && (
+          <p className="text-muted-foreground text-sm">Loading …</p>
+        )}
+        {usage.data && (
+          <>
+            <InstanceSummary data={usage.data} />
+            <MonthlyUsageTable data={usage.data} />
+            <StorageTable data={usage.data} />
+            <p className="text-muted-foreground text-xs">
+              Counts come from ClickHouse partition metadata, so they are read
+              without scanning the tables and stay fast on any instance size.
+              They count stored rows: updates to the same entity add a row
+              version until background merges collapse them, which makes these
+              numbers an upper bound on distinct entities. Sizes are for a
+              single replica and exclude blob storage.
+            </p>
+          </>
+        )}
+      </div>
+    </Page>
+  );
+}

--- a/web/src/features/instance-usage/lib/availability.ts
+++ b/web/src/features/instance-usage/lib/availability.ts
@@ -1,0 +1,19 @@
+import { env } from "@/src/env.mjs";
+
+/**
+ * Whether the instance usage page is available on this deployment.
+ *
+ * Self-hosted only: Langfuse Cloud has org-scoped usage views, and an
+ * instance-wide aggregate would cross tenant boundaries there.
+ *
+ * PR previews are the one exception. They build with
+ * `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION=DEV` (see .github/workflows/preview-build.yml),
+ * so a plain region check would hide the page from exactly the environment we
+ * review it in. Both conditions must hold — the DEV region AND a preview PR URL,
+ * which only the preview build sets — so a stray preview variable can never
+ * re-admit a real region (US/EU/STAGING/HIPAA/JP).
+ */
+export const isInstanceUsageAvailable = (): boolean =>
+  !env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ||
+  (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" &&
+    Boolean(env.NEXT_PUBLIC_PREVIEW_PR_URL));

--- a/web/src/features/instance-usage/lib/instanceUsage.clienttest.ts
+++ b/web/src/features/instance-usage/lib/instanceUsage.clienttest.ts
@@ -1,0 +1,194 @@
+import {
+  buildInstanceUsageCsv,
+  buildMonthlyUsage,
+  daysElapsedInMonth,
+  resolveUsageEntities,
+  type InstanceUsagePartitionRow,
+  type InstanceUsageResponse,
+} from "./instanceUsage";
+
+const partitionRow = (
+  overrides: Partial<InstanceUsagePartitionRow> & {
+    table: string;
+    month: string;
+  },
+): InstanceUsagePartitionRow => ({
+  rows: 0,
+  onDiskBytes: 0,
+  uncompressedBytes: 0,
+  parts: 1,
+  ...overrides,
+});
+
+describe("resolveUsageEntities", () => {
+  it("keeps legacy tables authoritative in dual mode so units are not doubled", () => {
+    expect(resolveUsageEntities("dual").map((e) => e.table)).toEqual([
+      "traces",
+      "observations",
+      "scores",
+    ]);
+  });
+
+  it("reports spans instead of traces + observations in events_only", () => {
+    expect(resolveUsageEntities("events_only").map((e) => e.table)).toEqual([
+      "events_core",
+      "scores",
+    ]);
+  });
+});
+
+describe("buildMonthlyUsage", () => {
+  const now = new Date("2026-08-06T00:00:00Z");
+
+  it("pivots partitions into months, newest first, and marks the partial month", () => {
+    const { months } = buildMonthlyUsage({
+      partitionRows: [
+        partitionRow({ table: "traces", month: "2026-07", rows: 10 }),
+        partitionRow({ table: "observations", month: "2026-07", rows: 40 }),
+        partitionRow({ table: "scores", month: "2026-07", rows: 2 }),
+        partitionRow({ table: "traces", month: "2026-08", rows: 5 }),
+      ],
+      entities: resolveUsageEntities("legacy"),
+      now,
+    });
+
+    expect(months.map((m) => m.month)).toEqual(["2026-08", "2026-07"]);
+    expect(months[0]).toMatchObject({ isPartial: true, tracingUnits: 5 });
+    expect(months[1]).toMatchObject({
+      isPartial: false,
+      tracingUnits: 52,
+      counts: { traces: 10, observations: 40, scores: 2 },
+    });
+  });
+
+  it("counts events_full bytes toward the month but never toward units", () => {
+    const { months, storage } = buildMonthlyUsage({
+      partitionRows: [
+        partitionRow({
+          table: "events_core",
+          month: "2026-07",
+          rows: 100,
+          onDiskBytes: 1_000,
+        }),
+        partitionRow({
+          table: "events_full",
+          month: "2026-07",
+          rows: 100,
+          onDiskBytes: 9_000,
+        }),
+      ],
+      entities: resolveUsageEntities("events_only"),
+      now,
+    });
+
+    expect(months[0].tracingUnits).toBe(100);
+    expect(months[0].onDiskBytes).toBe(10_000);
+    expect(storage.map((s) => s.table)).toEqual(["events_core", "events_full"]);
+  });
+
+  it("zero-fills entities that have no partitions yet", () => {
+    const { months } = buildMonthlyUsage({
+      partitionRows: [
+        partitionRow({ table: "traces", month: "2026-07", rows: 3 }),
+      ],
+      entities: resolveUsageEntities("legacy"),
+      now,
+    });
+
+    expect(months[0].counts).toEqual({
+      traces: 3,
+      observations: 0,
+      scores: 0,
+    });
+  });
+
+  it("sums parts and partitions per table across months", () => {
+    const { storage } = buildMonthlyUsage({
+      partitionRows: [
+        partitionRow({ table: "traces", month: "2026-07", rows: 3, parts: 4 }),
+        partitionRow({ table: "traces", month: "2026-06", rows: 7, parts: 2 }),
+      ],
+      entities: resolveUsageEntities("legacy"),
+      now,
+    });
+
+    expect(storage[0]).toMatchObject({
+      table: "traces",
+      rows: 10,
+      parts: 6,
+      partitions: 2,
+    });
+  });
+});
+
+describe("daysElapsedInMonth", () => {
+  it("uses elapsed days for the current month", () => {
+    expect(
+      daysElapsedInMonth("2026-08", new Date("2026-08-06T12:00:00Z")),
+    ).toBe(6);
+  });
+
+  it("uses the full length for past months, including leap February", () => {
+    const now = new Date("2026-08-06T00:00:00Z");
+    expect(daysElapsedInMonth("2026-07", now)).toBe(31);
+    expect(daysElapsedInMonth("2024-02", now)).toBe(29);
+    expect(daysElapsedInMonth("2026-02", now)).toBe(28);
+  });
+});
+
+describe("buildInstanceUsageCsv", () => {
+  const data: InstanceUsageResponse = {
+    generatedAt: "2026-08-06T10:00:00.000Z",
+    instance: {
+      dataModel: "legacy",
+      organizations: 2,
+      projects: 7,
+      users: 31,
+      projectsWithRetention: 1,
+      postgresBytes: 1234,
+    },
+    entities: resolveUsageEntities("legacy"),
+    months: [
+      {
+        month: "2026-07",
+        isPartial: false,
+        counts: { traces: 10, observations: 40, scores: 2 },
+        tracingUnits: 52,
+        onDiskBytes: 500,
+        uncompressedBytes: 5_000,
+      },
+    ],
+    storage: [],
+    warnings: [],
+  };
+
+  it("emits the preamble, a blank line, then the monthly table", () => {
+    const csv = buildInstanceUsageCsv({
+      data,
+      version: "4.6.0",
+      now: new Date("2026-08-06T10:00:00Z"),
+    });
+    const lines = csv.split("\n");
+
+    expect(lines[0]).toBe("Key,Value");
+    expect(lines).toContain("Langfuse version,4.6.0");
+    expect(lines[lines.indexOf("") + 1]).toBe(
+      "Month,Traces,Observations,Scores,Tracing units,Avg tracing units per day,ClickHouse on disk (bytes),ClickHouse uncompressed (bytes),Month complete",
+    );
+    // 52 units over July's 31 days rounds to 2.
+    expect(lines.at(-1)).toBe("2026-07,10,40,2,52,2,500,5000,yes");
+  });
+
+  it("quotes values that contain a comma", () => {
+    const csv = buildInstanceUsageCsv({
+      data: {
+        ...data,
+        entities: [{ key: "traces", label: "Traces, all", table: "traces" }],
+      },
+      version: "4.6.0",
+      now: new Date("2026-08-06T10:00:00Z"),
+    });
+
+    expect(csv).toContain('"Traces, all"');
+  });
+});

--- a/web/src/features/instance-usage/lib/instanceUsage.ts
+++ b/web/src/features/instance-usage/lib/instanceUsage.ts
@@ -1,0 +1,260 @@
+/**
+ * Shared contract and pure aggregation logic for the instance usage page.
+ *
+ * Kept free of server imports so both the tRPC router and the client-side CSV
+ * download work off the same shapes.
+ */
+
+/** V4 write mode, mirrored from `LANGFUSE_MIGRATION_V4_WRITE_MODE`. */
+export type InstanceDataModel = "legacy" | "dual" | "events_only";
+
+/** Every tracing table we report storage for. */
+export const INSTANCE_USAGE_STORAGE_TABLES = [
+  "traces",
+  "observations",
+  "scores",
+  "events_full",
+  "events_core",
+] as const;
+
+export type InstanceUsageStorageTable =
+  (typeof INSTANCE_USAGE_STORAGE_TABLES)[number];
+
+/** A pivot column: one tracing entity, backed by one ClickHouse table. */
+export type UsageEntity = {
+  key: string;
+  label: string;
+  table: InstanceUsageStorageTable;
+};
+
+export type InstanceUsagePartitionRow = {
+  table: string;
+  /** `YYYY-MM`, derived from the table's `toYYYYMM` partition id. */
+  month: string;
+  rows: number;
+  onDiskBytes: number;
+  uncompressedBytes: number;
+  parts: number;
+};
+
+export type InstanceUsageMonth = {
+  month: string;
+  /** True for the month still being written to, whose totals are incomplete. */
+  isPartial: boolean;
+  /** Entity key -> row count. Missing tables contribute 0. */
+  counts: Record<string, number>;
+  /** Sum of `counts`, the instance's tracing units for the month. */
+  tracingUnits: number;
+  /** On-disk bytes of every tracing table for that month, not just the units. */
+  onDiskBytes: number;
+  uncompressedBytes: number;
+};
+
+export type InstanceUsageStorageRow = {
+  table: string;
+  rows: number;
+  onDiskBytes: number;
+  uncompressedBytes: number;
+  parts: number;
+  partitions: number;
+};
+
+export type InstanceUsageResponse = {
+  generatedAt: string;
+  instance: {
+    dataModel: InstanceDataModel;
+    organizations: number;
+    projects: number;
+    users: number;
+    projectsWithRetention: number;
+    postgresBytes: number | null;
+  };
+  entities: UsageEntity[];
+  months: InstanceUsageMonth[];
+  storage: InstanceUsageStorageRow[];
+  warnings: string[];
+};
+
+/**
+ * Which tables carry the instance's tracing entities.
+ *
+ * In `events_only` a trace is no longer a stored row of its own — the root span
+ * in `events_core` is the trace — so the pivot reports spans rather than
+ * splitting traces from observations. `dual` writes both the legacy tables and
+ * `events_full`/`events_core`; counting both would double the units, so the
+ * legacy tables stay authoritative there and the events tables show up only
+ * under storage.
+ */
+export const resolveUsageEntities = (
+  dataModel: InstanceDataModel,
+): UsageEntity[] =>
+  dataModel === "events_only"
+    ? [
+        { key: "events", label: "Spans", table: "events_core" },
+        { key: "scores", label: "Scores", table: "scores" },
+      ]
+    : [
+        { key: "traces", label: "Traces", table: "traces" },
+        { key: "observations", label: "Observations", table: "observations" },
+        { key: "scores", label: "Scores", table: "scores" },
+      ];
+
+const toMonthKey = (date: Date): string =>
+  `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+
+/**
+ * Folds raw partition rows into the monthly pivot plus a per-table storage
+ * summary.
+ */
+export const buildMonthlyUsage = ({
+  partitionRows,
+  entities,
+  now,
+}: {
+  partitionRows: InstanceUsagePartitionRow[];
+  entities: UsageEntity[];
+  now: Date;
+}): { months: InstanceUsageMonth[]; storage: InstanceUsageStorageRow[] } => {
+  const currentMonth = toMonthKey(now);
+  const entityByTable = new Map(
+    entities.map((entity) => [entity.table, entity]),
+  );
+
+  const monthsByKey = new Map<string, InstanceUsageMonth>();
+  const storageByTable = new Map<string, InstanceUsageStorageRow>();
+
+  for (const row of partitionRows) {
+    const month = monthsByKey.get(row.month) ?? {
+      month: row.month,
+      isPartial: row.month === currentMonth,
+      counts: Object.fromEntries(entities.map((entity) => [entity.key, 0])),
+      tracingUnits: 0,
+      onDiskBytes: 0,
+      uncompressedBytes: 0,
+    };
+
+    // Bytes cover every tracing table: `events_full` holds the payloads and is
+    // usually the bulk of the disk footprint, so leaving it out would badly
+    // understate what a month of traffic costs to store.
+    month.onDiskBytes += row.onDiskBytes;
+    month.uncompressedBytes += row.uncompressedBytes;
+
+    const entity = entityByTable.get(row.table as InstanceUsageStorageTable);
+    if (entity) {
+      month.counts[entity.key] += row.rows;
+      month.tracingUnits += row.rows;
+    }
+
+    monthsByKey.set(row.month, month);
+
+    const storage = storageByTable.get(row.table) ?? {
+      table: row.table,
+      rows: 0,
+      onDiskBytes: 0,
+      uncompressedBytes: 0,
+      parts: 0,
+      partitions: 0,
+    };
+    storage.rows += row.rows;
+    storage.onDiskBytes += row.onDiskBytes;
+    storage.uncompressedBytes += row.uncompressedBytes;
+    storage.parts += row.parts;
+    storage.partitions += 1;
+    storageByTable.set(row.table, storage);
+  }
+
+  return {
+    months: [...monthsByKey.values()].sort((a, b) =>
+      b.month.localeCompare(a.month),
+    ),
+    storage: [...storageByTable.values()].sort((a, b) =>
+      a.table.localeCompare(b.table),
+    ),
+  };
+};
+
+/** Days of the month that have elapsed, used for the average-per-day column. */
+export const daysElapsedInMonth = (month: string, now: Date): number => {
+  const [year, monthNumber] = month.split("-").map(Number);
+  if (!year || !monthNumber) return 0;
+
+  const isCurrentMonth =
+    year === now.getUTCFullYear() && monthNumber === now.getUTCMonth() + 1;
+  if (isCurrentMonth) return now.getUTCDate();
+
+  // Day 0 of the next month is the last day of this one.
+  return new Date(Date.UTC(year, monthNumber, 0)).getUTCDate();
+};
+
+const csvCell = (value: string | number): string => {
+  const asString = String(value);
+  return /[",\n]/.test(asString)
+    ? `"${asString.replaceAll('"', '""')}"`
+    : asString;
+};
+
+const csvRow = (cells: (string | number)[]): string =>
+  cells.map(csvCell).join(",");
+
+/**
+ * Renders the page's data as a CSV an operator can hand to us unchanged.
+ *
+ * A leading `Key,Value` preamble carries the instance context (version, data
+ * model, scope) because the file travels on its own, detached from the page that
+ * produced it. Spreadsheets read this fine; the tabular section starts after the
+ * blank line.
+ */
+export const buildInstanceUsageCsv = ({
+  data,
+  version,
+  now,
+}: {
+  data: InstanceUsageResponse;
+  version: string;
+  now: Date;
+}): string => {
+  const preamble: (string | number)[][] = [
+    ["Key", "Value"],
+    ["Langfuse version", version],
+    ["Data model", data.instance.dataModel],
+    ["Generated at (UTC)", data.generatedAt],
+    ["Organizations", data.instance.organizations],
+    ["Projects", data.instance.projects],
+    ["Users", data.instance.users],
+    ["Projects with retention configured", data.instance.projectsWithRetention],
+    ["Postgres size (bytes)", data.instance.postgresBytes ?? ""],
+  ];
+
+  const header = [
+    "Month",
+    ...data.entities.map((entity) => entity.label),
+    "Tracing units",
+    "Avg tracing units per day",
+    "ClickHouse on disk (bytes)",
+    "ClickHouse uncompressed (bytes)",
+    "Month complete",
+  ];
+
+  const rows = data.months.map((month) => {
+    const days = daysElapsedInMonth(month.month, now);
+    return [
+      month.month,
+      ...data.entities.map((entity) => month.counts[entity.key] ?? 0),
+      month.tracingUnits,
+      days > 0 ? Math.round(month.tracingUnits / days) : 0,
+      month.onDiskBytes,
+      month.uncompressedBytes,
+      month.isPartial ? "no" : "yes",
+    ];
+  });
+
+  return [
+    ...preamble.map(csvRow),
+    "",
+    csvRow(header),
+    ...rows.map(csvRow),
+  ].join("\n");
+};
+
+export const instanceUsageCsvFilename = (now: Date): string =>
+  `langfuse-instance-usage-${now.toISOString().slice(0, 10)}.csv`;

--- a/web/src/features/instance-usage/server/instanceUsageRouter.ts
+++ b/web/src/features/instance-usage/server/instanceUsageRouter.ts
@@ -1,0 +1,187 @@
+import { TRPCError } from "@trpc/server";
+import {
+  createTRPCRouter,
+  authenticatedProcedure,
+} from "@/src/server/api/trpc";
+import { env } from "@/src/env.mjs";
+import { Role } from "@langfuse/shared/src/db";
+import { logger, queryClickhouse } from "@langfuse/shared/src/server";
+import {
+  INSTANCE_USAGE_STORAGE_TABLES,
+  buildMonthlyUsage,
+  resolveUsageEntities,
+  type InstanceUsagePartitionRow,
+  type InstanceUsageResponse,
+} from "@/src/features/instance-usage/lib/instanceUsage";
+
+/**
+ * The page is an operator tool for self-hosted instances: Langfuse Cloud has
+ * its own org-scoped usage views, and an instance-wide aggregate would cross
+ * tenant boundaries there.
+ */
+const denyOnLangfuseCloud = () => {
+  if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Instance usage is not available in Langfuse Cloud",
+    });
+  }
+};
+
+/**
+ * Instance usage aggregates across every organization on the instance, so a
+ * plain org membership is not enough. We require an org-level OWNER/ADMIN role
+ * somewhere on the instance — the roles a self-hosted operator holds — which
+ * keeps the numbers away from regular members and viewers.
+ */
+const denyNonInstanceOperators = (session: {
+  user: {
+    admin?: boolean | null;
+    organizations: { role: Role }[];
+  };
+}) => {
+  if (session.user.admin === true) return;
+
+  const isOrgOperator = session.user.organizations.some(
+    (org) => org.role === Role.OWNER || org.role === Role.ADMIN,
+  );
+  if (!isOrgOperator) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message:
+        "Instance usage requires an Owner or Admin role in at least one organization",
+    });
+  }
+};
+
+/**
+ * Monthly row counts and byte sizes straight from ClickHouse partition
+ * metadata.
+ *
+ * Every tracing table is partitioned by month (`toYYYYMM` of the entity
+ * timestamp), so `system.parts` already holds the exact pivot we want and
+ * answers in milliseconds regardless of instance size. Counting rows with
+ * `SELECT count(*) ... GROUP BY month` instead would scan a year of data on the
+ * very instances this page exists for — Langfuse Cloud's hourly metering job
+ * already runs into the ClickHouse request-timeout ceiling doing a single-hour
+ * count over one of these tables.
+ *
+ * `system.parts` is read locally, not through `clusterAllReplicas`: Langfuse's
+ * clustered schema is single-shard ReplicatedMergeTree, so every replica holds
+ * the full dataset and a cluster-wide union would multiply by the replica count.
+ */
+const getPartitionRows = async (): Promise<InstanceUsagePartitionRow[]> => {
+  const rows = await queryClickhouse<{
+    table: string;
+    partition_id: string;
+    rows: string;
+    bytes_on_disk: string;
+    data_uncompressed_bytes: string;
+    part_count: string;
+  }>({
+    query: `
+      SELECT
+        table,
+        partition_id,
+        sum(rows) AS rows,
+        sum(bytes_on_disk) AS bytes_on_disk,
+        sum(data_uncompressed_bytes) AS data_uncompressed_bytes,
+        count() AS part_count
+      FROM system.parts
+      WHERE database = currentDatabase()
+        AND active = 1
+        AND table IN ({tables: Array(String)})
+        AND match(partition_id, '^[0-9]{6}$')
+      GROUP BY table, partition_id
+      ORDER BY partition_id DESC, table ASC
+    `,
+    params: { tables: [...INSTANCE_USAGE_STORAGE_TABLES] },
+    tags: {
+      surface: "trpc",
+      route: "instanceUsage.get",
+    },
+  });
+
+  return rows.map((row) => ({
+    table: row.table,
+    month: `${row.partition_id.slice(0, 4)}-${row.partition_id.slice(4, 6)}`,
+    rows: Number(row.rows),
+    onDiskBytes: Number(row.bytes_on_disk),
+    uncompressedBytes: Number(row.data_uncompressed_bytes),
+    parts: Number(row.part_count),
+  }));
+};
+
+export const instanceUsageRouter = createTRPCRouter({
+  get: authenticatedProcedure.query(
+    async ({ ctx }): Promise<InstanceUsageResponse> => {
+      denyOnLangfuseCloud();
+      denyNonInstanceOperators(ctx.session);
+
+      const warnings: string[] = [];
+
+      const [
+        partitionRows,
+        organizations,
+        projects,
+        users,
+        projectsWithRetention,
+        postgresBytes,
+      ] = await Promise.all([
+        getPartitionRows().catch((error) => {
+          // A ClickHouse user without `system.parts` access should degrade to an
+          // empty table with an explanation, not a broken page.
+          logger.error("[INSTANCE USAGE] Failed to read system.parts", {
+            error,
+          });
+          warnings.push(
+            "Could not read ClickHouse partition metadata (system.parts). The ClickHouse user needs read access to system tables for usage numbers to appear.",
+          );
+          return [] as InstanceUsagePartitionRow[];
+        }),
+        ctx.prisma.organization.count(),
+        ctx.prisma.project.count({ where: { deletedAt: null } }),
+        ctx.prisma.user.count(),
+        ctx.prisma.project.count({
+          where: { deletedAt: null, retentionDays: { gt: 0 } },
+        }),
+        ctx.prisma.$queryRaw<
+          { size: bigint }[]
+        >`SELECT pg_database_size(current_database()) AS size`
+          .then((result) =>
+            result[0]?.size != null ? Number(result[0].size) : null,
+          )
+          .catch((error) => {
+            logger.warn("[INSTANCE USAGE] Failed to read Postgres size", {
+              error,
+            });
+            return null;
+          }),
+      ]);
+
+      const dataModel = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+      const entities = resolveUsageEntities(dataModel);
+      const { months, storage } = buildMonthlyUsage({
+        partitionRows,
+        entities,
+        now: new Date(),
+      });
+
+      return {
+        generatedAt: new Date().toISOString(),
+        instance: {
+          dataModel,
+          organizations,
+          projects,
+          users,
+          projectsWithRetention,
+          postgresBytes,
+        },
+        entities,
+        months,
+        storage,
+        warnings,
+      };
+    },
+  ),
+});

--- a/web/src/features/instance-usage/server/instanceUsageRouter.ts
+++ b/web/src/features/instance-usage/server/instanceUsageRouter.ts
@@ -6,6 +6,7 @@ import {
 import { env } from "@/src/env.mjs";
 import { Role } from "@langfuse/shared/src/db";
 import { logger, queryClickhouse } from "@langfuse/shared/src/server";
+import { isInstanceUsageAvailable } from "@/src/features/instance-usage/lib/availability";
 import {
   INSTANCE_USAGE_STORAGE_TABLES,
   buildMonthlyUsage,
@@ -14,13 +15,9 @@ import {
   type InstanceUsageResponse,
 } from "@/src/features/instance-usage/lib/instanceUsage";
 
-/**
- * The page is an operator tool for self-hosted instances: Langfuse Cloud has
- * its own org-scoped usage views, and an instance-wide aggregate would cross
- * tenant boundaries there.
- */
+/** The page is an operator tool; see `isInstanceUsageAvailable`. */
 const denyOnLangfuseCloud = () => {
-  if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+  if (!isInstanceUsageAvailable()) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "Instance usage is not available in Langfuse Cloud",

--- a/web/src/pages/instance-usage.tsx
+++ b/web/src/pages/instance-usage.tsx
@@ -1,0 +1,5 @@
+import InstanceUsage from "@/src/features/instance-usage/components/instance-usage";
+
+export default function InstanceUsagePage() {
+  return <InstanceUsage />;
+}

--- a/web/src/server/api/root.ts
+++ b/web/src/server/api/root.ts
@@ -41,6 +41,7 @@ import { queueItemRouter } from "@/src/features/annotation-queues/server/annotat
 import { experimentsRouter } from "@/src/features/experiments/server/router";
 import { mediaRouter } from "@/src/server/api/routers/media";
 import { backgroundMigrationsRouter } from "@/src/features/background-migrations/server/background-migrations-router";
+import { instanceUsageRouter } from "@/src/features/instance-usage/server/instanceUsageRouter";
 import { auditLogsRouter } from "./routers/auditLogs";
 import { tableRouter } from "@/src/features/table/server/tableRouter";
 import { batchActionRouter } from "@/src/features/batch-actions/server/batchActionRouter";
@@ -112,6 +113,7 @@ export const appRouter = createTRPCRouter({
   commentReactions: commentReactionsRouter,
   media: mediaRouter,
   backgroundMigrations: backgroundMigrationsRouter,
+  instanceUsage: instanceUsageRouter,
   auditLogs: auditLogsRouter,
   table: tableRouter,
   batchAction: batchActionRouter,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15854.preview.langfuse.com](https://pr-15854.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Closes [LFE-14708](https://linear.app/clickhouse/issue/LFE-14708/usage-overview-page-on-self-hosted-instances)

**Draft for design review.** The page renders end-to-end (verified locally against 8 months of seeded data), but the shape of the page is the thing to review, not the code polish. Open questions are at the bottom.

## What this adds

`/instance-usage` — "Instance Usage", reachable from the version dropdown right above Background Migrations, self-hosted only.

Three sections:

1. **Instance** — version, data model (v3 / dual / v4 events), organizations, projects (and how many have retention configured), users, total ClickHouse on-disk size, Postgres size, and the range of months that hold data.
2. **Usage by month** — the pivot from the issue: `Month | Traces | Observations | Scores | Tracing units | Units/day | On disk`, newest first, with a total row. The month still being written is marked "month to date".
3. **Storage by table** — per ClickHouse table: rows, on disk, uncompressed, compression ratio, months of partitions.

Plus a **Download CSV** button that builds the file client-side from the already-loaded data.

## Design rationale

**Numbers come from `system.parts`, not from `count(*)`.** Every tracing table is partitioned `toYYYYMM(<entity timestamp>)`, so ClickHouse partition metadata *already is* the monthly pivot. One metadata query returns month × table → rows + bytes in milliseconds, at any instance size, and it gives us the storage footprint from the same read. The alternative — `SELECT count(*) … GROUP BY toStartOfMonth(...)` over a year — scans a column across every partition, and it would be slowest on exactly the large enterprise instances this page exists to describe. Cloud's hourly metering job already runs into the ClickHouse request-timeout ceiling counting a *single hour* of one of these tables.

The tradeoff: these are stored **row versions**. Updating an entity writes a new version that lives until background merges collapse it, so the counts are an upper bound on distinct entities — off by a few percent on a merged instance, more in the current month. The page says so in a footnote. For sizing that seems like the right trade: rows-and-bytes-ingested is arguably the more relevant number anyway, and it's the one that never times out. If you'd rather have exact counts, the natural shape is a separate "compute exact counts" button that fires the scan on demand, so page load never pays for it.

**The pivot columns follow the instance's write mode.** On `events_only` there is no separate traces row to count — the root span in `events_core` is the trace — so the columns become `Spans | Scores`. On `dual`, both legacy and events tables are written, and summing both would double the units; the legacy tables stay authoritative for counts and the events tables appear only under storage. The card names which tables feed the number.

**No commercial language.** No plan, no limit, no price, no upgrade prompt. "Tracing units" is the one unit word, because it's the unit the rest of the product uses and it's what makes the CSV comparable to what we quote. Everything else is described in infrastructure terms.

**Access.** Self-hosted only (Cloud has org-scoped usage views and this would cross tenants there), and requires an org-level Owner or Admin somewhere on the instance — a plain member shouldn't see instance-wide aggregates. It reports instance totals only, never a per-org or per-project breakdown, which keeps a multi-tenant self-hosted instance from leaking tenant shape through this page.

**Degradation.** A ClickHouse user without `system.parts` access gets an empty table plus a banner explaining the missing grant, not a broken page. Same for `pg_database_size`.

**Reviewing this in the preview.** Previews build with `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION=DEV`, so a plain self-hosted check would hide the page from exactly the environment we review it in. Availability therefore also accepts the DEV region when `NEXT_PUBLIC_PREVIEW_PR_URL` is set, which only the preview build does. Both conditions must hold, so a stray preview variable can't re-admit a real Cloud region — covered by tests. If we'd rather not carry a preview carve-out in product code, the alternative is reviewing this locally with the region unset instead.

## What else an SA needs, beyond the pivot

The issue asked for month / units / traces / observations / scores. These are the additions I made, each because it changes the sizing answer:

- **On disk + uncompressed + ratio.** Volume alone doesn't size a deployment; bytes per month and the compression ratio do. Note the per-month bytes include `events_full` (the payload table), usually the bulk of the footprint — leaving it out would badly understate a month of traffic.
- **Units per day.** Monthly totals hide the throughput the worker fleet has to keep up with. (Caveat: an instance's first partial month divides by the full month length, so its per-day figure reads low.)
- **Data model / write mode.** Determines which upgrade path and which tables a migration touches; it's the first thing we ask anyway.
- **Retention configured.** Explains a flat storage curve. Without it, a retention-capped instance looks like one that isn't growing.
- **Organizations / projects / users.** Tenant shape and rough web-tier sizing.
- **Postgres size.** Small, but people forget Postgres exists until it doesn't fit.

Deliberately left out for now: peak day/hour (needs a scan), month-over-month growth (derivable from the CSV; adds an eighth column), ingestion-source mix (SDK vs OTel — useful, but it belongs on the v4 transition surface), blob-storage size (not cheaply queryable from the app).

## Open questions for review

1. **CSV shape.** Right now it's a `Key,Value` preamble with the instance context, a blank line, then the monthly table — spreadsheet-friendly, since the file travels to an SA detached from the page. A strict parser will trip on it. Prefer a strictly tabular CSV that drops the context, or is the preamble worth it?
2. **Approximate vs exact counts** — is the `system.parts` trade above the right default, and do you want the on-demand exact-count escape hatch?
3. **Access gate** — org Owner/Admin anywhere on the instance. Too loose, or should it match Background Migrations (any authenticated user)?
4. **A trend chart** above the table? I left it out to keep the draft focused and the CSV a faithful mirror of the screen; happy to add one via the charts library.
5. **"Tracing units"** as the column name, or something with no billing connotation at all (e.g. "Total rows")?

## Verification

- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-client src/features/instance-usage/lib/instanceUsage.clienttest.ts` → `Tests 10 passed (10)`
- `pnpm --filter web exec vitest run --project server-unit src/__tests__/server/unit/instance-usage-router.servertest.ts` → `Tests 10 passed (10)` (cloud guard, preview carve-out and its two negative cases, member/viewer rejection, Owner/Admin/instance-admin access, pivot mapping, `system.parts` failure path)
- Reviewed in a browser against `pnpm run seed -- outlier-traffic --days 200` + `scored-traces` (8 months of data in dual-write mode): page renders, dropdown entry appears, tRPC query returns in 47 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
