### PR TITLE
feat(worker): add posthog and mixpanel integrations to core data S3 export

### DIFF
--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -388,6 +388,50 @@ const coreDataTableExports: Array<
   (args) =>
     uploadTableCoreDataJsonl({
       ...args,
+      tableName: "posthogIntegrations",
+      // encryptedPosthogApiKey is excluded as it holds the project's API key
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ projectId: string }>) =>
+        prisma.posthogIntegration.findMany({
+          take,
+          ...(lastRow
+            ? { cursor: { projectId: lastRow.projectId }, skip: 1 }
+            : {}),
+          orderBy: { projectId: "asc" },
+          select: {
+            projectId: true,
+            posthogHostName: true,
+            lastSyncAt: true,
+            enabled: true,
+            exportSource: true,
+            createdAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "mixpanelIntegrations",
+      // encryptedMixpanelProjectToken is excluded as it holds the project token
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ projectId: string }>) =>
+        prisma.mixpanelIntegration.findMany({
+          take,
+          ...(lastRow
+            ? { cursor: { projectId: lastRow.projectId }, skip: 1 }
+            : {}),
+          orderBy: { projectId: "asc" },
+          select: {
+            projectId: true,
+            mixpanelRegion: true,
+            lastSyncAt: true,
+            enabled: true,
+            exportSource: true,
+            createdAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
       tableName: "ssoConfigs",
       // authConfig is excluded as it may contain client secrets
       fetchPage: ({ lastRow, take }: TablePageArgs<{ domain: string }>) =>


### PR DESCRIPTION
## Problem

The daily core data S3 export already ships `blobStorageIntegrations`, but the two other analytics integrations — PostHog and Mixpanel — are missing. The DWH therefore has no view of which projects have those integrations configured, whether they are enabled, which export source they use, or when they last synced.

## Changes

Adds two entries to `coreDataTableExports` in [coreDataS3ExportQueue.ts](worker/src/queues/coreDataS3ExportQueue.ts), placed next to `blobStorageIntegrations`:

- `posthogIntegrations.jsonl` — `projectId`, `posthogHostName`, `lastSyncAt`, `enabled`, `exportSource`, `createdAt`
- `mixpanelIntegrations.jsonl` — `projectId`, `mixpanelRegion`, `lastSyncAt`, `enabled`, `exportSource`, `createdAt`

Both use keyset pagination on the `projectId` primary key, matching the existing `blobStorageIntegrations` entry.

## Credential handling

Each `select` is explicit and omits the encrypted secret column — `encryptedPosthogApiKey` and `encryptedMixpanelProjectToken` respectively. This follows the precedent already set in this file: `blobStorageIntegrations` excludes `accessKeyId`/`secretAccessKey`, and `ssoConfigs` excludes `authConfig`. Every other column of both models is exported; neither model has an `updatedAt` column, so the exports carry `createdAt` only.

## Notes

- Table names are new, so this is purely additive for downstream DWH consumers — no existing object names change.
- `CORE_DATA_EXPORT_TABLE_CONCURRENCY` stays at 3, so the two extra tables do not raise peak Postgres connection usage for the job.
- No test changes: the existing suite covers the streaming/pagination helper and the two `mapRow` functions, and this change adds no new `mapRow`. The prior table-addition PR (#14313, blob storage) was likewise code-only.

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter worker run typecheck` — clean
- `pnpm --filter worker run test src/queues/__tests__/coreDataS3ExportQueue.test.ts` — `Tests 9 passed (9)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds PostHog and Mixpanel integration metadata to the daily internal core-data S3 export while excluding encrypted credentials.

- Registers `posthogIntegrations.jsonl` with project, host, synchronization, enablement, source, and creation metadata.
- Registers `mixpanelIntegrations.jsonl` with project, region, synchronization, enablement, source, and creation metadata.
- Uses stable `projectId` cursor pagination consistent with the existing integration export.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the added integration exports.

Both integration models have unique `projectId` cursors, the selected fields match their Prisma schemas, standard field types use an established serialization path, and encrypted credentials remain excluded.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): add posthog and mixpanel i..."](https://github.com/langfuse/langfuse/commit/13d433e461872a0561e0172276d65df65a3953eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51923224)</sub>

**Context used:**

- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)
- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->