### PR TITLE
fix(batch-export): stabilize scores, sessions and observations export pagination with unique id tiebreakers

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -809,6 +809,14 @@ const getObservationsTableInternal = async <T>(
       ? [{ column: "order_by_date", order: orderBy.order }, orderBy]
       : [orderBy ?? null];
 
+  // Append the unique observation id as a tiebreaker so offset-based
+  // pagination is stable when observations share the same sort-column
+  // value (e.g. start_time). The count query is a single aggregate row,
+  // so it must not receive the extra clause.
+  if (opts.select === "rows" && orderBy?.column !== "id") {
+    newDefaultOrder.push({ column: "id", order: "DESC" });
+  }
+
   const chOrderBy = orderByToClickhouseSql(newDefaultOrder, [
     ...observationsTableUiColumnDefinitions,
     {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1379,6 +1379,18 @@ const getScoresUiGeneric = async <T>(props: {
     props.select === "rows" ||
     scoresFilter.some((f) => f.clickhouseTable === "traces");
 
+  // Append the unique score id as a tiebreaker so offset-based pagination
+  // is stable when rows share a value in the user's chosen sort column
+  // (e.g. timestamp). The count query is a single aggregate row, so it
+  // must not receive the extra clause.
+  const scoresOrderBy: OrderByState[] = [];
+  if (orderBy) {
+    scoresOrderBy.push(orderBy);
+  }
+  if (props.select === "rows" && orderBy?.column !== "id") {
+    scoresOrderBy.push({ column: "id", order: "DESC" });
+  }
+
   const query = `
       SELECT
           ${select}
@@ -1387,7 +1399,7 @@ const getScoresUiGeneric = async <T>(props: {
       WHERE s.project_id = {projectId: String}
       AND s.data_type IN ({dataTypes: Array(String)})
       ${scoresFilterRes?.query ? `AND ${scoresFilterRes.query}` : ""}
-      ${orderByToClickhouseSql(orderBy ?? null, scoresTableUiColumnDefinitions)}
+      ${orderByToClickhouseSql(scoresOrderBy.length > 0 ? scoresOrderBy : null, scoresTableUiColumnDefinitions)}
       ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
@@ -1572,6 +1584,17 @@ const getScoresUiGenericFromEvents = async <T>(props: {
         ${includeHasMetadataFlag ? ",length(mapKeys(s.metadata)) > 0 AS has_metadata" : ""}
       `;
 
+  // Append the unique score id as a tiebreaker so offset-based pagination
+  // is stable when rows share a value in the user's chosen sort column.
+  // The count query is a single aggregate row, so it must not receive it.
+  const eventsScoresOrderBy: OrderByState[] = [];
+  if (orderBy) {
+    eventsScoresOrderBy.push(orderBy);
+  }
+  if (props.select === "rows" && orderBy?.column !== "id") {
+    eventsScoresOrderBy.push({ column: "id", order: "DESC" });
+  }
+
   const query = `
       ${tracesCTEClause}
       SELECT
@@ -1581,7 +1604,7 @@ const getScoresUiGenericFromEvents = async <T>(props: {
       WHERE s.project_id = {projectId: String}
       AND s.data_type IN ({dataTypes: Array(String)})
       ${scoreOnlyFilterRes?.query ? `AND ${scoreOnlyFilterRes.query}` : ""}
-      ${orderByToClickhouseSql(orderBy ?? null, scoresTableUiColumnDefinitionsFromEvents)}
+      ${orderByToClickhouseSql(eventsScoresOrderBy.length > 0 ? eventsScoresOrderBy : null, scoresTableUiColumnDefinitionsFromEvents)}
       ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -328,8 +328,19 @@ const getSessionsTableFromEventsGeneric = async <T>(
     queryBuilder.whereRaw(sessionsFilterRes.query, sessionsFilterRes.params);
   }
 
+  // Append the unique session_id as a tiebreaker so offset-based pagination
+  // is stable when sessions share the same sort-column value. The count
+  // query is a single aggregate row, so it must not receive the extra clause.
+  const eventsSessionsOrderBy: OrderByState[] = [];
+  if (orderBy) {
+    eventsSessionsOrderBy.push(orderBy);
+  }
+  if (select !== "count" && orderBy?.column !== "id") {
+    eventsSessionsOrderBy.push({ column: "id", order: "DESC" });
+  }
+
   const orderBySql = orderByToClickhouseSql(
-    orderBy ?? null,
+    eventsSessionsOrderBy.length > 0 ? eventsSessionsOrderBy : null,
     sessionEventsOrderByCols,
   );
   if (orderBySql) {

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -287,6 +287,18 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
   )`;
 
   // We use deduplicated traces and observations CTEs instead of final to be able to use Skip indices in Clickhouse.
+  // Append the unique session_id as a tiebreaker so offset-based pagination
+  // is stable when sessions share the same sort-column value (e.g. the
+  // creation-time derived createdAt). The count query is a single aggregate
+  // row, so it must not receive the extra clause.
+  const sessionsOrderBy: OrderByState[] = [];
+  if (orderBy) {
+    sessionsOrderBy.push(orderBy);
+  }
+  if (select !== "count" && orderBy?.column !== "id") {
+    sessionsOrderBy.push({ column: "id", order: "DESC" });
+  }
+
   const query = `
         WITH ${select === "metrics" || requiresScoresJoin ? `${scoresCte},` : ""}
         deduplicated_traces AS (
@@ -374,7 +386,7 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
         SELECT ${sqlSelect}
         FROM session_data s
         WHERE ${tracesFilterRes.query ? tracesFilterRes.query : ""}
-        ${orderByToClickhouseSql(orderBy ?? null, sessionCols)}
+        ${orderByToClickhouseSql(sessionsOrderBy.length > 0 ? sessionsOrderBy : null, sessionCols)}
         ${limit !== undefined && page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
         `;
 

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -1031,14 +1031,19 @@ describe("batch export test suite", () => {
     // Should only include scores with names "accuracy" or "relevance"
     expect(rows).toHaveLength(3);
 
-    // Verify the scores are sorted by timestamp ASC
-    expect(rows[0].name).toBe("accuracy");
-    expect(rows[0].value).toBe(0.85);
-    expect(rows[0].traceId).toBe(traces[0].id);
-
-    expect(rows[1].name).toBe("relevance");
-    expect(rows[1].value).toBe(0.75);
-    expect(rows[1].traceId).toBe(traces[0].id);
+    // Verify the scores are sorted by timestamp ASC. The two 2024-01-01
+    // scores share a timestamp and tie-break on the unique score id, so
+    // assert them as an unordered pair rather than relying on insertion
+    // order.
+    const firstDayRows = rows.slice(0, 2);
+    expect(firstDayRows.map((r) => r.name).sort()).toEqual([
+      "accuracy",
+      "relevance",
+    ]);
+    expect(firstDayRows.map((r) => r.value).sort()).toEqual([0.75, 0.85]);
+    firstDayRows.forEach((r) => {
+      expect(r.traceId).toBe(traces[0].id);
+    });
 
     expect(rows[2].name).toBe("accuracy");
     expect(rows[2].value).toBe(0.92);
@@ -5174,5 +5179,143 @@ maybeDescribe("getEventsForBlobStorageExport", () => {
     expect(Object.keys(rows[0]).sort()).toEqual(expectedColumns);
     expect(rows[0].input).toBe("hello");
     expect(rows[0].output).toBe("world");
+  });
+
+  it("should export observations without duplicates or omissions when observations share a start_time", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // ClickHouse batch page size is 500 (BATCH_EXPORT_PAGE_SIZE default).
+    // Insert more observations than a single page, all sharing the same
+    // start_time, so offset-based pagination must resolve ordering ties
+    // deterministically via the observation-id tiebreaker instead of
+    // duplicating or omitting rows across page boundaries.
+    const sharedStartTime = new Date("2024-02-14T12:00:00Z").getTime();
+    const traceId = randomUUID();
+    await createTracesCh([
+      createTrace({
+        project_id: projectId,
+        id: traceId,
+        timestamp: sharedStartTime,
+      }),
+    ]);
+
+    const observationCount = 550;
+    const observations = Array.from({ length: observationCount }, () =>
+      createObservation({
+        project_id: projectId,
+        trace_id: traceId,
+        id: randomUUID(),
+        type: "GENERATION",
+        start_time: sharedStartTime,
+      }),
+    );
+    await createObservationsCh(observations);
+
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId,
+      tableName: BatchExportTableName.Observations,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+      orderBy: { column: "startTime", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    const returnedIds = rows.map((r) => r.id);
+    expect(new Set(returnedIds).size).toBe(observationCount);
+    expect(rows).toHaveLength(observationCount);
+  });
+
+  it("should export scores without duplicates or omissions when scores share a timestamp", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // ClickHouse batch page size is 500 (BATCH_EXPORT_PAGE_SIZE default).
+    // Insert more scores than a single page, all sharing the same
+    // timestamp, so offset-based pagination must resolve ordering ties
+    // deterministically via the score-id tiebreaker instead of
+    // duplicating or omitting rows across page boundaries.
+    const sharedTimestamp = new Date("2024-02-15T12:00:00Z").getTime();
+    const traceId = randomUUID();
+    await createTracesCh([
+      createTrace({
+        project_id: projectId,
+        id: traceId,
+        timestamp: sharedTimestamp,
+      }),
+    ]);
+
+    const scoreCount = 550;
+    const scores = Array.from({ length: scoreCount }, () =>
+      createTraceScore({
+        project_id: projectId,
+        trace_id: traceId,
+        id: randomUUID(),
+        name: "pagination-tiebreaker",
+        value: 1,
+        timestamp: sharedTimestamp,
+      }),
+    );
+    await createScoresCh(scores);
+
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId,
+      tableName: BatchExportTableName.Scores,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+      orderBy: { column: "timestamp", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    const returnedIds = rows.map((r) => r.id);
+    expect(new Set(returnedIds).size).toBe(scoreCount);
+    expect(rows).toHaveLength(scoreCount);
+  });
+
+  it("should export sessions without duplicates or omissions when sessions share a creation timestamp", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // ClickHouse batch page size is 500 (BATCH_EXPORT_PAGE_SIZE default).
+    // Insert more sessions than a single page, all sharing the same
+    // min_timestamp, so offset-based pagination must resolve ordering
+    // ties deterministically via the session_id tiebreaker instead of
+    // duplicating or omitting rows across page boundaries.
+    const sharedTimestamp = new Date("2024-02-16T12:00:00Z").getTime();
+
+    const sessionCount = 550;
+    const traces = Array.from({ length: sessionCount }, () => {
+      const traceId = randomUUID();
+      const sessionId = randomUUID();
+      return createTrace({
+        project_id: projectId,
+        id: traceId,
+        session_id: sessionId,
+        timestamp: sharedTimestamp,
+      });
+    });
+    await createTracesCh(traces);
+
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId,
+      tableName: BatchExportTableName.Sessions,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+      orderBy: { column: "createdAt", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    const returnedIds = rows.map((r) => r.id);
+    expect(new Set(returnedIds).size).toBe(sessionCount);
+    expect(rows).toHaveLength(sessionCount);
   });
 });


### PR DESCRIPTION
## Problem

Batch exports page through ClickHouse with offset pagination, ordered by the user's chosen (non-unique) column. When many rows share a value in that column (e.g. the same timestamp), ClickHouse returns ties in an unspecified order, so rows can be duplicated or dropped across page boundaries. This is the same class of bug already addressed for traces exports with an `event_ts` tiebreaker.

## Changes

Append the unique row id as a secondary `DESC` sort key after the user's `orderBy` in the row queries. Count selects return a single aggregate row and are left unchanged:

- **scores**: `getScoresUiGeneric` and `getScoresUiGenericFromEvents`
- **sessions**: `getSessionsTableGeneric` and `getSessionsTableFromEventsGeneric`
- **observations**: `getObservationsTableInternal` (keeps the existing `order_by_date` performance optimization first)

## Tests

- Added three worker integration tests that insert 550 rows sharing a timestamp (forcing a page split at `BATCH_EXPORT_PAGE_SIZE=500`) and assert the export returns every row exactly once, for scores, sessions and observations.
- Reverting only the fix makes the scores and sessions tests fail (duplicate/dropped rows), confirming they guard the regression.
- One existing scores export test asserted insertion order for two rows sharing a timestamp; it now asserts them as an unordered pair since ties resolve by score id.
- Full `batchExport.test.ts` suite passes (79/79), and the affected web servertests (`sessions-ui-table`, `score-repository`) pass as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared ClickHouse list/export query ordering used by UI tables and batch exports; behavior change for tied sort keys (deterministic by id) but count queries are excluded and scope matches an existing traces tiebreaker pattern.
> 
> **Overview**
> Fixes **duplicate or missing rows** in batch exports (and UI list queries that share the same ClickHouse `ORDER BY` + `LIMIT`/`OFFSET` paths) when many rows share the same sort key (e.g. `timestamp`, `startTime`, `createdAt`).
> 
> Row queries now append a secondary **`id DESC`** sort after the user’s `orderBy`, so tie ordering is deterministic across pages. **Count** selects are unchanged (single aggregate row). Observations keep the existing `order_by_date` optimization when sorting by `startTime`.
> 
> Coverage spans **observations** (`getObservationsTableInternal`), **scores** (legacy + events UI generic queries), and **sessions** (legacy + events table services). Worker tests insert 550 rows with identical timestamps to force a page split at batch size 500 and assert every id appears exactly once; an existing scores export test now treats same-timestamp rows as an unordered pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8efa97f65751797ecd44fec8a6bf037311698061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Stabilizes offset-based ClickHouse pagination for score, session, and observation exports by adding unique IDs as secondary sort keys.
- Adds deterministic score-ID ordering to legacy and events-table score queries.
- Adds deterministic session-ID ordering to legacy and events-table session queries.
- Adds deterministic observation-ID ordering while retaining the date-based optimization.
- Adds integration coverage for page-boundary ties across all three export types.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with deterministic unique-ID ordering consistently applied to the affected paginated row queries.

The secondary keys resolve to valid unique identifiers in each ClickHouse query shape, count queries remain unchanged, and the new integration tests exercise ties spanning multiple export pages.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Export[Batch export stream] --> Query[ClickHouse row query]
  Query --> Sort[Sort by requested column]
  Sort --> Tie[Break ties by unique row ID DESC]
  Tie --> Page[Apply LIMIT and OFFSET]
  Page --> Result[Stable pages without duplicates or omissions]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(batch-export): stabilize scores, ses..."](https://github.com/langfuse/langfuse/commit/8efa97f65751797ecd44fec8a6bf037311698061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51095634)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)

<!-- /greptile_comment -->