### PR TITLE
fix(api): reject invalid public pagination pages

### DIFF
--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -59,7 +59,7 @@ export const paginationZod = {
 export const publicApiPaginationZod = {
   page: z.preprocess(
     (x) => (x === "" ? undefined : x),
-    z.coerce.number().gt(0).default(1),
+    z.coerce.number().int().gt(0).default(1),
   ),
   limit: publicApiPaginationLimitZod,
 };

--- a/web/src/__tests__/server/llm-connections-api.servertest.ts
+++ b/web/src/__tests__/server/llm-connections-api.servertest.ts
@@ -239,7 +239,24 @@ describe("/api/public/llm-connections API Endpoints", () => {
     });
 
     it("should return 400 for invalid query parameters", async () => {
-      const [negativePageResponse, negativeLimitResponse] = await Promise.all([
+      const [
+        zeroPageResponse,
+        fractionalPageResponse,
+        negativePageResponse,
+        negativeLimitResponse,
+      ] = await Promise.all([
+        makeAPICall(
+          "GET",
+          "/api/public/llm-connections?page=0&limit=10",
+          undefined,
+          auth,
+        ),
+        makeAPICall(
+          "GET",
+          "/api/public/llm-connections?page=0.5&limit=10",
+          undefined,
+          auth,
+        ),
         makeAPICall(
           "GET",
           "/api/public/llm-connections?page=-1&limit=10",
@@ -254,6 +271,8 @@ describe("/api/public/llm-connections API Endpoints", () => {
         ),
       ]);
 
+      expect(zeroPageResponse.status).toBe(400);
+      expect(fractionalPageResponse.status).toBe(400);
       expect(negativePageResponse.status).toBe(400);
       expect(negativeLimitResponse.status).toBe(400);
     });

--- a/web/src/features/public-api/types/llm-connections.ts
+++ b/web/src/features/public-api/types/llm-connections.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  paginationZod,
+  publicApiPaginationZod,
   LLMAdapter,
   type JSONValue,
   BedrockConfigSchema,
@@ -31,7 +31,7 @@ export const LlmConnectionResponse = z
 // GET /api/public/llm-connections query parameters
 export const GetLlmConnectionsV1Query = z
   .object({
-    ...paginationZod,
+    ...publicApiPaginationZod,
   })
   .strict();
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15918.preview.langfuse.com](https://pr-15918.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- reject page=0 on the public LLM connections endpoint with HTTP 400 instead of allowing a negative Prisma offset and returning HTTP 500
- require public pagination pages to be positive integers, preventing fractional pages such as 0.5 from reproducing the same negative-offset failure
- add HTTP regression coverage for zero, fractional, negative page, and negative limit inputs

Fixes [LFE-14889](https://linear.app/clickhouse/issue/LFE-14889).

## Impacted packages

- packages/shared
- web

## Verification

- Red: Tests 1 failed | 46 passed (47); page=0 received 500 instead of 400
- Red follow-up: Tests 1 failed | 46 passed (47); page=0.5 received 500 instead of 400
- Green: Tests 47 passed (47)
- pnpm run lint — Tasks: 7 successful, 7 total
- pnpm --filter web run typecheck — passed
- pnpm --filter worker run typecheck — passed
- pre-commit Prettier and lint hooks — passed

The existing Fern contract already defines page as an integer and documents that pagination starts at 1, so no Fern regeneration is required.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR tightens public pagination validation and applies it to the LLM-connections endpoint, preventing invalid pages from reaching Prisma as negative offsets.
- Requires public API page values to be positive integers.
- Switches the LLM-connections query schema to the public pagination contract.
- Adds HTTP regression coverage for zero, fractional, and negative pagination inputs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with validation aligned to the documented positive-integer pagination contract.

Invalid pages are now rejected before offset calculation, valid integer pagination and defaults remain unchanged, and the endpoint tests cover the reported failure cases.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): reject invalid public paginati..."](https://github.com/langfuse/langfuse/commit/cecc1950d8f0abd2201631ba1e8df38cee2217b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51550751)</sub>

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->