### PR TITLE
fix(observability): remove user emails from Datadog traces

### DIFF
--- a/packages/shared/src/server/instrumentation/index.test.ts
+++ b/packages/shared/src/server/instrumentation/index.test.ts
@@ -1,9 +1,14 @@
-import { context } from "@opentelemetry/api";
+import {
+  context,
+  propagation,
+  ROOT_CONTEXT,
+  type Span,
+} from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { normalizeClickHouseQueryTags } from "../clickhouse/queryTags";
 import { contextWithLangfuseProps } from "../headerPropagation";
-import { instrumentAsync, instrumentSync } from ".";
+import { addUserToSpan, instrumentAsync, instrumentSync } from ".";
 
 describe("instrumentation baggage propagation", () => {
   // Baggage only propagates through context.with once a manager is registered.
@@ -55,5 +60,28 @@ describe("instrumentation baggage propagation", () => {
       route: "langfuse.queue.monitor",
       projectId: "project-1",
     });
+  });
+
+  it("does not add user emails to span attributes or baggage", () => {
+    const span = {
+      setAttribute: vi.fn(),
+    } as unknown as Span;
+    const attributes = {
+      userId: "user-1",
+      email: "user@example.com",
+    } as Parameters<typeof addUserToSpan>[0];
+
+    const userContext = context.with(ROOT_CONTEXT, () =>
+      addUserToSpan(attributes, span),
+    );
+
+    expect(span.setAttribute).toHaveBeenCalledWith("user.id", "user-1");
+    expect(span.setAttribute).not.toHaveBeenCalledWith(
+      "user.email",
+      "user@example.com",
+    );
+    expect(propagation.getBaggage(userContext!)?.getEntry("user.email")).toBe(
+      undefined,
+    );
   });
 });

--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -210,7 +210,6 @@ export const addUserToSpan = (
   attributes: {
     userId?: string;
     projectId?: string;
-    email?: string;
     orgId?: string;
     plan?: string;
     apiKeyId?: string;
@@ -234,12 +233,6 @@ export const addUserToSpan = (
       value: attributes.userId,
     });
     activeSpan.setAttribute("user.id", attributes.userId);
-  }
-  if (attributes.email) {
-    baggage = baggage.setEntry("user.email", {
-      value: attributes.email,
-    });
-    activeSpan.setAttribute("user.email", attributes.email);
   }
   if (attributes.projectId) {
     baggage = baggage.setEntry("langfuse.project.id", {

--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -209,7 +209,6 @@ describe("in-app agent public API route auth", () => {
 
     expect(instrumentationMocks.addUserToSpan).toHaveBeenCalledWith({
       userId: "user-1",
-      email: "test@example.com",
     });
   });
 
@@ -1090,7 +1089,6 @@ describe("in-app agent public API route auth", () => {
       );
       expect(instrumentationMocks.addUserToSpan).toHaveBeenLastCalledWith({
         userId: sessionUser.id,
-        email: sessionUser.email,
         projectId: project.id,
         orgId: org.id,
         plan: "cloud:team",

--- a/web/src/__tests__/server/unit/getServerAuthSession-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/getServerAuthSession-invalid-callback-url.servertest.ts
@@ -6,12 +6,32 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getCookieName } from "@/src/server/utils/cookies";
 
-const { mockGetServerSession } = vi.hoisted(() => ({
-  mockGetServerSession: vi.fn(),
-}));
+const { mockAuthSpan, mockGetServerSession, mockInstrumentAsync } = vi.hoisted(
+  () => {
+    const mockAuthSpan = {
+      setAttributes: vi.fn(),
+    };
+
+    return {
+      mockAuthSpan,
+      mockGetServerSession: vi.fn(),
+      mockInstrumentAsync: vi.fn(
+        async (
+          _options: unknown,
+          callback: (span: typeof mockAuthSpan) => unknown,
+        ) => callback(mockAuthSpan),
+      ),
+    };
+  },
+);
 
 vi.mock("next-auth", () => ({
   getServerSession: mockGetServerSession,
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  instrumentAsync: mockInstrumentAsync,
 }));
 
 vi.mock("@/src/ee/features/multi-tenant-sso/utils", () => ({
@@ -110,5 +130,25 @@ describe("getServerAuthSession invalid callback URL handling", () => {
         baseUrl: "http://localhost:3000",
       }),
     ).toBe("http://localhost:3000");
+  });
+
+  it("does not attach the user email to the sign-in span", async () => {
+    const authOptions = await getAuthOptions();
+    const signIn = authOptions.callbacks?.signIn;
+    if (!signIn) throw new Error("Expected a sign-in callback");
+
+    await signIn({
+      user: { id: "user-1", email: "user@example.com" },
+      account: null,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(mockAuthSpan.setAttributes).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        "auth.email": "user@example.com",
+      }),
+    );
   });
 });

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -116,7 +116,6 @@ export default async function handler(request: Request) {
 
     addUserToSpan({
       userId,
-      email: user.email ?? undefined,
     });
 
     const bodyResult = await readBoundedJsonBody(
@@ -231,7 +230,6 @@ export default async function handler(request: Request) {
 
     addUserToSpan({
       userId,
-      email: user.email ?? undefined,
       projectId: rateLimitScope.projectId ?? undefined,
       orgId: rateLimitScope.orgId,
       plan: rateLimitScope.plan,

--- a/web/src/features/in-app-agent/server/watchHandler.ts
+++ b/web/src/features/in-app-agent/server/watchHandler.ts
@@ -26,7 +26,7 @@ export default async function watchHandler(request: Request) {
 
     const user = session.user;
 
-    addUserToSpan({ userId: user.id, email: user.email ?? undefined });
+    addUserToSpan({ userId: user.id });
 
     const url = new URL(request.url);
     const query = WatchQuerySchema.safeParse({

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -65,7 +65,6 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
 
   addUserToSpan({
     userId: session?.user?.id,
-    email: session?.user?.email ?? undefined,
   });
 
   return createInnerTRPCContext({ session, headers });

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -992,7 +992,7 @@ export async function getAuthOptions(signupAttribution?: {
         });
       },
       async signIn({ user, account, profile }) {
-        return instrumentAsync({ name: "next-auth-sign-in" }, async (span) => {
+        return instrumentAsync({ name: "next-auth-sign-in" }, async () => {
           // Block sign in without valid user.email
           const email = user.email?.toLowerCase();
           if (!email) {
@@ -1004,9 +1004,6 @@ export async function getAuthOptions(signupAttribution?: {
             throw new Error("Invalid email found in user object");
           }
 
-          span.setAttributes({
-            "auth.email": email,
-          });
           // EE: Check custom SSO enforcement, enforce the specific SSO provider on email domain
           // This also blocks setting a password for an email that is enforced to use SSO via password reset flow
           const userDomain = email.split("@")[1].toLowerCase();

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -844,7 +844,6 @@ export async function getAuthOptions(signupAttribution?: {
             },
           });
 
-          span.setAttribute("langfuse.user.email", dbUser?.email ?? "");
           span.setAttribute("langfuse.user.id", dbUser?.id ?? "");
           // V4 preview availability is governed by the write mode:
           // - events_only: the legacy traces/observations tables are no longer


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15908.preview.langfuse.com](https://pr-15908.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Removes user email addresses from Datadog/OpenTelemetry telemetry while retaining stable user IDs for debugging:

- stops adding user.email to span attributes and propagated baggage
- removes email attributes from auth session and sign-in spans
- removes email arguments from web tracing call sites
- adds regression coverage for shared baggage/attributes and NextAuth sign-in spans

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- @langfuse/shared
- web

## Verification

- pnpm run lint — Tasks: 7 successful, 7 total
- pnpm run typecheck — Tasks: 7 successful, 7 total
- pnpm --filter @langfuse/shared run test src/server/instrumentation/index.test.ts — Tests 3 passed (3)
- pnpm --filter web run test src/__tests__/server/unit/langfuse-context-propagation.servertest.ts — Tests 3 passed (3)
- pnpm --filter web run test src/__tests__/server/unit/getServerAuthSession-invalid-callback-url.servertest.ts — Tests 5 passed (5)
- targeted in-app agent auth expectations — Tests 2 passed | 28 skipped (30)
- multiline Datadog/OpenTelemetry production-source email attribute scan — 0 matches

## Mandatory Tasks

- [x] Self-reviewed the code
- [x] Confirmed no documentation update is required