### PR TITLE
chore(filters): move api key filter down

### DIFF
--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -98,11 +98,6 @@ export const observationEventsFilterConfig: FilterConfig = {
     },
     {
       type: "categorical" as const,
-      column: "ingestionApiKey",
-      label: getEventsColumnName("ingestionApiKey"),
-    },
-    {
-      type: "categorical" as const,
       column: "type",
       label: getEventsColumnName("type"),
       help: {
@@ -193,6 +188,11 @@ export const observationEventsFilterConfig: FilterConfig = {
       type: "categorical" as const,
       column: "userId",
       label: getEventsColumnName("userId"),
+    },
+    {
+      type: "categorical" as const,
+      column: "ingestionApiKey",
+      label: getEventsColumnName("ingestionApiKey"),
     },
     {
       type: "categorical" as const,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15934.preview.langfuse.com](https://pr-15934.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reorders the existing ingestion API key option in the observation-events filter menu, moving it below the user ID filter.

- Preserves the filter’s type, column, and label.
- Changes only its position in the configuration array.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only reorders an unchanged filter option and no actionable defect was identified.

The ingestion API key filter retains the same type, column, and label; only its display order in the configuration array changes.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(filters): move api key filter down"](https://github.com/langfuse/langfuse/commit/2173427c000216d405b9388e0e239898194859ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51738871)</sub>

<!-- /greptile_comment -->