### PR TITLE
fix(ingestion): add events_only rejection guidance

### DIFF
--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -151,16 +151,30 @@ export default async function handler(
         // writes would land in the legacy ClickHouse tables this deployment no
         // longer reads. Scores and SDK logs are unaffected and pass through.
         // Reject per-event so a mixed batch still processes its score events.
+        const isEventsOnlyMode =
+          env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only";
         const { batchForProcessing, rejectedErrors } = filterBatchForEventsOnly(
           parsedSchema.data.batch,
-          env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only",
+          isEventsOnlyMode,
         );
 
+        const attribution = createIngestionAttribution({
+          headers: req.headers,
+          authCheck,
+        });
+
+        if (isEventsOnlyMode && rejectedErrors.length > 0) {
+          logger.warn(
+            `Rejected ${rejectedErrors.length} event(s) from the legacy /api/public/ingestion endpoint for project ${projectId} because this Langfuse v4 deployment runs in events_only mode. These events were not stored. ${EVENTS_ONLY_INGESTION_REMEDIATION}`,
+            {
+              sdkName: attribution.ingestionSdkName,
+              sdkVersion: attribution.ingestionSdkVersion,
+            },
+          );
+        }
+
         const result = await processEventBatch(batchForProcessing, authCheck, {
-          attribution: createIngestionAttribution({
-            headers: req.headers,
-            authCheck,
-          }),
+          attribution,
         });
         if (rejectedErrors.length > 0) {
           result.errors = [...result.errors, ...rejectedErrors];
@@ -236,6 +250,15 @@ const EVENTS_ONLY_ALLOWED_TYPES = new Set<string>([
   eventTypes.SDK_LOG,
 ]);
 
+const EVENTS_ONLY_INGESTION_DOCS_URL =
+  "https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4";
+
+const EVENTS_ONLY_INGESTION_REMEDIATION = [
+  "Upgrade the client or integration to a v4-compatible SDK or OTLP ingestion path.",
+  "As a temporary migration bridge, set LANGFUSE_MIGRATION_V4_WRITE_MODE=dual on both the web and worker services and redeploy.",
+  `Docs: ${EVENTS_ONLY_INGESTION_DOCS_URL}`,
+].join(" ");
+
 function filterBatchForEventsOnly(
   batch: unknown[],
   isEventsOnlyMode: boolean,
@@ -277,7 +300,7 @@ function filterBatchForEventsOnly(
         id,
         status: 400,
         message: "Event type not accepted",
-        error: `Event type "${type ?? "unknown"}" is not accepted by /api/public/ingestion when LANGFUSE_MIGRATION_V4_WRITE_MODE is events_only. This endpoint only accepts score and log events.`,
+        error: `Event type "${type ?? "unknown"}" is not accepted by /api/public/ingestion when LANGFUSE_MIGRATION_V4_WRITE_MODE is events_only. This endpoint only accepts score and log events. ${EVENTS_ONLY_INGESTION_REMEDIATION}`,
       });
     }
   }


### PR DESCRIPTION
## Summary

- Add one actionable server warning when legacy ingestion events are rejected in `events_only` mode.
- Include project and SDK attribution in the warning.
- Extend the per-event API error with v4-compatible SDK/OTLP guidance, the temporary `dual` migration setting, and the upgrade docs link.
- Keep the warning explicitly scoped to `events_only` rejections.

## Root cause

In v4 `events_only` mode, legacy trace and observation events are rejected because the deployment no longer reads the legacy tables. The existing response identified the mode but did not tell self-hosted users how to recover.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds actionable diagnostics when the legacy ingestion endpoint rejects events in `events_only` mode.
- Emits one project- and SDK-attributed warning per affected request.
- Expands per-event errors with supported migration paths, temporary `dual`-mode guidance, and the v3-to-v4 upgrade documentation link.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new warning and remediation text remain scoped to events already rejected in events_only mode.

The change preserves filtering and processing behavior while adding operational attribution and recovery guidance, with no concrete blocking or independently actionable non-blocking defect identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): add events\_only rejectio..."](https://github.com/langfuse/langfuse/commit/443251719a42074f565bc45acc92192ef300e1ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51863276)</sub>

**Context used:**

- Knowledge Base — [Ingestion Pipeline: SDK/OTel Event to ClickHouse](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/ingestion-pipeline.md)
- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->