### PR TITLE
style(tracing): separate pulse chart with a top border (LFE-14829)

### DIFF
--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -382,7 +382,9 @@ export function EventsOutlierStrip({
   // needs the width, so painting before the first measurement would flash a
   // skeleton sized for nothing.
   return (
-    <div ref={wrapperRef} className="shrink-0 border-b">
+    // Ruled top and bottom (LFE-14829): the strip reads as its own band
+    // instead of floating between the toolbar and the table header.
+    <div ref={wrapperRef} className="shrink-0 border-y">
       {size === undefined ? null : (
         <div className="relative px-2 pt-1 pb-1">
           {!canApplyFilters ? (

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -386,7 +386,9 @@ export function EventsOutlierStrip({
     // instead of floating between the toolbar and the table header.
     <div ref={wrapperRef} className="shrink-0 border-y">
       {size === undefined ? null : (
-        <div className="relative px-2 pt-1 pb-1">
+        // pt-3 keeps the metric switcher off the top rule; the label then sits
+        // closer to its chart (mt-2) than to the band's edge.
+        <div className="relative px-2 pt-3 pb-1">
           {!canApplyFilters ? (
             <div>
               <div className="flex items-baseline gap-1.5">

--- a/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/EventsOutlierStrip.tsx
@@ -99,7 +99,7 @@ const AggDropdown = ({
       <DropdownMenu>
         <DropdownMenuTrigger
           aria-label={`${metricLabel} aggregation: ${value}`}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-[13px] leading-none underline-offset-2 hover:underline"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-xs leading-none underline-offset-2 hover:underline"
         >
           {value}
           <ChevronDown className="h-2.5 w-2.5" />
@@ -140,7 +140,8 @@ const ModeDropdown = ({
     <DropdownMenu>
       <DropdownMenuTrigger
         aria-label={`Chart mode: ${modeLabel(value)}`}
-        className="text-foreground hover:text-muted-foreground flex items-center gap-0.5 text-[13px] leading-none font-bold"
+        // Same typography as the Table/Chart tabs (toggleVariants + text-xs).
+        className="text-foreground hover:text-muted-foreground flex items-center gap-0.5 text-xs leading-none font-bold"
       >
         {modeLabel(value)}
         <ChevronDown className="h-2.5 w-2.5" />
@@ -386,9 +387,9 @@ export function EventsOutlierStrip({
     // instead of floating between the toolbar and the table header.
     <div ref={wrapperRef} className="shrink-0 border-y">
       {size === undefined ? null : (
-        // pt-3 keeps the metric switcher off the top rule; the label then sits
-        // closer to its chart (mt-2) than to the band's edge.
-        <div className="relative px-2 pt-3 pb-1">
+        // pt-2.5 keeps the metric switcher off the top rule; the label then
+        // sits closer to its chart (mt-1.5) than to the band's edge.
+        <div className="relative px-2 pt-2.5 pb-1">
           {!canApplyFilters ? (
             <div>
               <div className="flex items-baseline gap-1.5">
@@ -399,7 +400,7 @@ export function EventsOutlierStrip({
                 />
               </div>
               <OutlierBarStrip
-                className="mt-2"
+                className="mt-1.5"
                 dense={[]}
                 maxValue={0}
                 ticks={[]}
@@ -445,7 +446,7 @@ export function EventsOutlierStrip({
                 )}
               </div>
               <OutlierBarStrip
-                className="mt-2"
+                className="mt-1.5"
                 dense={series.dense}
                 maxValue={series.maxValue}
                 ticks={series.ticks}

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.stories.tsx
@@ -126,6 +126,18 @@ export const NoMetricData = meta.story({
   },
 });
 
+/** Nothing in the window at all. The notice centers on the bar canvas, so it
+ * sits in the plot's middle rather than drifting into the time-label band
+ * (LFE-14829). */
+export const EmptyRange = meta.story({
+  args: {
+    ...spikyCount,
+    dense: spikyCount.dense.map((bin) => ({ ...bin, value: null, count: 0 })),
+    maxValue: 0,
+    metric: "count",
+  },
+});
+
 export const MinimalNoLabels = meta.story({
   args: {
     ...spikyCost,

--- a/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
+++ b/web/src/features/events/components/outlier-strip/OutlierBarStrip.tsx
@@ -539,7 +539,12 @@ export function OutlierBarStrip({
       </svg>
 
       {!hasData && (
-        <span className="text-muted-foreground/70 pointer-events-none absolute inset-0 flex items-center justify-center text-[10px]">
+        // Centered on the bar canvas, not the svg: inset-0 would include the
+        // time-label band and push the notice below the plot's middle.
+        <span
+          className="text-muted-foreground/70 pointer-events-none absolute inset-x-0 top-0 flex items-center justify-center text-[10px]"
+          style={{ height: heightPx }}
+        >
           {hasActivity
             ? `No ${metricSpec.shortLabel.toLowerCase()} data in range`
             : "No observations in range"}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15870.preview.langfuse.com](https://pr-15870.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

**TL;DR** — The pulse strip above the Tracing table now has a hairline on top as well as underneath, so the chart reads as its own band instead of floating under the toolbar. One-class change (`border-b` → `border-y`).

## Why

The strip only had a bottom border. With nothing above it, its plot area butted straight into the table toolbar row (`Quality · Slow · Cost · My Views · Table/Chart … Columns`), so toolbar, chart and table header read as one undifferentiated stack — there was no visual answer to "where does the chart begin?".

## What

Rule the strip's wrapper on both edges (`border-y`, the design-system `--border` token — same hairline the bottom edge already used). The border lives on the strip's own container, so it appears and disappears with the strip: Chart mode and the scoped surfaces that hide the strip leave no orphan line, and the disabled / loading / error states inside the band inherit the same frame.

The rule spans the table column, not the whole content width — matching the existing bottom border and keeping the facet sidebar's full-height treatment intact.

<details>
<summary>Verification</summary>

Checked live at 1440×900 on the Tracing page with ~106K observations over 7 days:

- **Light**: `border-top: 1px solid rgb(226, 232, 240)` — visible hairline between the toolbar and the `Count ⌄` label.
- **Dark**: `rgb(38, 38, 38)` on a `rgb(15, 15, 15)` surface — present but not harsh, identical to every other border on the page.
- **Geometry**: the ruled wrapper spans the table column exactly (left edge flush with the table, 962px of a 1440px viewport), so no new horizontal overflow.
- **Chart mode**: `ruledWrappers: 0`, `stripCount: 0` — the strip and its borders unmount together, no orphan line.

`pnpm --filter=web run typecheck` clean; `turbo run lint` → `Tasks: 7 successful, 7 total`. No test changes — the strip's tests cover `lib/binning` + `lib/filterCompatibility` (pure), and this touches neither.

</details>

Closes LFE-14829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and empty-state positioning in the outlier strip; no query, filter, or drill behavior changes.
> 
> **Overview**
> The **Pulse** outlier strip above the Tracing table is framed as its own band: the wrapper uses **`border-y`** instead of **`border-b`**, with slightly more top padding and tighter spacing between the metric controls and the chart. Dropdown triggers use **`text-xs`** so they match the Table/Chart tab typography.
> 
> When there is no data in range, the empty notice is vertically centered on the **bar plot only** (fixed height on the overlay), not the full SVG including time labels. A Storybook **`EmptyRange`** story documents that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f0add9ce9fbb85e7e9d45b4db0fce7509142f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The tracing pulse strip is visually separated from adjacent controls by replacing its bottom-only border with matching top and bottom borders.
- Changes the wrapper utility from `border-b` to `border-y`.
- Adds an inline explanation referencing LFE-14829.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change only extends an existing wrapper border to both vertical edges and does not alter component behavior or state.
</details>

<sub>Reviews (1): Last reviewed commit: ["style(tracing): separate pulse chart wit..."](https://github.com/langfuse/langfuse/commit/52bceac832467c76465a6299eadd8b03f2198721) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51121467)</sub>

<!-- /greptile_comment -->