### PR TITLE
fix(sandbox): timeout Lambda MicroVM requests

### DIFF
--- a/packages/shared/src/in-app-agent/server/sandbox/providers/lambdaMicrovm.ts
+++ b/packages/shared/src/in-app-agent/server/sandbox/providers/lambdaMicrovm.ts
@@ -357,7 +357,11 @@ async function waitForBridge(params: {
   let lastError: unknown;
 
   while (Date.now() - startedAt < BRIDGE_READY_TIMEOUT_MS) {
-    const microvm = await getMicrovm(params.client, params.microvmId);
+    const microvm = await withBridgeRequestTimeout({
+      startedAt,
+      requestName: "status request",
+      request: (signal) => getMicrovm(params.client, params.microvmId, signal),
+    });
     if (!microvm) {
       throw new Error(
         `[Lambda MicroVM Sandbox] startup failed before bridge became ready: session ${params.microvmId} no longer exists`,
@@ -378,15 +382,17 @@ async function waitForBridge(params: {
         endpointPort: getEndpointPort(params.endpoint),
         sandboxServerPort: DEFAULT_SANDBOX_SERVER_PORT,
       });
-      const authToken = (await createMicrovmAuthToken(params)).value;
-      const remainingMs = BRIDGE_READY_TIMEOUT_MS - (Date.now() - startedAt);
-      if (remainingMs <= 0) {
-        break;
-      }
+      const authToken = (
+        await withBridgeRequestTimeout({
+          startedAt,
+          requestName: "auth token request",
+          request: (signal) => createMicrovmAuthToken(params, signal),
+        })
+      ).value;
 
-      const healthResult = await withRequestTimeout({
-        timeoutMs: remainingMs,
-        timeoutMessage: `Lambda MicroVM bridge health probe timed out after ${remainingMs}ms`,
+      const healthResult = await withBridgeRequestTimeout({
+        startedAt,
+        requestName: "health probe",
         request: async (signal) => {
           const response = await fetch(
             `${normalizeEndpoint(params.endpoint)}/health`,
@@ -419,7 +425,7 @@ async function waitForBridge(params: {
       lastError = error;
     }
 
-    const remainingMs = BRIDGE_READY_TIMEOUT_MS - (Date.now() - startedAt);
+    const remainingMs = getRemainingBridgeReadyMs(startedAt);
     if (remainingMs <= 0) {
       break;
     }
@@ -434,11 +440,14 @@ async function waitForBridge(params: {
     : new Error("[Lambda MicroVM Sandbox] bridge did not become ready");
 }
 
-async function createMicrovmAuthToken(params: {
-  client: LambdaMicrovmsClient;
-  microvmId: string;
-  endpoint: string;
-}) {
+async function createMicrovmAuthToken(
+  params: {
+    client: LambdaMicrovmsClient;
+    microvmId: string;
+    endpoint: string;
+  },
+  abortSignal?: AbortSignal,
+) {
   const endpointPort = getEndpointPort(params.endpoint);
   logger.debug("[Lambda MicroVM Sandbox] creating auth token", {
     microvmId: params.microvmId,
@@ -454,6 +463,7 @@ async function createMicrovmAuthToken(params: {
       expirationInMinutes: DEFAULT_AUTH_TOKEN_EXPIRATION_MINUTES,
       allowedPorts: [{ allPorts: {} }],
     }),
+    abortSignal ? { abortSignal } : undefined,
   );
 
   const token =
@@ -480,11 +490,16 @@ async function createMicrovmAuthToken(params: {
   };
 }
 
-async function getMicrovm(client: LambdaMicrovmsClient, microvmId: string) {
+async function getMicrovm(
+  client: LambdaMicrovmsClient,
+  microvmId: string,
+  abortSignal?: AbortSignal,
+) {
   try {
     return readMicrovmInfo(
       await client.send(
         new GetMicrovmCommand({ microvmIdentifier: microvmId }),
+        abortSignal ? { abortSignal } : undefined,
       ),
     );
   } catch (error) {
@@ -563,6 +578,28 @@ async function withRequestTimeout<T>(params: {
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+function withBridgeRequestTimeout<T>(params: {
+  startedAt: number;
+  requestName: string;
+  request: (signal: AbortSignal) => Promise<T>;
+}) {
+  const remainingMs = getRemainingBridgeReadyMs(params.startedAt);
+  const timeoutMessage = `Lambda MicroVM bridge ${params.requestName} timed out after ${Math.max(remainingMs, 0)}ms`;
+  if (remainingMs <= 0) {
+    throw new Error(timeoutMessage);
+  }
+
+  return withRequestTimeout({
+    timeoutMs: remainingMs,
+    timeoutMessage,
+    request: params.request,
+  });
+}
+
+function getRemainingBridgeReadyMs(startedAt: number) {
+  return BRIDGE_READY_TIMEOUT_MS - (Date.now() - startedAt);
 }
 
 function isMissingMicrovmError(error: unknown) {

--- a/packages/shared/src/in-app-agent/server/sandbox/providers/lambdaMicrovm.ts
+++ b/packages/shared/src/in-app-agent/server/sandbox/providers/lambdaMicrovm.ts
@@ -22,6 +22,10 @@ const DEFAULT_SUSPEND_AFTER_IDLE_SECONDS = 60;
 const DEFAULT_TERMINATE_AFTER_SUSPEND_SECONDS = 8 * 60 * 60;
 const DEFAULT_MAXIMUM_DURATION_SECONDS = 3_600;
 const BRIDGE_READY_TIMEOUT_MS = 30_000;
+const BRIDGE_RETRY_DELAY_MS = 500;
+const DEFAULT_OPERATION_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_BASH_TIMEOUT_MS = 120_000;
+const OPERATION_REQUEST_GRACE_PERIOD_MS = 5_000;
 
 const LambdaMicrovmErrorSchema = z.object({
   name: z.string().optional(),
@@ -196,47 +200,58 @@ export function createLambdaMicrovmSandboxProvider(params: {
       sandboxServerPort: DEFAULT_SANDBOX_SERVER_PORT,
     });
 
-    const response = await fetch(
-      `${normalizeEndpoint(session.endpoint)}/sandbox`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-aws-proxy-port": String(DEFAULT_SANDBOX_SERVER_PORT),
-          "X-aws-proxy-auth": session.authToken.value,
-        },
-        body: JSON.stringify({
-          ...operation,
-          toolCallFiles: session.toolCallFiles,
-        }),
+    const authToken = session.authToken.value;
+    const requestTimeoutMs = getOperationRequestTimeoutMs(operation);
+    return withRequestTimeout({
+      timeoutMs: requestTimeoutMs,
+      timeoutMessage: `Lambda MicroVM operation request timed out after ${requestTimeoutMs}ms`,
+      request: async (signal) => {
+        const response = await fetch(
+          `${normalizeEndpoint(session.endpoint)}/sandbox`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-aws-proxy-port": String(DEFAULT_SANDBOX_SERVER_PORT),
+              "X-aws-proxy-auth": authToken,
+            },
+            body: JSON.stringify({
+              ...operation,
+              toolCallFiles: session.toolCallFiles,
+            }),
+            signal,
+          },
+        );
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          logger.debug("[Lambda MicroVM Sandbox] operation request failed", {
+            sessionId,
+            operation: operation.operation,
+            endpoint: session.endpoint,
+            normalizedEndpoint: normalizeEndpoint(session.endpoint),
+            endpointPort: getEndpointPort(session.endpoint),
+            sandboxServerPort: DEFAULT_SANDBOX_SERVER_PORT,
+            status: response.status,
+            statusText: response.statusText,
+            body: errorText,
+          });
+          throw new Error(
+            errorText ||
+              `Lambda MicroVM bridge request failed: ${response.status}`,
+          );
+        }
+
+        const result = (await response.json()) as unknown;
+        const parsedResult =
+          LambdaMicrovmOperationResultSchema.safeParse(result);
+        if (parsedResult.success) {
+          return parsedResult.data.result;
+        }
+
+        return result;
       },
-    );
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      logger.debug("[Lambda MicroVM Sandbox] operation request failed", {
-        sessionId,
-        operation: operation.operation,
-        endpoint: session.endpoint,
-        normalizedEndpoint: normalizeEndpoint(session.endpoint),
-        endpointPort: getEndpointPort(session.endpoint),
-        sandboxServerPort: DEFAULT_SANDBOX_SERVER_PORT,
-        status: response.status,
-        statusText: response.statusText,
-        body: errorText,
-      });
-      throw new Error(
-        errorText || `Lambda MicroVM bridge request failed: ${response.status}`,
-      );
-    }
-
-    const result = (await response.json()) as unknown;
-    const parsedResult = LambdaMicrovmOperationResultSchema.safeParse(result);
-    if (parsedResult.success) {
-      return parsedResult.data.result;
-    }
-
-    return result;
+    });
   };
 
   const createSessionSandbox = (sessionId: string): SandboxSession => ({
@@ -363,29 +378,55 @@ async function waitForBridge(params: {
         endpointPort: getEndpointPort(params.endpoint),
         sandboxServerPort: DEFAULT_SANDBOX_SERVER_PORT,
       });
-      const response = await fetch(
-        `${normalizeEndpoint(params.endpoint)}/health`,
-        {
-          headers: {
-            "X-aws-proxy-port": String(DEFAULT_SANDBOX_SERVER_PORT),
-            "X-aws-proxy-auth": (await createMicrovmAuthToken(params)).value,
-          },
-        },
-      );
+      const authToken = (await createMicrovmAuthToken(params)).value;
+      const remainingMs = BRIDGE_READY_TIMEOUT_MS - (Date.now() - startedAt);
+      if (remainingMs <= 0) {
+        break;
+      }
 
-      if (response.ok) {
+      const healthResult = await withRequestTimeout({
+        timeoutMs: remainingMs,
+        timeoutMessage: `Lambda MicroVM bridge health probe timed out after ${remainingMs}ms`,
+        request: async (signal) => {
+          const response = await fetch(
+            `${normalizeEndpoint(params.endpoint)}/health`,
+            {
+              headers: {
+                "X-aws-proxy-port": String(DEFAULT_SANDBOX_SERVER_PORT),
+                "X-aws-proxy-auth": authToken,
+              },
+              signal,
+            },
+          );
+
+          return {
+            ok: response.ok,
+            status: response.status,
+            errorText: response.ok ? "" : await response.text(),
+          };
+        },
+      });
+
+      if (healthResult.ok) {
         return;
       }
 
       lastError = new Error(
-        (await response.text()) ||
-          `[Lambda MicroVM Sandbox] health probe failed with ${response.status}`,
+        healthResult.errorText ||
+          `[Lambda MicroVM Sandbox] health probe failed with ${healthResult.status}`,
       );
     } catch (error) {
       lastError = error;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    const remainingMs = BRIDGE_READY_TIMEOUT_MS - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      break;
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(BRIDGE_RETRY_DELAY_MS, remainingMs)),
+    );
   }
 
   throw lastError instanceof Error
@@ -498,6 +539,30 @@ function getEndpointPort(endpoint: string) {
   }
 
   return parsedEndpoint.protocol === "http:" ? 80 : 443;
+}
+
+function getOperationRequestTimeoutMs(operation: LambdaMicrovmOperation) {
+  return operation.operation === "bash"
+    ? (operation.timeoutMs ?? DEFAULT_BASH_TIMEOUT_MS) +
+        OPERATION_REQUEST_GRACE_PERIOD_MS
+    : DEFAULT_OPERATION_REQUEST_TIMEOUT_MS;
+}
+
+async function withRequestTimeout<T>(params: {
+  timeoutMs: number;
+  timeoutMessage: string;
+  request: (signal: AbortSignal) => Promise<T>;
+}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(new Error(params.timeoutMessage));
+  }, params.timeoutMs);
+
+  try {
+    return await params.request(controller.signal);
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 function isMissingMicrovmError(error: unknown) {

--- a/web/src/__tests__/server/unit/in-app-agent-lambda-microvm-provider.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-lambda-microvm-provider.servertest.ts
@@ -342,4 +342,67 @@ describe("in-app agent lambda microvm sandbox provider", () => {
     expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
     expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
+
+  it("aborts a hung auth token request within the bridge readiness deadline", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    microvmSendMock.mockImplementation(
+      async (
+        command: { input: unknown },
+        options?: { abortSignal?: AbortSignal },
+      ) => {
+        if (
+          command.constructor.name === "RunMicrovmCommand" ||
+          command.constructor.name === "GetMicrovmCommand"
+        ) {
+          return {
+            microvmId: "microvm-1",
+            endpoint: "https://microvm.example.com:8443",
+            state: "RUNNING",
+          };
+        }
+
+        if (command.constructor.name === "CreateMicrovmAuthTokenCommand") {
+          return new Promise((_resolve, reject) => {
+            options?.abortSignal?.addEventListener(
+              "abort",
+              () => reject(options.abortSignal?.reason),
+              { once: true },
+            );
+          });
+        }
+
+        throw new Error(`Unexpected command ${command.constructor.name}`);
+      },
+    );
+
+    const { createLambdaMicrovmSandboxProvider } =
+      await import("@langfuse/shared/in-app-agent/server/sandbox/providers/lambdaMicrovm");
+    const provider = createLambdaMicrovmSandboxProvider({
+      imageIdentifier: "image-1",
+      executionRoleArn: "arn:aws:iam::123456789012:role/sandbox",
+      region: "us-east-1",
+    });
+
+    const ensureSession = provider.ensureSession({
+      conversationId: "conversation-1",
+    });
+    const rejection = expect(ensureSession).rejects.toThrow(
+      "Lambda MicroVM bridge auth token request timed out",
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejection;
+
+    const authTokenCall = microvmSendMock.mock.calls.find(
+      ([command]) =>
+        command.constructor.name === "CreateMicrovmAuthTokenCommand",
+    );
+    expect(authTokenCall?.[1]?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(authTokenCall?.[1]?.abortSignal?.aborted).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/__tests__/server/unit/in-app-agent-lambda-microvm-provider.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-lambda-microvm-provider.servertest.ts
@@ -221,4 +221,125 @@ describe("in-app agent lambda microvm sandbox provider", () => {
       headers: { "X-aws-proxy-auth": "token-3" },
     });
   });
+
+  it("aborts a hung sandbox operation request", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((url, init) => {
+      if (String(url).endsWith("/health")) {
+        return Promise.resolve(new Response(null, { status: 200 }));
+      }
+
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(init.signal?.reason),
+          { once: true },
+        );
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    microvmSendMock.mockImplementation(async (command: { input: unknown }) => {
+      if (command.constructor.name === "RunMicrovmCommand") {
+        return {
+          microvmId: "microvm-1",
+          endpoint: "https://microvm.example.com:8443",
+          state: "RUNNING",
+        };
+      }
+
+      if (command.constructor.name === "GetMicrovmCommand") {
+        return {
+          microvmId: "microvm-1",
+          endpoint: "https://microvm.example.com:8443",
+          state: "RUNNING",
+        };
+      }
+
+      if (command.constructor.name === "CreateMicrovmAuthTokenCommand") {
+        return { authToken: { "X-aws-proxy-auth": "token-1" } };
+      }
+
+      throw new Error(`Unexpected command ${command.constructor.name}`);
+    });
+
+    const { createLambdaMicrovmSandboxProvider } =
+      await import("@langfuse/shared/in-app-agent/server/sandbox/providers/lambdaMicrovm");
+    const provider = createLambdaMicrovmSandboxProvider({
+      imageIdentifier: "image-1",
+      executionRoleArn: "arn:aws:iam::123456789012:role/sandbox",
+      region: "us-east-1",
+    });
+    const session = await provider.ensureSession({
+      conversationId: "conversation-1",
+    });
+
+    const operation = session.sandbox.read({ path: "notes.txt" });
+    const rejection = expect(operation).rejects.toThrow(
+      "Lambda MicroVM operation request timed out after 30000ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejection;
+
+    expect(fetchMock.mock.calls[1]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchMock.mock.calls[1]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("aborts a hung health probe within the bridge readiness deadline", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(init.signal?.reason),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    microvmSendMock.mockImplementation(async (command: { input: unknown }) => {
+      if (
+        command.constructor.name === "RunMicrovmCommand" ||
+        command.constructor.name === "GetMicrovmCommand"
+      ) {
+        return {
+          microvmId: "microvm-1",
+          endpoint: "https://microvm.example.com:8443",
+          state: "RUNNING",
+        };
+      }
+
+      if (command.constructor.name === "CreateMicrovmAuthTokenCommand") {
+        return { authToken: { "X-aws-proxy-auth": "token-1" } };
+      }
+
+      throw new Error(`Unexpected command ${command.constructor.name}`);
+    });
+
+    const { createLambdaMicrovmSandboxProvider } =
+      await import("@langfuse/shared/in-app-agent/server/sandbox/providers/lambdaMicrovm");
+    const provider = createLambdaMicrovmSandboxProvider({
+      imageIdentifier: "image-1",
+      executionRoleArn: "arn:aws:iam::123456789012:role/sandbox",
+      region: "us-east-1",
+    });
+
+    const ensureSession = provider.ensureSession({
+      conversationId: "conversation-1",
+    });
+    const rejection = expect(ensureSession).rejects.toThrow(
+      "Lambda MicroVM bridge health probe timed out",
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejection;
+
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- abort Lambda MicroVM sandbox operation requests after a bounded timeout
- preserve the requested bash execution budget with a five-second transport grace period
- cap each bridge health probe to the remaining readiness deadline, including response-body reads
- add regressions for hung sandbox operations and hung health probes

## Impacted packages

- @langfuse/shared
- web server unit tests

## Verification

- pnpm --filter @langfuse/shared run build (passes)
- pnpm --filter @langfuse/shared run lint (passes)
- pnpm --filter worker run typecheck (passes)
- pnpm --filter web run test src/__tests__/server/unit/in-app-agent-lambda-microvm-provider.servertest.ts (Test Files 1 passed (1); Tests 5 passed (5))
- pnpm exec prettier --check on both changed files (passes)
- git diff upstream/main...HEAD --check (passes)

## Notes

- The local machine runs Node 22 while the repo requires Node 24. Node 22 globSync returns Windows backslash paths, so the focused test used a temporary uncommitted path normalization to select the normal server-shared-source-unit project; CI runs the committed config on Node 24.
- pnpm run lint did not complete locally and was stopped after hanging without output; the focused shared lint passed.
- This change adds no new user-configurable URL or redirect behavior; the endpoint remains AWS-provided.

Closes #15956

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds AbortSignal-based time limits to Lambda MicroVM sandbox operations and bridge health probes, with additional regression tests for hung requests.

- Gives bash requests their execution budget plus five seconds of transport grace.
- Applies a fixed timeout to other sandbox operations.
- Bounds health-fetch and response-body processing by the remaining readiness deadline.
- Adds fake-timer tests covering hung operation and health requests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until auth-token acquisition is included in the bridge readiness deadline, otherwise session creation can still hang beyond the promised bound.

The health request and body are now abortable, but every probe first awaits an AWS SDK auth-token request without a timeout or outer guard, leaving ensureSession unbounded under a stalled token request.

**Files Needing Attention:** packages/shared/src/in-app-agent/server/sandbox/providers/lambdaMicrovm.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Session as ensureSession
  participant Bridge as waitForBridge
  participant AWS as Auth-token API
  participant Health as Bridge /health
  Session->>Bridge: wait for readiness (30s target)
  Bridge->>AWS: createMicrovmAuthToken
  Note over Bridge,AWS: No remaining-deadline timeout
  AWS-->>Bridge: token after unbounded delay
  Bridge->>Bridge: calculate remainingMs
  alt Deadline remains
    Bridge->>Health: fetch with AbortSignal(remainingMs)
    Health-->>Bridge: health result
  else Deadline expired
    Bridge-->>Session: readiness failure after excess wall time
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/in-app-agent/server/sandbox/providers/lambdaMicrovm.ts:381
**Auth request escapes readiness deadline**

When the Lambda MicroVM auth-token API stalls or exceeds the remaining readiness window, `waitForBridge` awaits it before calculating `remainingMs`, causing `ensureSession` to remain blocked beyond the intended 30-second bound.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandbox): timeout Lambda MicroVM req..."](https://github.com/langfuse/langfuse/commit/f22f548bb08e879925362d0853536ff745d971e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52105729)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->