### PR TITLE
fix(in-app-agent): preserve run framing across reconnects

### DIFF
--- a/packages/shared/src/in-app-agent/server/watch.test.ts
+++ b/packages/shared/src/in-app-agent/server/watch.test.ts
@@ -63,6 +63,7 @@ function fakePrisma(polls: Array<{ events: EventRow[]; run: RunRow | null }>) {
 async function collect(
   prisma: PrismaClient,
   cursor: number,
+  openRunId?: string,
 ): Promise<InAppAgentWatchFrame[]> {
   const frames: InAppAgentWatchFrame[] = [];
 
@@ -71,6 +72,7 @@ async function collect(
     projectId: "project-1",
     conversationId: "conversation-1",
     cursor,
+    openRunId,
     now: () => 0,
     sleep: async () => undefined,
   })) {
@@ -183,6 +185,24 @@ describe("watchConversationFrames", () => {
 
     // A drop right after the synthetic frame must re-read event 1, not skip it.
     expect(eventFrames(frames)[0]?.sequenceNumber).toBe(0);
+  });
+
+  it("continues an already-open run without synthesizing another start", async () => {
+    const frames = await collect(
+      fakePrisma([
+        {
+          events: [textMessage("run-1", 1), runFinished("run-1", 2)],
+          run: succeeded,
+        },
+      ]),
+      0,
+      "run-1",
+    );
+
+    expect(eventTypes(frames)).toEqual([
+      EventType.TEXT_MESSAGE_START,
+      EventType.RUN_FINISHED,
+    ]);
   });
 
   it("hands off from cursor to tail with no duplicated and no missed event", async () => {

--- a/packages/shared/src/in-app-agent/server/watch.ts
+++ b/packages/shared/src/in-app-agent/server/watch.ts
@@ -33,6 +33,7 @@ export async function* watchConversationFrames(params: {
   projectId: string;
   conversationId: string;
   cursor: number;
+  openRunId?: string;
   signal?: AbortSignal;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
@@ -45,7 +46,7 @@ export async function* watchConversationFrames(params: {
   const startedAt = now();
   let cursor = params.cursor;
   let lastKeepaliveAt = startedAt;
-  let openRunId: string | null = null;
+  let openRunId: string | null = params.openRunId ?? null;
   let lastStatusKey: string | null = null;
   let reconciledStaleRun = false;
 

--- a/web/src/features/in-app-agent/lib/backgroundAgentClient.ts
+++ b/web/src/features/in-app-agent/lib/backgroundAgentClient.ts
@@ -1,5 +1,5 @@
 import { AbstractAgent, type RunAgentInput } from "@ag-ui/client";
-import type { BaseEvent } from "@ag-ui/core";
+import { EventType, type BaseEvent } from "@ag-ui/core";
 import { Observable } from "rxjs";
 
 import { InAppAgentRunStatus } from "@langfuse/shared";
@@ -46,6 +46,10 @@ type StartRunFn = (params: {
   message: string;
   context: AgUiRunAgentInput["context"];
 }) => Promise<{ runId: string }>;
+
+type RunFramingState = {
+  openRunId: string | null;
+};
 
 // AG-UI's Zod v3 declarations resolve as unknown against this repo's Zod v4.
 function asAgUiRunAgentInput(input: RunAgentInput): AgUiRunAgentInput {
@@ -179,13 +183,14 @@ export class InAppAgentBackgroundClient extends AbstractAgent {
   ): Promise<void> {
     let consecutiveFailures = 0;
     let consecutiveQuietConnections = 0;
+    const runFraming: RunFramingState = { openRunId: null };
 
     while (!signal.aborted) {
       const cursorBeforeRequest = this.cursor;
       let sawDoneFrame: boolean;
 
       try {
-        sawDoneFrame = await this.streamOnce(subscriber, signal);
+        sawDoneFrame = await this.streamOnce(subscriber, signal, runFraming);
       } catch (error) {
         if (signal.aborted) {
           break;
@@ -243,6 +248,7 @@ export class InAppAgentBackgroundClient extends AbstractAgent {
   private async streamOnce(
     subscriber: { next: (event: BaseEvent) => void },
     signal: AbortSignal,
+    runFraming: RunFramingState,
   ): Promise<boolean> {
     const basePath = env.NEXT_PUBLIC_BASE_PATH ?? "";
     const url = new URL(
@@ -252,6 +258,9 @@ export class InAppAgentBackgroundClient extends AbstractAgent {
     url.searchParams.set("projectId", this.projectId);
     url.searchParams.set("conversationId", this.conversationId);
     url.searchParams.set("cursor", String(this.cursor));
+    if (runFraming.openRunId) {
+      url.searchParams.set("openRunId", runFraming.openRunId);
+    }
 
     const response = await fetch(url.toString(), {
       method: "GET",
@@ -324,9 +333,24 @@ export class InAppAgentBackgroundClient extends AbstractAgent {
           throw new Error(frame.data.message);
         }
 
+        const event = frame.data.event;
+
+        if (
+          event.type === EventType.RUN_STARTED &&
+          typeof event.runId === "string"
+        ) {
+          runFraming.openRunId = event.runId;
+        } else if (
+          (event.type === EventType.RUN_FINISHED ||
+            event.type === EventType.RUN_ERROR) &&
+          event.runId === runFraming.openRunId
+        ) {
+          runFraming.openRunId = null;
+        }
+
         this.cursor = frame.data.sequenceNumber;
         this.onCursor?.(this.cursor);
-        subscriber.next(frame.data.event as unknown as BaseEvent);
+        subscriber.next(event as unknown as BaseEvent);
       }
     }
 

--- a/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
@@ -1183,6 +1183,96 @@ describe("InAppAgentBackgroundClient reconnect", () => {
     expect(String(fetchMock.mock.calls[1]?.[0])).toContain("cursor=0");
   });
 
+  it("preserves an open run across watch reconnects", async () => {
+    const requestUrls: URL[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      requestUrls.push(url);
+
+      if (requestUrls.length === 1) {
+        return new Response(
+          [
+            sseFrame({
+              type: "event",
+              sequenceNumber: 0,
+              event: {
+                type: EventType.RUN_STARTED,
+                runId: "run-1",
+                threadId: "conversation-1",
+              },
+            }),
+            sseFrame({
+              type: "event",
+              sequenceNumber: 1,
+              event: {
+                type: EventType.TEXT_MESSAGE_START,
+                messageId: "message-1",
+                role: "assistant",
+              },
+            }),
+            sseFrame({
+              type: "event",
+              sequenceNumber: 2,
+              event: {
+                type: EventType.TEXT_MESSAGE_CONTENT,
+                messageId: "message-1",
+                delta: "Still working",
+              },
+            }),
+            sseFrame({
+              type: "event",
+              sequenceNumber: 3,
+              event: {
+                type: EventType.TEXT_MESSAGE_END,
+                messageId: "message-1",
+              },
+            }),
+          ].join(""),
+        );
+      }
+
+      return new Response(
+        [
+          ...(url.searchParams.get("openRunId")
+            ? []
+            : [
+                sseFrame({
+                  type: "event",
+                  sequenceNumber: 3,
+                  event: {
+                    type: EventType.RUN_STARTED,
+                    runId: "run-1",
+                    threadId: "conversation-1",
+                  },
+                }),
+              ]),
+          sseFrame({
+            type: "event",
+            sequenceNumber: 4,
+            event: {
+              type: EventType.RUN_FINISHED,
+              runId: "run-1",
+              threadId: "conversation-1",
+            },
+          }),
+          sseFrame({ type: "done" }),
+        ].join(""),
+      );
+    });
+    const client = new InAppAgentBackgroundClient({
+      projectId: "project-1",
+      conversationId: "conversation-1",
+      cursor: -1,
+      startRun: vi.fn(),
+    });
+
+    await client.connectAgent();
+
+    expect(requestUrls).toHaveLength(2);
+    expect(requestUrls[0]?.searchParams.has("openRunId")).toBe(false);
+    expect(requestUrls[1]?.searchParams.get("openRunId")).toBe("run-1");
+  });
+
   it("keeps watching across repeated quiet connection rotations", async () => {
     vi.useFakeTimers();
     const responses = [

--- a/web/src/features/in-app-agent/server/watchHandler.ts
+++ b/web/src/features/in-app-agent/server/watchHandler.ts
@@ -14,6 +14,7 @@ const WatchQuerySchema = z.object({
   projectId: z.string().min(1),
   conversationId: z.string().min(1),
   cursor: z.coerce.number().int().min(-1).default(-1),
+  openRunId: z.string().min(1).optional(),
 });
 
 export default async function watchHandler(request: Request) {
@@ -36,13 +37,14 @@ export default async function watchHandler(request: Request) {
         url.searchParams.get("cursor") ??
         request.headers.get("last-event-id") ??
         -1,
+      openRunId: url.searchParams.get("openRunId") ?? undefined,
     });
 
     if (!query.success) {
       return Response.json({ error: "Invalid watch query" }, { status: 400 });
     }
 
-    const { projectId, conversationId, cursor } = query.data;
+    const { projectId, conversationId, cursor, openRunId } = query.data;
 
     if (!isProjectMemberOrAdmin(user, projectId)) {
       throw new ForbiddenError("User is not a member of this project");
@@ -70,6 +72,7 @@ export default async function watchHandler(request: Request) {
       projectId,
       conversationId,
       cursor,
+      openRunId,
       signal: request.signal,
     });
 
@@ -98,6 +101,7 @@ function createWatchStream(params: {
   projectId: string;
   conversationId: string;
   cursor: number;
+  openRunId?: string;
   signal: AbortSignal;
 }): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -109,6 +113,7 @@ function createWatchStream(params: {
         projectId: params.projectId,
         conversationId: params.conversationId,
         cursor: params.cursor,
+        openRunId: params.openRunId,
         signal: params.signal,
       });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15939.preview.langfuse.com](https://pr-15939.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What this fixes

Watch reconnects started a fresh server-side framing state, so a mid-run reconnect synthesized another `RUN_STARTED`. The AG-UI verifier still had the original run open and rejected the duplicate.

- keep `openRunId` local to one logical client watch
- send it on physical reconnects
- validate and forward it through the watch endpoint
- seed the resumed server watch with that framing state

## Tests

Added two regression tests, both demonstrated failing before the implementation:

- server watch resumes an open run without synthesizing another start
- full `connectAgent()` reconnect runs through the real AG-UI verifier

Validation:
- `watch.test.ts`: 12 passed
- `backgroundExecutionSession.clienttest.ts`: 23 passed
- lint: 7 tasks passed
- typecheck: 7 tasks passed

Full service-backed suites require local PostgreSQL, Redis, ClickHouse, and S3; the self-contained shared suite passed 887 tests before those unavailable dependencies failed.

[LFE-14902](https://linear.app/clickhouse/issue/LFE-14902/in-app-agent-cannot-send-run-started-while-a-run-is-still-active-run) · [Sentry](https://langfuse.sentry.io/issues/7656879716/)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves AG-UI run framing across physical reconnects within one logical client watch.
- Tracks the currently open run in the background client and includes it in reconnect requests.
- Validates and forwards the framing state through the watch endpoint.
- Seeds server-side framing from the resumed run and adds client/server regression coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the reconnect framing state consistently propagated and covered at both client and server boundaries.

The client retains framing only within one logical watch, the endpoint preserves existing project and conversation access checks, and the server correctly resumes or transitions run framing based on subsequent authorized conversation events.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client as Background client
  participant Endpoint as Watch endpoint
  participant Watch as Server watch
  participant Verifier as AG-UI verifier
  Client->>Endpoint: GET watch(cursor)
  Endpoint->>Watch: watchConversationFrames(cursor)
  Watch-->>Client: RUN_STARTED(runId)
  Client->>Verifier: RUN_STARTED(runId)
  Note over Client: Store openRunId
  Watch--xClient: Physical connection closes
  Client->>Endpoint: GET watch(cursor, openRunId)
  Endpoint->>Watch: Seed resumed framing
  Watch-->>Client: Remaining run events
  Client->>Verifier: Continue existing run
  Watch-->>Client: RUN_FINISHED(runId)
  Note over Client: Clear openRunId
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): preserve run framing ..."](https://github.com/langfuse/langfuse/commit/f0e556397f282612c1c4d9a73f4d7f0b3ea4f96a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51764184)</sub>

<!-- /greptile_comment -->