### PR TITLE
fix(v4): prevent project overview layout shift; change deprecation date to Oct 9

### DIFF
--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -49,11 +49,11 @@ const OrganizationProjectTiles = ({
   search?: string;
 }) => {
   const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
-  const { data: lastTraceTimes } =
-    api.organizations.lastTraceByProject.useQuery(
-      { orgId: org.id },
-      { enabled: v4UpgradeUiEnabled },
-    );
+  const lastTraceQuery = api.organizations.lastTraceByProject.useQuery(
+    { orgId: org.id },
+    { enabled: v4UpgradeUiEnabled },
+  );
+  const { data: lastTraceTimes } = lastTraceQuery;
   const migrationStatusByProjectId = useAccountV4MigrationData({
     organizations: [
       {
@@ -104,14 +104,16 @@ const OrganizationProjectTiles = ({
               {!project.deletedAt && (
                 <CardContent className="min-h-7 pb-3">
                   <p className="text-muted-foreground text-xs">
-                    {(() => {
-                      const lastTraceAt = lastTraceTimes?.find(
-                        (t) => t.projectId === project.id,
-                      )?.lastTraceAt;
-                      return lastTraceAt
-                        ? `Last trace ${formatCompactRelativeTime(new Date(lastTraceAt))}`
-                        : "No traces in the last 30d";
-                    })()}
+                    {lastTraceQuery.isSuccess
+                      ? (() => {
+                          const lastTraceAt = lastTraceTimes.find(
+                            (t) => t.projectId === project.id,
+                          )?.lastTraceAt;
+                          return lastTraceAt
+                            ? `Last trace ${formatCompactRelativeTime(new Date(lastTraceAt))}`
+                            : "No traces in the last 30d";
+                        })()
+                      : null}
                   </p>
                 </CardContent>
               )}

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -101,11 +101,11 @@ const OrganizationProjectTiles = ({
                   )}
                 </div>
               </CardHeader>
-              {!project.deletedAt && lastTraceTimes && (
-                <CardContent className="pb-3">
+              {!project.deletedAt && (
+                <CardContent className="min-h-7 pb-3">
                   <p className="text-muted-foreground text-xs">
                     {(() => {
-                      const lastTraceAt = lastTraceTimes.find(
+                      const lastTraceAt = lastTraceTimes?.find(
                         (t) => t.projectId === project.id,
                       )?.lastTraceAt;
                       return lastTraceAt

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -53,7 +53,6 @@ const OrganizationProjectTiles = ({
     { orgId: org.id },
     { enabled: v4UpgradeUiEnabled },
   );
-  const { data: lastTraceTimes } = lastTraceQuery;
   const migrationStatusByProjectId = useAccountV4MigrationData({
     organizations: [
       {
@@ -106,7 +105,7 @@ const OrganizationProjectTiles = ({
                   <p className="text-muted-foreground text-xs">
                     {lastTraceQuery.isSuccess
                       ? (() => {
-                          const lastTraceAt = lastTraceTimes.find(
+                          const lastTraceAt = lastTraceQuery.data?.find(
                             (t) => t.projectId === project.id,
                           )?.lastTraceAt;
                           return lastTraceAt

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -401,7 +401,7 @@ describe("V4MigrationHeaderContent", () => {
         titleRowClassName="pr-6"
       />,
     );
-    const link = screen.getByRole("link", { name: "View Status" });
+    const link = screen.getByRole("link", { name: "View Org status" });
     expect(link).toHaveAttribute("href", "/v4-migration");
     expect(link.parentElement).toHaveClass("pr-6");
   });

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -52,7 +52,7 @@ import { api, reportNonTrpcError } from "@/src/utils/api";
 // (side panel and modal) render these components — edit copy here only.
 
 const V4_DOCS_URL = "https://langfuse.com/docs/v4";
-const V4_MIGRATION_DEADLINE = "Oct 31";
+export const V4_MIGRATION_DEADLINE = "Oct 31";
 const SDK_UPGRADE_URL =
   "https://langfuse.com/docs/observability/sdk/upgrade-path";
 const OTEL_V4_MIGRATION_URL =

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -52,6 +52,7 @@ import { api, reportNonTrpcError } from "@/src/utils/api";
 // (side panel and modal) render these components — edit copy here only.
 
 const V4_DOCS_URL = "https://langfuse.com/docs/v4";
+const V4_MIGRATION_DEADLINE = "October 31";
 const SDK_UPGRADE_URL =
   "https://langfuse.com/docs/observability/sdk/upgrade-path";
 const OTEL_V4_MIGRATION_URL =
@@ -421,7 +422,7 @@ export function V4MigrationHeaderContent({
           }}
           className="shrink-0 text-sm underline"
         >
-          View Status
+          View Org status
         </Link>
       </div>
       <p className="text-muted-foreground mb-3 text-sm leading-relaxed">
@@ -431,7 +432,7 @@ export function V4MigrationHeaderContent({
         is here: real-time, up to 165× faster, plus new dashboards, alerting,
         sessions, and trace view.
         {needsMigration &&
-          " This project still uses the previous setup, which stops working soon."}
+          ` This project still uses the previous setup, which stops working on ${V4_MIGRATION_DEADLINE}.`}
       </p>
       <div className="flex flex-col gap-2">
         {promptVisible && (
@@ -589,7 +590,7 @@ export function V4MigrationDetailsContent({
           </a>
         </div>
         <p className="text-muted-foreground text-sm">
-          Some features will stop working soon.
+          Some features will stop working on {V4_MIGRATION_DEADLINE}.
         </p>
         <div>
           <V4MigrationSdkSection sdk={migrationData.sdk} />
@@ -621,7 +622,7 @@ export function V4MigrationDetailsContent({
                   trace input/output, which{" "}
                   <span className="text-dark-yellow">
                     {migrationData.evals.count === 1 ? "stops" : "stop"} running
-                    soon
+                    on {V4_MIGRATION_DEADLINE}
                   </span>
                   . Repointing {migrationData.evals.count === 1 ? "it" : "them"}{" "}
                   at observations or experiments requires minimal changes
@@ -745,7 +746,8 @@ export function V4MigrationDetailsContent({
               <>
                 <p className="text-muted-foreground mb-2 text-sm">
                   You&apos;ve called these deprecated endpoints in the last{" "}
-                  {V4_MIGRATION_LOOKBACK_DAYS} days. They stop working soon; the{" "}
+                  {V4_MIGRATION_LOOKBACK_DAYS} days. They stop working on{" "}
+                  {V4_MIGRATION_DEADLINE}; the{" "}
                   <ExternalLink href={DEPRECATED_API_MIGRATION_URL}>
                     migration guide
                   </ExternalLink>{" "}

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -52,7 +52,7 @@ import { api, reportNonTrpcError } from "@/src/utils/api";
 // (side panel and modal) render these components — edit copy here only.
 
 const V4_DOCS_URL = "https://langfuse.com/docs/v4";
-const V4_MIGRATION_DEADLINE = "October 31";
+const V4_MIGRATION_DEADLINE = "Oct 31";
 const SDK_UPGRADE_URL =
   "https://langfuse.com/docs/observability/sdk/upgrade-path";
 const OTEL_V4_MIGRATION_URL =

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -411,7 +411,10 @@ export function V4MigrationHeaderContent({
           titleRowClassName,
         )}
       >
-        <p className="min-w-0 text-lg font-bold">
+        <p
+          className="min-w-0 flex-1 truncate text-lg font-bold"
+          title={projectName ? `Migrate ${projectName} to v4` : "Migrate to v4"}
+        >
           {projectName ? <>Migrate {projectName} to v4</> : "Migrate to v4"}
         </p>
         <Link

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -52,7 +52,7 @@ import { api, reportNonTrpcError } from "@/src/utils/api";
 // (side panel and modal) render these components — edit copy here only.
 
 const V4_DOCS_URL = "https://langfuse.com/docs/v4";
-export const V4_MIGRATION_DEADLINE = "Oct 31";
+export const V4_MIGRATION_DEADLINE = "Oct 9";
 const SDK_UPGRADE_URL =
   "https://langfuse.com/docs/observability/sdk/upgrade-path";
 const OTEL_V4_MIGRATION_URL =

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -67,6 +67,7 @@ vi.mock("@/src/features/in-app-agent/components/InAppAiAgentProvider", () => ({
 }));
 
 vi.mock("@/src/features/v4-migration/V4MigrationContent", () => ({
+  V4_MIGRATION_DEADLINE: "Oct 31",
   useCopyMigrationPrompt: () => vi.fn(),
 }));
 

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -67,7 +67,7 @@ vi.mock("@/src/features/in-app-agent/components/InAppAiAgentProvider", () => ({
 }));
 
 vi.mock("@/src/features/v4-migration/V4MigrationContent", () => ({
-  V4_MIGRATION_DEADLINE: "Oct 31",
+  V4_MIGRATION_DEADLINE: "Oct 9",
   useCopyMigrationPrompt: () => vi.fn(),
 }));
 

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -13,7 +13,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/src/components/ui/table";
-import { useCopyMigrationPrompt } from "@/src/features/v4-migration/V4MigrationContent";
+import {
+  useCopyMigrationPrompt,
+  V4_MIGRATION_DEADLINE,
+} from "@/src/features/v4-migration/V4MigrationContent";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { api } from "@/src/utils/api";
 import { formatCompactRelativeTime } from "@/src/utils/dates";
@@ -491,8 +494,8 @@ function V4MigrationStatusPageContent() {
           Yes, eventually. The{" "}
           <FaqLink href={SDK_UPGRADE_URL}>old SDKs</FaqLink>, trace-level evals,
           and APIs are frozen and stop working{" "}
-          <span className="underline">soon</span>. They keep running until then,
-          but we&apos;re no longer fixing bugs in them.
+          <span className="underline">{V4_MIGRATION_DEADLINE}</span>. They keep
+          running until then, but we&apos;re no longer fixing bugs in them.
         </>
       ),
     },
@@ -517,8 +520,8 @@ function V4MigrationStatusPageContent() {
       q: "What if I do nothing?",
       a: (
         <>
-          <span className="underline">Soon</span>, old SDKs stop sending data,
-          and the{" "}
+          <span className="underline">{V4_MIGRATION_DEADLINE}</span>, old SDKs
+          stop sending data, and the{" "}
           <FaqLink href={API_REFERENCE_URL}>
             deprecated evals and endpoints
           </FaqLink>{" "}

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -494,8 +494,8 @@ function V4MigrationStatusPageContent() {
           Yes, eventually. The{" "}
           <FaqLink href={SDK_UPGRADE_URL}>old SDKs</FaqLink>, trace-level evals,
           and APIs are frozen and stop working{" "}
-          <span className="underline">{V4_MIGRATION_DEADLINE}</span>. They keep
-          running until then, but we&apos;re no longer fixing bugs in them.
+          <span className="underline">on {V4_MIGRATION_DEADLINE}</span>. They
+          keep running until then, but we&apos;re no longer fixing bugs in them.
         </>
       ),
     },
@@ -520,8 +520,8 @@ function V4MigrationStatusPageContent() {
       q: "What if I do nothing?",
       a: (
         <>
-          <span className="underline">{V4_MIGRATION_DEADLINE}</span>, old SDKs
-          stop sending data, and the{" "}
+          <span className="underline">On {V4_MIGRATION_DEADLINE}</span>, old
+          SDKs stop sending data, and the{" "}
           <FaqLink href={API_REFERENCE_URL}>
             deprecated evals and endpoints
           </FaqLink>{" "}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15869.preview.langfuse.com](https://pr-15869.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- reserve the project overview trace-status row while its data loads to prevent layout shift
- replace the v4 migration modal's "soon" deadline copy with Oct 31
- rename "View Status" to "View Org status"
- truncate long migration titles on one line while preserving the full title in the native tooltip

## Verification

- `pnpm run format`
- Skipped lint and tests per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and layout-only changes in v4 migration and project overview UI; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **layout shift** on the org project overview by always rendering the trace-status row for active projects (`min-h-7`) and only filling in “last trace” text after `lastTraceByProject` succeeds, instead of mounting that block only when data exists.
> 
> Centralizes v4 deprecation messaging with **`V4_MIGRATION_DEADLINE` (`Oct 9`)** and replaces vague “soon” copy in the migration panel, details sections (evals, deprecated APIs), and status-page FAQ. Renames the panel link to **“View Org status”** and **truncates** long migration titles on one line with the full title in the native `title` tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85c590aaa566a35168be25eff8481243a9eb8d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->