### PR TITLE
fix(monitors): preserve monitor form state when adding an automation (LFE-10982)

### DIFF
--- a/web/src/features/automations/components/automationForm.tsx
+++ b/web/src/features/automations/components/automationForm.tsx
@@ -645,6 +645,13 @@ export const AutomationForm = ({
   const isProjectNotification =
     watchedEventSource === TriggerEventSource.ProjectNotification;
 
+  // A monitor-sourced trigger has nothing to configure, so with the source
+  // locked (e.g. created from the monitor form) the card is pure noise.
+  const hideTriggerCard =
+    isProjectNotification ||
+    (Boolean(lockedEventSource) &&
+      watchedEventSource === TriggerEventSource.Monitor);
+
   /** handleEventSourceChange resets eventAction + filter to defaults appropriate for the picked source. */
   const handleEventSourceChange = (value: TriggerEventSource) => {
     form.setValue("eventSource", value);
@@ -704,8 +711,7 @@ export const AutomationForm = ({
           </div>
         )}
 
-        {/* Project-notification triggers are match-all, so there is nothing to configure. */}
-        {!isProjectNotification && (
+        {!hideTriggerCard && (
           <Card>
             <CardHeader>
               <CardTitle>Trigger</CardTitle>

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.access.clienttest.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.access.clienttest.tsx
@@ -14,11 +14,10 @@ vi.mock("@/src/utils/api", () => ({
         useQuery: () => ({ data: [automationRow], isSuccess: true }),
       },
     },
+    useUtils: () => ({
+      automations: { getAutomations: { fetch: vi.fn(async () => []) } },
+    }),
   },
-}));
-
-vi.mock("next/router", () => ({
-  useRouter: () => ({ asPath: "/", push: vi.fn() }),
 }));
 
 import { MonitorAutomationsPanel } from "./MonitorAutomationsPanel";

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.create.clienttest.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.create.clienttest.tsx
@@ -16,6 +16,9 @@ const createdRow = {
 /** automations stands in for the server list; a save flips it the way invalidation would. */
 let automations: (typeof existingRow)[] = [];
 
+/** gateFetch defers the post-create list read so a test can interleave user input. */
+let gateFetch: Promise<unknown> | undefined;
+
 vi.mock("@/src/utils/api", () => ({
   api: {
     automations: {
@@ -25,7 +28,12 @@ vi.mock("@/src/utils/api", () => ({
     },
     useUtils: () => ({
       automations: {
-        getAutomations: { fetch: vi.fn(async () => automations) },
+        getAutomations: {
+          fetch: vi.fn(async () => {
+            await gateFetch;
+            return automations;
+          }),
+        },
       },
     }),
   },
@@ -57,6 +65,10 @@ const openCreateDialog = async (item: RegExp) => {
 };
 
 describe("MonitorAutomationsPanel automation creation", () => {
+  beforeEach(() => {
+    gateFetch = undefined;
+  });
+
   it("creates in place and selects the new trigger, never linking away from the monitor form", async () => {
     automations = [existingRow];
     stubSave = (onSuccess) => {
@@ -109,6 +121,38 @@ describe("MonitorAutomationsPanel automation creation", () => {
     fireEvent.click(screen.getByRole("button", { name: /saved the secret/i }));
     await waitFor(() =>
       expect(onTriggerIdsChange).toHaveBeenCalledWith(["trig-2"]),
+    );
+  });
+
+  it("keeps a selection made while the post-create list read is still in flight", async () => {
+    automations = [existingRow];
+    stubSave = (onSuccess) => {
+      automations = [existingRow, createdRow];
+      onSuccess("auto-2");
+    };
+    let releaseFetch = () => {};
+    gateFetch = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const onTriggerIdsChange = vi.fn();
+    const panel = (triggerIds: string[]) => (
+      <MonitorAutomationsPanel
+        projectId="p1"
+        triggerIds={triggerIds}
+        onTriggerIdsChange={onTriggerIdsChange}
+      />
+    );
+    const { rerender } = render(panel([]));
+
+    await openCreateDialog(/new automation/i);
+    fireEvent.click(await screen.findByRole("button", { name: /stub save/i }));
+
+    // The user ticks another automation before the read resolves.
+    rerender(panel(["trig-1"]));
+    releaseFetch();
+
+    await waitFor(() =>
+      expect(onTriggerIdsChange).toHaveBeenCalledWith(["trig-1", "trig-2"]),
     );
   });
 });

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.create.clienttest.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.create.clienttest.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const existingRow = {
+  id: "auto-1",
+  name: "Ping webhook",
+  trigger: { id: "trig-1" },
+  action: { type: "WEBHOOK" },
+};
+const createdRow = {
+  id: "auto-2",
+  name: "Deploy hook",
+  trigger: { id: "trig-2" },
+  action: { type: "WEBHOOK" },
+};
+
+/** automations stands in for the server list; a save flips it the way invalidation would. */
+let automations: (typeof existingRow)[] = [];
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    automations: {
+      getAutomations: {
+        useQuery: () => ({ data: automations, isPending: false }),
+      },
+    },
+    useUtils: () => ({
+      automations: {
+        getAutomations: { fetch: vi.fn(async () => automations) },
+      },
+    }),
+  },
+}));
+
+type SuccessHandler = (
+  automationId?: string,
+  webhookSecret?: string,
+  actionType?: "WEBHOOK" | "GITHUB_DISPATCH",
+) => void;
+
+/** stubSave stands in for the real form, whose contract with the panel is "prefill in, onSuccess out". */
+let stubSave: (onSuccess: SuccessHandler) => void;
+
+vi.mock("@/src/features/automations/components/automationForm", () => ({
+  AutomationForm: ({ onSuccess }: { onSuccess: SuccessHandler }) => (
+    <button onClick={() => stubSave(onSuccess)}>stub save</button>
+  ),
+}));
+
+import { MonitorAutomationsPanel } from "./MonitorAutomationsPanel";
+
+/** openCreateDialog opens the "+ Automation" menu and picks one of its items. */
+const openCreateDialog = async (item: RegExp) => {
+  fireEvent.keyDown(screen.getByRole("button", { name: /^automation$/i }), {
+    key: "Enter",
+  });
+  fireEvent.click(await screen.findByRole("menuitem", { name: item }));
+};
+
+describe("MonitorAutomationsPanel automation creation", () => {
+  it("creates in place and selects the new trigger, never linking away from the monitor form", async () => {
+    automations = [existingRow];
+    stubSave = (onSuccess) => {
+      automations = [existingRow, createdRow];
+      onSuccess("auto-2");
+    };
+    const onTriggerIdsChange = vi.fn();
+    render(
+      <MonitorAutomationsPanel
+        projectId="p1"
+        triggerIds={["trig-1"]}
+        onTriggerIdsChange={onTriggerIdsChange}
+      />,
+    );
+
+    await openCreateDialog(/new automation/i);
+    // Navigating to the automations page unmounted the monitor form (LFE-10982).
+    expect(document.querySelector('a[href*="/automations"]')).toBeNull();
+
+    fireEvent.click(await screen.findByRole("button", { name: /stub save/i }));
+
+    await waitFor(() =>
+      expect(onTriggerIdsChange).toHaveBeenCalledWith(["trig-1", "trig-2"]),
+    );
+  });
+
+  it("keeps the open dialog through the empty-state-to-list switch, so the once-only webhook secret still shows", async () => {
+    automations = [];
+    stubSave = (onSuccess) => onSuccess("auto-2", "whsec_stub", "WEBHOOK");
+    const onTriggerIdsChange = vi.fn();
+    // A fresh element per render: React bails out of re-rendering an identical one.
+    const panel = () => (
+      <MonitorAutomationsPanel
+        projectId="p1"
+        triggerIds={[]}
+        onTriggerIdsChange={onTriggerIdsChange}
+      />
+    );
+    const { rerender } = render(panel());
+
+    await openCreateDialog(/^webhook$/i);
+    // The create invalidates the list, so the first automation lands while the
+    // dialog is still open; that must not remount the dialog's owner.
+    automations = [createdRow];
+    rerender(panel());
+
+    fireEvent.click(await screen.findByRole("button", { name: /stub save/i }));
+    expect(await screen.findByText("whsec_stub")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /saved the secret/i }));
+    await waitFor(() =>
+      expect(onTriggerIdsChange).toHaveBeenCalledWith(["trig-2"]),
+    );
+  });
+});

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.prune.clienttest.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.prune.clienttest.tsx
@@ -16,11 +16,10 @@ vi.mock("@/src/utils/api", () => ({
         useQuery: () => useQueryMock(),
       },
     },
+    useUtils: () => ({
+      automations: { getAutomations: { fetch: vi.fn(async () => []) } },
+    }),
   },
-}));
-
-vi.mock("next/router", () => ({
-  useRouter: () => ({ asPath: "/", push: vi.fn() }),
 }));
 
 import { MonitorAutomationsPanel } from "./MonitorAutomationsPanel";

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.toggle.clienttest.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.toggle.clienttest.tsx
@@ -16,11 +16,10 @@ vi.mock("@/src/utils/api", () => ({
         useQuery: () => useQueryMock(),
       },
     },
+    useUtils: () => ({
+      automations: { getAutomations: { fetch: vi.fn(async () => []) } },
+    }),
   },
-}));
-
-vi.mock("next/router", () => ({
-  useRouter: () => ({ asPath: "/", push: vi.fn() }),
 }));
 
 import { MonitorAutomationsPanel } from "./MonitorAutomationsPanel";

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @repo/no-style-props */
-import { useMemo, useCallback, useState } from "react";
+import { useMemo, useCallback, useRef, useState } from "react";
 import {
   Check,
   Github,
@@ -67,7 +67,12 @@ export const MonitorAutomationsPanel = ({
     },
   );
 
-  /** selectCreatedAutomation ticks a just-created automation. The panel keys on trigger ids, so resolve the automation id against the refreshed cache instead of a render-time closure. */
+  // The user can keep toggling rows while the refetch below is in flight, so the
+  // write must not be based on a render-time snapshot of the selection.
+  const latestTriggerIds = useRef(triggerIds);
+  latestTriggerIds.current = triggerIds;
+
+  /** selectCreatedAutomation ticks a just-created automation, resolving its trigger id (the panel's key) from the refreshed list. */
   const selectCreatedAutomation = useCallback(
     async (automationId: string) => {
       const automations = await utils.automations.getAutomations.fetch({
@@ -76,10 +81,11 @@ export const MonitorAutomationsPanel = ({
       });
       const triggerId = automations?.find((a) => a.id === automationId)?.trigger
         .id;
-      if (!triggerId || triggerIds.includes(triggerId)) return;
-      onTriggerIdsChange([...triggerIds, triggerId]);
+      const selected = latestTriggerIds.current;
+      if (!triggerId || selected.includes(triggerId)) return;
+      onTriggerIdsChange([...selected, triggerId]);
     },
-    [utils, projectId, triggerIds, onTriggerIdsChange],
+    [utils, projectId, onTriggerIdsChange],
   );
 
   const automations = data ?? [];

--- a/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
+++ b/web/src/features/monitors/components/MonitorAutomationsPanel.tsx
@@ -1,7 +1,5 @@
-/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
-import { type ReactNode, useMemo, useCallback } from "react";
-import Link from "next/link";
-import { useRouter } from "next/router";
+/* eslint-disable @repo/no-style-props */
+import { useMemo, useCallback, useState } from "react";
 import {
   Check,
   Github,
@@ -14,12 +12,22 @@ import { api } from "@/src/utils/api";
 import { Button } from "@/src/components/ui/button";
 import { Card, CardContent } from "@/src/components/ui/card";
 import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import { automationCreateHref } from "@/src/features/automations/components/automationForm";
+import { AutomationForm } from "@/src/features/automations/components/automationForm";
+import { WebhookSecretRender } from "@/src/features/automations/components/WebhookSecretRender";
 import { cn } from "@/src/utils/tailwind";
 import {
   ActionTypeSchema,
@@ -47,6 +55,7 @@ export const MonitorAutomationsPanel = ({
   onTriggerIdsChange: (next: string[]) => void;
   hasAccess?: boolean;
 }) => {
+  const utils = api.useUtils();
   const { data, isPending } = api.automations.getAutomations.useQuery(
     {
       projectId,
@@ -58,54 +67,62 @@ export const MonitorAutomationsPanel = ({
     },
   );
 
-  if (isPending || !data || data?.length == 0)
-    return (
-      <SetupMonitorAutomationsCard
-        projectId={projectId}
-        isDisabled={!hasAccess}
-      />
-    );
+  /** selectCreatedAutomation ticks a just-created automation. The panel keys on trigger ids, so resolve the automation id against the refreshed cache instead of a render-time closure. */
+  const selectCreatedAutomation = useCallback(
+    async (automationId: string) => {
+      const automations = await utils.automations.getAutomations.fetch({
+        projectId,
+        eventSource: TriggerEventSource.Monitor,
+      });
+      const triggerId = automations?.find((a) => a.id === automationId)?.trigger
+        .id;
+      if (!triggerId || triggerIds.includes(triggerId)) return;
+      onTriggerIdsChange([...triggerIds, triggerId]);
+    },
+    [utils, projectId, triggerIds, onTriggerIdsChange],
+  );
+
+  const automations = data ?? [];
+  const isEmpty = isPending || automations.length === 0;
 
   return (
-    <MonitorAutomationsListCard
-      projectId={projectId}
-      isDisabled={!hasAccess}
-      automations={data}
-      selectedTriggerIds={triggerIds}
-      onSelectedTriggerIdsChange={onTriggerIdsChange}
-    />
+    <div className="space-y-3">
+      <Card>
+        <CardContent className="space-y-3 pt-4">
+          {isEmpty ? (
+            <p className="text-muted-foreground px-4 py-6 text-center text-base">
+              Set up Slack, Webhook, and Github Action Automations to Receive
+              Alerts
+            </p>
+          ) : (
+            <MonitorAutomationsSelectableList
+              isDisabled={!hasAccess}
+              automations={automations}
+              selectedTriggerIds={triggerIds}
+              onSelectedTriggerIdsChange={onTriggerIdsChange}
+            />
+          )}
+          {/* One CTA for both states: it owns the create dialog, so it must stay
+              mounted when the first automation turns the empty state into a list. */}
+          <AddAutomationDropdown
+            projectId={projectId}
+            fullWidth
+            isDisabled={!hasAccess}
+            onAutomationCreated={selectCreatedAutomation}
+          />
+        </CardContent>
+      </Card>
+    </div>
   );
 };
 
-/** SetupMonitorAutomationsCard is the empty state prompting creation of the first automation. */
-const SetupMonitorAutomationsCard = ({
-  isDisabled,
-  projectId,
-}: {
-  isDisabled: boolean;
-  projectId: string;
-}) => (
-  <MonitorAutomationsCard>
-    <p className="text-muted-foreground px-4 py-6 text-center text-base">
-      Set up Slack, Webhook, and Github Action Automations to Receive Alerts
-    </p>
-    <AddAutomationDropdown
-      projectId={projectId}
-      fullWidth
-      isDisabled={isDisabled}
-    />
-  </MonitorAutomationsCard>
-);
-
-/** MonitorAutomationsListCard renders the selectable automations and reports the selected trigger IDs. */
-const MonitorAutomationsListCard = ({
-  projectId,
+/** MonitorAutomationsSelectableList renders the selectable automations and reports the selected trigger IDs. */
+const MonitorAutomationsSelectableList = ({
   isDisabled,
   automations,
   selectedTriggerIds,
   onSelectedTriggerIdsChange,
 }: {
-  projectId: string;
   isDisabled: boolean;
   automations: AutomationDomain[];
   selectedTriggerIds: string[];
@@ -136,30 +153,14 @@ const MonitorAutomationsListCard = ({
   );
 
   return (
-    <MonitorAutomationsCard>
-      <MonitorAutomationsList
-        automations={automations}
-        isDisabled={isDisabled}
-        selectedTriggerIds={activeSelectedTriggerIds}
-        onClick={toggleSelectedTriggerId}
-      />
-      <AddAutomationDropdown
-        projectId={projectId}
-        fullWidth
-        isDisabled={isDisabled}
-      />
-    </MonitorAutomationsCard>
+    <MonitorAutomationsList
+      automations={automations}
+      isDisabled={isDisabled}
+      selectedTriggerIds={activeSelectedTriggerIds}
+      onClick={toggleSelectedTriggerId}
+    />
   );
 };
-
-/** MonitorAutomationsCard is the shared card shell for the panel's contents. */
-const MonitorAutomationsCard = ({ children }: { children: ReactNode }) => (
-  <div className="space-y-3">
-    <Card>
-      <CardContent className="space-y-3 pt-4">{children}</CardContent>
-    </Card>
-  </div>
-);
 
 /** MonitorAutomationsList renders one selectable row per automation. */
 const MonitorAutomationsList = ({
@@ -239,49 +240,138 @@ const RowCheckbox = ({ checked }: { checked: boolean }) => (
   </span>
 );
 
-/** AddAutomationDropdown renders the "+ Automation" CTA for the empty state and the list footer. */
+/** NewAutomationDraft is the pending create-automation dialog; an absent actionType lets the form pick its own default. */
+type NewAutomationDraft = { actionType?: ActionTypes };
+
+/** CreatedWebhookSecret is the signing secret of a just-created webhook automation, shown once before the dialog closes. */
+type CreatedWebhookSecret = { automationId: string; webhookSecret: string };
+
+/**
+ * AddAutomationDropdown renders the "+ Automation" CTA for the empty state and
+ * the list footer. Creation happens in a dialog on this page: navigating to the
+ * automations page unmounted the monitor form and lost the draft (LFE-10982).
+ */
 const AddAutomationDropdown = ({
   projectId,
   fullWidth,
   isDisabled,
+  onAutomationCreated,
 }: {
   projectId: string;
   fullWidth?: boolean;
   isDisabled?: boolean;
+  onAutomationCreated: (automationId: string) => void;
 }) => {
-  const router = useRouter();
+  const [draft, setDraft] = useState<NewAutomationDraft | null>(null);
+  const [createdSecret, setCreatedSecret] =
+    useState<CreatedWebhookSecret | null>(null);
+
+  /** closeDialog dismisses both dialog phases, selecting the automation when one was created. */
+  const closeDialog = (createdAutomationId?: string) => {
+    setDraft(null);
+    setCreatedSecret(null);
+    if (createdAutomationId) onAutomationCreated(createdAutomationId);
+  };
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="lg"
-          disabled={isDisabled}
-          className={fullWidth ? "w-full" : undefined}
-        >
-          <Plus className="mr-2 h-4 w-4" />
-          Automation
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuItem asChild>
-          <Link
-            href={automationCreateHref(projectId, undefined, router.asPath)}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="lg"
+            disabled={isDisabled}
+            className={fullWidth ? "w-full" : undefined}
           >
+            <Plus className="mr-2 h-4 w-4" />
+            Automation
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuItem onSelect={() => setDraft({})}>
             <Plus className="mr-2 h-3.5 w-3.5" />
             New automation
-          </Link>
-        </DropdownMenuItem>
-        {ActionTypeSchema.options.map((t) => (
-          <DropdownMenuItem key={t} asChild>
-            <Link href={automationCreateHref(projectId, t, router.asPath)}>
+          </DropdownMenuItem>
+          {ActionTypeSchema.options.map((t) => (
+            <DropdownMenuItem
+              key={t}
+              onSelect={() => setDraft({ actionType: t })}
+            >
               <ActionIcon type={t} className="mr-2 h-3.5 w-3.5" />
               {actionLabel[t]}
-            </Link>
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Dialog
+        open={draft !== null}
+        onOpenChange={(open) => {
+          if (!open) closeDialog(createdSecret?.automationId);
+        }}
+      >
+        <DialogContent
+          size="lg"
+          // The dialog portals out of the monitor <form>, but React events still
+          // bubble through the REACT tree: without this, saving the automation
+          // would submit the monitor too. Mirrors DialogContent's own onClick.
+          onSubmit={(e) => e.stopPropagation()}
+        >
+          {createdSecret ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>Webhook secret created</DialogTitle>
+                <DialogDescription>
+                  Copy the webhook secret below — it will only be shown once.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogBody>
+                <WebhookSecretRender
+                  webhookSecret={createdSecret.webhookSecret}
+                />
+              </DialogBody>
+              <DialogFooter>
+                <Button onClick={() => closeDialog(createdSecret.automationId)}>
+                  {"I've saved the secret"}
+                </Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <>
+              <DialogHeader>
+                <DialogTitle>New automation</DialogTitle>
+                <DialogDescription>
+                  This automation stays available to every monitor in the
+                  project.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogBody>
+                <AutomationForm
+                  projectId={projectId}
+                  isEditing
+                  lockedEventSource={TriggerEventSource.Monitor}
+                  prefill={{
+                    eventSource: TriggerEventSource.Monitor,
+                    actionType: draft?.actionType,
+                  }}
+                  onSuccess={(automationId, webhookSecret, actionType) => {
+                    if (
+                      automationId &&
+                      webhookSecret &&
+                      actionType === "WEBHOOK"
+                    ) {
+                      setCreatedSecret({ automationId, webhookSecret });
+                      return;
+                    }
+                    closeDialog(automationId);
+                  }}
+                  onCancel={() => closeDialog()}
+                />
+              </DialogBody>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15883.preview.langfuse.com](https://pr-15883.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Adding an automation while creating a monitor wiped the monitor you were configuring — target filters, thresholds, name, tags, all gone. The "+ Automation" button was a **link to another page**, so the form unmounted. It now opens the automation form in a dialog on the monitor page, and ticks the new automation for you.

## Why

Reported from monitor setup: *"When I set up a new automation during monitor creation my whole previous setup of which observations to target etc. is just removed and I have to redo."*

Not a stray `reset()` — the dropdown items were `<Link href="/project/…/automations?view=create&prefill=…">`. Clicking one is a route change: `MonitorForm` unmounts and its react-hook-form state dies. The existing `prefill.redirectUrl` round-trip brought you *back* to `/monitors/new` after saving, which made the trip feel closed while the draft was already lost — you returned to a fresh form seeded from `createDefaults()`, with the automation you just created sitting there unticked.

Measured on `main` before the fix: filter `Level` → gone, name → blank, alert threshold `42` → blank.

## What

Create the automation **in place**, in a dialog on the monitor page:

- `AutomationForm` was already built to be embedded (`prefill` / `onSuccess` / `onCancel` / `lockedEventSource`) — the automations page is just one host. The monitor page becomes a second one, so nothing unmounts and there is no state to preserve.
- On save, the new automation is **ticked for this monitor** — resolving its trigger id from the refreshed list, since the panel keys on trigger ids.
- The once-only webhook signing secret is shown in the same dialog before it closes.
- Event source is locked to Monitor, which also drops a Trigger card that had nothing in it but a link back to the page you are already on.
- The deep link stays for the monitors onboarding entry point, which returns to the monitors *list* — nothing to lose there.

## Result

The monitor draft survives the whole flow, and the automation you created is already selected when the dialog closes.

<details>
<summary>Mechanism, hazards, verification</summary>

**Nested forms.** The dialog is a React child of the monitor `<form>`. Its DOM portals out to the `modal` layer, but React synthetic events still bubble through the *React* tree — so saving the automation would also submit the monitor. `DialogContent` gets `onSubmit={(e) => e.stopPropagation()}`, mirroring what shared `DialogContent`/`DialogOverlay` already do for clicks. Verified: after saving the automation, `monitors` table count stayed `0`; the monitor was only created when "Create Monitor" was pressed.

**One CTA for both panel states.** The panel used to render two different cards (empty state vs. list), each with its own "+ Automation". That would have shipped a fresh bug: creating the *first* automation invalidates the list, so the card swaps *while the dialog is open* — remounting the dialog's owner and throwing away the webhook secret the user only gets once. The CTA is now a single stable sibling of the swapping body. `MonitorAutomationsPanel.create.clienttest.tsx` pins this by flipping the list mid-dialog; it fails against the two-card shape with `Unable to find "stub save"`.

**Tests.** Both regression tests were confirmed to fail against the code they guard:
- no-navigation: against `main` → `AssertionError: expected <a role="menuitem" …> to be null`
- dialog survives the empty→list switch: against the two-card shape → dialog gone

The sibling panel tests lose their now-dead `next/router` mock and gain a `useUtils` stub.

**Browser pass** (`/monitors/new`, filter `Level any of ERROR` + name + threshold): dialog opens in place → save → still on `/monitors/new`, secret phase shows, all three fields intact → dismiss → automation ticked (`aria-pressed="true"`) → "Create Monitor" persists name, threshold and the auto-selected trigger id. Cancel path leaves the draft untouched and selects nothing.

**Checks.** `pnpm run lint` → `Tasks: 7 successful, 7 total`; `pnpm --filter web run typecheck` → clean; `pnpm --filter web run test-client src/features/monitors src/features/automations` → `Tests 62 passed (62)`.

</details>

Out of scope, per the ticket's own musing: the general form-state-management refactor and the widget-creation equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only monitor/automation flow changes with event bubbling guarded via `stopPropagation` on dialog submit; no backend or auth changes.
> 
> **Overview**
> Fixes **LFE-10982** by replacing **"+ Automation"** navigation to the automations page with an **in-page dialog** that embeds `AutomationForm`, so the monitor draft stays mounted.
> 
> After save, the panel **refetches** monitor automations and **adds the new trigger** to the current selection (using a ref so in-flight toggles are not overwritten). **Webhook** creations show the **one-time secret** in the same dialog before close. The create CTA is a **single stable sibling** of the empty/list body so the dialog survives the first automation flipping the panel from empty to list.
> 
> `AutomationForm` now **hides the Trigger card** when the event source is locked to **Monitor** (nothing to configure). New client tests cover no navigation links, dialog persistence across list refresh, and selection during a deferred fetch; sibling panel tests drop `next/router` mocks and stub `useUtils`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e705edf1cfb7be4d138eaa11a39cd3c0835267c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces monitor automation deep links with an embedded creation dialog so the active monitor draft remains mounted. It also:
- Auto-selects newly created automations
- Preserves the one-time webhook-secret display
- Hides the non-configurable locked monitor trigger card
- Adds focused client tests for creation and panel-state transitions
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code failure remains after checking the embedded form, selection, and dialog lifecycle paths.

The embedded form retains the established automation creation semantics, monitor triggers require no hidden configuration, and the dialog and refreshed-query flow preserve the monitor draft while selecting the persisted automation.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant Monitor as Monitor Form
  participant Dialog as Automation Dialog
  participant API as Automation API
  User->>Monitor: Configure monitor draft
  User->>Dialog: Open + Automation
  Dialog->>API: Create monitor-sourced automation
  API-->>Dialog: Automation ID and optional webhook secret
  alt Webhook secret returned
    Dialog-->>User: Show one-time secret
    User->>Dialog: Close secret phase
  end
  Dialog->>API: Fetch refreshed monitor automations
  API-->>Dialog: Created trigger ID
  Dialog->>Monitor: Add trigger ID to current draft
  Note over Monitor: Existing form state remains mounted
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(monitors): preserve monitor form sta..."](https://github.com/langfuse/langfuse/commit/b386de8834d4cd27fea0a9539534214e3c083f15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51130371)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->