### PR TITLE
fix(integrations): return not found for repeated deletes

### DIFF
--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -68,10 +68,13 @@ describe("Mixpanel Integration delete", () => {
     const caller = appRouter.createCaller({ ...ctx, prisma });
 
     vi.spyOn(prisma.mixpanelIntegration, "delete").mockRejectedValueOnce(
-      new Prisma.PrismaClientKnownRequestError("Record to delete does not exist.", {
-        code: "P2025",
-        clientVersion: "test",
-      }),
+      new Prisma.PrismaClientKnownRequestError(
+        "Record to delete does not exist.",
+        {
+          code: "P2025",
+          clientVersion: "test",
+        },
+      ),
     );
 
     await expect(

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -1,5 +1,5 @@
 import type { Session } from "next-auth";
-import { prisma } from "@langfuse/shared/src/db";
+import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
@@ -52,6 +52,32 @@ const buildSession = (orgId: string, projectId: string): Session => ({
     admin: true,
   },
   environment: {} as any,
+});
+
+describe("Mixpanel Integration delete", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns NOT_FOUND when the integration is already absent", async () => {
+    const { project, orgId } = await createOrgProjectAndApiKey();
+    const ctx = createInnerTRPCContext({
+      session: buildSession(orgId, project.id),
+      headers: {},
+    });
+    const caller = appRouter.createCaller({ ...ctx, prisma });
+
+    vi.spyOn(prisma.mixpanelIntegration, "delete").mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("Record to delete does not exist.", {
+        code: "P2025",
+        clientVersion: "test",
+      }),
+    );
+
+    await expect(
+      caller.mixpanelIntegration.delete({ projectId: project.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
 });
 
 describe("Mixpanel Integration legacy export source cutoff gate", () => {

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -109,10 +109,13 @@ describe("PostHog Integration delete", () => {
     const caller = appRouter.createCaller({ ...ctx, prisma });
 
     vi.spyOn(prisma.posthogIntegration, "delete").mockRejectedValueOnce(
-      new Prisma.PrismaClientKnownRequestError("Record to delete does not exist.", {
-        code: "P2025",
-        clientVersion: "test",
-      }),
+      new Prisma.PrismaClientKnownRequestError(
+        "Record to delete does not exist.",
+        {
+          code: "P2025",
+          clientVersion: "test",
+        },
+      ),
     );
 
     await expect(

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -1,5 +1,5 @@
 import type { Session } from "next-auth";
-import { prisma } from "@langfuse/shared/src/db";
+import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
@@ -92,6 +92,32 @@ describe("PostHog Integration SSRF Protection", () => {
         enabled: true,
       }),
     ).rejects.toThrow(/Invalid PostHog hostname.*Blocked/);
+  });
+});
+
+describe("PostHog Integration delete", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns NOT_FOUND when the integration is already absent", async () => {
+    const { project, orgId } = await createOrgProjectAndApiKey();
+    const ctx = createInnerTRPCContext({
+      session: buildSession(orgId, project.id),
+      headers: {},
+    });
+    const caller = appRouter.createCaller({ ...ctx, prisma });
+
+    vi.spyOn(prisma.posthogIntegration, "delete").mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("Record to delete does not exist.", {
+        code: "P2025",
+        clientVersion: "test",
+      }),
+    );
+
+    await expect(
+      caller.posthogIntegration.delete({ projectId: project.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -16,8 +16,14 @@ import {
   AnalyticsIntegrationExportSource,
   areLegacyWritesActive,
   InvalidRequestError,
+  LangfuseNotFoundError,
   validateExportSource,
 } from "@langfuse/shared";
+import { Prisma } from "@langfuse/shared/src/db";
+
+const isMixpanelIntegrationNotFoundError = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError &&
+  error.code === "P2025";
 
 export const mixpanelIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
@@ -207,29 +213,30 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
   delete: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      try {
-        throwIfNoProjectAccess({
-          session: ctx.session,
-          projectId: input.projectId,
-          scope: "integrations:CRUD",
-        });
-        await auditLog({
-          session: ctx.session,
-          action: "delete",
-          resourceType: "mixpanelIntegration",
-          resourceId: input.projectId,
-        });
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "integrations:CRUD",
+      });
+      await auditLog({
+        session: ctx.session,
+        action: "delete",
+        resourceType: "mixpanelIntegration",
+        resourceId: input.projectId,
+      });
 
+      try {
         await ctx.prisma.mixpanelIntegration.delete({
           where: {
             projectId: input.projectId,
           },
         });
-      } catch (e) {
-        console.log("mixpanel integration delete", e);
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-        });
+      } catch (error) {
+        if (isMixpanelIntegrationNotFoundError(error)) {
+          throw new LangfuseNotFoundError("Mixpanel integration not found");
+        }
+
+        throw error;
       }
     }),
 });

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -17,8 +17,14 @@ import {
   AnalyticsIntegrationExportSource,
   areLegacyWritesActive,
   InvalidRequestError,
+  LangfuseNotFoundError,
   validateExportSource,
 } from "@langfuse/shared";
+import { Prisma } from "@langfuse/shared/src/db";
+
+const isPostHogIntegrationNotFoundError = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError &&
+  error.code === "P2025";
 
 export const posthogIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
@@ -220,29 +226,30 @@ export const posthogIntegrationRouter = createTRPCRouter({
   delete: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      try {
-        throwIfNoProjectAccess({
-          session: ctx.session,
-          projectId: input.projectId,
-          scope: "integrations:CRUD",
-        });
-        await auditLog({
-          session: ctx.session,
-          action: "delete",
-          resourceType: "posthogIntegration",
-          resourceId: input.projectId,
-        });
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "integrations:CRUD",
+      });
+      await auditLog({
+        session: ctx.session,
+        action: "delete",
+        resourceType: "posthogIntegration",
+        resourceId: input.projectId,
+      });
 
+      try {
         await ctx.prisma.posthogIntegration.delete({
           where: {
             projectId: input.projectId,
           },
         });
-      } catch (e) {
-        console.log("posthog integration delete", e);
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-        });
+      } catch (error) {
+        if (isPostHogIntegrationNotFoundError(error)) {
+          throw new LangfuseNotFoundError("PostHog integration not found");
+        }
+
+        throw error;
       }
     }),
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15924.preview.langfuse.com](https://pr-15924.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- translate Prisma `P2025` errors from repeated PostHog and Mixpanel integration deletes to `NOT_FOUND` / HTTP 404
- preserve unrelated error handling by rethrowing non-`P2025` failures
- add focused tRPC regression coverage for both integration adapters

## Root cause

The delete procedures caught every failure and replaced it with `INTERNAL_SERVER_ERROR`. Once an integration had already been deleted, Prisma raised `P2025`, so repeated authenticated delete requests incorrectly surfaced as HTTP 500 responses.

This follows the narrow Prisma-error translation pattern established in #15923.

Expected missing-resource errors are handled without new Sentry capture or suppression; genuine unknown failures continue through the existing server error path.

Fixes [LFE-14892](https://linear.app/clickhouse/issue/LFE-14892/bug-repeated-posthog-and-mixpanel-deletes-return-http-500-in-prod-eu).

## Verification

- targeted PostHog and Mixpanel server tests: `Tests 39 passed (39)`
- `pnpm run lint`: `Tasks: 7 successful, 7 total`
- `pnpm run typecheck`: `Tasks: 7 successful, 7 total`
- `git diff --check`: clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrowly translates Prisma missing-record errors from repeated PostHog and Mixpanel integration deletes into not-found responses while preserving normal handling for unrelated failures.
- Adds matching P2025 classifiers and `LangfuseNotFoundError` translation to both integration routers.
- Moves authorization and audit operations outside the database-error translation block.
- Adds focused tRPC regression tests for both adapters.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new handlers recognize the same Prisma P2025 error class emitted by the shared client, map it through the established not-found error pipeline, and leave unrelated failures on the existing sanitized server-error path.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(integrations): return not found for ..."](https://github.com/langfuse/langfuse/commit/869bc3b2b6875a9906451a749cac98df0df31ceb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51599885)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->