### PR TITLE
fix(shared): prevent regex backtracking denial of service

### DIFF
--- a/packages/shared/src/utils/stringChecks.ts
+++ b/packages/shared/src/utils/stringChecks.ts
@@ -12,7 +12,7 @@ export const VARIABLE_REGEX = /^\p{L}[\p{L}\p{N}_]*$/u;
 export const MUSTACHE_REGEX = /{{([^{}]*)}}/g;
 
 // Regex to find multiline variables
-export const MULTILINE_VARIABLE_REGEX = /{{[^{}]*\n[^{}]*}}/g;
+export const MULTILINE_VARIABLE_REGEX = /{{[^{}\n]*\n[^{}]*}}/g;
 
 // Regex to find unclosed variables
 export const UNCLOSED_VARIABLE_REGEX = /{{(?!{)(?![^{]*}})/g;

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -176,16 +176,43 @@ export const noUrlCheck = (value: string) => !urlRegex.test(value);
 
 export const NonEmptyString = z.string().min(1);
 
-export const htmlRegex = /<[^>]*>/g;
+export const htmlRegex = /<[^<>]*>/g;
+const containsHtmlRegex = /<[^<>]*>/;
 
-export const StringNoHTML = z.string().refine((val) => !htmlRegex.test(val), {
-  message: "Text cannot contain HTML tags",
-});
+function removeHtmlTags(input: string): string {
+  const parts: string[] = [];
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const tagStart = input.indexOf("<", cursor);
+    if (tagStart === -1) {
+      parts.push(input.slice(cursor));
+      break;
+    }
+
+    const tagEnd = input.indexOf(">", tagStart + 1);
+    if (tagEnd === -1) {
+      parts.push(input.slice(cursor));
+      break;
+    }
+
+    parts.push(input.slice(cursor, tagStart));
+    cursor = tagEnd + 1;
+  }
+
+  return parts.join("");
+}
+
+export const StringNoHTML = z
+  .string()
+  .refine((val) => !containsHtmlRegex.test(val), {
+    message: "Text cannot contain HTML tags",
+  });
 
 export const StringNoHTMLNonEmpty = z
   .string()
   .min(1, "Text cannot be empty")
-  .refine((val) => !htmlRegex.test(val), {
+  .refine((val) => !containsHtmlRegex.test(val), {
     message: "Text cannot contain HTML tags",
   });
 
@@ -246,18 +273,14 @@ export type JSONArray = z.infer<typeof JSONArraySchema>;
  * sanitizeEmailSubject("Test<script>alert(1)</script>") // Returns "Testscriptalert(1)/script"
  */
 export function sanitizeEmailSubject(input: string): string {
-  return (
-    input
-      // Remove carriage return and line feed (CRLF injection prevention)
-      .replace(/[\r\n]/g, "")
-      // Remove all control characters (ASCII 0-31 and 127)
-      // eslint-disable-next-line no-control-regex
-      .replace(/[\x00-\x1F\x7F]/g, "")
-      // Remove HTML tags (defensive layer)
-      .replace(htmlRegex, "")
-      // Trim whitespace
-      .trim()
-  );
+  const withoutControlCharacters = input
+    // Remove carriage return and line feed (CRLF injection prevention)
+    .replace(/[\r\n]/g, "")
+    // Remove all control characters (ASCII 0-31 and 127)
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1F\x7F]/g, "");
+
+  return removeHtmlTags(withoutControlCharacters).trim();
 }
 
 /**

--- a/web/src/__tests__/server/zod.servertest.ts
+++ b/web/src/__tests__/server/zod.servertest.ts
@@ -5,6 +5,8 @@ import {
   paginationZod,
   parseJsonPrioritised,
   publicApiPaginationLimitZod,
+  sanitizeEmailSubject,
+  StringNoHTML,
 } from "@langfuse/shared";
 import { ZodError } from "zod";
 
@@ -127,5 +129,27 @@ describe("isJsonNumberLiteral", () => {
     expect(isJsonNumberLiteral("-1.23e+4")).toBe(true);
     expect(isJsonNumberLiteral("plain107505301260286111")).toBe(false);
     expect(isJsonNumberLiteral("01")).toBe(false);
+  });
+});
+
+describe("StringNoHTML", () => {
+  it("rejects HTML consistently across validation calls", () => {
+    expect(StringNoHTML.safeParse("<b>").success).toBe(false);
+    expect(StringNoHTML.safeParse("<i>").success).toBe(false);
+  });
+
+  it("handles long unterminated tags without excessive backtracking", () => {
+    const input = "<".repeat(50_000);
+    const startedAt = performance.now();
+
+    expect(StringNoHTML.safeParse(input).success).toBe(true);
+    expect(performance.now() - startedAt).toBeLessThan(100);
+  });
+
+  it("removes every HTML tag from email subjects", () => {
+    expect(sanitizeEmailSubject("Project <b>one</b> <i>two</i>")).toBe(
+      "Project one two",
+    );
+    expect(sanitizeEmailSubject("Project <script<script>>")).toBe("Project >");
   });
 });

--- a/web/src/components/editor/CodeMirrorEditor.clienttest.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.clienttest.tsx
@@ -15,4 +15,28 @@ describe("getPromptVariableDiagnostics", () => {
       }),
     ]);
   });
+
+  it("reports variables spanning multiple lines", () => {
+    expect(
+      getPromptVariableDiagnostics("Use {{first\nsecond\nthird}} here"),
+    ).toContainEqual(
+      expect.objectContaining({
+        from: 4,
+        message: "Variables cannot span multiple lines",
+      }),
+    );
+  });
+
+  it("handles long unterminated multiline variables without excessive backtracking", () => {
+    const content = `{{${"\n".repeat(20_000)}`;
+    const startedAt = performance.now();
+
+    expect(getPromptVariableDiagnostics(content)).toEqual([
+      expect.objectContaining({
+        from: 0,
+        message: "Unclosed variable brackets",
+      }),
+    ]);
+    expect(performance.now() - startedAt).toBeLessThan(100);
+  });
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15891.preview.langfuse.com](https://pr-15891.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- make HTML-tag validation and multiline-variable detection linear in adversarial input length
- separate stateful global HTML matching from boolean validation
- preserve email-subject sanitization semantics with a forward-only scanner
- add regression coverage for repeated validation and both backtracking input shapes

Impacted packages: `@langfuse/shared`, `web`

## Verification

- `pnpm --filter web run test zod.servertest.ts` — `Tests  30 passed (30)`
- `pnpm --filter web run test-client CodeMirrorEditor.clienttest.tsx` — `Tests  4 passed (4)`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter worker run typecheck` — passed
- bounded equivalence check — 21,845 HTML validation cases and 21,845 multiline matching cases matched previous behavior

## Security review

The change introduces no URL handling, outbound requests, tenant-scoped data access, secrets, permissions, or new API surface. The visible editor diagnostics remain unchanged; only worst-case matching time changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces potentially backtracking HTML and multiline-variable matching paths with linear-time alternatives while separating stateful matching from boolean validation.
- Adds a forward-only HTML-tag removal scanner for email subjects.
- Uses a non-global regex for repeated Zod HTML validation.
- Makes multiline-variable matching deterministic around the first newline.
- Adds behavioral and adversarial-input regression tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with only non-blocking concern that the new fixed-duration performance checks may intermittently fail on loaded CI workers.

The changed matching and sanitization behavior remains consistent while removing ambiguous backtracking, but the regression tests use strict wall-clock deadlines that do not isolate algorithmic performance from host scheduling variance.

**Files Needing Attention:** web/src/__tests__/server/zod.servertest.ts; web/src/components/editor/CodeMirrorEditor.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/zod.servertest.ts:143-146
**Fixed wall-clock test threshold**

The fixed 100 ms deadline measures CI scheduling and host load as well as algorithmic complexity, so the new regression test can intermittently fail for a correct linear-time implementation; the editor test introduces the same issue for its 20,000-newline input.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): prevent regex backtracking ..."](https://github.com/langfuse/langfuse/commit/555a9d5cb56a938eeb22aa0a8488472755e11b9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51246995)</sub>

<!-- /greptile_comment -->