### PR TITLE
fix(filters): stop the sidebar from reordering mid-interaction (LFE-14843)

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -462,6 +462,44 @@ describe("DataTableControls facet ordering", () => {
     expect(labelOrder("Alpha", "Beta")).toBe(true);
   });
 
+  it("restores catalog order on Clear all, even with an in-list interaction outstanding", () => {
+    const { rerender } = render(
+      <TooltipProvider>
+        <DataTableControls
+          queryFilter={queryFilter([
+            categoricalFilter("alpha", "Alpha", false),
+            categoricalFilter("beta", "Beta", true),
+          ])}
+        />
+      </TooltipProvider>,
+    );
+    expect(labelOrder("Beta", "Alpha")).toBe(true);
+
+    // An in-list interaction that changes no promotion leaves its attribution
+    // outstanding — Clear all must not inherit it and keep Beta pinned.
+    fireEvent.pointerDown(screen.getByText("Beta"));
+    // Radix opens the menu on pointer-down, which jsdom doesn't synthesize
+    // reliably; the keyboard path opens it without PointerEvent support.
+    fireEvent.keyDown(screen.getByRole("button", { name: "Filter options" }), {
+      key: "Enter",
+    });
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Clear all filters" }),
+    );
+
+    rerender(
+      <TooltipProvider>
+        <DataTableControls
+          queryFilter={queryFilter([
+            categoricalFilter("alpha", "Alpha", false),
+            categoricalFilter("beta", "Beta", false),
+          ])}
+        />
+      </TooltipProvider>,
+    );
+    expect(labelOrder("Alpha", "Beta")).toBe(true);
+  });
+
   it("re-sorts immediately when a facet's activity changes externally", () => {
     const { rerender } = render(
       <TooltipProvider>

--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -419,7 +419,50 @@ describe("DataTableControls facet ordering", () => {
     expect(labelOrder("Beta", "Alpha")).toBe(true);
   });
 
-  it("re-sorts immediately when a facet's activity changes", () => {
+  it("keeps the order while the user works the list, and re-settles on an external change (LFE-14843)", () => {
+    const { rerender } = render(
+      <TooltipProvider>
+        <DataTableControls
+          queryFilter={queryFilter([
+            categoricalFilter("alpha", "Alpha", false),
+            categoricalFilter("beta", "Beta", true),
+          ])}
+        />
+      </TooltipProvider>,
+    );
+    expect(labelOrder("Beta", "Alpha")).toBe(true);
+
+    // Clicking inside the facet list marks what follows as the user's own
+    // edit: Alpha activating must not teleport out from under the cursor.
+    fireEvent.pointerDown(screen.getByText("Alpha"));
+    rerender(
+      <TooltipProvider>
+        <DataTableControls
+          queryFilter={queryFilter([
+            categoricalFilter("alpha", "Alpha", true),
+            categoricalFilter("beta", "Beta", true),
+          ])}
+        />
+      </TooltipProvider>,
+    );
+    expect(labelOrder("Beta", "Alpha")).toBe(true);
+
+    // A change from outside the sidebar (search bar, saved view, Clear all,
+    // AI apply) carries no facet interaction, so the order settles.
+    rerender(
+      <TooltipProvider>
+        <DataTableControls
+          queryFilter={queryFilter([
+            categoricalFilter("alpha", "Alpha", true),
+            categoricalFilter("beta", "Beta", false),
+          ])}
+        />
+      </TooltipProvider>,
+    );
+    expect(labelOrder("Alpha", "Beta")).toBe(true);
+  });
+
+  it("re-sorts immediately when a facet's activity changes externally", () => {
     const { rerender } = render(
       <TooltipProvider>
         <DataTableControls

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -26,6 +26,7 @@ import {
   advanceFacetOrder,
   orderFacets,
   promoteFacet,
+  settleOnNextChange,
   EMPTY_FACET_ORDER,
 } from "@/src/features/filters/lib/facet-order";
 import { useMediaQuery } from "react-responsive";
@@ -248,6 +249,14 @@ export function DataTableControls({
   const noteFacetInteraction = () => {
     facetInteractionRef.current += 1;
   };
+  // Boundaries the sidebar owns itself (Clear all, AI apply): the change they
+  // cause must settle, so drop any attribution still outstanding.
+  const noteSettleBoundary = useCallback(() => {
+    facetOrderRef.current = settleOnNextChange(
+      facetOrderRef.current,
+      facetInteractionRef.current,
+    );
+  }, []);
 
   const orderedFilters = orderFacets(queryFilter.filters, facetOrder);
   const displayedFilters = showOnlyActive
@@ -363,6 +372,7 @@ export function DataTableControls({
   const handleFiltersGenerated = useCallback(
     (filters: FilterState) => {
       // Apply filters
+      noteSettleBoundary();
       queryFilter.setFilterState(filters);
       // The v3 wand previously emitted nothing at its only intent seam
       // (metadata only: count of generated conditions, never their values).
@@ -386,14 +396,19 @@ export function DataTableControls({
       // Close popover
       setAiPopoverOpen(false);
     },
-    [queryFilter, capture, tableName],
+    [queryFilter, capture, tableName, noteSettleBoundary],
   );
 
   // Separator position: the SETTLED promoted block, not the live one — a facet
   // activated mid-session keeps its place below the line until the next settle.
-  const promotedFacetCount = displayedFilters.filter((filter) =>
-    facetOrder.promoted.has(filter.column),
-  ).length;
+  // Active-only mode has no inactive catalog to divide from, so no separator:
+  // counting every displayed facet keeps the divider out of the render loop's
+  // range, as the live count did before.
+  const promotedFacetCount = showOnlyActive
+    ? displayedFilters.length
+    : displayedFilters.filter((filter) =>
+        facetOrder.promoted.has(filter.column),
+      ).length;
 
   const renderFacet = (filter: UIFilter) => {
     // A column the current surface can't honour blocks the facet whether or
@@ -912,6 +927,7 @@ export function DataTableControls({
                     // this, a value-less added facet stays pinned after
                     // Clear all and the active-only empty state can never
                     // render again this mount.
+                    noteSettleBoundary();
                     setRevealedColumns([]);
                     queryFilter.clearAll();
                   }}

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -22,6 +22,12 @@ import {
   getFacetSummaryValue,
   rankFacetOptions,
 } from "@/src/features/filters/lib/facet-display";
+import {
+  advanceFacetOrder,
+  orderFacets,
+  promoteFacet,
+  EMPTY_FACET_ORDER,
+} from "@/src/features/filters/lib/facet-order";
 import { useMediaQuery } from "react-responsive";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { cn } from "@/src/utils/tailwind";
@@ -216,19 +222,34 @@ export function DataTableControls({
   const [revealedColumns, setRevealedColumns] = useState<string[]>([]);
 
   // Selected filters on top: a facet is PROMOTED when it carries an active
-  // filter OR the user explicitly added it via "Add filter" — the explicit
-  // add is a promotion in itself, so typing a first value (facet becomes
-  // active) or clearing it again (inactive) never moves the facet around
-  // while someone is working in it. Config order is preserved within each
-  // group, the sort updates immediately, and both display modes share the
-  // exact same order. When an interaction does move a facet (activation by
-  // direct click), the follow-scroll effect below keeps it in view.
+  // filter OR the user explicitly added it via "Add filter". The order is
+  // SETTLED, not live (LFE-14843): the promoted set that drives it is
+  // recomputed at deliberate boundaries — mount, permalink hydration, a saved
+  // view, Clear all, an AI or search-bar apply — and held still while someone
+  // works the sidebar, so a facet activated by direct click never teleports
+  // out from under the cursor. Membership stays live: `showOnlyActive` and the
+  // active counts read isPromoted, only the ORDER is frozen.
   const revealedSet = new Set(revealedColumns);
   const isPromoted = (filter: UIFilter) =>
     filter.isActive || revealedSet.has(filter.column);
-  const orderedFilters = [...queryFilter.filters].sort(
-    (a, b) => Number(isPromoted(b)) - Number(isPromoted(a)),
+  const livePromotedColumns = queryFilter.filters
+    .filter(isPromoted)
+    .map((filter) => filter.column);
+  // Bumped by any interaction inside the facet list (below); the pure reducer
+  // attributes the next promotion change to it instead of re-settling.
+  const facetInteractionRef = useRef(0);
+  const facetOrderRef = useRef(EMPTY_FACET_ORDER);
+  const facetOrder = advanceFacetOrder(
+    facetOrderRef.current,
+    livePromotedColumns,
+    facetInteractionRef.current,
   );
+  facetOrderRef.current = facetOrder;
+  const noteFacetInteraction = () => {
+    facetInteractionRef.current += 1;
+  };
+
+  const orderedFilters = orderFacets(queryFilter.filters, facetOrder);
   const displayedFilters = showOnlyActive
     ? orderedFilters.filter(isPromoted)
     : orderedFilters;
@@ -251,12 +272,13 @@ export function DataTableControls({
     : [];
 
   // Follow-scroll + recency: DOM scrolling is the external system here, so an
-  // effect is the right integration boundary. When exactly one facet changed
-  // activity (the user's own interaction — bulk changes like Clear all, AI
-  // apply, or a restored view skip the scroll), the re-sort has already moved
-  // it by the time this runs; scroll the list to its new position.
+  // effect is the right integration boundary. A single facet's activity change
+  // that DID move it (a re-settle, e.g. one filter applied from the search bar
+  // — the user's own sidebar edits no longer reorder anything) has moved it by
+  // the time this runs; scroll the list to its new position. Bulk changes
+  // (Clear all, AI apply, a restored view) skip the scroll.
   const scrollRootRef = useRef<HTMLDivElement>(null);
-  // Last focused element inside the list: re-sorting moves DOM nodes, and a
+  // Last focused element inside the list: a re-settle moves DOM nodes, and a
   // reinserted node loses focus even when React merely reorders it — typing
   // the first character into a facet's input must not kick the caret out.
   const lastFocusedRef = useRef<HTMLElement | null>(null);
@@ -309,6 +331,10 @@ export function DataTableControls({
     if (!queryFilter.expanded.includes(column)) {
       queryFilter.onExpandedChange([...queryFilter.expanded, column]);
     }
+    // Deliberate promotion: the added facet joins the top block without
+    // re-settling the facets around it.
+    noteFacetInteraction();
+    facetOrderRef.current = promoteFacet(facetOrderRef.current, column);
     // The added facet lands at its config-order slot within the promoted
     // group — bring it into view once the re-render has painted.
     requestAnimationFrame(() => {
@@ -363,7 +389,11 @@ export function DataTableControls({
     [queryFilter, capture, tableName],
   );
 
-  const promotedFacetCount = displayedFilters.filter(isPromoted).length;
+  // Separator position: the SETTLED promoted block, not the live one — a facet
+  // activated mid-session keeps its place below the line until the next settle.
+  const promotedFacetCount = displayedFilters.filter((filter) =>
+    facetOrder.promoted.has(filter.column),
+  ).length;
 
   const renderFacet = (filter: UIFilter) => {
     // A column the current surface can't honour blocks the facet whether or
@@ -570,6 +600,13 @@ export function DataTableControls({
         layout === "inline" ? "w-full" : "w-0 min-w-full",
         "pt-1 pb-10",
       )}
+      // Any interaction in the list marks the filter change it causes as the
+      // user's own edit, so the order holds still (LFE-14843). Capture phase,
+      // and on this node rather than the scroll root: React events propagate
+      // through portals by the React tree, so a facet's portalled dropdown
+      // (metadata keys, score names) counts too.
+      onPointerDownCapture={noteFacetInteraction}
+      onKeyDownCapture={noteFacetInteraction}
     >
       <Accordion
         type="multiple"

--- a/web/src/features/filters/lib/facet-order.clienttest.ts
+++ b/web/src/features/filters/lib/facet-order.clienttest.ts
@@ -4,6 +4,7 @@ import {
   orderFacets,
   promoteFacet,
   settleFacetOrder,
+  settleOnNextChange,
 } from "./facet-order";
 import type { FacetOrder } from "./facet-order";
 
@@ -47,6 +48,33 @@ describe("facet order", () => {
     // no new facet interaction, so the order settles to reality.
     order = advanceFacetOrder(order, ["alpha", "gamma"], 2);
     expect(shown(order)).toEqual(["alpha", "gamma", "beta"]);
+  });
+
+  it("never holds a stale block: an outstanding interaction cannot survive an empty set or a boundary", () => {
+    // beta settled on top, then three in-list edits that changed values but not
+    // promotion: none of them consumed its token, so one is still outstanding.
+    const order = settleFacetOrder(["beta"]);
+    const token = 3;
+
+    // Clearing everything settles regardless — no block to hold, no separator.
+    expect(shown(advanceFacetOrder(order, [], token))).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+
+    // Left outstanding, the attribution would hold the old block…
+    expect(shown(advanceFacetOrder(order, ["gamma"], token))).toEqual([
+      "beta",
+      "alpha",
+      "gamma",
+    ]);
+    // …so a boundary the sidebar owns (Clear all, AI apply) drops it first.
+    expect(
+      shown(
+        advanceFacetOrder(settleOnNextChange(order, token), ["gamma"], token),
+      ),
+    ).toEqual(["gamma", "alpha", "beta"]);
   });
 
   it("promotes an added facet into the top block without re-settling the rest", () => {

--- a/web/src/features/filters/lib/facet-order.clienttest.ts
+++ b/web/src/features/filters/lib/facet-order.clienttest.ts
@@ -1,0 +1,69 @@
+import {
+  advanceFacetOrder,
+  EMPTY_FACET_ORDER,
+  orderFacets,
+  promoteFacet,
+  settleFacetOrder,
+} from "./facet-order";
+import type { FacetOrder } from "./facet-order";
+
+const CATALOG = [{ column: "alpha" }, { column: "beta" }, { column: "gamma" }];
+const shown = (order: FacetOrder) =>
+  orderFacets(CATALOG, order).map((facet) => facet.column);
+
+describe("facet order", () => {
+  it("settles promoted-first, config order within each group", () => {
+    expect(shown(settleFacetOrder(["beta"]))).toEqual([
+      "beta",
+      "alpha",
+      "gamma",
+    ]);
+    expect(shown(settleFacetOrder(["gamma", "beta"]))).toEqual([
+      "beta",
+      "gamma",
+      "alpha",
+    ]);
+    // no promotion at all: the config order stands
+    expect(shown(EMPTY_FACET_ORDER)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("holds the order through the user's own edits and re-settles on the next external change", () => {
+    // Boundary (mount / permalink hydration): beta arrives active and promoted.
+    let order = advanceFacetOrder(EMPTY_FACET_ORDER, ["beta"], 0);
+    expect(shown(order)).toEqual(["beta", "alpha", "gamma"]);
+
+    // The user clicks a value on gamma, low in the list: it activates in place.
+    order = advanceFacetOrder(order, ["beta", "gamma"], 1);
+    expect(shown(order)).toEqual(["beta", "alpha", "gamma"]);
+
+    // A StrictMode re-render with the same inputs must not move anything.
+    expect(advanceFacetOrder(order, ["beta", "gamma"], 1)).toBe(order);
+
+    // Clearing beta mid-session leaves the layout alone too.
+    order = advanceFacetOrder(order, ["gamma"], 2);
+    expect(shown(order)).toEqual(["beta", "alpha", "gamma"]);
+
+    // An apply from elsewhere (search bar, saved view, Clear all, AI) carries
+    // no new facet interaction, so the order settles to reality.
+    order = advanceFacetOrder(order, ["alpha", "gamma"], 2);
+    expect(shown(order)).toEqual(["alpha", "gamma", "beta"]);
+  });
+
+  it("promotes an added facet into the top block without re-settling the rest", () => {
+    // alpha activated in place during the session, so it stays below the line.
+    let order = advanceFacetOrder(
+      settleFacetOrder(["beta"]),
+      ["alpha", "beta"],
+      1,
+    );
+    expect(shown(order)).toEqual(["beta", "alpha", "gamma"]);
+
+    // "Add filter" → gamma: a deliberate promotion of gamma only.
+    order = advanceFacetOrder(
+      promoteFacet(order, "gamma"),
+      ["alpha", "beta", "gamma"],
+      2,
+    );
+    expect(shown(order)).toEqual(["beta", "gamma", "alpha"]);
+  });
+});

--- a/web/src/features/filters/lib/facet-order.ts
+++ b/web/src/features/filters/lib/facet-order.ts
@@ -56,9 +56,29 @@ export function advanceFacetOrder(
 ): FacetOrder {
   const key = orderKey(promotedColumns);
   if (key === order.key) return order;
-  return interactionToken !== order.interactionToken
+  // Nothing promoted means there is no block to protect, so never hold a stale
+  // one: whatever emptied the filters (Clear all, a cleared search bar) must
+  // fall back to plain config order.
+  const holdOrder =
+    promotedColumns.length > 0 && interactionToken !== order.interactionToken;
+  return holdOrder
     ? { promoted: order.promoted, key, interactionToken }
     : settleFacetOrder(promotedColumns, interactionToken);
+}
+
+/**
+ * Cancel any pending in-list attribution, so the change a boundary action
+ * causes settles even if an earlier interaction left one outstanding (an
+ * in-list edit that changed values without changing promotion never consumed
+ * its token). Called by the boundaries the sidebar owns: Clear all, AI apply.
+ */
+export function settleOnNextChange(
+  order: FacetOrder,
+  interactionToken: number,
+): FacetOrder {
+  return order.interactionToken === interactionToken
+    ? order
+    : { ...order, interactionToken };
 }
 
 /**

--- a/web/src/features/filters/lib/facet-order.ts
+++ b/web/src/features/filters/lib/facet-order.ts
@@ -1,0 +1,84 @@
+// Pure facet-ordering helpers for the filter sidebar
+// (data-table-controls.tsx). No React, no state — unit-testable.
+
+/**
+ * The settled promotion order: which facet columns sit in the sidebar's top
+ * block. Held across renders so the list does not reorder under the hands of
+ * someone working it (LFE-14843).
+ */
+export type FacetOrder = {
+  /** Columns in the top block, as settled at the last boundary. */
+  promoted: ReadonlySet<string>;
+  /** The live promoted columns this order was last reconciled against. */
+  key: string;
+  /** The facet-list interaction this order last attributed a change to. */
+  interactionToken: number;
+};
+
+export const EMPTY_FACET_ORDER: FacetOrder = {
+  promoted: new Set(),
+  key: "",
+  interactionToken: 0,
+};
+
+const orderKey = (promotedColumns: readonly string[]) =>
+  promotedColumns.join(",");
+
+/** Settle the order to the live promotion state. */
+export function settleFacetOrder(
+  promotedColumns: readonly string[],
+  interactionToken = 0,
+): FacetOrder {
+  return {
+    promoted: new Set(promotedColumns),
+    key: orderKey(promotedColumns),
+    interactionToken,
+  };
+}
+
+/**
+ * The order for the current render, given the live promoted columns and the
+ * facet list's interaction counter.
+ *
+ * A promotion change that follows an interaction inside the facet list is the
+ * user's own edit: the order stays as settled, so the facet being worked in
+ * never moves under the cursor. Every other cause — permalink hydration, a
+ * saved view, Clear all, an AI or search-bar apply — re-settles.
+ *
+ * Attribution consumes the token only when the promoted set actually changes,
+ * so an unrelated re-render between the click and the filter landing cannot
+ * eat it. Idempotent: same inputs, same output (StrictMode re-renders).
+ */
+export function advanceFacetOrder(
+  order: FacetOrder,
+  promotedColumns: readonly string[],
+  interactionToken: number,
+): FacetOrder {
+  const key = orderKey(promotedColumns);
+  if (key === order.key) return order;
+  return interactionToken !== order.interactionToken
+    ? { promoted: order.promoted, key, interactionToken }
+    : settleFacetOrder(promotedColumns, interactionToken);
+}
+
+/**
+ * "Add filter" is a deliberate promotion: the picked facet joins the top block
+ * (in config order) without re-settling the facets around it.
+ */
+export function promoteFacet(order: FacetOrder, column: string): FacetOrder {
+  if (order.promoted.has(column)) return order;
+  return { ...order, promoted: new Set(order.promoted).add(column) };
+}
+
+/** Promoted facets first, config order preserved within each group. */
+export function orderFacets<T extends { column: string }>(
+  facets: readonly T[],
+  order: FacetOrder,
+): T[] {
+  const promoted: T[] = [];
+  const rest: T[] = [];
+  for (const facet of facets) {
+    (order.promoted.has(facet.column) ? promoted : rest).push(facet);
+  }
+  return [...promoted, ...rest];
+}


### PR DESCRIPTION
## TL;DR

The filter sidebar's "selected first" ordering no longer re-sorts while you are working in it. A facet you activate by clicking it in the full list **stays exactly where it is**. The order settles only at deliberate boundaries — page load, a permalink, a saved view, Clear all, an AI or search-bar apply — so someone opening a shared link still sees the applied filters first.

## Why

Reported feedback: _"in our filter sidebar, it is unclear when filters jump and get resorted when we enter them, unintuitive."_

Promotion (`isActive || explicitly added`) was recomputed live on every render, so the list re-sorted as a side effect of the user's own edits. Three earlier mitigations already covered parts of this — `revealedColumns` (a facet added via "Add filter" is promoted by the *add*, so typing its first value doesn't move it), a follow-scroll effect, and focus retention across the DOM move — but the sharp remaining case was untouched: **a facet activated by a direct click in the full list teleports to the top from under the cursor**, and every later activity change reshuffles its neighbours.

Two ways out were on the table: turn active-first off by default and make it an opt-in in the `…` menu, or keep it and settle the order only at deliberate boundaries. This is the second — it keeps the reason active-first exists (a link recipient with 3 of 20 facets applied shouldn't have to hunt for them) and adds no new persisted per-user setting.

## What

The order is **settled**, not live. A pure reducer (`web/src/features/filters/lib/facet-order.ts`, sibling of `facet-display.ts`) holds the promoted set steady while someone works the list and recomputes it at boundaries.

**Boundaries that DO re-settle** — every cause that isn't an edit inside the facet list:

- first render / page load, **including late-arriving URL filters** (the Pages Router populates params after mount, so a mount-only snapshot would have broken exactly the shared-link case)
- a permalink or shared link
- a saved-view switch (the sidebar is keyed by `selectedViewId`, so this is a remount)
- "Clear all filters" (`…` menu)
- "Filter with AI" apply
- an apply from the search bar
- anything else authored outside the facet list

**Never re-settles**: checking/unchecking values, typing in a facet input, switching a facet's Select/Text mode or operator, clearing one facet, expanding/collapsing. "Add filter" is the one in-list action that still moves a facet — it promotes *only* that facet into the top block (unchanged behaviour) and the existing scroll brings it into view.

**Membership stays live**, only the order is frozen: "Show only active", the active count badge, and the rail tooltip all still read current promotion, so a filter applied mid-session is never hidden. The promoted/rest separator follows the settled block, so a facet activated in place keeps its position below the line until the next settle.

## Result

Verified against the local dev server (traces sidebar, 38-facet catalog):

| step | before | after |
| --- | --- | --- |
| click a value on `userId` (position 18 of 38) | facet jumps to position 1 | order identical, `y 259 → 259` |
| then `level`, then `traceTags` | reshuffles on each apply | order identical after all three |
| reload / open the 3-filter permalink | applied filters first | applied filters first (`userId > traceTags > level > …`) |

<details>
<summary>Mechanism, failure direction, and checks</summary>

**Attribution.** `onPointerDownCapture` / `onKeyDownCapture` on the facet-list container bump an interaction counter. The reducer treats a promotion change that follows a new interaction as the user's own edit and keeps the settled order; otherwise it settles. Capture-phase on that node (rather than the scroll root) is deliberate: React propagates events through portals by the **React** tree, so a facet's portalled dropdown (metadata keys, score names) counts as an in-list interaction too.

**Why a counter and not a flag.** The counter is consumed only when the promoted set actually changes, so an unrelated re-render landing between the click and the filter change cannot eat it — this matters for debounced facet inputs, where the filter lands several renders after the keystroke. It also makes the derivation idempotent, which it has to be: `reactStrictMode` is on and the component body runs twice per render.

**Failure direction.** If attribution ever misfires, it misses a re-settle (the order stays as it was) rather than reordering under the cursor — the benign direction. The one way to get there is an in-list interaction that changes no promotion followed by an external apply; that costs one settle, never a jump.

**State placement.** The settled order is a ref advanced during render by a pure function, not effect-derived state — no `useEffect` was added. The follow-scroll and focus-restoration effect is unchanged (it still owns DOM scrolling as its external system); its comment now describes when a facet actually moves.

**Two guards keep a stale block from ever surviving.** An in-list edit that changes values but not promotion (a second value on the same facet) never consumes its attribution, so it would still be outstanding when the next change lands. First, an empty promoted set always settles — there is no block to hold, so Clear all or a cleared search bar can never keep a stale block and its separator. Second, the boundaries the sidebar owns (Clear all, AI apply) drop any outstanding attribution before applying. What remains is bounded and benign: an in-list edit of that shape followed by a *search-bar* apply holds the order for one more change instead of re-settling, and self-corrects at the next boundary.

**Checks**
- `pnpm --filter web run test-client src/features/filters/lib/facet-order.clienttest.ts` → `Tests 4 passed (4)` — settle order, hold-through-edits + StrictMode idempotence, the stale-block guards, add-filter promotion.
- `pnpm --filter web run test-client src/components/table/data-table-controls.clienttest.tsx` → `Tests 20 passed (20)`, including a new pin that Clear all restores catalog order with an interaction outstanding. (Under node 26 two unrelated `localStorage` tests fail on this branch *and* on the base; both pass on the repo's node 24.)
- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` → clean (this tsconfig includes `**/*.tsx`, so the client tests are covered)
- Browser, after the guards landed: two applies on one facet held the order; Clear all with the attribution outstanding restored catalog order with the filter dropped from the URL; a 3-filter permalink settled its block to the top with one separator, and "Show only active" rendered none.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
