### PR TITLE
fix(billing): dedupe Stripe meter events so a retried metering job does not double bill

### DIFF
--- a/worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts
+++ b/worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts
@@ -125,40 +125,47 @@ describe("Cloud Usage Metering idempotent retry after a mid-loop Stripe failure"
       updateProgress: vi.fn(),
     } as any;
 
-    // Run 1: org B's meter call always fails (stands in for backOff's 3
-    // attempts all failing and the error propagating out of the job). Org A's
-    // calls succeed. Iteration order over findMany isn't assumed, so which org
-    // succeeds before B fails is read back from the outcomes below.
+    // Run 1: the job makes two meter calls per org (observations + events).
+    // Fail on the third call so the first org processed is fully billed and
+    // the second one fails partway, which is the partial-progress-then-failure
+    // case. This doesn't assume which org comes first, since findMany has no
+    // orderBy and Postgres can return either order.
     const settledRun1: Array<{
       customerId: string;
       identifier: string | undefined;
       ok: boolean;
     }> = [];
+    let run1Calls = 0;
     meterEventsCreate.mockImplementation(async (args: any) => {
       const customerId = args?.payload?.stripe_customer_id as string;
       const identifier = args?.identifier as string | undefined;
-      if (customerId === "cus_test_org_b") {
+      run1Calls += 1;
+      if (run1Calls >= 3) {
         settledRun1.push({ customerId, identifier, ok: false });
-        throw new Error("simulated transient Stripe failure for org B");
+        throw new Error("simulated transient Stripe failure");
       }
       settledRun1.push({ customerId, identifier, ok: true });
       return { id: "me_1" };
     });
 
     await expect(handleCloudUsageMeteringJob(fakeJob)).rejects.toThrow(
-      "simulated transient Stripe failure for org B",
+      "simulated transient Stripe failure",
     );
 
     const successfulRun1 = settledRun1.filter((s) => s.ok);
-    // At least one call has to go through before org B fails, otherwise the
-    // test isn't exercising the partial-progress-then-failure case.
-    expect(successfulRun1.length).toBeGreaterThan(0);
+    // The first org is billed in full before the failure: its observations and
+    // events calls, all for the same customer.
+    expect(successfulRun1).toHaveLength(2);
+    const billedCustomer = successfulRun1[0].customerId;
+    expect(successfulRun1.every((s) => s.customerId === billedCustomer)).toBe(
+      true,
+    );
 
-    // Every successful call must carry a well-formed, non-empty identifier
-    // (the fix under test) rather than relying on Stripe's random default.
+    // Each of those carries a stable identifier (the fix) rather than a random
+    // one from Stripe.
     for (const call of successfulRun1) {
       expect(call.identifier).toMatch(
-        /^lf-cum-test-org-a-tracing_(observations|events)-\d+$/,
+        /^lf-cum-test-org-[ab]-tracing_(observations|events)-\d+$/,
       );
     }
 
@@ -188,12 +195,12 @@ describe("Cloud Usage Metering idempotent retry after a mid-loop Stripe failure"
     // again. Stripe keeps identifiers unique for at least 24h, so the resend
     // is a no-op instead of a second charge, which is the bug this catches.
     const run1Identifiers = new Set(successfulRun1.map((s) => s.identifier));
-    const run2IdentifiersForRebilledCustomers = settledRun2
-      .filter((s) => s.customerId === "cus_test_org_a")
+    const run2IdentifiersForBilledCustomer = settledRun2
+      .filter((s) => s.customerId === billedCustomer)
       .map((s) => s.identifier);
 
-    expect(run2IdentifiersForRebilledCustomers.length).toBeGreaterThan(0);
-    for (const identifier of run2IdentifiersForRebilledCustomers) {
+    expect(run2IdentifiersForBilledCustomer.length).toBeGreaterThan(0);
+    for (const identifier of run2IdentifiersForBilledCustomer) {
       expect(run1Identifiers.has(identifier)).toBe(true);
     }
   });

--- a/worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts
+++ b/worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts
@@ -1,0 +1,200 @@
+/**
+ * The metering job bills every org in one loop and only advances the cron
+ * marker after the whole loop finishes. If one org's Stripe call fails, the
+ * queue re-enqueues the same interval and the retry re-bills the orgs that
+ * already succeeded. Stripe dedupes meter events by identifier, so the fix is
+ * to send a stable identifier per org/event/interval. Stripe is mocked here,
+ * so this checks the property that makes the dedupe work: the same org, event
+ * type and interval produce the same identifier on the first run and the retry.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { prisma } from "@langfuse/shared/src/db";
+import { CloudConfigSchema } from "@langfuse/shared";
+
+const meterEventsCreate = vi.fn();
+
+vi.mock("stripe", () => {
+  function FakeStripe() {
+    return {
+      billing: {
+        meterEvents: {
+          create: meterEventsCreate,
+        },
+      },
+    };
+  }
+  return { default: FakeStripe };
+});
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    getObservationCountsByProjectInCreationInterval: vi.fn(async () => [
+      { projectId: "cum-test-project-a", count: 10 },
+      { projectId: "cum-test-project-b", count: 20 },
+    ]),
+    getTraceCountsByProjectInCreationInterval: vi.fn(async () => []),
+    getScoreCountsByProjectInCreationInterval: vi.fn(async () => []),
+    // Never actually enqueue follow-up jobs against real redis/BullMQ.
+    CloudUsageMeteringQueue: { getInstance: () => ({ add: vi.fn() }) },
+    CloudSpendAlertQueue: { getInstance: () => ({ add: vi.fn() }) },
+  };
+});
+
+describe("Cloud Usage Metering idempotent retry after a mid-loop Stripe failure", () => {
+  const orgAId = "cum-test-org-a";
+  const orgBId = "cum-test-org-b";
+  const projectAId = "cum-test-project-a";
+  const projectBId = "cum-test-project-b";
+  const cronName = "cloud_usage_metering";
+
+  const hourStart = new Date(
+    Math.floor(Date.now() / 3600000) * 3600000 - 3 * 3600000,
+  );
+
+  beforeEach(async () => {
+    meterEventsCreate.mockReset();
+
+    await prisma.project.deleteMany({
+      where: { id: { in: [projectAId, projectBId] } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: [orgAId, orgBId] } },
+    });
+    await prisma.cronJobs.deleteMany({ where: { name: cronName } });
+
+    await prisma.organization.create({
+      data: {
+        id: orgAId,
+        name: "CUM Test Org A",
+        cloudConfig: CloudConfigSchema.parse({
+          stripe: { customerId: "cus_test_org_a" },
+        }),
+      },
+    });
+    await prisma.project.create({
+      data: { id: projectAId, name: "CUM Test Project A", orgId: orgAId },
+    });
+
+    await prisma.organization.create({
+      data: {
+        id: orgBId,
+        name: "CUM Test Org B",
+        cloudConfig: CloudConfigSchema.parse({
+          stripe: { customerId: "cus_test_org_b" },
+        }),
+      },
+    });
+    await prisma.project.create({
+      data: { id: projectBId, name: "CUM Test Project B", orgId: orgBId },
+    });
+
+    // Cron row primed so the job is immediately due (lastRun far enough in
+    // the past) and in the Queued state.
+    await prisma.cronJobs.create({
+      data: {
+        name: cronName,
+        state: "queued",
+        lastRun: hourStart,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.project.deleteMany({
+      where: { id: { in: [projectAId, projectBId] } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: [orgAId, orgBId] } },
+    });
+    await prisma.cronJobs.deleteMany({ where: { name: cronName } });
+    vi.restoreAllMocks();
+  });
+
+  it("reuses the same meter-event identifier for an org across a failed run and its retry", async () => {
+    const { handleCloudUsageMeteringJob } = await import(
+      "../ee/cloudUsageMetering/handleCloudUsageMeteringJob"
+    );
+
+    const fakeJob = {
+      id: "job-1",
+      data: {},
+      opts: {},
+      updateProgress: vi.fn(),
+    } as any;
+
+    // Run 1: org B's meter call always fails (stands in for backOff's 3
+    // attempts all failing and the error propagating out of the job). Org A's
+    // calls succeed. Iteration order over findMany isn't assumed, so which org
+    // succeeds before B fails is read back from the outcomes below.
+    const settledRun1: Array<{
+      customerId: string;
+      identifier: string | undefined;
+      ok: boolean;
+    }> = [];
+    meterEventsCreate.mockImplementation(async (args: any) => {
+      const customerId = args?.payload?.stripe_customer_id as string;
+      const identifier = args?.identifier as string | undefined;
+      if (customerId === "cus_test_org_b") {
+        settledRun1.push({ customerId, identifier, ok: false });
+        throw new Error("simulated transient Stripe failure for org B");
+      }
+      settledRun1.push({ customerId, identifier, ok: true });
+      return { id: "me_1" };
+    });
+
+    await expect(handleCloudUsageMeteringJob(fakeJob)).rejects.toThrow(
+      "simulated transient Stripe failure for org B",
+    );
+
+    const successfulRun1 = settledRun1.filter((s) => s.ok);
+    // At least one call has to go through before org B fails, otherwise the
+    // test isn't exercising the partial-progress-then-failure case.
+    expect(successfulRun1.length).toBeGreaterThan(0);
+
+    // Every successful call must carry a well-formed, non-empty identifier
+    // (the fix under test) rather than relying on Stripe's random default.
+    for (const call of successfulRun1) {
+      expect(call.identifier).toMatch(
+        /^lf-cum-test-org-a-tracing_(observations|events)-\d+$/,
+      );
+    }
+
+    // Do what the queue processor does on error: reset the cron row to
+    // Queued (jobStartedAt: null) and leave lastRun untouched. See the catch
+    // block in worker/src/queues/cloudUsageMeteringQueue.ts.
+    await prisma.cronJobs.update({
+      where: { name: cronName },
+      data: { state: "queued", jobStartedAt: null },
+    });
+
+    // Run 2 is the retry for the same, still-unadvanced interval. Both orgs
+    // succeed this time.
+    const settledRun2: Array<{
+      customerId: string;
+      identifier: string | undefined;
+    }> = [];
+    meterEventsCreate.mockImplementation(async (args: any) => {
+      const customerId = args?.payload?.stripe_customer_id as string;
+      const identifier = args?.identifier as string | undefined;
+      settledRun2.push({ customerId, identifier });
+      return { id: "me_2" };
+    });
+    await handleCloudUsageMeteringJob(fakeJob);
+
+    // For every identifier that succeeded in run 1, run 2 sends the same one
+    // again. Stripe keeps identifiers unique for at least 24h, so the resend
+    // is a no-op instead of a second charge, which is the bug this catches.
+    const run1Identifiers = new Set(successfulRun1.map((s) => s.identifier));
+    const run2IdentifiersForRebilledCustomers = settledRun2
+      .filter((s) => s.customerId === "cus_test_org_a")
+      .map((s) => s.identifier);
+
+    expect(run2IdentifiersForRebilledCustomers.length).toBeGreaterThan(0);
+    for (const identifier of run2IdentifiersForRebilledCustomers) {
+      expect(run1Identifiers.has(identifier)).toBe(true);
+    }
+  });
+});

--- a/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
+++ b/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
@@ -224,6 +224,13 @@ export const handleCloudUsageMeteringJob = async (job: Job) => {
           await stripe.billing.meterEvents.create({
             event_name: "tracing_observations",
             timestamp: meterIntervalEnd.getTime() / 1000,
+            // The whole job re-enqueues from the start if any org's Stripe
+            // call fails (see cloudUsageMeteringQueue.ts), so orgs already
+            // billed in the failed run get billed again on retry. A stable
+            // identifier per org, event type and interval lets Stripe dedupe
+            // the resubmission instead of charging twice. Stripe holds
+            // identifiers unique for at least 24h.
+            identifier: `lf-${org.id}-tracing_observations-${meterIntervalEnd.getTime()}`,
             payload: {
               stripe_customer_id: stripeCustomerId,
               value: countObservations.toString(), // value is a string in stripe
@@ -253,6 +260,9 @@ export const handleCloudUsageMeteringJob = async (job: Job) => {
           await stripe.billing.meterEvents.create({
             event_name: "tracing_events",
             timestamp: meterIntervalEnd.getTime() / 1000,
+            // Same idempotency reason as the tracing_observations call above,
+            // with the event type in the key so the two don't collide.
+            identifier: `lf-${org.id}-tracing_events-${meterIntervalEnd.getTime()}`,
             payload: {
               stripe_customer_id: stripeCustomerId,
               value: countEvents.toString(), // value is a string in stripe


### PR DESCRIPTION
### What

The cloud usage metering job (`handleCloudUsageMeteringJob`) loops over every Stripe-billed org and calls `stripe.billing.meterEvents.create()` for each, then advances the cron marker (`cron.lastRun`) only after the whole loop finishes. The `meterEvents.create` calls had no `identifier`, so Stripe assigned a random one each time.

If any org's Stripe call fails after its retries, the job throws, the queue resets the cron row and re-enqueues the same interval, and the retry loops from the start again. Every org that already succeeded in the failed run gets billed a second time for that hour.

This isn't only theoretical: #15043 raised this job's query timeout specifically because the count queries were timing out and firing the metering failure in production, which is exactly the path that triggers the re-enqueue.

### Fix

Send a deterministic `identifier` per org, event type and interval (`lf-<orgId>-<eventName>-<intervalEndMs>`). Stripe keeps identifiers unique for at least 24h and collapses a resubmission with the same one into a no-op, so a retry after a partial failure stops double billing.

### Test

`worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts` (the job had no coverage before). It bills two orgs, fails one mid-loop so the job throws, then reruns the same interval and asserts the retry sends the same identifiers for the org that was already billed. Fails on the current code, passes with the fix.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds deterministic Stripe meter-event identifiers and a regression test intended to prevent duplicate billing when a partially completed hourly metering run is retried.
- Scopes identifiers by organization, event type, and interval end.
- Covers a failed run followed by a retry against two test organizations.
- The protection remains time-limited by Stripe's deduplication retention, while retries are not similarly bounded.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The delayed-retry double-billing path should be addressed before merging because failed intervals can outlive Stripe's identifier-retention guarantee.

Deterministic identifiers prevent immediate duplicate submissions, but the queue can resubmit a partially billed interval without a deadline, allowing the same events to be accepted again after Stripe stops retaining the identifiers; the new test also has a non-deterministic ordering dependency.

**Files Needing Attention:** worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts; worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts:233
**Deduplication expires before retries**

If a partially completed interval is retried after Stripe's 24-hour identifier-retention period, the unbounded re-enqueue path resubmits events that Stripe can accept again, causing organizations billed before the original failure to be double billed.

### Issue 2
worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts:136-140
**Test depends on row ordering**

The handler retrieves organizations without an `orderBy` and processes them sequentially, so PostgreSQL can return org B first and trigger this failure before any successful call. That leaves `successfulRun1` empty and makes the regression test fail despite correct production behavior.

### Issue 3
worker/src/__tests__/cloudUsageMeteringDoubleBilling.test.ts:112-114
**Import is inside test callback**

The new test dynamically imports `handleCloudUsageMeteringJob` inside the test function, contrary to the repository rule requiring imports at module scope and making module initialization and mock dependencies less explicit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): dedupe Stripe meter events..."](https://github.com/langfuse/langfuse/commit/7fb4dd11cb649807050a6a50cc3340a105d59c93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51502495)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->