### PR TITLE
fix(batch-action): parse OTLP JSON-string metadata before dataset mapping

### DIFF
--- a/worker/src/__tests__/event-stream-dataset-metadata.unit.test.ts
+++ b/worker/src/__tests__/event-stream-dataset-metadata.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { parseMetadataCHRecordToDomain } from "../../../packages/shared/src/server/utils/metadata_conversion";
+import { getEventsStreamForDataset } from "../features/database-read-stream/event-stream";
 
 const chainableQueryBuilder = {
   selectFieldSet: vi.fn().mockReturnThis(),
@@ -29,8 +30,6 @@ vi.mock("@langfuse/shared/src/server", () => ({
   queryClickhouseStream: mocks.queryClickhouseStream,
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
-
-import { getEventsStreamForDataset } from "../features/database-read-stream/event-stream";
 
 describe("getEventsStreamForDataset metadata parsing", () => {
   it("parses JSON-string metadata values into objects/arrays, like the read API does", async () => {

--- a/worker/src/__tests__/event-stream-dataset-metadata.unit.test.ts
+++ b/worker/src/__tests__/event-stream-dataset-metadata.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseMetadataCHRecordToDomain } from "../../../packages/shared/src/server/utils/metadata_conversion";
+
+const chainableQueryBuilder = {
+  selectFieldSet: vi.fn().mockReturnThis(),
+  selectIO: vi.fn().mockReturnThis(),
+  buildWithParams: vi.fn(() => ({ query: "SELECT 1", params: {} })),
+};
+
+const mocks = vi.hoisted(() => ({
+  queryClickhouseStream: vi.fn(),
+}));
+
+vi.mock("../env", () => ({
+  env: { BATCH_EXPORT_ROW_LIMIT: 1_000_000 },
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {},
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  buildEventsStreamQuery: vi.fn(() => ({
+    queryBuilder: chainableQueryBuilder,
+  })),
+  buildEventsBlobExportStreamQuery: vi.fn(),
+  getDistinctScoreNames: vi.fn(),
+  parseMetadataCHRecordToDomain,
+  queryClickhouseStream: mocks.queryClickhouseStream,
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import { getEventsStreamForDataset } from "../features/database-read-stream/event-stream";
+
+describe("getEventsStreamForDataset metadata parsing", () => {
+  it("parses JSON-string metadata values into objects/arrays, like the read API does", async () => {
+    mocks.queryClickhouseStream.mockReturnValue(
+      (async function* () {
+        yield {
+          id: "obs-1",
+          trace_id: "trace-1",
+          input: null,
+          output: "some output text",
+          metadata: {
+            config: '{"name":"example"}',
+            events: '[{"kind":"a","text":"hello"},{"kind":"b"}]',
+            label: "plain-string",
+          },
+        };
+      })(),
+    );
+
+    const stream = await getEventsStreamForDataset({
+      projectId: "project-1",
+      cutoffCreatedAt: new Date(),
+      filter: [],
+      rowLimit: 100,
+    });
+
+    const rows: Array<{ metadata: unknown }> = [];
+    for await (const row of stream) {
+      rows.push(row as { metadata: unknown });
+    }
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.metadata).toEqual({
+      config: { name: "example" },
+      events: [{ kind: "a", text: "hello" }, { kind: "b" }],
+      label: "plain-string",
+    });
+  });
+});

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -16,6 +16,7 @@ import {
   buildEventsBlobExportStreamQuery,
   buildEventsStreamQuery,
   getDistinctScoreNames,
+  parseMetadataCHRecordToDomain,
   queryClickhouseStream,
   logger,
 } from "@langfuse/shared/src/server";
@@ -356,7 +357,11 @@ export const getEventsStreamForDataset = async (props: {
           traceId: row.trace_id,
           input: row.input,
           output: row.output,
-          metadata: row.metadata,
+          metadata: row.metadata
+            ? parseMetadataCHRecordToDomain(
+                row.metadata as Record<string, string>,
+              )
+            : row.metadata,
         };
       }
     })(),


### PR DESCRIPTION
## What does this PR do?

Fixes #15964: adding observations to a dataset via the batch action, using a
JSONPath that descends into a nested `metadata` value, resolves correctly in
the mapping Preview but misses when the background job runs — for
observations ingested through the OTLP endpoint.

OTel span attributes are scalars, so a sender JSON-encodes any nested
metadata value. The read API (`observations.byId`, used by the mapping
Preview) parses those values back into objects/arrays via
`parseMetadataCHRecordToDomain`. The worker's `getEventsStreamForDataset`
(used by `processAddObservationsToDataset`) streamed the ClickHouse
`Map(String, String)` metadata column through unparsed, so
`evaluateJsonPath` — which only auto-parses when the *entire* input is a
string, not when individual map values are — saw a string where it expected
an object and any JSONPath descending past the first segment missed.

### Fix

Apply the same `parseMetadataCHRecordToDomain` normalization already used by
the read path to the rows yielded by `getEventsStreamForDataset`, so the
Preview and the executor operate on the same value shapes.

`packages/shared/src/features/batchAction/applyFieldMapping.ts` (the shared
mapping/JSONPath logic) is untouched — the asymmetry was in the input shape,
not the mapping logic, matching the issue's root-cause analysis.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

Added `worker/src/__tests__/event-stream-dataset-metadata.unit.test.ts`,
which mocks the ClickHouse stream and asserts `getEventsStreamForDataset`
returns metadata with JSON-string values parsed into objects/arrays (mirrors
the issue's repro: `config`/`events` become nested structures, `label` stays
a plain string).

Confirmed the test fails without the fix (reverted the source change,
reran):

```
AssertionError: expected { config: '{"name":"example"}', …(2) } to deeply equal { config: { name: 'example' }, …(2) }
 FAIL  src/__tests__/event-stream-dataset-metadata.unit.test.ts > getEventsStreamForDataset metadata parsing > parses JSON-string metadata values into objects/arrays, like the read API does
```

With the fix restored:

```
✓ src/__tests__/event-stream-dataset-metadata.unit.test.ts (1 test) 7ms
✓ src/__tests__/applyFieldMapping.test.ts (51 tests) 28ms
Test Files  2 passed (2)
     Tests  52 passed (52)
```

`pnpm --filter worker run lint`:
```
Tasks: 8 successful, 8 total
```

`pnpm --filter worker run typecheck`: clean, no errors.

Note: this sandbox has no ClickHouse/Postgres/.env available, so the
existing DB-integration-style stream tests
(`event-stream-score-filters.test.ts`,
`handleBatchActionJob-comment-filters.unit.test.ts`) don't run here either
(same pre-existing failure on unmodified `main`, unrelated to this change) —
verified by stashing this fix and reproducing the identical `CLICKHOUSE_URL`
env error on the base commit.

## AI disclosure

This PR was authored with the assistance of an AI coding agent (Claude).

Fixes #15964

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns dataset batch-action metadata with the observation read path by parsing JSON-encoded ClickHouse metadata values before field mapping.
- Normalizes streamed observation metadata through the shared metadata converter.
- Adds a focused unit test covering nested objects, arrays, and unchanged plain strings.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge; the only identified issue is non-blocking import organization in the new test.

The production change reuses the established read-path metadata parser and the regression test covers the intended object, array, and plain-string behavior; only the test module's import placement needs cleanup.

**Files Needing Attention:** worker/src/__tests__/event-stream-dataset-metadata.unit.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/__tests__/event-stream-dataset-metadata.unit.test.ts:41
**Static import follows mock setup**

The `getEventsStreamForDataset` import is placed after module-level constants and mock declarations rather than with the imports at the top, making dependency organization inconsistent with the repository convention.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(batch-action): parse OTLP JSON-strin..."](https://github.com/langfuse/langfuse/commit/730386a6af85858a4ab3957345f3393b9730b790) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52038083)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)

<!-- /greptile_comment -->