### PR TITLE
fix(worker): bound Mixpanel import requests with a timeout

### DIFF
--- a/worker/src/__tests__/mixpanelExportVolume.test.ts
+++ b/worker/src/__tests__/mixpanelExportVolume.test.ts
@@ -12,7 +12,40 @@ describe("MixpanelClient export volume", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
 
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("aborts a hung sendBatch instead of leaving flush() pending indefinitely", async () => {
+    vi.useFakeTimers();
+
+    // Simulate an unresponsive Mixpanel endpoint: the request never settles
+    // on its own, only when the abort signal fires (mirrors real fetch).
+    fetchMock.mockImplementation(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => {
+            const abortError = new Error("The operation was aborted");
+            abortError.name = "AbortError";
+            reject(abortError);
+          });
+        }),
+    );
+
+    const client = new MixpanelClient({ projectToken: "t", region: "api" });
+    client.addEvent({
+      event: "trace",
+      properties: { token: "t", distinct_id: "1", $insert_id: 1 },
+    } as unknown as MixpanelEvent);
+
+    const flushPromise = client.flush();
+    const rejection = expect(flushPromise).rejects.toThrow(/timed out/i);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await rejection;
+  });
 
   it("accumulates gzipped on-wire bytes across sendBatch chunks", async () => {
     const client = new MixpanelClient({ projectToken: "t", region: "api" });

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -148,6 +148,9 @@ const EnvSchema = z.object({
   // Delay (ms) inserted after each Mixpanel flush to throttle analytics exports
   // and avoid overwhelming the target instance (see issue #12786).
   LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: z.coerce.number().min(0).default(100),
+  // Timeout (ms) for each Mixpanel import request, so an unresponsive endpoint
+  // cannot hold the integration job indefinitely (see issue #15958).
+  LANGFUSE_MIXPANEL_TIMEOUT_MS: z.coerce.number().positive().default(30000),
   // Delay (ms) after each PostHog flush. Together with 1,000-event flushes,
   // this bounds the export rate for fast-acknowledging target instances.
   LANGFUSE_POSTHOG_FLUSH_DELAY_MS: z.coerce.number().min(0).default(100),

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -1,5 +1,6 @@
 import { logger } from "@langfuse/shared/src/server";
 import { gzipSync } from "zlib";
+import { env } from "../../env";
 import type { MixpanelEvent } from "./transformers";
 
 type MixpanelClientConfig = {
@@ -73,6 +74,13 @@ export class MixpanelClient {
     // Create Basic Auth header (token as username, empty password)
     const authHeader = `Basic ${Buffer.from(`${this.config.projectToken}:`).toString("base64")}`;
 
+    // Bound the request so an unresponsive endpoint cannot hold the flush
+    // (and the worker job behind it) indefinitely.
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => {
+      abortController.abort();
+    }, env.LANGFUSE_MIXPANEL_TIMEOUT_MS);
+
     try {
       const response = await fetch(url, {
         method: "POST",
@@ -82,6 +90,7 @@ export class MixpanelClient {
           Authorization: authHeader,
         },
         body: compressedBody as unknown as BodyInit,
+        signal: abortController.signal,
       });
 
       if (!response.ok) {
@@ -129,8 +138,17 @@ export class MixpanelClient {
         result,
       });
     } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        const timeoutError = new Error(
+          `Mixpanel request timed out after ${env.LANGFUSE_MIXPANEL_TIMEOUT_MS}ms`,
+        );
+        logger.error("Error sending batch to Mixpanel", timeoutError);
+        throw timeoutError;
+      }
       logger.error("Error sending batch to Mixpanel", error);
       throw error;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

`MixpanelClient.sendBatch` issued a raw `fetch` with no `AbortSignal` or timeout, and `flush()` awaits each chunk serially. An unresponsive Mixpanel `import` endpoint could therefore hold the flush — and the worker integration job behind it — indefinitely.

This adds an `AbortController`-based timeout around the Mixpanel `fetch` call, mirroring the existing pattern used for webhook requests in `worker/src/queues/webhooks.ts`. A timed-out request now rejects with a clear `Mixpanel request timed out after <ms>ms` error instead of hanging, so BullMQ's existing retry/stall handling can take over. The timeout is configurable via a new `LANGFUSE_MIXPANEL_TIMEOUT_MS` env var (default 30s).

Fixes langfuse/langfuse#15958

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

* I have read the [contributing guide](<https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md>)
* My code follows the style guidelines of this project (`pnpm run format`)
* I have added tests that prove my fix is effective
* I have checked that new and existing unit tests pass locally with my changes

## Test plan

Added a regression test in `worker/src/__tests__/mixpanelExportVolume.test.ts` that simulates an unresponsive Mixpanel endpoint (a `fetch` mock that only settles when the abort signal fires) and asserts `flush()` rejects with a timeout error instead of hanging.

Confirmed the new test fails without the fix (`git checkout HEAD~1 -- worker/src/features/mixpanel/mixpanelClient.ts worker/src/env.ts` then rerunning) — it fails because `sendBatch` never passes an abort signal to `fetch`, so the mock's `init.signal` is `undefined` and the request never settles.

```
$ pnpm --filter worker run test mixpanelExportVolume.test.ts

 RUN  v4.1.10 .../worker

 ✓ src/__tests__/mixpanelExportVolume.test.ts (2 tests) 14ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Also ran the full Mixpanel suite and worker lint/typecheck:

```
$ pnpm --filter worker run test mixpanel

 ✓ src/__tests__/mixpanelTransformers.test.ts (54 tests) 30ms
 ✓ src/__tests__/mixpanelIntegrationProjectJob.test.ts (8 tests) 13ms
 ✓ src/__tests__/mixpanelExportVolume.test.ts (2 tests) 14ms

 Test Files  3 passed (3)
      Tests  64 passed (64)
```

```
$ pnpm run lint --filter worker
 Tasks:    4 successful, 4 total

$ pnpm run typecheck --filter worker
 Tasks:    4 successful, 4 total
```

## AI disclosure

This change was implemented by an autonomous AI coding agent (Claude), based on the reproduction steps and suggested fix pattern described in the issue. It was reviewed for correctness before submission.

<details><summary>Greptile Summary</summary>

This PR bounds Mixpanel import requests with a configurable AbortController timeout so unresponsive endpoints fail into the worker retry path rather than hanging indefinitely.

* Adds `LANGFUSE_MIXPANEL_TIMEOUT_MS`, defaulting to 30 seconds.
* Aborts timed-out Mixpanel requests and emits a clear timeout error.
* Adds regression coverage for a request that remains pending until aborted.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge, with the timeout correctly bounded, cleaned up, and covered by a regression test.

The changed request path supplies the abort signal, converts timer-triggered aborts into a clear failure for BullMQ retry handling, and clears the timer on every exit path without introducing a blocking failure.

</details>

Reviews (1): Last reviewed commit: ["fix(worker): bound Mixpanel import reque..."](<https://github.com/langfuse/langfuse/commit/444ec04fa09af7f5f4fc6edaa2b1b51af1199546>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=52040547>)

**Context used:**

* Knowledge Base — [Notifications, Automations, and Outbound Integrations](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md>)