### PR TITLE
fix(scim): ignore password attribute in user provisioning

### DIFF
--- a/fern/apis/server/definition/scim.yml
+++ b/fern/apis/server/definition/scim.yml
@@ -62,6 +62,18 @@ service:
             active:
               docs: Whether the user is active
               type: optional<boolean>
+            password:
+              docs: >-
+                Ignored. Accepted only for compatibility with identity
+                providers that always send a password on user creation (Okta
+                sends a placeholder value even when password sync is disabled).
+                No credential is created for the user; provisioned users
+                authenticate via SSO or set a password themselves through the
+                password reset flow.
+              type: optional<string>
+              availability:
+                status: deprecated
+                message: "This attribute is ignored. SCIM provisioning never sets a password; provisioned users authenticate via SSO or the password reset flow."
       response: ScimUser
 
     getUser:

--- a/fern/apis/server/definition/scim.yml
+++ b/fern/apis/server/definition/scim.yml
@@ -62,9 +62,6 @@ service:
             active:
               docs: Whether the user is active
               type: optional<boolean>
-            password:
-              docs: Initial password for the user
-              type: optional<string>
       response: ScimUser
 
     getUser:

--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -9,7 +9,6 @@ import {
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
-import { verifyPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
 
 // Schema for SCIM User response
 const ScimUserSchema = z.object({
@@ -227,6 +226,12 @@ describe("SCIM API", () => {
       expect(response.body.Resources[0].id).toContain(
         "urn:ietf:params:scim:schemas:core:2.0:User",
       );
+      // `password` must not be advertised: schema discovery is how a SCIM
+      // client learns the attribute is unsupported (LFINT-1989).
+      const attributeNames = response.body.Resources[0].attributes.map(
+        (attribute) => (attribute as { name: string }).name,
+      );
+      expect(attributeNames).not.toContain("password");
     });
 
     it("should return 401 when invalid API keys are provided", async () => {
@@ -473,7 +478,7 @@ describe("SCIM API", () => {
         expect(user?.name).toBe("Test User");
       });
 
-      it("should create a new user with password", async () => {
+      it("accepts a password attribute but never sets a credential", async () => {
         const uniqueEmail = `test.user.${randomUUID().substring(0, 8)}@example.com`;
         const password = `password-${randomUUID().substring(0, 8)}`;
         const response = await makeZodVerifiedAPICall(
@@ -517,9 +522,11 @@ describe("SCIM API", () => {
         expect(user).not.toBeNull();
         expect(user?.email).toBe(uniqueEmail);
         expect(user?.name).toBe("Test User With Password");
-        // Verify password was created
-        expect(user?.password).not.toBeNull();
-        expect(await verifyPassword(password, user?.password ?? "")).toBe(true);
+        // The password attribute is ignored, so the account has no usable
+        // credential and cannot be signed into with the supplied value
+        // (LFINT-1989). Okta sends a placeholder password on every create, so
+        // the request must still succeed rather than 4xx.
+        expect(user?.password).toBeNull();
       });
 
       it("should return 400 when userName is missing", async () => {

--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -227,7 +227,7 @@ describe("SCIM API", () => {
         "urn:ietf:params:scim:schemas:core:2.0:User",
       );
       // `password` must not be advertised: schema discovery is how a SCIM
-      // client learns the attribute is unsupported (LFINT-1989).
+      // client learns the attribute is unsupported.
       const attributeNames = response.body.Resources[0].attributes.map(
         (attribute) => (attribute as { name: string }).name,
       );
@@ -523,9 +523,9 @@ describe("SCIM API", () => {
         expect(user?.email).toBe(uniqueEmail);
         expect(user?.name).toBe("Test User With Password");
         // The password attribute is ignored, so the account has no usable
-        // credential and cannot be signed into with the supplied value
-        // (LFINT-1989). Okta sends a placeholder password on every create, so
-        // the request must still succeed rather than 4xx.
+        // credential and cannot be signed into with the supplied value. Okta
+        // sends a placeholder password on every create, so the request must
+        // still succeed rather than 4xx.
         expect(user?.password).toBeNull();
       });
 

--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -223,6 +223,8 @@ describe("SCIM API", () => {
         "urn:ietf:params:scim:api:messages:2.0:ListResponse",
       );
       expect(response.body.Resources.length).toBeGreaterThan(0);
+      // RFC 7644 3.4.2: `totalResults` must match what was actually returned.
+      expect(response.body.totalResults).toBe(response.body.Resources.length);
       expect(response.body.Resources[0].id).toContain(
         "urn:ietf:params:scim:schemas:core:2.0:User",
       );

--- a/web/src/pages/api/public/scim/Schemas.ts
+++ b/web/src/pages/api/public/scim/Schemas.ts
@@ -52,7 +52,10 @@ export default async function handler(
   // Return the schemas
   return res.status(200).json({
     schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    totalResults: 2,
+    // Only the User schema is advertised; `Resources` has one entry, and RFC
+    // 7644 3.4.2 wants `totalResults` to match what was returned. Sibling
+    // `/ResourceTypes` already gets this right.
+    totalResults: 1,
     Resources: [
       // User Schema
       {

--- a/web/src/pages/api/public/scim/Schemas.ts
+++ b/web/src/pages/api/public/scim/Schemas.ts
@@ -151,17 +151,6 @@ export default async function handler(
             uniqueness: "none",
           },
           {
-            name: "password",
-            type: "string",
-            multiValued: false,
-            description: "The user's password",
-            required: false,
-            caseExact: false,
-            mutability: "writeOnly",
-            returned: "never",
-            uniqueness: "none",
-          },
-          {
             name: "meta",
             type: "complex",
             multiValued: false,

--- a/web/src/pages/api/public/scim/ServiceProviderConfig.ts
+++ b/web/src/pages/api/public/scim/ServiceProviderConfig.ts
@@ -52,7 +52,8 @@ export default async function handler(
   // Return the service provider configuration
   return res.status(200).json({
     schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
-    documentationUri: "https://docs.langfuse.com/scim",
+    documentationUri:
+      "https://langfuse.com/docs/administration/scim-and-org-api",
     patch: {
       supported: false,
     },

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -172,16 +172,16 @@ export default async function handler(
         }
       }
 
-      // A `password` in the request body is accepted and ignored (LFINT-1989).
-      // Setting it created a usable login credential for an email address
-      // nobody had verified, so an org-scoped key could pre-register an
-      // account for someone else's address. Ignoring rather than rejecting is
-      // deliberate: RFC 7644 3.3 lets a service provider ignore POSTed
-      // content, the attribute is `returned: "never"` so no conformant client
-      // can observe the difference, and Okta sends a placeholder password on
-      // every create even when password sync is disabled — rejecting it would
-      // break those syncs. Users authenticate via SSO, or claim the account
-      // through the password-reset flow.
+      // A `password` in the request body is accepted and ignored. Setting it
+      // created a usable login credential for an email address nobody had
+      // verified, so an org-scoped key could pre-register an account for
+      // someone else's address. Ignoring rather than rejecting is deliberate:
+      // RFC 7644 3.3 lets a service provider ignore POSTed content, the
+      // attribute is `returned: "never"` so no conformant client can observe
+      // the difference, and Okta sends a placeholder password on every create
+      // even when password sync is disabled — rejecting it would break those
+      // syncs. Users authenticate via SSO, or claim the account through the
+      // password-reset flow.
       const { userName, name, displayName, roles } = body;
 
       if (!userName) {

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -4,7 +4,6 @@ import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 
 import { type NextApiRequest, type NextApiResponse } from "next";
-import { hashPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
 import { z } from "zod";
 import { type Role } from "@langfuse/shared";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
@@ -173,7 +172,17 @@ export default async function handler(
         }
       }
 
-      const { userName, name, password, displayName, roles } = body;
+      // A `password` in the request body is accepted and ignored (LFINT-1989).
+      // Setting it created a usable login credential for an email address
+      // nobody had verified, so an org-scoped key could pre-register an
+      // account for someone else's address. Ignoring rather than rejecting is
+      // deliberate: RFC 7644 3.3 lets a service provider ignore POSTed
+      // content, the attribute is `returned: "never"` so no conformant client
+      // can observe the difference, and Okta sends a placeholder password on
+      // every create even when password sync is disabled — rejecting it would
+      // break those syncs. Users authenticate via SSO, or claim the account
+      // through the password-reset flow.
+      const { userName, name, displayName, roles } = body;
 
       if (!userName) {
         logger.warn("[SCIM] userName is required for user creation");
@@ -235,7 +244,6 @@ export default async function handler(
         create: {
           email: normalizedEmail,
           name: name?.formatted || displayName,
-          password: password ? await hashPassword(password) : undefined,
         },
         update: {},
       });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15997.preview.langfuse.com](https://pr-15997.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Fixes a medium-severity security finding from an external review of the SCIM provisioning endpoint.

## Problem

`POST /api/public/scim/Users` hashed and stored a `password` supplied in the request body, so an org-scoped API key could pre-register an account for an email address whose ownership nobody had verified — and pick its password. The legitimate owner can recover via password reset, but the attacker's session may outlive that recovery.

## Change

The attribute is now **accepted and ignored**, not rejected:

- **Ignoring is spec-legal.** RFC 7644 §3.3: *"Since the server is free to alter and/or ignore POSTed content, returning the full representation can be useful to the client…"*. RFC 7643 §4.1.1 defines `password` as `mutability: writeOnly`, `returned: never`, so **no conformant client can observe whether we stored it** — the 201 response is unchanged either way.
- **Rejecting would break real syncs.** Okta [documents](https://support.okta.com/help/s/article/password-sent-during-user-creation-to-custom-scim-integration-even-with-password-sync-disabled?language=en_US) that it *"sends the password parameter in a create user request, even if password sync is not enabled. This parameter acts as a placeholder for legacy provisioning platforms, and its value is not relevant or sensitive in nature."* A 4xx would force those admins to retune their Okta password policy.
- **`password` is removed from `/Schemas`**, which is the spec's mechanism for a client to discover that an attribute is unsupported.

Provisioned users authenticate via SSO, or claim the account through the password-reset flow, which confirms control of the email address.

Also fixes a stale `documentationUri` in `/ServiceProviderConfig` (pointed at `docs.langfuse.com/scim`, which is not where the SCIM docs live).

## Who this affects, measured

I measured the real blast radius before writing this, because `password` never appears in logs. `hashPassword` is bcryptjs cost 12 — a fixed ~400ms CPU block — so its presence is visible per-request as `total − sfdc.upsertUser − (sfdc.setUserRole, else sfdc.removeUser/2)`. Calibration: `/api/auth/callback/credentials`, which does exactly one bcrypt compare at cost 12, has p50 342–371ms in the same environments.

Over the 15-day Datadog hot window (2026-07-27 → 08-11), all four prod environments:

- `POST /Users` ≈ **366 calls across 33 orgs** (US site 252/20, EU site 114/13).
- Requests **without** a password: 17–51ms of non-SFDC time. Requests **with** one: 379–472ms. The split is org-consistent, not random.
- **~11 orgs send a password** — and **100% of them use `Okta SCIM Client 1.0.0`**. Every custom client (python-httpx/urllib/requests/aiohttp, Go-http-client, curl, kiota-dotnet, n8n) sends none.

So no tenant appears to be *using* this feature: their IdP pads the payload with a placeholder, and Langfuse turns it into a real credential. That is the argument for ignoring rather than deprecating with a migration window.

## Reviewer decisions

1. **Should this carry `!` / `BREAKING CHANGE:`?** I left it off deliberately: `!` would bump the major line via release-it, which seems wrong for a security fix, and no conformant client can detect the change. Your call.
2. **One thing I could not measure:** whether any existing account actually signs in with a SCIM-set password. Telemetry can't attribute sign-ins to orgs. A database read would settle it, and would also tell us whether existing stored placeholder hashes should be cleared:
   ```sql
   SELECT u.id, u.email, u.created_at, (a.id IS NOT NULL) AS has_sso_account
   FROM users u
   JOIN organization_memberships m ON m.user_id = u.id
   LEFT JOIN accounts a ON a.user_id = u.id
   WHERE u.password IS NOT NULL AND m.org_id IN (:affected_orgs);
   ```
   The affected organization ids are in the tracking issue. This PR intentionally does **not** retroactively clear those hashes.

## Impacted packages

- `web` — SCIM public API routes and their server tests. No schema, worker, or shared changes.

## Verification

- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `web/src/__tests__/server/scim-api.servertest.ts` updated: the test that asserted the password *was* stored now asserts `user.password` is null while the request still returns 201, and the `/Schemas` test asserts `password` is no longer advertised. **Not run locally** — these are HTTP servertests and this worktree has the known dev-server/vitest `DATABASE_URL` split (`langfuse_test` vs `postgres`), so they are left to CI rather than fought locally.

Docs counterpart: langfuse/langfuse-docs#3504 — merge that after this ships.
