### PR TITLE
fix(ingestion): sum all provided cost keys when deriving total cost

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1543,11 +1543,12 @@ export class IngestionService {
       const cost_details = { ...provided_cost_details };
       const finalTotalCost =
         (provided_cost_details ?? {})["total"] ??
-        // Use provided input and output cost if available, but only if no other cost points are provided
-        (providedCostKeys.every((key) => ["input", "output"].includes(key))
-          ? ((provided_cost_details ?? {})["input"] ?? 0) +
-            ((provided_cost_details ?? {})["output"] ?? 0)
-          : undefined);
+        // Provided costs are authoritative: sum every provided cost point
+        // when no explicit total is given, not just input/output.
+        providedCostKeys.reduce(
+          (sum, key) => sum + ((provided_cost_details ?? {})[key] ?? 0),
+          0,
+        );
 
       if (
         !Object.prototype.hasOwnProperty.call(cost_details, "total") &&

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -296,6 +296,20 @@ describe("Token Cost Calculation", () => {
           total_cost: 2,
         },
       },
+
+      // mixed key set beyond {input, output}, missing total (issue #15961)
+      {
+        userProvidedCosts: {
+          input: 1,
+          output: 2,
+          cache_read_input_tokens: 3,
+        },
+        expectedCost: {
+          input_cost: 1,
+          output_cost: 2,
+          total_cost: 6,
+        },
+      },
     ];
 
     for (const { userProvidedCosts, expectedCost } of data) {


### PR DESCRIPTION
## Summary

Fixes #15961: `total_cost` stayed `$0.00` when provided `cost_details` had a
key set beyond `{input, output}` (e.g. `cache_read_input_tokens`) and no
explicit `total` key, even when the model was correctly matched in the
pricing table.

`IngestionService.calculateUsageCosts` treats provided cost details as
authoritative, but only derived the total from:

1. an explicit `total` key, or
2. `input + output`, **only if the provided key set was exactly
   `{input, output}`**.

Any additional provided cost point (e.g. `cache_read_input_tokens`) made
`finalTotalCost` `undefined`, so `cost`/`total_cost` stayed `null` and the UI
rendered `$0.00` despite correct per-type costs being present. This mirrors
the existing behavior of the model-based cost path, which already sums *all*
calculated cost entries — the provided-cost path was the only one with this
gap (as previously noted in the issue and confirmed by @dosu's analysis
against `worker/src/services/IngestionService/index.ts`).

## Fix

Sum every provided numeric cost key (not just `input`/`output`) when no
explicit `total` is given, consistent with the "provided costs are
authoritative" contract and the model-based path's existing summing
behavior.

## Test plan

Extended the existing parametrized suite in
`worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts`
("should correctly calculate token costs when only some user provided costs
are given") with a case mirroring the issue: `{input: 1, output: 2,
cache_read_input_tokens: 3}` with no `total`, expecting `total_cost: 6`.

Confirmed the new case fails without the fix:
```
AssertionError: expected undefined to be 6 // Object.is equality
- Expected: 6
+ Received: undefined
 ❯ .../calculateTokenCost.unit.test.ts:330:40
```

And passes with the fix, with the full file green:
```
✓ src/services/IngestionService/tests/calculateTokenCost.unit.test.ts (30 tests) 490ms
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

- [x] `pnpm --filter worker run lint` — clean
- [x] `pnpm --filter worker run typecheck` — clean
- [x] `pnpm --filter worker run test calculateTokenCost.unit.test.ts` — 30/30 passed
- [x] `pnpm --filter worker run test IngestionService` — same 7 pre-existing
      failures reproduced on unmodified `main` (unrelated tokenizer/env
      issues in `IngestionService.integration.test.ts` involving
      `usage_details`/model matching, not `cost_details`/`total_cost`); no
      new failures introduced by this change.

## Disclosure

This PR was prepared with AI assistance (Claude Code), including the code
change, test, and verification steps described above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes ingestion cost derivation so provided cost details without an explicit total are summed across every supplied cost category.

- Replaces the input/output-only fallback with a reduction over all provided cost keys.
- Adds a regression case covering input, output, and cached-input token costs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The fallback now consistently sums all provided cost categories while preserving explicit totals, and the regression test covers the reported mixed-key case.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): sum all provided cost ke..."](https://github.com/langfuse/langfuse/commit/c39b53913e53d8d72745d969973673039058e2fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52041132)</sub>

<!-- /greptile_comment -->