### PR TITLE
ci(perf): cache web test compilation across modes

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -583,7 +583,7 @@ jobs:
         env:
           POSTGRES_VERSION: ${{ matrix.postgres-version }}
       - name: Build
-        run: pnpm turbo run build:test --filter=web --filter=worker
+        run: pnpm turbo run build:test --filter=web --filter=worker --filter=@repo/in-app-agent-sandbox-runtime
         env:
           NODE_OPTIONS: --max_old_space_size=8192
           # TypeScript is checked explicitly in the lint job; skip duplicate

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -583,7 +583,7 @@ jobs:
         env:
           POSTGRES_VERSION: ${{ matrix.postgres-version }}
       - name: Build
-        run: pnpm turbo run build:test --filter=web --filter=worker --filter=@repo/in-app-agent-sandbox-runtime
+        run: pnpm turbo run build:test
         env:
           NODE_OPTIONS: --max_old_space_size=8192
           # TypeScript is checked explicitly in the lint job; skip duplicate

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -545,30 +545,33 @@ jobs:
           pnpm install
       - name: Load default env
         run: |
-          cp .env.dev${{ matrix.deploy-mode }}.example .env
-          grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev${{ matrix.deploy-mode }}.example > .env
-          echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1" >> .env
-          echo "LANGFUSE_CACHE_PROMPT_ENABLED=false" >> .env
-          echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1" >> .env
-          echo "LANGFUSE_TRACE_DELETE_DELAY_MS=1" >> .env
-          echo "LANGFUSE_TRACE_DELETE_CONCURRENCY=100" >> .env
-          echo "ADMIN_API_KEY=admin-api-key" >> .env
-          echo "LANGFUSE_EE_LICENSE_KEY=langfuse_ee_test" >> .env
-          echo "LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION=true" >> .env
-          echo "LANGFUSE_ENABLE_SCORES_V3_API=true" >> .env
+          write_test_env() {
+            {
+              grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' "$1"
+              echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1"
+              echo "LANGFUSE_CACHE_PROMPT_ENABLED=false"
+              echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1"
+              echo "LANGFUSE_TRACE_DELETE_DELAY_MS=1"
+              echo "LANGFUSE_TRACE_DELETE_CONCURRENCY=100"
+              echo "ADMIN_API_KEY=admin-api-key"
+              echo "LANGFUSE_EE_LICENSE_KEY=langfuse_ee_test"
+              echo "LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION=true"
+              echo "LANGFUSE_ENABLE_SCORES_V3_API=true"
+            } > "$2"
+          }
+
+          # Compile once under the default test environment. Next's generate
+          # phase below reapplies the mode-specific config and prerendering.
+          write_test_env .env.dev.example .env
+          write_test_env .env.dev${{ matrix.deploy-mode }}.example .env.runtime
       - name: Setup Turbo cache
         if: env.CI_CACHE_ALLOWED == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # zizmor: ignore[cache-poisoning] test job cache only; publish jobs rebuild artifacts and do not restore this cache
         with:
           path: .turbo
-          # Turbo hashes the whole .env (turbo.json globalDependencies) and
-          # each deploy-mode writes a different .env, so keys must be
-          # mode-scoped for every matrix job to replay its own builds. The
-          # default mode gets an explicit "-default" segment so its restore
-          # prefix cannot match the other modes' keys.
-          key: ${{ runner.os }}-turbo-mode${{ matrix.deploy-mode == '' && '-default' || matrix.deploy-mode }}-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-tests-web-compile-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-mode${{ matrix.deploy-mode == '' && '-default' || matrix.deploy-mode }}-
+            ${{ runner.os }}-turbo-tests-web-compile-
       # No Next.js build cache here on purpose: its ~30s/job restore+save cost
       # roughly cancels the build speedup, and the Turbo cache above already
       # replays unchanged builds.
@@ -576,22 +579,29 @@ jobs:
         # Independent of the build, so let the build overlap the ~15-20s
         # container startup. "Wait for dev containers" collects the result.
         run: |
-          (set +e; docker compose -f docker-compose.dev${{ matrix.deploy-mode }}.yml up -d --wait --wait-timeout 180 > /tmp/compose-up.log 2>&1; echo $? > /tmp/compose-up.exit) &
+          (set +e; docker compose --env-file .env.runtime -f docker-compose.dev${{ matrix.deploy-mode }}.yml up -d --wait --wait-timeout 180 > /tmp/compose-up.log 2>&1; echo $? > /tmp/compose-up.exit) &
         env:
           POSTGRES_VERSION: ${{ matrix.postgres-version }}
       - name: Build
-        run: pnpm run build
+        run: pnpm turbo run build:test --filter=web --filter=worker
         env:
           NODE_OPTIONS: --max_old_space_size=8192
           # TypeScript is checked explicitly in the lint job; skip duplicate
           # Next.js type checks in test builds to reduce CI runtime.
+          NEXT_IGNORE_BUILD_ERRORS: "true"
+      - name: Finalize build for runtime environment
+        run: |
+          cp .env.runtime .env
+          pnpm --filter web exec dotenv -e ../.env -- next build --experimental-build-mode generate
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
           NEXT_IGNORE_BUILD_ERRORS: "true"
       - name: Wait for dev containers
         run: |
           timeout 300 bash -c 'until [ -f /tmp/compose-up.exit ]; do sleep 1; done' \
             || { echo "Timed out waiting for background docker compose up"; cat /tmp/compose-up.log; exit 1; }
           cat /tmp/compose-up.log
-          docker compose ps
+          docker compose --env-file .env.runtime -f docker-compose.dev${{ matrix.deploy-mode }}.yml ps
           exit "$(cat /tmp/compose-up.exit)"
       - name: Migrate DB
         run: |

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -107,7 +107,7 @@ jobs:
         # depends on db:generate, which is offline.
         run: |
           if [ "${{ matrix.env_profile }}" = "tests-web" ]; then
-            pnpm turbo run build:test --filter=web --filter=worker --filter=@repo/in-app-agent-sandbox-runtime
+            pnpm turbo run build:test
           else
             pnpm run build
           fi

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -107,7 +107,7 @@ jobs:
         # depends on db:generate, which is offline.
         run: |
           if [ "${{ matrix.env_profile }}" = "tests-web" ]; then
-            pnpm turbo run build:test --filter=web --filter=worker
+            pnpm turbo run build:test --filter=web --filter=worker --filter=@repo/in-app-agent-sandbox-runtime
           else
             pnpm run build
           fi

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -49,14 +49,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cache_scope: mode-default
+          - cache_scope: tests-web-compile
             deploy-mode: ""
-            env_profile: tests-web
-          - cache_scope: mode-azure
-            deploy-mode: -azure
-            env_profile: tests-web
-          - cache_scope: mode-redis-cluster
-            deploy-mode: -redis-cluster
             env_profile: tests-web
           - cache_scope: server-e2e
             deploy-mode: ""
@@ -111,7 +105,12 @@ jobs:
       - name: Build
         # dev containers / Postgres are not needed: the build task only
         # depends on db:generate, which is offline.
-        run: pnpm run build
+        run: |
+          if [ "${{ matrix.env_profile }}" = "tests-web" ]; then
+            pnpm turbo run build:test --filter=web --filter=worker
+          else
+            pnpm run build
+          fi
         env:
           NODE_OPTIONS: --max_old_space_size=8192
           # TypeScript is checked explicitly in the lint job; skip duplicate

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -10,7 +10,7 @@ name: Warm CI caches
 # (contradicting their documented 7-day LRU eviction), so most branch runs
 # find nothing and pay a cold pnpm install plus a cold turbo build (~+2min on
 # the tests-web critical path). This workflow re-saves the pnpm store and the
-# mode-scoped turbo caches from main every few hours so branch runs keep
+# task-scoped Turbo caches from main every few hours so branch runs keep
 # hitting them. Once Blacksmith retention is back to days, drop the schedule
 # to daily or delete the workflow — it is purely compensatory.
 on:
@@ -44,7 +44,7 @@ jobs:
       # Mirror the consuming test jobs so Turbo task hashes match.
       NODE_ENV: test
     strategy:
-      # One mode failing must not cancel the other warmers — a partially
+      # One profile failing must not cancel the other warmer — a partially
       # warmed pool still helps.
       fail-fast: false
       matrix:

--- a/packages/in-app-agent-sandbox-runtime/package.json
+++ b/packages/in-app-agent-sandbox-runtime/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:test": "tsc",
     "build:docker-image": "docker build . -t langfuse-in-app-agent-sandbox:latest && touch .local-image-built",
     "start": "node ./dist/server.js",
     "format": "prettier --write .",

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,13 @@
       "cache": true,
       "outputLogs": "errors-only"
     },
+    "build:test": {
+      "dependsOn": ["db:generate", "^build"],
+      "env": ["NEXT_IGNORE_BUILD_ERRORS"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
+      "cache": true,
+      "outputLogs": "errors-only"
+    },
     "start": {
       "dependsOn": ["^start"]
     },

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "INLINE_RUNTIME_CHUNK=false dotenv -e ../.env -- next build",
+    "build:test": "INLINE_RUNTIME_CHUNK=false dotenv -e ../.env -- next build --experimental-build-mode compile",
     "build:check": "NEXT_DIST_DIR=.next-check INLINE_RUNTIME_CHUNK=false dotenv -e ../.env -- next build",
     "typecheck": "dotenv -e ../.env -- tsc -p tsconfig.json --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo",
     "dev": "dotenv -e ../.env -- next dev",

--- a/worker/package.json
+++ b/worker/package.json
@@ -18,6 +18,7 @@
     "coverage": "vitest run --coverage",
     "start": "dotenv -e ../.env -- node dist/index.js",
     "build": "tsc",
+    "build:test": "tsc",
     "build:check": "tsc",
     "typecheck": "dotenv -e ../.env -- tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo",
     "dev": "dotenv -e ../.env -- tsx watch --clear-screen=false --include '../packages/shared/dist/*'  src/index.ts",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15899.preview.langfuse.com](https://pr-15899.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Split the web-test production build into a cacheable, environment-independent Turbopack compile and a mode-specific Next.js generate phase.
- Share one compile cache across the default, Azure, and Redis Cluster web-test jobs while preserving their existing runtime environments.
- Reduce the six-hour warmer from three web-build profiles to one compile profile; retain the separate server-E2E cache.

## Measured Results

Comparison uses [run 31181968937](https://github.com/langfuse/langfuse/actions/runs/31181968937) as the recent pre-change baseline and the final, simultaneous warm-cache matrix in [run 31191896273](https://github.com/langfuse/langfuse/actions/runs/31191896273). Runner wait is excluded from every job duration.

| `tests-web` mode | Before: job | Before: full build | After: cache replay | After: mode generate | After: build path | Build-path saving | After: job | Job delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Default | 3:28 | 0:56 | 0:04 | 0:13 | 0:17 | **-0:39 (-70%)** | 2:51 | **-0:37 (-18%)** |
| Azure | 3:21 | 1:10 | 0:04 | 0:10 | 0:14 | **-0:56 (-80%)** | 2:33 | **-0:48 (-24%)** |
| Redis Cluster | 3:01 | 0:57 | 0:06 | 0:15 | 0:21 | **-0:36 (-63%)** | 3:34 | +0:33 (+18%) |
| **Median** | **3:21** | **0:57** | **0:04** | **0:13** | **0:17** | **-0:40 (-70%)** | **2:51** | **-0:30 (-15%)** |

The build optimization is real and consistent, but the end-to-end job is not reliably below three minutes. Test execution was slower in the final run (median 1:41 versus 1:20 in the baseline), masking part of the build saving. Redis is the clearest example: its build path saved 36 seconds while its tests regressed by 53 seconds.

The final merge-blocking pipeline completed in **3:53 wall-clock excluding runner wait** (first required job started at 15:18:07; `all-ci-passed` completed at 15:22:00), so it remains below the broader five-minute ceiling.

Cold-cache behavior is deliberately worse: the first corrected run took 3:59–4:10 because it paid the compile and cache-population cost. The scheduled warmer is therefore part of this design, not an optional enhancement.

## Cache-Warmer Cost

The warmer still runs every six hours on the existing 4-vCPU runner; this PR changes neither runner size nor sharding.

| | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Scheduled profiles | 4 (3 web modes + server E2E) | 2 (1 web compile + server E2E) | **-50%** |
| Jobs/day | 16 | 8 | **-8 jobs/day** |
| Estimated monthly warmer cost at $0.008/min | ~$9.53 | ~$4.69 | **~-$4.84/month** |

The cost estimate extrapolates the successful cold manual warmer run ([31191339348](https://github.com/langfuse/langfuse/actions/runs/31191339348): 2:31 web compile, 2:22 server E2E) and assumes the removed web profiles had the same duration as the retained web profile.

## Linear

- None

## Major Decisions

- Use Next.js 16's experimental `compile` / `generate` build modes instead of sharing finalized artifacts across environments. `next.config.mjs` embeds mode-specific CSP values, so finalized Azure and default builds are not interchangeable.
- Keep the PR as a draft: Next.js labels the split build API experimental, and Sentry prints a warning that it does not fully support this build mode. Production image builds are unchanged; the warning applies only to this test artifact.
- Do not claim that this reaches the broader sub-three-minute goal. It cuts the median build path by 39 seconds, but test runtime is now the limiting and variable portion.

## Verification

- Corrected cold matrix: all three web modes passed in run 31189857252.
- Final warm matrix: all three web modes passed and replayed the same compile cache; build steps completed in 4–6 seconds.
- Cache warmer: both retained profiles passed in run 31191339348.
- Local finalized artifact: `next start` returned `{"status":"OK","version":"4.6.0"}` from `/api/public/health`.
- Local Azure finalization rewrote the generated CSP from the default `localhost:9090` media endpoint to Azure's `localhost:10000`, confirming that generate reapplies the mode-specific Next config.
- `prettier --check`: all changed files use Prettier style.
- `actionlint`: no new workflow findings; it reports the repository's existing custom Blacksmith runner-label and shellcheck warnings.

## Review Focus

- Whether a median 30-second job saving justifies depending on an experimental Next/Sentry path.
- Whether the generated production artifact preserves the mode-specific Next config in every matrix leg.
- Whether the cache warmer's cold-cache penalty and six-hour cadence are acceptable operationally.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR separates web-test compilation from mode-specific Next.js generation so the default, Azure, and Redis Cluster jobs can share one Turbo compile cache. It also consolidates the scheduled web cache warmers while leaving production builds unchanged.

- Adds cacheable `build:test` tasks for the web, worker, and sandbox-runtime packages.
- Compiles once under the default test environment, then generates the final web artifact with each matrix leg’s runtime environment.
- Replaces three mode-specific web cache profiles with one shared compile profile.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified in the shared compile-cache or mode-specific generation paths.

The warmer and test workflow use compatible Turbo keys, environments, and task graphs, and each matrix leg restores its runtime environment before final generation and server startup.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  W[Scheduled cache warmer] -->|default test environment| C[Next.js compile]
  C --> T[(Shared Turbo compile cache)]
  T --> D[Default test job]
  T --> A[Azure test job]
  T --> R[Redis Cluster test job]
  D --> GD[Generate with default environment]
  A --> GA[Generate with Azure environment]
  R --> GR[Generate with Redis Cluster environment]
  GD --> TD[Run default web tests]
  GA --> TA[Run Azure web tests]
  GR --> TR[Run Redis Cluster web tests]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(ci): clarify cache warmer profiles"](https://github.com/langfuse/langfuse/commit/c4410a9709d5d020aaee3ac5efa8fc974c02050b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51210608)</sub>

<!-- /greptile_comment -->