### PR TITLE
fix(auth): reject non-POST credentials callback requests with 405

### DIFF
--- a/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
@@ -192,3 +192,54 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
     expect(mockNextAuth).not.toHaveBeenCalled();
   });
 });
+
+describe("[...nextauth] credentials callback method guard", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a GET to the credentials callback with 405 and an Allow: POST header", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res.getHeader("Allow")).toBe("POST");
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("rejects a PUT to the credentials callback with 405", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "PUT",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("passes a POST to the credentials callback through to next-auth", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("still returns 200 for a HEAD to the credentials callback", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "HEAD",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -59,6 +59,21 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
     return res.status(200).end();
   }
 
+  // next-auth answers non-POST requests to the credentials callback with a
+  // bare, unlogged 500, so scanners probing this URL page our error-rate
+  // monitors. Reject them with a 405 before next-auth sees them.
+  const isCredentialsCallback =
+    Array.isArray(req.query.nextauth) &&
+    req.query.nextauth[0] === "callback" &&
+    req.query.nextauth[1] === "credentials";
+  if (isCredentialsCallback && req.method !== "POST") {
+    logger.warn(
+      `[NEXT_AUTH] Rejected ${req.method} to credentials callback with 405`,
+    );
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ message: "Method Not Allowed" });
+  }
+
   // next-auth rejects malformed callbackUrl values (query param or cookie)
   // with a hardcoded 500, so vulnerability scanners probing auth routes page
   // our server-error monitors. Malformed client input is a 4xx; reject it

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -12,9 +12,15 @@ const authErrorFallback = "Configuration";
 
 type AuthErrorSource = "query" | "path";
 
-const getAuthAction = (req: NextApiRequest) => {
+// Single parse of the [...nextauth] catch-all: [action, provider], e.g.
+// /api/auth/callback/credentials -> ["callback", "credentials"].
+const getNextAuthSegments = (
+  req: NextApiRequest,
+): [string | undefined, string | undefined] => {
   const nextauth = req.query.nextauth;
-  return Array.isArray(nextauth) ? nextauth[0] : nextauth;
+  return Array.isArray(nextauth)
+    ? [nextauth[0], nextauth[1]]
+    : [nextauth, undefined];
 };
 
 const logAuthErrorFallback = (
@@ -53,6 +59,8 @@ const encodeAuthError = (error: unknown, source: AuthErrorSource) => {
 };
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
+  const [nextAuthAction, nextAuthProvider] = getNextAuthSegments(req);
+
   // Workaround for corporate email link checkers (e.g., Outlook SafeLink)
   // https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
   if (req.method === "HEAD") {
@@ -63,9 +71,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // bare, unlogged 500, so scanners probing this URL page our error-rate
   // monitors. Reject them with a 405 before next-auth sees them.
   const isCredentialsCallback =
-    Array.isArray(req.query.nextauth) &&
-    req.query.nextauth[0] === "callback" &&
-    req.query.nextauth[1] === "credentials";
+    nextAuthAction === "callback" && nextAuthProvider === "credentials";
   if (isCredentialsCallback && req.method !== "POST") {
     logger.warn(
       `[NEXT_AUTH] Rejected ${req.method} to credentials callback with 405`,
@@ -81,9 +87,6 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // falsy values are treated as absent (assertConfig checks truthiness), and
   // GET requests to next-auth's HTML page actions are exempt — those never
   // 500; next-auth redirects them to the configured error page.
-  const nextAuthAction = Array.isArray(req.query.nextauth)
-    ? req.query.nextauth[0]
-    : req.query.nextauth;
   const rendersHtmlErrorPage =
     req.method === "GET" &&
     ["signin", "signout", "error", "verify-request"].includes(
@@ -111,10 +114,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // This happens before NextAuth processes the callback, allowing us to preserve
   // the IdP's error_description which NextAuth would otherwise strip
   // Only intercept if this is an OAuth callback request (path starts with 'callback')
-  const isCallbackRequest =
-    Array.isArray(req.query.nextauth) &&
-    req.query.nextauth.length > 0 &&
-    req.query.nextauth[0] === "callback";
+  const isCallbackRequest = nextAuthAction === "callback";
 
   if (
     isCallbackRequest &&
@@ -153,10 +153,8 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // NextAuth interpolates unknown error values directly into a Location
   // header. Encode user-controlled text before it reaches that code path so
   // control characters cannot make Node throw ERR_INVALID_CHAR.
-  if (getAuthAction(req) === "error") {
-    const nextauth = req.query.nextauth;
-    const error =
-      req.query.error ?? (Array.isArray(nextauth) ? nextauth[1] : undefined);
+  if (nextAuthAction === "error") {
+    const error = req.query.error ?? nextAuthProvider;
     if (error !== undefined) {
       const source = req.query.error !== undefined ? "query" : "path";
       req.query.error = encodeAuthError(error, source);


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15989.preview.langfuse.com](https://pr-15989.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

next-auth v4 answers non-POST requests to `/api/auth/callback/credentials` with a bare, unlogged HTTP 500 (its internal "Callback for provider type credentials not supported" fallback returns directly without calling the logger). Security scanners routinely probe this URL, producing silent 500s that pollute server-error monitoring while real users are unaffected.

This PR intercepts non-POST requests to the credentials callback in the custom `[...nextauth].ts` wrapper handler — mirroring the existing malformed-`callbackUrl` guard — and responds `405 Method Not Allowed` with an `Allow: POST` header plus a single warn-level log line. `POST` requests still pass through to next-auth unchanged, and the existing `HEAD` short-circuit keeps returning 200.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective (GET/PUT → 405 with `Allow: POST`; POST passes through; HEAD still 200)
- [x] New and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents non-POST requests to the NextAuth credentials callback from reaching NextAuth and generating unlogged 500 responses.

- Returns HTTP 405 with `Allow: POST` for unsupported credentials callback methods.
- Preserves the global HEAD-request behavior used for link-checker compatibility.
- Adds server tests covering GET, PUT, POST, and HEAD requests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the credentials callback method guard and compatibility behavior adequately covered.

The changed route rejects unsupported credentials callback methods before NextAuth executes, permits POST requests, and retains the intentional global HEAD response without introducing an established failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): reject non-POST credentials c..."](https://github.com/langfuse/langfuse/commit/eaa188ab6bcf0049e4b5746e6dc708d557ed5ab2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52153794)</sub>

**Context used:**

- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)

<!-- /greptile_comment -->