### PR TITLE
feat(web): self-hosting newsletter opt-in step in signup onboarding

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -231,6 +231,10 @@ LANGFUSE_BACKGROUND_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL=false
 # Legacy tracing UI controls
 LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH=false
 
+# Set to `true` to skip the post-signup onboarding step and send new users
+# straight to their workspace.
+LANGFUSE_DISABLE_SIGNUP_ONBOARDING=false
+
 CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE="true"
 # `auto` detects affected ClickHouse versions on startup. Set `true` to force
 # the workaround or `false` to force-disable it.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -277,6 +277,11 @@ LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=true
 # Disable input/output full-text search in legacy V3 tracing tables (metadata search remains available)
 # LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH=false
 
+# Onboarding
+# Skip the post-signup onboarding step (self-hosting newsletter opt-in) and send
+# new users straight to their workspace. No survey response is recorded.
+# LANGFUSE_DISABLE_SIGNUP_ONBOARDING=false
+
 ### START Enterprise Edition Configuration
 
 # Allowlisted users that can create new organizations, by default all users can create organizations

--- a/web/src/__tests__/server/unit/newsletterService.servertest.ts
+++ b/web/src/__tests__/server/unit/newsletterService.servertest.ts
@@ -1,0 +1,117 @@
+const { envMock } = vi.hoisted(() => ({
+  envMock: {} as Record<string, unknown>,
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: envMock,
+}));
+
+import { logger } from "@langfuse/shared/src/server";
+import {
+  isNewsletterSignupAvailable,
+  subscribeToNewsletter,
+} from "@/src/features/onboarding/server/newsletterService";
+
+const setEnv = (values: Record<string, unknown>) => {
+  for (const key of Object.keys(envMock)) delete envMock[key];
+  Object.assign(envMock, values);
+};
+
+describe("newsletterService", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  // Spied rather than module-mocked: the shared test teardown imports this same
+  // logger, so replacing the module would break it.
+  let loggerMock: {
+    info: ReturnType<typeof vi.spyOn>;
+    warn: ReturnType<typeof vi.spyOn>;
+    error: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    setEnv({});
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    loggerMock = {
+      info: vi.spyOn(logger, "info").mockReturnValue(logger),
+      warn: vi.spyOn(logger, "warn").mockReturnValue(logger),
+      error: vi.spyOn(logger, "error").mockReturnValue(logger),
+    };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("isNewsletterSignupAvailable", () => {
+    it("offers the in-product signup on a plain self-hosted instance", () => {
+      setEnv({});
+      expect(isNewsletterSignupAvailable()).toBe(true);
+    });
+
+    it("does not offer it on Langfuse Cloud", () => {
+      setEnv({ NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: "EU" });
+      expect(isNewsletterSignupAvailable()).toBe(false);
+    });
+
+    it("honors an operator who disabled the telemetry ping", () => {
+      setEnv({ TELEMETRY_ENABLED: "false" });
+      expect(isNewsletterSignupAvailable()).toBe(false);
+    });
+  });
+
+  describe("subscribeToNewsletter", () => {
+    it("posts the email to the langfuse.com signup proxy for the oss list", async () => {
+      fetchMock.mockResolvedValue({ ok: true });
+
+      await expect(
+        subscribeToNewsletter({ email: "user@example.com" }),
+      ).resolves.toBe("subscribed");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://langfuse.com/api/productUpdateSignup");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(String(init.body))).toEqual({
+        email: "user@example.com",
+        list: "oss",
+        source: "self-host-onboarding",
+      });
+      // Must not hang the onboarding step on an unreachable network.
+      expect(init.signal).toBeDefined();
+    });
+
+    it("reports unavailable without a request when signup is turned off", async () => {
+      setEnv({ TELEMETRY_ENABLED: "false" });
+
+      await expect(
+        subscribeToNewsletter({ email: "user@example.com" }),
+      ).resolves.toBe("unavailable");
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("reports unavailable when the instance cannot reach langfuse.com", async () => {
+      // The airgapped case: no route out, so the fetch rejects.
+      fetchMock.mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+
+      await expect(
+        subscribeToNewsletter({ email: "user@example.com" }),
+      ).resolves.toBe("unavailable");
+
+      // Expected for airgapped deployments, so it must not report as an error.
+      expect(loggerMock.error).not.toHaveBeenCalled();
+      expect(loggerMock.info).toHaveBeenCalled();
+    });
+
+    it("reports unavailable when the proxy rejects the request", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+      await expect(
+        subscribeToNewsletter({ email: "user@example.com" }),
+      ).resolves.toBe("unavailable");
+
+      expect(loggerMock.warn).toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/__tests__/server/unit/onboardingService.servertest.ts
+++ b/web/src/__tests__/server/unit/onboardingService.servertest.ts
@@ -1,29 +1,45 @@
-const { auditLogMock } = vi.hoisted(() => ({
+const { auditLogMock, envMock } = vi.hoisted(() => ({
   auditLogMock: vi.fn(),
+  envMock: {} as Record<string, unknown>,
 }));
 
 vi.mock("@/src/features/audit-logs/auditLog", () => ({
   auditLog: auditLogMock,
 }));
 
+// Seeded from the real env so only the flag under test differs; the service also
+// reads NEXT_PUBLIC_DEMO_ORG_ID.
+vi.mock("@/src/env.mjs", async (importOriginal) => {
+  const actual = (await importOriginal()) as { env: Record<string, unknown> };
+  Object.assign(envMock, actual.env);
+  return { env: envMock };
+});
+
 import { type Prisma, Role, SurveyName } from "@langfuse/shared/src/db";
 import {
-  completeCloudSignupOnboarding,
-  getCloudSignupOnboardingStatus,
+  completeSignupOnboarding,
+  getSignupOnboardingStatus,
+  isSignupOnboardingEnabled,
   provisionStarterOrganizationForNewUser,
   resolveOnboardingRedirectTarget,
   type RealOrganizationMembership,
 } from "@/src/features/onboarding/server/onboardingService";
 
+const disableSignupOnboarding = () => {
+  envMock.LANGFUSE_DISABLE_SIGNUP_ONBOARDING = "true";
+};
+
+afterEach(() => {
+  envMock.LANGFUSE_DISABLE_SIGNUP_ONBOARDING = "false";
+});
+
 type CompletionPrisma = Parameters<
-  typeof completeCloudSignupOnboarding
+  typeof completeSignupOnboarding
 >[0]["prisma"];
 type RedirectPrisma = Parameters<
   typeof resolveOnboardingRedirectTarget
 >[0]["prisma"];
-type StatusPrisma = Parameters<
-  typeof getCloudSignupOnboardingStatus
->[0]["prisma"];
+type StatusPrisma = Parameters<typeof getSignupOnboardingStatus>[0]["prisma"];
 
 const makeMembership = ({
   orgId,
@@ -126,9 +142,9 @@ describe("resolveOnboardingRedirectTarget", () => {
   });
 });
 
-describe("getCloudSignupOnboardingStatus", () => {
+describe("getSignupOnboardingStatus", () => {
   const getStatus = (prisma: StatusPrisma) =>
-    getCloudSignupOnboardingStatus({
+    getSignupOnboardingStatus({
       prisma,
       userId: "user-1",
       canCreateOrganizations: true,
@@ -159,9 +175,52 @@ describe("getCloudSignupOnboardingStatus", () => {
       redirectTo: "/project/project-1",
     });
   });
+
+  it("reports completed without touching surveys when onboarding is disabled", async () => {
+    disableSignupOnboarding();
+
+    const disabled = makeCompletionPrisma({
+      memberships: [
+        makeMembership({ orgId: "org-1", projects: [{ id: "project-1" }] }),
+      ],
+    });
+
+    await expect(
+      getStatus(disabled.tx as unknown as StatusPrisma),
+    ).resolves.toEqual({
+      completed: true,
+      redirectTo: "/project/project-1",
+    });
+
+    // Short-circuits ahead of the completion-marker lookup, so a disabled
+    // instance pays for no extra query.
+    expect(disabled.tx.survey.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("still resolves a target for a user with no organization yet", async () => {
+    disableSignupOnboarding();
+
+    const disabled = makeCompletionPrisma();
+
+    await expect(
+      getStatus(disabled.tx as unknown as StatusPrisma),
+    ).resolves.toEqual({
+      completed: true,
+      redirectTo: "/setup",
+    });
+  });
 });
 
-describe("completeCloudSignupOnboarding", () => {
+describe("isSignupOnboardingEnabled", () => {
+  it("is enabled by default and disabled by the opt-out flag", () => {
+    expect(isSignupOnboardingEnabled()).toBe(true);
+
+    disableSignupOnboarding();
+    expect(isSignupOnboardingEnabled()).toBe(false);
+  });
+});
+
+describe("completeSignupOnboarding", () => {
   it("locks the user row and writes one trimmed onboarding survey once", async () => {
     const { prisma, tx } = makeCompletionPrisma({
       memberships: [
@@ -178,7 +237,7 @@ describe("completeCloudSignupOnboarding", () => {
     });
 
     await expect(
-      completeCloudSignupOnboarding({
+      completeSignupOnboarding({
         prisma,
         userId: "user-1",
         userEmail: "user@example.com",
@@ -216,7 +275,7 @@ describe("completeCloudSignupOnboarding", () => {
 
     tx.survey.findFirst.mockResolvedValue({ id: "survey-1" });
 
-    await completeCloudSignupOnboarding({
+    await completeSignupOnboarding({
       prisma,
       userId: "user-1",
       userEmail: "user@example.com",
@@ -225,6 +284,98 @@ describe("completeCloudSignupOnboarding", () => {
     });
 
     expect(tx.survey.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("records the self-hosting newsletter decision alongside the survey", async () => {
+    const { prisma, tx } = makeCompletionPrisma({
+      memberships: [
+        makeMembership({
+          orgId: "org-1",
+          projects: [{ id: "project-1" }],
+        }),
+      ],
+    });
+
+    await completeSignupOnboarding({
+      prisma,
+      userId: "user-1",
+      userEmail: "user@example.com",
+      canCreateOrganizations: true,
+      newsletterOptIn: true,
+    });
+
+    expect(tx.survey.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          response: { newsletterOptIn: true },
+        }),
+      }),
+    );
+  });
+
+  it("distinguishes declining the newsletter from never being asked", async () => {
+    const declined = makeCompletionPrisma({
+      memberships: [
+        makeMembership({ orgId: "org-1", projects: [{ id: "project-1" }] }),
+      ],
+    });
+
+    await completeSignupOnboarding({
+      prisma: declined.prisma,
+      userId: "user-1",
+      canCreateOrganizations: true,
+      newsletterOptIn: false,
+    });
+
+    expect(declined.tx.survey.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          response: { newsletterOptIn: false },
+        }),
+      }),
+    );
+
+    const notAsked = makeCompletionPrisma({
+      memberships: [
+        makeMembership({ orgId: "org-1", projects: [{ id: "project-1" }] }),
+      ],
+    });
+
+    await completeSignupOnboarding({
+      prisma: notAsked.prisma,
+      userId: "user-2",
+      canCreateOrganizations: true,
+      referralSource: "Reddit",
+    });
+
+    expect(notAsked.tx.survey.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          response: { referralSource: "Reddit" },
+        }),
+      }),
+    );
+  });
+
+  it("records nothing but still redirects when onboarding is disabled", async () => {
+    disableSignupOnboarding();
+
+    const { prisma, tx } = makeCompletionPrisma({
+      memberships: [
+        makeMembership({ orgId: "org-1", projects: [{ id: "project-1" }] }),
+      ],
+    });
+
+    await expect(
+      completeSignupOnboarding({
+        prisma,
+        userId: "user-1",
+        canCreateOrganizations: true,
+        newsletterOptIn: true,
+      }),
+    ).resolves.toEqual({ redirectTo: "/project/project-1" });
+
+    expect(tx.survey.create).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/components/layouts/doc-popup.tsx
+++ b/web/src/components/layouts/doc-popup.tsx
@@ -14,12 +14,19 @@ export type DocPopupProps = {
   description: React.ReactNode;
   href?: string;
   className?: string;
+  /**
+   * `wide` widens the card for multi-paragraph explanations, which wrap into a
+   * very tall column at the default 16rem and cannot fit long literals such as
+   * a URL or an environment variable name on one line.
+   */
+  width?: "default" | "wide";
 };
 
 export default function DocPopup({
   description,
   href,
   className,
+  width = "default",
 }: DocPopupProps) {
   const capture = usePostHogClientCapture();
   // Controlled so a CLICK/TAP on the icon also opens the card: HoverCard
@@ -57,7 +64,11 @@ export default function DocPopup({
         </div>
       </HoverCardTrigger>
       <HoverCardPortal>
-        <HoverCardContent>
+        <HoverCardContent
+          className={
+            width === "wide" ? "w-96 max-w-[calc(100vw-2rem)]" : undefined
+          }
+        >
           <div
             className={cn(
               "text-primary text-xs font-normal whitespace-break-spaces sm:pl-0",

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -482,6 +482,13 @@ export const env = createEnv({
     LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH: z
       .enum(["true", "false"])
       .default("false"),
+    // Skips the post-signup onboarding step, sending new users straight to
+    // their workspace. Deliberately a runtime server variable rather than a
+    // NEXT_PUBLIC_ one: self-hosters run the prebuilt Docker image, where
+    // NEXT_PUBLIC_ values are baked at build time and could not be set.
+    LANGFUSE_DISABLE_SIGNUP_ONBOARDING: z
+      .enum(["true", "false"])
+      .default("false"),
     // V4 write mode. Mirrors worker/src/env.ts so the web package can gate
     // public API routes that rely on the legacy traces/observations tables.
     // The worker owns the writes; the web only needs to know whether legacy
@@ -1005,6 +1012,8 @@ export const env = createEnv({
     // Legacy tracing search controls
     LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH:
       process.env.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH,
+    LANGFUSE_DISABLE_SIGNUP_ONBOARDING:
+      process.env.LANGFUSE_DISABLE_SIGNUP_ONBOARDING,
     LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE:
       process.env.LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE,
     LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY:

--- a/web/src/features/onboarding/components/OnboardingCard.tsx
+++ b/web/src/features/onboarding/components/OnboardingCard.tsx
@@ -1,0 +1,60 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ReactNode } from "react";
+import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { cn } from "@/src/utils/tailwind";
+
+const onboardingCardVariants = cva(
+  "bg-background mt-6 rounded-lg shadow-sm sm:mx-auto sm:mt-16 sm:w-full sm:max-w-[480px] sm:px-12",
+  {
+    variants: {
+      // Interactive steps sit tighter than the standalone status screens, which
+      // are centered on a short line of text.
+      variant: {
+        form: "px-6 py-6 sm:py-10",
+        message: "px-6 py-10 sm:py-12",
+      },
+    },
+    defaultVariants: { variant: "form" },
+  },
+);
+
+type OnboardingCardProps = VariantProps<typeof onboardingCardVariants> & {
+  children: ReactNode;
+};
+
+/** Chrome-less card shell shared by every step of the signup onboarding flow. */
+export function OnboardingCard({ children, variant }: OnboardingCardProps) {
+  return (
+    <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-start sm:px-6 sm:py-12 lg:px-8">
+      <div className="flex items-center justify-center gap-2 sm:mx-auto sm:w-full sm:max-w-md">
+        <LangfuseIcon size={32} />
+      </div>
+
+      <div className={onboardingCardVariants({ variant })}>{children}</div>
+    </div>
+  );
+}
+
+/** Terminal state of the flow: completing, redirecting, or failed to load. */
+export function OnboardingMessage({
+  title,
+  description,
+  showSpinner = false,
+}: {
+  title: string;
+  description: string;
+  showSpinner?: boolean;
+}) {
+  return (
+    <OnboardingCard variant="message">
+      <div className="flex flex-col items-center text-center">
+        {showSpinner && <Spinner size="xl" variant="muted" />}
+        <h1 className={cn("text-xl font-bold", showSpinner && "mt-6")}>
+          {title}
+        </h1>
+        <p className="text-muted-foreground mt-2 text-sm">{description}</p>
+      </div>
+    </OnboardingCard>
+  );
+}

--- a/web/src/features/onboarding/components/OnboardingSurvey.tsx
+++ b/web/src/features/onboarding/components/OnboardingSurvey.tsx
@@ -1,6 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/router";
-import { useSession } from "next-auth/react";
+import { useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -12,98 +10,43 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
-import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
-import Spinner from "@/src/components/design-system/Spinner/Spinner";
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { api } from "@/src/utils/api";
+import {
+  OnboardingCard,
+  OnboardingMessage,
+} from "@/src/features/onboarding/components/OnboardingCard";
+import { useCompleteOnboarding } from "@/src/features/onboarding/hooks/useCompleteOnboarding";
 import type { SurveyFormData } from "../lib/surveyTypes";
-import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
 
+/** Langfuse Cloud signup step: a single attribution question. */
 export function OnboardingSurvey() {
-  const router = useRouter();
-  const { update: updateSession } = useSession();
-  const utils = api.useUtils();
   const form = useForm<SurveyFormData>({
     defaultValues: {
       referralSource: undefined,
     },
   });
-  const onboardingStatus = api.onboarding.status.useQuery();
-  const completeOnboardingMutation = api.onboarding.complete.useMutation();
-  const [hasStartedOnboardingCompletion, setHasStartedOnboardingCompletion] =
-    useState(false);
+  const { finishOnboarding, isCompletingOnboarding, isStatusError } =
+    useCompleteOnboarding();
 
-  const [finishOnboarding, isFinishingOnboarding] = useWatchedPromiseCallback(
-    async (data?: SurveyFormData) => {
-      setHasStartedOnboardingCompletion(true);
+  const submitSurvey = useCallback(
+    (data?: SurveyFormData) => {
+      const referralSource = data?.referralSource?.trim();
 
-      try {
-        const referralSource = data?.referralSource?.trim();
-        const onboardingResult = await completeOnboardingMutation.mutateAsync(
-          referralSource ? { referralSource } : undefined,
-        );
-        utils.onboarding.status.setData(undefined, {
-          completed: true,
-          redirectTo: onboardingResult.redirectTo,
-        });
-        await updateSession();
-        await router.replace(onboardingResult.redirectTo);
-      } catch (error) {
-        setHasStartedOnboardingCompletion(false);
-        showErrorToast(
-          "Failed to finish onboarding",
-          error instanceof Error ? error.message : "Please try again.",
-        );
-      }
-    },
-    [completeOnboardingMutation, router, updateSession, utils],
-  );
-
-  const [redirectCompletedOnboarding, isRedirectingCompletedOnboarding] =
-    useWatchedPromiseCallback(
-      async (redirectTo: string) => {
-        setHasStartedOnboardingCompletion(true);
-
-        try {
-          await router.replace(redirectTo);
-        } catch (error) {
-          setHasStartedOnboardingCompletion(false);
-          showErrorToast(
-            "Failed to continue onboarding",
-            error instanceof Error ? error.message : "Please try again.",
-          );
-        }
-      },
-      [router],
-    );
-
-  useEffect(() => {
-    if (onboardingStatus.data?.completed && !hasStartedOnboardingCompletion) {
-      redirectCompletedOnboarding(onboardingStatus.data.redirectTo).catch(
+      finishOnboarding(referralSource ? { referralSource } : undefined).catch(
         () => undefined,
       );
-    }
-  }, [
-    hasStartedOnboardingCompletion,
-    onboardingStatus.data,
-    redirectCompletedOnboarding,
-  ]);
-
-  const onSubmit = useCallback(
-    async (data: SurveyFormData) => {
-      await finishOnboarding(data);
     },
     [finishOnboarding],
   );
 
+  const onSubmit = useCallback(
+    async (data: SurveyFormData) => {
+      submitSurvey(data);
+    },
+    [submitSurvey],
+  );
+
   const currentValue = form.watch("referralSource");
   const isSubmittingSurvey = form.formState.isSubmitting;
-  const isCompletingOnboarding =
-    hasStartedOnboardingCompletion ||
-    isFinishingOnboarding ||
-    isRedirectingCompletedOnboarding ||
-    onboardingStatus.isLoading ||
-    onboardingStatus.data?.completed === true;
   const isBusy = isCompletingOnboarding || isSubmittingSurvey;
 
   const isEmpty = (v: unknown) =>
@@ -113,112 +56,86 @@ export function OnboardingSurvey() {
 
   if (isCompletingOnboarding) {
     return (
-      <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-start sm:px-6 sm:py-12 lg:px-8">
-        <div className="flex items-center justify-center gap-2 sm:mx-auto sm:w-full sm:max-w-md">
-          <LangfuseIcon size={32} />
-        </div>
-
-        <div className="bg-background mt-6 rounded-lg px-6 py-10 shadow-sm sm:mx-auto sm:mt-16 sm:w-full sm:max-w-[480px] sm:px-12 sm:py-12">
-          <div className="flex flex-col items-center text-center">
-            <Spinner size="xl" variant="muted" />
-            <h1 className="mt-6 text-xl font-bold">Setting up your project</h1>
-            <p className="text-muted-foreground mt-2 text-sm">
-              Taking you to tracing...
-            </p>
-          </div>
-        </div>
-      </div>
+      <OnboardingMessage
+        showSpinner
+        title="Setting up your project"
+        description="Taking you to tracing..."
+      />
     );
   }
 
-  if (onboardingStatus.isError) {
+  if (isStatusError) {
     return (
-      <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-start sm:px-6 sm:py-12 lg:px-8">
-        <div className="flex items-center justify-center gap-2 sm:mx-auto sm:w-full sm:max-w-md">
-          <LangfuseIcon size={32} />
-        </div>
-
-        <div className="bg-background mt-6 rounded-lg px-6 py-10 shadow-sm sm:mx-auto sm:mt-16 sm:w-full sm:max-w-[480px] sm:px-12 sm:py-12">
-          <div className="flex flex-col items-center text-center">
-            <h1 className="text-xl font-bold">Failed to load onboarding</h1>
-            <p className="text-muted-foreground mt-2 text-sm">
-              Refresh the page to try again.
-            </p>
-          </div>
-        </div>
-      </div>
+      <OnboardingMessage
+        title="Failed to load onboarding"
+        description="Refresh the page to try again."
+      />
     );
   }
 
   return (
-    <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-start sm:px-6 sm:py-12 lg:px-8">
-      <div className="flex items-center justify-center gap-2 sm:mx-auto sm:w-full sm:max-w-md">
-        <LangfuseIcon size={32} />
-      </div>
-
-      <div className="bg-background mt-6 rounded-lg px-6 py-6 shadow-sm sm:mx-auto sm:mt-16 sm:w-full sm:max-w-[480px] sm:px-12 sm:py-10">
-        <Form {...form}>
-          <form
-            className="flex h-full flex-col"
-            onSubmit={form.handleSubmit(onSubmit)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && currentEmpty) {
-                event.preventDefault();
-                finishOnboarding(form.getValues()).catch(() => undefined);
-              }
-            }}
-          >
-            <div className="flex-1">
-              <FormField
-                control={form.control}
-                name="referralSource"
-                render={({ field }) => (
-                  <FormItem className="flex flex-col gap-2">
-                    <FormLabel className="text-xl font-bold">
-                      Where did you hear about us?
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        autoFocus
-                        maxLength={500}
-                        placeholder="Colleague, Word of Mouth, X, Reddit, Event"
-                        {...field}
-                        value={field.value ?? ""}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <div className="flex justify-end pt-6">
-              {showSkip ? (
-                <Button
-                  type="button"
-                  onClick={() => {
-                    finishOnboarding(form.getValues()).catch(() => undefined);
-                  }}
-                  variant="ghost"
-                  className="w-20"
-                  disabled={isBusy}
-                >
-                  Skip
-                </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  variant="default"
-                  className="w-20"
-                  disabled={isBusy}
-                >
-                  Finish
-                </Button>
+    <OnboardingCard>
+      <Form {...form}>
+        <form
+          className="flex h-full flex-col"
+          onSubmit={form.handleSubmit(onSubmit)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && currentEmpty) {
+              event.preventDefault();
+              submitSurvey(form.getValues());
+            }
+          }}
+        >
+          <div className="flex-1">
+            <FormField
+              control={form.control}
+              name="referralSource"
+              render={({ field }) => (
+                <FormItem className="flex flex-col gap-2">
+                  <FormLabel className="text-xl font-bold">
+                    Where did you hear about us?
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      autoFocus
+                      maxLength={500}
+                      placeholder="Colleague, Word of Mouth, X, Reddit, Event"
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-          </form>
-        </Form>
-      </div>
-    </div>
+            />
+          </div>
+
+          <div className="flex justify-end pt-6">
+            {showSkip ? (
+              <Button
+                type="button"
+                onClick={() => {
+                  submitSurvey(form.getValues());
+                }}
+                variant="ghost"
+                className="w-20"
+                disabled={isBusy}
+              >
+                Skip
+              </Button>
+            ) : (
+              <Button
+                type="submit"
+                variant="default"
+                className="w-20"
+                disabled={isBusy}
+              >
+                Finish
+              </Button>
+            )}
+          </div>
+        </form>
+      </Form>
+    </OnboardingCard>
   );
 }

--- a/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
+++ b/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SelfHostedNewsletterStep } from "./SelfHostedNewsletterStep";
+
+const mocks = vi.hoisted(() => {
+  return {
+    completeMutateAsyncMock: vi.fn(),
+    subscribeMutateAsyncMock: vi.fn(),
+    routerMock: {
+      replace: vi.fn(),
+    },
+    statusSetDataMock: vi.fn(),
+    statusUseQueryMock: vi.fn(),
+    newsletterStatusUseQueryMock: vi.fn(),
+    updateSessionMock: vi.fn(),
+    showErrorToastMock: vi.fn(),
+  };
+});
+
+vi.mock("next/router", () => ({
+  useRouter: () => mocks.routerMock,
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { email: "engineer@acme.com" } },
+    status: "authenticated",
+    update: mocks.updateSessionMock,
+  }),
+}));
+
+vi.mock("@/src/features/notifications/showErrorToast", () => ({
+  showErrorToast: mocks.showErrorToastMock,
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      onboarding: {
+        status: {
+          setData: mocks.statusSetDataMock,
+        },
+      },
+    }),
+    onboarding: {
+      status: {
+        useQuery: mocks.statusUseQueryMock,
+      },
+      newsletterStatus: {
+        useQuery: mocks.newsletterStatusUseQueryMock,
+      },
+      complete: {
+        useMutation: () => ({
+          mutateAsync: mocks.completeMutateAsyncMock,
+        }),
+      },
+      subscribeToNewsletter: {
+        useMutation: () => ({
+          mutateAsync: mocks.subscribeMutateAsyncMock,
+        }),
+      },
+    },
+  },
+}));
+
+describe("SelfHostedNewsletterStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.statusUseQueryMock.mockReturnValue({
+      data: { completed: false },
+      isError: false,
+      isLoading: false,
+    });
+    mocks.newsletterStatusUseQueryMock.mockReturnValue({
+      data: { available: true },
+      isError: false,
+      isLoading: false,
+    });
+    mocks.completeMutateAsyncMock.mockResolvedValue({ redirectTo: "/setup" });
+    mocks.updateSessionMock.mockResolvedValue(undefined);
+  });
+
+  it("prefills the signed-in email and records the opt-in on success", async () => {
+    mocks.subscribeMutateAsyncMock.mockResolvedValue({ status: "subscribed" });
+
+    render(<SelfHostedNewsletterStep />);
+
+    expect(screen.getByRole("textbox")).toHaveValue("engineer@acme.com");
+
+    fireEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    await waitFor(() => {
+      expect(mocks.subscribeMutateAsyncMock).toHaveBeenCalledWith({
+        email: "engineer@acme.com",
+      });
+      expect(mocks.completeMutateAsyncMock).toHaveBeenCalledWith({
+        newsletterOptIn: true,
+      });
+      expect(mocks.routerMock.replace).toHaveBeenCalledWith("/setup");
+    });
+  });
+
+  it("subscribes the edited email rather than the session email", async () => {
+    mocks.subscribeMutateAsyncMock.mockResolvedValue({ status: "subscribed" });
+
+    render(<SelfHostedNewsletterStep />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "ops@acme.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    await waitFor(() => {
+      expect(mocks.subscribeMutateAsyncMock).toHaveBeenCalledWith({
+        email: "ops@acme.com",
+      });
+    });
+  });
+
+  it("falls back to the hosted form when the instance cannot reach langfuse.com", async () => {
+    mocks.subscribeMutateAsyncMock.mockResolvedValue({ status: "unavailable" });
+
+    render(<SelfHostedNewsletterStep />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/could not reach langfuse\.com/i),
+      ).toBeInTheDocument();
+    });
+
+    // Onboarding must not be blocked by an unreachable signup endpoint.
+    expect(screen.getByRole("link", { name: "langfuse.com" })).toHaveAttribute(
+      "href",
+      "https://langfuse.com/self-hosting/upgrade",
+    );
+    expect(mocks.completeMutateAsyncMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(mocks.completeMutateAsyncMock).toHaveBeenCalledWith({
+        newsletterOptIn: false,
+      });
+    });
+  });
+
+  it("skips straight to completion and records the decline", async () => {
+    render(<SelfHostedNewsletterStep />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+
+    await waitFor(() => {
+      expect(mocks.completeMutateAsyncMock).toHaveBeenCalledWith({
+        newsletterOptIn: false,
+      });
+    });
+    expect(mocks.subscribeMutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("offers no form when in-product signup is disabled on the instance", () => {
+    mocks.newsletterStatusUseQueryMock.mockReturnValue({
+      data: { available: false },
+      isError: false,
+      isLoading: false,
+    });
+
+    render(<SelfHostedNewsletterStep />);
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/turned off on this instance/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+  });
+
+  it("does not show the step again once onboarding is complete", async () => {
+    mocks.statusUseQueryMock.mockReturnValue({
+      data: { completed: true, redirectTo: "/project/project-1/traces" },
+      isError: false,
+      isLoading: false,
+    });
+
+    render(<SelfHostedNewsletterStep />);
+
+    await waitFor(() => {
+      expect(mocks.routerMock.replace).toHaveBeenCalledWith(
+        "/project/project-1/traces",
+      );
+    });
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
+++ b/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
@@ -130,8 +130,13 @@ describe("SelfHostedNewsletterStep", () => {
       ).toBeInTheDocument();
     });
 
-    // Onboarding must not be blocked by an unreachable signup endpoint.
-    expect(screen.getByRole("link", { name: "langfuse.com" })).toHaveAttribute(
+    // Onboarding must not be blocked by an unreachable signup endpoint. The URL
+    // is spelled out so it stays usable from a machine that cannot follow links.
+    expect(
+      screen.getByRole("link", {
+        name: "https://langfuse.com/self-hosting/oss-newsletter",
+      }),
+    ).toHaveAttribute(
       "href",
       "https://langfuse.com/self-hosting/oss-newsletter",
     );

--- a/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
+++ b/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
@@ -133,7 +133,7 @@ describe("SelfHostedNewsletterStep", () => {
     // Onboarding must not be blocked by an unreachable signup endpoint.
     expect(screen.getByRole("link", { name: "langfuse.com" })).toHaveAttribute(
       "href",
-      "https://langfuse.com/self-hosting/upgrade",
+      "https://langfuse.com/self-hosting/oss-newsletter",
     );
     expect(mocks.completeMutateAsyncMock).not.toHaveBeenCalled();
 

--- a/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
+++ b/web/src/features/onboarding/components/SelfHostedNewsletterStep.clienttest.tsx
@@ -151,6 +151,33 @@ describe("SelfHostedNewsletterStep", () => {
     });
   });
 
+  it("explains where the address goes, including the opt-outs and the admin flag", async () => {
+    const { container } = render(<SelfHostedNewsletterStep />);
+
+    // The ⓘ trigger is an icon with no accessible role of its own.
+    const infoTrigger = container.querySelector(".lucide-info")?.parentElement;
+    expect(infoTrigger).toBeTruthy();
+
+    fireEvent.click(infoTrigger as Element);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Langfuse OSS mailing list/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/monthly updates/i)).toBeInTheDocument();
+    expect(screen.getByText(/unsubscribe/i)).toBeInTheDocument();
+    // The outbound request and the admin opt-out are the two facts a reviewer
+    // would otherwise have to read the source to discover.
+    expect(
+      screen.getByText("https://langfuse.com/api/productUpdateSignup"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("LANGFUSE_DISABLE_SIGNUP_ONBOARDING=true"),
+    ).toBeInTheDocument();
+  });
+
   it("skips straight to completion and records the decline", async () => {
     render(<SelfHostedNewsletterStep />);
 

--- a/web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx
+++ b/web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx
@@ -12,6 +12,7 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
+import DocPopup from "@/src/components/layouts/doc-popup";
 import {
   OnboardingCard,
   OnboardingMessage,
@@ -34,6 +35,48 @@ type NewsletterFormData = z.infer<typeof newsletterFormSchema>;
 
 const PITCH =
   "Subscribe to the Langfuse OSS email newsletter to stay informed about new features and important updates.";
+
+/**
+ * Answers the "what actually happens to my address?" question in place.
+ *
+ * Self-hosters are the audience least willing to accept an unexplained email
+ * field, so this spells out the destination, the outbound request their
+ * instance makes, and the opt-outs — including the flag their admin can set.
+ */
+function NewsletterExplainer() {
+  return (
+    <div className="flex flex-col gap-2">
+      <p>
+        By submitting your email, you will be added to the new Langfuse OSS
+        mailing list. You can expect monthly updates about all new features
+        available to self-hosted Langfuse instances.
+      </p>
+      <p>
+        You can unsubscribe from the email updates directly in the first message
+        or by contacting us.
+      </p>
+      <p>
+        This question is shown to new users, both on net-new instances and to
+        new members added to an existing organization. To sign you up, this
+        instance sends a POST request to{" "}
+        {/* break-words, not break-all: the literal moves to its own line whole
+            and only splits if it still cannot fit, e.g. on a narrow screen. */}
+        <span className="font-mono break-words">
+          https://langfuse.com/api/productUpdateSignup
+        </span>{" "}
+        to add your email to the list. If the instance is air-gapped and that
+        request fails, it shows a link to a sign-up form instead.
+      </p>
+      <p>
+        Langfuse admins can disable this question entirely by setting{" "}
+        <span className="font-mono break-words">
+          LANGFUSE_DISABLE_SIGNUP_ONBOARDING=true
+        </span>
+        .
+      </p>
+    </div>
+  );
+}
 
 /**
  * Self-hosted signup step: opt in to the Langfuse self-hosting newsletter.
@@ -120,7 +163,10 @@ export function SelfHostedNewsletterStep() {
   return (
     <OnboardingCard>
       <div className="flex flex-col gap-2">
-        <h1 className="text-xl font-bold">Stay up to date</h1>
+        <div className="flex items-center">
+          <h1 className="text-xl font-bold">Stay up to date</h1>
+          <DocPopup description={<NewsletterExplainer />} width="wide" />
+        </div>
         <p className="text-muted-foreground text-sm">{PITCH}</p>
       </div>
 

--- a/web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx
+++ b/web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx
@@ -33,7 +33,7 @@ const newsletterFormSchema = z.object({
 type NewsletterFormData = z.infer<typeof newsletterFormSchema>;
 
 const PITCH =
-  "Get an email when we ship important features and new releases for self-hosted Langfuse. Self-hosting updates only, no marketing or spam.";
+  "Subscribe to the Langfuse OSS email newsletter to stay informed about new features and important updates.";
 
 /**
  * Self-hosted signup step: opt in to the Langfuse self-hosting newsletter.
@@ -140,7 +140,9 @@ export function SelfHostedNewsletterStep() {
         <NewsletterSignupFallback
           reason={
             isSignupUnreachable
-              ? "This instance could not reach langfuse.com, so it cannot subscribe you directly."
+              ? // Prefixed as an error only here: an unreachable proxy is a
+                // failure, whereas a switched-off signup is a deliberate choice.
+                "Error: This instance could not reach langfuse.com, so it cannot subscribe you directly."
               : "In-product signup is turned off on this instance."
           }
           onContinue={continueWithoutSubscribing}
@@ -223,14 +225,16 @@ function NewsletterSignupFallback({
   return (
     <div className="mt-6 flex flex-col">
       <p className="text-muted-foreground text-sm">
-        {reason} You can subscribe from{" "}
+        {reason} You can subscribe on{" "}
         <a
           href={NEWSLETTER_SIGNUP_FALLBACK_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-primary underline underline-offset-2"
+          className="text-primary break-words underline underline-offset-2"
         >
-          langfuse.com
+          {/* Spelled out rather than labelled: the URL has to be readable to
+              someone who cannot follow the link from an airgapped machine. */}
+          {NEWSLETTER_SIGNUP_FALLBACK_URL}
         </a>{" "}
         instead.
       </p>

--- a/web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx
+++ b/web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useSession } from "next-auth/react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "@/src/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/src/components/ui/form";
+import { Input } from "@/src/components/ui/input";
+import {
+  OnboardingCard,
+  OnboardingMessage,
+} from "@/src/features/onboarding/components/OnboardingCard";
+import { useCompleteOnboarding } from "@/src/features/onboarding/hooks/useCompleteOnboarding";
+import { NEWSLETTER_SIGNUP_FALLBACK_URL } from "@/src/features/onboarding/lib/newsletterConstants";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
+import { api } from "@/src/utils/api";
+
+const newsletterFormSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .max(320)
+    .pipe(z.email("Enter a valid email address")),
+});
+
+type NewsletterFormData = z.infer<typeof newsletterFormSchema>;
+
+const PITCH =
+  "Get an email when we ship important features and new releases for self-hosted Langfuse. Self-hosting updates only, no marketing or spam.";
+
+/**
+ * Self-hosted signup step: opt in to the Langfuse self-hosting newsletter.
+ *
+ * Replaces the attribution question shown on Langfuse Cloud — self-hosters have
+ * no equivalent step today, and release announcements are the update channel
+ * they otherwise have to discover on GitHub.
+ */
+export function SelfHostedNewsletterStep() {
+  const { data: session, status: sessionStatus } = useSession();
+  const {
+    finishOnboarding,
+    isCompletingOnboarding,
+    isStatusLoading,
+    isStatusError,
+  } = useCompleteOnboarding();
+  const newsletterStatus = api.onboarding.newsletterStatus.useQuery();
+  const subscribeMutation = api.onboarding.subscribeToNewsletter.useMutation();
+  // Set once the server reports it could not reach the signup proxy, which is
+  // how an airgapped instance surfaces: discovered on submit, never probed.
+  const [isSignupUnreachable, setIsSignupUnreachable] = useState(false);
+
+  const continueWithoutSubscribing = useCallback(() => {
+    finishOnboarding({ newsletterOptIn: false }).catch(() => undefined);
+  }, [finishOnboarding]);
+
+  const [subscribe, isSubscribing] = useWatchedPromiseCallback(
+    async ({ email }: NewsletterFormData) => {
+      try {
+        const result = await subscribeMutation.mutateAsync({ email });
+
+        if (result.status === "subscribed") {
+          await finishOnboarding({ newsletterOptIn: true });
+          return;
+        }
+
+        setIsSignupUnreachable(true);
+      } catch (error) {
+        showErrorToast(
+          "Failed to subscribe",
+          error instanceof Error ? error.message : "Please try again.",
+        );
+      }
+    },
+    [finishOnboarding, subscribeMutation],
+  );
+
+  if (isStatusError) {
+    return (
+      <OnboardingMessage
+        title="Failed to load onboarding"
+        description="Refresh the page to try again."
+      />
+    );
+  }
+
+  if (
+    isStatusLoading ||
+    sessionStatus === "loading" ||
+    newsletterStatus.isLoading
+  ) {
+    return (
+      <OnboardingMessage
+        showSpinner
+        title="Loading"
+        description="One moment..."
+      />
+    );
+  }
+
+  if (isCompletingOnboarding) {
+    return (
+      <OnboardingMessage
+        showSpinner
+        title="Finishing setup"
+        description="Taking you to your workspace..."
+      />
+    );
+  }
+
+  const canSubscribeInProduct =
+    newsletterStatus.data?.available === true && !isSignupUnreachable;
+
+  return (
+    <OnboardingCard>
+      <div className="flex flex-col gap-2">
+        <h1 className="text-xl font-bold">Stay up to date</h1>
+        <p className="text-muted-foreground text-sm">{PITCH}</p>
+      </div>
+
+      {canSubscribeInProduct ? (
+        // Keyed on the session email so the prefilled default is set when the
+        // form first mounts, instead of synced into state afterwards.
+        <NewsletterEmailForm
+          key={session?.user?.email ?? ""}
+          defaultEmail={session?.user?.email ?? ""}
+          isBusy={isSubscribing}
+          onSubscribe={(data) => {
+            subscribe(data).catch(() => undefined);
+          }}
+          onSkip={continueWithoutSubscribing}
+        />
+      ) : (
+        <NewsletterSignupFallback
+          reason={
+            isSignupUnreachable
+              ? "This instance could not reach langfuse.com, so it cannot subscribe you directly."
+              : "In-product signup is turned off on this instance."
+          }
+          onContinue={continueWithoutSubscribing}
+          isBusy={isCompletingOnboarding}
+        />
+      )}
+    </OnboardingCard>
+  );
+}
+
+function NewsletterEmailForm({
+  defaultEmail,
+  isBusy,
+  onSubscribe,
+  onSkip,
+}: {
+  defaultEmail: string;
+  isBusy: boolean;
+  onSubscribe: (data: NewsletterFormData) => void;
+  onSkip: () => void;
+}) {
+  const form = useForm<NewsletterFormData>({
+    resolver: zodResolver(newsletterFormSchema),
+    defaultValues: { email: defaultEmail },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        className="mt-6 flex flex-col"
+        onSubmit={form.handleSubmit(onSubscribe)}
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2">
+              <FormControl>
+                <Input
+                  autoFocus
+                  type="email"
+                  maxLength={320}
+                  placeholder="you@company.com"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex justify-end gap-2 pt-6">
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-20"
+            disabled={isBusy}
+            onClick={onSkip}
+          >
+            Skip
+          </Button>
+          <Button type="submit" variant="default" disabled={isBusy}>
+            Subscribe
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+function NewsletterSignupFallback({
+  reason,
+  isBusy,
+  onContinue,
+}: {
+  reason: string;
+  isBusy: boolean;
+  onContinue: () => void;
+}) {
+  return (
+    <div className="mt-6 flex flex-col">
+      <p className="text-muted-foreground text-sm">
+        {reason} You can subscribe from{" "}
+        <a
+          href={NEWSLETTER_SIGNUP_FALLBACK_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline underline-offset-2"
+        >
+          langfuse.com
+        </a>{" "}
+        instead.
+      </p>
+
+      <div className="flex justify-end pt-6">
+        <Button
+          type="button"
+          variant="default"
+          disabled={isBusy}
+          onClick={onContinue}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/onboarding/hooks/useCompleteOnboarding.tsx
+++ b/web/src/features/onboarding/hooks/useCompleteOnboarding.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { useSession } from "next-auth/react";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
+import { api } from "@/src/utils/api";
+
+export type OnboardingCompletionInput = {
+  referralSource?: string;
+  newsletterOptIn?: boolean;
+};
+
+/**
+ * Owns the shared tail of every onboarding step: persist the survey row, refresh
+ * the session, and navigate to wherever the server says this user belongs.
+ *
+ * Shared by the Langfuse Cloud referral survey and the self-hosted newsletter
+ * step, which differ only in what they render before calling `finishOnboarding`.
+ */
+export function useCompleteOnboarding() {
+  const router = useRouter();
+  const { update: updateSession } = useSession();
+  const utils = api.useUtils();
+  const onboardingStatus = api.onboarding.status.useQuery();
+  const completeOnboardingMutation = api.onboarding.complete.useMutation();
+  const [hasStartedOnboardingCompletion, setHasStartedOnboardingCompletion] =
+    useState(false);
+
+  const [finishOnboarding, isFinishingOnboarding] = useWatchedPromiseCallback(
+    async (input?: OnboardingCompletionInput) => {
+      setHasStartedOnboardingCompletion(true);
+
+      try {
+        const onboardingResult =
+          await completeOnboardingMutation.mutateAsync(input);
+        utils.onboarding.status.setData(undefined, {
+          completed: true,
+          redirectTo: onboardingResult.redirectTo,
+        });
+        await updateSession();
+        await router.replace(onboardingResult.redirectTo);
+      } catch (error) {
+        setHasStartedOnboardingCompletion(false);
+        showErrorToast(
+          "Failed to finish onboarding",
+          error instanceof Error ? error.message : "Please try again.",
+        );
+      }
+    },
+    [completeOnboardingMutation, router, updateSession, utils],
+  );
+
+  const [redirectCompletedOnboarding, isRedirectingCompletedOnboarding] =
+    useWatchedPromiseCallback(
+      async (redirectTo: string) => {
+        setHasStartedOnboardingCompletion(true);
+
+        try {
+          await router.replace(redirectTo);
+        } catch (error) {
+          setHasStartedOnboardingCompletion(false);
+          showErrorToast(
+            "Failed to continue onboarding",
+            error instanceof Error ? error.message : "Please try again.",
+          );
+        }
+      },
+      [router],
+    );
+
+  // External system: the Next.js router. A user who already completed
+  // onboarding must be pushed out of the flow rather than shown a step again.
+  useEffect(() => {
+    if (onboardingStatus.data?.completed && !hasStartedOnboardingCompletion) {
+      redirectCompletedOnboarding(onboardingStatus.data.redirectTo).catch(
+        () => undefined,
+      );
+    }
+  }, [
+    hasStartedOnboardingCompletion,
+    onboardingStatus.data,
+    redirectCompletedOnboarding,
+  ]);
+
+  const isCompletingOnboarding =
+    hasStartedOnboardingCompletion ||
+    isFinishingOnboarding ||
+    isRedirectingCompletedOnboarding ||
+    onboardingStatus.isLoading ||
+    onboardingStatus.data?.completed === true;
+
+  return {
+    finishOnboarding,
+    isCompletingOnboarding,
+    // Exposed separately so a step can show a neutral loading state instead of
+    // claiming it is already finishing, which `isCompletingOnboarding` folds in.
+    isStatusLoading: onboardingStatus.isLoading,
+    isStatusError: onboardingStatus.isError,
+  };
+}

--- a/web/src/features/onboarding/lib/newsletterConstants.ts
+++ b/web/src/features/onboarding/lib/newsletterConstants.ts
@@ -1,0 +1,9 @@
+/**
+ * Hosted signup form for the Langfuse self-hosting newsletter.
+ *
+ * Client-safe on purpose: the onboarding step links here when this instance
+ * cannot reach the signup proxy itself, so the constant must not drag the
+ * server-only newsletter service into the client bundle.
+ */
+export const NEWSLETTER_SIGNUP_FALLBACK_URL =
+  "https://langfuse.com/self-hosting/upgrade";

--- a/web/src/features/onboarding/lib/newsletterConstants.ts
+++ b/web/src/features/onboarding/lib/newsletterConstants.ts
@@ -1,9 +1,9 @@
 /**
- * Hosted signup form for the Langfuse self-hosting newsletter.
+ * Hosted signup page for the Langfuse self-hosting newsletter.
  *
  * Client-safe on purpose: the onboarding step links here when this instance
  * cannot reach the signup proxy itself, so the constant must not drag the
  * server-only newsletter service into the client bundle.
  */
 export const NEWSLETTER_SIGNUP_FALLBACK_URL =
-  "https://langfuse.com/self-hosting/upgrade";
+  "https://langfuse.com/self-hosting/oss-newsletter";

--- a/web/src/features/onboarding/server/newsletterService.ts
+++ b/web/src/features/onboarding/server/newsletterService.ts
@@ -12,9 +12,9 @@ import { logger } from "@langfuse/shared/src/server";
  * instance only sends an email address and a source label.
  *
  * `list: "oss"` resolves to the "Langfuse OSS updates" mailing list, the same
- * one the signup form on langfuse.com/self-hosting/upgrade writes to. The list
- * is referenced by name rather than by id so an instance cannot inject an
- * arbitrary Loops list, and no Loops identifier needs to live in this repo.
+ * one the hosted signup page at langfuse.com/self-hosting/oss-newsletter writes
+ * to. The list is referenced by name rather than by id so an instance cannot
+ * inject an arbitrary Loops list, and no Loops identifier lives in this repo.
  *
  * Posting from the server (not the browser) is required: the proxy sends no
  * CORS headers, so a cross-origin request from a self-hosted origin is blocked.

--- a/web/src/features/onboarding/server/newsletterService.ts
+++ b/web/src/features/onboarding/server/newsletterService.ts
@@ -1,0 +1,83 @@
+import { env } from "@/src/env.mjs";
+import { logger } from "@langfuse/shared/src/server";
+
+/**
+ * Self-hosting newsletter signup for the onboarding step.
+ *
+ * The signup is proxied through langfuse.com rather than sent to Loops
+ * directly: subscribing to a Loops mailing list requires a Loops API key, and a
+ * self-hosted instance must never carry Langfuse-operated credentials. The
+ * marketing site already exposes the proxy its own signup forms use, holds the
+ * key, and maps the named `list` key onto a mailing list — so a self-hosted
+ * instance only sends an email address and a source label.
+ *
+ * `list: "oss"` resolves to the "Langfuse OSS updates" mailing list, the same
+ * one the signup form on langfuse.com/self-hosting/upgrade writes to. The list
+ * is referenced by name rather than by id so an instance cannot inject an
+ * arbitrary Loops list, and no Loops identifier needs to live in this repo.
+ *
+ * Posting from the server (not the browser) is required: the proxy sends no
+ * CORS headers, so a cross-origin request from a self-hosted origin is blocked.
+ * It also keeps the user's browser from contacting langfuse.com at all.
+ */
+const SIGNUP_ENDPOINT = "https://langfuse.com/api/productUpdateSignup";
+const SIGNUP_LIST = "oss";
+const SIGNUP_SOURCE = "self-host-onboarding";
+const SIGNUP_TIMEOUT_MS = 5_000;
+
+export type NewsletterSignupStatus = "subscribed" | "unavailable";
+
+/**
+ * Whether to offer the in-product signup at all.
+ *
+ * This is an intent check, not a connectivity check — reachability is only
+ * knowable by trying, which `subscribeToNewsletter` does on explicit user
+ * submit. Deliberately not probed on page load: `public.checkUpdate` shows what
+ * that costs on an airgapped instance, where it logs a failure on every mount.
+ */
+export const isNewsletterSignupAvailable = () =>
+  // On Langfuse Cloud the marketing site owns newsletter signup.
+  !env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
+  // Operators who switched off the telemetry ping opted out of calls to
+  // Langfuse-operated services. Honor that instead of offering a form whose
+  // only possible outcome is a failed request.
+  env.TELEMETRY_ENABLED !== "false";
+
+export const subscribeToNewsletter = async ({
+  email,
+}: {
+  email: string;
+}): Promise<NewsletterSignupStatus> => {
+  if (!isNewsletterSignupAvailable()) return "unavailable";
+
+  try {
+    const response = await fetch(SIGNUP_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        list: SIGNUP_LIST,
+        source: SIGNUP_SOURCE,
+      }),
+      signal: AbortSignal.timeout(SIGNUP_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        "[onboarding.newsletter] signup proxy rejected the request, falling back to the hosted form",
+        { status: response.status },
+      );
+      return "unavailable";
+    }
+
+    return "subscribed";
+  } catch (error) {
+    // Airgapped and otherwise offline instances land here. Expected for those
+    // deployments, so this is not reported as an application error.
+    logger.info(
+      "[onboarding.newsletter] signup proxy unreachable, falling back to the hosted form",
+      { error },
+    );
+    return "unavailable";
+  }
+};

--- a/web/src/features/onboarding/server/onboardingRouter.ts
+++ b/web/src/features/onboarding/server/onboardingRouter.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 import {
-  completeCloudSignupOnboarding,
-  getCloudSignupOnboardingStatus,
+  completeSignupOnboarding,
+  getSignupOnboardingStatus,
 } from "@/src/features/onboarding/server/onboardingService";
+import {
+  isNewsletterSignupAvailable,
+  subscribeToNewsletter,
+} from "@/src/features/onboarding/server/newsletterService";
 import {
   createTRPCRouter,
   authenticatedProcedure,
@@ -10,28 +14,43 @@ import {
 
 export const onboardingRouter = createTRPCRouter({
   status: authenticatedProcedure.query(async ({ ctx }) => {
-    return getCloudSignupOnboardingStatus({
+    return getSignupOnboardingStatus({
       prisma: ctx.prisma,
       userId: ctx.session.user.id,
       canCreateOrganizations: ctx.session.user.canCreateOrganizations,
     });
   }),
 
+  // Whether to render the self-hosting newsletter step. Reflects deployment
+  // configuration only — whether the signup proxy is actually reachable is
+  // discovered on submit rather than probed here.
+  newsletterStatus: authenticatedProcedure.query(() => ({
+    available: isNewsletterSignupAvailable(),
+  })),
+
+  subscribeToNewsletter: authenticatedProcedure
+    .input(z.object({ email: z.string().trim().max(320).pipe(z.email()) }))
+    .mutation(async ({ input }) => ({
+      status: await subscribeToNewsletter({ email: input.email }),
+    })),
+
   complete: authenticatedProcedure
     .input(
       z
         .object({
           referralSource: z.string().trim().max(500).optional(),
+          newsletterOptIn: z.boolean().optional(),
         })
         .optional(),
     )
     .mutation(async ({ ctx, input }) => {
-      return completeCloudSignupOnboarding({
+      return completeSignupOnboarding({
         prisma: ctx.prisma,
         userId: ctx.session.user.id,
         userEmail: ctx.session.user.email,
         canCreateOrganizations: ctx.session.user.canCreateOrganizations,
         referralSource: input?.referralSource,
+        newsletterOptIn: input?.newsletterOptIn,
       });
     }),
 });

--- a/web/src/features/onboarding/server/onboardingService.ts
+++ b/web/src/features/onboarding/server/onboardingService.ts
@@ -221,7 +221,17 @@ export const resolveOnboardingRedirectTargetWithFallback = async ({
     redirectTo: canCreateOrganizations ? "/setup" : "/",
   };
 
-export const getCloudSignupOnboardingStatus = async ({
+/**
+ * Whether new users see the post-signup onboarding step at all.
+ *
+ * Operators switch this off with `LANGFUSE_DISABLE_SIGNUP_ONBOARDING=true`,
+ * typically on self-hosted instances that provision users centrally and do not
+ * want an interstitial between signup and the workspace.
+ */
+export const isSignupOnboardingEnabled = () =>
+  env.LANGFUSE_DISABLE_SIGNUP_ONBOARDING !== "true";
+
+export const getSignupOnboardingStatus = async ({
   prisma,
   userId,
   canCreateOrganizations,
@@ -230,6 +240,22 @@ export const getCloudSignupOnboardingStatus = async ({
   userId: string;
   canCreateOrganizations: boolean;
 }) => {
+  // A disabled flow behaves exactly like an already-completed one: resolve where
+  // this user belongs and send them there, without recording a survey response.
+  // Checked before the survey lookup so a disabled instance skips that query.
+  if (!isSignupOnboardingEnabled()) {
+    const redirectTarget = await resolveOnboardingRedirectTargetWithFallback({
+      prisma,
+      userId,
+      canCreateOrganizations,
+    });
+
+    return {
+      completed: true as const,
+      redirectTo: redirectTarget.redirectTo,
+    };
+  }
+
   const completedSurvey = await prisma.survey.findFirst({
     where: {
       userId,
@@ -258,18 +284,20 @@ export const getCloudSignupOnboardingStatus = async ({
   };
 };
 
-export const completeCloudSignupOnboarding = async ({
+export const completeSignupOnboarding = async ({
   prisma,
   userId,
   userEmail,
   canCreateOrganizations,
   referralSource,
+  newsletterOptIn,
 }: {
   prisma: PrismaClient;
   userId: string;
   userEmail?: string | null;
   canCreateOrganizations: boolean;
   referralSource?: string;
+  newsletterOptIn?: boolean;
 }) =>
   prisma.$transaction(async (tx) => {
     await tx.$queryRaw`
@@ -295,17 +323,21 @@ export const completeCloudSignupOnboarding = async ({
       canCreateOrganizations,
     });
 
-    if (!existingSurvey) {
+    // A disabled flow renders no step, so there is no response to record. Guard
+    // anyway so a client that was already open when the flag flipped cannot
+    // start writing survey rows on an instance that opted out.
+    if (!existingSurvey && isSignupOnboardingEnabled()) {
       const normalizedReferralSource = referralSource?.trim();
 
       await tx.survey.create({
         data: {
           surveyName: SurveyName.USER_ONBOARDING,
-          response: normalizedReferralSource
-            ? {
-                referralSource: normalizedReferralSource,
-              }
-            : {},
+          response: {
+            ...(normalizedReferralSource
+              ? { referralSource: normalizedReferralSource }
+              : {}),
+            ...(newsletterOptIn === undefined ? {} : { newsletterOptIn }),
+          },
           userId,
           userEmail: userEmail ?? undefined,
           orgId: redirectTarget.orgId,

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -78,7 +78,6 @@ export default function SignUp({
 function StandardSignupFlow({
   authProviders,
 }: Pick<PageProps, "authProviders" | "emailVerificationRequired">) {
-  const { isLangfuseCloud } = useLangfuseCloudRegion();
   const router = useRouter();
   const capture = usePostHogClientCapture();
 
@@ -211,11 +210,10 @@ function StandardSignupFlow({
       await signIn<"credentials">("credentials", {
         email: values.email,
         password: values.password,
+        // Onboarding runs on both deployment types; the page picks the cloud
+        // attribution question or the self-hosting newsletter step.
         callbackUrl:
-          targetPath ??
-          (isLangfuseCloud
-            ? `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/onboarding`
-            : `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/`),
+          targetPath ?? `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/onboarding`,
       });
     } catch {
       setFormError("An error occurred. Please try again.");

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -1,15 +1,21 @@
-// This page is part of the cloud signup flow and can also be opened directly for local testing.
+// This page is part of the signup flow and can also be opened directly for local testing.
+// Langfuse Cloud asks the attribution question; self-hosted deployments get the
+// self-hosting newsletter step instead.
 
 import Head from "next/head";
 import { OnboardingSurvey } from "@/src/features/onboarding/components/OnboardingSurvey";
+import { SelfHostedNewsletterStep } from "@/src/features/onboarding/components/SelfHostedNewsletterStep";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 
 export default function OnboardingPage() {
+  const { isLangfuseCloud } = useLangfuseCloudRegion();
+
   return (
     <>
       <Head>
         <title>Onboarding | Langfuse</title>
       </Head>
-      <OnboardingSurvey />
+      {isLangfuseCloud ? <OnboardingSurvey /> : <SelfHostedNewsletterStep />}
     </>
   );
 }

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -68,6 +68,7 @@ import { getSSOBlockedDomains } from "@/src/features/auth-credentials/server/sig
 import { createSupportEmailHash } from "@/src/features/support-chat/createSupportEmailHash";
 import { canToggleV4 } from "@/src/features/events/lib/v4Rollout";
 import { canCreateOrganizations } from "@/src/features/organizations/server/canCreateOrganizations";
+import { isSignupOnboardingEnabled } from "@/src/features/onboarding/server/onboardingService";
 
 const staticProviders: Provider[] = [
   CredentialsProvider({
@@ -1105,10 +1106,12 @@ export async function getAuthOptions(signupAttribution?: {
     pages: {
       signIn: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/sign-in`,
       error: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/error`,
-      ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
-        ? {
-            newUser: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/onboarding`,
-          }
+      // Both deployment types run the onboarding step; the page picks the cloud
+      // attribution question or the self-hosting newsletter step. Operators can
+      // opt out with LANGFUSE_DISABLE_SIGNUP_ONBOARDING, which skips the
+      // interstitial entirely rather than routing through it to bounce back.
+      ...(isSignupOnboardingEnabled()
+        ? { newUser: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/onboarding` }
         : {}),
     },
     cookies: {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15936.preview.langfuse.com](https://pr-15936.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Adds a post-signup onboarding step for **self-hosted** deployments that offers an opt-in to the Langfuse self-hosting newsletter ("Langfuse OSS updates"). Langfuse Cloud is unchanged.

Self-hosters previously saw **no onboarding at all**: both `pages.newUser` ([auth.ts](https://github.com/langfuse/langfuse/blob/main/web/src/server/auth.ts)) and the credentials `callbackUrl` ([sign-up.tsx](https://github.com/langfuse/langfuse/blob/main/web/src/pages/auth/sign-up.tsx)) routed to `/onboarding` only when `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` was set. So there was no in-product path to release announcements — self-hosters had to discover them on GitHub. Onboarding now runs on both deployment types and `onboarding.tsx` picks the variant: Cloud keeps the attribution question, self-hosted gets the newsletter step.

Fixes # (no issue)

### Why the signup is proxied through langfuse.com

Subscribing to a Loops mailing list requires a Loops API key, which a self-hosted instance must never carry. The marketing site already exposes the proxy its own signup forms use and holds the key, so an instance only sends an email address and a source label:

```
POST https://langfuse.com/api/productUpdateSignup   { email, list: "oss", source: "self-host-onboarding" }
```

Two deliberate details:
- The list is referenced **by name** (`list: "oss"`), never by id, so an instance cannot inject an arbitrary Loops list. No Loops identifier lives in this repo.
- The call is made **server-side**. The proxy sends no CORS headers, so a cross-origin browser request would be blocked — and this also keeps the user's browser from contacting langfuse.com at all.

### Airgap handling — no connectivity probing

1. `TELEMETRY_ENABLED=false` is read as the operator having opted out of calls to Langfuse-operated services, so the form is not offered.
2. Otherwise reachability is discovered **on explicit submit**. A failed request swaps in a link to the hosted form and never blocks onboarding.

Reachability is deliberately *not* probed on page load: `public.checkUpdate` shows what that costs on an airgapped instance, where it logs a failure on every layout mount. The unreachable path logs at `info`, not `error`, since it is expected for those deployments.

### New environment variable

```bash
LANGFUSE_DISABLE_SIGNUP_ONBOARDING=true   # default: false
```

For operators who provision users centrally and want no interstitial. A runtime **server** variable rather than `NEXT_PUBLIC_*` on purpose: self-hosters run the prebuilt Docker image, where `NEXT_PUBLIC_*` values are baked at build time and so could not be set by the audience this targets. It gates two places off one predicate (`isSignupOnboardingEnabled`): NextAuth's `newUser` page, so SSO/OAuth users are never routed there; and `onboarding.status`, which reports a disabled flow exactly like an already-completed one. Nothing is recorded when disabled.

### Storage

The opt-in rides in the existing free-form `Survey.response` JSON under the existing `USER_ONBOARDING` name — **no migration**. `newsletterOptIn: false` distinguishes declining from never being asked.

### Refactor included

Shared completion logic moved into `useCompleteOnboarding` and the card shell into `OnboardingCard` so the two variants don't duplicate ~90 lines. `completeCloudSignupOnboarding` / `getCloudSignupOnboardingStatus` were renamed to drop the now-inaccurate "Cloud".

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Reviewer notes

**Verified locally** against a self-hosted-mode production build:

- `Tests 20 passed (20)` server-unit, `Tests 7 passed (7)` client, `Tasks: 7 successful, 7 total` for both `lint` and `typecheck`
- A **real subscribe** was exercised end-to-end against the production endpoint with a throwaway address, confirming langfuse.com already maps `list: "oss"` and accepts the new `source`. No `[onboarding.newsletter]` warn/info fired.
- The `TELEMETRY_ENABLED=false` fallback renders link-only with no dead form; `LANGFUSE_DISABLE_SIGNUP_ONBOARDING=true` bounced `/onboarding` straight to the workspace with **0** survey rows written afterwards.
- Light and dark themes both checked.

**Follow-ups intentionally not in this PR:**

- **Docs**: `LANGFUSE_DISABLE_SIGNUP_ONBOARDING` and the new step need entries in the self-hosting docs, plus the `oss-newsletter` page itself (separate `langfuse-docs` repo).
- The self-hosted step *replaces* rather than adds to the attribution question — self-hosters get no referral question. Say the word if that is wrong.
- No PostHog event: self-hosted images bake no PostHog key, and the Cloud survey is not instrumented either.
- The "set initial password" path (`ResetPasswordPage.tsx`) still sends self-hosters to `/`; left alone as out of scope.
- **The fallback link target must ship first.** `NEWSLETTER_SIGNUP_FALLBACK_URL` points at `langfuse.com/self-hosting/oss-newsletter`, the dedicated signup page. That page currently **404s** — it needs to be live before this merges, or the airgapped fallback sends users to a dead link.

**One thing worth a second opinion:** the disable flag applies wherever it is set, including Cloud. I chose predictability ("set this → no onboarding step") over a Cloud carve-out that would silently no-op, but that is a judgement call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds self-hosted signup onboarding with an OSS newsletter opt-in, while retaining the existing Cloud attribution survey.

- Routes new credentials and OAuth/SSO users through deployment-specific onboarding.
- Adds a server-side newsletter proxy call with an airgap fallback and telemetry-aware availability.
- Adds a runtime operator flag to disable onboarding and refactors shared completion/card behavior.
- Persists newsletter decisions in the existing onboarding survey response.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

This PR should not merge until newsletter enrollment is bound to valid recipient consent and newsletter-status failures are handled separately from an intentional opt-out.

The new authenticated endpoint can submit arbitrary third-party addresses to the mailing-list proxy, while a transient availability-query failure is misrepresented as disabled signup and can persist an incorrect decline.

**Files Needing Attention:** web/src/features/onboarding/server/onboardingRouter.ts; web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx
</details>

<details open><summary><h3>Security Review</h3></summary>

The authenticated newsletter mutation accepts an arbitrary email address and forwards it to the external mailing-list proxy without binding it to the session identity or otherwise establishing recipient consent.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as New user
  participant UI as Onboarding page
  participant RPC as Onboarding tRPC router
  participant Proxy as langfuse.com signup proxy
  participant DB as Survey storage

  U->>UI: Complete signup
  UI->>RPC: Query onboarding/newsletter status
  alt Cloud deployment
    UI->>U: Show attribution survey
    U->>RPC: Complete with referral source
  else Self-hosted and available
    UI->>U: Show newsletter opt-in
    U->>RPC: Subscribe with email
    RPC->>Proxy: "POST email, list=oss, source"
    Proxy-->>RPC: Subscription status
    U->>RPC: Complete with newsletterOptIn
  else Disabled or unreachable
    UI->>U: Show fallback/continue
    U->>RPC: "Complete with newsletterOptIn=false"
  end
  RPC->>DB: Persist USER_ONBOARDING response
  RPC-->>UI: Redirect target
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/onboarding/server/onboardingRouter.ts:31-35
**Unbound newsletter recipient consent**

When an authenticated user supplies another person's email, this mutation forwards it to the external mailing-list proxy without binding it to `ctx.session.user.email` or requiring recipient confirmation, causing an unrelated address to be enrolled without the recipient initiating the request.

**How this was verified:** The authenticated procedure accepts `input.email` and passes it directly to the external signup service without using the session email.

### Issue 2
web/src/features/onboarding/components/SelfHostedNewsletterStep.tsx:160-161
**Status errors become false declines**

When the `newsletterStatus` query fails after its retries, `data` remains undefined and this expression treats the failure as disabled signup. The user sees the operator-disabled fallback, and clicking Continue permanently records `newsletterOptIn: false` even though the opt-in form failed to load.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): explain the newsletter step w..."](https://github.com/langfuse/langfuse/commit/5f739b6b6f3c324f71e59a44b627c695b95bcec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54675721)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)

<!-- /greptile_comment -->