### PR TITLE
feat(web): show hello text on sign-in page

### DIFF
--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -844,6 +844,9 @@ export default function SignIn({
           <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">
             Sign in to your account
           </h2>
+          <p className="text-muted-foreground mt-2 text-center text-sm">
+            hello
+          </p>
         </div>
 
         {isLangfuseCloud && (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16004.preview.langfuse.com](https://pr-16004.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "hello" line to the sign-in page, rendered directly under the "Sign in to your account" heading.

The request was to "add a hello print to the signin page"; this interprets "print" as user-visible output on the page rather than a console log, so it shows up in the rendered UI.

## Changes

- `web/src/pages/auth/sign-in.tsx`: render a muted, centered `hello` paragraph below the page heading.

## Verification

- `pnpm run lint` (pre-commit hook): `Tasks: 7 successful, 7 total`
- Prettier: `All matched files use Prettier code style!`
- Browser review of `/auth/sign-in` against the locally built Docker stack: "hello" renders under the heading, form layout unchanged, no errors.

[Sign-in page showing hello under the heading](https://cursor.com/agents/bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsignin_hello_text.webp)

## Note for the Cursor Cloud environment setup

`scripts/agents/start-cursor-cloud.sh` failed on boot in this run: the repo-local `.env` created by postinstall (host-oriented `localhost` URLs for Postgres, ClickHouse, Redis, MinIO) is picked up by Docker Compose variable interpolation, so the containerized web/worker got `DATABASE_URL=...@localhost:5432` and crash-looped on Prisma `P1001`. Running the same compose command with `--env-file /dev/null` brings all six services up healthy. Not fixed here to keep this PR scoped.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

