### PR TITLE
feat(tracing): show cost source in breakdown

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -129,6 +129,9 @@ export type ObservationsTableRow = {
   usageDetails: Record<string, number>;
   totalCost?: number;
   costDetails: Record<string, number>;
+  providedCostDetails: Record<string, number>;
+  modelId?: string;
+  usagePricingTierId?: string | null;
   usagePricingTierName?: string | null;
   model?: string;
   promptName?: string;
@@ -864,6 +867,18 @@ export default function ObservationsTable({
             details={row.original.costDetails}
             isCost
             pricingTierName={row.original.usagePricingTierName ?? undefined}
+            costSource={
+              Object.values(row.original.providedCostDetails).some(
+                (cost) => cost != null,
+              )
+                ? { type: "provided" }
+                : row.original.modelId && row.original.usagePricingTierId
+                  ? {
+                      type: "model",
+                      href: `/project/${projectId}/settings/models/${row.original.modelId}?pricingTier=${row.original.usagePricingTierId}`,
+                    }
+                  : undefined
+            }
           >
             <div className="flex items-center gap-1">
               <span>{usdFormatter(value)}</span>
@@ -1397,6 +1412,8 @@ export default function ObservationsTable({
             timestamp: generation.traceTimestamp ?? undefined,
             usageDetails: generation.usageDetails ?? {},
             costDetails: generation.costDetails ?? {},
+            providedCostDetails: generation.providedCostDetails ?? {},
+            usagePricingTierId: generation.usagePricingTierId ?? undefined,
             usagePricingTierName: generation.usagePricingTierName ?? undefined,
             environment: generation.environment ?? undefined,
             toolDefinitions: generation.toolDefinitionsCount ?? undefined,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -202,6 +202,8 @@ export type EventsTableRow = {
     outputCost?: number;
   };
   costDetails: Record<string, number>;
+  providedCostDetails: Record<string, number>;
+  usagePricingTierId?: string | null;
   usagePricingTierName?: string | null;
 
   // Performance metrics
@@ -1364,6 +1366,18 @@ export default function ObservationsEventsTable({
             details={row.original.costDetails}
             isCost
             pricingTierName={row.original.usagePricingTierName ?? undefined}
+            costSource={
+              Object.values(row.original.providedCostDetails).some(
+                (cost) => cost != null,
+              )
+                ? { type: "provided" }
+                : row.original.modelId && row.original.usagePricingTierId
+                  ? {
+                      type: "model",
+                      href: `/project/${projectId}/settings/models/${row.original.modelId}?pricingTier=${row.original.usagePricingTierId}`,
+                    }
+                  : undefined
+            }
           >
             <div className="flex items-center gap-1">
               <span>{usdFormatter(value)}</span>
@@ -1847,6 +1861,8 @@ export default function ObservationsEventsTable({
               timestamp: observation.startTime ?? undefined,
               usageDetails: observation.usageDetails ?? {},
               costDetails: observation.costDetails ?? {},
+              providedCostDetails: observation.providedCostDetails ?? {},
+              usagePricingTierId: observation.usagePricingTierId ?? undefined,
               usagePricingTierName:
                 observation.usagePricingTierName ?? undefined,
               environment: observation.environment ?? undefined,

--- a/web/src/features/traces/components/BreakdownTooltip.stories.tsx
+++ b/web/src/features/traces/components/BreakdownTooltip.stories.tsx
@@ -1,0 +1,116 @@
+import { expect, userEvent, within } from "storybook/test";
+
+import preview from "../../../../.storybook/preview";
+import { BreakdownTooltip } from "./BreakdownTooltip";
+
+const costDetails = {
+  input: 0.000012,
+  output: 0.000034,
+  total: 0.000046,
+};
+
+const meta = preview.meta({
+  component: BreakdownTooltip,
+  parameters: { a11y: { test: "error" } },
+});
+
+export default meta;
+
+export const ModelPricing = meta.story({
+  args: {
+    children: "View cost breakdown",
+    details: costDetails,
+    isCost: true,
+    pricingTierName: "Standard",
+    costSource: {
+      type: "model",
+      href: "/project/project-1/settings/models/model-1?pricingTier=tier-1",
+    },
+  },
+});
+
+export const ProvidedByApplication = meta.story({
+  args: {
+    children: "View cost breakdown",
+    details: costDetails,
+    isCost: true,
+    costSource: { type: "provided" },
+  },
+});
+
+export const Aggregate = meta.story({
+  args: {
+    children: "View aggregate cost breakdown",
+    details: [costDetails, { input: 0.00002, output: 0.00001, total: 0.00003 }],
+    isCost: true,
+  },
+});
+
+export const Usage = meta.story({
+  args: {
+    children: "View usage breakdown",
+    details: { input: 12, output: 8, total: 20 },
+  },
+});
+
+export const TestShowsModelPricingSource = meta.story({
+  name: "(Test) Shows model pricing source",
+  args: {
+    children: "View cost breakdown",
+    details: costDetails,
+    isCost: true,
+    pricingTierName: "Standard",
+    costSource: {
+      type: "model",
+      href: "/project/project-1/settings/models/model-1?pricingTier=tier-1",
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "View cost breakdown" }),
+    );
+
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(body.getAllByText("Cost breakdown").length).toBeGreaterThan(0);
+    await expect(body.getAllByText("Standard").length).toBeGreaterThan(0);
+    const modelPricingLinks = body.getAllByRole("link", {
+      name: /Langfuse model pricing/i,
+      hidden: true,
+    });
+    await expect(modelPricingLinks.length).toBeGreaterThan(0);
+    for (const modelPricingLink of modelPricingLinks) {
+      await expect(modelPricingLink).toHaveAttribute(
+        "href",
+        "/project/project-1/settings/models/model-1?pricingTier=tier-1",
+      );
+    }
+  },
+});
+
+export const TestShowsProvidedCostSource = meta.story({
+  name: "(Test) Shows provided cost source",
+  args: {
+    children: "View cost breakdown",
+    details: costDetails,
+    isCost: true,
+    costSource: { type: "provided" },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "View cost breakdown" }),
+    );
+
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      body.getAllByText("Provided by application").length,
+    ).toBeGreaterThan(0);
+    await expect(
+      body.queryAllByRole("link", {
+        name: /Langfuse model pricing/i,
+        hidden: true,
+      }),
+    ).toHaveLength(0);
+  },
+});

--- a/web/src/features/traces/components/BreakdownTooltip.tsx
+++ b/web/src/features/traces/components/BreakdownTooltip.tsx
@@ -8,12 +8,19 @@ import { useState } from "react";
 import Decimal from "decimal.js";
 import { getMaxDecimals } from "@/src/features/models/utils";
 import { type Details } from "@/src/features/traces/fns/calculateAggregatedUsage";
+import Link from "next/link";
+import { ExternalLinkIcon } from "lucide-react";
+
+export type BreakdownTooltipCostSource =
+  | { type: "provided" }
+  | { type: "model"; href: string };
 
 interface BreakdownTooltipProps {
   details: Details | Details[];
   children: React.ReactNode;
   isCost?: boolean;
   pricingTierName?: string;
+  costSource?: BreakdownTooltipCostSource;
 }
 
 export const BreakdownTooltip = ({
@@ -21,6 +28,7 @@ export const BreakdownTooltip = ({
   children,
   isCost = false,
   pricingTierName,
+  costSource,
 }: BreakdownTooltipProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -75,6 +83,22 @@ export const BreakdownTooltip = ({
                 <div className="text-muted-foreground flex justify-between text-xs">
                   <span>Pricing Tier:</span>
                   <span className="font-mono">{pricingTierName}</span>
+                </div>
+              )}
+              {isCost && costSource && (
+                <div className="text-muted-foreground flex justify-between gap-4 text-xs">
+                  <span>Cost source:</span>
+                  {costSource.type === "provided" ? (
+                    <span className="text-right">Provided by application</span>
+                  ) : (
+                    <Link
+                      href={costSource.href}
+                      className="flex items-center gap-1 text-right underline-offset-2 hover:underline"
+                    >
+                      Langfuse model pricing
+                      <ExternalLinkIcon className="h-3 w-3 shrink-0" />
+                    </Link>
+                  )}
                 </div>
               )}
             </div>

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader.tsx
@@ -67,6 +67,9 @@ import { CollapsibleBadgeRow } from "@/src/features/traces/components/Collapsibl
 import { useIsMobile } from "@/src/hooks/use-mobile";
 import { cn } from "@/src/utils/tailwind";
 
+const hasProvidedCosts = (costDetails: Record<string, number>) =>
+  Object.values(costDetails).some((value) => value != null);
+
 export interface ObservationDetailViewHeaderProps {
   observation: ObservationReturnTypeWithMetadata;
   observationWithIO:
@@ -409,6 +412,24 @@ export const ObservationDetailViewHeader = memo(
                 }
                 costDetails={
                   subtreeMetrics?.costDetails ?? observation.costDetails
+                }
+                pricingTierName={
+                  subtreeMetrics
+                    ? undefined
+                    : (observation.usagePricingTierName ?? undefined)
+                }
+                costSource={
+                  subtreeMetrics
+                    ? undefined
+                    : hasProvidedCosts(observation.providedCostDetails)
+                      ? { type: "provided" }
+                      : observation.internalModelId &&
+                          observation.usagePricingTierId
+                        ? {
+                            type: "model",
+                            href: `/project/${projectId}/settings/models/${observation.internalModelId}?pricingTier=${observation.usagePricingTierId}`,
+                          }
+                        : undefined
                 }
               />
               {subtreeMetrics ? (

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -5,22 +5,34 @@
 
 import { type ObservationType, isGenerationLike } from "@langfuse/shared";
 import { Badge } from "@/src/components/ui/badge";
-import { BreakdownTooltip } from "@/src/features/traces/components/BreakdownTooltip";
+import {
+  BreakdownTooltip,
+  type BreakdownTooltipCostSource,
+} from "@/src/features/traces/components/BreakdownTooltip";
 import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
 import { InfoIcon } from "lucide-react";
 
 export function CostBadge({
   totalCost,
   costDetails,
+  pricingTierName,
+  costSource,
 }: {
   totalCost: number | null;
   costDetails: Record<string, number> | undefined;
+  pricingTierName?: string;
+  costSource?: BreakdownTooltipCostSource;
 }) {
   // Don't show if no cost data or cost is 0
   if (totalCost == null || totalCost === 0 || !costDetails) return null;
 
   return (
-    <BreakdownTooltip details={costDetails} isCost={true}>
+    <BreakdownTooltip
+      details={costDetails}
+      isCost
+      pricingTierName={pricingTierName}
+      costSource={costSource}
+    >
       <Badge variant="tertiary" className="flex items-center gap-1">
         <span>{usdFormatter(totalCost)}</span>
         <InfoIcon className="h-3 w-3" />


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15947.preview.langfuse.com](https://pr-15947.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- identify whether observation costs were provided by the application or calculated from Langfuse model pricing
- link Langfuse-calculated costs to the exact matched model and pricing tier
- keep aggregate trace/root breakdowns source-neutral when multiple observations may contribute
- add isolated Storybook states and interaction coverage for the shared breakdown tooltip

Linear: [LFE-14930](https://linear.app/clickhouse/issue/LFE-14930/show-cost-source-and-matched-model-pricing-in-cost-breakdown)

## Impacted package

- web

## Verification

- pnpm --filter web run test-storybook src/features/traces/components/BreakdownTooltip.stories.tsx — Tests 6 passed (6)
- pnpm --filter web run lint — completed with no warnings
- pnpm exec dotenv -e ../.env -- tsc -p tsconfig.json --noEmit --skipLibCheck --incremental false (from web/) — completed with no errors
- pre-commit Prettier check — All matched files use Prettier code style!
- git diff --check — clean

The configured Playwright MCP was not exposed in this session. The focused Storybook suite ran in real Chromium and opened both model-priced and application-provided tooltip states.

## Analytics

No PostHog event added: following the model-pricing link is ordinary navigation/autocapture-grade and does not answer a distinct actionable product question.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds cost-source attribution to observation cost breakdowns, linking Langfuse-calculated costs to the matched model pricing tier while keeping aggregate breakdowns source-neutral.

- Extends observation and event table rows with provided-cost and pricing-tier metadata.
- Shows application-provided or Langfuse model-pricing sources in shared cost tooltips.
- Adds Storybook states and interaction checks for source presentation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable issues identified.

The new source classification follows the ingestion cost-source invariant, aggregate views omit ambiguous attribution, and model-pricing links match the existing model settings route and pricing-tier query contract.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tracing): show cost source in break..."](https://github.com/langfuse/langfuse/commit/9ac57c7c399466a65ff8b53a331ae15c38590e63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51825172)</sub>

<!-- /greptile_comment -->