### PR TITLE
fix(evals): load v4 filter options from events

### DIFF
--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -22,6 +22,20 @@ export const eventsTableTraceNameSelectSqlForAlias = (alias: string) =>
   `ifNull(${eventsTableTraceNameSqlForAlias(alias)}, '')`;
 export const eventsTableTraceNameSelectSql =
   eventsTableTraceNameSelectSqlForAlias("e");
+/**
+ * Maps the wire form of `eventsTableTraceNameSelectSql` ('' == no trace name)
+ * back to the null every JS-facing surface uses - tRPC/UI, the public API, the
+ * eval stream, analytics integrations, and batch export.
+ *
+ * Blob storage export deliberately does NOT use this: its published contract
+ * types `trace_name` as a plain string
+ * (https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields),
+ * and its raw JSONL / Parquet paths never pass through JS, so normalizing only
+ * the enriched path would make the three export formats disagree.
+ */
+export const normalizeEventsTraceName = (
+  traceName: string | null | undefined,
+): string | null => traceName || null;
 export const eventsTableTraceNameAggregationSqlForAlias = (alias: string) =>
   `COALESCE(nullIf(argMaxIf(${alias}.trace_name, ${alias}.event_ts, ${alias}.trace_name <> ''), ''), nullIf(argMaxIf(${alias}.name, ${alias}.event_ts, ${eventsTableIsRootObservationSqlForAlias(alias)} AND ${alias}.name <> ''), ''))`;
 export const eventsTableTraceNameAggregationSql =

--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -10,6 +10,18 @@ export const eventsTableIsRootObservationSql =
 export const eventsTableTraceNameSqlForAlias = (alias: string) =>
   `COALESCE(nullIf(${alias}.trace_name, ''), if(${eventsTableIsRootObservationSqlForAlias(alias)}, nullIf(${alias}.name, ''), NULL))`;
 export const eventsTableTraceNameSql = eventsTableTraceNameSqlForAlias("e");
+// Row-projection variant. The fallback above is Nullable(String), but
+// events_core.trace_name is a non-null String. Projecting the nullable
+// expression under the column's own name while a filter reads the physical
+// column puts two `trace_name` headers of different types into one pipeline,
+// and ClickHouse 25.x rejects that with AMBIGUOUS_COLUMN_NAME (code 352) as
+// soon as the query also sorts (LFE-14924). Matching the stored String type
+// keeps the alias — an export/stream wire name — stable. "no trace name" is
+// therefore '' on the wire; JS consumers map it back to null.
+export const eventsTableTraceNameSelectSqlForAlias = (alias: string) =>
+  `ifNull(${eventsTableTraceNameSqlForAlias(alias)}, '')`;
+export const eventsTableTraceNameSelectSql =
+  eventsTableTraceNameSelectSqlForAlias("e");
 export const eventsTableTraceNameAggregationSqlForAlias = (alias: string) =>
   `COALESCE(nullIf(argMaxIf(${alias}.trace_name, ${alias}.event_ts, ${alias}.trace_name <> ''), ''), nullIf(argMaxIf(${alias}.name, ${alias}.event_ts, ${eventsTableIsRootObservationSqlForAlias(alias)} AND ${alias}.name <> ''), ''))`;
 export const eventsTableTraceNameAggregationSql =

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -5,7 +5,7 @@ import {
 import {
   eventsTableIsRootObservationSql,
   eventsTableTraceNameAggregationSql,
-  eventsTableTraceNameSql,
+  eventsTableTraceNameSelectSql,
 } from "../../../eventsTable";
 import { OBSERVATIONS_TO_TRACE_INTERVAL } from "../../repositories/constants";
 import { FilterList, StringFilter } from "./clickhouse-filter";
@@ -132,7 +132,8 @@ const EVENTS_FIELDS = {
   public: "e.public as public",
   userId: 'e.user_id as "user_id"',
   sessionId: 'e.session_id as "session_id"',
-  traceName: `${eventsTableTraceNameSql} as "trace_name"`,
+  // String-typed on purpose; see eventsTableTraceNameSelectSql (LFE-14924).
+  traceName: `${eventsTableTraceNameSelectSql} as "trace_name"`,
 
   // Time fields
   startTime: 'e.start_time as "start_time"',

--- a/packages/shared/src/server/repositories/events-stream.ts
+++ b/packages/shared/src/server/repositories/events-stream.ts
@@ -100,6 +100,9 @@ export const getEventsStreamForEval = async (props: {
           ...row,
           span_id: row.id,
           parent_span_id: row.parent_observation_id,
+          // The events table ships "no trace name" as '' (see
+          // eventsTableTraceNameSelectSql); evals expect null.
+          trace_name: row.trace_name || null,
         };
       }
     })(),

--- a/packages/shared/src/server/repositories/events-stream.ts
+++ b/packages/shared/src/server/repositories/events-stream.ts
@@ -1,4 +1,5 @@
 import { Readable } from "stream";
+import { normalizeEventsTraceName } from "../../eventsTable";
 import type { FilterCondition } from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
 import { buildEventsStreamQuery } from "../queries";
@@ -100,9 +101,7 @@ export const getEventsStreamForEval = async (props: {
           ...row,
           span_id: row.id,
           parent_span_id: row.parent_observation_id,
-          // The events table ships "no trace name" as '' (see
-          // eventsTableTraceNameSelectSql); evals expect null.
-          trace_name: row.trace_name || null,
+          trace_name: normalizeEventsTraceName(row.trace_name),
         };
       }
     })(),

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3252,7 +3252,7 @@ export const getEventsForAnalyticsIntegrations = async function* (
     yield {
       timestamp: record.start_time,
       langfuse_observation_name: record.name,
-      langfuse_trace_name: record.trace_name,
+      langfuse_trace_name: record.trace_name || null,
       langfuse_trace_id: record.trace_id,
       langfuse_url: `${baseUrl}/project/${projectId}/traces/${encodeURIComponent(record.trace_id as string)}?observation=${encodeURIComponent(record.id as string)}`,
       langfuse_user_url: record.user_id

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -121,6 +121,7 @@ import {
 import { type EventsObservationPublic } from "../queries/createGenerationsQuery";
 import {
   eventsTableCols,
+  normalizeEventsTraceName,
   type NumericEventsTableColumnId,
 } from "../../eventsTable";
 import type { TraceDeleteBatchActionCursor } from "../../features/batchAction/types";
@@ -3252,7 +3253,11 @@ export const getEventsForAnalyticsIntegrations = async function* (
     yield {
       timestamp: record.start_time,
       langfuse_observation_name: record.name,
-      langfuse_trace_name: record.trace_name || null,
+      // The row type here is Record<string, unknown>; the column is a String
+      // projection (eventsTableTraceNameSelectSql).
+      langfuse_trace_name: normalizeEventsTraceName(
+        record.trace_name as string | null | undefined,
+      ),
       langfuse_trace_id: record.trace_id,
       langfuse_url: `${baseUrl}/project/${projectId}/traces/${encodeURIComponent(record.trace_id as string)}?observation=${encodeURIComponent(record.id as string)}`,
       langfuse_user_url: record.user_id

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -418,7 +418,8 @@ export function convertEventsObservation(
       ...(record.is_root_observation !== undefined && {
         isRootObservation: record.is_root_observation,
       }),
-      traceName: record.trace_name ?? null,
+      // '' is the events table's "no trace name" (eventsTableTraceNameSelectSql).
+      traceName: record.trace_name || null,
       release: record.release ?? null,
       tags: record.tags ?? null,
       bookmarked: record.bookmarked!,
@@ -438,7 +439,9 @@ export function convertEventsObservation(
     ...(record.is_root_observation !== undefined && {
       isRootObservation: record.is_root_observation,
     }),
-    ...(record.trace_name !== undefined && { traceName: record.trace_name }),
+    ...(record.trace_name !== undefined && {
+      traceName: record.trace_name || null,
+    }),
     ...(record.release !== undefined && { release: record.release }),
     ...(record.tags !== undefined && { tags: record.tags }),
     ...(record.bookmarked !== undefined && { bookmarked: record.bookmarked }),

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -1,4 +1,5 @@
 import { parseClickhouseUTCDateTimeFormat } from "./clickhouse";
+import { normalizeEventsTraceName } from "../../eventsTable";
 import {
   ObservationRecordReadType,
   EventsObservationRecordReadType,
@@ -418,8 +419,7 @@ export function convertEventsObservation(
       ...(record.is_root_observation !== undefined && {
         isRootObservation: record.is_root_observation,
       }),
-      // '' is the events table's "no trace name" (eventsTableTraceNameSelectSql).
-      traceName: record.trace_name || null,
+      traceName: normalizeEventsTraceName(record.trace_name),
       release: record.release ?? null,
       tags: record.tags ?? null,
       bookmarked: record.bookmarked!,
@@ -440,7 +440,7 @@ export function convertEventsObservation(
       isRootObservation: record.is_root_observation,
     }),
     ...(record.trace_name !== undefined && {
-      traceName: record.trace_name || null,
+      traceName: normalizeEventsTraceName(record.trace_name),
     }),
     ...(record.release !== undefined && { release: record.release }),
     ...(record.tags !== undefined && { tags: record.tags }),

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -1499,6 +1499,40 @@ describe("/api/public/v2/observations API Endpoint", () => {
     }
   });
 
+  maybe("trace_context group: unresolvable trace name", () => {
+    // The events table ships "no resolvable trace name" as '' on the wire
+    // (eventsTableTraceNameSelectSql, LFE-14924). The API contract is null, so
+    // the partial (field-group) converter must map it back.
+    it("returns null traceName for a child span without a stored trace name", async () => {
+      const traceId = randomUUID();
+      const observationId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: observationId,
+          span_id: observationId,
+          parent_span_id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          type: "SPAN",
+          name: "child-without-trace-name",
+          trace_name: "",
+        }),
+      ]);
+
+      const response = await getObservations(
+        `/api/public/v2/observations?fields=trace_context&traceId=${traceId}`,
+      );
+
+      expect(response.status).toBe(200);
+      const observation = response.body.data.find(
+        (candidate: { id: string }) => candidate.id === observationId,
+      );
+      expect(observation).toBeDefined();
+      expect(observation?.traceName).toBeNull();
+    });
+  });
+
   maybe("Metadata expansion with expandMetadata parameter", () => {
     it("should return full metadata values when expandMetadata is specified", async () => {
       const traceId = randomUUID();

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -63,6 +63,81 @@ describe("Clickhouse Events Repository Test", () => {
   });
 
   maybe("getObservationsWithModelDataFromEventsTable", () => {
+    // LFE-14924: the events table projects the resolved trace name (a nullable
+    // fallback expression) under the same name as the non-null events_core
+    // column it reads. With a trace-name filter AND an ORDER BY — the events
+    // table's default shape — ClickHouse 25.x compares the two `trace_name`
+    // block headers and fails with AMBIGUOUS_COLUMN_NAME (code 352). The sort
+    // is load-bearing: without it the same query succeeds.
+    it("filters observations by their resolved trace name while sorting", async () => {
+      const traceId = randomUUID();
+      const observationId = randomUUID();
+      const traceName = `trace-${randomUUID()}`;
+
+      await createEventsCh([
+        createEvent({
+          id: observationId,
+          span_id: observationId,
+          project_id: projectId,
+          trace_id: traceId,
+          trace_name: traceName,
+          type: "GENERATION",
+          name: "trace-name-filter-event",
+        }),
+      ]);
+
+      const result = await getObservationsWithModelDataFromEventsTable({
+        projectId,
+        filter: [
+          {
+            column: "traceName",
+            type: "stringOptions",
+            operator: "any of",
+            value: [traceName],
+          },
+        ],
+        orderBy: { column: "startTime", order: "DESC" },
+        limit: 1000,
+        offset: 0,
+      });
+
+      expect(result.map((observation) => observation.id)).toContain(
+        observationId,
+      );
+      expect(
+        result.find((observation) => observation.id === observationId),
+      ).toMatchObject({ traceName });
+    });
+
+    it("returns null when an observation has no resolved trace name", async () => {
+      const traceId = randomUUID();
+      const observationId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: observationId,
+          span_id: observationId,
+          parent_span_id: randomUUID(),
+          project_id: projectId,
+          trace_id: traceId,
+          trace_name: "",
+          type: "SPAN",
+          name: "child-without-trace-name",
+        }),
+      ]);
+
+      const result = await getObservationsWithModelDataFromEventsTable({
+        projectId,
+        filter: [idFilter(observationId)],
+        limit: 1000,
+        offset: 0,
+      });
+
+      expect(
+        result.find((observation) => observation.id === observationId),
+      ).toMatchObject({ traceName: null });
+    });
+
     it("should return trace tags for events table observations", async () => {
       const traceId = randomUUID();
       const observationId = randomUUID();

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -376,7 +376,11 @@ export const InnerEvaluatorForm = (props: {
     observationEvalFilterOptions,
     experimentEvalFilterOptions,
     datasetFilterOptions,
-  } = useEvalConfigFilterOptions({ projectId: props.projectId });
+  } = useEvalConfigFilterOptions({
+    projectId: props.projectId,
+    useEventsTable: isBetaEnabled,
+    includeLegacyTraceOptions: showLegacyTargetOptions,
+  });
 
   const targetState = useEvaluatorTargetState();
 

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.clienttest.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.clienttest.ts
@@ -1,0 +1,137 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  eventsData: {} as Record<string, unknown>,
+  eventsInput: undefined as unknown,
+  eventsOptions: undefined as unknown,
+  generationsData: {} as Record<string, unknown>,
+  generationsOptions: undefined as unknown,
+  tracesData: {} as Record<string, unknown>,
+  tracesOptions: undefined as unknown,
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    datasets: {
+      allDatasetMeta: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+    events: {
+      filterOptions: {
+        useQuery: (input: unknown, options: unknown) => {
+          mocks.eventsInput = input;
+          mocks.eventsOptions = options;
+          return { data: mocks.eventsData };
+        },
+      },
+    },
+    generations: {
+      filterOptions: {
+        useQuery: (_input: unknown, options: unknown) => {
+          mocks.generationsOptions = options;
+          return { data: mocks.generationsData };
+        },
+      },
+    },
+    projects: {
+      environmentFilterOptions: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+    traces: {
+      filterOptions: {
+        useQuery: (_input: unknown, options: unknown) => {
+          mocks.tracesOptions = options;
+          return { data: mocks.tracesData };
+        },
+      },
+    },
+  },
+}));
+
+import { useEvalConfigFilterOptions } from "./useEvalConfigFilterOptions";
+
+describe("useEvalConfigFilterOptions", () => {
+  beforeEach(() => {
+    mocks.eventsData = {};
+    mocks.eventsInput = undefined;
+    mocks.eventsOptions = undefined;
+    mocks.generationsData = {};
+    mocks.generationsOptions = undefined;
+    mocks.tracesData = {};
+    mocks.tracesOptions = undefined;
+  });
+
+  it("uses events-backed trace options for v4 evaluators", () => {
+    mocks.eventsData = {
+      traceName: [{ value: "events-trace", count: 2 }],
+      traceTags: [{ value: "events-tag" }],
+      name: [{ value: "events-observation" }],
+      calledToolNames: [{ value: "events-tool" }],
+    };
+    const { result } = renderHook(() =>
+      useEvalConfigFilterOptions({
+        projectId: "project-id",
+        useEventsTable: true,
+        includeLegacyTraceOptions: false,
+      }),
+    );
+
+    expect(mocks.eventsInput).toMatchObject({
+      projectId: "project-id",
+      columns: ["traceName", "traceTags", "name", "calledToolNames"],
+    });
+    expect(mocks.eventsOptions).toMatchObject({ enabled: true });
+    expect(mocks.generationsOptions).toMatchObject({ enabled: false });
+    expect(mocks.tracesOptions).toMatchObject({ enabled: false });
+    expect(result.current.observationEvalFilterOptions).toMatchObject({
+      traceName: [{ value: "events-trace" }],
+      tags: [{ value: "events-tag" }],
+      name: [{ value: "events-observation" }],
+      calledToolNames: [{ value: "events-tool" }],
+    });
+  });
+
+  it("loads legacy trace options when editing a legacy evaluator on v4", () => {
+    renderHook(() =>
+      useEvalConfigFilterOptions({
+        projectId: "project-id",
+        useEventsTable: true,
+        includeLegacyTraceOptions: true,
+      }),
+    );
+
+    expect(mocks.tracesOptions).toMatchObject({ enabled: true });
+  });
+
+  it("keeps legacy evaluator options on the legacy repositories", () => {
+    mocks.tracesData = {
+      name: [{ value: "legacy-trace", count: "1" }],
+      tags: [{ value: "legacy-tag" }],
+    };
+    mocks.generationsData = {
+      name: [{ value: "legacy-observation" }],
+      calledToolNames: [{ value: "legacy-tool" }],
+    };
+
+    const { result } = renderHook(() =>
+      useEvalConfigFilterOptions({
+        projectId: "project-id",
+        useEventsTable: false,
+        includeLegacyTraceOptions: false,
+      }),
+    );
+
+    expect(mocks.eventsOptions).toMatchObject({ enabled: false });
+    expect(mocks.generationsOptions).toMatchObject({ enabled: true });
+    expect(mocks.tracesOptions).toMatchObject({ enabled: true });
+    expect(result.current.observationEvalFilterOptions).toMatchObject({
+      traceName: [{ value: "legacy-trace" }],
+      tags: [{ value: "legacy-tag" }],
+      name: [{ value: "legacy-observation" }],
+      calledToolNames: [{ value: "legacy-tool" }],
+    });
+  });
+});

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.clienttest.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.clienttest.ts
@@ -1,6 +1,10 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// vi.mock is hoisted above these imports, and the mock state lives in
+// vi.hoisted, so the hook still loads against the mocked api module.
+import { useEvalConfigFilterOptions } from "./useEvalConfigFilterOptions";
+
 const mocks = vi.hoisted(() => ({
   eventsData: {} as Record<string, unknown>,
   eventsInput: undefined as unknown,
@@ -50,8 +54,6 @@ vi.mock("@/src/utils/api", () => ({
     },
   },
 }));
-
-import { useEvalConfigFilterOptions } from "./useEvalConfigFilterOptions";
 
 describe("useEvalConfigFilterOptions", () => {
   beforeEach(() => {

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
@@ -29,8 +29,14 @@ const getLowerBoundTimeFilter = (
 
 export function useEvalConfigFilterOptions({
   projectId,
+  useEventsTable,
+  includeLegacyTraceOptions,
 }: {
   projectId: string;
+  useEventsTable: boolean;
+  // Legacy trace-target evaluators stay editable on v4, and their options
+  // still come from the legacy traces table.
+  includeLegacyTraceOptions: boolean;
 }) {
   const filterOptionsFrom = useMemo(
     () => getBucketedEvalFilterOptionsFrom(),
@@ -42,7 +48,22 @@ export function useEvalConfigFilterOptions({
       projectId,
       timestampFilter: getLowerBoundTimeFilter("timestamp", filterOptionsFrom),
     },
-    evalFilterOptionsQueryOptions,
+    {
+      ...evalFilterOptionsQueryOptions,
+      enabled: !useEventsTable || includeLegacyTraceOptions,
+    },
+  );
+
+  const eventsFilterOptionsResponse = api.events.filterOptions.useQuery(
+    {
+      projectId,
+      startTimeFilter: getLowerBoundTimeFilter("startTime", filterOptionsFrom),
+      columns: ["traceName", "traceTags", "name", "calledToolNames"],
+    },
+    {
+      ...evalFilterOptionsQueryOptions,
+      enabled: useEventsTable,
+    },
   );
 
   const environmentFilterOptionsResponse =
@@ -64,7 +85,10 @@ export function useEvalConfigFilterOptions({
           filterOptionsFrom,
         ),
       },
-      evalFilterOptionsQueryOptions,
+      {
+        ...evalFilterOptionsQueryOptions,
+        enabled: !useEventsTable,
+      },
     );
 
   const traceFilterOptions = useMemo(() => {
@@ -122,27 +146,41 @@ export function useEvalConfigFilterOptions({
   }, [datasets.data]);
 
   const observationEvalFilterOptions: ObservationEvalOptions = useMemo(() => {
+    const traceNames = useEventsTable
+      ? eventsFilterOptionsResponse.data?.traceName
+      : traceFilterOptionsResponse.data?.name;
+    const traceTags = useEventsTable
+      ? eventsFilterOptionsResponse.data?.traceTags
+      : traceFilterOptionsResponse.data?.tags;
+    const observationNames = useEventsTable
+      ? eventsFilterOptionsResponse.data?.name
+      : observationsFilterOptionsResponse.data?.name;
+    const calledToolNames = useEventsTable
+      ? eventsFilterOptionsResponse.data?.calledToolNames
+      : observationsFilterOptionsResponse.data?.calledToolNames;
+
     return {
       environment: environmentFilterOptionsResponse.data?.map((e) => ({
         value: e.environment,
       })),
       tags: sortOptionValues(
-        traceFilterOptionsResponse.data?.tags?.map((t) => ({
-          value: t.value,
+        traceTags?.map((tag) => ({
+          value: tag.value,
         })),
       ),
-      traceName: traceFilterOptionsResponse.data?.name?.map((n) => ({
-        value: n.value,
+      traceName: traceNames?.map((name) => ({
+        value: name.value,
       })),
-      name: observationsFilterOptionsResponse.data?.name?.map((n) => ({
-        value: n.value,
+      name: observationNames?.map((name) => ({
+        value: name.value,
       })),
-      calledToolNames:
-        observationsFilterOptionsResponse.data?.calledToolNames?.map((t) => ({
-          value: t.value,
-        })),
+      calledToolNames: calledToolNames?.map((toolName) => ({
+        value: toolName.value,
+      })),
     };
   }, [
+    useEventsTable,
+    eventsFilterOptionsResponse.data,
     traceFilterOptionsResponse.data,
     environmentFilterOptionsResponse.data,
     observationsFilterOptionsResponse.data,

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -4731,6 +4731,43 @@ describe("batch export test suite", () => {
 });
 
 maybeDescribe("getEventsForBlobStorageExport", () => {
+  // The published field reference types `trace_name` as a plain string, not
+  // "string or null":
+  // https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields
+  // Exports therefore keep the events table's '' wire form instead of the null
+  // that JS-facing surfaces normalize to (normalizeEventsTraceName), and the
+  // raw JSONL / Parquet paths never pass through JS at all.
+  it("exports an unresolvable trace name as '' rather than null", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const now = Date.now();
+
+    const event = createEvent({
+      project_id: projectId,
+      trace_id: randomUUID(),
+      parent_span_id: randomUUID(),
+      type: "SPAN",
+      name: "child-without-trace-name",
+      trace_name: "",
+      start_time: now * 1000,
+    });
+
+    await createEventsCh([event]);
+
+    const stream = getEventsForBlobStorageExport(
+      projectId,
+      new Date(now - 60 * 60 * 1000),
+      new Date(now + 60 * 60 * 1000),
+    );
+
+    const rows: Record<string, unknown>[] = [];
+    for await (const row of stream) {
+      rows.push(row);
+    }
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].trace_name).toBe("");
+  });
+
   it("should stream events for blob storage export", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     const now = Date.now();

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -9,6 +9,7 @@
 
 import {
   FilterCondition,
+  normalizeEventsTraceName,
   type ScoreDataTypeType,
   TracingSearchType,
 } from "@langfuse/shared";
@@ -192,9 +193,7 @@ export const getEventsStream = async (props: {
     const eventRow: BatchExportEventsRow = {
       id: bufferedRow.id,
       traceId: bufferedRow.trace_id,
-      // The events table ships "no trace name" as '' (see
-      // eventsTableTraceNameSelectSql); the export column stays nullable.
-      traceName: bufferedRow.trace_name || null,
+      traceName: normalizeEventsTraceName(bufferedRow.trace_name),
       type: bufferedRow.type,
       name: bufferedRow.name ?? "",
       startTime: bufferedRow.start_time,

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -192,7 +192,9 @@ export const getEventsStream = async (props: {
     const eventRow: BatchExportEventsRow = {
       id: bufferedRow.id,
       traceId: bufferedRow.trace_id,
-      traceName: bufferedRow.trace_name,
+      // The events table ships "no trace name" as '' (see
+      // eventsTableTraceNameSelectSql); the export column stays nullable.
+      traceName: bufferedRow.trace_name || null,
       type: bufferedRow.type,
       name: bufferedRow.name ?? "",
       startTime: bufferedRow.start_time,


### PR DESCRIPTION
🟡 **Live preview: [pr-15975.preview.langfuse.com](<https://pr-15975.preview.langfuse.com>)**

🟡 **Live preview: [pr-15975.preview.langfuse.com](<https://pr-15975.preview.langfuse.com>)**

## What does this PR do?

Fixes langfuse/langfuse#15941

Linear: langfuse/langfuse#15941

* Loads evaluator trace / observation filter options from `events.filterOptions` on v4 instead of querying empty legacy tables.
* Keeps legacy trace options available when editing an existing trace-target evaluator.
* Avoids the ClickHouse `trace_name` block-structure mismatch for filtered event queries while preserving `null` at consumer boundaries.
* Adds client coverage for legacy / events option routing and ClickHouse-backed regression coverage for trace-name filtering.

**Blob storage export contract check** (`packages/shared/AGENTS.md:116-124`): the row projection now ships `''` instead of SQL `NULL` when no trace name resolves, so I checked the [published field reference](<https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields>). `trace_name` for `observations_v2/` is documented as `string`, not "string or null" - that page marks genuinely nullable fields explicitly. langfuse/langfuse#15723 made it nullable on 2026-08-04 without a docs change; this PR restores the documented shape. No docs update needed.

Reasoning:

* Exports (enriched JSON, raw JSONL, Parquet) all keep `''` - the raw and Parquet paths never pass through JS, so normalizing only the enriched path would split the contract across formats.
* JS-facing surfaces (tRPC / UI, public API, eval stream, analytics integrations, batch export) keep `null` via a single `normalizeEventsTraceName` helper next to the SQL definition.
* Both behaviours are pinned by tests: `''` in the export contract test, `null` in the events-repository and public-API v2 regressions.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

* ClickHouse server regression: `Tests  2 passed | 82 skipped (84)`
* Evaluator client regression: `Tests  3 passed (3)`
* Shared query builder: `Tests  10 passed (10)`
* Worker analytics enrichment: `Tests  4 passed (4)`
* Shared / web / worker typechecks passed
* Lint: `Tasks: 7 successful, 7 total`
* Blob storage export contract: `Tests  8 passed | 70 skipped (78)`
* Public API v2 (incl. unresolvable trace name): `Tests  41 passed (41)`
* Prettier: `All matched files use Prettier code style!`

<details><summary>Greptile Summary</summary>

The PR routes v4 evaluator filter options through the unified events endpoint while retaining legacy trace options for applicable edit flows. It also gives ClickHouse trace-name row projections a stable non-null wire type and restores null semantics in downstream consumers.

* Adds events-backed trace, tag, observation-name, and tool-name filter options for v4 evaluators.
* Preserves legacy trace option loading where legacy evaluator targets remain available.
* Normalizes empty trace-name wire values across evaluator streams, converters, analytics integrations, and batch exports.
* Adds client routing tests and ClickHouse regression coverage.

</details>

<details><summary>Confidence Score: 4/5</summary>

The PR appears safe to merge, with only a non-blocking import-placement issue in the new client test.

The events and legacy option routes align with their target modes, and identified trace-name consumers restore null at their boundaries; the remaining issue is limited to repository-required test-module organization.

**Files Needing Attention:** web/src/features/evals/hooks/useEvalConfigFilterOptions.clienttest.ts

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
### Issue 1
web/src/features/evals/hooks/useEvalConfigFilterOptions.clienttest.ts:52
**Late module import placement**

`useEvalConfigFilterOptions` is imported after the executable `vi.mock(...)` setup rather than with the imports at the top of the module, violating the repository's required import organization and making dependencies harder to identify and maintain.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
```

</details>

Reviews (1): Last reviewed commit: ["fix(evals): load v4 filter options from ..."](<https://github.com/langfuse/langfuse/commit/688c143dca61effd030eb79aa814f7619e3d8c34>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=52118526>)

<details><summary>Context used (4)</summary>

* Rule used - Move imports to the top of the module instead of p... ([source](<https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12>))

**Learned From** [langfuse/langfuse-python#1387](<https://github.com/langfuse/langfuse-python/pull/1387>)

* Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md>)
* Knowledge Base — [Shared Package](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md>)
* Knowledge Base — [Worker Queues](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md>)

</details>