### PR TITLE
fix(rbac): scope project role updates to organization

### DIFF
--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -614,3 +614,50 @@ describe("membersRouter.updateProjectRole - orgMembership/userId consistency", (
     expect(row?.orgMembershipId).toBe(orgMembership.id);
   });
 });
+
+describe("membersRouter.updateProjectRole - project organization consistency", () => {
+  it("rejects a project from another organization without writing membership or audit log", async () => {
+    const { org, ownerUser, caller } = await prepare("cloud:core");
+    const { project: otherOrgProject } = await createTestOrg("cloud:core");
+
+    const orgMembership = await prisma.organizationMembership.findUniqueOrThrow(
+      {
+        where: {
+          orgId_userId: {
+            orgId: org.id,
+            userId: ownerUser.id,
+          },
+        },
+      },
+    );
+
+    await expect(
+      caller.members.updateProjectRole({
+        orgId: org.id,
+        orgMembershipId: orgMembership.id,
+        userId: ownerUser.id,
+        projectId: otherOrgProject.id,
+        projectRole: Role.OWNER,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    const projectMembership = await prisma.projectMembership.findUnique({
+      where: {
+        projectId_userId: {
+          projectId: otherOrgProject.id,
+          userId: ownerUser.id,
+        },
+      },
+    });
+    expect(projectMembership).toBeNull();
+
+    const auditLogs = await prisma.auditLog.findMany({
+      where: {
+        orgId: org.id,
+        resourceType: "projectMembership",
+        resourceId: `${otherOrgProject.id}--${ownerUser.id}`,
+      },
+    });
+    expect(auditLogs).toHaveLength(0);
+  });
+});

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -652,6 +652,23 @@ export const membersRouter = createTRPCRouter({
         });
       }
 
+      const project = await ctx.prisma.project.findFirst({
+        where: {
+          id: input.projectId,
+          orgId: input.orgId,
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+        },
+      });
+      if (!project) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Project not found",
+        });
+      }
+
       // check org membership id, can be trusted after this check
       const orgMembership = await ctx.prisma.organizationMembership.findUnique({
         where: {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15940.preview.langfuse.com](https://pr-15940.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- require the target project to belong to the supplied organization before updating project roles
- reject deleted, missing, or mismatched projects before membership reads or writes
- add a cross-organization regression test that verifies no project membership or audit log is created

## Root cause

`updateProjectRole` allowed either organization-level or project-level permission, but did not verify that the independently supplied project and organization IDs belonged together. Organization-level permission could therefore authorize a write referencing a project from another organization.

## Impact

Legitimate organization admins and project admins continue to use the existing permission paths when the project belongs to the supplied organization. Inconsistent project/organization pairs now return `NOT_FOUND`.

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- targeted server suite passed after the fix: `Tests 14 passed (14)`
- latest-base targeted rerun was blocked because local PostgreSQL and Redis were stopped; skipped per request

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR scopes project-role updates to active projects belonging to the supplied organization and adds a cross-organization regression test. The new validation blocks ordinary mismatched requests, but it is not atomic with the membership write.

- Adds an organization- and deletion-scoped project lookup before membership reads and writes.
- Returns `NOT_FOUND` for missing, deleted, or cross-organization projects.
- Verifies that a rejected cross-organization request creates neither a project membership nor an audit log.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The project-to-organization validation should be made atomic with the membership write before merging to prevent persistent cross-organization membership records during concurrent transfers.

A project transfer can commit between the new ownership check and the later upsert, allowing updateProjectRole to persist an organization-A membership against a project that now belongs to organization B.

**Files Needing Attention:** web/src/features/rbac/server/membersRouter.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as updateProjectRole
  participant DB as PostgreSQL
  participant T as project transfer
  U->>DB: Validate project belongs to org A
  DB-->>U: Project found
  T->>DB: Transaction: delete memberships
  T->>DB: Transaction: move project to org B
  DB-->>T: Commit
  U->>DB: Upsert membership using org A membership
  DB-->>U: Cross-org membership persisted
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/rbac/server/membersRouter.ts:655-662
**Transfer invalidates organization validation**

If a project transfer overlaps this mutation after the ownership lookup, the transfer can delete memberships and change `Project.orgId` before this mutation upserts using the original organization's `orgMembershipId`, causing a persistent cross-organization `ProjectMembership` record.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): scope project role updates to..."](https://github.com/langfuse/langfuse/commit/64e443d40c83d9c3fee28afe8c01d2e7a255ee51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51769422)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)

<!-- /greptile_comment -->