### PR TITLE
docs(agents): forbid internal ticket ids in published text

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -32,6 +32,11 @@ evaluating, and debugging AI applications.
 - Always quote file paths in shell commands, or use `noglob` for path-heavy
   commands, to avoid zsh glob expansion issues with dynamic Next.js routes.
 - Never invoke Node-installed binaries through `./node_modules/.bin/*`. Always run them through `pnpm`.
+- Never put internal ticket ids (`LFE-1234`, `LFINT-1234`, `CLI-Q226-12`) or
+  Linear URLs into anything this repo publishes: code comments, docs prose,
+  commit messages, PR titles and descriptions, or changelog entries. They mean
+  nothing to OSS readers. Describe the problem on its own terms; a
+  ticket-prefixed branch name is the one place the identifier belongs.
 - Never commit secrets or credentials. Keep `.env*.example` files in
   sync with required env vars.
 

--- a/.agents/skills/changelog-writing/SKILL.md
+++ b/.agents/skills/changelog-writing/SKILL.md
@@ -27,6 +27,8 @@ Use this skill when a completed feature branch needs a changelog entry.
 ## Writing Rules
 
 - Write for users, not internal implementation detail
+- Never mention internal ticket ids or Linear URLs in the entry, even though
+  step 2 gathers the Linear issue for context
 - Prefer second person: "you can now..."
 - Focus on what changed, why it matters, and how to use it
 - Match the structure and tone of recent changelog posts

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -34,6 +34,10 @@ operations.
 - PR titles are validated by `.github/workflows/validate-pr-title.yml`.
 - In PR descriptions, list impacted packages and executed verification
   commands.
+- Keep internal ticket ids and Linear URLs out of commit messages, PR titles,
+  and PR descriptions — this repo is public, and a squash merge puts the PR
+  title into `main`'s permanent history. Describe the change on its own terms
+  and carry the identifier in the branch name instead.
 
 ## GitHub
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15998.preview.langfuse.com](https://pr-15998.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Why

Agents repeatedly put internal Linear ids into code comments, commit messages, and PR descriptions. Nothing in `.agents/` said not to, so the mistake kept recurring — I hit it again today and got called on it.

Two facts make this worth writing down rather than fixing case by case:

- This repo is public, so an internal id in a comment or docs page is noise for every OSS reader.
- PRs are squash-merged, so the **PR title** lands in `main`'s permanent history. Of the last 400 commits on `main`, exactly 1 title carries an LFINT id and 0 bodies reference `linear.app` — the convention already exists, it just wasn't written down anywhere an agent would read.

## Change

Three files, placed by scope:

- **`.agents/AGENTS.md`** — one cross-cutting rule, because the affected surfaces span code comments, docs prose, commit messages, PR text, and changelog entries. Kept to a single bullet per the agent-setup-maintenance guidance to keep root `AGENTS.md` concise.
- **`.agents/skills/git-workflow/SKILL.md`** — the commit/PR specifics next to the existing Conventional Commits rules, including the squash-merge reason.
- **`.agents/skills/changelog-writing/SKILL.md`** — an explicit "do not mention it", because step 2 of that workflow tells the agent to *gather* the Linear issue, which invites including it.

Branch names remain the place for the identifier, so traceability is unaffected.

## Verification

- `pnpm run agents:sync` → clean, only the three canonical files changed
- `pnpm run agents:check` → exit 0
- `pnpm run lint` → `Tasks: 7 successful, 7 total`

Mirror PR in the docs repo: langfuse/langfuse-docs#3505

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR adds repository-wide guidance preventing internal ticket identifiers and Linear URLs from appearing in public text while retaining identifiers in branch names.
- Adds the cross-cutting publication rule to the root agent guidelines.
- Documents commit and pull-request requirements in the Git workflow skill.
- Adds matching output guidance to the changelog-writing skill.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after correcting the non-blocking cross-reference in the changelog-writing guidance.

The publication rules are consistent across all three files, with only one misleading step-number reference that does not undermine the core prohibition.

**Files Needing Attention:** .agents/skills/changelog-writing/SKILL.md
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.agents/skills/changelog-writing/SKILL.md:31-32
**Incorrect workflow step reference**

The new rule says step 2 gathers the Linear issue, but step 2 studies recent changelog patterns; issue gathering is under `What To Gather`. This misleading pointer makes the distinction between gathering internal context and excluding it from published text unnecessarily confusing.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): forbid internal ticket ids..."](https://github.com/langfuse/langfuse/commit/cdcdba54aba784ebf2de5c419d66960f5b81cdae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52220187)</sub>

<!-- /greptile_comment -->