### PR TITLE
ci(perf): warm e2e server build cache

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1028,6 +1028,14 @@ jobs:
       - name: Load default env
         run: |
           cp .env.dev.example .env
+      - name: Setup Turbo cache
+        if: env.CI_CACHE_ALLOWED == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # zizmor: ignore[cache-poisoning] server e2e build cache only; publish jobs rebuild artifacts without restoring this cache
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-e2e-server-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-e2e-server-
       # The next two downloads/startups have no dependency on the build, so
       # they run in the background and the build overlaps them. Later steps
       # wait on their marker files.
@@ -1076,6 +1084,9 @@ jobs:
           timeout 10 bash -c 'until curl -f http://localhost:3000/api/public/health; do sleep 2; done'
       - name: Run e2e tests
         run: pnpm --filter=web run test:e2e:server
+      - name: Prune stale turbo cache entries
+        if: env.CI_CACHE_ALLOWED == 'true'
+        run: find .turbo/cache -type f -mtime +3 -delete 2>/dev/null || true
 
   all-ci-passed:
     # This allows us to have a branch protection rule for tests and deploys with matrix

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1033,9 +1033,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # zizmor: ignore[cache-poisoning] server e2e build cache only; publish jobs rebuild artifacts without restoring this cache
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-e2e-server-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-server-e2e-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-e2e-server-
+            ${{ runner.os }}-turbo-server-e2e-
       # The next two downloads/startups have no dependency on the build, so
       # they run in the background and the build overlaps them. Later steps
       # wait on their marker files.

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -58,7 +58,7 @@ jobs:
           - cache_scope: mode-redis-cluster
             deploy-mode: -redis-cluster
             env_profile: tests-web
-          - cache_scope: e2e-server
+          - cache_scope: server-e2e
             deploy-mode: ""
             env_profile: e2e-server
     steps:

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -39,16 +39,28 @@ jobs:
     # warm nothing.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
-    name: warm (mode${{ matrix.deploy-mode }})
+    name: warm (${{ matrix.cache_scope }})
     env:
-      # Mirror the tests-web job env so turbo task hashes match.
+      # Mirror the consuming test jobs so Turbo task hashes match.
       NODE_ENV: test
     strategy:
       # One mode failing must not cancel the other warmers — a partially
       # warmed pool still helps.
       fail-fast: false
       matrix:
-        deploy-mode: ["", "-azure", "-redis-cluster"]
+        include:
+          - cache_scope: mode-default
+            deploy-mode: ""
+            env_profile: tests-web
+          - cache_scope: mode-azure
+            deploy-mode: -azure
+            env_profile: tests-web
+          - cache_scope: mode-redis-cluster
+            deploy-mode: -redis-cluster
+            env_profile: tests-web
+          - cache_scope: e2e-server
+            deploy-mode: ""
+            env_profile: e2e-server
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -68,31 +80,34 @@ jobs:
         run: |
           pnpm install
       - name: Load default env
-        # Must stay byte-identical to the tests-web "Load default env" step in
-        # pipeline.yml: turbo hashes the whole .env (turbo.json
-        # globalDependencies), so any drift makes the warmed build hashes
-        # useless to tests-web.
+        # Must stay byte-identical to the matching pipeline job: Turbo hashes
+        # the whole .env, so even test-only differences invalidate the build.
         run: |
-          cp .env.dev${{ matrix.deploy-mode }}.example .env
-          grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev${{ matrix.deploy-mode }}.example > .env
-          echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1" >> .env
-          echo "LANGFUSE_CACHE_PROMPT_ENABLED=false" >> .env
-          echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1" >> .env
-          echo "LANGFUSE_TRACE_DELETE_DELAY_MS=1" >> .env
-          echo "LANGFUSE_TRACE_DELETE_CONCURRENCY=100" >> .env
-          echo "ADMIN_API_KEY=admin-api-key" >> .env
-          echo "LANGFUSE_EE_LICENSE_KEY=langfuse_ee_test" >> .env
-          echo "LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION=true" >> .env
-          echo "LANGFUSE_ENABLE_SCORES_V3_API=true" >> .env
+          if [ "${{ matrix.env_profile }}" = "tests-web" ]; then
+            {
+              grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev${{ matrix.deploy-mode }}.example
+              echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1"
+              echo "LANGFUSE_CACHE_PROMPT_ENABLED=false"
+              echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1"
+              echo "LANGFUSE_TRACE_DELETE_DELAY_MS=1"
+              echo "LANGFUSE_TRACE_DELETE_CONCURRENCY=100"
+              echo "ADMIN_API_KEY=admin-api-key"
+              echo "LANGFUSE_EE_LICENSE_KEY=langfuse_ee_test"
+              echo "LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION=true"
+              echo "LANGFUSE_ENABLE_SCORES_V3_API=true"
+            } > .env
+          else
+            cp .env.dev${{ matrix.deploy-mode }}.example .env
+          fi
       - name: Setup Turbo cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # zizmor: ignore[cache-poisoning] scheduled cache warmer for test-job turbo caches only; runs on main, publish jobs rebuild artifacts and do not restore this cache
         with:
           path: .turbo
-          # Same key shape as the tests-web "Setup Turbo cache" step so branch
-          # runs restore these archives via their restore-keys prefix.
-          key: ${{ runner.os }}-turbo-mode${{ matrix.deploy-mode == '' && '-default' || matrix.deploy-mode }}-${{ github.sha }}
+          # Same key shape as the consuming pipeline job so branch runs restore
+          # these archives via their restore-keys prefix.
+          key: ${{ runner.os }}-turbo-${{ matrix.cache_scope }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-mode${{ matrix.deploy-mode == '' && '-default' || matrix.deploy-mode }}-
+            ${{ runner.os }}-turbo-${{ matrix.cache_scope }}-
       - name: Build
         # dev containers / Postgres are not needed: the build task only
         # depends on db:generate, which is offline.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15892.preview.langfuse.com](https://pr-15892.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Restore and save a dedicated Turbo build cache in `e2e-server-tests`, reducing its median warm runtime from 3:15 to 2:00.
- Add an exact-environment `e2e-server` profile to the six-hour cache warmer without changing the existing mode cache keys or the E2E test environment.

## Measurements

All warm samples rerun the same job on the same commit after its cold attempt saved the dedicated cache.

| Measurement | Cold | Warm 1 | Warm 2 | Warm 3 | Warm median | Savings |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Turbo build | 1:22.823 | 0:04.311 | 0:03.336 | 0:03.238 | **0:03.336** | **-1:19.487 (-96%)** |
| GitHub `Build` step | 1:27 | 0:05 | 0:04 | 0:03 | **0:04** | **-1:23 (-95%)** |
| Server E2E tests | 0:52 | 0:52 | 0:51 | 0:52 | **0:52** | no change |
| Whole `e2e-server-tests` job | 3:15 | 2:00 | 2:00 | 1:56 | **2:00** | **-1:15 (-38%)** |

Evidence: [cold attempt](https://github.com/langfuse/langfuse/actions/runs/31181968937/job/92877175025), [warm 1](https://github.com/langfuse/langfuse/actions/runs/31181968937/job/92878148975), [warm 2](https://github.com/langfuse/langfuse/actions/runs/31181968937/job/92878967713), and [warm 3](https://github.com/langfuse/langfuse/actions/runs/31181968937/job/92880204663). Each warm run restored the exact dedicated key and reported `Tasks: 7 successful, 7 total`. After review, the final key was renamed from `turbo-e2e-server-` to `turbo-server-e2e-` so it cannot overlap the browser E2E job's `turbo-e2e-` fallback prefix; final-key validation is recorded below.

The independently dispatched [cache warmer](https://github.com/langfuse/langfuse/actions/runs/31183329851/job/92881700170) also passed. Its first cold run took 1:54 total, including an 1:21 build, and saved the dedicated archive.

Final namespace validation: after renaming the key to avoid the browser E2E prefix, the [final cold attempt](https://github.com/langfuse/langfuse/actions/runs/31184680621/job/92886156477) took 3:45 with a 1:55 build and saved `Linux-turbo-server-e2e-<sha>`. Its [warm rerun](https://github.com/langfuse/langfuse/actions/runs/31184680621/job/92887922406) restored that exact key, completed in 2:03, and reported `Tasks: 7 successful, 7 total` in 3.755s. This reproduces the optimization on the final configuration.

### Overall pipeline impact

The job-level saving is stable, but pipeline latency is the maximum of all required jobs:

| Scenario | Before | With this cache | Pipeline saving |
| --- | ---: | ---: | ---: |
| Earlier baseline where `e2e-server-tests` was critical | 3:27 | ~2:54 (next-slowest job) | **~0:33** |
| This PR's cold full run, where `tests-web` took 3:28 | 3:47 | ~3:47 | **0:00** |

This removes `e2e-server-tests` as a frequent critical-path contender; it cannot compensate for variance in a slower matrix job.

### Cost

Assuming the current 4-vCPU runner rate of $0.008/minute and four scheduled runs per day:

| Item | Estimate |
| --- | ---: |
| Extra warmer leg | **~$0.57-$1.85/month** (warm-hit to every-run-cold bound) |
| Saving per `e2e-server-tests` invocation | **~$0.01** (1.25 runner-minutes) |
| Break-even | **~57-185 CI invocations/month** |

## Linear

- None

## Major Decisions

- Keep the E2E environment unchanged and warm its exact Turbo hash instead of aligning it with another test job.
- Scope the cache to test builds only; release, preview, and Docker publishing jobs do not restore it.
- Continue disabling cache restores for fork PRs through the existing `CI_CACHE_ALLOWED` guard.

## Review Focus

- Whether the warmer profile remains byte-identical to `e2e-server-tests` for `.env`, `NODE_ENV`, and `NEXT_IGNORE_BUILD_ERRORS`.
- Whether the stable 1:15 job saving justifies the small scheduled warmer cost despite variable end-to-end critical-path impact.
