### PR TITLE
fix(tables): use full row height for Input/Output cells (LFE-14586)

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2513,15 +2513,19 @@ export const getObservationsBatchIOFromEventsTable = async <
   const outputSelect = charLimit
     ? `leftUTF8(e.output, ${charLimit}) as output`
     : `e.output as output`;
-  // events_core already stores metadata values pre-truncated; on a full read
-  // cap them alongside I/O so an explicit limit bounds the whole payload.
-  const metadataValues = fullReadCharLimit
-    ? `arrayMap(v -> leftUTF8(v, ${fullReadCharLimit}), e.metadata_values)`
-    : `e.metadata_values`;
+  // events_core already stores these pre-truncated, so only a full read needs
+  // capping — an explicit limit has to bound every large field, not just I/O.
+  const capOnFullRead = (expr: string) =>
+    fullReadCharLimit ? `leftUTF8(${expr}, ${fullReadCharLimit})` : expr;
+  const capEachOnFullRead = (expr: string) =>
+    fullReadCharLimit
+      ? `arrayMap(v -> leftUTF8(v, ${fullReadCharLimit}), ${expr})`
+      : expr;
+  const metadataValues = capEachOnFullRead("e.metadata_values");
   const experimentFieldsSelect = opts.includeExperimentFields
     ? `
-      experiment_item_expected_output,
-      mapFromArrays(arrayReverse(e.experiment_item_metadata_names), arrayReverse(e.experiment_item_metadata_values)) as experiment_item_metadata,
+      ${capOnFullRead("e.experiment_item_expected_output")} as experiment_item_expected_output,
+      mapFromArrays(arrayReverse(e.experiment_item_metadata_names), arrayReverse(${capEachOnFullRead("e.experiment_item_metadata_values")})) as experiment_item_metadata,
     `
     : "";
   const toolCallFieldsSelect = opts.includeToolCallFields

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2470,6 +2470,12 @@ export const getObservationsBatchIOFromEventsTable = async <
   minStartTime: Date;
   maxStartTime: Date;
   truncated?: boolean; // Default true for performance, false for full data
+  /**
+   * Chars of I/O and of each metadata value to ship on a full read. Lets a
+   * caller that needs more than events_core's pre-truncated I/O still bound
+   * the payload. Ignored for truncated reads (events_core caps far tighter).
+   */
+  ioCharLimit?: number;
   includeExperimentFields?: TIncludeExperiment;
   /** Opt-in: tool-call arrays can be large; only eval consumers need them. */
   includeToolCallFields?: TIncludeToolCalls;
@@ -2481,6 +2487,12 @@ export const getObservationsBatchIOFromEventsTable = async <
   }
 
   const truncated = opts.truncated ?? true;
+  // Interpolated into SQL, so coerce to a positive integer here rather than
+  // trusting the caller's number.
+  const fullReadCharLimit =
+    !truncated && opts.ioCharLimit !== undefined
+      ? Math.max(1, Math.trunc(opts.ioCharLimit))
+      : undefined;
 
   // Extract IDs and trace IDs for filtering
   const observationIds = opts.observations.map((o) => o.id);
@@ -2492,12 +2504,20 @@ export const getObservationsBatchIOFromEventsTable = async <
 
   // Use events_core for truncated reads (lightweight), events_full for full I/O
   const tableName = truncated ? "events_core" : "events_full";
-  const inputSelect = truncated
-    ? `leftUTF8(e.input, ${env.LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT}) as input`
+  const charLimit = truncated
+    ? env.LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT
+    : fullReadCharLimit;
+  const inputSelect = charLimit
+    ? `leftUTF8(e.input, ${charLimit}) as input`
     : `e.input as input`;
-  const outputSelect = truncated
-    ? `leftUTF8(e.output, ${env.LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT}) as output`
+  const outputSelect = charLimit
+    ? `leftUTF8(e.output, ${charLimit}) as output`
     : `e.output as output`;
+  // events_core already stores metadata values pre-truncated; on a full read
+  // cap them alongside I/O so an explicit limit bounds the whole payload.
+  const metadataValues = fullReadCharLimit
+    ? `arrayMap(v -> leftUTF8(v, ${fullReadCharLimit}), e.metadata_values)`
+    : `e.metadata_values`;
   const experimentFieldsSelect = opts.includeExperimentFields
     ? `
       experiment_item_expected_output,
@@ -2518,7 +2538,7 @@ export const getObservationsBatchIOFromEventsTable = async <
       ${outputSelect},
       ${experimentFieldsSelect}
       ${toolCallFieldsSelect}
-      mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values)) as metadata
+      mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(${metadataValues})) as metadata
     FROM ${tableName} e
     WHERE e.project_id = {projectId: String}
       AND e.span_id IN {observationIds: Array(String)}

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -3789,6 +3789,7 @@ describe("Clickhouse Events Repository Test", () => {
       const longInput = "i".repeat(3 * charLimit);
       const longOutput = "o".repeat(3 * charLimit);
       const longMetadataValue = "m".repeat(3 * charLimit);
+      const longExpectedOutput = "e".repeat(3 * charLimit);
 
       await createEventsCh([
         createEvent({
@@ -3802,6 +3803,7 @@ describe("Clickhouse Events Repository Test", () => {
           output: longOutput,
           metadata_names: ["long"],
           metadata_values: [longMetadataValue],
+          experiment_item_expected_output: longExpectedOutput,
           start_time: nowMicro,
         }),
       ]);
@@ -3818,14 +3820,19 @@ describe("Clickhouse Events Repository Test", () => {
       const truncated = await getObservationsBatchIOFromEventsTable(baseParams);
       expect(truncated[0]?.input?.length).toBeLessThan(charLimit);
 
+      // The limit has to bound every large field the read returns, not just I/O.
       const capped = await getObservationsBatchIOFromEventsTable({
         ...baseParams,
         truncated: false,
         ioCharLimit: charLimit,
+        includeExperimentFields: true,
       });
       expect(capped[0]?.input).toBe("i".repeat(charLimit));
       expect(capped[0]?.output).toBe("o".repeat(charLimit));
       expect(capped[0]?.metadata?.long).toBe("m".repeat(charLimit));
+      expect(capped[0]?.experimentItemExpectedOutput).toBe(
+        "e".repeat(charLimit),
+      );
 
       // Without a limit an untruncated read still returns everything.
       const full = await getObservationsBatchIOFromEventsTable({

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -3779,6 +3779,62 @@ describe("Clickhouse Events Repository Test", () => {
       expect(withToolCalls[0]?.toolCalls).toEqual([storedToolCall]);
       expect(withToolCalls[0]?.toolCallNames).toEqual(["get_weather"]);
     });
+
+    it("should serve ioCharLimit chars of I/O and metadata on an untruncated read", async () => {
+      const traceId = randomUUID();
+      const observationId = randomUUID();
+      const nowMicro = Date.now() * 1000;
+      const timestamp = new Date(nowMicro / 1000);
+      const charLimit = 1_000;
+      const longInput = "i".repeat(3 * charLimit);
+      const longOutput = "o".repeat(3 * charLimit);
+      const longMetadataValue = "m".repeat(3 * charLimit);
+
+      await createEventsCh([
+        createEvent({
+          id: observationId,
+          span_id: observationId,
+          project_id: projectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "test-io-char-limit",
+          input: longInput,
+          output: longOutput,
+          metadata_names: ["long"],
+          metadata_values: [longMetadataValue],
+          start_time: nowMicro,
+        }),
+      ]);
+
+      const baseParams = {
+        projectId,
+        observations: [{ id: observationId, traceId }],
+        minStartTime: timestamp,
+        maxStartTime: timestamp,
+      };
+
+      // The default read serves events_core, whose I/O is stored pre-truncated
+      // well below what a taller table row can display (LFE-14586).
+      const truncated = await getObservationsBatchIOFromEventsTable(baseParams);
+      expect(truncated[0]?.input?.length).toBeLessThan(charLimit);
+
+      const capped = await getObservationsBatchIOFromEventsTable({
+        ...baseParams,
+        truncated: false,
+        ioCharLimit: charLimit,
+      });
+      expect(capped[0]?.input).toBe("i".repeat(charLimit));
+      expect(capped[0]?.output).toBe("o".repeat(charLimit));
+      expect(capped[0]?.metadata?.long).toBe("m".repeat(charLimit));
+
+      // Without a limit an untruncated read still returns everything.
+      const full = await getObservationsBatchIOFromEventsTable({
+        ...baseParams,
+        truncated: false,
+      });
+      expect(full[0]?.input).toBe(longInput);
+      expect(full[0]?.metadata?.long).toBe(longMetadataValue);
+    });
   });
 
   maybe("getLatestSdkVersionInfoFromEvents", () => {

--- a/web/src/components/table/data-table-row-height-switch.tsx
+++ b/web/src/components/table/data-table-row-height-switch.tsx
@@ -28,6 +28,18 @@ const defaultHeights: Record<RowHeight, string> = {
 export type RowHeight = (typeof heightOptions)[number]["id"];
 export type CustomHeights = Record<RowHeight, string>;
 
+/**
+ * Chars of Input/Output a taller row needs to fill its cells. Small shows a
+ * single truncated line, so it stays on the cheap pre-truncated read; Medium
+ * and Large have room for far more text than that (LFE-14586). Sized to fill a
+ * Large row even at a generously widened column.
+ */
+export const EXPANDED_ROW_IO_CHAR_LIMIT = 2_000;
+
+/** Undefined for Small, which keeps the default truncated read. */
+export const getRowHeightIOCharLimit = (rowHeight: RowHeight) =>
+  rowHeight === "s" ? undefined : EXPANDED_ROW_IO_CHAR_LIMIT;
+
 export const getRowHeightTailwindClass = (
   rowHeight?: RowHeight,
   customHeights?: CustomHeights,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -48,7 +48,10 @@ import {
   usdFormatter,
 } from "@/src/utils/numbers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
-import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
+import {
+  getRowHeightIOCharLimit,
+  useRowHeightLocalStorage,
+} from "@/src/components/table/data-table-row-height-switch";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import {
   toAbsoluteTimeRange,
@@ -840,6 +843,7 @@ export default function ObservationsEventsTable({
     // In chart mode the table is hidden and the chart runs its own aggregate
     // query — don't also run the expensive row + batched-I/O fetches.
     rowsEnabled: !chartActive,
+    ioCharLimit: getRowHeightIOCharLimit(rowHeight),
   });
 
   useApplyAppRootFallback({

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -43,6 +43,11 @@ type UseEventsTableDataParams = {
    * fetches don't run alongside the chart's aggregate query.
    */
   rowsEnabled?: boolean;
+  /**
+   * Chars of I/O to fetch per cell. Undefined keeps the cheap pre-truncated
+   * read, which holds too little text to fill a taller row (LFE-14586).
+   */
+  ioCharLimit?: number;
 };
 
 export function useEventsTableData({
@@ -57,6 +62,7 @@ export function useEventsTableData({
   setSelectedRows,
   appRootFallbackEnabled = false,
   rowsEnabled = true,
+  ioCharLimit,
 }: UseEventsTableDataParams) {
   // Prepare query payloads
   const getCountPayload = useMemo(
@@ -158,11 +164,17 @@ export function useEventsTableData({
       })),
       minStartTime,
       maxStartTime,
+      // events_core's pre-truncated I/O can't fill a taller row, so ask for a
+      // bounded slice of the full I/O instead.
+      ...(ioCharLimit !== undefined
+        ? { truncated: false as const, ioCharLimit }
+        : {}),
     };
   }, [
     activeObservations.data?.observations,
     activeObservations.isPlaceholderData,
     projectId,
+    ioCharLimit,
   ]);
 
   // Fetch I/O data

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -89,6 +89,10 @@ export const BatchIOInput = zodSchema.object({
   minStartTime: zodSchema.date(),
   maxStartTime: zodSchema.date(),
   truncated: zodSchema.boolean().optional(), // Defaults to true for performance
+  // Caps the chars of I/O (and of each metadata value) an untruncated read
+  // ships. Bounded by the char limit above which the table cell stops
+  // rendering anyway (IO_TABLE_CHAR_LIMIT).
+  ioCharLimit: zodSchema.number().int().positive().max(10_000).optional(),
   includeToolCalls: zodSchema.boolean().optional(), // Defaults to false; tool-call arrays can be large
   // Opts into trace-level auth (public traces) in protectedGetEventsTraceProcedure
   traceId: zodSchema.string().optional(),
@@ -214,6 +218,7 @@ export const eventsRouter = createTRPCRouter({
             minStartTime: input.minStartTime,
             maxStartTime: input.maxStartTime,
             truncated: input.truncated,
+            ioCharLimit: input.ioCharLimit,
             includeToolCallFields: input.includeToolCalls,
           });
 
@@ -236,6 +241,7 @@ export const eventsRouter = createTRPCRouter({
             minStartTime: input.minStartTime,
             maxStartTime: input.maxStartTime,
             truncated: input.truncated,
+            ioCharLimit: input.ioCharLimit,
             includeExperimentFields: true,
             includeToolCallFields: input.includeToolCalls,
           });

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -846,6 +846,7 @@ interface GetEventBatchIOParams<
   minStartTime: Date;
   maxStartTime: Date;
   truncated?: boolean;
+  ioCharLimit?: number;
   includeExperimentFields?: TIncludeExperiment;
   /** Opt-in: tool-call arrays can be large; only eval consumers need them. */
   includeToolCallFields?: TIncludeToolCalls;
@@ -866,6 +867,7 @@ export async function getEventBatchIO<
     minStartTime: params.minStartTime,
     maxStartTime: params.maxStartTime,
     truncated: params.truncated,
+    ioCharLimit: params.ioCharLimit,
     includeExperimentFields: params.includeExperimentFields,
     includeToolCallFields: params.includeToolCallFields,
   });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15875.preview.langfuse.com](https://pr-15875.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Large/Medium row height in the Tracing table showed a few lines of Input/Output and
then a big empty band. The cause was **not** CSS — the table was only ever *given*
**200 characters** per cell. Taller rows now fetch a bounded slice of the real I/O, so
they fill. Small row height keeps the cheap read, so the default view's cost is
unchanged.

closes #15566

## Why

The Tracing table fetches Input/Output/Metadata for the visible page through one
batched read, which defaulted to the lightweight `events_core` table. That table
stores I/O and metadata values **pre-truncated to 200 characters**. 200 characters is
plenty for the single truncated line a Small row shows, but a Large row has room for
~15 lines — so the row grew, the content ran out after ~6 lines, and the rest of the
row stayed blank. The reporter's screenshot cuts off mid-token (`"code": nu`), which is
exactly the 200-character mark, not a clipped line.

Worth noting since the issue thread pointed elsewhere: the `h-full` chain from the
row-height wrapper down through `IOTableCell` is intact and already hands the cell the
full row height (measured: 248px of usable height inside a Large row). Adding the
row-height class to the intermediate wrapper would have changed nothing — there was no
more text to show. This is browser-independent, so the Firefox angle in the report is
incidental.

## What

- The batched I/O read takes an optional `ioCharLimit`, which caps input, output and
  each metadata value in SQL (`leftUTF8`) on an untruncated read. Callers that need
  everything (trace log view, eval/experiment previews) are unaffected.
- The Tracing table passes that limit for Medium/Large and nothing for Small, so Small
  stays on the pre-truncated read.

## Result

Same row, Large row height, measured in the browser:

| Row height | Chars per cell | Content height vs. available |
| --- | --- | --- |
| Small | 202 → 202 (unchanged) | single truncated line |
| Medium | 202 → 2,007 | 90px → fills 88px |
| Large | 202 → 2,007 | 90px in a 248px box → fills 248px |

<details>
<summary>Mechanism, cost, and verification</summary>

**Where the cap came from.** `events_core` is a materialized view over `events_full`
that stores `leftUTF8(input, 200)`, `leftUTF8(output, 200)` and per-value
`leftUTF8(metadata_values, 200)`. `getObservationsBatchIOFromEventsTable` reads it
whenever `truncated` is left at its default `true` — and the Tracing table was the only
caller that did. Every other caller already passes `truncated: false`.

**Why a bounded slice rather than `truncated: false`.** A plain untruncated read returns
whole payloads, which can be megabytes per row across a 50-row page. `ioCharLimit`
reads `events_full` but ships at most N characters per field, so the payload stays
bounded. Metadata values are capped by the same limit, mirroring what `events_core`
already does — that also fixes the metadata cell in the report.

**Limit.** `EXPANDED_ROW_IO_CHAR_LIMIT = 2000`, sized to fill a Large row even at a
generously widened column (a Large row at default width holds ~540 characters; ~1,650
at a 3×-widened column). The router bounds the field at 10,000, above which the cell
stops rendering anyway.

**Cost.** Measured locally on a 50-row page: Small `26ms / 36KB`, Large `36–55ms /
117KB`. Only an explicit switch to Medium/Large pays it; the default Small view issues
the identical query it does today.

**Verification.**
- New repository test pins the contract (capped read returns exactly the requested
  slice for input, output and metadata; the default read returns less; an unlimited
  untruncated read still returns everything). Confirmed it fails against the
  pre-fix behavior.
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `event-repository.servertest.ts -t getObservationsBatchIOFromEventsTable` →
  `Tests 6 passed | 76 skipped (82)`
- One targeted worker check → `Tests 11 passed (11)`
- Browser: Small/Medium/Large measured on the same row (table above); Small's payload
  byte-for-byte unchanged.

**Not in scope.** #11821 (Datasets UI) is a different path — dataset items carry their
I/O with no server-side character cap, and that issue's symptom was a cell that clipped
content it already had. This change touches neither the Datasets query nor the shared
cell component, so it neither fixes nor regresses that surface.

**Follow-up worth considering.** The batch I/O path returns a capped value with no
truncation marker, so a cell gives no hint that more text exists (true before this
change too, at 200 characters). Other read paths append `...[truncated]`; doing that
here would need care, since appending inside a JSON string breaks the JSON view.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and read-path tuning with validated SQL bounds; default Small-row behavior and unlimited untruncated callers are unchanged.
> 
> **Overview**
> **Medium and large** tracing table rows were mostly empty because batch I/O came from `events_core` (~200 chars per field). The table now requests a **bounded slice** from `events_full` when row height is not Small.
> 
> Adds optional **`ioCharLimit`** on the batched events I/O path: untruncated reads apply `leftUTF8` in ClickHouse to input, output, each metadata value, and experiment fields. **Small** rows keep the default truncated read; **Medium/Large** pass `ioCharLimit: 2000` via `getRowHeightIOCharLimit`. The limit is threaded through tRPC (`max 10_000`), the events service, and `useEventsTableData`, with a repository test for capped vs default vs unlimited reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ef858089c5b09ececdf97fcb4c4fac1a00f5b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR lets medium and large tracing-table rows request a bounded 2,000-character slice from `events_full`, while small rows retain the inexpensive pre-truncated query.

- Adds bounded ClickHouse truncation for input, output, and individual metadata values.
- Threads the optional limit through the tRPC router, service, hook, and row-height UI state.
- Adds a server repository test covering capped, default-truncated, and unlimited reads.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The row-height change produces distinct query inputs and refetches appropriately, while the repository preserves existing default and unlimited behavior and applies a validated bound consistently to input, output, and metadata.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Tracing table
  participant Hook as useEventsTableData
  participant API as eventsRouter.batchIO
  participant Service as getEventBatchIO
  participant CH as ClickHouse repository
  UI->>Hook: row height
  alt Small row
    Hook->>API: batch I/O (default truncated read)
    API->>Service: truncated defaults to true
    Service->>CH: query events_core
  else Medium or Large row
    Hook->>API: "truncated=false, ioCharLimit=2000"
    API->>Service: bounded full-read options
    Service->>CH: query events_full with leftUTF8(..., 2000)
  end
  CH-->>UI: input, output, and metadata
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tables): use full row height for Inp..."](https://github.com/langfuse/langfuse/commit/9105220313c5ccf518909edfce56901b289b63c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51123973)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->