### PR TITLE
fix(v4): route AI-disabled eval migrations to wizard

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -26,7 +26,6 @@ import { useLazyEvaluatorExecutionCounts } from "@/src/features/evals/hooks/useL
 import { TablePeekView } from "@/src/components/table/peek";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
-import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
 
 const PeekViewEvaluatorConfigDetail = ({
@@ -48,8 +47,6 @@ const PeekViewEvaluatorConfigDetail = ({
     evaluatorId: evalConfig?.id,
     evaluator: evalConfig,
   });
-  const canUseAgent = useCanUseInAppAgent();
-
   const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
 
   if (!evalConfig) {
@@ -121,7 +118,7 @@ const PeekViewEvaluatorConfigDetail = ({
         </div>
       </div>
 
-      {evaluatorRequiresMigration && evalConfig.evalTemplate && canUseAgent && (
+      {evaluatorRequiresMigration && evalConfig.evalTemplate && (
         <V4MigrationUpdateRequiredBadge />
       )}
 

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -9,7 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { V4MigrationUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
+import { V4MigrationEvaluatorUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
 import { UserCircle2Icon } from "lucide-react";
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { DeleteEvalConfigButton } from "@/src/components/deleteButton";
@@ -27,7 +27,6 @@ import { TablePeekView } from "@/src/components/table/peek";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
-import { useCanUseAgentForMigration } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
 
 const PeekViewEvaluatorConfigDetail = ({
   projectId,
@@ -48,7 +47,6 @@ const PeekViewEvaluatorConfigDetail = ({
     evaluatorId: evalConfig?.id,
     evaluator: evalConfig,
   });
-  const canUseAgent = useCanUseAgentForMigration();
   const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
 
   if (!evalConfig) {
@@ -120,8 +118,11 @@ const PeekViewEvaluatorConfigDetail = ({
         </div>
       </div>
 
-      {evaluatorRequiresMigration && evalConfig.evalTemplate && canUseAgent && (
-        <V4MigrationUpdateRequiredBadge />
+      {evaluatorRequiresMigration && evalConfig.evalTemplate && (
+        <V4MigrationEvaluatorUpdateRequiredBadge
+          projectId={projectId}
+          evaluatorId={evalConfig.id}
+        />
       )}
 
       <EvaluatorPausedCallout projectId={projectId} evalConfig={evalConfig} />

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -27,6 +27,7 @@ import { TablePeekView } from "@/src/components/table/peek";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
+import { useCanUseAgentForMigration } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
 
 const PeekViewEvaluatorConfigDetail = ({
   projectId,
@@ -47,6 +48,7 @@ const PeekViewEvaluatorConfigDetail = ({
     evaluatorId: evalConfig?.id,
     evaluator: evalConfig,
   });
+  const canUseAgent = useCanUseAgentForMigration();
   const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
 
   if (!evalConfig) {
@@ -118,7 +120,7 @@ const PeekViewEvaluatorConfigDetail = ({
         </div>
       </div>
 
-      {evaluatorRequiresMigration && evalConfig.evalTemplate && (
+      {evaluatorRequiresMigration && evalConfig.evalTemplate && canUseAgent && (
         <V4MigrationUpdateRequiredBadge />
       )}
 

--- a/web/src/features/in-app-agent/components/InAppAgentDisabledDialog.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDisabledDialog.tsx
@@ -27,7 +27,9 @@ export function InAppAgentDisabledDialog({
         <DialogBody>
           <AIFeaturesDisabledNotice
             organizationId={organizationId}
-            onSettingsOpened={() => onOpenChange(false)}
+            onSettingsOpened={() => {
+              onOpenChange(false);
+            }}
           >
             The Langfuse Assistant requires AI features to be enabled for this
             organization.

--- a/web/src/features/in-app-agent/components/InAppAgentDisabledDialog.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDisabledDialog.tsx
@@ -25,7 +25,10 @@ export function InAppAgentDisabledDialog({
           <DialogTitle>AI features are disabled</DialogTitle>
         </DialogHeader>
         <DialogBody>
-          <AIFeaturesDisabledNotice organizationId={organizationId}>
+          <AIFeaturesDisabledNotice
+            organizationId={organizationId}
+            onSettingsOpened={() => onOpenChange(false)}
+          >
             The Langfuse Assistant requires AI features to be enabled for this
             organization.
           </AIFeaturesDisabledNotice>

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -12,7 +12,11 @@ import type { AgUiMessage } from "@langfuse/shared/in-app-agent";
 
 import { TooltipProvider } from "@/src/components/ui/tooltip";
 import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
-import { InAppAiAgentProvider, useInAppAiAgent } from "./InAppAiAgentProvider";
+import {
+  InAppAiAgentProvider,
+  useCanUseInAppAgent,
+  useInAppAiAgent,
+} from "./InAppAiAgentProvider";
 import styles from "./InAppAgentWindow.module.css";
 
 const providerMocks = vi.hoisted(() => {
@@ -22,6 +26,7 @@ const providerMocks = vi.hoisted(() => {
 
   return {
     backgroundExecutionEnabled: false,
+    organization: { aiFeaturesEnabled: true },
     capture: vi.fn(),
     startRun,
     cancelRun,
@@ -106,8 +111,12 @@ vi.mock("@/src/features/entitlements/hooks", () => ({
 
 vi.mock("@/src/features/projects/hooks", () => ({
   useQueryProjectOrOrganization: () => ({
-    organization: { aiFeaturesEnabled: true },
+    organization: providerMocks.organization,
   }),
+}));
+
+vi.mock("@/src/features/organizations/hooks", () => ({
+  useLangfuseCloudRegion: () => ({ isLangfuseCloud: true }),
 }));
 
 vi.mock("@/src/features/in-app-agent/lib/executionMode", () => ({
@@ -212,8 +221,30 @@ describe("in-app agent execution", () => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
     providerMocks.backgroundExecutionEnabled = false;
+    providerMocks.organization.aiFeaturesEnabled = true;
     providerMocks.conversationQuery.data = undefined;
     window.sessionStorage.clear();
+  });
+
+  it("does not report the assistant as available when AI features are disabled", () => {
+    providerMocks.organization.aiFeaturesEnabled = false;
+
+    function AvailabilityProbe() {
+      const canUseAgent = useCanUseInAppAgent();
+      return (
+        <span data-testid="assistant-availability">{String(canUseAgent)}</span>
+      );
+    }
+
+    render(
+      <InAppAiAgentProvider>
+        <AvailabilityProbe />
+      </InAppAiAgentProvider>,
+    );
+
+    expect(screen.getByTestId("assistant-availability")).toHaveTextContent(
+      "false",
+    );
   });
 
   it("keeps foreground submission and approval working when background execution is disabled", async () => {

--- a/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentExecution.clienttest.tsx
@@ -12,11 +12,7 @@ import type { AgUiMessage } from "@langfuse/shared/in-app-agent";
 
 import { TooltipProvider } from "@/src/components/ui/tooltip";
 import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
-import {
-  InAppAiAgentProvider,
-  useCanUseInAppAgent,
-  useInAppAiAgent,
-} from "./InAppAiAgentProvider";
+import { InAppAiAgentProvider, useInAppAiAgent } from "./InAppAiAgentProvider";
 import styles from "./InAppAgentWindow.module.css";
 
 const providerMocks = vi.hoisted(() => {
@@ -26,7 +22,6 @@ const providerMocks = vi.hoisted(() => {
 
   return {
     backgroundExecutionEnabled: false,
-    organization: { aiFeaturesEnabled: true },
     capture: vi.fn(),
     startRun,
     cancelRun,
@@ -111,12 +106,8 @@ vi.mock("@/src/features/entitlements/hooks", () => ({
 
 vi.mock("@/src/features/projects/hooks", () => ({
   useQueryProjectOrOrganization: () => ({
-    organization: providerMocks.organization,
+    organization: { aiFeaturesEnabled: true },
   }),
-}));
-
-vi.mock("@/src/features/organizations/hooks", () => ({
-  useLangfuseCloudRegion: () => ({ isLangfuseCloud: true }),
 }));
 
 vi.mock("@/src/features/in-app-agent/lib/executionMode", () => ({
@@ -221,30 +212,8 @@ describe("in-app agent execution", () => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
     providerMocks.backgroundExecutionEnabled = false;
-    providerMocks.organization.aiFeaturesEnabled = true;
     providerMocks.conversationQuery.data = undefined;
     window.sessionStorage.clear();
-  });
-
-  it("does not report the assistant as available when AI features are disabled", () => {
-    providerMocks.organization.aiFeaturesEnabled = false;
-
-    function AvailabilityProbe() {
-      const canUseAgent = useCanUseInAppAgent();
-      return (
-        <span data-testid="assistant-availability">{String(canUseAgent)}</span>
-      );
-    }
-
-    render(
-      <InAppAiAgentProvider>
-        <AvailabilityProbe />
-      </InAppAiAgentProvider>,
-    );
-
-    expect(screen.getByTestId("assistant-availability")).toHaveTextContent(
-      "false",
-    );
   });
 
   it("keeps foreground submission and approval working when background execution is disabled", async () => {

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -109,7 +109,8 @@ const EMPTY_BACKGROUND_VIEW: BackgroundExecutionView = {
 export type InAppAgentEntryPoint =
   | "top_nav"
   | "keyboard_shortcut"
-  | "dashboard_widget";
+  | "dashboard_widget"
+  | "v4_migration";
 
 const getConversationAgentState = (
   projectId: string,

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -2037,6 +2037,6 @@ export function useCanUseInAppAgent() {
     isAvailable &&
     hasInAppAgentEntitlement &&
     isLangfuseCloud &&
-    Boolean(organization?.aiFeaturesEnabled)
+    Boolean(organization)
   );
 }

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -2037,6 +2037,6 @@ export function useCanUseInAppAgent() {
     isAvailable &&
     hasInAppAgentEntitlement &&
     isLangfuseCloud &&
-    Boolean(organization)
+    Boolean(organization?.aiFeaturesEnabled)
   );
 }

--- a/web/src/features/organizations/components/AIFeaturesDisabledNotice.tsx
+++ b/web/src/features/organizations/components/AIFeaturesDisabledNotice.tsx
@@ -15,9 +15,11 @@ export function openAIFeaturesSettings(organizationId: string) {
 export function AIFeaturesDisabledNotice({
   organizationId,
   children,
+  onSettingsOpened,
 }: {
   organizationId: string | undefined;
   children: ReactNode;
+  onSettingsOpened?: () => void;
 }) {
   const canUpdateOrgSettings = useHasOrganizationAccess({
     organizationId,
@@ -34,7 +36,10 @@ export function AIFeaturesDisabledNotice({
       </p>
       {canUpdateOrgSettings && organizationId ? (
         <Button
-          onClick={() => openAIFeaturesSettings(organizationId)}
+          onClick={() => {
+            openAIFeaturesSettings(organizationId);
+            onSettingsOpened?.();
+          }}
           variant="outline"
           size="sm"
           className="w-fit"

--- a/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
+++ b/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
@@ -130,7 +130,7 @@ export function EvaluatorMigrationDialog({
                   >
                     <BotMessageSquare className="h-5 w-5 shrink-0" />
                     <span className="flex flex-col gap-1">
-                      <span className="font-semibold">Use Assistant</span>
+                      <span className="font-bold">Use Assistant</span>
                       <span className="text-muted-foreground text-sm font-normal">
                         Suggest upgrading all deprecated evaluators at once.
                       </span>
@@ -145,7 +145,7 @@ export function EvaluatorMigrationDialog({
                 >
                   <Wrench className="h-5 w-5 shrink-0" />
                   <span className="flex flex-col gap-1">
-                    <span className="font-semibold">
+                    <span className="font-bold">
                       {isSingleEvaluator
                         ? "Upgrade just this evaluator"
                         : "Upgrade manually"}

--- a/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
+++ b/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
@@ -9,11 +9,13 @@ import {
   DialogTitle,
 } from "@/src/components/ui/dialog";
 import { Button } from "@/src/components/ui/button";
+import { CodeBlock } from "@/src/components/design-system/Codeblock/Codeblock";
 import {
   useCanUseInAppAgent,
   useInAppAiAgent,
 } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 
 type EvaluatorMigrationScope = { type: "all" } | { type: "single" };
 
@@ -22,28 +24,37 @@ type EvaluatorMigrationDialogProps = {
   onOpenChange: (open: boolean) => void;
   scope: EvaluatorMigrationScope;
   assistantPrompt: string;
-  onManualMigration: () => void;
+  onManualUpgrade: () => void;
   onAssistantStarted: () => void;
 };
 
-type SelectedMigrationAction = "assistant" | "manual";
+type SelectedMigrationAction = "assistant";
+
+const ADMIN_REQUEST_MESSAGE =
+  "Hi! Could you enable AI features for our Langfuse organization? I need them to use the Assistant to upgrade our deprecated evaluators for v4. Thanks!";
 
 export function EvaluatorMigrationDialog({
   open,
   onOpenChange,
   scope,
   assistantPrompt,
-  onManualMigration,
+  onManualUpgrade,
   onAssistantStarted,
 }: EvaluatorMigrationDialogProps) {
   const canUseAssistant = useCanUseInAppAgent();
   const { organization } = useQueryProjectOrOrganization();
   const { openAssistant, submit } = useInAppAiAgent();
+  const canUpdateOrgSettings = useHasOrganizationAccess({
+    organizationId: organization?.id,
+    scope: "organization:update",
+  });
   const [selectedAction, setSelectedAction] =
     useState<SelectedMigrationAction | null>(null);
+  const [orgAdminNoticeOpen, setOrgAdminNoticeOpen] = useState(false);
 
   const aiFeaturesEnabled = Boolean(organization?.aiFeaturesEnabled);
   const isSingleEvaluator = scope.type === "single";
+  const showAssistantOption = canUseAssistant;
 
   const startAssistant = async () => {
     const opened = openAssistant("v4_migration");
@@ -55,6 +66,12 @@ export function EvaluatorMigrationDialog({
   };
 
   const handleAssistantClick = () => {
+    if (!aiFeaturesEnabled && !canUpdateOrgSettings) {
+      onOpenChange(false);
+      setOrgAdminNoticeOpen(true);
+      return;
+    }
+
     setSelectedAction("assistant");
     if (!aiFeaturesEnabled) {
       openAssistant("v4_migration");
@@ -63,97 +80,103 @@ export function EvaluatorMigrationDialog({
 
   const handleManualClick = () => {
     if (isSingleEvaluator) {
-      setSelectedAction("manual");
+      onManualUpgrade();
       return;
     }
-    onManualMigration();
+    onManualUpgrade();
+  };
+
+  const closeOrgAdminNotice = () => {
+    setOrgAdminNoticeOpen(false);
+    if (!isSingleEvaluator) {
+      onOpenChange(true);
+    }
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen) setSelectedAction(null);
-        onOpenChange(nextOpen);
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {selectedAction === "assistant"
-              ? "Ready to start your evaluator upgrade?"
-              : selectedAction === "manual"
-                ? "Ready to migrate this evaluator?"
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setSelectedAction(null);
+          onOpenChange(nextOpen);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {selectedAction === "assistant"
+                ? "Ready to start your evaluator upgrade?"
                 : isSingleEvaluator
-                  ? "How would you like to migrate this evaluator?"
-                  : "How would you like to migrate your evaluators?"}
-          </DialogTitle>
-        </DialogHeader>
-        <DialogBody className="gap-3">
-          {selectedAction === "assistant" ? (
-            <p className="text-muted-foreground text-sm">
-              {aiFeaturesEnabled
-                ? "The Assistant will review your deprecated evaluators and suggest upgrading all of them at once."
-                : "Enable AI features in the dialog above, then return here to start the upgrade with the Assistant."}
-            </p>
-          ) : selectedAction === "manual" ? (
-            <p className="text-muted-foreground text-sm">
-              Open the evaluator upgrade form to review the legacy configuration
-              and create its replacement.
-            </p>
-          ) : (
-            <>
-              {canUseAssistant ? (
+                  ? "How would you like to upgrade this evaluator?"
+                  : "How would you like to upgrade your evaluators?"}
+            </DialogTitle>
+          </DialogHeader>
+          <DialogBody className="gap-3">
+            {selectedAction === "assistant" ? (
+              <p className="text-muted-foreground text-sm">
+                {aiFeaturesEnabled
+                  ? "The Assistant will review your deprecated evaluators and suggest upgrading all of them at once."
+                  : "Enable AI features in the other tab, then return here to start the upgrade with the Assistant."}
+              </p>
+            ) : (
+              <>
+                {showAssistantOption ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-auto justify-start gap-3 p-4 text-left"
+                    onClick={handleAssistantClick}
+                  >
+                    <BotMessageSquare className="h-5 w-5 shrink-0" />
+                    <span className="flex flex-col gap-1">
+                      <span className="font-semibold">Use Assistant</span>
+                      <span className="text-muted-foreground text-sm font-normal">
+                        Suggest upgrading all deprecated evaluators at once.
+                      </span>
+                    </span>
+                  </Button>
+                ) : null}
                 <Button
                   type="button"
                   variant="outline"
                   className="h-auto justify-start gap-3 p-4 text-left"
-                  onClick={handleAssistantClick}
+                  onClick={handleManualClick}
                 >
-                  <BotMessageSquare className="h-5 w-5 shrink-0" />
+                  <Wrench className="h-5 w-5 shrink-0" />
                   <span className="flex flex-col gap-1">
-                    <span className="font-semibold">Use Assistant</span>
+                    <span className="font-semibold">
+                      {isSingleEvaluator
+                        ? "Upgrade just this evaluator"
+                        : "Upgrade manually"}
+                    </span>
                     <span className="text-muted-foreground text-sm font-normal">
-                      Suggest upgrading all deprecated evaluators at once.
+                      {isSingleEvaluator ? (
+                        "Open the evaluator upgrade form."
+                      ) : (
+                        <>
+                          Click evaluators with the Deprecated label to review{" "}
+                          <br />
+                          them and start each upgrade individually.
+                        </>
+                      )}
                     </span>
                   </span>
                 </Button>
-              ) : null}
+              </>
+            )}
+          </DialogBody>
+          {selectedAction ? (
+            <DialogFooter>
               <Button
                 type="button"
                 variant="outline"
-                className="h-auto justify-start gap-3 p-4 text-left"
-                onClick={handleManualClick}
+                onClick={() => {
+                  setSelectedAction(null);
+                }}
               >
-                <Wrench className="h-5 w-5 shrink-0" />
-                <span className="flex flex-col gap-1">
-                  <span className="font-semibold">
-                    {isSingleEvaluator
-                      ? "Migrate just this evaluator"
-                      : "Migrate manually"}
-                  </span>
-                  <span className="text-muted-foreground text-sm font-normal">
-                    {isSingleEvaluator
-                      ? "Open the evaluator upgrade form."
-                      : "Review each evaluator marked Deprecated and migrate it individually."}
-                  </span>
-                </span>
+                Back
               </Button>
-            </>
-          )}
-        </DialogBody>
-        {selectedAction ? (
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                setSelectedAction(null);
-              }}
-            >
-              Back
-            </Button>
-            {selectedAction === "assistant" ? (
               <Button
                 type="button"
                 onClick={startAssistant}
@@ -161,14 +184,61 @@ export function EvaluatorMigrationDialog({
               >
                 Start upgrade now
               </Button>
-            ) : (
-              <Button type="button" onClick={onManualMigration}>
-                Start now
+            </DialogFooter>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={orgAdminNoticeOpen} onOpenChange={setOrgAdminNoticeOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Ask your organization admin to enable AI features
+            </DialogTitle>
+          </DialogHeader>
+          <DialogBody className="gap-3">
+            <p className="text-muted-foreground text-sm">
+              The Assistant can help you upgrade all deprecated evaluators at
+              once. An organization admin needs to enable AI features for your
+              organization before you can use it.
+            </p>
+            <a
+              href="https://langfuse.com/security/ai-features"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary text-sm underline"
+            >
+              Learn more about AI features
+            </a>
+            <div className="flex flex-col gap-2">
+              <p className="text-muted-foreground text-sm">
+                You can send your admin this message:
+              </p>
+              <CodeBlock language="text" value={ADMIN_REQUEST_MESSAGE} />
+            </div>
+          </DialogBody>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeOrgAdminNotice}
+            >
+              Close
+            </Button>
+            {isSingleEvaluator ? (
+              <Button
+                type="button"
+                onClick={() => {
+                  setOrgAdminNoticeOpen(false);
+                  onManualUpgrade();
+                }}
+              >
+                Start manual upgrade
               </Button>
-            )}
+            ) : null}
           </DialogFooter>
-        ) : null}
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
+++ b/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
@@ -1,0 +1,174 @@
+import { BotMessageSquare, Wrench } from "lucide-react";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { Button } from "@/src/components/ui/button";
+import {
+  useCanUseInAppAgent,
+  useInAppAiAgent,
+} from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+
+type EvaluatorMigrationScope = { type: "all" } | { type: "single" };
+
+type EvaluatorMigrationDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scope: EvaluatorMigrationScope;
+  assistantPrompt: string;
+  onManualMigration: () => void;
+  onAssistantStarted: () => void;
+};
+
+type SelectedMigrationAction = "assistant" | "manual";
+
+export function EvaluatorMigrationDialog({
+  open,
+  onOpenChange,
+  scope,
+  assistantPrompt,
+  onManualMigration,
+  onAssistantStarted,
+}: EvaluatorMigrationDialogProps) {
+  const canUseAssistant = useCanUseInAppAgent();
+  const { organization } = useQueryProjectOrOrganization();
+  const { openAssistant, submit } = useInAppAiAgent();
+  const [selectedAction, setSelectedAction] =
+    useState<SelectedMigrationAction | null>(null);
+
+  const aiFeaturesEnabled = Boolean(organization?.aiFeaturesEnabled);
+  const isSingleEvaluator = scope.type === "single";
+
+  const startAssistant = async () => {
+    const opened = openAssistant("v4_migration");
+    if (!opened) return;
+
+    onAssistantStarted();
+    onOpenChange(false);
+    await submit(assistantPrompt, { newConversation: true });
+  };
+
+  const handleAssistantClick = () => {
+    setSelectedAction("assistant");
+    if (!aiFeaturesEnabled) {
+      openAssistant("v4_migration");
+    }
+  };
+
+  const handleManualClick = () => {
+    if (isSingleEvaluator) {
+      setSelectedAction("manual");
+      return;
+    }
+    onManualMigration();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) setSelectedAction(null);
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {selectedAction === "assistant"
+              ? "Ready to start your evaluator upgrade?"
+              : selectedAction === "manual"
+                ? "Ready to migrate this evaluator?"
+                : isSingleEvaluator
+                  ? "How would you like to migrate this evaluator?"
+                  : "How would you like to migrate your evaluators?"}
+          </DialogTitle>
+        </DialogHeader>
+        <DialogBody className="gap-3">
+          {selectedAction === "assistant" ? (
+            <p className="text-muted-foreground text-sm">
+              {aiFeaturesEnabled
+                ? "The Assistant will review your deprecated evaluators and suggest upgrading all of them at once."
+                : "Enable AI features in the dialog above, then return here to start the upgrade with the Assistant."}
+            </p>
+          ) : selectedAction === "manual" ? (
+            <p className="text-muted-foreground text-sm">
+              Open the evaluator upgrade form to review the legacy configuration
+              and create its replacement.
+            </p>
+          ) : (
+            <>
+              {canUseAssistant ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-auto justify-start gap-3 p-4 text-left"
+                  onClick={handleAssistantClick}
+                >
+                  <BotMessageSquare className="h-5 w-5 shrink-0" />
+                  <span className="flex flex-col gap-1">
+                    <span className="font-semibold">Use Assistant</span>
+                    <span className="text-muted-foreground text-sm font-normal">
+                      Suggest upgrading all deprecated evaluators at once.
+                    </span>
+                  </span>
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                variant="outline"
+                className="h-auto justify-start gap-3 p-4 text-left"
+                onClick={handleManualClick}
+              >
+                <Wrench className="h-5 w-5 shrink-0" />
+                <span className="flex flex-col gap-1">
+                  <span className="font-semibold">
+                    {isSingleEvaluator
+                      ? "Migrate just this evaluator"
+                      : "Migrate manually"}
+                  </span>
+                  <span className="text-muted-foreground text-sm font-normal">
+                    {isSingleEvaluator
+                      ? "Open the evaluator upgrade form."
+                      : "Review each evaluator marked Deprecated and migrate it individually."}
+                  </span>
+                </span>
+              </Button>
+            </>
+          )}
+        </DialogBody>
+        {selectedAction ? (
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setSelectedAction(null);
+              }}
+            >
+              Back
+            </Button>
+            {selectedAction === "assistant" ? (
+              <Button
+                type="button"
+                onClick={startAssistant}
+                disabled={!aiFeaturesEnabled}
+              >
+                Start upgrade now
+              </Button>
+            ) : (
+              <Button type="button" onClick={onManualMigration}>
+                Start now
+              </Button>
+            )}
+          </DialogFooter>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -53,6 +53,8 @@ const mocks = vi.hoisted(() => ({
   },
   canToggleV4: true,
   hasApiKeyCreateAccess: true,
+  canUpdateOrgSettings: true,
+  aiFeaturesEnabled: true,
   createProjectApiKey: vi.fn(),
 }));
 
@@ -90,12 +92,19 @@ vi.mock("@/src/utils/api", () => ({
 vi.mock("@/src/features/projects/hooks", () => ({
   useProject: () => ({ organization: { id: "org-1" } }),
   useQueryProjectOrOrganization: () => ({
-    organization: { id: "org-1", aiFeaturesEnabled: true },
+    organization: {
+      id: "org-1",
+      aiFeaturesEnabled: mocks.aiFeaturesEnabled,
+    },
   }),
 }));
 
 vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
   useHasProjectAccess: () => mocks.hasApiKeyCreateAccess,
+}));
+
+vi.mock("@/src/features/rbac/utils/checkOrganizationAccess", () => ({
+  useHasOrganizationAccess: () => mocks.canUpdateOrgSettings,
 }));
 
 vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
@@ -153,6 +162,8 @@ describe("V4MigrationDetailsContent", () => {
     };
     mocks.migrationData.experimentInstrumentationUpgradePath = null;
     mocks.canToggleV4 = true;
+    mocks.canUpdateOrgSettings = true;
+    mocks.aiFeaturesEnabled = true;
     mocks.migrationData.sdk.status = "latest";
     mocks.migrationData.apis = { status: "loaded", count: 1 };
     mocks.migrationData.exports = { status: "loaded", count: 3 };
@@ -317,7 +328,9 @@ describe("V4MigrationDetailsContent", () => {
     fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
     const migrationDialog = screen.getByRole("dialog");
     fireEvent.click(
-      within(migrationDialog).getByRole("button", { name: "Use Assistant" }),
+      within(migrationDialog).getByRole("button", {
+        name: /^Use Assistant/,
+      }),
     );
     fireEvent.click(
       within(migrationDialog).getByRole("button", {
@@ -332,6 +345,34 @@ describe("V4MigrationDetailsContent", () => {
       "eval-upgrade-prompt",
       { newConversation: true },
     );
+  });
+
+  it("shows the admin handoff after a non-admin chooses the Assistant", () => {
+    mocks.migrationData.evals = { status: "loaded", count: 1 };
+    mocks.canUpdateOrgSettings = false;
+    mocks.aiFeaturesEnabled = false;
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
+    const migrationDialog = screen.getByRole("dialog");
+    fireEvent.click(
+      within(migrationDialog).getByRole("button", {
+        name: /^Use Assistant/,
+      }),
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Ask your organization admin to enable AI features",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/enable AI features for our Langfuse organization/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Continue with manual upgrade" }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -19,7 +19,7 @@ import { type V4MigrationSdkState } from "./sdkVersionStatus";
 
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
-  setAgentOpen: vi.fn(),
+  openAssistant: vi.fn(),
   submitAgentMessage: vi.fn(),
   upgradePlan: {
     canUseAssistant: true,
@@ -89,6 +89,9 @@ vi.mock("@/src/utils/api", () => ({
 
 vi.mock("@/src/features/projects/hooks", () => ({
   useProject: () => ({ organization: { id: "org-1" } }),
+  useQueryProjectOrOrganization: () => ({
+    organization: { id: "org-1", aiFeaturesEnabled: true },
+  }),
 }));
 
 vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
@@ -110,7 +113,7 @@ vi.mock("@/src/features/v4-migration/useV4UpgradeAssistantSupport", () => ({
 vi.mock("@/src/features/in-app-agent/components/InAppAiAgentProvider", () => ({
   useCanUseInAppAgent: () => true,
   useInAppAiAgent: () => ({
-    setOpen: mocks.setAgentOpen,
+    openAssistant: mocks.openAssistant,
     submit: mocks.submitAgentMessage,
   }),
 }));
@@ -305,39 +308,25 @@ describe("V4MigrationDetailsContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("navigates to evals when migrating with the assistant", async () => {
+  it("starts the assistant only after confirmation", async () => {
     mocks.migrationData.evals = { status: "loaded", count: 1 };
+    mocks.openAssistant.mockReturnValue(true);
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
+    const migrationDialog = screen.getByRole("dialog");
     fireEvent.click(
-      screen.getByRole("button", { name: "Migrate with assistant" }),
+      within(migrationDialog).getByRole("button", { name: "Use Assistant" }),
+    );
+    fireEvent.click(
+      within(migrationDialog).getByRole("button", {
+        name: "Start upgrade now",
+      }),
     );
 
     await waitFor(() => {
-      expect(mocks.routerPush).toHaveBeenCalledWith("/project/project-1/evals");
-    });
-    expect(mocks.setAgentOpen).toHaveBeenCalledWith(true);
-    expect(mocks.submitAgentMessage).toHaveBeenCalledWith(
-      "eval-upgrade-prompt",
-      { newConversation: true },
-    );
-  });
-
-  it("opens the assistant when navigation to evals is interrupted", async () => {
-    mocks.migrationData.evals = { status: "loaded", count: 1 };
-    mocks.routerPush.mockRejectedValueOnce(
-      new Error("Abort fetching component for route"),
-    );
-
-    render(<V4MigrationDetailsContent projectId="project-1" />);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Migrate with assistant" }),
-    );
-
-    await waitFor(() => {
-      expect(mocks.setAgentOpen).toHaveBeenCalledWith(true);
+      expect(mocks.openAssistant).toHaveBeenCalledWith("v4_migration");
     });
     expect(mocks.submitAgentMessage).toHaveBeenCalledWith(
       "eval-upgrade-prompt",

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -10,7 +10,7 @@ import {
   LifeBuoy,
   TriangleAlert,
 } from "lucide-react";
-import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { Button } from "@/src/components/ui/button";
 import { CodeView } from "@/src/components/ui/CodeJsonViewer";
@@ -47,6 +47,8 @@ import {
 } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api, reportNonTrpcError } from "@/src/utils/api";
+import { EvaluatorMigrationDialog } from "@/src/features/v4-migration/EvaluatorMigrationDialog";
+import { buildDeprecatedEvaluatorsUrl } from "@/src/features/v4-migration/evaluatorMigrationUrls";
 
 // Single source of truth for the v4-migration copy and content. Both surfaces
 // (side panel and modal) render these components — edit copy here only.
@@ -520,25 +522,25 @@ export function V4MigrationDetailsContent({
     onNavigate?.();
     openSupportDrawerWithMode("form", { topic: "V4 Migration" });
   };
-  const { setOpen: setAgentOpen, submit: submitAgentMessage } =
-    useInAppAiAgent();
+  const canUseAssistant = useCanUseInAppAgent();
+  const [evalMigrationDialogOpen, setEvalMigrationDialogOpen] = useState(false);
   const upgradePlan = useEvalUpgradeAssistantPlan({
     projectId,
     orgId: organization?.id,
     enabled: Boolean(projectId),
   });
   const evalsUrl =
-    typeof projectId === "string" ? `/project/${projectId}/evals` : undefined;
-  const handleMigrateEvalsWithAgent = async () => {
+    typeof projectId === "string"
+      ? buildDeprecatedEvaluatorsUrl(projectId)
+      : undefined;
+  const handleMigrateEvalsWithAgent = () => {
     capture("v4_migration:migrate_evals_with_agent_clicked");
+    setEvalMigrationDialogOpen(true);
+  };
+  const handleManualEvalMigration = () => {
+    setEvalMigrationDialogOpen(false);
     onNavigate?.();
-    if (evalsUrl) {
-      await router.push(evalsUrl).catch(() => undefined);
-    }
-    setAgentOpen(true);
-    await submitAgentMessage(upgradePlan.assistantPrompt, {
-      newConversation: true,
-    });
+    if (evalsUrl) void router.push(evalsUrl);
   };
   const integrationsUrl =
     typeof projectId === "string"
@@ -629,7 +631,7 @@ export function V4MigrationDetailsContent({
                   </span>
                   . Repointing {migrationData.evals.count === 1 ? "it" : "them"}{" "}
                   at observations or experiments requires minimal changes
-                  {upgradePlan.showAssistantButton
+                  {canUseAssistant
                     ? upgradePlan.mode === "evals-ready"
                       ? " — the assistant can do it for you"
                       : " — the assistant can help you choose the upgrade order"
@@ -637,14 +639,14 @@ export function V4MigrationDetailsContent({
                   .
                 </p>
                 <div className="flex items-center gap-3">
-                  {upgradePlan.showAssistantButton && (
+                  {canUseAssistant && (
                     <Button
                       variant="outline"
                       size="sm"
                       onClick={handleMigrateEvalsWithAgent}
                     >
                       <BotMessageSquare className="mr-1.5 h-4 w-4" />
-                      Migrate with assistant
+                      Use Assistant
                     </Button>
                   )}
                   {evalsUrl ? (
@@ -884,6 +886,16 @@ export function V4MigrationDetailsContent({
           </Button>
         </div>
       </div>
+      {projectId ? (
+        <EvaluatorMigrationDialog
+          open={evalMigrationDialogOpen}
+          onOpenChange={setEvalMigrationDialogOpen}
+          scope={{ type: "all" }}
+          assistantPrompt={upgradePlan.assistantPrompt}
+          onManualMigration={handleManualEvalMigration}
+          onAssistantStarted={() => onNavigate?.()}
+        />
+      ) : null}
     </>
   );
 }

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -540,7 +540,7 @@ export function V4MigrationDetailsContent({
   const handleManualEvalUpgrade = () => {
     setEvalMigrationDialogOpen(false);
     onNavigate?.();
-    if (evalsUrl) void router.push(evalsUrl);
+    if (evalsUrl) router.push(evalsUrl);
   };
   const integrationsUrl =
     typeof projectId === "string"

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -537,7 +537,7 @@ export function V4MigrationDetailsContent({
     capture("v4_migration:migrate_evals_with_agent_clicked");
     setEvalMigrationDialogOpen(true);
   };
-  const handleManualEvalMigration = () => {
+  const handleManualEvalUpgrade = () => {
     setEvalMigrationDialogOpen(false);
     onNavigate?.();
     if (evalsUrl) void router.push(evalsUrl);
@@ -892,7 +892,7 @@ export function V4MigrationDetailsContent({
           onOpenChange={setEvalMigrationDialogOpen}
           scope={{ type: "all" }}
           assistantPrompt={upgradePlan.assistantPrompt}
-          onManualMigration={handleManualEvalMigration}
+          onManualUpgrade={handleManualEvalUpgrade}
           onAssistantStarted={() => onNavigate?.()}
         />
       ) : null}

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
 import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -6,12 +8,13 @@ import {
   useProjectV4EvalData,
   useProjectV4SdkData,
 } from "@/src/features/v4-migration/hooks/useV4MigrationData";
-import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
-import {
-  useCanUseAgentForMigration,
-  useEvalUpgradeAssistantPlan,
-} from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
+import { useEvalUpgradeAssistantPlan } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
 import { V4MigrationBadgeContent } from "@/src/features/v4-migration/V4MigrationBadgeContent";
+import { EvaluatorMigrationDialog } from "@/src/features/v4-migration/EvaluatorMigrationDialog";
+import {
+  buildDeprecatedEvaluatorsUrl,
+  buildEvaluatorUpgradeUrl,
+} from "@/src/features/v4-migration/evaluatorMigrationUrls";
 
 export function V4MigrationDelayBadge() {
   const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
@@ -63,15 +66,13 @@ function useEvalUpdateRequiredBadgeState() {
   return { project, organization, enabled, visible };
 }
 
-/** Opens the v4 migration drawer if no in-app agent is available, otherwise opens the in-app agent */
+/** Opens the evaluator migration choices from the v4 migration badge. */
 export function V4MigrationUpdateRequiredBadge() {
-  const openMigrationPanel = useOpenV4MigrationPanel();
+  const router = useRouter();
+  const [dialogOpen, setDialogOpen] = useState(false);
   const capture = usePostHogClientCapture();
-  const canUseAgent = useCanUseAgentForMigration();
   const { project, visible, enabled, organization } =
     useEvalUpdateRequiredBadgeState();
-  const { setOpen: setAgentOpen, submit: submitAgentMessage } =
-    useInAppAiAgent();
   const upgradePlan = useEvalUpgradeAssistantPlan({
     projectId: project?.id,
     orgId: organization?.id,
@@ -82,23 +83,82 @@ export function V4MigrationUpdateRequiredBadge() {
     return null;
   }
 
-  const handleClick = async () => {
+  const handleClick = () => {
     capture("v4_migration:update_required_badge_clicked");
-    if (canUseAgent) {
-      setAgentOpen(true);
-      await submitAgentMessage(upgradePlan.assistantPrompt, {
-        newConversation: true,
-      });
-      return;
-    }
-    openMigrationPanel({ id: project.id, name: project.name });
+    setDialogOpen(true);
+  };
+
+  const handleManualMigration = () => {
+    if (!project) return;
+    setDialogOpen(false);
+    void router.push(buildDeprecatedEvaluatorsUrl(project.id));
   };
 
   return (
-    <V4MigrationBadgeContent
-      onClick={handleClick}
-      title="Action required"
-      description="Start the upgrade now"
-    />
+    <>
+      <V4MigrationBadgeContent
+        onClick={handleClick}
+        title="Action required"
+        description="Choose how to upgrade"
+      />
+      <EvaluatorMigrationDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        scope={{ type: "all" }}
+        assistantPrompt={upgradePlan.assistantPrompt}
+        onManualMigration={handleManualMigration}
+        onAssistantStarted={() => undefined}
+      />
+    </>
+  );
+}
+
+/** Opens the evaluator migration choices from an individual evaluator peek. */
+export function V4MigrationEvaluatorUpdateRequiredBadge({
+  projectId,
+  evaluatorId,
+}: {
+  projectId: string;
+  evaluatorId: string;
+}) {
+  const router = useRouter();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const capture = usePostHogClientCapture();
+  const { organization } = useQueryProject();
+  const upgradePlan = useEvalUpgradeAssistantPlan({
+    projectId,
+    orgId: organization?.id,
+    enabled: true,
+  });
+  const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
+
+  if (!v4UpgradeUiEnabled) return null;
+
+  const handleManualMigration = () => {
+    setDialogOpen(false);
+    void router.push(buildEvaluatorUpgradeUrl(projectId, evaluatorId));
+  };
+
+  return (
+    <>
+      <V4MigrationBadgeContent
+        onClick={() => {
+          capture("v4_migration:update_required_badge_clicked", {
+            scope: "single",
+          });
+          setDialogOpen(true);
+        }}
+        title="Action required"
+        description="Choose how to upgrade"
+      />
+      <EvaluatorMigrationDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        scope={{ type: "single" }}
+        assistantPrompt={upgradePlan.assistantPrompt}
+        onManualMigration={handleManualMigration}
+        onAssistantStarted={() => undefined}
+      />
+    </>
   );
 }

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -6,11 +6,11 @@ import {
   useProjectV4EvalData,
   useProjectV4SdkData,
 } from "@/src/features/v4-migration/hooks/useV4MigrationData";
+import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import {
-  useCanUseInAppAgent,
-  useInAppAiAgent,
-} from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
-import { useEvalUpgradeAssistantPlan } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
+  useCanUseAgentForMigration,
+  useEvalUpgradeAssistantPlan,
+} from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
 import { V4MigrationBadgeContent } from "@/src/features/v4-migration/V4MigrationBadgeContent";
 
 export function V4MigrationDelayBadge() {
@@ -67,7 +67,7 @@ function useEvalUpdateRequiredBadgeState() {
 export function V4MigrationUpdateRequiredBadge() {
   const openMigrationPanel = useOpenV4MigrationPanel();
   const capture = usePostHogClientCapture();
-  const canUseAgent = useCanUseInAppAgent();
+  const canUseAgent = useCanUseAgentForMigration();
   const { project, visible, enabled, organization } =
     useEvalUpdateRequiredBadgeState();
   const { setOpen: setAgentOpen, submit: submitAgentMessage } =

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -9,6 +9,7 @@ import {
   useProjectV4SdkData,
 } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 import { useEvalUpgradeAssistantPlan } from "@/src/features/v4-migration/useV4UpgradeAssistantSupport";
+import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { V4MigrationBadgeContent } from "@/src/features/v4-migration/V4MigrationBadgeContent";
 import { EvaluatorMigrationDialog } from "@/src/features/v4-migration/EvaluatorMigrationDialog";
 import {
@@ -88,7 +89,7 @@ export function V4MigrationUpdateRequiredBadge() {
     setDialogOpen(true);
   };
 
-  const handleManualMigration = () => {
+  const handleManualUpgrade = () => {
     if (!project) return;
     setDialogOpen(false);
     void router.push(buildDeprecatedEvaluatorsUrl(project.id));
@@ -106,7 +107,7 @@ export function V4MigrationUpdateRequiredBadge() {
         onOpenChange={setDialogOpen}
         scope={{ type: "all" }}
         assistantPrompt={upgradePlan.assistantPrompt}
-        onManualMigration={handleManualMigration}
+        onManualUpgrade={handleManualUpgrade}
         onAssistantStarted={() => undefined}
       />
     </>
@@ -124,6 +125,7 @@ export function V4MigrationEvaluatorUpdateRequiredBadge({
   const router = useRouter();
   const [dialogOpen, setDialogOpen] = useState(false);
   const capture = usePostHogClientCapture();
+  const canUseAssistant = useCanUseInAppAgent();
   const { organization } = useQueryProject();
   const upgradePlan = useEvalUpgradeAssistantPlan({
     projectId,
@@ -134,29 +136,37 @@ export function V4MigrationEvaluatorUpdateRequiredBadge({
 
   if (!v4UpgradeUiEnabled) return null;
 
-  const handleManualMigration = () => {
+  const handleManualUpgrade = () => {
     setDialogOpen(false);
     void router.push(buildEvaluatorUpgradeUrl(projectId, evaluatorId));
+  };
+
+  const handleClick = () => {
+    capture("v4_migration:update_required_badge_clicked", {
+      scope: "single",
+    });
+    if (!canUseAssistant) {
+      handleManualUpgrade();
+      return;
+    }
+    setDialogOpen(true);
   };
 
   return (
     <>
       <V4MigrationBadgeContent
-        onClick={() => {
-          capture("v4_migration:update_required_badge_clicked", {
-            scope: "single",
-          });
-          setDialogOpen(true);
-        }}
+        onClick={handleClick}
         title="Action required"
-        description="Choose how to upgrade"
+        description={
+          canUseAssistant ? "Choose how to upgrade" : "Start upgrade now"
+        }
       />
       <EvaluatorMigrationDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         scope={{ type: "single" }}
         assistantPrompt={upgradePlan.assistantPrompt}
-        onManualMigration={handleManualMigration}
+        onManualUpgrade={handleManualUpgrade}
         onAssistantStarted={() => undefined}
       />
     </>

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -92,7 +92,7 @@ export function V4MigrationUpdateRequiredBadge() {
   const handleManualUpgrade = () => {
     if (!project) return;
     setDialogOpen(false);
-    void router.push(buildDeprecatedEvaluatorsUrl(project.id));
+    router.push(buildDeprecatedEvaluatorsUrl(project.id));
   };
 
   return (
@@ -138,7 +138,7 @@ export function V4MigrationEvaluatorUpdateRequiredBadge({
 
   const handleManualUpgrade = () => {
     setDialogOpen(false);
-    void router.push(buildEvaluatorUpgradeUrl(projectId, evaluatorId));
+    router.push(buildEvaluatorUpgradeUrl(projectId, evaluatorId));
   };
 
   const handleClick = () => {

--- a/web/src/features/v4-migration/V4MigrationModal.tsx
+++ b/web/src/features/v4-migration/V4MigrationModal.tsx
@@ -56,7 +56,7 @@ function V4MigrationModalContent({
         closeOnInteractionOutside
       >
         <DialogTitle className="sr-only">
-          {`Migrate ${project.name} to v4`}
+          {`Upgrade ${project.name} to v4`}
         </DialogTitle>
         <DialogBody className="gap-0 p-4">
           <V4MigrationHeaderContent

--- a/web/src/features/v4-migration/evaluatorMigrationUrls.ts
+++ b/web/src/features/v4-migration/evaluatorMigrationUrls.ts
@@ -1,0 +1,26 @@
+import { encodeFiltersGeneric, type FilterState } from "@langfuse/shared";
+
+const DEPRECATED_EVALUATOR_FILTERS: FilterState = [
+  {
+    column: "target",
+    type: "stringOptions",
+    operator: "any of",
+    value: ["trace", "dataset"],
+  },
+];
+
+/** Opens the evaluator list with only the deprecated target types visible. */
+export function buildDeprecatedEvaluatorsUrl(projectId: string) {
+  const filter = encodeURIComponent(
+    encodeFiltersGeneric(DEPRECATED_EVALUATOR_FILTERS),
+  );
+
+  return `/project/${projectId}/evals?filter=${filter}`;
+}
+
+export function buildEvaluatorUpgradeUrl(
+  projectId: string,
+  evaluatorId: string,
+) {
+  return `/project/${projectId}/evals/remap?evaluator=${encodeURIComponent(evaluatorId)}`;
+}

--- a/web/src/features/v4-migration/useV4UpgradeAssistantSupport.clienttest.ts
+++ b/web/src/features/v4-migration/useV4UpgradeAssistantSupport.clienttest.ts
@@ -1,23 +1,9 @@
-import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  V4_CODING_AGENT_PROMPT,
-  useCanUseAgentForMigration,
-} from "./useV4UpgradeAssistantSupport";
-
-const mocks = vi.hoisted(() => ({
-  organization: { aiFeaturesEnabled: false },
-}));
+import { V4_CODING_AGENT_PROMPT } from "./useV4UpgradeAssistantSupport";
 
 vi.mock("@/src/features/in-app-agent/components/InAppAiAgentProvider", () => ({
   useCanUseInAppAgent: () => true,
-}));
-
-vi.mock("@/src/features/projects/hooks", () => ({
-  useQueryProjectOrOrganization: () => ({
-    organization: mocks.organization,
-  }),
 }));
 
 describe("V4_CODING_AGENT_PROMPT", () => {
@@ -30,13 +16,5 @@ describe("V4_CODING_AGENT_PROMPT", () => {
       "Do not stop to install the Langfuse CLI or request credentials.",
     );
     expect(V4_CODING_AGENT_PROMPT).toContain("seven-row readiness report");
-  });
-});
-
-describe("useCanUseAgentForMigration", () => {
-  it("requires AI features to be enabled", () => {
-    const { result } = renderHook(() => useCanUseAgentForMigration());
-
-    expect(result.current).toBe(false);
   });
 });

--- a/web/src/features/v4-migration/useV4UpgradeAssistantSupport.clienttest.ts
+++ b/web/src/features/v4-migration/useV4UpgradeAssistantSupport.clienttest.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
-import { V4_CODING_AGENT_PROMPT } from "./useV4UpgradeAssistantSupport";
+import {
+  V4_CODING_AGENT_PROMPT,
+  useCanUseAgentForMigration,
+} from "./useV4UpgradeAssistantSupport";
+
+const mocks = vi.hoisted(() => ({
+  organization: { aiFeaturesEnabled: false },
+}));
+
+vi.mock("@/src/features/in-app-agent/components/InAppAiAgentProvider", () => ({
+  useCanUseInAppAgent: () => true,
+}));
+
+vi.mock("@/src/features/projects/hooks", () => ({
+  useQueryProjectOrOrganization: () => ({
+    organization: mocks.organization,
+  }),
+}));
 
 describe("V4_CODING_AGENT_PROMPT", () => {
   it("hands coding agents off to the canonical v4 migration skill", () => {
@@ -12,5 +30,13 @@ describe("V4_CODING_AGENT_PROMPT", () => {
       "Do not stop to install the Langfuse CLI or request credentials.",
     );
     expect(V4_CODING_AGENT_PROMPT).toContain("seven-row readiness report");
+  });
+});
+
+describe("useCanUseAgentForMigration", () => {
+  it("requires AI features to be enabled", () => {
+    const { result } = renderHook(() => useCanUseAgentForMigration());
+
+    expect(result.current).toBe(false);
   });
 });

--- a/web/src/features/v4-migration/useV4UpgradeAssistantSupport.ts
+++ b/web/src/features/v4-migration/useV4UpgradeAssistantSupport.ts
@@ -1,5 +1,4 @@
 import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
-import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useProjectV4SdkData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 import { api } from "@/src/utils/api";
 
@@ -37,14 +36,6 @@ ${V4_CODING_AGENT_PROMPT}
 """
 Also ask me whether I would instead like to complete the upgrade by deactivating or deleting all deprecated evaluators — if I say yes, help me do that here, confirming each one with me first.`;
 
-/** Whether the in-app assistant can be used for v4 migration actions. */
-export function useCanUseAgentForMigration() {
-  const canUseAgent = useCanUseInAppAgent();
-  const { organization } = useQueryProjectOrOrganization();
-
-  return canUseAgent && Boolean(organization?.aiFeaturesEnabled);
-}
-
 export type V4UpgradeAssistantMode =
   | "evals-ready"
   | "sdk-first-choice"
@@ -67,7 +58,7 @@ export function useEvalUpgradeAssistantPlan(params: {
   orgId: string | undefined;
   enabled: boolean;
 }) {
-  const canUseAssistant = useCanUseAgentForMigration();
+  const canUseAssistant = useCanUseInAppAgent();
   const sdk = useProjectV4SdkData(params);
   const evalQuery = api.v4Transition.traceLevelEvalSummary.useQuery(
     { projectId: params.projectId ?? "" },
@@ -89,7 +80,7 @@ export function useEvalUpgradeAssistantPlan(params: {
   return {
     canUseAssistant,
     mode,
-    /** Show the "Migrate with assistant" CTA in the migration panel. */
+    /** Whether the migration panel may show the Assistant CTA. */
     showAssistantButton: canUseAssistant && mode !== "outside",
     assistantPrompt:
       mode === "evals-ready"

--- a/web/src/features/v4-migration/useV4UpgradeAssistantSupport.ts
+++ b/web/src/features/v4-migration/useV4UpgradeAssistantSupport.ts
@@ -1,4 +1,5 @@
 import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useProjectV4SdkData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 import { api } from "@/src/utils/api";
 
@@ -36,6 +37,14 @@ ${V4_CODING_AGENT_PROMPT}
 """
 Also ask me whether I would instead like to complete the upgrade by deactivating or deleting all deprecated evaluators — if I say yes, help me do that here, confirming each one with me first.`;
 
+/** Whether the in-app assistant can be used for v4 migration actions. */
+export function useCanUseAgentForMigration() {
+  const canUseAgent = useCanUseInAppAgent();
+  const { organization } = useQueryProjectOrOrganization();
+
+  return canUseAgent && Boolean(organization?.aiFeaturesEnabled);
+}
+
 export type V4UpgradeAssistantMode =
   | "evals-ready"
   | "sdk-first-choice"
@@ -58,7 +67,7 @@ export function useEvalUpgradeAssistantPlan(params: {
   orgId: string | undefined;
   enabled: boolean;
 }) {
-  const canUseAssistant = useCanUseInAppAgent();
+  const canUseAssistant = useCanUseAgentForMigration();
   const sdk = useProjectV4SdkData(params);
   const evalQuery = api.v4Transition.traceLevelEvalSummary.useQuery(
     { projectId: params.projectId ?? "" },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15894.preview.langfuse.com](https://pr-15894.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Require organization AI features to be enabled before treating the in-app assistant as available.
- Route eval migration actions to the existing wizard when AI is disabled.
- Add regression coverage for the capability gate.

## Root cause

The client-side `useCanUseInAppAgent` check did not include `organization.aiFeaturesEnabled`, while the server rejects assistant runs for organizations with AI features disabled.

## Verification

- `git diff --check`
- Targeted client test attempted but blocked because the isolated worktree required a dependency install and registry access was unavailable.

Refs LFE-14865

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side capability gate aligned with existing server enforcement; no auth or data-path changes beyond routing users to the wizard when AI is disabled.
> 
> **Overview**
> Aligns v4 eval migration UX with the server by requiring **`organization.aiFeaturesEnabled`** before treating the in-app assistant as available for migration.
> 
> Introduces **`useCanUseAgentForMigration`**, which ANDs the existing in-app agent check with the org AI flag. **`useEvalUpgradeAssistantPlan`**, **`V4MigrationUpdateRequiredBadge`**, and the evaluator peek detail now use this hook instead of **`useCanUseInAppAgent`** alone. When AI is off, the “Action required” badge opens the **migration panel/wizard** (same as when the agent is unavailable); the peek view only shows that badge when the stricter gate passes.
> 
> Adds a client test asserting the hook returns **false** when AI features are disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1b567bdee215ab7aa4592351f30e0c6eda7572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns the client-side in-app assistant capability check with the existing server-side organization AI-feature gate.

- Requires `organization.aiFeaturesEnabled` before reporting the assistant as available.
- Routes AI-disabled evaluation migrations through the existing wizard behavior.
- Adds regression coverage for organizations with AI features disabled.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The stricter client capability check matches the persisted organization setting and the existing server-side requirement, while the regression test covers the disabled state.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): route AI-disabled eval migratio..."](https://github.com/langfuse/langfuse/commit/d2ef758454971eaab9513a0d2364d73ee4d14b87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51172916)</sub>

<!-- /greptile_comment -->