### PR TITLE
fix(prompts): return conflict for concurrent version creation

### DIFF
--- a/web/src/__tests__/server/prompts-trpc.servertest.ts
+++ b/web/src/__tests__/server/prompts-trpc.servertest.ts
@@ -1,7 +1,7 @@
 import { disconnectQueues } from "@/src/__tests__/test-utils";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import { prisma } from "@langfuse/shared/src/db";
+import { prisma, Prisma } from "@langfuse/shared/src/db";
 import {
   createOrgProjectAndApiKey,
   EntityChangeQueue,
@@ -95,6 +95,39 @@ describe("prompts trpc", () => {
   afterAll(async () => {
     await disconnectQueues();
   });
+  describe("prompts.create", () => {
+    it("returns CONFLICT when concurrent requests allocate the same prompt version", async () => {
+      const { project, caller } = await prepare();
+      const transactionSpy = vi
+        .spyOn(prisma, "$transaction")
+        .mockRejectedValueOnce(
+          new Prisma.PrismaClientKnownRequestError(
+            "Unique constraint failed on the fields: (`project_id`,`name`,`version`)",
+            {
+              code: "P2002",
+              clientVersion: "test",
+              meta: { target: ["project_id", "name", "version"] },
+            },
+          ),
+        );
+
+      try {
+        await expect(
+          caller.prompts.create({
+            projectId: project.id,
+            name: `concurrent-${v4()}`,
+            prompt: "test",
+            type: PromptType.Text,
+            labels: [],
+            config: {},
+          }),
+        ).rejects.toMatchObject({ code: "CONFLICT" });
+      } finally {
+        transactionSpy.mockRestore();
+      }
+    });
+  });
+
   describe("prompts.all input validation", () => {
     it.each([
       {

--- a/web/src/__tests__/server/prompts.v1.servertest.ts
+++ b/web/src/__tests__/server/prompts.v1.servertest.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@langfuse/shared/src/db";
+import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { makeAPICall } from "@/src/__tests__/test-utils";
 import { v4 as uuidv4, v4 } from "uuid";
 import { type Prompt, PromptType } from "@langfuse/shared";
@@ -10,6 +10,7 @@ import {
   createOrgProjectAndApiKey,
   getObservationById,
 } from "@langfuse/shared/src/server";
+import { createPromptForApi } from "@/src/features/prompts/server/prompt-api-service";
 
 describe("/api/public/prompts API Endpoint", () => {
   let auth: string;
@@ -24,6 +25,42 @@ describe("/api/public/prompts API Endpoint", () => {
     const setup = await createOrgProjectAndApiKey();
     auth = setup.auth;
     projectId = setup.projectId;
+  });
+
+  it("keeps prompt version conflicts as invalid public API requests", async () => {
+    const transactionSpy = vi
+      .spyOn(prisma, "$transaction")
+      .mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError(
+          "Unique constraint failed on the fields: (`project_id`,`name`,`version`)",
+          {
+            code: "P2002",
+            clientVersion: "test",
+            meta: { target: ["project_id", "name", "version"] },
+          },
+        ),
+      );
+
+    try {
+      await expect(
+        createPromptForApi({
+          context: {
+            projectId,
+            orgId: "test-org",
+            apiKeyId: "test-api-key",
+          },
+          input: {
+            name: "concurrent-prompt",
+            prompt: "test",
+            type: PromptType.Text,
+            labels: [],
+            config: {},
+          },
+        }),
+      ).rejects.toMatchObject({ httpCode: 400 });
+    } finally {
+      transactionSpy.mockRestore();
+    }
   });
 
   it("should fetch a prompt", async () => {

--- a/web/src/features/prompts/server/actions/createPrompt.ts
+++ b/web/src/features/prompts/server/actions/createPrompt.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import {
   InvalidRequestError,
+  LangfuseConflictError,
   parsePromptDependencyTags,
   jsonSchema,
   type PromptDependency,
@@ -10,7 +11,7 @@ import {
   PromptType,
   extractVariables,
 } from "@langfuse/shared";
-import { type PrismaClient } from "@langfuse/shared/src/db";
+import { type PrismaClient, Prisma } from "@langfuse/shared/src/db";
 import { removeLabelsFromPreviousPromptVersions } from "@/src/features/prompts/server/utils/updatePromptLabels";
 import { updatePromptTagsOnAllVersions } from "@/src/features/prompts/server/utils/updatePromptTags";
 import {
@@ -49,6 +50,22 @@ type DuplicateFolderParams = {
   createdBy: string;
   prisma: PrismaClient;
   user?: { id: string; name: string | null; email: string | null };
+};
+
+const isPromptVersionConflict = (error: unknown): boolean => {
+  if (
+    !(error instanceof Prisma.PrismaClientKnownRequestError) ||
+    error.code !== "P2002"
+  ) {
+    return false;
+  }
+
+  const target = error.meta?.target;
+
+  return (
+    Array.isArray(target) &&
+    ["project_id", "name", "version"].every((column) => target.includes(column))
+  );
 };
 
 const extractChatVariableAndPlaceholderNames = (
@@ -202,10 +219,22 @@ export const createPrompt = async ({
   }
 
   // Create prompt and update previous prompt versions
-  const [createdPrompt] = (await prisma.$transaction(create)) as [
-    Prompt,
-    ...PromptDependency[],
-  ];
+  let transactionResult: [Prompt, ...PromptDependency[]];
+  try {
+    transactionResult = (await prisma.$transaction(create)) as [
+      Prompt,
+      ...PromptDependency[],
+    ];
+  } catch (error) {
+    if (isPromptVersionConflict(error)) {
+      throw new LangfuseConflictError(
+        "A prompt version was created concurrently. Please retry.",
+      );
+    }
+
+    throw error;
+  }
+  const [createdPrompt] = transactionResult;
 
   // Once the transaction commits, side-effect failures must not report the
   // persisted prompt as failed and cause callers to create another version.

--- a/web/src/features/prompts/server/prompt-api-service.ts
+++ b/web/src/features/prompts/server/prompt-api-service.ts
@@ -5,7 +5,11 @@ import type {
   GetPromptsMetaSchema,
   Prompt,
 } from "@langfuse/shared";
-import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
+import {
+  InvalidRequestError,
+  LangfuseConflictError,
+  LangfuseNotFoundError,
+} from "@langfuse/shared";
 import type { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
@@ -50,6 +54,12 @@ export const createPromptForApi = async ({
     createdBy: "API",
     prisma,
   }).catch((err) => {
+    const promptVersionConflictMessage = `Failed to create prompt '${input.name}' due to unique constraint failure. This is likely due to too many concurrent prompt creations for this prompt name. Please add a delay.`;
+
+    if (err instanceof LangfuseConflictError) {
+      throw new InvalidRequestError(promptVersionConflictMessage);
+    }
+
     if (
       typeof err === "object" &&
       err?.constructor.name === "PrismaClientKnownRequestError" &&
@@ -57,9 +67,7 @@ export const createPromptForApi = async ({
       // Unique constraint failed: https://www.prisma.io/docs/orm/reference/error-reference#p2002
       err.code === "P2002"
     ) {
-      throw new InvalidRequestError(
-        `Failed to create prompt '${input.name}' due to unique constraint failure. This is likely due to too many concurrent prompt creations for this prompt name. Please add a delay.`,
-      );
+      throw new InvalidRequestError(promptVersionConflictMessage);
     }
 
     throw err;

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -57,22 +57,6 @@ const buildPathPrefixFilter = (pathPrefix?: string): Prisma.Sql => {
   return Prisma.sql` AND (p.name LIKE ${`${escapedPathPrefix}/%`} ESCAPE '\\' OR p.name = ${pathPrefix})`;
 };
 
-const isPromptVersionConflict = (error: unknown): boolean => {
-  if (
-    !(error instanceof Prisma.PrismaClientKnownRequestError) ||
-    error.code !== "P2002"
-  ) {
-    return false;
-  }
-
-  const target = error.meta?.target;
-
-  return (
-    Array.isArray(target) &&
-    ["project_id", "name", "version"].every((column) => target.includes(column))
-  );
-};
-
 const PromptFilterOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
   filter: z.array(singleFilter),
@@ -343,29 +327,16 @@ export const promptRouter = createTRPCRouter({
         });
       }
 
-      let prompt: Prompt | null;
-
-      try {
-        prompt = await createPrompt({
-          ...input,
-          prisma: ctx.prisma,
-          createdBy: ctx.session.user.id,
-          user: {
-            id: ctx.session.user.id,
-            name: ctx.session.user.name ?? null,
-            email: ctx.session.user.email ?? null,
-          },
-        });
-      } catch (error) {
-        if (isPromptVersionConflict(error)) {
-          throw new TRPCError({
-            code: "CONFLICT",
-            message: "A prompt version was created concurrently. Please retry.",
-          });
-        }
-
-        throw error;
-      }
+      const prompt = await createPrompt({
+        ...input,
+        prisma: ctx.prisma,
+        createdBy: ctx.session.user.id,
+        user: {
+          id: ctx.session.user.id,
+          name: ctx.session.user.name ?? null,
+          email: ctx.session.user.email ?? null,
+        },
+      });
 
       if (!prompt) {
         throw new Error("Failed to create prompt");

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -56,6 +56,23 @@ const buildPathPrefixFilter = (pathPrefix?: string): Prisma.Sql => {
   const escapedPathPrefix = escapeSqlLikePattern(pathPrefix);
   return Prisma.sql` AND (p.name LIKE ${`${escapedPathPrefix}/%`} ESCAPE '\\' OR p.name = ${pathPrefix})`;
 };
+
+const isPromptVersionConflict = (error: unknown): boolean => {
+  if (
+    !(error instanceof Prisma.PrismaClientKnownRequestError) ||
+    error.code !== "P2002"
+  ) {
+    return false;
+  }
+
+  const target = error.meta?.target;
+
+  return (
+    Array.isArray(target) &&
+    ["project_id", "name", "version"].every((column) => target.includes(column))
+  );
+};
+
 const PromptFilterOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
   filter: z.array(singleFilter),
@@ -326,16 +343,29 @@ export const promptRouter = createTRPCRouter({
         });
       }
 
-      const prompt = await createPrompt({
-        ...input,
-        prisma: ctx.prisma,
-        createdBy: ctx.session.user.id,
-        user: {
-          id: ctx.session.user.id,
-          name: ctx.session.user.name ?? null,
-          email: ctx.session.user.email ?? null,
-        },
-      });
+      let prompt: Prompt | null;
+
+      try {
+        prompt = await createPrompt({
+          ...input,
+          prisma: ctx.prisma,
+          createdBy: ctx.session.user.id,
+          user: {
+            id: ctx.session.user.id,
+            name: ctx.session.user.name ?? null,
+            email: ctx.session.user.email ?? null,
+          },
+        });
+      } catch (error) {
+        if (isPromptVersionConflict(error)) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "A prompt version was created concurrently. Please retry.",
+          });
+        }
+
+        throw error;
+      }
 
       if (!prompt) {
         throw new Error("Failed to create prompt");


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15923.preview.langfuse.com](https://pr-15923.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- translate prompt-version P2002 races in the authenticated tRPC create route to CONFLICT / HTTP 409
- keep unrelated uniqueness errors and the public API contract unchanged
- add a focused regression test for the production failure shape

Fixes [LFE-14899](https://linear.app/clickhouse/issue/LFE-14899/bug-promptscreate-returns-http-500-when-concurrent-requests-allocate).

## Test plan
- focused prompts.create server regression: 1 passed
- pnpm run lint: 7 successful, 7 total
- pnpm run typecheck: 7 successful, 7 total

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR converts prompt-version allocation races on the authenticated tRPC create route into a retryable conflict response while preserving unrelated error handling and the public API behavior.
- Adds a narrow classifier for the prompt `(project_id, name, version)` uniqueness constraint.
- Translates matching Prisma P2002 errors into tRPC `CONFLICT`.
- Adds a focused server regression test for the concurrent-allocation failure shape.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed conflict-handling path.

The classifier is limited to the prompt version uniqueness target, the failed insertion remains atomic, and unrelated Prisma errors continue to propagate unchanged.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): return conflict for concur..."](https://github.com/langfuse/langfuse/commit/57a5f9e282f0a0c248ece8e2b999feefe03e78a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51596345)</sub>

**Context used:**

- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->