### PR TITLE
fix(pricing): replace claude-opus-5 placeholder uuid with real id

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3483,16 +3483,16 @@
     ]
   },
   {
-    "id": "a5b2c3d4-e5f6-4789-8abc-def012345678",
+    "id": "abd84c5c-9437-4946-a516-de7e3df434fd",
     "modelName": "claude-opus-5",
     "matchPattern": "(?i)^((anthropic\\/)?claude-opus-5|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-5(-v1(:0)?)?)$",
     "createdAt": "2026-07-25T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-09T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
       {
-        "id": "a5b2c3d4-e5f6-4789-8abc-def012345678_tier_default",
+        "id": "abd84c5c-9437-4946-a516-de7e3df434fd_tier_default",
         "name": "Standard",
         "isDefault": true,
         "priority": 0,


### PR DESCRIPTION
## What

Fixes the `claude-opus-5` entry in `worker/src/constants/default-model-prices.json` by replacing the placeholder/test UUID (`a5b2c3d4-e5f6-4789-8abc-def012345678`) with a real generated UUID for both the model `id` and the default tier `id`, and refreshing `updatedAt`.

Refs langfuse/langfuse#15834

## Why

Two things came out of digging into langfuse/langfuse#15834:

1. **The standard prices are correct.** `claude-opus-5` at $5/$25 per MTok (input/output), with 5m cache writes at 1.25x, 1h cache writes at 2x, and cache reads at 0.1x, matches Anthropic's official pricing exactly. The existing entry was verified against the docs and needs no price change, consistent with the check already done in the issue thread.
2. **But the entry carries a placeholder UUID as its database primary key.** The `id` field is the primary key for default models (`upsertDefaultModelPrices.ts` upserts on `{ projectId: null, id }`), and this `a5b2c3d4-...` value is the only non-real id among all 166 entries in the file. Every other id is either a legitimate cuid/ULID-style string or a real lowercase UUID. Shipping a placeholder here means the row can collide with or shadow real data, and it breaks the "preserve existing IDs / generate a new lowercase UUID" audit rule for default model pricing.

## On fast mode, batch, and US-only rates (the open question in the issue)

These are separate price points that the langfuse pricing schema cannot currently represent, so they are intentionally left out:

* **Fast mode** ($10/$50 MTok) is not a separate model id. It is enabled on the *same* `claude-opus-5` model via a `speed: "fast"` request parameter plus a beta flag (`fast-mode-2026-02-01`), and only on the first-party Anthropic API, not Bedrock/Vertex/Foundry. Since langfuse prices by model id / match pattern, a per-request rate modifier has nowhere to live in this schema.
* **Batch** ($2.50/$12.50) and **US-only inference** (1.1x) are likewise delivery/region modifiers rather than distinct models.

If any of those become representable (for example a per-tier condition or request-param-based pricing), the opus-5 entry can be extended then.

## Caveat for ops

`id` is the upsert key for default model prices. If the placeholder-id row was already upserted to a production database, deploying this change would create a *second* `claude-opus-5` row under the new id. In that case the stale placeholder-id row should be deleted during the deploy. If it was never upserted, this is a no-op cleanup.

## Validation

* `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs` -> "Validated 166 pricing entries"
* `--usage-key-model claude-opus-5` -> usage-key coverage validated
* `test-match-pattern.mjs --model claude-opus-5` with 9 accept / 6 reject samples -> all pass

<details><summary>Greptile Summary</summary>

Replaces the placeholder identifiers for the `claude-opus-5` default model and pricing tier with a generated UUID and refreshes the entry timestamp.

* Updates the model’s primary identifier.
* Keeps the default tier identifier aligned with the model identifier.
* Leaves model matching and prices unchanged.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge with the documented operational cleanup for databases that already contain the placeholder-ID row.

The model and tier identifiers are updated consistently, pricing behavior is unchanged, and the known persistence consequence is explicitly covered by the deployment instructions.

</details>

Reviews (1): Last reviewed commit: ["fix(pricing): replace claude-opus-5 plac..."](<https://github.com/langfuse/langfuse/commit/4d87d694051860a483ada97adf1d9fb7b1b36e3e>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=51585570>)