### PR TITLE
feat(traces): show project members in top bar

### DIFF
--- a/web/src/__tests__/server/unit/projectMembersRoute.servertest.ts
+++ b/web/src/__tests__/server/unit/projectMembersRoute.servertest.ts
@@ -22,7 +22,7 @@ const createRequest = ({
   method = "GET",
   projectId = "project-1",
 }: {
-  method?: string;
+  method?: "GET" | "POST";
   projectId?: string | string[];
 } = {}) =>
   createMocks<NextApiRequest, NextApiResponse>({

--- a/web/src/__tests__/server/unit/projectMembersRoute.servertest.ts
+++ b/web/src/__tests__/server/unit/projectMembersRoute.servertest.ts
@@ -1,0 +1,108 @@
+/** @vitest-environment node */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import handler from "@/src/pages/api/project/[projectId]/members";
+
+const { getServerAuthSessionMock, getProjectMemberNamesMock } = vi.hoisted(
+  () => ({
+    getServerAuthSessionMock: vi.fn(),
+    getProjectMemberNamesMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/src/server/auth", () => ({
+  getServerAuthSession: getServerAuthSessionMock,
+}));
+
+vi.mock("@/src/features/rbac/server/getProjectMemberNames", () => ({
+  getProjectMemberNames: getProjectMemberNamesMock,
+}));
+
+const createRequest = ({
+  method = "GET",
+  projectId = "project-1",
+}: {
+  method?: string;
+  projectId?: string | string[];
+} = {}) =>
+  createMocks<NextApiRequest, NextApiResponse>({
+    method,
+    query: { projectId },
+  });
+
+const projectMemberSession = {
+  user: {
+    organizations: [
+      {
+        id: "organization-1",
+        projects: [{ id: "project-1" }],
+      },
+    ],
+  },
+};
+
+describe("GET /api/project/[projectId]/members", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServerAuthSessionMock.mockResolvedValue(projectMemberSession);
+    getProjectMemberNamesMock.mockResolvedValue([
+      { id: "user-1", name: "Ada Lovelace" },
+      { id: "user-2", name: "Grace Hopper" },
+    ]);
+  });
+
+  it("returns all project member names", async () => {
+    const { req, res } = createRequest();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      members: [
+        { id: "user-1", name: "Ada Lovelace" },
+        { id: "user-2", name: "Grace Hopper" },
+      ],
+    });
+    expect(getProjectMemberNamesMock).toHaveBeenCalledWith({
+      projectId: "project-1",
+      orgId: "organization-1",
+    });
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    getServerAuthSessionMock.mockResolvedValue(null);
+    const { req, res } = createRequest();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(getProjectMemberNamesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects access to projects outside the session", async () => {
+    const { req, res } = createRequest({ projectId: "project-2" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(getProjectMemberNamesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid project id", async () => {
+    const { req, res } = createRequest({ projectId: [] });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(getProjectMemberNamesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported methods", async () => {
+    const { req, res } = createRequest({ method: "POST" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(getServerAuthSessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/rbac/components/ProjectMemberNames.tsx
+++ b/web/src/features/rbac/components/ProjectMemberNames.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import { env } from "@/src/env.mjs";
+import { ProjectMemberNamesResponse } from "@/src/features/rbac/types/project-member-names";
+
+export function ProjectMemberNames({ projectId }: { projectId: string }) {
+  const membersQuery = useQuery({
+    queryKey: ["project-member-names", projectId],
+    queryFn: async () => {
+      const response = await fetch(
+        `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/project/${encodeURIComponent(projectId)}/members`,
+      );
+      if (!response.ok) {
+        throw new Error("Failed to load project members");
+      }
+      return ProjectMemberNamesResponse.parse(await response.json());
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const memberNames = membersQuery.isPending
+    ? "Loading…"
+    : membersQuery.isError
+      ? "Unavailable"
+      : membersQuery.data.members.length > 0
+        ? membersQuery.data.members.map((member) => member.name).join(", ")
+        : "No members";
+
+  return (
+    <span
+      aria-label="Project team members"
+      className="text-muted-foreground text-xs"
+    >
+      Team: {memberNames}
+    </span>
+  );
+}

--- a/web/src/features/rbac/server/getProjectMemberNames.ts
+++ b/web/src/features/rbac/server/getProjectMemberNames.ts
@@ -1,0 +1,23 @@
+import { Prisma } from "@langfuse/shared";
+import { getUserProjectRoles } from "@langfuse/shared/src/server";
+import type { ProjectMemberNamesResponse } from "@/src/features/rbac/types/project-member-names";
+
+export async function getProjectMemberNames({
+  projectId,
+  orgId,
+}: {
+  projectId: string;
+  orgId: string;
+}): Promise<ProjectMemberNamesResponse["members"]> {
+  const users = await getUserProjectRoles({
+    projectId,
+    orgId,
+    filterCondition: [],
+    orderBy: Prisma.sql`ORDER BY all_eligible_users.name ASC NULLS LAST, all_eligible_users.email ASC NULLS LAST`,
+  });
+
+  return users.map((user) => ({
+    id: user.id,
+    name: user.name || "Unnamed member",
+  }));
+}

--- a/web/src/features/rbac/server/getProjectMemberNames.ts
+++ b/web/src/features/rbac/server/getProjectMemberNames.ts
@@ -13,6 +13,7 @@ export async function getProjectMemberNames({
     projectId,
     orgId,
     filterCondition: [],
+    searchFilter: Prisma.empty,
     orderBy: Prisma.sql`ORDER BY all_eligible_users.name ASC NULLS LAST, all_eligible_users.email ASC NULLS LAST`,
   });
 

--- a/web/src/features/rbac/types/project-member-names.ts
+++ b/web/src/features/rbac/types/project-member-names.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const ProjectMemberNamesResponse = z.object({
+  members: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+});
+
+export type ProjectMemberNamesResponse = z.infer<
+  typeof ProjectMemberNamesResponse
+>;

--- a/web/src/pages/api/project/[projectId]/members.ts
+++ b/web/src/pages/api/project/[projectId]/members.ts
@@ -1,0 +1,46 @@
+import {
+  ForbiddenError,
+  InvalidRequestError,
+  UnauthorizedError,
+} from "@langfuse/shared";
+import { z } from "zod";
+import { getProjectMemberNames } from "@/src/features/rbac/server/getProjectMemberNames";
+import { ProjectMemberNamesResponse } from "@/src/features/rbac/types/project-member-names";
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { getServerAuthSession } from "@/src/server/auth";
+
+const querySchema = z.object({
+  projectId: z.string().min(1),
+});
+
+export default withMiddlewares({
+  GET: async (req, res) => {
+    const query = querySchema.safeParse(req.query);
+    if (!query.success) {
+      throw new InvalidRequestError("Invalid project id");
+    }
+
+    const session = await getServerAuthSession({ req, res });
+    if (!session?.user) {
+      throw new UnauthorizedError("Unauthorized");
+    }
+
+    const projectOrganization = session.user.organizations.find(
+      (organization) =>
+        organization.projects.some(
+          (project) => project.id === query.data.projectId,
+        ),
+    );
+    if (!projectOrganization) {
+      throw new ForbiddenError("Project access required");
+    }
+
+    const members = await getProjectMemberNames({
+      projectId: query.data.projectId,
+      orgId: projectOrganization.id,
+    });
+    const response = ProjectMemberNamesResponse.parse({ members });
+
+    return res.status(200).json(response);
+  },
+});

--- a/web/src/pages/project/[projectId]/traces/index.tsx
+++ b/web/src/pages/project/[projectId]/traces/index.tsx
@@ -62,9 +62,7 @@ export default function Traces() {
       headerProps={{
         title: "Tracing",
         titleBadges: <V4MigrationDelayBadge />,
-        breadcrumbBadges: isBetaEnabled ? (
-          <ProjectMemberNames projectId={projectId} />
-        ) : undefined,
+        breadcrumbBadges: <ProjectMemberNames projectId={projectId} />,
         help: {
           description: (
             <>

--- a/web/src/pages/project/[projectId]/traces/index.tsx
+++ b/web/src/pages/project/[projectId]/traces/index.tsx
@@ -11,6 +11,7 @@ import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import ObservationsEventsTable from "@/src/features/events/components/EventsTable";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import { V4MigrationDelayBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
+import { ProjectMemberNames } from "@/src/features/rbac/components/ProjectMemberNames";
 
 export default function Traces() {
   const router = useRouter();
@@ -61,6 +62,9 @@ export default function Traces() {
       headerProps={{
         title: "Tracing",
         titleBadges: <V4MigrationDelayBadge />,
+        breadcrumbBadges: isBetaEnabled ? (
+          <ProjectMemberNames projectId={projectId} />
+        ) : undefined,
         help: {
           description: (
             <>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16005.preview.langfuse.com](https://pr-16005.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Shows the names of every member who has access to the project in the very top row of the traces page, including the new v4/events-backed view.

- Adds `GET /api/project/[projectId]/members`, authenticated with the current NextAuth session and scoped to projects in that session.
- Resolves effective project access through the canonical project-role query, covering inherited organization roles and explicit project roles.
- Returns only member IDs and display names; null names render as `Unnamed member`.
- Adds a `Team: …` label to the existing top-row breadcrumb badge slot.

Fixes # (issue)

### Local new/v4 verification

[local_new_traces_team_members_top_bar.mp4](https://cursor.com/agents/bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocal_new_traces_team_members_top_bar.mp4)

[Local new traces page showing project team members in the top bar](https://cursor.com/agents/bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocal_traces_team_members.webp)

### PR preview verification

[preview_traces_project_team_members.mp4](https://cursor.com/agents/bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_traces_project_team_members.mp4)

[PR preview showing project team members in the traces top bar](https://cursor.com/agents/bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_traces_team_members.webp)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Checked formatting and lint (`Tasks: 7 successful, 7 total`)
- [x] Added API authentication, tenant isolation, response, and method tests
- [x] Ran targeted server tests locally (`Tests 5 passed (5)`)
- [x] Ran the web TypeScript check locally
- [x] Rebuilt the local Docker stack and tested before creating the preview PR
- [x] Confirmed the local API returned 200 and the new/v4 header displayed `Team: Demo User, Demo User 2`
- [x] Re-tested both local traces toggle states after making the top bar consistent across views
- [x] Tested commit `2af7ab5` on https://pr-16005.preview.langfuse.com
- [x] Confirmed the preview API returned 200 with both seeded members and the header rendered both names without layout regressions
- [x] CI: 32 successful, 0 failed, 0 pending

## Impacted package

- `web`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d7c63da-8b9a-4713-acae-5d79e7af55e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

