### PR TITLE
fix(agents): repair Docker socket reachability on Cursor Cloud start

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -246,6 +246,12 @@ and public build controls are passed into Compose. The seed command also receive
 explicit local connection URLs so an exported secret cannot redirect it to an
 external database.
 
+Nested Cursor VMs sometimes leave `/var/run` mode `0700`, which hides
+`docker.sock` from the `ubuntu` agent user even when that user is in the
+`docker` group. `start-cursor-cloud.sh` opens search/execute on the socket
+parent directories (and loosens the socket if needed) before probing the
+daemon, including again after `service docker start`.
+
 ### Cursor team tools
 
 Repository files cannot publish or authenticate Cursor Team Marketplace MCPs.

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -67,6 +67,12 @@ RUN mkdir -p /etc/docker \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
+# /run (and the /var/run symlink target) can land mode 0700 in nested Docker
+# VMs. Keep the directory searchable so the docker-group ubuntu user can reach
+# docker.sock. start-cursor-cloud.sh also repairs this at runtime after
+# `service docker start`, which may recreate a private /var/run.
+RUN chmod 755 /run /var/run 2>/dev/null || true
+
 RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu \
     && groupadd -f docker \
     && usermod -aG docker,sudo ubuntu \

--- a/scripts/agents/start-cursor-cloud.sh
+++ b/scripts/agents/start-cursor-cloud.sh
@@ -36,6 +36,39 @@ compose() {
     docker compose --env-file /dev/null -f "$compose_file" "$@"
 }
 
+# Nested Cursor VMs have been observed with /var/run (or /run) mode 0700.
+# The ubuntu agent user is in the docker group and docker.sock may already be
+# group/world accessible, but a non-executable parent directory still makes
+# `docker info` fail with "permission denied" even when dockerd is healthy.
+# Open search/execute on the socket parent dirs (and loosen the socket itself
+# if needed) before probing the daemon.
+ensure_docker_socket_reachable() {
+  local sock="${CURSOR_DOCKER_SOCKET:-/var/run/docker.sock}"
+  local sock_dir
+  sock_dir="$(dirname "$sock")"
+
+  if [ -S "$sock" ] && [ -r "$sock" ] && [ -w "$sock" ]; then
+    return 0
+  fi
+
+  if ! command -v sudo >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Prefer the real runtime dirs; CURSOR_DOCKER_SOCKET is for tests.
+  sudo chmod a+rx "$sock_dir" 2>/dev/null || true
+  if [ "$sock_dir" = "/var/run" ] || [ "$sock_dir" = "/run" ]; then
+    sudo chmod a+rx /var/run /run 2>/dev/null || true
+  fi
+
+  if sudo test -S "$sock" 2>/dev/null; then
+    if ! { [ -r "$sock" ] && [ -w "$sock" ]; } 2>/dev/null; then
+      sudo chgrp docker "$sock" 2>/dev/null || true
+      sudo chmod 666 "$sock" 2>/dev/null || true
+    fi
+  fi
+}
+
 dump_diagnostics() {
   local exit_code=$?
   trap - ERR
@@ -51,11 +84,16 @@ dump_diagnostics() {
 
 trap dump_diagnostics ERR
 
+ensure_docker_socket_reachable
+
 if ! docker info >/dev/null 2>&1; then
   sudo service docker start
+  # service start can recreate /var/run with mode 0700 again.
+  ensure_docker_socket_reachable
 fi
 
 for _ in $(seq 1 60); do
+  ensure_docker_socket_reachable
   if docker info >/dev/null 2>&1; then
     break
   fi

--- a/scripts/agents/start-cursor-cloud.test.sh
+++ b/scripts/agents/start-cursor-cloud.test.sh
@@ -6,13 +6,14 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 tmpdir="$(mktemp -d)"
 command_log="$tmpdir/commands.log"
 docker_ready="$tmpdir/docker-ready"
+test_docker_socket="$tmpdir/locked/docker.sock"
 
 cleanup() {
   rm -rf "$tmpdir"
 }
 
 trap cleanup EXIT
-mkdir -p "$tmpdir/bin"
+mkdir -p "$tmpdir/bin" "$tmpdir/locked"
 
 cat <<EOF > "$tmpdir/bin/docker"
 #!/usr/bin/env bash
@@ -43,17 +44,33 @@ cat <<EOF > "$tmpdir/bin/curl"
 printf 'curl %s\n' "\$*" >> "$command_log"
 EOF
 
-cat <<'EOF' > "$tmpdir/bin/sudo"
+cat <<EOF > "$tmpdir/bin/sudo"
 #!/usr/bin/env bash
-exec "$@"
+printf 'sudo %s\n' "\$*" >> "$command_log"
+exec "\$@"
 EOF
 
-chmod +x "$tmpdir/bin/docker" "$tmpdir/bin/service" "$tmpdir/bin/pnpm" "$tmpdir/bin/curl" "$tmpdir/bin/sudo"
+cat <<EOF > "$tmpdir/bin/chmod"
+#!/usr/bin/env bash
+printf 'chmod %s\n' "\$*" >> "$command_log"
+exit 0
+EOF
 
+chmod +x \
+  "$tmpdir/bin/docker" \
+  "$tmpdir/bin/service" \
+  "$tmpdir/bin/pnpm" \
+  "$tmpdir/bin/curl" \
+  "$tmpdir/bin/sudo" \
+  "$tmpdir/bin/chmod"
+
+# Leave $test_docker_socket missing so ensure_docker_socket_reachable must
+# repair the parent directory before the daemon probe loop.
 PATH="$tmpdir/bin:$PATH" \
 DATABASE_URL="postgresql://external.example:5432/production" \
 CLICKHOUSE_URL="https://external.example:8443" \
 CURSOR_COMPOSE_WAIT_TIMEOUT_SECONDS=321 \
+CURSOR_DOCKER_SOCKET="$test_docker_socket" \
   bash "$repo_root/scripts/agents/start-cursor-cloud.sh"
 
 assert_command() {
@@ -65,6 +82,7 @@ assert_command() {
   fi
 }
 
+assert_command "chmod a+rx $tmpdir/locked"
 assert_command "service docker start"
 assert_command "docker compose --env-file /dev/null -f $repo_root/docker-compose.build.yml up -d --build --wait --wait-timeout 321"
 assert_command "compose DATABASE_URL=<unset>"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Cursor Cloud `start-cursor-cloud.sh` was failing with Docker "permission denied" even when `dockerd` was running.

**Cause:** nested VMs sometimes leave `/var/run` mode `0700`. The `ubuntu` agent user is in the `docker` group and `docker.sock` may already be accessible, but a non-executable parent directory still blocks traversal — so `docker info` fails, the script restarts Docker, and startup still fails.

**Fix:**
- `ensure_docker_socket_reachable` in `start-cursor-cloud.sh` opens search/execute on the socket parent dirs (and loosens the socket if needed) before probing the daemon, including again after `service docker start`
- Harden `.cursor/Dockerfile` with `chmod 755 /run /var/run` as a best-effort image-time guard
- Extend the start-script regression test to assert the repair path
- Document the pitfall in `.agents/README.md`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- My code follows the style guidelines of this project
- I have added tests that prove my fix is effective
- I have checked that new and existing unit tests pass locally with my changes

### Verification

- `bash scripts/agents/start-cursor-cloud.test.sh` → `Cursor Cloud startup command regression test passed`
- Live repro: `/var/run` mode `0700` made `docker info` fail; after `ensure_docker_socket_reachable`, Docker was reachable again
- Pre-commit lint → `Tasks: 7 successful, 7 total`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-10838](https://linear.app/clickhouse/issue/LFE-10838/widgets-are-being-hard-blocked-by-high-cardinality)

<div><a href="https://cursor.com/agents/bc-2d162d0a-31a4-4723-a437-50ebdb87affa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d162d0a-31a4-4723-a437-50ebdb87affa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR repairs Docker socket reachability in nested Cursor Cloud environments and documents the `/var/run` traversal issue.
- Adds runtime repair before and during Docker daemon probing.
- Adds a best-effort image-time permission guard for `/run`.
- Extends startup command assertions and documents the nested-VM behavior.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The Docker socket must not be made world-writable before this PR is merged; the regression fixture should also validate the real permission failure.

The repair correctly targets parent traversal but broadens access to the root-equivalent Docker API beyond the configured docker group, while its test only verifies command emission rather than restored socket reachability.

**Files Needing Attention:** scripts/agents/start-cursor-cloud.sh and scripts/agents/start-cursor-cloud.test.sh
</details>

<details open><summary><h3>Security Review</h3></summary>

The socket repair can set `docker.sock` to mode `0666`, exposing the root-equivalent Docker API to processes outside the `docker` group. **How this was verified:** The changed branch applies `chmod 666` after assigning the socket to the `docker` group, and the complete script contains no permission restoration.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Cursor startup] --> B{Socket accessible?}
  B -->|Yes| C[Probe Docker daemon]
  B -->|No| D[Open parent traversal]
  D --> E[Assign socket to docker group]
  E --> F[Set socket mode 0666]
  F --> G[Any local UID can access Docker API]
  G --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/agents/start-cursor-cloud.sh:67
**World-writable Docker socket**

When the socket exists but is inaccessible to the agent user, this branch sets it to mode `0666`, allowing any local process outside the `docker` group to access the root-equivalent Docker API. The preceding `chgrp docker` already establishes the intended access path, so retain write access only for the owner and group. **How this was verified:** The changed branch applies `chmod 666` after assigning the socket to the `docker` group, and the script contains no operation that restores restrictive permissions.

```suggestion
      sudo chmod 660 "$sock" 2>/dev/null || true
```

### Issue 2
scripts/agents/start-cursor-cloud.test.sh:67-68
**Fixture does not test reachability**

The fixture leaves `docker.sock` missing and mocks `chmod` as a no-op, while the mocked service independently makes `docker info` succeed. It therefore verifies only that a command was emitted, not that repairing a mode-0700 parent restores access to an existing socket, so a regression in the actual permission fix would remain undetected.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agents): repair Docker socket reacha..."](https://github.com/langfuse/langfuse/commit/1b8c7849a66530fd063e8cd40784483cddadd606) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52347216)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->