### PR TITLE
fix(evals): validate default model structured output

### DIFF
--- a/packages/shared/src/server/llm/testModelCall.test.ts
+++ b/packages/shared/src/server/llm/testModelCall.test.ts
@@ -1,0 +1,57 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { MockLanguageModelV4 } from "ai/test";
+import { describe, expect, it, vi } from "vitest";
+
+import { encrypt } from "../../encryption";
+import { testModelCall } from "./testModelCall";
+import { LLMAdapter } from "./types";
+
+vi.mock("@ai-sdk/openai", () => ({ createOpenAI: vi.fn() }));
+
+describe("testModelCall", () => {
+  it("rejects when the model produces no structured output", async () => {
+    vi.mocked(createOpenAI).mockReturnValue({
+      chat: () =>
+        new MockLanguageModelV4({
+          doGenerate: {
+            content: [],
+            finishReason: { unified: "length", raw: "length" },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: { total: 1, text: 0, reasoning: 1 },
+            },
+            warnings: [],
+          },
+        }),
+      responses: vi.fn(),
+    } as never);
+
+    await expect(
+      testModelCall({
+        provider: "openai",
+        model: "reasoning-model",
+        apiKey: {
+          id: "api-key-id",
+          projectId: "project-id",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          adapter: LLMAdapter.OpenAI,
+          provider: "openai",
+          displaySecretKey: "sk-...test",
+          secretKey: encrypt("sk-test"),
+          extraHeaders: null,
+          extraHeaderKeys: [],
+          baseURL: null,
+          customModels: [],
+          withDefaultModels: true,
+          config: null,
+        },
+      }),
+    ).rejects.toMatchObject({ name: "AI_NoOutputGeneratedError" });
+  });
+});

--- a/packages/shared/src/server/llm/testModelCall.ts
+++ b/packages/shared/src/server/llm/testModelCall.ts
@@ -36,7 +36,7 @@ export const testModelCall = async ({
       reasoning: z.string(),
     });
 
-  await generateLLMText({
+  const result = await generateLLMText({
     ...mapLegacyLLMCompletionParams({
       connection: apiKey,
       messages: [
@@ -57,4 +57,7 @@ export const testModelCall = async ({
     output: createLLMOutput(schema),
     timeout,
   });
+
+  // Accessing output makes the AI SDK validate that structured output exists.
+  const { output: _output } = result;
 };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15888.preview.langfuse.com](https://pr-15888.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

Ensure default evaluation model validation reads the AI SDK structured output result so responses with no generated output fail before the model configuration is saved.

Adds a regression test covering an OpenAI-compatible-style response that finishes with `length` and produces no structured content.

Linear: https://linear.app/clickhouse/issue/LFE-14838/bug-default-evaluation-model-validation-succeeds-when-structured
GitHub issue: https://github.com/langfuse/langfuse/issues/15862

## Scope

Impacted package: `@langfuse/shared`

This intentionally does not change OpenAI-compatible structured-output capability selection; that broader compatibility policy needs separate product/design work.

## Verification

- `pnpm --filter @langfuse/shared run test src/server/llm/testModelCall.test.ts`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm run lint`
- `pnpm --filter web run test src/__tests__/server/unit/evaluator-preflight.servertest.ts`
- `pnpm --filter worker run test src/features/evaluation/__tests__/evalExecutionDeps.test.ts`
- `pnpm exec prettier --check packages/shared/src/server/llm/testModelCall.ts packages/shared/src/server/llm/testModelCall.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to pre-save model validation in `@langfuse/shared`; stricter failure behavior only, no auth or data-path changes.
> 
> **Overview**
> **Default evaluation model checks** no longer treat “no structured output” as success when saving configuration.
> 
> `testModelCall` now reads the `output` field on the `generateLLMText` result so the AI SDK runs its structured-output validation; responses that finish without parseable content (e.g. `length` with empty content) throw instead of passing silently.
> 
> A **regression test** mocks that empty-output case and expects `AI_NoOutputGeneratedError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ee413747fe3d9c5aa313bfe1618dfa571a8735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ensures default evaluation model validation consumes the AI SDK structured-output result so model responses without generated structured content fail before configuration is saved.

- Reads the generated result’s `output` property to trigger structured-output validation.
- Adds a regression test for an empty response that terminates because of the output-length limit.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed validation matching the intended missing-output failure behavior.

The output getter is accessed after the structured generation call, the existing caller already handles validation errors, and no reachable regression was identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): validate default model struc..."](https://github.com/langfuse/langfuse/commit/94ee413747fe3d9c5aa313bfe1618dfa571a8735) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51153070)</sub>

**Context used:**

- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->