### PR TITLE
refactor(integrations): share prisma not found classifier

### DIFF
--- a/web/src/features/analytics-integrations/server/isPrismaRecordNotFoundError.ts
+++ b/web/src/features/analytics-integrations/server/isPrismaRecordNotFoundError.ts
@@ -1,0 +1,5 @@
+import { Prisma } from "@langfuse/shared/src/db";
+
+export const isPrismaRecordNotFoundError = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError &&
+  error.code === "P2025";

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+import { isPrismaRecordNotFoundError } from "@/src/features/analytics-integrations/server/isPrismaRecordNotFoundError";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   createTRPCRouter,
@@ -19,11 +20,6 @@ import {
   LangfuseNotFoundError,
   validateExportSource,
 } from "@langfuse/shared";
-import { Prisma } from "@langfuse/shared/src/db";
-
-const isMixpanelIntegrationNotFoundError = (error: unknown): boolean =>
-  error instanceof Prisma.PrismaClientKnownRequestError &&
-  error.code === "P2025";
 
 export const mixpanelIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
@@ -232,7 +228,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           },
         });
       } catch (error) {
-        if (isMixpanelIntegrationNotFoundError(error)) {
+        if (isPrismaRecordNotFoundError(error)) {
           throw new LangfuseNotFoundError("Mixpanel integration not found");
         }
 

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+import { isPrismaRecordNotFoundError } from "@/src/features/analytics-integrations/server/isPrismaRecordNotFoundError";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   createTRPCRouter,
@@ -20,11 +21,6 @@ import {
   LangfuseNotFoundError,
   validateExportSource,
 } from "@langfuse/shared";
-import { Prisma } from "@langfuse/shared/src/db";
-
-const isPostHogIntegrationNotFoundError = (error: unknown): boolean =>
-  error instanceof Prisma.PrismaClientKnownRequestError &&
-  error.code === "P2025";
 
 export const posthogIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
@@ -245,7 +241,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
           },
         });
       } catch (error) {
-        if (isPostHogIntegrationNotFoundError(error)) {
+        if (isPrismaRecordNotFoundError(error)) {
           throw new LangfuseNotFoundError("PostHog integration not found");
         }
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15926.preview.langfuse.com](https://pr-15926.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- extract a shared Prisma `P2025` classifier under `analytics-integrations/server`
- reuse it in the PostHog and Mixpanel delete handlers
- remove the two byte-identical local helpers

## Context

#15924 has merged and owns the behavioral fix for repeated integration deletes. This PR is the review follow-up requested on that PR and contains no behavior change.

## Verification

- targeted PostHog and Mixpanel server tests: `Tests 39 passed (39)`
- `pnpm run lint`: `Tasks: 7 successful, 7 total`
- `pnpm run typecheck`: `Tasks: 7 successful, 7 total`
- Prettier: passed
- `git diff --check`: clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the duplicated Prisma `P2025` classifier into a shared analytics-integration helper without changing delete behavior.

- Adds `isPrismaRecordNotFoundError` under the shared analytics-integrations server directory.
- Reuses the classifier in the PostHog and Mixpanel delete handlers.
- Removes the byte-identical router-local helpers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the extraction preserves the existing Prisma error classification and delete-handler behavior.

The shared helper uses the same Prisma import, `instanceof` check, and `P2025` comparison as both removed local helpers, while the new imports resolve through an established alias and focused tests exercise both affected delete paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(integrations): share prisma not..."](https://github.com/langfuse/langfuse/commit/6334e6b459b61fc08c30c43c3ef00ca2ec109569) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51601526)</sub>

<!-- /greptile_comment -->