### PR TITLE
fix(tracing): validate agent graph timestamps

### DIFF
--- a/web/src/__tests__/server/traces-trpc-events-only.servertest.ts
+++ b/web/src/__tests__/server/traces-trpc-events-only.servertest.ts
@@ -154,6 +154,33 @@ maybe("traces trpc (events_only write mode)", () => {
     expect(result.observations).toHaveLength(2);
   });
 
+  it("rejects invalid agent graph timestamps as a bad request", async () => {
+    const traceId = randomUUID();
+
+    await createEventsCh([
+      createEvent({
+        id: traceId,
+        span_id: traceId,
+        trace_id: traceId,
+        project_id: projectId,
+        parent_span_id: null,
+      }),
+    ]);
+    await waitForExpect(async () => {
+      const trace = await getTraceByIdFromEventsTable({ projectId, traceId });
+      expect(trace?.id).toBe(traceId);
+    });
+
+    await expect(
+      caller.events.getAgentGraphData({
+        projectId,
+        traceId,
+        minStartTime: "'",
+        maxStartTime: "2026-08-08T22:25:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
   // On a fresh events_only deployment tracing data is written ONLY to the
   // events tables; the legacy `traces` table stays intentionally empty. The
   // onboarding gate must detect data in the events table, otherwise the

--- a/web/src/__tests__/server/traces-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-trpc.servertest.ts
@@ -967,6 +967,25 @@ describe("traces trpc", () => {
   });
 
   describe("traces.getAgentGraphData", () => {
+    it("rejects invalid agent graph timestamps as a bad request", async () => {
+      const trace = createTrace({
+        project_id: projectId,
+      });
+
+      await createTracesCh([trace]);
+
+      await expect(
+        caller.traces.getAgentGraphData({
+          projectId,
+          traceId: trace.id,
+          minStartTime: "'",
+          maxStartTime: "2026-08-08T22:25:00.000Z",
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      });
+    });
+
     it("should allow unauthenticated access to public trace agent graph data", async () => {
       const unAuthedSession = createInnerTRPCContext({
         session: null,

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -326,8 +326,8 @@ export const eventsRouter = createTRPCRouter({
       zodSchema.object({
         projectId: zodSchema.string(),
         traceId: zodSchema.string(),
-        minStartTime: zodSchema.string(),
-        maxStartTime: zodSchema.string(),
+        minStartTime: zodSchema.iso.datetime({ offset: true }),
+        maxStartTime: zodSchema.iso.datetime({ offset: true }),
       }),
     )
     .query(async ({ input }): Promise<Required<AgentGraphDataResponse>[]> => {

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -680,8 +680,8 @@ export const traceRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         traceId: z.string(),
-        minStartTime: z.string(),
-        maxStartTime: z.string(),
+        minStartTime: z.iso.datetime({ offset: true }),
+        maxStartTime: z.iso.datetime({ offset: true }),
         // Optional fields for enforceTraceAccess middleware (supports public traces)
         timestamp: z.date().nullish(),
         fromTimestamp: z.date().nullish(),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15919.preview.langfuse.com](https://pr-15919.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- validate `events.getAgentGraphData` and `traces.getAgentGraphData` time bounds as ISO datetimes before ClickHouse conversion
- return `BAD_REQUEST` for malformed bounds instead of allowing `Invalid Date` to reach `toISOString()` and become HTTP 500
- cover both v4 events and legacy traces execution paths with regression tests

Fixes [LFE-14890](https://linear.app/clickhouse/issue/LFE-14890/bug-eventsgetagentgraphdata-invalid-time-returns-http-500-in-prod-eu).

## Root cause

The normal frontend path derives both bounds from observation `Date#getTime()` values and serializes them with `toISOString()`. It cannot emit a single quote: a valid date becomes canonical ISO text, while an invalid date throws in the browser before the request is sent.

Datadog shows all 20 production failures came from one authenticated Bugcrowd security-testing identity and one user-agent over about 68 seconds. The requests alternately mutated one bound through values such as a quote, backtick, `not-a-date`, impossible month/day, epoch text, extreme year, and template-expression probes while preserving the other valid bound. This was authenticated request fuzzing/replay of the browser-called tRPC endpoint, not malformed serialization by `TraceGraphDataContext`.

The server contract accepted arbitrary strings on both graph-data routes. `new Date(invalidString)` produced `Invalid Date`; `convertDateToClickhouseDateTime` then called `toISOString()`, which raised `RangeError` and surfaced as `INTERNAL_SERVER_ERROR`.

## Impacted packages

- `web`

## Verification

- red test, events route: malformed time returned `INTERNAL_SERVER_ERROR` before the production change
- red test, legacy route: malformed time returned `INTERNAL_SERVER_ERROR` before the production change
- `pnpm --filter web run test traces-trpc.servertest.ts traces-trpc-events-only.servertest.ts` — `Test Files 2 passed (2)`, `Tests 35 passed (35)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`

## Local baseline notes

- `pnpm run typecheck` reaches `Tasks: 6 successful, 7 total` and fails in pre-existing unrelated web files; none of the changed files appear in the diagnostics.
- the standalone full web suite requires the API server and fully migrated isolated test databases; locally it failed broadly with `ECONNREFUSED localhost:3000`, stale isolated schema errors, and a ClickHouse memory-limit error. Targeted owning coverage is green.
