### PR TITLE
test(otel): pin exclusive OpenInference usage buckets against explicit total

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -7969,6 +7969,105 @@ describe("OTel Resource Span Mapping", () => {
       expect(usageDetails.output_reasoning_tokens).toBe(25);
       expect(usageDetails["reasoning.output_tokens"]).toBeUndefined();
     });
+
+    it("should keep normalized OpenInference buckets summing to an explicit llm.token_count.total", async () => {
+      // completion (1746) is inclusive of reasoning (1680); total (3219) =
+      // prompt (1473) + completion. Normalized buckets must stay mutually
+      // exclusive so the non-total sum equals the explicit total (else
+      // ingestion fires the total-mismatch warning).
+      const traceId = "abcdef1234567890abcdef1234567898";
+
+      const openinferenceTotalSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "openinference.instrumentation.google_genai",
+              version: "0.1.0",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("1234567890abcde7", "hex"),
+                name: "openinference-reasoning-with-total",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "llm.token_count.prompt",
+                    value: {
+                      intValue: { low: 1473, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "llm.token_count.completion",
+                    value: {
+                      intValue: { low: 1746, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "llm.token_count.completion_details.reasoning",
+                    value: {
+                      intValue: { low: 1680, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "llm.token_count.total",
+                    value: {
+                      intValue: { low: 3219, high: 0, unsigned: false },
+                    },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        openinferenceTotalSpan,
+        new Set(),
+      );
+      const observationEvent = events.find(
+        (e) => e.type === "generation-create" || e.type === "span-create",
+      );
+
+      expect(observationEvent).toBeDefined();
+      const usageDetails = observationEvent?.body.usageDetails as Record<
+        string,
+        number
+      >;
+      expect(usageDetails.input).toBe(1473);
+      // output must be the non-reasoning remainder: 1746 - 1680 = 66
+      expect(usageDetails.output).toBe(66);
+      expect(usageDetails.output_reasoning_tokens).toBe(1680);
+      // The explicit total must be preserved as-is
+      expect(usageDetails.total).toBe(3219);
+      // The invariant checked by IngestionService.warnOnUsageTotalMismatch:
+      // non-total buckets must not sum to more than the provided total.
+      const nonTotalBucketSum = Object.entries(usageDetails)
+        .filter(([key]) => key !== "total")
+        .reduce((acc, [, value]) => acc + value, 0);
+      expect(nonTotalBucketSum).toBe(3219);
+      expect(usageDetails["completion_details.reasoning"]).toBeUndefined();
+    });
   });
 
   describe("Google ADK blob-derived cache usage", () => {

--- a/worker/src/__tests__/usageTotalMismatchWarning.unit.test.ts
+++ b/worker/src/__tests__/usageTotalMismatchWarning.unit.test.ts
@@ -1,0 +1,83 @@
+/**
+ * warnOnUsageTotalMismatch must stay silent for OTEL usage details that
+ * OtelIngestionProcessor normalized into mutually exclusive buckets (mapping
+ * pinned in web/src/__tests__/server/api/otel/otelMapping.servertest.ts) and
+ * still fire for the additive interpretation of the same payload.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { recordIncrementMock } = vi.hoisted(() => ({
+  recordIncrementMock: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...mod,
+    recordIncrement: recordIncrementMock,
+  };
+});
+
+import { logger } from "@langfuse/shared/src/server";
+import { IngestionService } from "../services/IngestionService";
+
+const MISMATCH_METRIC = "langfuse.ingestion.usage_details.total_mismatch";
+
+const createService = () =>
+  // warnOnUsageTotalMismatch touches none of the constructor dependencies.
+  new IngestionService(null as any, null as any, null as any, null as any);
+
+const callWarn = (usageDetails: Record<string, unknown>) =>
+  (createService() as any).warnOnUsageTotalMismatch(
+    usageDetails,
+    { id: "test-observation", project_id: "test-project" },
+    "events",
+  );
+
+describe("warnOnUsageTotalMismatch with OTEL-normalized usage details", () => {
+  beforeEach(() => {
+    recordIncrementMock.mockClear();
+    // Bypass the 60s warn-log rate limit so logger assertions are deterministic.
+    (IngestionService as any).lastUsageTotalMismatchLogAt = 0;
+  });
+
+  it("does not fire for exclusive buckets summing to the explicit total", () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    // OpenInference completion (1746) inclusive of reasoning (1680), after
+    // normalization: output holds the 66-token remainder.
+    callWarn({
+      input: 1473,
+      output: 66,
+      output_reasoning_tokens: 1680,
+      total: 3219,
+    });
+
+    expect(recordIncrementMock).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("fires for the additive interpretation of the same payload (control)", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+
+    // Reasoning treated as an extra bucket on top of the inclusive output:
+    // 1473 + 1746 + 1680 = 4899 > 3219.
+    callWarn({
+      input: 1473,
+      output: 1746,
+      output_reasoning_tokens: 1680,
+      total: 3219,
+    });
+
+    expect(recordIncrementMock).toHaveBeenCalledWith(MISMATCH_METRIC, 1, {
+      write_path: "events",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("exceeds provided total"),
+      expect.objectContaining({ providedTotal: 3219, bucketSum: 4899 }),
+    );
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds regression tests pinning the generic OpenInference OTel usage normalization (#15415) against a real-world payload that carries an explicit `llm.token_count.total`, and unit tests that the ingestion total-mismatch warning stays silent for the normalized buckets.

**Bug class being pinned.** A valid OpenInference span (seen from `openinference.instrumentation.google_genai`, but the `llm.token_count.*` mapping is scope-agnostic) reports:

| attribute | value |
| --- | --- |
| `llm.token_count.prompt` | 1473 |
| `llm.token_count.completion` | 1746 |
| `llm.token_count.completion_details.reasoning` | 1680 |
| `llm.token_count.total` | 3219 |

Per the OpenInference convention, `completion` is **inclusive** of the reasoning detail (`total = prompt + completion`). Before #15415, `extractGenericGenAiUsageDetails` (`packages/shared/src/server/otel/OtelIngestionProcessor.ts:2805`) passed `completion_details.reasoning` through as an additive bucket, so the non-total buckets summed to 1473 + 1746 + 1680 = 4899 > 3219 — double-counting reasoning tokens and firing `IngestionService.warnOnUsageTotalMismatch` (`worker/src/services/IngestionService/index.ts:1479`): metric `langfuse.ingestion.usage_details.total_mismatch` plus the "Sum of provided non-total usage_details buckets exceeds provided total" warning. Since #15415, the mapping normalizes to mutually exclusive buckets: `input: 1473`, `output: 66` (= 1746 − 1680), `output_reasoning_tokens: 1680`, with the explicit `total: 3219` preserved verbatim.

**Coverage added here** (#15415's tests did not exercise an explicit `llm.token_count.total` on the OpenInference path, nor the warning path):

- `web/src/__tests__/server/api/otel/otelMapping.servertest.ts`: the exact payload above maps to `{input: 1473, output: 66, output_reasoning_tokens: 1680, total: 3219}`, the raw `completion_details.reasoning` key is not passed through, and the non-total bucket sum equals the provided total — the invariant `warnOnUsageTotalMismatch` checks.
- `worker/src/__tests__/usageTotalMismatchWarning.unit.test.ts`: `warnOnUsageTotalMismatch` emits no metric and no warn log for the normalized shape, and still fires for the additive interpretation of the same payload (control, `bucketSum: 4899` vs `providedTotal: 3219`).

Flat `langfuse.observation.usage_details.*` handling is untouched — that contract is already exclusive.

**Related issues**

- Related to #14987 (not fixed here): that report is about the OpenAI usage-schema ingestion path (`packages/shared/src/server/ingestion/types.ts`), where `completion_tokens_details.reasoning_tokens` (109) exceeds `completion_tokens` (102); this PR does not change that path. The analogous OTel-side boundary (output floors at 0 when reasoning exceeds completion) landed with #15415 and is covered by its clamp test.
- Follows up #11264, which applied the same subtract-inclusive-details normalization on the AI SDK path, and #15415 (generic OTel path, refs #12057).

**Known remaining gap (pre-existing, unchanged here as in #15415):** `llm.token_count.prompt_details.audio` and other unrecognized `prompt_details.*` / `completion_details.*` sub-buckets still pass through additively (the passthrough reducer at `OtelIngestionProcessor.ts:2895` only strips a `details.` prefix), so a valid payload using those keys alongside an explicit total can still trip the mismatch warning.

## Verification

```bash
cd web && pnpm exec vitest run src/__tests__/server/api/otel/otelMapping.servertest.ts
# Tests  237 passed | 1 skipped (238)
cd worker && pnpm exec vitest run src/__tests__/usageTotalMismatchWarning.unit.test.ts
# Tests  2 passed (2)
pnpm exec prettier --check web/src/__tests__/server/api/otel/otelMapping.servertest.ts worker/src/__tests__/usageTotalMismatchWarning.unit.test.ts
# All matched files use Prettier code style!
```

ESLint reports no problems on the changed web file; the worker ESLint config ignores test files.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work) — tests only; the fix itself landed upstream in #15415

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

All template checklist bullets are satisfied (removed per template instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
