### PR TITLE
fix(datasets): restore dataset item IO scrolling

### DIFF
--- a/web/src/components/table/DataTable.stories.tsx
+++ b/web/src/components/table/DataTable.stories.tsx
@@ -985,6 +985,59 @@ export const Comfortable = meta.story({
   ),
 });
 
+const LONG_IO_TRACE_ROW: TraceRow = {
+  ...makeTraceRow(0),
+  id: "trace-long-io-content",
+  input: {
+    request: "dataset-item-input",
+    messages: Array.from({ length: 24 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `Message ${index + 1}: ${"This is deliberately long JSON content to verify that the fixed-height IO cell retains its vertical scrollbar. ".repeat(3)}`,
+    })),
+  },
+  output: {
+    result: "dataset-item-output",
+    details: Object.fromEntries(
+      Array.from({ length: 24 }, (_, index) => [
+        `field-${index + 1}`,
+        `Value ${index + 1}: ${"long output content ".repeat(8)}`,
+      ]),
+    ),
+  },
+  metadata: Object.fromEntries(
+    Array.from({ length: 24 }, (_, index) => [
+      `metadata-${index + 1}`,
+      `value-${index + 1}`,
+    ]),
+  ),
+};
+
+function LongIOContentStory() {
+  const columns = useMemo(() => buildTraceColumns("l"), []);
+  return (
+    <DataTable<TraceRow, unknown>
+      tableName="story-long-io-content"
+      columns={columns}
+      data={{
+        isLoading: false,
+        isError: false,
+        data: [LONG_IO_TRACE_ROW],
+      }}
+      pagination={{
+        totalCount: 1,
+        onChange: fn(),
+        state: { pageIndex: 0, pageSize: 1 },
+      }}
+      rowHeight="l"
+      cellPadding="comfortable"
+    />
+  );
+}
+
+export const LongIOContent = meta.story({
+  render: () => <LongIOContentStory />,
+});
+
 // -----------------------------------------------------------------------------
 // 6. Density matrix (design showcase)
 // -----------------------------------------------------------------------------

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -123,7 +123,7 @@ export function JSONView(props: {
           </code>
         ) : (
           <div
-            className="max-w-full min-w-0 flex-1 overflow-hidden"
+            className="max-w-full min-w-0 flex-1"
             onClick={() => {
               // If externally collapsed and user clicks to expand, sync the state
               if (props.externalJsonCollapsed && props.onToggleCollapse) {

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -218,7 +218,9 @@ export function DatasetItemsTable({
       cell: ({ row }) => {
         const input = row.getValue("input") as RowData["input"];
         return input !== null ? (
-          <IOTableCell data={input} singleLine={rowHeight === "s"} />
+          <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
+            <IOTableCell data={input} singleLine={rowHeight === "s"} />
+          </div>
         ) : null;
       },
     },
@@ -233,11 +235,13 @@ export function DatasetItemsTable({
           "expectedOutput",
         ) as RowData["expectedOutput"];
         return expectedOutput !== null ? (
-          <IOTableCell
-            data={expectedOutput}
-            className="bg-accent-light-green"
-            singleLine={rowHeight === "s"}
-          />
+          <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
+            <IOTableCell
+              data={expectedOutput}
+              className="bg-accent-light-green"
+              singleLine={rowHeight === "s"}
+            />
+          </div>
         ) : null;
       },
     },
@@ -250,7 +254,9 @@ export function DatasetItemsTable({
       cell: ({ row }) => {
         const metadata = row.getValue("metadata") as RowData["metadata"];
         return metadata !== null ? (
-          <IOTableCell data={metadata} singleLine={rowHeight === "s"} />
+          <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
+            <IOTableCell data={metadata} singleLine={rowHeight === "s"} />
+          </div>
         ) : null;
       },
     },

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -218,9 +218,7 @@ export function DatasetItemsTable({
       cell: ({ row }) => {
         const input = row.getValue("input") as RowData["input"];
         return input !== null ? (
-          <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
-            <IOTableCell data={input} singleLine={rowHeight === "s"} />
-          </div>
+          <IOTableCell data={input} singleLine={rowHeight === "s"} />
         ) : null;
       },
     },
@@ -235,13 +233,11 @@ export function DatasetItemsTable({
           "expectedOutput",
         ) as RowData["expectedOutput"];
         return expectedOutput !== null ? (
-          <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
-            <IOTableCell
-              data={expectedOutput}
-              className="bg-accent-light-green"
-              singleLine={rowHeight === "s"}
-            />
-          </div>
+          <IOTableCell
+            data={expectedOutput}
+            className="bg-accent-light-green"
+            singleLine={rowHeight === "s"}
+          />
         ) : null;
       },
     },
@@ -254,9 +250,7 @@ export function DatasetItemsTable({
       cell: ({ row }) => {
         const metadata = row.getValue("metadata") as RowData["metadata"];
         return metadata !== null ? (
-          <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
-            <IOTableCell data={metadata} singleLine={rowHeight === "s"} />
-          </div>
+          <IOTableCell data={metadata} singleLine={rowHeight === "s"} />
         ) : null;
       },
     },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-15999.preview.langfuse.com](https://pr-15999.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- constrain dataset item Input, Expected Output, and Metadata cells so their JSON viewers can scroll within the row
- keep the change scoped to DatasetItemsTable

## Root cause
The dataset item I/O cells were rendered directly inside the table row flex wrapper, so the viewer did not receive a bounded flex container for its internal scroll area.

## Verification
- Prettier check passed
- Full lint passed: Tasks: 7 successful, 7 total
- No new client tests added
- Browser review was blocked because the local dev server could not bind to port 3000

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adjusts the shared JSON viewer’s flex-overflow behavior and adds a long-content DataTable story to demonstrate scrolling.

- Removes inner overflow clipping from expanded JSON content.
- Adds long input, output, and metadata fixtures to Storybook.
- The new fixture uses trace columns rather than the DatasetItemsTable path named by the fix.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with a non-blocking concern that the added Storybook fixture does not exercise the dataset-item layout it is intended to protect.

No current runtime failure was established, but the regression fixture uses trace-table renderers and therefore cannot reliably reveal a recurrence in DatasetItemsTable’s distinct cell-container hierarchy.

**Files Needing Attention:** web/src/components/table/DataTable.stories.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/DataTable.stories.tsx:1016
**Story misses dataset cell layout**

`LongIOContentStory` uses `buildTraceColumns("l")`, whose IO renderers do not include the DatasetItemsTable container hierarchy targeted by this fix. The story can therefore remain correct while dataset-item scrolling regresses, reducing its value as a manual or visual regression fixture; use DatasetItemsTable or reproduce its exact cell wrappers instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: lint"](https://github.com/langfuse/langfuse/commit/71f9f6bd742e54e3e64369b2e08777454413f2c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52371056)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->