### PR TITLE
fix(web): lock viewport scale so mobile focus does not zoom

### DIFF
--- a/web/src/components/movable-resizable-panel.clienttest.tsx
+++ b/web/src/components/movable-resizable-panel.clienttest.tsx
@@ -356,6 +356,44 @@ describe("MovableResizablePanel", () => {
     );
   });
 
+  it("keeps clamping clear of the safe-area insets", () => {
+    // Silent-failure guard: a wrong var name would just read 0 and place the
+    // panel under the home indicator with nothing to notice.
+    document.documentElement.style.setProperty(
+      "--safe-area-inset-right",
+      "20px",
+    );
+    document.documentElement.style.setProperty(
+      "--safe-area-inset-bottom",
+      "34px",
+    );
+
+    render(<TestPanel />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const handle = screen.getByTestId("drag-handle");
+
+    firePointerEvent(handle, "pointerdown", {
+      pointerId: 1,
+      clientX: 140,
+      clientY: 150,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 5000,
+      clientY: 5000,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    // 1024 - 10 padding - 20 inset - 300 wide, 768 - 10 - 34 - 240 tall.
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "694,484,300,240",
+    );
+
+    document.documentElement.style.removeProperty("--safe-area-inset-right");
+    document.documentElement.style.removeProperty("--safe-area-inset-bottom");
+  });
+
   it("does not start dragging from explicitly ignored elements inside a handle", () => {
     const onActionClick = vi.fn();
 

--- a/web/src/components/movable-resizable-panel.tsx
+++ b/web/src/components/movable-resizable-panel.tsx
@@ -233,6 +233,18 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
+// The OS reserves the safe-area edges (home indicator, notch), and
+// `viewport-fit=cover` means innerWidth/innerHeight now span them, so bounds
+// have to subtract them or the panel places and clamps under system UI.
+// globals.css mirrors each `env()` inset into a var for this; 0 without a notch.
+function getSafeAreaInset(edge: "top" | "right" | "bottom" | "left"): number {
+  const value = getComputedStyle(document.documentElement).getPropertyValue(
+    `--safe-area-inset-${edge}`,
+  );
+
+  return Number.parseFloat(value) || 0;
+}
+
 function getViewportBounds(
   boundsPadding: number,
 ): MovableResizablePanelViewportBounds {
@@ -246,10 +258,10 @@ function getViewportBounds(
   }
 
   return {
-    minLeft: boundsPadding,
-    minTop: boundsPadding,
-    maxRight: window.innerWidth - boundsPadding,
-    maxBottom: window.innerHeight - boundsPadding,
+    minLeft: boundsPadding + getSafeAreaInset("left"),
+    minTop: boundsPadding + getSafeAreaInset("top"),
+    maxRight: window.innerWidth - boundsPadding - getSafeAreaInset("right"),
+    maxBottom: window.innerHeight - boundsPadding - getSafeAreaInset("bottom"),
   };
 }
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -82,9 +82,12 @@ export function InAppAgentWindowShell({
   // layer ORDER stacks the whole `agent` layer below every transient overlay.
   if (isExpanded) {
     return (
+      // `--banner-offset` carries the top inset; the other three edges add
+      // theirs here, because the viewport meta's `viewport-fit=cover` extends
+      // layout under the home indicator and, in landscape, the notch.
       <div
         ref={panelRef}
-        className="pointer-events-auto fixed inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3 origin-top-left"
+        className="pointer-events-auto fixed top-[calc(var(--banner-offset)+0.75rem)] right-[calc(0.75rem+env(safe-area-inset-right,0px))] bottom-[calc(0.75rem+env(safe-area-inset-bottom,0px))] left-[calc(0.75rem+env(safe-area-inset-left,0px))] origin-top-left"
         data-ignore-outside-interaction
       >
         <div

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -4,6 +4,7 @@
 import "@/src/polyfills/crypto-random-uuid";
 
 import { type AppType } from "next/app";
+import Head from "next/head";
 import { type Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { setUser } from "@sentry/nextjs";
@@ -144,49 +145,63 @@ const MyApp: AppType<{ session: Session | null }> = ({
   );
 
   return (
-    <QueryParamProvider
-      adapter={NextAdapterPagesWithReadyGuard}
-      options={{ enableBatching: true }}
-    >
-      <TooltipProvider>
-        <CommandMenuProvider>
-          <PostHogProvider client={posthog}>
-            <SessionProvider
-              session={session}
-              refetchOnWindowFocus={true}
-              refetchInterval={5 * 60} // 5 minutes
-              basePath={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/auth`}
-            >
-              <DetailPageListsProvider>
-                <MarkdownContextProvider>
-                  <ThemeProvider
-                    attribute="class"
-                    enableSystem
-                    disableTransitionOnChange
-                  >
-                    <ScoreCacheProvider>
-                      <CorrectionCacheProvider>
-                        <SupportDrawerProvider defaultOpen={false}>
-                          <V4MigrationPanelProvider defaultOpen={false}>
-                            <InAppAiAgentProvider defaultOpen={false}>
-                              {skipAppLayout ? (
-                                page
-                              ) : (
-                                <AppLayout>{page}</AppLayout>
-                              )}
-                            </InAppAiAgentProvider>
-                          </V4MigrationPanelProvider>
-                        </SupportDrawerProvider>
-                      </CorrectionCacheProvider>
-                    </ScoreCacheProvider>
-                  </ThemeProvider>
-                </MarkdownContextProvider>
-              </DetailPageListsProvider>
-            </SessionProvider>
-          </PostHogProvider>
-        </CommandMenuProvider>
-      </TooltipProvider>
-    </QueryParamProvider>
+    <>
+      {/* Replaces Next's default `width=device-width` (next/head dedupes by
+          name). `maximum-scale=1` stops iOS Safari auto-zooming a focused
+          sub-16px field; iOS ignores `user-scalable=no` for user gestures, so
+          the engine-level zoom block is `touch-action` on html/body
+          (styles/globals.css). `viewport-fit=cover` is what makes
+          `env(safe-area-inset-*)` non-zero. */}
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, height=device-height, initial-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no, viewport-fit=cover"
+        />
+      </Head>
+      <QueryParamProvider
+        adapter={NextAdapterPagesWithReadyGuard}
+        options={{ enableBatching: true }}
+      >
+        <TooltipProvider>
+          <CommandMenuProvider>
+            <PostHogProvider client={posthog}>
+              <SessionProvider
+                session={session}
+                refetchOnWindowFocus={true}
+                refetchInterval={5 * 60} // 5 minutes
+                basePath={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/auth`}
+              >
+                <DetailPageListsProvider>
+                  <MarkdownContextProvider>
+                    <ThemeProvider
+                      attribute="class"
+                      enableSystem
+                      disableTransitionOnChange
+                    >
+                      <ScoreCacheProvider>
+                        <CorrectionCacheProvider>
+                          <SupportDrawerProvider defaultOpen={false}>
+                            <V4MigrationPanelProvider defaultOpen={false}>
+                              <InAppAiAgentProvider defaultOpen={false}>
+                                {skipAppLayout ? (
+                                  page
+                                ) : (
+                                  <AppLayout>{page}</AppLayout>
+                                )}
+                              </InAppAiAgentProvider>
+                            </V4MigrationPanelProvider>
+                          </SupportDrawerProvider>
+                        </CorrectionCacheProvider>
+                      </ScoreCacheProvider>
+                    </ThemeProvider>
+                  </MarkdownContextProvider>
+                </DetailPageListsProvider>
+              </SessionProvider>
+            </PostHogProvider>
+          </CommandMenuProvider>
+        </TooltipProvider>
+      </QueryParamProvider>
+    </>
   );
 };
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -572,6 +572,11 @@
   body {
     /* Prevent pull-to-refresh and rubber-banding on the page level only */
     overscroll-behavior-y: none;
+    /* Omitting `pinch-zoom` blocks pinch and double-tap zoom at the engine
+       level, which modern iOS honors where it ignores `user-scalable=no`
+       (viewport meta lives in pages/_app.tsx). Elements that own their own
+       gestures set their own `touch-action`. */
+    touch-action: pan-x pan-y;
   }
 
   body {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -397,6 +397,14 @@
     --banner-offset: calc(
       env(safe-area-inset-top, 0px) + var(--banner-height, 0px)
     );
+
+    /* `env()` is CSS-only, so mirror the insets into custom properties that JS
+       can read (getComputedStyle resolves them to px). Non-zero only because
+       the viewport meta sets `viewport-fit=cover` — see pages/_app.tsx. */
+    --safe-area-inset-top: env(safe-area-inset-top, 0px);
+    --safe-area-inset-right: env(safe-area-inset-right, 0px);
+    --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-area-inset-left: env(safe-area-inset-left, 0px);
   }
 
   .dark {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16001.preview.langfuse.com](https://pr-16001.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Tapping the Assistant composer on a phone made iOS Safari zoom the page in abruptly, pushing the send button off-screen. Cause: **we shipped no viewport meta at all**, so nothing capped page scale, and any focused field under 16px triggers iOS auto-zoom. This declares an explicit viewport meta that locks page scale, plus `touch-action: pan-x pan-y` on `html, body`. Two files, five lines of behavior. A deliberate step toward an app-like mobile experience.

**The accessibility trade-off, up front so review doesn't have to find it:** `user-scalable=no` / `maximum-scale=1` is a WCAG 1.4.4 concern and Lighthouse/axe will flag it. Taking that on knowingly:

- **Modern iOS ignores `user-scalable=no` for user gestures regardless** — that half of the meta is belt-and-braces, not the mechanism.
- **`touch-action: pan-x pan-y` is the deliberate part.** Omitting `pinch-zoom` removes pinch and double-tap zoom at the engine level, which is the lever iOS still honors.
- **Text scaling is untouched.** OS-level text size, Safari's own text-size control and Reader all keep working — this caps *layout* scale, not text size.
- **Desktop zoom is untouched.** Desktop browsers ignore the viewport meta entirely; ⌘ +/− is unaffected, verified below.
- **A global lock is safer than a conditional one.** Scoping the block to "only while the Assistant is open" would create a trap: zoom in, open the Assistant, and pinch plus double-tap both die while the panel — being `position: fixed` — is laid out to a viewport wider than what you can see. The unconditional lock has no such state, because a zoomed page is never reachable.

## Why

Three things stacked up:

1. **No viewport meta anywhere.** `web/src/pages/_document.tsx` renders a bare `<Head />`, and `web/src/app/layout.tsx` is the untouched Next scaffold stub — the App Router only serves `/api` here, so the Pages Router owns the HTML and that stub is inert. We were inheriting Next's default, which caps nothing.
2. **The composer computes to 13.2px** (`text-sm`), as do the shared `Input` and `Textarea` primitives. iOS Safari auto-zooms any focused field whose computed font-size is under 16px.
3. **The panel is `position: fixed`.** So when iOS scales the visual viewport, the panel edge carrying the send button moves out of view.

## What

1. **`web/src/pages/_app.tsx`** — declare the viewport meta through `next/head`. Deliberately not `_document.tsx`: Next warns about viewport metas there, and `@next/next/no-document-viewport-meta` flags them.
2. **`web/src/styles/globals.css`** — add `touch-action: pan-x pan-y` to the existing `html, body` rule, next to `overscroll-behavior-y: none`.

Plus the consequence of `viewport-fit=cover`, which makes `env(safe-area-inset-*)` non-zero for the first time and so needs the Assistant panel to stop measuring from the physical screen edge (both variants, found while reviewing this change — see below):

3. **`web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx`** — the expanded panel's `bottom-3` / `inset-x-3` gain their insets. Its top edge already resolved through `--banner-offset`, which was safe-area-aware all along.
4. **`web/src/components/movable-resizable-panel.tsx`** — `getViewportBounds` subtracts the insets, so the floating panel's placement, drag clamping and resize maxima all stay clear of system UI. `env()` is CSS-only, so `globals.css` mirrors each inset into a custom property for JS to read.

## Result

Measured in the served DOM, before and after — and it **replaces** the default rather than duplicating it, because `next/head` dedupes `<meta>` by `name`:

```diff
- <meta name="viewport" content="width=device-width">
+ <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no, viewport-fit=cover">
```

Still exactly one viewport meta in `<head>`. Computed `touch-action` on both `html` and `body` is `pan-x pan-y`, with `overscroll-behavior-y: none` intact.

<details>
<summary>Mechanism, verification, and what is deliberately not here</summary>

### The safe-area follow-on, in both panel variants

`viewport-fit=cover` extends layout to the physical screen edges, so anything that measured from the viewport edge now measures past the OS-reserved areas. Two places in the Assistant did:

- **Expanded panel** — `bottom-3` and `inset-x-3` are bare offsets, so the composer landed in the home-indicator gesture strip and, in landscape, the panel ran under the notch. Fixed by adding the insets per edge; the pattern mirrors `CommentList.tsx:711`, which already did this.
- **Floating panel** — this one is the *default* on a phone (`isExpanded` starts `false` and is only toggled by the header button), and it is positioned by JS pixels rather than CSS. Measured at 390×844: the panel's bottom edge sat at 836 and the send button's at 829, i.e. 15px from the physical bottom, inside the ~34px indicator strip. Because `getGeometry()` runs the initial geometry through `clampPanelBounds`, and both that and `getPanelSizeConstraints` derive from `getViewportBounds`, subtracting the insets in that one function corrects initial placement, drag clamping and resize maxima together.

Reading `env()` from JS goes through custom properties mirrored in `globals.css`; verified in a browser that `getComputedStyle` substitutes them to a resolved px length rather than handing back the literal `env(...)` token stream. Every inset is 0 without a notch, so desktop geometry is unchanged by construction — the existing 12 panel tests still pass, and the new 13th pins the subtraction, because a mistyped var name would silently read 0 and reintroduce the bug with nothing to notice.

### Why it replaces instead of duplicating

Next's Pages Router `defaultHead()` emits `<meta charSet="utf-8">` and `<meta name="viewport" content="width=device-width">`, the latter keyed `"viewport"`. `next/head` dedupes meta tags by `name`, so ours takes its place. Confirmed by measurement, not just by reading the source: one `meta[name=viewport]` in the DOM, carrying our content.

### Verified locally

- Served-HTML diff above, and `document.querySelectorAll('meta[name=viewport]').length === 1`.
- Computed `touch-action` = `pan-x pan-y` on `html` and `body`; `overscroll-behavior-y` still `none`.
- No horizontal overflow introduced: `documentElement.scrollWidth === innerWidth` at both 390×844 and 1440×900.
- Inner scroll containers unaffected. `pan-x pan-y` at the root removes only pinch and double-tap zoom; both-axis panning still resolves, so nested scrollers keep scrolling.
- Assistant at 390×844 with the panel open: `position: fixed`, composer 13.2px, and both the composer and the send button fully inside the viewport at 1× — so the pre-existing layout is sound and page scale was the only thing putting the send button off-screen.
- Typecheck and lint clean repo-wide; all 10 in-app-agent client suites pass (112 tests).

**Not verifiable off-device, by nature:** Chrome emulation cannot reproduce iOS focus auto-zoom, so the actual symptom is signed off on a real iPhone against this PR's preview.

### Gesture surfaces that keep working

`touch-action` is not inherited and resolves as the intersection of the hit element and its ancestors, so an element that owns its own gestures still gets them. The trace graph view implements pinch in JS through d3-zoom (and benefits — the browser no longer competes for the gesture); the trace-timeline gutter and the movable panel already set `touch-action: none` themselves.

### Deliberately not in this PR

- **Bumping the `Input`/`Textarea` primitives to 16px on mobile.** Held in reserve for the case where the device pass still shows residual zoom — but worth recording that the obvious form of this, `text-base md:text-sm`, would not work here. Our design-system scale is compressed: `--text-sm` is `0.825rem` (13.2px, measured on the live composer) and `--text-base` is `0.9rem` (**14.4px**), still under iOS's 16px threshold. `--text-lg` (`1.1rem`, 17.6px) is the first token that clears it. So the reserve fix is an explicit 16px or a new scale token, not a token step up — a decision for the design system rather than a two-line change.
- **`interactive-widget=resizes-content`.** It would make the layout viewport shrink with the on-screen keyboard so a fixed composer stays visible — but it is Chromium 108+ / Firefox 132+ only, WebKit has not implemented it, so it is a no-op on iOS while making Android diverge. It also turns keyboard-open into an app-wide layout event that touches `window.innerHeight`-derived panel geometry and virtualized table measurement. Keyboard-versus-composer is better solved once for both platforms via the VisualViewport API, alongside the full-screen Assistant work in flight.
- **`position: fixed; overflow: hidden` on `html, body`.** The other half of a true app shell, and the natural next step for the mobile strategy — but it removes document-level scrolling, which the auth, onboarding and public-share pages may still rely on. That needs its own pass and its own device check.
- **Tests.** The change is a meta string and one CSS declaration; there is no logic to pin, and asserting the literal string back would just be a constant test.

</details>

## Test on a real iPhone

Chrome emulation cannot reproduce iOS focus auto-zoom, so this needs a device. Open the preview root once first so a session exists, then:

1. Open the Assistant and tap the composer → no zoom jump; the send button stays visible.
2. Type a long multi-line message → the composer grows, the send button stays visible.
3. Double-tap the page background → no zoom.
4. Pinch → expected: nothing happens.
5. Check the gap under the composer, then rotate to landscape and check it again along with the panel's side edges. This is the newly-active safe-area path, in both the default floating panel and the expanded one (header expand button): nothing should sit against the home indicator or run under the notch.
6. Desktop regression: ⌘ +/− still zooms, and no layout change at any breakpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
