### PR TITLE
fix(dashboard): exclude v3 trace presets from widget suggestions (LFE-14444)

### DIFF
--- a/packages/shared/src/features/query/types.ts
+++ b/packages/shared/src/features/query/types.ts
@@ -129,6 +129,20 @@ export const viewsV2 = z.enum([
   "scores-boolean",
 ]);
 
+/**
+ * Persisted dashboard-widget view ids → query view ids. Lives here (not with
+ * the server-only DashboardService types) so client code can classify a stored
+ * widget; DashboardService's Prisma-keyed map is this constant, so the two
+ * cannot drift.
+ */
+export const persistedWidgetViewToQueryView = {
+  TRACES: "traces",
+  OBSERVATIONS: "observations",
+  SCORES_NUMERIC: "scores-numeric",
+  SCORES_BOOLEAN: "scores-boolean",
+  SCORES_CATEGORICAL: "scores-categorical",
+} as const satisfies Record<string, z.infer<typeof views>>;
+
 export const viewVersions = z.enum(["v1", "v2"]);
 export type ViewVersion = z.infer<typeof viewVersions>;
 

--- a/packages/shared/src/features/query/widgetVersion.test.ts
+++ b/packages/shared/src/features/query/widgetVersion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getWidgetRequiredVersion,
+  isSuggestedWidgetView,
   resolveWidgetEditorVersion,
   resolveWidgetRenderVersion,
   type WidgetQueryShape,
@@ -54,6 +55,20 @@ describe("widget query version selection", () => {
       ).toBe(expected);
     },
   );
+
+  // v4 suggestions must not offer v3 trace-based widgets (LFE-14444), in
+  // either the persisted (Prisma) or query view spelling.
+  it.each([
+    ["traces", "v2", false],
+    ["TRACES", "v2", false],
+    ["observations", "v2", true],
+    ["OBSERVATIONS", "v2", true],
+    ["SCORES_NUMERIC", "v2", true],
+    ["traces", "v1", true],
+    ["TRACES", "v1", true],
+  ] as const)("suggests %s in %s: %s", (view, version, expected) => {
+    expect(isSuggestedWidgetView(view, version)).toBe(expected);
+  });
 
   it.each([
     ["v1 editor", v1Shape, 1, "v1", "v1"],

--- a/packages/shared/src/features/query/widgetVersion.ts
+++ b/packages/shared/src/features/query/widgetVersion.ts
@@ -1,5 +1,9 @@
 import { requiresV2 } from "./dataModel";
-import type { ViewVersion } from "./types";
+import {
+  persistedWidgetViewToQueryView,
+  viewsV2,
+  type ViewVersion,
+} from "./types";
 
 export type WidgetQueryVersion = 1 | 2;
 export type WidgetQueryShape = Parameters<typeof requiresV2>[0];
@@ -13,6 +17,25 @@ export function getWidgetRequiredVersion(
   shape: WidgetQueryShape,
 ): WidgetQueryVersion {
   return requiresV2(shape) ? 2 : 1;
+}
+
+/**
+ * Whether a widget view may be *offered* for a target version. v2 derives
+ * traces at read time from the events model, so `viewsV2` — already the
+ * allowlist for new v4 widget definitions — is also the suggestion allowlist.
+ * Existing `traces` widgets stay readable (v2 has an events-backed traces
+ * declaration); they are just not suggested. (LFE-14444)
+ */
+export function isSuggestedWidgetView(
+  view: string,
+  targetVersion: ViewVersion,
+): boolean {
+  if (targetVersion !== "v2") return true;
+  const queryView =
+    persistedWidgetViewToQueryView[
+      view as keyof typeof persistedWidgetViewToQueryView
+    ] ?? view;
+  return viewsV2.safeParse(queryView).success;
 }
 
 function resolveEffectiveWidgetVersion(params: {

--- a/packages/shared/src/server/services/DashboardService/types.ts
+++ b/packages/shared/src/server/services/DashboardService/types.ts
@@ -1,16 +1,21 @@
 import { DashboardWidgetChartType, DashboardWidgetViews } from "@prisma/client";
 import { z } from "zod";
 import { singleFilter } from "../../../";
-import { type views } from "../../../features/query";
+import {
+  persistedWidgetViewToQueryView,
+  type views,
+} from "../../../features/query";
 
-/** Maps the persisted Prisma enum to the query model's public view id. */
-export const dashboardWidgetViewToQueryView = {
-  [DashboardWidgetViews.TRACES]: "traces",
-  [DashboardWidgetViews.OBSERVATIONS]: "observations",
-  [DashboardWidgetViews.SCORES_NUMERIC]: "scores-numeric",
-  [DashboardWidgetViews.SCORES_BOOLEAN]: "scores-boolean",
-  [DashboardWidgetViews.SCORES_CATEGORICAL]: "scores-categorical",
-} as const satisfies Record<DashboardWidgetViews, z.infer<typeof views>>;
+/**
+ * Maps the persisted Prisma enum to the query model's public view id. The map
+ * itself is client-safe (`persistedWidgetViewToQueryView`); the `satisfies`
+ * here is what keeps it exhaustive against the Prisma enum.
+ */
+export const dashboardWidgetViewToQueryView =
+  persistedWidgetViewToQueryView satisfies Record<
+    DashboardWidgetViews,
+    z.infer<typeof views>
+  >;
 
 /** Maps the query model's public view id to the persisted Prisma enum. */
 export const queryViewToDashboardWidgetView = {

--- a/web/src/features/dashboard/components/home-preset-registry.tsx
+++ b/web/src/features/dashboard/components/home-preset-registry.tsx
@@ -1,5 +1,9 @@
 import { type ReactNode } from "react";
-import { type FilterState, type HomeDashboardPresetId } from "@langfuse/shared";
+import {
+  HOME_DASHBOARD_PRESET_IDS,
+  type FilterState,
+  type HomeDashboardPresetId,
+} from "@langfuse/shared";
 import { type ViewVersion } from "@langfuse/shared/query";
 import { type DashboardDateRangeAggregationOption } from "@/src/utils/date-range-utils";
 import { TracesBarListChart } from "@/src/features/dashboard/components/TracesBarListChart";
@@ -205,11 +209,19 @@ const HOME_PRESETS: Record<
 
 /**
  * Display metadata for the preset picker (Add Widget dialog). `illustration`
- * keys into ChartTypeIllustration.
+ * keys into ChartTypeIllustration. `queriesTracesView` marks a preset whose
+ * query still targets the legacy `traces` view under v2, so it is not
+ * suggested to v4 users (LFE-14444) — every other card branches to the events
+ * model on its own.
  */
 export const HOME_PRESET_METADATA: Record<
   HomeDashboardPresetId,
-  { name: string; description: string; illustration: string }
+  {
+    name: string;
+    description: string;
+    illustration: string;
+    queriesTracesView?: true;
+  }
 > = {
   "home-traces": {
     name: "Traces",
@@ -250,6 +262,8 @@ export const HOME_PRESET_METADATA: Record<
     name: "Trace Latency Percentiles",
     description: "p50–p99 latencies per trace name",
     illustration: "PIVOT_TABLE",
+    // LatencyTable kind="traces" has no v2 branch: always `view: "traces"`.
+    queriesTracesView: true,
   },
   "home-latency-table-generations": {
     name: "Generation Latency Percentiles",
@@ -272,6 +286,16 @@ export const HOME_PRESET_METADATA: Record<
     illustration: "HISTOGRAM",
   },
 };
+
+/** Home cards offered in the Add Widget dialog for a metrics version. */
+export function getSuggestedHomePresetIds(
+  version: ViewVersion,
+): HomeDashboardPresetId[] {
+  return HOME_DASHBOARD_PRESET_IDS.filter(
+    (presetId) =>
+      version !== "v2" || !HOME_PRESET_METADATA[presetId].queriesTracesView,
+  );
+}
 
 export function getHomePreset(
   presetId: string,

--- a/web/src/features/dashboard/components/homePresetSuggestions.clienttest.ts
+++ b/web/src/features/dashboard/components/homePresetSuggestions.clienttest.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { HOME_DASHBOARD_PRESET_IDS } from "@langfuse/shared";
+import { getSuggestedHomePresetIds } from "@/src/features/dashboard/components/home-preset-registry";
+
+describe("Add Widget home-card suggestions", () => {
+  it("drops presets that still query the legacy traces view on v4", () => {
+    expect(getSuggestedHomePresetIds("v2")).not.toContain(
+      "home-latency-table-traces",
+    );
+    expect(getSuggestedHomePresetIds("v1")).toEqual(HOME_DASHBOARD_PRESET_IDS);
+  });
+});

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -138,7 +138,7 @@ export function SelectWidgetDialog({
   // Suggestions obey the same view allowlist the widget editor uses for new
   // definitions, so v4 users are never offered a v3 trace-based widget.
   // Legacy trace widgets stay listed and editable under /widgets. (LFE-14444)
-  const { isBetaEnabled } = useV4Beta();
+  const { isBetaEnabled, isInitializing } = useV4Beta();
   const suggestedVersion: ViewVersion = isBetaEnabled ? "v2" : "v1";
   const allProjectWidgets = widgets.data?.widgets ?? [];
   const projectWidgets = allProjectWidgets.filter((widget) =>
@@ -146,6 +146,12 @@ export function SelectWidgetDialog({
   );
   const hiddenWidgetCount = allProjectWidgets.length - projectWidgets.length;
   const suggestedPresetIds = getSuggestedHomePresetIds(suggestedVersion);
+  // Replaces the generic empty state when it hid every widget, so the two can
+  // never contradict each other.
+  const hiddenWidgetsNote =
+    hiddenWidgetCount > 0
+      ? `${hiddenWidgetCount} trace-based widget${hiddenWidgetCount === 1 ? "" : "s"} hidden — the Traces view is not available for new charts. Manage them under Widgets.`
+      : null;
 
   const selectWidget = (widget: WidgetItem) => {
     capture("dashboard:widget_added", {
@@ -167,7 +173,9 @@ export function SelectWidgetDialog({
         </DialogHeader>
 
         <DialogBody>
-          {widgets.isPending ? (
+          {/* isInitializing: an unresolved session reads as v1, which would
+              briefly offer the unfiltered list to a v4 user. */}
+          {widgets.isPending || isInitializing ? (
             <div className="py-8 text-center">Loading widgets...</div>
           ) : widgets.isError ? (
             <div className="text-destructive py-8 text-center">
@@ -201,8 +209,12 @@ export function SelectWidgetDialog({
               </button>
 
               <Tabs
+                // Open on the project tab when it has something to say — a
+                // hidden-widget note included, so it is not missed.
                 defaultValue={
-                  projectWidgets.length > 0 ? "project" : "home-cards"
+                  projectWidgets.length > 0 || hiddenWidgetsNote
+                    ? "project"
+                    : "home-cards"
                 }
                 onValueChange={(tab) =>
                   capture("dashboard:add_widget_tab_switch", { tab })
@@ -220,28 +232,23 @@ export function SelectWidgetDialog({
                 </TabsList>
                 <TabsContent value="project">
                   <div className="flex max-h-[360px] flex-col gap-2 overflow-y-auto p-1">
+                    {projectWidgets.map((widget) => (
+                      <WidgetRow
+                        key={widget.id}
+                        widget={widget as WidgetItem}
+                        onClick={() => selectWidget(widget as WidgetItem)}
+                      />
+                    ))}
                     {projectWidgets.length === 0 ? (
                       <div className="text-muted-foreground py-8 text-center text-sm">
-                        No saved widgets in this project yet — build one with
-                        Custom Chart.
+                        {hiddenWidgetsNote ??
+                          "No saved widgets in this project yet — build one with Custom Chart."}
                       </div>
-                    ) : (
-                      projectWidgets.map((widget) => (
-                        <WidgetRow
-                          key={widget.id}
-                          widget={widget as WidgetItem}
-                          onClick={() => selectWidget(widget as WidgetItem)}
-                        />
-                      ))
-                    )}
-                    {hiddenWidgetCount > 0 && (
+                    ) : hiddenWidgetsNote ? (
                       <div className="text-muted-foreground px-1 py-2 text-xs">
-                        {hiddenWidgetCount} trace-based widget
-                        {hiddenWidgetCount === 1 ? "" : "s"} hidden — the Traces
-                        view is not available for new charts. Manage them under
-                        Widgets.
+                        {hiddenWidgetsNote}
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 </TabsContent>
                 {onSelectPreset && (

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -20,11 +20,16 @@ import {
 import startCase from "lodash/startCase";
 import { getChartTypeDisplayName } from "@/src/features/widgets/chart-library/utils";
 import { ChartTypeIllustration } from "@/src/features/widgets/components/ChartTypeIllustration";
+import { type HomeDashboardPresetId } from "@langfuse/shared";
 import {
-  HOME_DASHBOARD_PRESET_IDS,
-  type HomeDashboardPresetId,
-} from "@langfuse/shared";
-import { HOME_PRESET_METADATA } from "@/src/features/dashboard/components/home-preset-registry";
+  isSuggestedWidgetView,
+  type ViewVersion,
+} from "@langfuse/shared/query";
+import {
+  getSuggestedHomePresetIds,
+  HOME_PRESET_METADATA,
+} from "@/src/features/dashboard/components/home-preset-registry";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
 import { InAppAgentWidgetComposer } from "@/src/features/in-app-agent/components/InAppAgentWidgetComposer";
 
@@ -130,7 +135,17 @@ export function SelectWidgetDialog({
     },
   );
 
-  const projectWidgets = widgets.data?.widgets ?? [];
+  // Suggestions obey the same view allowlist the widget editor uses for new
+  // definitions, so v4 users are never offered a v3 trace-based widget.
+  // Legacy trace widgets stay listed and editable under /widgets. (LFE-14444)
+  const { isBetaEnabled } = useV4Beta();
+  const suggestedVersion: ViewVersion = isBetaEnabled ? "v2" : "v1";
+  const allProjectWidgets = widgets.data?.widgets ?? [];
+  const projectWidgets = allProjectWidgets.filter((widget) =>
+    isSuggestedWidgetView(widget.view, suggestedVersion),
+  );
+  const hiddenWidgetCount = allProjectWidgets.length - projectWidgets.length;
+  const suggestedPresetIds = getSuggestedHomePresetIds(suggestedVersion);
 
   const selectWidget = (widget: WidgetItem) => {
     capture("dashboard:widget_added", {
@@ -199,7 +214,7 @@ export function SelectWidgetDialog({
                   </TabsTrigger>
                   {onSelectPreset && (
                     <TabsTrigger value="home-cards">
-                      Home cards ({HOME_DASHBOARD_PRESET_IDS.length})
+                      Home cards ({suggestedPresetIds.length})
                     </TabsTrigger>
                   )}
                 </TabsList>
@@ -219,12 +234,20 @@ export function SelectWidgetDialog({
                         />
                       ))
                     )}
+                    {hiddenWidgetCount > 0 && (
+                      <div className="text-muted-foreground px-1 py-2 text-xs">
+                        {hiddenWidgetCount} trace-based widget
+                        {hiddenWidgetCount === 1 ? "" : "s"} hidden — the Traces
+                        view is not available for new charts. Manage them under
+                        Widgets.
+                      </div>
+                    )}
                   </div>
                 </TabsContent>
                 {onSelectPreset && (
                   <TabsContent value="home-cards">
                     <div className="flex max-h-[360px] flex-col gap-2 overflow-y-auto p-1">
-                      {HOME_DASHBOARD_PRESET_IDS.map((presetId) => {
+                      {suggestedPresetIds.map((presetId) => {
                         const meta = HOME_PRESET_METADATA[presetId];
                         return (
                           <button


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15885.preview.langfuse.com](https://pr-15885.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The **Add Widget** dialog offered every saved widget and every Home card — including ones built on the legacy `traces` view. For a v4 user those are v3-shaped suggestions the widget editor itself already refuses. The suggestion list now obeys the **same `viewsV2` allowlist** the editor uses for new definitions, so no second v3/v4 signal is invented. Legacy trace widgets stay readable, listed and editable under **Widgets** — they're just not suggested.

## Why

A customer building per-service analytics hit the trace-vs-observation model head-on in dashboard widgets. In v4 traces are *derived at read time* from the events model, and the widget editor's View picker already excludes `Traces` for v4 (`viewsV2`), as does the Assistant's widget tool. The one surface that never asked was the suggestion list you get when adding a widget — so v4 users were still being handed v3 trace widgets to start from.

## What

- `isSuggestedWidgetView(view, version)` joins `widgetVersion.ts` — the module that already owns widget↔version policy — and accepts both the persisted (`TRACES`) and the query (`traces`) spelling.
- `persistedWidgetViewToQueryView` moves to the client-safe query module so the browser can classify a stored widget; `DashboardService`'s Prisma-keyed map **is** that constant now, with the `satisfies Record<DashboardWidgetViews, …>` kept, so the two cannot drift and a new Prisma view still fails the build.
- `SelectWidgetDialog` filters both tabs and notes how many widgets it hid (otherwise a missing widget reads as a bug).
- Exactly **one** Home card (`Trace Latency Percentiles`) still issues a `view: "traces"` query under v2 and is dropped for v4; every other card already branches to the events model on its own, so the list goes 12 → 11, not gutted.

## Result

| | v4 preview on | v4 preview off |
|---|---|---|
| Your widgets | trace-view widgets hidden + count note | unchanged |
| Home cards | 11 | 12 |
| Custom Chart view picker | already excluded `Traces` | unchanged |

<details>
<summary>Mechanism, scope and verification</summary>

**Why `viewsV2` is the right allowlist.** v2 *does* have an events-backed `traces` declaration (`eventsTracesView`) for legacy widget parity, so trace widgets keep rendering under v4 — this change is about what we *offer*, not what we can read. `viewsV2` is already the "views a new v4 widget may use" contract, shared by the editor's View picker and the unstable widget API. Reusing it means the three surfaces cannot disagree.

**Gate.** `useV4Beta().isBetaEnabled → "v2" | "v1"`, the same mapping `WidgetForm` uses for `activeVersion`. A v3-only self-hosted instance sees the full list unchanged.

**Home cards audited individually** — each preset's query under v2: `home-traces` and `home-users` switch to `uniq(trace_id)` over observations; `home-traces-obs-time-series` disables its traces query entirely; the generation/observation latency tables, model usage/cost, and all score cards are already observations/scores-based. Only `LatencyTable kind="traces"` has no v2 branch.

**Not in scope, worth a follow-up:** the 9 Langfuse-maintained widgets with `view: TRACES` (on the 3 curated dashboards) are not reachable from this dialog, but "edit" → *Create my copy* still seeds the editor with `view = Traces`, bypassing the picker's exclusion. And v4 users lose the only per-trace-name latency percentile preset; the nearest remaining card is per observation type+name.

**Verified locally** (v4 preview on and off, two projects — one with v4 events, one with v3-only data): tab counts, the hidden-widget note, the absent Home card, the View picker options, and all 11 remaining Home cards plus an observations widget added to a scratch dashboard — every tile rendered data.

Checks: `turbo run typecheck` 7 successful, 7 total · `turbo run lint` 7 successful, 7 total · shared `Tests 21 passed (21)` · web client `Tests 366 passed (366)` + new preset test `1 passed (1)` · widget min-version servertest `6 passed (6)` · one worker check `51 passed (51)`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard suggestion filtering only; no auth, persistence, or query execution changes, and v3 behavior is unchanged when v4 preview is off.
> 
> **Overview**
> Aligns **Add widget** suggestions with the same **`viewsV2`** allowlist the widget editor already uses for new v4 definitions, so trace-based widgets are not offered even though legacy trace widgets remain readable.
> 
> Adds **`isSuggestedWidgetView`** and moves **`persistedWidgetViewToQueryView`** into shared query types so the client can classify stored widgets; **`DashboardService`** now re-exports that map with Prisma exhaustiveness checks so server and client cannot drift.
> 
> **`SelectWidgetDialog`** filters project widgets and home presets when v4 preview is on (via **`useV4Beta`**), shows a count when trace widgets are hidden, and waits on beta initialization to avoid briefly showing the full v1 list. **`getSuggestedHomePresetIds`** drops the **Trace Latency Percentiles** home card under v2 because it still queries the legacy traces view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6099b6fc623d217fa9ec1ad67a7d29144e6a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes persisted-to-query widget view mapping and applies the v4 view allowlist to project-widget and Home-card suggestions.
- Filters legacy trace widgets from the Add Widget dialog for v4 users and reports the hidden count.
- Marks and excludes the trace-latency Home preset under v4.
- Adds shared policy and client tests for v1/v2 suggestion behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking initialization race that can briefly expose the legacy suggestions it intends to hide.

The filtering and mappings are otherwise exhaustive and consistent, but the dialog treats an unresolved session as v1 and remains interactive until the v4 gate resolves.

**Files Needing Attention:** web/src/features/widgets/components/SelectWidgetDialog.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/widgets/components/SelectWidgetDialog.tsx:141-142
**Guard unresolved v4 state**

While the session is initializing, `isBetaEnabled` falls back to `false`, so the dialog renders and enables the unfiltered v1 widget and preset lists for a v4 user. Legacy trace suggestions can therefore be selected before the feature state resolves, after which the editor presents an unsupported trace-view state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): exclude v3 trace presets..."](https://github.com/langfuse/langfuse/commit/b43e5432326f376e91b6a8e1f33cadaec6b8e18f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51131444)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->