### PR TITLE
fix(api): stabilize legacy observations list pagination with unique id tiebreaker

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -2085,6 +2085,11 @@ export const generateObservationsForPublicApi = async ({
 
   const disableObservationsFinal = await shouldSkipObservationsFinal(projectId);
 
+  // Offset pagination must order by a unique key as tiebreaker: many
+  // observations share a start_time, and ClickHouse returns ties in an
+  // unspecified order, so rows could be duplicated or dropped across page
+  // boundaries. The unique observation id resolves ties deterministically
+  // in both the paginated keys CTE and the final result ordering.
   const query = `
     with clickhouse_keys as (
       SELECT DISTINCT
@@ -2098,7 +2103,7 @@ export const generateObservationsForPublicApi = async ({
       WHERE o.project_id = {projectId: String}
         ${traceFilter ? `AND t.project_id = {projectId: String}` : ""}
         AND ${appliedFilter.query}
-      ORDER BY start_time DESC
+      ORDER BY start_time DESC, id DESC
         LIMIT {limit: Int32} OFFSET {offset: Int32}
     )
     SELECT
@@ -2135,7 +2140,7 @@ export const generateObservationsForPublicApi = async ({
     FROM observations o ${disableObservationsFinal ? "" : "FINAL"}
     WHERE o.project_id = {projectId: String}
       AND (id, trace_id, project_id, type, toDate(start_time)) in (select * from clickhouse_keys)
-    ORDER BY start_time DESC
+    ORDER BY start_time DESC, id DESC
   `;
 
   const input = {

--- a/web/src/__tests__/server/observations-api.servertest.ts
+++ b/web/src/__tests__/server/observations-api.servertest.ts
@@ -1272,4 +1272,51 @@ describe("/api/public/observations API Endpoint", () => {
     }
     runParentObservationIdFilterTestSuite(false); // with observations table
   });
+
+  describe("GET /api/public/observations pagination stability (legacy observations table)", () => {
+    it("should not duplicate or omit observations sharing a start_time across pages", async () => {
+      const traceId = randomUUID();
+      const sharedStartTime = new Date("2024-03-01T12:00:00Z").getTime();
+
+      const trace = createTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: sharedStartTime,
+      });
+      await createTracesCh([trace]);
+
+      // More observations than one page (limit 50 below), all sharing the
+      // same start_time, so every page boundary falls inside a run of
+      // ordering ties. Without a unique tiebreaker, ClickHouse resolves
+      // ties arbitrarily and rows get duplicated or dropped across pages.
+      const observationCount = 150;
+      const observations = Array.from({ length: observationCount }, (_, i) =>
+        createObservation({
+          project_id: projectId,
+          trace_id: traceId,
+          id: randomUUID(),
+          name: `pagination-tie-${i}`,
+          type: "SPAN",
+          start_time: sharedStartTime,
+        }),
+      );
+      await createObservationsCh(observations);
+
+      const returnedIds: string[] = [];
+      for (const page of [1, 2, 3]) {
+        const response = await makeZodVerifiedAPICall(
+          GetObservationsV1Response,
+          "GET",
+          `/api/public/observations?traceId=${traceId}&limit=50&page=${page}`,
+          undefined,
+          auth,
+        );
+        expect(response.status).toBe(200);
+        returnedIds.push(...response.body.data.map((o) => o.id));
+      }
+
+      expect(returnedIds.length).toBe(observationCount);
+      expect(new Set(returnedIds).size).toBe(observationCount);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The legacy v1 `GET /api/public/observations` path pages through ClickHouse with `LIMIT/OFFSET` inside a keys CTE, ordered only by `start_time DESC`. Many observations share a `start_time`, and ClickHouse returns ties in an unspecified order, so rows can be duplicated or dropped across page boundaries.

## Changes

- Append the unique observation `id` as a secondary `DESC` sort key to both the paginated keys CTE and the final result ordering in `generateObservationsForPublicApi`, matching the stable multi-key ordering the events-table path already uses and the id-tiebreaker pattern used in batch export queries.
- Add a public API regression test that inserts 150 observations sharing one `start_time` (three pages of limit 50) and asserts every id is returned exactly once across pages.

## Files changed

- `packages/shared/src/server/repositories/observations.ts` — added `id DESC` tiebreaker
- `web/src/__tests__/server/observations-api.servertest.ts` — added pagination stability regression test

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR stabilizes offset pagination for the legacy observations API by adding the unique observation ID as a secondary descending sort key in both key selection and final output.

- Applies consistent `start_time DESC, id DESC` ordering to the legacy ClickHouse query.
- Adds a three-page regression test covering 150 observations with identical start times.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the query and regression test consistently addressing unstable pagination ties.

The secondary unique-ID ordering is applied consistently during paginated key selection and final result ordering, and no changed-code-triggered failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): stabilize legacy observations ..."](https://github.com/langfuse/langfuse/commit/32883faaf31943455a883b499bcf974066b8f29f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51375791)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->