### PR TITLE
fix(dashboard): round costs to cents

### DIFF
--- a/web/src/utils/numbers.clienttest.ts
+++ b/web/src/utils/numbers.clienttest.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { costFormatter } from "@/src/utils/numbers";
+
+describe("costFormatter", () => {
+  it("formats dashboard costs with cent precision", () => {
+    expect(costFormatter(4.402973)).toBe("$4.40");
+    expect(costFormatter(0.068415)).toBe("$0.07");
+    expect(costFormatter(0.015427)).toBe("$0.02");
+    expect(costFormatter(0)).toBe("$0.00");
+  });
+});

--- a/web/src/utils/numbers.ts
+++ b/web/src/utils/numbers.ts
@@ -77,11 +77,7 @@ export const usdFormatter = (
 };
 
 export const costFormatter = (totalCost?: number) => {
-  return totalCost
-    ? totalCost < 5
-      ? usdFormatter(totalCost, 2, 6)
-      : usdFormatter(totalCost, 2, 2)
-    : usdFormatter(0);
+  return usdFormatter(totalCost, 2, 2);
 };
 
 export const formatTokenCounts = (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15866.preview.langfuse.com](https://pr-15866.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- render dashboard cost totals and breakdowns with exactly two decimal places
- keep the general USD formatter's sub-cent capability unchanged for non-dashboard surfaces
- add a focused client regression test using the reported cost values

## Why

Dashboard aggregates below $5 were shown with up to six decimals, producing noisy values such as `$4.402973` and `$0.068415`. Aggregate dashboard cards should be quickly scannable and use normal cent precision.

Root cause: the dashboard `costFormatter` explicitly switched to six maximum fraction digits for every non-zero value below $5.

## Impact

Dashboard cost widgets that use `costFormatter` now show values such as:

- `$4.402973` → `$4.40`
- `$0.068415` → `$0.07`
- `$0.015427` → `$0.02`

Raw values, queries, aggregation, APIs, ingestion, and pricing are unchanged.

Linear: [LF-80](https://linear.app/clickhouse/issue/LF-80/dashboard-cost-totals-show-excessive-decimal-precision)

## Verification

- `pnpm exec dotenv -e .env.dev.example -- pnpm --filter web run test-client src/utils/numbers.clienttest.ts` — `Tests  1 passed (1)`
- `pnpm --filter web exec eslint 'src/utils/numbers.ts' 'src/utils/numbers.clienttest.ts' --max-warnings 0` — passed with no output
- `pnpm exec prettier --check 'web/src/utils/numbers.ts' 'web/src/utils/numbers.clienttest.ts'` — `All matched files use Prettier code style!`
- `git diff --check` — passed with no output

Repository-wide `pnpm --filter web run lint` was also attempted. It reported `0 errors` and 574 pre-existing warnings in unrelated files, then failed because the command enforces `--max-warnings 0`. The changed files pass targeted ESLint.

Browser review was not run because Docker is unavailable locally, so the seeded dashboard data stack could not be started.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting in dashboard widgets; no API, aggregation, or pricing logic changes.
> 
> **Overview**
> Dashboard cost display now always shows **two decimal places** instead of up to six for amounts under $5.
> 
> `costFormatter` no longer branches on a $5 threshold; it always calls `usdFormatter` with min/max fraction digits of 2, so totals and breakdowns read like `$4.40` and `$0.07` instead of long fractional strings. The shared `usdFormatter` default (up to six decimals) is unchanged for other surfaces.
> 
> A **Vitest** regression test locks in the reported examples plus `$0.00`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b6b7b447d3f8b9caa139076245ac37615e9ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR standardizes dashboard cost totals and breakdowns to exactly two decimal places while preserving the general USD formatter’s sub-cent precision.
- Simplifies `costFormatter` to consistently request two fraction digits.
- Adds focused regression coverage for reported low-cost values and zero.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The changed formatter preserves nullish-input handling through `usdFormatter`, affects only dashboard aggregate call sites, and implements the explicitly documented cent-rounding behavior with focused regression coverage.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): round costs to cents"](https://github.com/langfuse/langfuse/commit/54b6b7b447d3f8b9caa139076245ac37615e9ca9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51146750)</sub>

<!-- /greptile_comment -->