### PR TITLE
fix(trace): drop the date window from the trace-scoped Scores tab (LFE-14851)

### DIFF
--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -190,6 +190,13 @@ export default function ScoresTable({
       ]
     : [];
 
+  // Scoped to a single trace (trace/observation detail): a time window can only
+  // hide that trace's own scores — the trace id already bounds the query — so the
+  // rows are unwindowed and the picker is not offered. The window still bounds the
+  // filter-option queries, which are project-wide either way.
+  const isTraceScoped = Boolean(traceId);
+  const rowDateRangeFilter: FilterState = isTraceScoped ? [] : dateRangeFilter;
+
   const environmentFilterOptions =
     api.projects.environmentFilterOptions.useQuery(
       {
@@ -382,7 +389,7 @@ export default function ScoresTable({
   );
 
   const filterState = createFilterState(
-    queryFilter.effectiveFilterState.concat(dateRangeFilter),
+    queryFilter.effectiveFilterState.concat(rowDateRangeFilter),
     [
       ...(userId ? [{ key: "User ID", value: userId }] : []),
       ...(traceId ? [{ key: "Trace ID", value: traceId }] : []),
@@ -1000,8 +1007,12 @@ export default function ScoresTable({
           ]}
           rowHeight={rowHeight}
           setRowHeight={setRowHeight}
-          timeRange={showControlsInPageHeader ? undefined : timeRange}
-          setTimeRange={showControlsInPageHeader ? undefined : setTimeRange}
+          timeRange={
+            showControlsInPageHeader || isTraceScoped ? undefined : timeRange
+          }
+          setTimeRange={
+            showControlsInPageHeader || isTraceScoped ? undefined : setTimeRange
+          }
           multiSelect={{
             selectAll,
             setSelectAll,


### PR DESCRIPTION
Linear: [LFE-14851](https://linear.app/clickhouse/issue/LFE-14851) (subtask of [LFE-14405](https://linear.app/clickhouse/issue/LFE-14405))

## TL;DR

The Scores tab inside trace detail applied the **project-wide** table date range
to its rows, so it came up empty for any trace outside that window — default
past 1 day — while the tree badge still listed the scores. A trace-scoped scores
table now queries unwindowed and stops offering a picker that could only hide its
own rows.

## Why

Found while reproducing #15876 (root-span trace-level scores): that tab is a
second, independent way to get an empty Scores table.

`ScoresTable` takes its window from `useTableDateRange`, which is **shared per
project** with the traces/observations tables. Two consequences:

- Open a trace older than the window → the tab is empty at every level, even
  though the badges next to it show the scores.
- Narrow the range once anywhere in the project (say to "Past 30 min" while
  triaging a live issue) and *every* trace detail's Scores tab goes empty until
  you widen it again, in a view where nothing explains why.

The trace id already bounds the query to one trace, so a time window can only
ever subtract that trace's own scores.

**Before / after**, same seeded trace with the range set to "Past 30 min":

| | before | after |
| --- | --- | --- |
| Span Scores tab | "No scores found." | 6 rows |
| Time-range picker in the tab toolbar | shown | not shown |
| Project-wide `/scores` page | picker + 45 rows | unchanged |

## What

`isTraceScoped = Boolean(traceId)` — true for the trace and observation detail
tabs, false for the project Scores page and the user-detail table. When set:

- the row and count queries drop the `timestamp` filter;
- the toolbar gets no `timeRange`/`setTimeRange`, so the picker is not rendered
  (the toolbar already renders it only when both are passed).

## Result

The tab shows a trace's scores regardless of when the trace ran, and no longer
carries a control whose only effect was to hide them. Project-wide and
user-scoped scores tables keep their window and picker.

<details>
<summary>Scope note and verification</summary>

**Filter options stay windowed.** `scores.filterOptions` /
`filterOptionsFromEvents` and `projects.environmentFilterOptions` still receive
the date range. Those queries are project-wide in this tab already — they are not
trace-scoped, so their counts never described the trace — and leaving them bounded
keeps them off an unbounded `GROUP BY` over the project's scores. The consequence
is narrow: a score name that exists only on an old trace may be absent from the
Name facet's suggestion list, while the rows themselves are complete.

**No new unit test.** The change is a boolean gate on an existing filter array;
pinning it would assert `traceId ? [] : dateRangeFilter`. Verified in the browser
instead, on a v4 trace seeded with
`pnpm run seed -- scored-traces --traces 3 --v4`, reading row counts and toolbar
buttons out of the DOM with the range forced via `?dateRange=30m` — the table
above.

`Tasks: 7 successful, 7 total` for both `pnpm run lint` and `pnpm tc`.

</details>

Stacked conceptually on #15876 (same ticket, independent diffs — either can merge
first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
