### PR TITLE
fix(mcp): Bring back rate limits for in-app agent

### DIFF
--- a/packages/shared/src/server/auth/apiKeys.ts
+++ b/packages/shared/src/server/auth/apiKeys.ts
@@ -45,7 +45,6 @@ export async function createAndAddApiKeysToDb(p: {
   entityId: string;
   scope: ApiKeyScope;
   note?: string;
-  // Internal-only API keys may set this because they bypass Public API rate limits.
   isInAppAgentKey?: boolean;
   /** User who created the key, e.g. via the UI. */
   createdByUserId?: string;

--- a/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
@@ -3,26 +3,9 @@ import {
   createInAppAgentMcpRunOverride,
   InAppAgentMcpRunOverrideSchema,
 } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
-import {
-  applyMcpPublicApiRateLimit,
-  getInAppAgentContext,
-} from "@/src/pages/api/public/mcp";
-import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
-import type { ApiAccessScope } from "@langfuse/shared/src/server";
+import { getInAppAgentContext } from "@/src/pages/api/public/mcp";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-
-const createApiAccessScope = (isInAppAgentKey: boolean): ApiAccessScope => ({
-  projectId: "project-id",
-  orgId: "org-id",
-  apiKeyId: "api-key-id",
-  publicKey: "pk-lf-test",
-  accessLevel: "project",
-  plan: "oss",
-  rateLimitOverrides: [],
-  isIngestionSuspended: false,
-  isInAppAgentKey,
-});
 
 describe("MCP route in-app-agent context", () => {
   const createRequest = (overrideHeader?: string) => {
@@ -79,53 +62,5 @@ describe("MCP route in-app-agent context", () => {
       permissions: "single-tool-override",
       allowedToolName: "upsertDataset",
     });
-  });
-});
-
-describe("MCP route public API rate limiting", () => {
-  const rateLimitRequest = vi.fn();
-
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    rateLimitRequest.mockReset();
-    vi.spyOn(RateLimitService, "getInstance").mockReturnValue({
-      rateLimitRequest,
-    } as unknown as RateLimitService);
-  });
-
-  it("exempts authenticated in-app-agent keys", async () => {
-    const { res } = createMocks<NextApiRequest, NextApiResponse>();
-
-    const responseSent = await applyMcpPublicApiRateLimit(
-      createApiAccessScope(true),
-      res,
-    );
-
-    expect(responseSent).toBe(false);
-    expect(rateLimitRequest).not.toHaveBeenCalled();
-  });
-
-  it("rate limits normal keys based only on authenticated scope", async () => {
-    const { res } = createMocks<NextApiRequest, NextApiResponse>();
-    const sendRestResponseIfLimited = vi.fn((response: NextApiResponse) =>
-      response.status(429).end(),
-    );
-    rateLimitRequest.mockResolvedValue({
-      isRateLimited: () => true,
-      sendRestResponseIfLimited,
-    });
-
-    const responseSent = await applyMcpPublicApiRateLimit(
-      createApiAccessScope(false),
-      res,
-    );
-
-    expect(responseSent).toBe(true);
-    expect(rateLimitRequest).toHaveBeenCalledWith(
-      createApiAccessScope(false),
-      "public-api",
-    );
-    expect(sendRestResponseIfLimited).toHaveBeenCalledWith(res);
-    expect(res.statusCode).toBe(429);
   });
 });

--- a/web/src/features/in-app-agent/README.md
+++ b/web/src/features/in-app-agent/README.md
@@ -216,8 +216,6 @@ The supported worker path uses two run-scoped inputs when calling Langfuse MCP:
 
 The API key authenticates the request and scopes it to the project. Without an override, in-app-agent keys are restricted to MCP tools annotated with `readOnlyHint: true`. When the user approves a single Langfuse MCP tool call, the worker continuation creates a JSON override naming that one unprefixed MCP registry tool and passes it to the MCP route through the request header above. The retained POST adapter creates equivalent inputs inside `server/handler.ts`.
 
-Foreground and background runs use the same HTTP MCP route because the background runtime executes in `worker` while the MCP registry and its domain handlers are owned by `web`. Requests authenticated with a temporary in-app-agent key are exempt from the route's customer-facing `public-api` rate-limit bucket; the assistant's run and concurrency limits are enforced before the MCP client starts. The exemption trusts only the authenticated API-key classification, never the user-agent or override header. Direct in-process execution is deferred because it would require moving the web-owned MCP handler dependencies into code shared with the worker.
-
 MCP registry behavior:
 
 - Normal project API keys can call all enabled MCP tools.

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -33,13 +33,7 @@ import {
 } from "@/src/features/mcp/server/security";
 import { formatErrorForUser } from "@/src/features/mcp/core/error-formatting";
 import { type ServerContext } from "@/src/features/mcp/types";
-import {
-  addTagsToCurrentSpan,
-  addUserToSpan,
-  logger,
-  redis,
-  type ApiAccessScope,
-} from "@langfuse/shared/src/server";
+import { addUserToSpan, logger, redis } from "@langfuse/shared/src/server";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import { prisma } from "@langfuse/shared/src/db";
@@ -126,8 +120,15 @@ export default async function handler(
       );
     }
 
-    if (await applyMcpPublicApiRateLimit(authCheck.scope, res)) {
-      return;
+    // Rate limit MCP requests
+    const rateLimitCheck =
+      await RateLimitService.getInstance().rateLimitRequest(
+        authCheck.scope,
+        "public-api",
+      );
+
+    if (rateLimitCheck?.isRateLimited()) {
+      return rateLimitCheck.sendRestResponseIfLimited(res);
     }
 
     // Build ServerContext from authenticated scope. In-app-agent keys need a
@@ -187,34 +188,6 @@ export default async function handler(
       });
     }
   }
-}
-
-export async function applyMcpPublicApiRateLimit(
-  scope: ApiAccessScope,
-  res: NextApiResponse,
-): Promise<boolean> {
-  const isInAppAgent = scope.isInAppAgentKey === true;
-
-  addTagsToCurrentSpan({
-    "mcp.is_in_app_agent": isInAppAgent,
-  });
-
-  // Assistant runs have separate limits; trust only the authenticated key flag for this exemption.
-  if (isInAppAgent) {
-    return false;
-  }
-
-  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
-    scope,
-    "public-api",
-  );
-
-  if (!rateLimitCheck?.isRateLimited()) {
-    return false;
-  }
-
-  rateLimitCheck.sendRestResponseIfLimited(res);
-  return true;
 }
 
 export function getInAppAgentContext(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15948.preview.langfuse.com](https://pr-15948.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Reverts langfuse/langfuse#15880

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Reverts the special public API rate-limit exemption for authenticated in-app-agent MCP requests.

- Routes all MCP requests through the existing `public-api` rate-limit bucket.
- Removes the exemption helper, its unit tests, related tracing, and documentation.
- Retains the existing in-app-agent authentication and tool-access behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it consistently restores the prior MCP rate-limiting behavior and no unacknowledged actionable defect remains.

The implementation, tests, comments, and documentation consistently remove the authenticated in-app-agent exemption while preserving existing MCP authentication and request handling.
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(mcp): exempt in-app agent fr..."](https://github.com/langfuse/langfuse/commit/ed86fd5e78a6377106476d3715c22bb4dfd3a41e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51830909)</sub>

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->