### PR TITLE
fix(web): restore dataset cell scrollbar in JSONView

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -123,7 +123,7 @@ export function JSONView(props: {
           </code>
         ) : (
           <div
-            className="max-w-full min-w-0 flex-1 overflow-hidden"
+            className="max-w-full min-w-0 flex-1"
             onClick={() => {
               // If externally collapsed and user clicks to expand, sync the state
               if (props.externalJsonCollapsed && props.onToggleCollapse) {

--- a/web/src/components/ui/IOTableCell.clienttest.tsx
+++ b/web/src/components/ui/IOTableCell.clienttest.tsx
@@ -192,4 +192,22 @@ describe("IOTableCell media chip rendering", () => {
 
     expect(container.textContent).toContain("truncated");
   });
+
+  it("multi-line: scrollable content is not clipped by an inner overflow-hidden", () => {
+    // Long table-cell text must scroll via `.io-message-content.overflow-y-auto`.
+    // An inner `overflow-hidden` on the JSONView body clips before that
+    // scrollport can take effect, making overflow unreachable.
+    const { container } = renderCell({
+      data: "y".repeat(2000),
+      singleLine: false,
+    });
+
+    const scrollContainer = container.querySelector(
+      ".io-message-content.overflow-y-auto",
+    );
+    expect(scrollContainer).not.toBeNull();
+
+    const contentDiv = scrollContainer?.querySelector(".flex-1");
+    expect(contentDiv?.classList.contains("overflow-hidden")).toBe(false);
+  });
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16006.preview.langfuse.com](https://pr-16006.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long IO cells in the dataset view (and other tables using `IOTableCell` / `JSONView`) lost their scrollbar after the trace overflow fix in #14489 (first shipped in v3.196.0). Overflowing text was clipped with no way to scroll; the only workaround was copying the cell.

Root cause: `JSONView` gained an inner `overflow-hidden` on the content wrapper. In table cells, `IOTableCell` already sets `codeClassName="min-h-0 h-full overflow-y-auto"` on `.io-message-content` as the intended scrollport, but the inner wrapper clipped overflow before that scrollport could engage:

```
div.io-message-content (overflow-y-auto)  ← intended scroll container
  └─ div (flex-1 overflow-hidden)         ← clipped overflow
```

## Fix

Drop `overflow-hidden` from the inner content div while keeping `max-w-full min-w-0 flex-1` (width constraints from #14489 remain). The scrollable wrapper sees the overflow again. The `scrollable` branch of `JSONView` is untouched.

Related: community analysis in #15702; complementary cell-height wrapping in #15999.

## Impacted packages

- `web`

## Verification

```
pnpm --filter web run test-client src/components/ui/IOTableCell.clienttest.tsx
# Test Files  1 passed (1)
# Tests  14 passed (14)
```

Fail-before / pass-after confirmed for the new regression test.

Browser review was blocked in this environment (no Docker / local stack for seeding dataset rows).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14631](https://linear.app/clickhouse/issue/LFE-14631/ui-bug-missing-scrollbar-in-dataset-view-for-long-text-cells)

<div><a href="https://cursor.com/agents/bc-ae3371ba-75c0-4dc8-a136-8d34f0955885?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae3371ba-75c0-4dc8-a136-8d34f0955885&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores scrolling for long JSON content in dataset table cells by removing an inner overflow constraint while retaining existing width constraints.

- Removes `overflow-hidden` from the non-scrollable `JSONView` content wrapper.
- Adds a regression test confirming that `IOTableCell` retains its intended outer scroll container without inner clipping.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): restore dataset cell scrollbar..."](https://github.com/langfuse/langfuse/commit/9506d1a095f6f48293fd216027dbbcdda7888269) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52341540)</sub>

<!-- /greptile_comment -->