### PR TITLE
fix(dashboards): allow userId/sessionId time-series widget breakdowns

### DIFF
--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -718,12 +718,15 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
 
 // v2 scores dimensions
 const scoresV2BaseDimensions: DimensionsDeclarationType = {
+  // Keep sessionId/userId cardinality aligned with v1 and events_traces: these
+  // are common widget breakdowns (including time series). Do not mark them
+  // highCardinality — that hard-blocks timeDimension queries even for small
+  // projects. Truly unbounded ids (traceId, observationId, …) stay flagged below.
   sessionId: {
     sql: "scores.session_id",
     alias: "sessionId",
     type: "string",
     description: "Identifier of the session.",
-    highCardinality: true,
   },
   // Run-level scores (dataset_run_id on scores table). Used by experiment
   // widgets via entityDimension + filters.
@@ -749,7 +752,6 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
     type: "string",
     relationTable: "events_traces",
     description: "Identifier of the user.",
-    highCardinality: true,
   },
   tags: {
     sql: "events_traces.tags",
@@ -1171,20 +1173,22 @@ export const eventsObservationsView: ViewDeclarationType = {
       type: "string",
       description: "Version of the observation.",
     },
-    // Denormalized trace fields from events table
+    // Denormalized trace fields from events table.
+    // Keep userId/sessionId cardinality aligned with v1: widgets commonly break
+    // down time series by these fields, and highCardinality would hard-block
+    // those queries even when cardinality is small. Unbounded identifiers
+    // (id/traceId/parentObservationId) remain highCardinality + uiHidden above.
     userId: {
       sql: "nullIf(events_observations.user_id, '')",
       alias: "userId",
       type: "string",
       description: "Identifier of the user triggering the observation.",
-      highCardinality: true,
     },
     sessionId: {
       sql: "nullIf(events_observations.session_id, '')",
       alias: "sessionId",
       type: "string",
       description: "Identifier of the session triggering the observation.",
-      highCardinality: true,
     },
     tags: {
       sql: "events_observations.tags",

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -312,4 +312,27 @@ describe("legacy traces compatibility when routed through v2", () => {
       expect(validateQuery(query, "v2")).toEqual({ valid: true });
     },
   );
+
+  it.each([
+    ["observations", "userId"],
+    ["observations", "sessionId"],
+    ["scores-numeric", "userId"],
+    ["scores-numeric", "sessionId"],
+  ] as const)(
+    "allows %s %s time-series breakdowns in v2 without high-cardinality block",
+    (view, dimension) => {
+      const query = {
+        view,
+        dimensions: [{ field: dimension }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [],
+        timeDimension: { granularity: "auto" },
+        fromTimestamp: "2025-01-01T00:00:00.000Z",
+        toTimestamp: "2025-01-02T00:00:00.000Z",
+        orderBy: null,
+      } as QueryType;
+
+      expect(validateQuery(query, "v2")).toEqual({ valid: true });
+    },
+  );
 });

--- a/packages/shared/src/features/query/validateQuery.ts
+++ b/packages/shared/src/features/query/validateQuery.ts
@@ -144,7 +144,7 @@ function validateEntityDimension(
  * Validates a query for safety before execution.
  * Performs sanity checks for high cardinality dimension validation.
  *
- * High cardinality dimensions (id, traceId, userId, sessionId, etc.) are only allowed when:
+ * High cardinality dimensions (id, traceId, observationId, etc.) are only allowed when:
  * 1. timeDimension is NOT set (timeseries with high cardinality produces unbounded results)
  * 2. config.row_limit (or chartConfig.row_limit) is explicitly specified (LIMIT)
  * 3. orderBy with direction 'desc' on a measure field is specified (for top-N queries)

--- a/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
+++ b/web/src/__tests__/server/dashboard-v1-v2-consistency.servertest.ts
@@ -693,7 +693,7 @@ describe("dashboard v1 vs v2 consistency", () => {
           },
         ],
         timeDimension: null,
-        // userId is high-cardinality in v2, so we need orderBy + row_limit
+        // Cap to a stable top-N so v1/v2 comparisons stay bounded.
         orderBy: [{ field: "sum_totalCost", direction: "desc" }],
         chartConfig: { type: "table", row_limit: 100 },
         fromTimestamp: from,

--- a/web/src/__tests__/server/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-v2-api.servertest.ts
@@ -542,13 +542,9 @@ describe("/api/public/v2/metrics API Endpoint", () => {
     it.each([
       ["id", "observations"],
       ["traceId", "observations"],
-      ["userId", "observations"],
-      ["sessionId", "observations"],
       ["parentObservationId", "observations"],
       ["id", "scores-numeric"],
       ["traceId", "scores-numeric"],
-      ["userId", "scores-numeric"],
-      ["sessionId", "scores-numeric"],
       ["observationId", "scores-numeric"],
     ])(
       "should reject high cardinality dimension %s in %s view without LIMIT and ORDER DESC",

--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -4485,7 +4485,7 @@ describe("validateQuery", () => {
   it("should return invalid when high cardinality dimension is used without ORDER DESC", () => {
     const query: QueryType = {
       ...baseQuery,
-      dimensions: [{ field: "userId" }], // high cardinality
+      dimensions: [{ field: "traceId" }], // high cardinality
       chartConfig: { type: "table", row_limit: 10 },
       orderBy: [{ field: "sum_totalCost", direction: "asc" }], // asc, not desc
     };
@@ -4494,7 +4494,7 @@ describe("validateQuery", () => {
 
     expect(result.valid).toBe(false);
     expect((result as { valid: false; reason: string }).reason).toContain(
-      "High cardinality dimension(s) 'userId'",
+      "High cardinality dimension(s) 'traceId'",
     );
     expect((result as { valid: false; reason: string }).reason).toContain(
       "require both 'config.row_limit' and 'orderBy' with direction 'desc'",
@@ -4554,7 +4554,7 @@ describe("validateQuery", () => {
   it("should return invalid for multiple high cardinality dimensions without required config", () => {
     const query: QueryType = {
       ...baseQuery,
-      dimensions: [{ field: "traceId" }, { field: "sessionId" }], // both high cardinality
+      dimensions: [{ field: "traceId" }, { field: "id" }], // both high cardinality
       // missing row_limit and orderBy desc
     };
 
@@ -4564,9 +4564,7 @@ describe("validateQuery", () => {
     expect((result as { valid: false; reason: string }).reason).toContain(
       "traceId",
     );
-    expect((result as { valid: false; reason: string }).reason).toContain(
-      "sessionId",
-    );
+    expect((result as { valid: false; reason: string }).reason).toContain("id");
   });
 
   it("should support public API 'config' field name for row_limit", () => {
@@ -4639,6 +4637,34 @@ describe("validateQuery", () => {
 
     expect(result).toEqual({ valid: true });
   });
+
+  it.each(["userId", "sessionId"] as const)(
+    "should allow %s time-series breakdowns on observations (not high-cardinality)",
+    (field) => {
+      const query: QueryType = {
+        ...baseQuery,
+        dimensions: [{ field }],
+        timeDimension: { granularity: "day" },
+      };
+
+      expect(validateQuery(query, "v2")).toEqual({ valid: true });
+    },
+  );
+
+  it.each(["userId", "sessionId"] as const)(
+    "should allow %s time-series breakdowns on scores-numeric (not high-cardinality)",
+    (field) => {
+      const query: QueryType = {
+        ...baseQuery,
+        view: "scores-numeric",
+        dimensions: [{ field }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        timeDimension: { granularity: "day" },
+      };
+
+      expect(validateQuery(query, "v2")).toEqual({ valid: true });
+    },
+  );
 });
 
 describe("getValidAggregationsForMeasureType", () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16008.preview.langfuse.com](https://pr-16008.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

V2 observations/scores views marked `userId` and `sessionId` as `highCardinality`, so `validateQuery` hard-blocked any widget that combined those breakdowns with `timeDimension` — even for projects with only a handful of users. Traces/v1 already allowed these breakdowns; observations/scores did not.

This removes the `highCardinality` flag from `userId`/`sessionId` on those views so time-series widgets can render (client charts still cap rendered series). Truly unbounded ids (`traceId`, `id`, `observationId`, …) stay high-cardinality and blocked.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- My code follows the style guidelines of this project (`pnpm run format` / lint)
- I have added tests that prove my fix is effective
- I have checked that new and existing unit tests pass locally with my changes

### Impacted packages

- `@langfuse/shared` (query data model + validation)
- `web` (tests)

### Verification

- `pnpm --filter @langfuse/shared run test queryBuilder.filterValidation` → `Tests  24 passed (24)`
- `pnpm --filter web run test queryBuilder.servertest` → `Tests  113 passed (113)`
- Pre-commit lint → `Tasks: 7 successful, 7 total`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-10838](https://linear.app/clickhouse/issue/LFE-10838/widgets-are-being-hard-blocked-by-high-cardinality)

<div><a href="https://cursor.com/agents/bc-2d162d0a-31a4-4723-a437-50ebdb87affa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d162d0a-31a4-4723-a437-50ebdb87affa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

