### PR TITLE
chore(deps): bump nanoid to 3.3.16

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ overrides:
   esbuild: 0.28.1
   undici@7: 7.29.0
   zod: 4.3.6
-  nanoid: ^3.3.8
+  nanoid: 3.3.16
   katex: ^0.16.21
   tar-fs: ^2.1.2
   rollup@^4.0.0: ^4.22.4
@@ -782,8 +782,8 @@ importers:
         specifier: ^0.552.0
         version: 0.552.0(react@19.2.4)
       nanoid:
-        specifier: ^3.3.8
-        version: 3.3.12
+        specifier: 3.3.16
+        version: 3.3.16
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -9554,8 +9554,8 @@ packages:
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12244,7 +12244,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       secure-json-parse: 2.7.0
       zod: 4.3.6
 
@@ -21182,7 +21182,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   markdown-table@3.0.3: {}
 
@@ -21699,7 +21699,7 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -22333,7 +22333,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -23591,7 +23591,7 @@ snapshots:
   terser@5.47.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -23732,7 +23732,7 @@ snapshots:
       graphql: 16.13.2
       graphql-query-complexity: 0.12.0(graphql@16.13.2)
       graphql-scalars: 1.25.0(graphql@16.13.2)
-      semver: 7.8.4
+      semver: 7.8.5
       tslib: 2.8.1
     optionalDependencies:
       class-validator: 0.14.4
@@ -24155,10 +24155,10 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
+      acorn: 8.17.0
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.3
+      enhanced-resolve: 5.24.2
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,7 @@ overrides:
   esbuild: "0.28.1"
   "undici@7": 7.29.0
   zod: 4.3.6
-  nanoid: ^3.3.8
+  nanoid: 3.3.16
   katex: ^0.16.21
   tar-fs: ^2.1.2
   rollup@^4.0.0: ^4.22.4

--- a/web/package.json
+++ b/web/package.json
@@ -134,7 +134,7 @@
     "langfuse": "3.38.4",
     "lodash": "^4.18.1",
     "lucide-react": "^0.552.0",
-    "nanoid": "^3.3.11",
+    "nanoid": "3.3.16",
     "next": "16.2.11",
     "next-auth": "^4.24.14",
     "next-query-params": "^5.1.0",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15990.preview.langfuse.com](https://pr-15990.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR pins nanoid to version 3.3.16 in the web package and workspace override, updating all overridden nanoid lockfile resolutions. It also refreshes several unrelated transitive build-tool resolutions.
- Pins the direct web dependency and workspace override to nanoid 3.3.16.
- Resolves nanoid consumers such as PostCSS and AI SDK utilities to 3.3.16.
- Updates unrelated semver, acorn, and enhanced-resolve snapshot selections.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, though the unrelated build-tool resolution changes should preferably be removed or explicitly validated.

The nanoid pin is internally consistent and no compatibility or security failure was established; the remaining concern is the unnecessary expansion of the lockfile update into webpack and terser dependencies.

**Files Needing Attention:** pnpm-lock.yaml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
pnpm-lock.yaml:24158-24161
**Unrelated build dependencies updated**

This nanoid-only update also changes the versions of `acorn` and `enhanced-resolve` selected for webpack, as well as other unrelated transitive resolutions, broadening the build-behavior surface and making regressions harder to attribute to the intended dependency bump.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump nanoid to 3.3.16"](https://github.com/langfuse/langfuse/commit/6233d7661ad37f66c5f0d4435ff1553e433810a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52160948)</sub>

<!-- /greptile_comment -->