### PR TITLE
fix(score-analytics): include BOOLEAN data type in categorical comparison detection

### DIFF
--- a/web/src/features/score-analytics/server/scoreAnalyticsRouter.ts
+++ b/web/src/features/score-analytics/server/scoreAnalyticsRouter.ts
@@ -304,6 +304,8 @@ export const scoreAnalyticsRouter = createTRPCRouter({
         !isNumeric && // Any non-numeric comparison
         (score1.dataType === "CATEGORICAL" ||
           score2.dataType === "CATEGORICAL" ||
+          score1.dataType === "BOOLEAN" ||
+          score2.dataType === "BOOLEAN" ||
           isCrossType);
 
       // Build comprehensive analytics query


### PR DESCRIPTION
## Problem

When comparing two BOOLEAN scores (or a BOOLEAN vs CATEGORICAL), the score analytics router skips the three-CTE query path and falls back to an incompatible aggregation strategy.

The `isCategoricalComparison` flag controls which SQL branch runs:

```ts
const isCategoricalComparison =
  !isNumeric &&
  (score1.dataType === "CATEGORICAL" ||
    score2.dataType === "CATEGORICAL" ||
    isCrossType);
```

BOOLEAN scores are non-numeric, but neither side is checked for `"BOOLEAN"`. A BOOLEAN vs BOOLEAN comparison sets `isNumeric = false` and neither `CATEGORICAL` condition matches — the flag stays `false` and the CTE path is skipped.

## Fix

Add BOOLEAN to the dataType checks:

```ts
const isCategoricalComparison =
  !isNumeric &&
  (score1.dataType === "CATEGORICAL" ||
    score2.dataType === "CATEGORICAL" ||
    score1.dataType === "BOOLEAN" ||
    score2.dataType === "BOOLEAN" ||
    isCrossType);
```

## Changes

- `web/src/features/score-analytics/server/scoreAnalyticsRouter.ts` — two additional dataType checks in `isCategoricalComparison`