### PR TITLE
fix(ingestion): recover malformed surrogate batches

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -7,7 +7,7 @@ import { propagation, context } from "@opentelemetry/api";
 import { ClickHouseLogger, mapLogLevel } from "./clickhouse-logger";
 import { getClickHouseCompatibilitySettings } from "./compatibility";
 
-export { EXCEPTION_TAG_HEADER_NAME } from "@clickhouse/client";
+export { ClickHouseError, EXCEPTION_TAG_HEADER_NAME } from "@clickhouse/client";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 

--- a/web/src/__tests__/server/ingestion-api.servertest.ts
+++ b/web/src/__tests__/server/ingestion-api.servertest.ts
@@ -154,45 +154,33 @@ describe("/api/public/ingestion API Endpoint", () => {
     },
   );
 
-  it("should preserve an ingestion batch containing a malformed surrogate pair", async () => {
-    const malformedTraceId = randomUUID();
-    const healthyTraceId = randomUUID();
-    const malformedInput = `before${String.fromCharCode(0xd800)}after`;
-    const response = await postIngestion({
-      batch: [
-        {
-          id: randomUUID(),
-          type: "trace-create",
-          timestamp: new Date().toISOString(),
-          body: {
-            id: malformedTraceId,
-            timestamp: new Date().toISOString(),
-            input: malformedInput,
-          },
-        },
-        {
-          id: randomUUID(),
-          type: "trace-create",
-          timestamp: new Date().toISOString(),
-          body: {
-            id: healthyTraceId,
-            timestamp: new Date().toISOString(),
-            input: "unchanged",
-          },
-        },
-      ],
-    });
-
-    expect(response.status).toBe(207);
-    await waitForExpect(async () => {
-      const [malformedTrace, healthyTrace] = await Promise.all([
-        getTraceById({ traceId: malformedTraceId, projectId }),
-        getTraceById({ traceId: healthyTraceId, projectId }),
-      ]);
-      expect(malformedTrace?.input).toBe("before�after");
-      expect(healthyTrace?.input).toBe("unchanged");
-    }, 15_000);
-  });
+  // Disabled within test sequence as we're using a clickhouse version which doesn't support this
+  // it("should replace bad escape sequences on clickhouse", async () => {
+  //   const entity = {
+  //     id: randomUUID(),
+  //     type: "trace-create",
+  //     timestamp: new Date().toISOString(),
+  //     body: {
+  //       id: randomUUID(),
+  //       timestamp: new Date().toISOString(),
+  //       metadata: { hello: "world" },
+  //       input: "test\\ud8000test",
+  //       environment: "production",
+  //     },
+  //   };
+  //   const response = await postIngestion({
+  //     batch: [entity],
+  //   });
+  //
+  //   expect(response.status).toBe(207);
+  //   await waitForExpect(async () => {
+  //     const trace = await getTraceById({ traceId: entity.body.id, projectId });
+  //     expect(trace).toBeDefined();
+  //     expect(trace!.id).toBe(entity.body.id);
+  //     expect(trace!.projectId).toBe(projectId);
+  //     expect(trace!.input).toContain("test");
+  //   });
+  // });
 
   it.each([
     [

--- a/web/src/__tests__/server/ingestion-api.servertest.ts
+++ b/web/src/__tests__/server/ingestion-api.servertest.ts
@@ -154,33 +154,45 @@ describe("/api/public/ingestion API Endpoint", () => {
     },
   );
 
-  // Disabled within test sequence as we're using a clickhouse version which doesn't support this
-  // it("should replace bad escape sequences on clickhouse", async () => {
-  //   const entity = {
-  //     id: randomUUID(),
-  //     type: "trace-create",
-  //     timestamp: new Date().toISOString(),
-  //     body: {
-  //       id: randomUUID(),
-  //       timestamp: new Date().toISOString(),
-  //       metadata: { hello: "world" },
-  //       input: "test\\ud8000test",
-  //       environment: "production",
-  //     },
-  //   };
-  //   const response = await postIngestion({
-  //     batch: [entity],
-  //   });
-  //
-  //   expect(response.status).toBe(207);
-  //   await waitForExpect(async () => {
-  //     const trace = await getTraceById({ traceId: entity.body.id, projectId });
-  //     expect(trace).toBeDefined();
-  //     expect(trace!.id).toBe(entity.body.id);
-  //     expect(trace!.projectId).toBe(projectId);
-  //     expect(trace!.input).toContain("test");
-  //   });
-  // });
+  it("should preserve an ingestion batch containing a malformed surrogate pair", async () => {
+    const malformedTraceId = randomUUID();
+    const healthyTraceId = randomUUID();
+    const malformedInput = `before${String.fromCharCode(0xd800)}after`;
+    const response = await postIngestion({
+      batch: [
+        {
+          id: randomUUID(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: malformedTraceId,
+            timestamp: new Date().toISOString(),
+            input: malformedInput,
+          },
+        },
+        {
+          id: randomUUID(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: healthyTraceId,
+            timestamp: new Date().toISOString(),
+            input: "unchanged",
+          },
+        },
+      ],
+    });
+
+    expect(response.status).toBe(207);
+    await waitForExpect(async () => {
+      const [malformedTrace, healthyTrace] = await Promise.all([
+        getTraceById({ traceId: malformedTraceId, projectId }),
+        getTraceById({ traceId: healthyTraceId, projectId }),
+      ]);
+      expect(malformedTrace?.input).toBe("before�after");
+      expect(healthyTrace?.input).toBe("unchanged");
+    }, 15_000);
+  });
 
   it.each([
     [

--- a/worker/src/queues/__tests__/otelToObservationForEval.test.ts
+++ b/worker/src/queues/__tests__/otelToObservationForEval.test.ts
@@ -119,6 +119,102 @@ describe("OTEL to ObservationForEval Schema Validation", () => {
     vi.clearAllMocks();
   });
 
+  it("preserves malformed surrogates through OTEL parsing for writer repair", async () => {
+    const malformedInput = `before${String.fromCharCode(0xd800)}after`;
+    const resourceSpan = {
+      resource: { attributes: [] },
+      scopeSpans: [
+        {
+          scope: { name: "langfuse-sdk", version: "3.0.0" },
+          spans: [
+            {
+              traceId: createBufferId("2cce18f7e8cd065a0b4e634eef728391"),
+              spanId: createBufferId("57f0255417974100"),
+              name: "malformed-input",
+              kind: 1,
+              startTimeUnixNano: createNanoTimestamp(
+                BigInt(1714488530686000000),
+              ),
+              endTimeUnixNano: createNanoTimestamp(BigInt(1714488530687000000)),
+              attributes: [
+                {
+                  key: "langfuse.observation.type",
+                  value: { stringValue: "span" },
+                },
+                {
+                  key: "langfuse.observation.input",
+                  value: { stringValue: malformedInput },
+                },
+              ],
+              status: {},
+            },
+            {
+              traceId: createBufferId("2cce18f7e8cd065a0b4e634eef728391"),
+              spanId: createBufferId("57f0255417974101"),
+              name: "healthy-input",
+              kind: 1,
+              startTimeUnixNano: createNanoTimestamp(
+                BigInt(1714488530686000000),
+              ),
+              endTimeUnixNano: createNanoTimestamp(BigInt(1714488530687000000)),
+              attributes: [
+                {
+                  key: "langfuse.observation.type",
+                  value: { stringValue: "span" },
+                },
+                {
+                  key: "langfuse.observation.input",
+                  value: { stringValue: "unchanged" },
+                },
+              ],
+              status: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const eventInputs = createTestOtelProcessor().processToEvent([
+      resourceSpan,
+    ]);
+    expect(eventInputs.map(({ input }) => input)).toEqual([
+      malformedInput,
+      "unchanged",
+    ]);
+
+    const eventRecords = await Promise.all(
+      eventInputs.map((eventInput) =>
+        ingestionService.createEventRecord(eventInput, "test/otel/test.json"),
+      ),
+    );
+    expect(eventRecords.map(({ input }) => input)).toEqual([
+      malformedInput,
+      "unchanged",
+    ]);
+
+    await Promise.all(
+      eventRecords.map((eventRecord) =>
+        ingestionService.writeEventRecord(eventRecord),
+      ),
+    );
+    expect(mockAddToClickhouseWriter).toHaveBeenCalledTimes(2);
+    expect(
+      mockAddToClickhouseWriter.mock.calls.map(([table, record]) => ({
+        table,
+        input: record.input,
+      })),
+    ).toEqual([
+      {
+        table: clickhouseWriterExports.TableName.EventsFull,
+        input: malformedInput,
+      },
+      {
+        table: clickhouseWriterExports.TableName.EventsFull,
+        input: "unchanged",
+      },
+    ]);
+  });
+
   describe("Langfuse SDK spans", () => {
     it("should convert a Langfuse SDK generation span to valid ObservationForEval", async () => {
       const langfuseOtelSpan = {

--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -38,10 +38,32 @@ vi.mock("../../env", async (importOriginal) => {
 });
 
 describe("ClickhouseWriter", () => {
+  const malformedInput = `before${String.fromCharCode(0xd800)}after`;
+  const missingSurrogatePairMessage =
+    "Cannot parse escape sequence: missing second part of surrogate pair";
   let clickhouseClientMock: {
     insert: ReturnType<typeof vi.fn>;
   };
   let writer: ClickhouseWriter;
+
+  const createClickHouseError = (
+    overrides: Partial<{ code: string; type: string; message: string }> = {},
+  ) =>
+    new serverExports.ClickHouseError({
+      code: "25",
+      type: "CANNOT_PARSE_ESCAPE_SEQUENCE",
+      message: missingSurrogatePairMessage,
+      ...overrides,
+    });
+
+  const queueMalformedTraceAndFlush = async () => {
+    writer.addToQueue(TableName.Traces, {
+      id: "malformed",
+      input: malformedInput,
+    } as any);
+    await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    await vi.advanceTimersByTimeAsync(200);
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -210,6 +232,119 @@ describe("ClickhouseWriter", () => {
       expect.anything(),
       expect.anything(),
     );
+  });
+
+  it.each([
+    "Cannot parse escape sequence: incorrect surrogate pair of unicode escape sequences in JSON",
+    "Cannot parse escape sequence: missing second part of surrogate pair",
+  ])(
+    "should preserve a batch when ClickHouse rejects a malformed surrogate pair: %s",
+    async (message) => {
+      const mockInsert = vi
+        .spyOn(clickhouseClientMock, "insert")
+        .mockRejectedValueOnce(createClickHouseError({ message }))
+        .mockResolvedValueOnce();
+
+      writer.addToQueue(TableName.Traces, {
+        id: "malformed",
+        input: malformedInput,
+      } as any);
+      writer.addToQueue(TableName.Traces, {
+        id: "healthy",
+        input: "unchanged",
+      } as any);
+
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(mockInsert).toHaveBeenCalledTimes(2);
+      expect(mockInsert.mock.calls[0][0].values).toEqual([
+        expect.objectContaining({ id: "malformed", input: malformedInput }),
+        expect.objectContaining({ id: "healthy", input: "unchanged" }),
+      ]);
+      expect(mockInsert.mock.calls[1][0].values).toEqual([
+        expect.objectContaining({ id: "malformed", input: "before�after" }),
+        expect.objectContaining({ id: "healthy", input: "unchanged" }),
+      ]);
+      expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    {
+      code: "25",
+      type: "CANNOT_PARSE_ESCAPE_SEQUENCE",
+      message: "Cannot parse escape sequence: invalid hexadecimal value",
+    },
+    {
+      code: "26",
+      type: "CANNOT_PARSE_ESCAPE_SEQUENCE",
+      message:
+        "Cannot parse escape sequence: missing second part of surrogate pair",
+    },
+    {
+      code: "25",
+      type: "CANNOT_PARSE_INPUT_ASSERTION_FAILED",
+      message:
+        "Cannot parse escape sequence: missing second part of surrogate pair",
+    },
+  ])(
+    "should not repair unrelated ClickHouse parsing errors: $code $type",
+    async ({ code, type, message }) => {
+      const mockInsert = vi
+        .spyOn(clickhouseClientMock, "insert")
+        .mockRejectedValue(createClickHouseError({ code, type, message }));
+
+      await queueMalformedTraceAndFlush();
+
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+      expect(writer["queue"][TableName.Traces]).toHaveLength(1);
+    },
+  );
+
+  it("should not repair a non-ClickHouse error with matching fields", async () => {
+    const lookalikeError = Object.assign(
+      new Error(missingSurrogatePairMessage),
+      { code: "25", type: "CANNOT_PARSE_ESCAPE_SEQUENCE" },
+    );
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(lookalikeError);
+
+    await queueMalformedTraceAndFlush();
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(writer["queue"][TableName.Traces]).toHaveLength(1);
+  });
+
+  it("should attempt malformed surrogate repair only once", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(createClickHouseError());
+
+    await queueMalformedTraceAndFlush();
+
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+    expect(writer["queue"][TableName.Traces]).toHaveLength(1);
+  });
+
+  it("should repair malformed surrogates when general retries are disabled", async () => {
+    const previousMaxAttempts = env.LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS;
+    (env as any).LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS = 1;
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValueOnce(createClickHouseError())
+      .mockResolvedValueOnce();
+
+    try {
+      await queueMalformedTraceAndFlush();
+
+      expect(mockInsert).toHaveBeenCalledTimes(2);
+      expect(mockInsert.mock.calls[1][0].values[0].input).toBe("before�after");
+    } finally {
+      (env as any).LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS =
+        previousMaxAttempts;
+    }
   });
 
   it("should shutdown gracefully", async () => {

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -1,5 +1,6 @@
 import {
   clickhouseClient,
+  ClickHouseError,
   ClickhouseClientType,
   BlobStorageFileLogInsertType,
   getCurrentSpan,
@@ -31,6 +32,8 @@ const DECIMAL_64_12_LIMIT = new Decimal("1e6");
 const DECIMAL_64_12_MAX_NUM = 999_999.999_999;
 const DECIMAL_64_12_MIN_NUM = -DECIMAL_64_12_MAX_NUM;
 const MULTI_PROJECT_LOG_COMMENT_PROJECT_ID = "MULTI_PROJECT";
+const MALFORMED_SURROGATE_PAIR_MESSAGE =
+  /cannot parse escape sequence: (?:missing second part of surrogate pair|incorrect surrogate pair of unicode escape sequences in JSON)/i;
 
 export class ClickhouseWriter {
   private static instance: ClickhouseWriter | null = null;
@@ -168,6 +171,41 @@ export class ClickhouseWriter {
 
     // Node.js string size errors
     return errorMessage.includes("invalid string length");
+  }
+
+  private isMalformedSurrogatePairError(error: unknown): boolean {
+    return (
+      error instanceof ClickHouseError &&
+      error.code === "25" &&
+      error.type === "CANNOT_PARSE_ESCAPE_SEQUENCE" &&
+      MALFORMED_SURROGATE_PAIR_MESSAGE.test(error.message)
+    );
+  }
+
+  private makeStringsWellFormed<T>(value: T): T {
+    if (typeof value === "string") {
+      return value.toWellFormed() as T;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) => this.makeStringsWellFormed(item)) as T;
+    }
+
+    if (!value || typeof value !== "object") {
+      return value;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return value;
+    }
+
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key.toWellFormed(),
+        this.makeStringsWellFormed(item),
+      ]),
+    ) as T;
   }
 
   /**
@@ -402,13 +440,48 @@ export class ClickhouseWriter {
         this.clampDecimal64Fields(tableName, r),
       );
       let hasBeenTruncated = false;
+      let hasRepairedMalformedSurrogates = false;
 
       await backOff(
-        async () =>
-          this.writeToClickhouse({
-            table: tableName,
-            records: recordsToWrite,
-          }),
+        async () => {
+          try {
+            await this.writeToClickhouse({
+              table: tableName,
+              records: recordsToWrite,
+            });
+          } catch (error) {
+            if (
+              hasRepairedMalformedSurrogates ||
+              !this.isMalformedSurrogatePairError(error)
+            ) {
+              throw error;
+            }
+
+            recordsToWrite = recordsToWrite.map((record) =>
+              this.makeStringsWellFormed(record),
+            );
+            hasRepairedMalformedSurrogates = true;
+
+            logger.warn(
+              `ClickHouse Writer rejected malformed surrogate pairs for ${tableName}; repairing the failed batch and retrying once`,
+              { batchSize: recordsToWrite.length },
+            );
+            recordIncrement(
+              "langfuse.queue.clickhouse_writer.malformed_surrogate_pair_batch_repair",
+              1,
+              { entity_type: tableName },
+            );
+            currentSpan?.addEvent(
+              "clickhouse-query-malformed-surrogate-retry",
+              { "batch.size": recordsToWrite.length },
+            );
+
+            await this.writeToClickhouse({
+              table: tableName,
+              records: recordsToWrite,
+            });
+          }
+        },
         {
           numOfAttempts: env.LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS,
           retry: (error: Error, attemptNumber: number) => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15916.preview.langfuse.com](https://pr-15916.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- recover ClickHouse JSONEachRow batches only when error code 25, type CANNOT_PARSE_ESCAPE_SEQUENCE, and an official malformed-surrogate diagnostic all match
- normalize strings in the failed batch once with String.prototype.toWellFormed() and retry without adding successful-path scanning
- cover classifier boundaries, retry behavior, and the active OTEL parsing path through the EventsFull writer boundary

## Verification

- pnpm --filter worker run test ClickhouseWriter.unit.test.ts
- pnpm --filter worker run test otelToObservationForEval.test.ts
- pnpm run lint
- pnpm run typecheck