### PR TITLE
fix(assistant): fix silent MCP tool schema validation

### DIFF
--- a/packages/shared/src/in-app-agent/server/tools.ts
+++ b/packages/shared/src/in-app-agent/server/tools.ts
@@ -549,6 +549,26 @@ export type CompletedInAppAgentMcpToolCall = {
   createdAt: Date;
 };
 
+type WrappableMcpTool = Pick<
+  Tool,
+  "execute" | "inputSchema" | "toModelOutput"
+> &
+  Required<Pick<Tool, "execute" | "inputSchema">>;
+
+function isWrappableMcpTool(tool: unknown): tool is WrappableMcpTool {
+  return (
+    typeof tool === "object" &&
+    tool !== null &&
+    "execute" in tool &&
+    typeof tool.execute === "function" &&
+    "inputSchema" in tool &&
+    tool.inputSchema !== undefined &&
+    (!("toModelOutput" in tool) ||
+      tool.toModelOutput === undefined ||
+      typeof tool.toModelOutput === "function")
+  );
+}
+
 export function withOptionalSilentMcpOutput(params: {
   tools: Record<string, unknown> | undefined;
   sandbox?: InAppAgentSandbox;
@@ -560,14 +580,13 @@ export function withOptionalSilentMcpOutput(params: {
         return [toolName, tool];
       }
 
-      if (!(tool instanceof Tool)) {
+      // MCPClient may construct tools with a different @mastra/core module
+      // instance, so instanceof Tool is not reliable across package realms.
+      if (!isWrappableMcpTool(tool)) {
         return [toolName, tool];
       }
 
       const { execute, inputSchema, toModelOutput } = tool;
-      if (!execute || !inputSchema) {
-        return [toolName, tool];
-      }
 
       if (inputSchema instanceof z.ZodObject) {
         tool.inputSchema = inputSchema.extend({

--- a/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
@@ -11,6 +11,7 @@ import {
 } from "@langfuse/shared/in-app-agent/server/persistence";
 import { createInAppAgentSandbox } from "@langfuse/shared/in-app-agent/server/sandbox";
 import { withOptionalSilentMcpOutput } from "@langfuse/shared/in-app-agent/server/tools";
+import { listObservationsTool } from "@/src/features/mcp/features/observations/tools/listObservations";
 
 describe("in-app agent sandbox", () => {
   it("redacts silent MCP output from persisted conversation display", async () => {
@@ -356,24 +357,22 @@ describe("in-app agent sandbox", () => {
     );
   });
 
-  it("advertises silent MCP output for JSON Schema tools", () => {
+  it("supports silent output for the listObservations JSON Schema", async () => {
+    let receivedInput: unknown;
     const tools = withOptionalSilentMcpOutput({
       tools: {
-        search: new Tool({
-          id: "search",
-          description: "Search",
-          inputSchema: {
-            type: "object",
-            properties: {
-              query: { type: "string" },
+        // MCP tools can originate from a different @mastra/core module instance.
+        listObservations: {
+          ...new Tool({
+            id: "listObservations",
+            description: listObservationsTool.description,
+            inputSchema: listObservationsTool.inputSchema,
+            execute: async (input) => {
+              receivedInput = input;
+              return { data: [] };
             },
-            required: ["query"],
-            additionalProperties: false,
-          },
-          execute: async (input: { query: string }) => ({
-            result: input.query,
           }),
-        }),
+        },
       },
       sandbox: {
         async read() {
@@ -391,11 +390,14 @@ describe("in-app agent sandbox", () => {
       },
     });
 
-    if (!tools.search.inputSchema) {
+    if (!tools.listObservations.inputSchema) {
       throw new Error("Expected an input schema");
     }
 
-    expect(standardSchemaToJSONSchema(tools.search.inputSchema)).toMatchObject({
+    expect(
+      standardSchemaToJSONSchema(tools.listObservations.inputSchema),
+    ).toMatchObject({
+      additionalProperties: false,
       properties: {
         silent: {
           type: "boolean",
@@ -404,6 +406,17 @@ describe("in-app agent sandbox", () => {
         },
       },
     });
+
+    await expect(
+      tools.listObservations.execute?.(
+        { limit: 10, silent: true },
+        {} as never,
+      ),
+    ).resolves.toEqual({
+      type: "silent-mcp-output",
+      output: { data: [] },
+    });
+    expect(receivedInput).toEqual({ limit: 10 });
   });
 
   it("returns normal MCP output when silent is omitted", async () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15889.preview.langfuse.com](https://pr-15889.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow change to in-app agent MCP tool wrapping and tests; behavior for same-realm `Tool` instances should be unchanged aside from fixing the cross-module case.
> 
> **Overview**
> **Fixes silent MCP tooling when MCPClient builds tools from a different `@mastra/core` copy**, where `instanceof Tool` skipped wrapping so the optional `silent` field was never added to JSON Schema tools and validation could fail.
> 
> `withOptionalSilentMcpOutput` now uses a structural `isWrappableMcpTool` check (`execute`, `inputSchema`, optional `toModelOutput`) instead of `instanceof`. The unit test exercises the real `listObservations` JSON Schema path and asserts `silent` is advertised, stripped before `execute`, and returns the silent-mcp-output envelope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae68c2260392434ab5ef11f9cda417e9150eddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes silent MCP output wrapping for tools created by a different `@mastra/core` module instance.

- Replaces the realm-sensitive `Tool instanceof` check with structural validation of required tool members.
- Extends the sandbox test to exercise silent schema advertisement, input stripping, and output wrapping on a structurally copied MCP tool.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code failure identified.

The structural guard validates the executable members used by the wrapper, and the updated test covers the intended cross-module tool shape through schema advertisement and execution.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): fix silent MCP tool s..."](https://github.com/langfuse/langfuse/commit/4ae68c2260392434ab5ef11f9cda417e9150eddc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51152437)</sub>

<!-- /greptile_comment -->