### PR TITLE
fix(mcp): support placeholder messages in createChatPrompt

### DIFF
--- a/web/src/__tests__/server/unit/mcp-create-chat-prompt-placeholder.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-create-chat-prompt-placeholder.servertest.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ChatMessageSchema,
+  createChatPromptTool,
+} from "@/src/features/mcp/features/prompts/tools/createChatPrompt";
+
+type JsonSchema = Record<string, unknown>;
+
+const promptItemJsonSchema = () => {
+  const inputSchema = createChatPromptTool.inputSchema as {
+    properties?: Record<string, unknown>;
+  };
+  const prompt = inputSchema.properties?.prompt as JsonSchema;
+  return prompt.items as JsonSchema;
+};
+
+describe("createChatPrompt placeholder messages", () => {
+  it("accepts literal chat messages (role + content)", () => {
+    expect(ChatMessageSchema.parse({ role: "user", content: "Hello" })).toEqual(
+      { role: "user", content: "Hello" },
+    );
+  });
+
+  it("accepts literal chat messages with an explicit 'message' type", () => {
+    expect(
+      ChatMessageSchema.parse({
+        type: "message",
+        role: "user",
+        content: "Hello",
+      }),
+    ).toEqual({ role: "user", content: "Hello" });
+  });
+
+  it("accepts placeholder messages referencing a runtime variable", () => {
+    expect(
+      ChatMessageSchema.parse({ type: "placeholder", name: "history" }),
+    ).toEqual({ type: "placeholder", name: "history" });
+  });
+
+  it("rejects placeholder messages without a name", () => {
+    expect(() => ChatMessageSchema.parse({ type: "placeholder" })).toThrow();
+  });
+
+  it("rejects placeholder names that do not start with a letter", () => {
+    expect(() =>
+      ChatMessageSchema.parse({ type: "placeholder", name: "1history" }),
+    ).toThrow();
+  });
+
+  it("rejects placeholder names containing invalid characters", () => {
+    expect(() =>
+      ChatMessageSchema.parse({ type: "placeholder", name: "hist ory" }),
+    ).toThrow();
+  });
+
+  it("serializes the base schema to JSON Schema without unions", () => {
+    const serialized = JSON.stringify(createChatPromptTool.inputSchema);
+    expect(serialized).not.toContain("oneOf");
+    expect(serialized).not.toContain("anyOf");
+    expect(serialized).not.toContain("allOf");
+  });
+
+  it("exposes the placeholder shape on the JSON Schema message items", () => {
+    const items = promptItemJsonSchema();
+    const properties = items.properties as Record<string, unknown>;
+
+    expect(properties.type).toEqual(
+      expect.objectContaining({ enum: ["message", "placeholder"] }),
+    );
+    expect(properties.name).toBeDefined();
+    expect(properties.role).toBeDefined();
+    expect(properties.content).toBeDefined();
+  });
+});

--- a/web/src/features/mcp/features/prompts/tools/createChatPrompt.ts
+++ b/web/src/features/mcp/features/prompts/tools/createChatPrompt.ts
@@ -14,18 +14,52 @@ import {
   PROMPT_NAME_MAX_LENGTH,
 } from "@langfuse/shared";
 import { createPromptForApi } from "@/src/features/prompts/server/prompt-api-service";
-import { buildPromptUrl } from "@langfuse/shared/src/server";
+import {
+  buildPromptUrl,
+  PromptChatMessageSchema,
+} from "@langfuse/shared/src/server";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { ParamCreatePromptLabels } from "../validation";
 
 /**
- * Schema for a single chat message (role + content)
- * Note: Using simple object schema instead of union to comply with MCP spec
+ * JSON Schema facing shape for a single chat message (used by MCP clients for
+ * display). Kept union-free with all fields optional because MCP tool input
+ * schemas must serialize to a plain object schema (unions are rejected by
+ * defineTool). The runtime input schema below enforces the actual message
+ * shape ({role, content} or {type: 'placeholder', name}).
  */
-const ChatMessageSchema = z.object({
-  role: z.string().describe("The role (e.g., 'system', 'user', 'assistant')"),
-  content: z.string().describe("The message content"),
+export const ChatMessageBaseSchema = z.object({
+  type: z
+    .enum(["message", "placeholder"])
+    .optional()
+    .describe(
+      "Message type. Defaults to 'message'. Use 'placeholder' to reference a runtime variable value (e.g. conversation history) instead of a literal message.",
+    ),
+  role: z
+    .string()
+    .optional()
+    .describe(
+      "The role (e.g., 'system', 'user', 'assistant'). Required for 'message' type.",
+    ),
+  content: z
+    .string()
+    .optional()
+    .describe("The message content. Required for 'message' type."),
+  name: z
+    .string()
+    .optional()
+    .describe(
+      "The variable name for 'placeholder' type messages (e.g. 'history'). Required for 'placeholder' type.",
+    ),
 });
+
+/**
+ * Runtime schema for a single chat message: a literal message ({role, content})
+ * or a placeholder reference ({type: 'placeholder', name}) that is replaced
+ * with a runtime variable value when the prompt is compiled. A strict union is
+ * only used at runtime — the base schema stays union-free for JSON Schema.
+ */
+export const ChatMessageSchema = PromptChatMessageSchema;
 
 /**
  * Base schema for JSON Schema generation (MCP client display)
@@ -38,9 +72,11 @@ const CreateChatPromptBaseSchema = z.object({
     .max(PROMPT_NAME_MAX_LENGTH)
     .describe("The name of the prompt"),
   prompt: z
-    .array(ChatMessageSchema)
+    .array(ChatMessageBaseSchema)
     .min(1)
-    .describe("Array of chat messages with role and content"),
+    .describe(
+      "Array of chat messages. Each message is either {role, content} or a placeholder {type: 'placeholder', name: '<variable>'} that is replaced with a runtime variable value",
+    ),
   labels: z
     .array(z.string())
     .optional()
@@ -95,7 +131,8 @@ export const [createChatPromptTool, handleCreateChatPrompt] = defineTool({
     "- Labels are unique across versions",
     "",
     "Message roles: system (instructions), user (input, can contain {{variables}}), assistant (examples)",
-    "Accepts: name, prompt (array of {role, content}), optional labels, config, tags, commitMessage",
+    "Placeholder messages: {type: 'placeholder', name: '<variable>'} reference runtime variable values (e.g. conversation history) inserted when the prompt is used",
+    "Accepts: name, prompt (array of {role, content} or {type: 'placeholder', name}), optional labels, config, tags, commitMessage",
   ].join("\n"),
   baseSchema: CreateChatPromptBaseSchema,
   inputSchema: CreateChatPromptInputSchema,


### PR DESCRIPTION
## Why

The MCP `createChatPrompt` tool cannot create chat prompts containing **placeholder messages** (`{type: "placeholder", name: "<variable>"}`), which are a first-class feature of Langfuse chat prompts (used to reference runtime values such as conversation history). The tool's message schema only accepts literal `{role, content}` messages, so any placeholder message fails runtime validation with a Zod error.

Fixes https://github.com/langfuse/langfuse/issues/15905

## What changed

- `web/src/features/mcp/features/prompts/tools/createChatPrompt.ts`
  - Split the single `ChatMessageSchema` into two schemas with distinct roles:
    - `ChatMessageBaseSchema` — a **union-free plain object** (all fields optional) used for the MCP tool's JSON Schema (`baseSchema`). MCP tool inputs must serialize to a plain object schema: `defineTool` rejects schemas containing `oneOf`/`anyOf`/`allOf`. The base schema now advertises an optional `type` enum (`message` | `placeholder`) plus the placeholder `name` field.
    - `ChatMessageSchema` — now the shared `PromptChatMessageSchema` union (`{role, content}` | `PlaceholderMessageSchema`), used only for **runtime validation** (`inputSchema`), which supports unions.
  - Updated the tool description to document placeholder messages.
- `web/src/__tests__/server/unit/mcp-create-chat-prompt-placeholder.servertest.ts` — new regression tests: literal and placeholder messages both parse, malformed placeholders are rejected (missing name, name not starting with a letter, name with invalid characters), and the serialized base schema stays union-free while exposing the placeholder fields.

The parsed `prompt` array flows unchanged into `createPromptForApi` → `createPrompt`, whose `CreateChatPromptSchema.prompt` already uses `PromptChatMessageSchema`, so placeholder messages are stored and compiled downstream exactly like chat prompts created via the API/SDK.

## Verification

- `pnpm prettier --write` on the changed files — clean
- `tsc -p tsconfig.json --noEmit --skipLibCheck` (web) — clean
- `vitest run --project server-unit` on the new test plus the existing MCP unit tests (`mcp-define-tool`, `mcp-route-in-app-agent-context`) — 19/19 pass (8 new + 11 existing)

## Impacted packages

- `web` — MCP `createChatPrompt` tool and its unit test
- `packages/shared` — consumed `PromptChatMessageSchema` (no code change)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR enables placeholder messages in the MCP `createChatPrompt` tool by separating its union-free client-facing schema from its strict runtime schema.
- Advertises literal and placeholder message fields without unsupported JSON Schema unions.
- Validates runtime input with the shared `PromptChatMessageSchema`.
- Adds regression coverage for valid messages, malformed placeholders, and serialized schema compatibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

Runtime requests are validated with the existing shared placeholder-aware schema before flowing unchanged through prompt creation, while the separately advertised schema remains compatible with the MCP tool registration constraints.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): support placeholder messages i..."](https://github.com/langfuse/langfuse/commit/d34e30f4a4502236c2e835418d426f78c4fde2d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51661262)</sub>

<!-- /greptile_comment -->