### PR TITLE
fix(assistant): fill the screen on mobile instead of a floating window (LFE-14977)

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -37,6 +37,7 @@ function InAppAgentWindowStoryShell({
       floatingPanelHandle={floatingPanelHandle}
       isExpanded={isExpanded}
       onClose={() => undefined}
+      open
       panelRef={panelRef}
     >
       {children}

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -36,6 +36,7 @@ function InAppAgentWindowStoryShell({
     <InAppAgentWindowShell
       floatingPanelHandle={floatingPanelHandle}
       isExpanded={isExpanded}
+      onClose={() => undefined}
       panelRef={panelRef}
     >
       {children}

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -35,7 +35,7 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import { cn } from "@/src/utils/tailwind";
-import { useIsMobile } from "@/src/hooks/use-mobile";
+import { useIsHandheld } from "@/src/hooks/use-mobile";
 import { formatApproximateDuration } from "@/src/utils/dates";
 import {
   InAppAgentMessage,
@@ -400,8 +400,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     screenContextDescription,
   );
   const capture = usePostHogClientCapture();
-  // No auto-focus on mobile — it springs the keyboard and buries the panel.
-  const isMobile = useIsMobile();
+  // A phone renders the assistant full-screen (see InAppAgentWindowShell), so
+  // it drops the window chrome and never auto-focuses — that springs the
+  // keyboard over the conversation.
+  const isHandheld = useIsHandheld();
   const isRateLimited = isInAppAgentRateLimited(error);
   const isComposerDisabled = isConversationInteractionDisabled;
   const isSubmitDisabled =
@@ -506,13 +508,13 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         ((previousIsInputDisabledRef.current && !isComposerDisabled) ||
           (previousIsAssistantTurnInProgressRef.current &&
             !isAssistantTurnInProgress)) &&
-        !isMobile;
+        !isHandheld;
 
       if (input && shouldRefocusInput) {
         input.focus();
       }
     },
-    [isAssistantTurnInProgress, isComposerDisabled, isMobile],
+    [isAssistantTurnInProgress, isComposerDisabled, isHandheld],
   );
 
   useEffect(() => {
@@ -529,7 +531,11 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   return (
     <section
       aria-label="Assistant"
-      className="bg-background flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-xl border shadow/5"
+      className={cn(
+        "bg-background flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-xl border shadow/5",
+        // Full-bleed on mobile: the drawer owns the edge, so drop the window chrome.
+        isHandheld && "rounded-none border-0 shadow-none",
+      )}
     >
       <header
         data-in-app-agent-window-drag-handle={
@@ -669,29 +675,32 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               ) : null}
             </DropdownMenuContent>
           </DropdownMenu>
-          <Tooltip delayDuration={100} disableHoverableContent>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-6"
-                aria-label={isExpanded ? "Collapse window" : "Expand window"}
-                onClick={() => {
-                  onExpandedChange(!isExpanded);
-                }}
-              >
-                {isExpanded ? (
-                  <Minimize2 className="size-3" />
-                ) : (
-                  <Maximize2 className="size-3" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {isExpanded ? "Collapse window" : "Expand window"}
-            </TooltipContent>
-          </Tooltip>
+          {/* Mobile is always full-screen, so there is nothing to expand. */}
+          {!isHandheld ? (
+            <Tooltip delayDuration={100} disableHoverableContent>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-6"
+                  aria-label={isExpanded ? "Collapse window" : "Expand window"}
+                  onClick={() => {
+                    onExpandedChange(!isExpanded);
+                  }}
+                >
+                  {isExpanded ? (
+                    <Minimize2 className="size-3" />
+                  ) : (
+                    <Maximize2 className="size-3" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isExpanded ? "Collapse window" : "Expand window"}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
           {props.showCloseButton !== false ? (
             <Tooltip delayDuration={100} disableHoverableContent>
               <TooltipTrigger asChild>
@@ -714,7 +723,9 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
       <div className="relative flex min-h-0 flex-1 flex-col">
         <div
           ref={viewportRef}
-          className="min-h-0 flex-1 overflow-y-auto"
+          // `overscroll-contain`: the conversation is the only scroller, so its
+          // rubber-band must not chain out to whatever is behind it.
+          className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
           onScroll={(event) => {
             const viewport = event.currentTarget;
             const distanceFromBottom =
@@ -972,7 +983,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             }}
           >
             <textarea
-              autoFocus={!isExpanded && !isMobile}
+              autoFocus={!isExpanded && !isHandheld}
               ref={setInputRef}
               value={input}
               onChange={(event) => {

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -376,7 +376,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     hasMoreConversations,
     isAssistantTurnInProgress,
     isHeaderDragHandleEnabled = false,
-    isExpanded,
     isConversationInteractionDisabled,
     isLoadingMoreConversations,
     messages,
@@ -405,6 +404,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   // it drops the window chrome and never auto-focuses — that springs the
   // keyboard over the conversation.
   const isHandheld = useIsHandheld();
+  // Full-screen has no expanded variant. Narrowing a desktop window into
+  // handheld while expanded would otherwise keep the desktop-expanded layout
+  // with no toggle left to undo it; the prop survives, so widening restores it.
+  const isExpanded = props.isExpanded && !isHandheld;
   const isRateLimited = isInAppAgentRateLimited(error);
   const isComposerDisabled = isConversationInteractionDisabled;
   const isSubmitDisabled =

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -19,6 +19,7 @@ import {
   SendHorizontal,
   Square,
   Trash2,
+  X,
 } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -709,13 +710,23 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                   variant="ghost"
                   size="icon"
                   className="size-6"
-                  aria-label="Minimize assistant"
+                  // Full-screen has nothing to minimize into, and with no
+                  // drag-to-dismiss this is the only way out.
+                  aria-label={
+                    isHandheld ? "Close assistant" : "Minimize assistant"
+                  }
                   onClick={props.onClose}
                 >
-                  <Minus className="size-3" />
+                  {isHandheld ? (
+                    <X className="size-3" />
+                  ) : (
+                    <Minus className="size-3" />
+                  )}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Minimize assistant</TooltipContent>
+              <TooltipContent>
+                {isHandheld ? "Close assistant" : "Minimize assistant"}
+              </TooltipContent>
             </Tooltip>
           ) : null}
         </div>

--- a/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
@@ -132,10 +132,14 @@ describe("InAppAgentWindowHost", () => {
   });
 
   it("renders a full-screen drawer instead of the movable panel on a handheld", () => {
+    // A landscape phone: too wide for the `md` width clause, so only the
+    // coarse-pointer clause can match. Pins that the shell asks the handheld
+    // predicate, not the width-only one that sent a rotated phone back to the
+    // floating window.
     vi.stubGlobal(
       "matchMedia",
-      vi.fn(() => ({
-        matches: true,
+      vi.fn((query: string) => ({
+        matches: query.includes("pointer: coarse"),
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
       })),

--- a/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
@@ -61,17 +61,20 @@ describe("InAppAgentWindowHost", () => {
     HTMLElement.prototype.setPointerCapture = vi.fn();
     HTMLElement.prototype.releasePointerCapture = vi.fn();
 
-    // The `agent` overlay layer container normally declared in _document.
+    // The overlay layer containers normally declared in _document.
     const overlayRoot = document.createElement("div");
     overlayRoot.setAttribute("data-overlay-root", "");
-    const agentLayer = document.createElement("div");
-    agentLayer.setAttribute("data-layer", "agent");
-    overlayRoot.appendChild(agentLayer);
+    for (const layer of ["panel", "agent"]) {
+      const layerNode = document.createElement("div");
+      layerNode.setAttribute("data-layer", layer);
+      overlayRoot.appendChild(layerNode);
+    }
     document.body.appendChild(overlayRoot);
   });
 
   afterEach(() => {
     document.querySelector("[data-overlay-root]")?.remove();
+    vi.unstubAllGlobals();
   });
 
   it("keeps geometry while open and resets it on close/reopen", () => {
@@ -126,5 +129,24 @@ describe("InAppAgentWindowHost", () => {
     expect(screen.getByTestId("movable-resizable-panel").style.top).toBe(
       "88px",
     );
+  });
+
+  it("renders a full-screen drawer instead of the movable panel on a handheld", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    mocks.open = true;
+
+    render(<InAppAgentWindowHost />);
+
+    // No drag/resize on touch, and the drawer is the modal that scroll-locks
+    // the page behind it.
+    expect(screen.queryByTestId("movable-resizable-panel")).toBeNull();
+    expect(document.querySelector("#in-app-agent-drawer")).not.toBeNull();
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
@@ -142,11 +142,20 @@ describe("InAppAgentWindowHost", () => {
     );
     mocks.open = true;
 
-    render(<InAppAgentWindowHost />);
+    const { rerender } = render(<InAppAgentWindowHost />);
 
     // No drag/resize on touch, and the drawer is the modal that scroll-locks
     // the page behind it.
     expect(screen.queryByTestId("movable-resizable-panel")).toBeNull();
     expect(document.querySelector("#in-app-agent-drawer")).not.toBeNull();
+
+    // Closing drives the drawer's own `open` prop rather than unmounting the
+    // tree from under it, so Vaul can animate itself out.
+    mocks.open = false;
+    rerender(<InAppAgentWindowHost />);
+    expect(document.querySelector("#in-app-agent-drawer")).toHaveAttribute(
+      "data-state",
+      "closed",
+    );
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentWindowHost.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowHost.tsx
@@ -138,6 +138,9 @@ export function InAppAgentWindowHost() {
           <InAppAgentWindowShell
             floatingPanelHandle={floatingPanelHandle}
             isExpanded={isExpanded}
+            onClose={() => {
+              setOpen(false);
+            }}
             panelRef={panelRef}
           >
             {({ isHeaderDragHandleEnabled }) => (

--- a/web/src/features/in-app-agent/components/InAppAgentWindowHost.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowHost.tsx
@@ -113,7 +113,9 @@ export function InAppAgentWindowHost() {
     floatingPanelHandle.initializeGeometry();
   }, [floatingPanelHandle, isExpanded, open]);
 
-  if (!canUseAgent || !open) {
+  // Only `canUseAgent` gates the tree: the shell owns the `open` guard so the
+  // handheld drawer stays mounted and can animate itself closed.
+  if (!canUseAgent) {
     return null;
   }
 
@@ -141,6 +143,7 @@ export function InAppAgentWindowHost() {
             onClose={() => {
               setOpen(false);
             }}
+            open={open}
             panelRef={panelRef}
           >
             {({ isHeaderDragHandleEnabled }) => (

--- a/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -84,6 +84,12 @@ export function InAppAgentWindowShell({
   // drawers — so the page behind is scroll-locked and there is exactly one
   // scroller, and never the movable panel (drag/resize is meaningless on
   // touch). Stays mounted while closed so Vaul can animate itself out.
+  //
+  // `dismissible={false}`: this is a page, not a sheet, so it never follows a
+  // drag and you cannot pull it down to close — the header's close button is
+  // the way out. That also makes Vaul swallow every close routed through
+  // `onOpenChange`, so Escape is re-armed explicitly below (it still matters in
+  // a narrow desktop window, which is handheld too).
   if (isHandheld) {
     return (
       <Drawer
@@ -93,6 +99,7 @@ export function InAppAgentWindowShell({
             onClose();
           }
         }}
+        dismissible={false}
         forceDirection="bottom"
       >
         <DrawerContent
@@ -106,6 +113,10 @@ export function InAppAgentWindowShell({
           // off-screen by the banner offset. Vaul still overrides the height to
           // dodge the on-screen keyboard.
           className="top-banner-offset inset-x-0 bottom-0 h-auto rounded-none border-0 md:h-auto"
+          onEscapeKeyDown={(event) => {
+            event.preventDefault();
+            onClose();
+          }}
         >
           <DrawerTitle className="sr-only">Assistant</DrawerTitle>
           {children({ isHeaderDragHandleEnabled: false })}

--- a/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -8,6 +8,8 @@ import {
   type MovableResizablePanelSize,
   useMovableResizablePanelControl,
 } from "@/src/components/movable-resizable-panel";
+import { Drawer, DrawerContent, DrawerTitle } from "@/src/components/ui/drawer";
+import { useIsHandheld } from "@/src/hooks/use-mobile";
 
 const IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX = 8;
 const IN_APP_AGENT_WINDOW_SHELL_DEFAULT_WIDTH_PX = 448;
@@ -62,6 +64,7 @@ type InAppAgentWindowShellProps = {
   children: (props: { isHeaderDragHandleEnabled: boolean }) => ReactNode;
   floatingPanelHandle: MovableResizablePanelHandle;
   isExpanded: boolean;
+  onClose: () => void;
   panelRef: RefObject<HTMLDivElement | null>;
 };
 
@@ -69,8 +72,41 @@ export function InAppAgentWindowShell({
   children,
   floatingPanelHandle,
   isExpanded,
+  onClose,
   panelRef,
 }: InAppAgentWindowShellProps) {
+  const isHandheld = useIsHandheld();
+
+  // A phone has one presentation: the whole screen below the banner. A real
+  // (Vaul) modal drawer — the same treatment as the support / migration
+  // drawers — so the page behind is scroll-locked and there is exactly one
+  // scroller, and never the movable panel (drag/resize is meaningless on
+  // touch). `h-auto` drops the drawer's default height so top/bottom anchoring
+  // owns the geometry; Vaul still overrides the height to dodge the on-screen
+  // keyboard.
+  if (isHandheld) {
+    return (
+      <Drawer
+        open
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            onClose();
+          }
+        }}
+        forceDirection="bottom"
+      >
+        <DrawerContent
+          id="in-app-agent-drawer"
+          size="full"
+          className="top-banner-offset inset-x-0 bottom-0 h-auto rounded-none border-0"
+        >
+          <DrawerTitle className="sr-only">Assistant</DrawerTitle>
+          {children({ isHeaderDragHandleEnabled: false })}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
   if (!isExpanded && !floatingPanelHandle.geometry) {
     return null;
   }

--- a/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -65,6 +65,7 @@ type InAppAgentWindowShellProps = {
   floatingPanelHandle: MovableResizablePanelHandle;
   isExpanded: boolean;
   onClose: () => void;
+  open: boolean;
   panelRef: RefObject<HTMLDivElement | null>;
 };
 
@@ -73,6 +74,7 @@ export function InAppAgentWindowShell({
   floatingPanelHandle,
   isExpanded,
   onClose,
+  open,
   panelRef,
 }: InAppAgentWindowShellProps) {
   const isHandheld = useIsHandheld();
@@ -81,13 +83,11 @@ export function InAppAgentWindowShell({
   // (Vaul) modal drawer — the same treatment as the support / migration
   // drawers — so the page behind is scroll-locked and there is exactly one
   // scroller, and never the movable panel (drag/resize is meaningless on
-  // touch). `h-auto` drops the drawer's default height so top/bottom anchoring
-  // owns the geometry; Vaul still overrides the height to dodge the on-screen
-  // keyboard.
+  // touch). Stays mounted while closed so Vaul can animate itself out.
   if (isHandheld) {
     return (
       <Drawer
-        open
+        open={open}
         onOpenChange={(nextOpen) => {
           if (!nextOpen) {
             onClose();
@@ -98,7 +98,14 @@ export function InAppAgentWindowShell({
         <DrawerContent
           id="in-app-agent-drawer"
           size="full"
-          className="top-banner-offset inset-x-0 bottom-0 h-auto rounded-none border-0"
+          // `h-auto` at every breakpoint so top/bottom anchoring owns the
+          // geometry: the drawer's default height variant is `h-1/3 md:h-full`,
+          // and the `md:` half survives tailwind-merge — a landscape phone is
+          // both handheld and wider than `md`, and `top` + `bottom` + `height`
+          // over-constrains the box, dropping `bottom` and pushing the composer
+          // off-screen by the banner offset. Vaul still overrides the height to
+          // dodge the on-screen keyboard.
+          className="top-banner-offset inset-x-0 bottom-0 h-auto rounded-none border-0 md:h-auto"
         >
           <DrawerTitle className="sr-only">Assistant</DrawerTitle>
           {children({ isHeaderDragHandleEnabled: false })}
@@ -107,7 +114,7 @@ export function InAppAgentWindowShell({
     );
   }
 
-  if (!isExpanded && !floatingPanelHandle.geometry) {
+  if (!open || (!isExpanded && !floatingPanelHandle.geometry)) {
     return null;
   }
 

--- a/web/src/hooks/use-mobile.tsx
+++ b/web/src/hooks/use-mobile.tsx
@@ -3,20 +3,30 @@ import { useSyncExternalStore } from "react";
 // tailwind default breakpoint, corresponds to `md`, https://tailwindcss.com/docs/responsive-design
 const MOBILE_BREAKPOINT = 768;
 const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
-
-function subscribe(onStoreChange: () => void) {
-  if (typeof window === "undefined" || !window.matchMedia) return () => {};
-  const mql = window.matchMedia(MOBILE_QUERY);
-  mql.addEventListener("change", onStoreChange);
-  return () => mql.removeEventListener("change", onStoreChange);
-}
+// Phone-sized in EITHER orientation: narrow, or a touch screen that is short
+// (an iPhone in landscape is wider than `md` but only ~390px tall).
+const HANDHELD_QUERY = `${MOBILE_QUERY}, (pointer: coarse) and (max-height: ${MOBILE_BREAKPOINT - 1}px)`;
 
 // Guarded so it's safe where `matchMedia` is absent (jsdom tests, SSR, old
-// browsers) — treat those as non-mobile.
-function getSnapshot() {
-  if (typeof window === "undefined" || !window.matchMedia) return false;
-  return window.matchMedia(MOBILE_QUERY).matches;
+// browsers) — treat those as non-mobile. Module-level so the store functions
+// stay referentially stable across renders.
+function createMediaQueryStore(query: string) {
+  return {
+    subscribe(onStoreChange: () => void) {
+      if (typeof window === "undefined" || !window.matchMedia) return () => {};
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", onStoreChange);
+      return () => mql.removeEventListener("change", onStoreChange);
+    },
+    getSnapshot() {
+      if (typeof window === "undefined" || !window.matchMedia) return false;
+      return window.matchMedia(query).matches;
+    },
+  };
 }
+
+const mobileStore = createMediaQueryStore(MOBILE_QUERY);
+const handheldStore = createMediaQueryStore(HANDHELD_QUERY);
 
 /**
  * True when the viewport is below the `md` breakpoint. Reads the media query
@@ -25,5 +35,23 @@ function getSnapshot() {
  * SSR has no viewport, so it assumes desktop and hydration corrects it.
  */
 export function useIsMobile() {
-  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+  return useSyncExternalStore(
+    mobileStore.subscribe,
+    mobileStore.getSnapshot,
+    () => false,
+  );
+}
+
+/**
+ * True on phone-sized screens in either orientation — `useIsMobile()` plus a
+ * short touch screen, which is a phone held sideways. Use it for presentation
+ * that a rotation must not undo (full-screen panels, suppressing drag/resize
+ * affordances that need a precise pointer).
+ */
+export function useIsHandheld() {
+  return useSyncExternalStore(
+    handheldStore.subscribe,
+    handheldStore.getSnapshot,
+    () => false,
+  );
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16000.preview.langfuse.com](https://pr-16000.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

On a phone the assistant was a **draggable, resizable desktop window** floating over a page that kept its own live scroller — two scroll surfaces, touches landing on whichever. Now it is simply **the whole screen**, with the conversation as the only scroller.

## Why

Open the assistant on a phone and you got the desktop presentation: `isExpanded` defaults to `false`, so mobile rendered the floating `MovableResizablePanel` — a drag handle and resize grips, on a touch screen — sized `min(448, vw−16) × min(672, vh−32)`. That leaves 8px gutters all round, and the assistant renders into the deliberately non-modal `agent` overlay layer, so nothing scroll-locked the page underneath. Measured on a 390×700 viewport before the change: assistant at `(8, 24) 374×668`, and the page's table scroller still live at `1489/386`.

Even the existing *expanded* mode wasn't full-bleed (`inset-x-3 … bottom-3`), so the page showed and scrolled around it.

## What

**Option A — route the phone presentation through the house full-screen drawer.** The app already renders Support and V4 Migration as full-height mobile drawers; that is the established answer to "mobile full-screen panel", and because it is a real (Vaul) modal it scroll-locks everything behind it for free — including *inner* page scrollers, which a plain `overflow: hidden` on the body would not have touched. It also brings Vaul's on-screen-keyboard handling, which would otherwise have to be hand-rolled against `visualViewport`.

- `InAppAgentWindowShell` gains a handheld branch: a bottom `Drawer`, flush below the banner, no gutters and no radius. The movable panel is never rendered on touch.
- `useIsHandheld()` sits alongside `useIsMobile()`: below `md` **or** a short touch screen. An iPhone in landscape is 844×390 — wider than `md` — so a width-only check would have handed a rotated phone the floating window back.
- The window drops its own chrome and the expand/collapse control when handheld (nothing to expand from full-screen), and the conversation viewport gets `overscroll-behavior: contain` so its rubber-band cannot chain out.
- The host still lives in the authenticated layout, so the open conversation survives navigation — verified below, it was the condition for choosing this option.
- It is a **page, not a sheet**: `dismissible={false}`, so it never follows a drag and cannot be pulled down to close. The header control is the way out, and it reads *Close* with an X rather than *Minimize* — a full-screen page has nothing to minimize into.

Deliberately unchanged: the desktop floating/expanded modes, and the mobile autofocus suppression from #15429 — going full-screen must not start popping the keyboard open.

## Result

Full-bleed in both orientations, one scroller, page position preserved on close.

<details>
<summary>Verification (Chrome + a real touch context, portrait and landscape)</summary>

Measured with an iPhone 14 device profile (coarse pointer), assistant open on the tracing table:

| Check | Portrait 390×664 | Landscape 844×390 |
| --- | --- | --- |
| Full-screen drawer / floating panel | yes / no | yes / no |
| Drawer rect | `0,0 390×664` | `0,0 844×390` |
| All four viewport corners inside the assistant | yes | yes |
| Expand control present | no | no |
| Page scroll-locked | yes | yes |
| Page scroller accepts wheel/touch | **blocked** | **blocked** |
| Conversation scroller accepts wheel/touch | allowed | allowed |
| Composer fully inside the viewport **with a 28px banner** | yes (bottom 658 ≤ 664) | yes (bottom 384 ≤ 390) |
| Focused element on open | not the composer | not the composer |

- **Close restores the page:** page scroller at `400` → open → close → still `400`. The closed drawer lingers only for its slide-out (`data-state="closed"`), then within ~600ms it unmounts, the assistant unmounts, and `data-scroll-locked` plus the body style are fully released — the page scrolls again.
- **Navigation:** with the assistant open, routed tracing → sessions → tracing via the router. The drawer stayed mounted and full-bleed each time, scroll-lock intact, page scroller still blocked.
- **Desktop regression (1280×800):** nothing mounted while closed; opens at `824,120 448×672` with its rounded chrome and expand control; drags to `644,50`; expand → the gutter branch; collapse → back to the *dragged* `644,50`; close → fully unmounted. No drawer, no scroll-lock. (Re-verified after the `open` guard moved from the host into the shell.)
- **It does not move:** dragged the header down 220px on a touch device — the drawer held at `transform: none`, `top: 0`, and stayed open on release. Escape closes it (re-armed by hand, since `dismissible={false}` makes Vaul swallow `onOpenChange` closes), and so does the header's Close button; both release the scroll lock.
- **Composer clear of the keyboard:** pinned at the bottom of the drawer (`y 806–838` in an 844-tall viewport), and Vaul re-sizes the drawer against `visualViewport` when the keyboard opens.

Regression test in `InAppAgentWindowHost.clienttest.tsx` pins "handheld renders the drawer, never the movable panel" — confirmed failing against the old behavior before the fix.

`turbo lint` → `Tasks: 7 successful, 7 total`. `turbo typecheck` → `Tasks: 7 successful, 7 total`. Agent client suites → `Tests 9 passed (9)`.

</details>

<details>
<summary>Review findings, all four fixed</summary>

- **Composer cut off in landscape when a banner is shown.** `drawerVariants`' default height is `h-1/3 md:h-full`, and the `md:` half survives `tailwind-merge` — a landscape phone is both handheld *and* wider than `md`, so `top` + `bottom` + `height` over-constrained the fixed box, `bottom` was dropped, and the drawer overshot by the banner offset. Reproduced at 844×390 with a 28px banner: drawer ended at `418` and the composer's bottom edge at `412`, in a 390-tall viewport. My original landscape pass missed it because local dev has no banner, so `--banner-offset` was `0`. Fixed by pinning `md:h-auto`; now height `362`, composer bottom `384`.
- **No slide-out on close.** The drawer was rendered with `open` hardcoded `true`, and Vaul's `closeDrawer` flips `isOpen` immediately, so the host's `!open` guard unmounted the tree before any transition could play. The shell now owns the `open` guard and drives the drawer's own prop. Verified the lingering closed node is transient and releases everything (see the close bullet above).

- **Desktop-expanded layout leaked into the full-screen presentation.** `isExpanded` is provider state that only resets on close, so expanding on desktop and then narrowing past the breakpoint (a resized window, an iPad Slide-Over) kept the expanded layout inside the drawer — messages flush to the screen edge at `0` padding, the bordered column composer with its text Send button — while the expand toggle is hidden when handheld, leaving nothing to undo it. Measured at 390px wide before the fix: `padding-left: 0px`, column composer, no toggle. After: `12px`, icon composer. The prop survives, so widening restores desktop expanded exactly.
- **The handheld test's `matchMedia` stub matched every query.** It now answers per query, simulating a landscape phone: too wide for the width clause, so only the coarse-pointer clause can match. Swapping the shell back to the width-only hook — the likeliest regression, since it is what sent a rotated phone to the floating window — now fails the test, which it did not before. Residual gap: nothing evaluates the query string's own operator semantics, since jsdom does not implement media queries and the evaluator in the tree is not resolvable from `web`.
</details>

<details>
<summary>Left for follow-ups</summary>

- `useIsMobile()` stays width-only, so the rest of the mobile shell (top bar, page title) still flips to the desktop layout when a phone is rotated. Only the assistant is orientation-proof here; making the whole shell handheld-aware is a bigger change than this fix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR routes phone-sized assistant windows through the application’s full-screen modal drawer while retaining the movable and expanded desktop presentations.
- Adds an orientation-aware `useIsHandheld` media-query hook.
- Uses a full-bleed drawer with background scroll locking on handheld screens.
- Removes handheld window chrome, expansion controls, and automatic composer focus.
- Adds host coverage for selecting the drawer rather than the movable panel.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking test gap around the landscape-phone classification that motivated the change.

The responsive drawer and desktop branches have coherent state and dismissal wiring, but the added test bypasses the compound media-query behavior and would not catch a regression specific to wide, short phones.

**Files Needing Attention:** web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Open[Assistant opens] --> Detect{useIsHandheld}
  Detect -->|true| Drawer[Full-screen modal drawer]
  Drawer --> Lock[Lock background scrolling]
  Drawer --> MobileUI[Hide window chrome and expansion control]
  Detect -->|false| Expanded{isExpanded}
  Expanded -->|true| FullDesktop[Expanded desktop panel]
  Expanded -->|false| Floating[Movable resizable desktop panel]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx:135-143
**Handheld test bypasses classification**

The `matchMedia` stub returns `true` for every query, so this test does not exercise the new coarse-pointer and short-height landscape-phone condition. It will continue passing if that clause regresses and landscape phones receive the movable panel again.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(assistant): pin the handheld full-s..."](https://github.com/langfuse/langfuse/commit/52788f048892f1f49ed213a542d444ddccb19261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52256548)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->


