### PR TITLE
fix(evals): drop foreign key on job configurations

### DIFF
--- a/packages/shared/prisma/migrations/20260807120000_drop_job_execution_configuration_fk/migration.sql
+++ b/packages/shared/prisma/migrations/20260807120000_drop_job_execution_configuration_fk/migration.sql
@@ -1,0 +1,10 @@
+-- Prisma does not automatically wrap PostgreSQL migrations in a transaction.
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE "job_executions"
+  DROP CONSTRAINT IF EXISTS "job_executions_job_configuration_id_fkey";
+
+COMMIT;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -953,7 +953,6 @@ model JobConfiguration {
   sampling        Decimal // ratio of jobs that are executed for sampling (0..1)
   delay           Int // delay in milliseconds
   timeScope       String[]       @default(["NEW"]) @map("time_scope")
-  JobExecution    JobExecution[]
 
   @@index([projectId, id])
   @@map("job_configurations")
@@ -975,8 +974,7 @@ model JobExecution {
   projectId String  @map("project_id")
   project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
-  jobConfigurationId String           @map("job_configuration_id")
-  jobConfiguration   JobConfiguration @relation(fields: [jobConfigurationId], references: [id], onDelete: Cascade)
+  jobConfigurationId String @map("job_configuration_id") // no fk constraint - deletion handled in application code (deleteJobConfigurationWithExecutions) and via project cascade
 
   jobTemplateId String?       @map("job_template_id")
 

--- a/web/src/__tests__/server/evaluator-repository.servertest.ts
+++ b/web/src/__tests__/server/evaluator-repository.servertest.ts
@@ -2,6 +2,7 @@ import { EvalTemplateType } from "@prisma/client";
 import { prisma } from "@langfuse/shared/src/db";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import {
+  deleteJobConfigurationWithExecutions,
   deleteEvalTemplatesByIds,
   findDefaultModelEvalTemplateIds,
   findEvalTemplateById,
@@ -103,6 +104,41 @@ describe("evaluatorRepository", () => {
       expect(ids).toContain(dependentTemplate.id);
       expect(ids).not.toContain(templateWithOwnModel.id);
       expect(ids).not.toContain(codeTemplate.id);
+    });
+  });
+
+  describe("deleteJobConfigurationWithExecutions", () => {
+    it("deletes executions before deleting their job configuration", async () => {
+      const project = await prepareProject();
+      const template = await createTemplate({
+        projectId: project.id,
+        name: "delete-config-with-executions",
+      });
+      const config = await createJobConfiguration({
+        projectId: project.id,
+        evalTemplateId: template.id,
+        scoreName: "delete-config-with-executions",
+      });
+      const execution = await prisma.jobExecution.create({
+        data: {
+          projectId: project.id,
+          jobConfigurationId: config.id,
+          status: "PENDING",
+        },
+      });
+
+      await deleteJobConfigurationWithExecutions({
+        prisma,
+        projectId: project.id,
+        jobConfigurationId: config.id,
+      });
+
+      await expect(
+        prisma.jobExecution.findUnique({ where: { id: execution.id } }),
+      ).resolves.toBeNull();
+      await expect(
+        prisma.jobConfiguration.findUnique({ where: { id: config.id } }),
+      ).resolves.toBeNull();
     });
   });
 

--- a/web/src/features/evals/server/evaluatorRepository.ts
+++ b/web/src/features/evals/server/evaluatorRepository.ts
@@ -1,4 +1,8 @@
-import { EvalTemplateType, Prisma } from "@langfuse/shared/src/db";
+import {
+  EvalTemplateType,
+  Prisma,
+  type PrismaClient,
+} from "@langfuse/shared/src/db";
 
 /**
  * Data access for eval templates ("evaluators" in the public naming).
@@ -116,4 +120,29 @@ export async function deleteEvalTemplatesByIds({
   await tx.evalTemplate.deleteMany({
     where: { projectId, id: { in: evalTemplateIds } },
   });
+}
+
+/**
+ * Deletes a job configuration and its executions atomically. Takes the plain
+ * client rather than a `tx` because it runs a batch (array) transaction: an
+ * interactive `$transaction(async (tx) => …)` would cap the delete at Prisma's
+ * default 5s timeout, which configurations with a long execution history exceed.
+ */
+export async function deleteJobConfigurationWithExecutions({
+  prisma,
+  projectId,
+  jobConfigurationId,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  jobConfigurationId: string;
+}) {
+  await prisma.$transaction([
+    prisma.jobExecution.deleteMany({
+      where: { projectId, jobConfigurationId },
+    }),
+    prisma.jobConfiguration.delete({
+      where: { id: jobConfigurationId, projectId },
+    }),
+  ]);
 }

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -96,6 +96,7 @@ import {
   prepareConfigsForTemplateUpgrade,
   prepareVariableMappingForEvaluatorUpgrade,
 } from "@/src/features/evals/server/evaluatorUpgrade";
+import { deleteJobConfigurationWithExecutions } from "@/src/features/evals/server/evaluatorRepository";
 export { CreateEvalTemplateInputSchema } from "@/src/features/evals/server/evalTemplateCreation";
 
 // Filter columns that used to be backed by the Postgres `traces` and
@@ -1751,11 +1752,10 @@ export const evalRouter = createTRPCRouter({
         action: "delete",
       });
 
-      await ctx.prisma.jobConfiguration.delete({
-        where: {
-          id: evalConfigId,
-          projectId: projectId,
-        },
+      await deleteJobConfigurationWithExecutions({
+        prisma: ctx.prisma,
+        projectId,
+        jobConfigurationId: evalConfigId,
       });
 
       // Clear the "no job configs" caches to ensure they are re-evaluated

--- a/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
@@ -43,6 +43,7 @@ import {
 } from "./validation";
 import { createUnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import { assertUnreachable } from "@/src/utils/types";
+import { deleteJobConfigurationWithExecutions } from "@/src/features/evals/server/evaluatorRepository";
 
 const MAX_ACTIVE_EVALUATION_RULES = 500;
 
@@ -473,11 +474,10 @@ export async function deletePublicEvaluationRule(params: {
   const existing = await findPublicEvaluationRuleOrThrow(params);
   const existingPublic = toApiWritableEvaluationRule(existing);
 
-  await prisma.jobConfiguration.delete({
-    where: {
-      id: params.evaluationRuleId,
-      projectId: params.projectId,
-    },
+  await deleteJobConfigurationWithExecutions({
+    prisma,
+    projectId: params.projectId,
+    jobConfigurationId: params.evaluationRuleId,
   });
 
   await invalidateProjectEvalConfigCaches(params.projectId);


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15994.preview.langfuse.com](https://pr-15994.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Drops the `job_executions.job_configuration_id` foreign key. Eval execution inserts no longer take a `FOR KEY SHARE` lock on the parent configuration row, and configuration deletion no longer depends on a DB-level `ON DELETE CASCADE`.
- Moves the cascade into application code: `deleteJobConfigurationWithExecutions` deletes a configuration's executions and then the configuration itself, shared by the tRPC `deleteEvalJob` mutation and the unstable public evaluation-rule API so both paths behave identically.
- The migration drops the constraint under a short `lock_timeout` so it fails fast instead of queueing an `ACCESS EXCLUSIVE` lock behind a long-running writer and stalling all traffic on `job_executions`.

## Linear

- [LFE-14965](https://linear.app/clickhouse/issue/LFE-14965/drop-foreign-key-on-job-configurations)

## Major Decisions

- The helper uses a batch (array) `$transaction([...])` rather than the interactive `$transaction(async (tx) => …)` form. The interactive form applies Prisma's default 5s transaction timeout, which configurations with a long execution history would exceed — `job_executions` has no retention pruning, so a trace-level rule on a busy project accumulates a lot of rows, and the delete would abort with P2028 and leave the configuration permanently undeletable. The batch form keeps a single `BEGIN … COMMIT` without that cap.

## Review Focus

- Migration lock behaviour: dropping an FK needs `ACCESS EXCLUSIVE` on both `job_executions` and `job_configurations`, so with `lock_timeout = '5s'` the worst case is roughly two 5s waits. Failure is clean and nothing is half-applied, but it does not self-heal: `web/entrypoint.sh` runs `prisma migrate deploy` on every container start and exits on failure, and once Prisma records the migration as failed every later deploy aborts with P3009 rather than retrying — so a transient lock holder means a crash-looping web container until someone runs `prisma migrate resolve`. Worth deciding whether to accept that or wrap the `ALTER` in a bounded retry that catches `lock_not_available`.
- Orphan rows are now possible in principle. I checked the current delete paths — the two migrated call sites are the only ones, and project/org deletion still cascades through `job_executions.project_id` — but any future config-delete path that skips the helper will leave executions behind. The schema comment on `jobConfigurationId` records this.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes the database foreign key between evaluation executions and job configurations to avoid parent-row locking, replacing its delete cascade with a shared atomic application helper.
- Adds a transactional helper that deletes executions before their configuration.
- Migrates the tRPC and unstable public API deletion paths to the helper.
- Adds repository coverage for deleting a configuration with executions.
- Adds a bounded-lock migration that drops the foreign-key constraint.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the material orphaning and migration-lock tradeoffs already explicitly documented for maintainers.

All current production configuration-deletion paths remove executions through either the new atomic helper or the retained project cascade, and no unacknowledged actionable defect remains.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as tRPC / Public API
  participant Helper as deleteJobConfigurationWithExecutions
  participant DB as PostgreSQL
  API->>Helper: Delete evaluation configuration
  Helper->>DB: BEGIN
  Helper->>DB: DELETE matching JobExecution rows
  Helper->>DB: DELETE JobConfiguration
  Helper->>DB: COMMIT
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): drop foreign key on job conf..."](https://github.com/langfuse/langfuse/commit/7af319e2444ab662d3e88c50b29ec59685635523) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52185970)</sub>

**Context used:**

- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->