### PR TITLE
feat(analytics): track authenticated backend activity

### DIFF
--- a/web/src/__tests__/server/backend-activity-middleware.servertest.ts
+++ b/web/src/__tests__/server/backend-activity-middleware.servertest.ts
@@ -1,0 +1,116 @@
+import type { Session } from "next-auth";
+import * as z from "zod";
+
+const { recordBackendActivityMock } = vi.hoisted(() => ({
+  recordBackendActivityMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/src/features/posthog-analytics/server/backendActivity", () => ({
+  recordBackendActivity: recordBackendActivityMock,
+}));
+
+import {
+  createInnerTRPCContext,
+  createTRPCRouter,
+  protectedOrganizationProcedure,
+  protectedProjectProcedureWithoutTracing,
+} from "@/src/server/api/trpc";
+
+const activityRouter = createTRPCRouter({
+  project: protectedProjectProcedureWithoutTracing
+    .input(z.object({ projectId: z.string() }))
+    .query(() => ({ ok: true })),
+  organization: protectedOrganizationProcedure
+    .input(z.object({ orgId: z.string() }))
+    .query(() => ({ ok: true })),
+});
+
+const session = {
+  expires: "1",
+  user: {
+    id: "user-1",
+    email: "user@example.com",
+    name: "Example User",
+    admin: false,
+    canCreateOrganizations: true,
+    featureFlags: {},
+    organizations: [
+      {
+        id: "org-1",
+        name: "Example Organization",
+        role: "MEMBER",
+        plan: "cloud:hobby",
+        cloudConfig: undefined,
+        metadata: {},
+        projects: [
+          {
+            id: "project-1",
+            name: "Example Project",
+            role: "MEMBER",
+            retentionDays: 30,
+            deletedAt: null,
+          },
+        ],
+      },
+    ],
+  },
+  environment: {},
+} as Session;
+
+const createCaller = (callerSession: Session | null = session) =>
+  activityRouter.createCaller(
+    createInnerTRPCContext({ session: callerSession, headers: {} }),
+  );
+
+describe("backend activity authorization middleware", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("records server-derived user, organization, and project ids after project authorization", async () => {
+    await expect(
+      createCaller().project({ projectId: "project-1" }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(recordBackendActivityMock).toHaveBeenCalledOnce();
+    expect(recordBackendActivityMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+  });
+
+  it("records organization activity after organization authorization", async () => {
+    await expect(
+      createCaller().organization({ orgId: "org-1" }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(recordBackendActivityMock).toHaveBeenCalledOnce();
+    expect(recordBackendActivityMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+  });
+
+  it("does not wait for analytics before continuing the API request", async () => {
+    recordBackendActivityMock.mockReturnValueOnce(new Promise(() => {}));
+
+    await expect(
+      createCaller().project({ projectId: "project-1" }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("does not record activity for a project outside the user's session", async () => {
+    await expect(
+      createCaller().project({ projectId: "project-other" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+
+    expect(recordBackendActivityMock).not.toHaveBeenCalled();
+  });
+
+  it("does not record activity for an unauthenticated request", async () => {
+    await expect(
+      createCaller(null).project({ projectId: "project-1" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+
+    expect(recordBackendActivityMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/server/unit/backendActivity.servertest.ts
+++ b/web/src/__tests__/server/unit/backendActivity.servertest.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: { debug: vi.fn(), warn: vi.fn() },
+  redis: null,
+  ClickHouseClientManager: {
+    getInstance: () => ({ closeAllConnections: vi.fn() }),
+  },
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: { NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: "US" },
+}));
+
+vi.mock("@/src/features/posthog-analytics/ServerPosthog", () => ({
+  ServerPosthog: class {
+    capture() {}
+  },
+}));
+
+import { createBackendActivityTracker } from "@/src/features/posthog-analytics/server/backendActivity";
+
+const createTracker = (
+  options: {
+    cloudRegion?: string;
+    now?: Date;
+    wasFirstActivity?: boolean;
+  } = {},
+) => {
+  const cloudRegion = Object.hasOwn(options, "cloudRegion")
+    ? options.cloudRegion
+    : "US";
+  const now = options.now ?? new Date("2026-08-10T12:00:00.000Z");
+  const wasFirstActivity = options.wasFirstActivity ?? true;
+  const capture = vi.fn();
+  const setIfAbsent = vi.fn().mockResolvedValue(wasFirstActivity);
+  const tracker = createBackendActivityTracker({
+    capture,
+    cloudRegion,
+    now: () => now,
+    setIfAbsent,
+  });
+
+  return { capture, setIfAbsent, tracker };
+};
+
+describe("backend activity tracking", () => {
+  it("captures a project-scoped activity event once per UTC day", async () => {
+    const { capture, setIfAbsent, tracker } = createTracker();
+
+    await tracker({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+    await tracker({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+
+    expect(setIfAbsent).toHaveBeenCalledOnce();
+    expect(setIfAbsent).toHaveBeenCalledWith(
+      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
+      172_800,
+    );
+    expect(capture).toHaveBeenCalledOnce();
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: "user-1",
+      event: "backend:activity",
+      properties: {
+        activityScope: "project",
+        cloudRegion: "US",
+        organizationId: "org-1",
+        projectId: "project-1",
+      },
+      timestamp: new Date("2026-08-10T12:00:00.000Z"),
+      disableGeoip: true,
+    });
+  });
+
+  it("tracks organization activity separately from project activity", async () => {
+    const { capture, setIfAbsent, tracker } = createTracker();
+
+    await tracker({ userId: "user-1", organizationId: "org-1" });
+    await tracker({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+
+    expect(setIfAbsent).toHaveBeenCalledTimes(2);
+    expect(capture).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        properties: {
+          activityScope: "organization",
+          cloudRegion: "US",
+          organizationId: "org-1",
+        },
+      }),
+    );
+    expect(capture).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        properties: {
+          activityScope: "project",
+          cloudRegion: "US",
+          organizationId: "org-1",
+          projectId: "project-1",
+        },
+      }),
+    );
+  });
+
+  it("captures the same project again on the next UTC day", async () => {
+    let now = new Date("2026-08-10T23:59:59.000Z");
+    const capture = vi.fn();
+    const setIfAbsent = vi.fn().mockResolvedValue(true);
+    const tracker = createBackendActivityTracker({
+      capture,
+      cloudRegion: "US",
+      now: () => now,
+      setIfAbsent,
+    });
+
+    await tracker({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+    now = new Date("2026-08-11T00:00:01.000Z");
+    await tracker({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+
+    expect(setIfAbsent).toHaveBeenCalledTimes(2);
+    expect(setIfAbsent).toHaveBeenNthCalledWith(
+      1,
+      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
+      172_800,
+    );
+    expect(setIfAbsent).toHaveBeenNthCalledWith(
+      2,
+      "langfuse:backend-activity:2026-08-11:user-1:project:project-1",
+      172_800,
+    );
+    expect(capture).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not capture when another server already recorded the activity", async () => {
+    const { capture, setIfAbsent, tracker } = createTracker({
+      wasFirstActivity: false,
+    });
+
+    await tracker({ userId: "user-1", organizationId: "org-1" });
+    await tracker({ userId: "user-1", organizationId: "org-1" });
+
+    expect(setIfAbsent).toHaveBeenCalledOnce();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("does not track outside Langfuse Cloud", async () => {
+    const { capture, setIfAbsent, tracker } = createTracker({
+      cloudRegion: undefined,
+    });
+
+    await tracker({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+
+    expect(setIfAbsent).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("keeps tracking failures off the authenticated API path", async () => {
+    const capture = vi.fn();
+    const tracker = createBackendActivityTracker({
+      capture,
+      cloudRegion: "US",
+      now: () => new Date("2026-08-10T12:00:00.000Z"),
+      setIfAbsent: vi.fn().mockRejectedValue(new Error("Redis unavailable")),
+    });
+
+    await expect(
+      tracker({ userId: "user-1", organizationId: "org-1" }),
+    ).resolves.toBeUndefined();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("keeps PostHog capture failures off the authenticated API path", async () => {
+    const tracker = createBackendActivityTracker({
+      capture: vi.fn(() => {
+        throw new Error("PostHog unavailable");
+      }),
+      cloudRegion: "US",
+      now: () => new Date("2026-08-10T12:00:00.000Z"),
+      setIfAbsent: vi.fn().mockResolvedValue(true),
+    });
+
+    await expect(
+      tracker({ userId: "user-1", organizationId: "org-1" }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/web/src/features/posthog-analytics/server/backendActivity.ts
+++ b/web/src/features/posthog-analytics/server/backendActivity.ts
@@ -1,0 +1,107 @@
+import { logger, redis } from "@langfuse/shared/src/server";
+
+import { env } from "@/src/env.mjs";
+import { ServerPosthog } from "@/src/features/posthog-analytics/ServerPosthog";
+
+const BACKEND_ACTIVITY_EVENT = "backend:activity";
+const DEDUPLICATION_TTL_SECONDS = 2 * 24 * 60 * 60;
+const LOCAL_CACHE_MAX_ENTRIES = 100_000;
+
+type BackendActivity = {
+  userId: string;
+  organizationId: string;
+  projectId?: string;
+};
+
+type BackendActivityTrackerDependencies = {
+  capture: ServerPosthog["capture"];
+  cloudRegion?: string;
+  now: () => Date;
+  setIfAbsent: (key: string, ttlSeconds: number) => Promise<boolean>;
+};
+
+export const createBackendActivityTracker = ({
+  capture,
+  cloudRegion,
+  now,
+  setIfAbsent,
+}: BackendActivityTrackerDependencies) => {
+  const localCache = new Set<string>();
+
+  const cacheLocally = (key: string) => {
+    if (localCache.size >= LOCAL_CACHE_MAX_ENTRIES) {
+      const oldestKey = localCache.values().next().value;
+      if (oldestKey) localCache.delete(oldestKey);
+    }
+    localCache.add(key);
+  };
+
+  return async ({
+    userId,
+    organizationId,
+    projectId,
+  }: BackendActivity): Promise<void> => {
+    if (!cloudRegion) return;
+
+    const timestamp = now();
+    const activityScope = projectId ? "project" : "organization";
+    const scopeId = projectId ?? organizationId;
+    const utcDate = timestamp.toISOString().slice(0, 10);
+    const deduplicationKey = [
+      "langfuse",
+      "backend-activity",
+      utcDate,
+      userId,
+      activityScope,
+      scopeId,
+    ].join(":");
+
+    if (localCache.has(deduplicationKey)) return;
+    // Mark the attempt before the first await so concurrent requests and Redis
+    // outages cannot create an analytics retry storm in this web process.
+    cacheLocally(deduplicationKey);
+
+    try {
+      const isFirstActivity = await setIfAbsent(
+        deduplicationKey,
+        DEDUPLICATION_TTL_SECONDS,
+      );
+
+      if (!isFirstActivity) return;
+
+      capture({
+        distinctId: userId,
+        event: BACKEND_ACTIVITY_EVENT,
+        properties: {
+          activityScope,
+          cloudRegion,
+          organizationId,
+          ...(projectId ? { projectId } : {}),
+        },
+        timestamp,
+        disableGeoip: true,
+      });
+    } catch (error) {
+      // Product analytics must never make an authenticated API request fail.
+      logger.warn("Failed to record backend activity", { error });
+    }
+  };
+};
+
+let serverPosthog: ServerPosthog | undefined;
+
+export const recordBackendActivity = createBackendActivityTracker({
+  capture: (event) => {
+    serverPosthog ??= new ServerPosthog();
+    serverPosthog.capture(event);
+  },
+  cloudRegion:
+    env.NODE_ENV === "production"
+      ? env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+      : undefined,
+  now: () => new Date(),
+  setIfAbsent: async (key, ttlSeconds) => {
+    if (!redis) return false;
+    return (await redis.set(key, "1", "EX", ttlSeconds, "NX")) === "OK";
+  },
+});

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -95,6 +95,7 @@ import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApi
 import { env } from "@/src/env.mjs";
 import { isBaseError, parseIO } from "@langfuse/shared";
 import { type Flag } from "@/src/features/feature-flags/types";
+import { recordBackendActivity } from "@/src/features/posthog-analytics/server/backendActivity";
 
 setUpSuperjson();
 
@@ -281,6 +282,14 @@ const inputProjectSchema = z.object({
   projectId: z.string(),
 });
 
+const scheduleBackendActivity = (
+  activity: Parameters<typeof recordBackendActivity>[0],
+) => {
+  recordBackendActivity(activity).catch((error) => {
+    logger.warn("Failed to schedule backend activity", { error });
+  });
+};
+
 /**
  * Protected (authenticated) procedure with project role
  */
@@ -331,6 +340,11 @@ const enforceUserIsAuthedAndProjectMember = t.middleware(async (opts) => {
         projectId,
         orgId: dbProject.orgId,
       });
+      scheduleBackendActivity({
+        userId: ctx.session.user.id,
+        organizationId: dbProject.orgId,
+        projectId,
+      });
       return next({
         ctx: {
           // infers the `session` as non-nullable
@@ -360,6 +374,12 @@ const enforceUserIsAuthedAndProjectMember = t.middleware(async (opts) => {
       orgId: sessionProject.organization.id,
     });
   }
+
+  scheduleBackendActivity({
+    userId: ctx.session.user.id,
+    organizationId: sessionProject.organization.id,
+    projectId,
+  });
 
   return next({
     ctx: {
@@ -455,6 +475,11 @@ const enforceIsAuthedAndOrgMember = t.middleware(async (opts) => {
       orgId,
     });
   }
+
+  scheduleBackendActivity({
+    userId: ctx.session.user.id,
+    organizationId: orgId,
+  });
 
   return next({
     ctx: {

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -282,11 +282,11 @@ const inputProjectSchema = z.object({
   projectId: z.string(),
 });
 
-const scheduleBackendActivity = (
+const trackPosthogActivity = (
   activity: Parameters<typeof recordBackendActivity>[0],
 ) => {
   recordBackendActivity(activity).catch((error) => {
-    logger.warn("Failed to schedule backend activity", { error });
+    logger.warn("Failed to track PostHog activity", { error });
   });
 };
 
@@ -340,7 +340,7 @@ const enforceUserIsAuthedAndProjectMember = t.middleware(async (opts) => {
         projectId,
         orgId: dbProject.orgId,
       });
-      scheduleBackendActivity({
+      trackPosthogActivity({
         userId: ctx.session.user.id,
         organizationId: dbProject.orgId,
         projectId,
@@ -375,7 +375,7 @@ const enforceUserIsAuthedAndProjectMember = t.middleware(async (opts) => {
     });
   }
 
-  scheduleBackendActivity({
+  trackPosthogActivity({
     userId: ctx.session.user.id,
     organizationId: sessionProject.organization.id,
     projectId,
@@ -476,7 +476,7 @@ const enforceIsAuthedAndOrgMember = t.middleware(async (opts) => {
     });
   }
 
-  scheduleBackendActivity({
+  trackPosthogActivity({
     userId: ctx.session.user.id,
     organizationId: orgId,
   });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15963.preview.langfuse.com](https://pr-15963.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Closes LFF-17

## Summary

- record Cloud-only backend:activity events after project or organization authorization succeeds
- correlate the authenticated user with opaque organization/project IDs and UTC event time
- deduplicate to one event per user/scope/UTC day with Redis SET NX plus a bounded process cache
- keep analytics non-blocking and fail closed when Redis/PostHog is unavailable

## Tracking plan

Question: Which authenticated users were active in which organization/project on a given day?

Event: backend:activity

Properties: activityScope, cloudRegion, organizationId, optional projectId. The PostHog distinct ID is the authenticated user ID.

Trigger: successful project/organization authorization in the shared protected tRPC middleware.

## Privacy and cost

Payloads contain only opaque internal IDs and metadata; no names, emails, URLs, or customer content. GeoIP is disabled. This intentionally does not use PostHog Groups because Langfuse previously removed group analytics to control cost. The daily Redis dedupe bounds event volume. Self-hosted, development, and test environments do not emit.

## Verification

- pnpm --filter web run typecheck
- targeted Vitest: 3 files passed, 20 tests passed
- pnpm run lint: 7 successful, 7 total
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds Cloud-only analytics for authenticated project and organization activity, with daily Redis and process-local deduplication.

- Records opaque user and scope identifiers after authorization succeeds.
- Keeps analytics off the request-critical path and suppresses emission when dependencies are unavailable.
- Adds unit and middleware coverage for authorization, deduplication, Cloud gating, and failure handling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The activity hooks run only after scope authorization, derive identifiers from authorized server state, bound local memory usage, and isolate Redis and PostHog failures from authenticated requests.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as Authenticated user
  participant T as Protected tRPC middleware
  participant A as Activity tracker
  participant R as Redis
  participant P as PostHog
  U->>T: Project or organization request
  T->>T: Authorize scope membership
  T-->>A: Schedule user and scope activity
  T-->>U: Continue request
  A->>A: Check bounded local cache
  A->>R: SET daily key NX with TTL
  alt First activity for UTC day
    R-->>A: OK
    A-->>P: Capture backend:activity
  else Already recorded or unavailable
    R-->>A: Not set or error
    A-->>A: Suppress event
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): track authenticated bac..."](https://github.com/langfuse/langfuse/commit/a72d2ed3dd66c5c6a9aef5e72b8c11c9340adb6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51986776)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->