### PR TITLE
fix(web): add missing Anthropic cache usage types to model price prefill

### DIFF
--- a/web/src/features/models/components/pricing-tiers/TierPrefillButtons.tsx
+++ b/web/src/features/models/components/pricing-tiers/TierPrefillButtons.tsx
@@ -50,6 +50,9 @@ export function TierPrefillButtons({
               cache_read_input_tokens: 0,
               input_cache_creation_5m: 0,
               input_cache_creation_1h: 0,
+              input_cache_creation: 0,
+              input_cache_read: 0,
+              input_cached_tokens: 0,
               ...prices,
             });
           }}


### PR DESCRIPTION
## What does this PR do?

The Anthropic template in the model pricing tier prefill was missing three cache usage-type keys that Langfuse ingestion persists: `input_cache_creation`, `input_cache_read`, and `input_cached_tokens`. Without them, a user prefilling from the Anthropic template gets a price entry that leaves those buckets unpriced.\
\
This brings the prefill in line with [the documented Claude key set](https://github.com/langfuse/langfuse/blob/d18a59ad663ffc7c04afc61354186c141b3ec0f3/.agents/skills/add-model-price/references/provider-usage-key-matrix.md?plain=1#L46-L57).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands the Anthropic model-pricing prefill with three cache usage keys persisted by ingestion.
- Adds `input_cache_creation`, `input_cache_read`, and `input_cached_tokens` placeholders.
- Preserves manually supplied prices because the existing `prices` map is spread after the defaults.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The added keys are accepted by the pricing schema, correspond to established ingestion usage details, and retain the existing override behavior for user-provided prices.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): add missing Anthropic cache us..."](https://github.com/langfuse/langfuse/commit/7beba972a5748a89386075cec823945a6816b4e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52130781)</sub>

<!-- /greptile_comment -->