### PR TITLE
fix(charts): improve threshold annotation label contrast

### DIFF
--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.clienttest.ts
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.clienttest.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { __test } from "./LineChartTimeSeries";
+
+const { thresholdAnnotationLabelProps } = __test;
+
+/**
+ * Contrast contract for threshold annotation labels ("Alert" / "Warning").
+ * The prior styling reused the reference-line stroke (`*-600`) at 11px with no
+ * weight or halo, so red "Alert" text washed out against the tinted violation
+ * band and was easy to miss on the monitor live preview.
+ */
+describe("thresholdAnnotationLabelProps", () => {
+  it("uses a darker palette step than the reference-line stroke for fill", () => {
+    const props = thresholdAnnotationLabelProps("red");
+    // Reference line stroke is `*-600`; the label must be at least `*-800`.
+    expect(props.fill).toBe("var(--color-red-800)");
+    expect(props.fill).not.toBe("var(--color-red-600)");
+  });
+
+  it("renders at a readable size with the app bold weight role", () => {
+    const props = thresholdAnnotationLabelProps("yellow");
+    expect(props.fontSize).toBeGreaterThanOrEqual(12);
+    expect(props.className).toContain("font-bold");
+  });
+
+  it("paints a background-colored halo so the label stays legible on the tint", () => {
+    const props = thresholdAnnotationLabelProps("red");
+    expect(props.paintOrder).toBe("stroke fill");
+    expect(props.stroke).toBe("var(--color-background)");
+    expect(props.strokeWidth).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.clienttest.ts
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.clienttest.ts
@@ -14,7 +14,9 @@ describe("thresholdAnnotationChipAppearance", () => {
   it("pairs a solid threshold-color fill with white foreground text", () => {
     const appearance = thresholdAnnotationChipAppearance("red");
     expect(appearance.background).toBe("var(--color-red-600)");
-    expect(appearance.foreground).toBe("#fff");
+    // CSS fill utility — SVG fill attributes lose to ancestor currentColor.
+    expect(appearance.textClassName).toContain("fill-white");
+    expect(appearance.textClassName).toContain("font-bold");
   });
 
   it("keeps the chip compact but bold-readable", () => {

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.clienttest.ts
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.clienttest.ts
@@ -2,32 +2,50 @@ import { describe, expect, it } from "vitest";
 
 import { __test } from "./LineChartTimeSeries";
 
-const { thresholdAnnotationLabelProps } = __test;
+const { thresholdAnnotationChipAppearance, layoutThresholdAnnotationChip } =
+  __test;
 
 /**
- * Contrast contract for threshold annotation labels ("Alert" / "Warning").
- * The prior styling reused the reference-line stroke (`*-600`) at 11px with no
- * weight or halo, so red "Alert" text washed out against the tinted violation
- * band and was easy to miss on the monitor live preview.
+ * Contrast contract for threshold annotation chips ("Alert" / "Warning").
+ * Bare colored text on the translucent violation band was easy to miss on the
+ * monitor live preview; chips use solid fills with white labels instead.
  */
-describe("thresholdAnnotationLabelProps", () => {
-  it("uses a darker palette step than the reference-line stroke for fill", () => {
-    const props = thresholdAnnotationLabelProps("red");
-    // Reference line stroke is `*-600`; the label must be at least `*-800`.
-    expect(props.fill).toBe("var(--color-red-800)");
-    expect(props.fill).not.toBe("var(--color-red-600)");
+describe("thresholdAnnotationChipAppearance", () => {
+  it("pairs a solid threshold-color fill with white foreground text", () => {
+    const appearance = thresholdAnnotationChipAppearance("red");
+    expect(appearance.background).toBe("var(--color-red-600)");
+    expect(appearance.foreground).toBe("#fff");
   });
 
-  it("renders at a readable size with the app bold weight role", () => {
-    const props = thresholdAnnotationLabelProps("yellow");
-    expect(props.fontSize).toBeGreaterThanOrEqual(12);
-    expect(props.className).toContain("font-bold");
+  it("keeps the chip compact but bold-readable", () => {
+    const appearance = thresholdAnnotationChipAppearance("yellow");
+    expect(appearance.fontSize).toBeGreaterThanOrEqual(11);
+    expect(appearance.paddingX).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("layoutThresholdAnnotationChip", () => {
+  it("anchors the chip to the top-right of the reference-line viewBox", () => {
+    const appearance = thresholdAnnotationChipAppearance("red");
+    const layout = layoutThresholdAnnotationChip({
+      label: "Alert",
+      viewBox: { x: 40, y: 120, width: 400 },
+      appearance,
+    });
+
+    expect(layout.x + layout.width).toBe(40 + 400 - appearance.gapFromRight);
+    expect(layout.y + layout.height).toBe(120 - appearance.gapFromLine);
+    expect(layout.width).toBeGreaterThan(layout.height);
   });
 
-  it("paints a background-colored halo so the label stays legible on the tint", () => {
-    const props = thresholdAnnotationLabelProps("red");
-    expect(props.paintOrder).toBe("stroke fill");
-    expect(props.stroke).toBe("var(--color-background)");
-    expect(props.strokeWidth).toBeGreaterThanOrEqual(3);
+  it("drops the chip below the line when above would clip the chart top", () => {
+    const appearance = thresholdAnnotationChipAppearance("red");
+    const layout = layoutThresholdAnnotationChip({
+      label: "Alert",
+      viewBox: { x: 40, y: 8, width: 400 },
+      appearance,
+    });
+
+    expect(layout.y).toBe(8 + appearance.gapFromLine);
   });
 });

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.stories.tsx
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.stories.tsx
@@ -227,6 +227,32 @@ export const WithLongSeriesNames = meta.story({
   },
 });
 
+// ── Threshold annotations ────────────────────────────────────────────────────
+// Monitor live preview (and any chart that passes `thresholds`) draws a tinted
+// violation band with an "Alert" / "Warning" label. The label must stay
+// legible on that tint — use the theme toggle to check both modes.
+
+export const WithAlertAndWarningThresholds = meta.story({
+  args: {
+    data: singleSeriesData,
+    legendPosition: "none",
+    thresholds: [
+      {
+        value: 90_000,
+        operator: "GT",
+        color: "yellow",
+        label: "Warning",
+      },
+      {
+        value: 120_000,
+        operator: "GT",
+        color: "red",
+        label: "Alert",
+      },
+    ],
+  },
+});
+
 export const SyncedTimeline = meta.story({
   parameters: { controls: { disable: true } },
   render: () => (

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
@@ -21,6 +21,7 @@ import {
 import {
   type ChartProps,
   type ChartThreshold,
+  type ChartThresholdColor,
 } from "@/src/features/widgets/chart-library/chart-props";
 import {
   formatMetric,
@@ -57,6 +58,22 @@ const computeMetricExtent = (
   }
   return Number.isFinite(min) && Number.isFinite(max) ? { min, max } : null;
 };
+
+/**
+ * SVG text props for a threshold annotation label ("Alert" / "Warning").
+ * Darker than the reference-line stroke, bold, and haloed with the chart
+ * background so the text stays legible on the tinted violation band.
+ */
+const thresholdAnnotationLabelProps = (color: ChartThresholdColor) => ({
+  fill: `var(--color-${color}-800)`,
+  fontSize: 12,
+  className: "font-bold",
+  // paintOrder draws the background stroke under the fill (text halo).
+  paintOrder: "stroke fill" as const,
+  stroke: "var(--color-background)",
+  strokeWidth: 3,
+  strokeLinejoin: "round" as const,
+});
 
 /** ThresholdOverlay returns the ReferenceLine + (operator-derived) ReferenceArea recharts elements for a single ChartThreshold. */
 const ThresholdOverlay = ({
@@ -164,8 +181,7 @@ const ThresholdOverlay = ({
         <Label
           value={threshold.label}
           position="insideTopRight"
-          fill={stroke}
-          fontSize={11}
+          {...thresholdAnnotationLabelProps(threshold.color)}
         />
       )}
     </ReferenceLine>,
@@ -173,6 +189,8 @@ const ThresholdOverlay = ({
 
   return <>{elements}</>;
 };
+
+export const __test = { thresholdAnnotationLabelProps };
 
 /**
  * LineChartTimeSeries component

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
@@ -63,10 +63,14 @@ const computeMetricExtent = (
  * Appearance for a threshold annotation chip ("Alert" / "Warning").
  * White text on a solid tint of the threshold color — readable on both the
  * translucent violation band and light/dark chart backgrounds.
+ *
+ * Text uses the `fill-white` utility (not an SVG `fill` attribute): chart
+ * ancestors set CSS `fill: currentColor`, which overrides presentation
+ * attributes on `<text>`.
  */
 const thresholdAnnotationChipAppearance = (color: ChartThresholdColor) => ({
   background: `var(--color-${color}-600)`,
-  foreground: "#fff",
+  textClassName: "fill-white font-bold",
   fontSize: 11,
   paddingX: 5,
   paddingY: 2,
@@ -155,9 +159,8 @@ const ThresholdAnnotationChip = ({
         y={layout.textY}
         textAnchor="middle"
         dominantBaseline="central"
-        fill={appearance.foreground}
         fontSize={appearance.fontSize}
-        className="font-bold"
+        className={appearance.textClassName}
       >
         {label}
       </text>

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
@@ -60,20 +60,110 @@ const computeMetricExtent = (
 };
 
 /**
- * SVG text props for a threshold annotation label ("Alert" / "Warning").
- * Darker than the reference-line stroke, bold, and haloed with the chart
- * background so the text stays legible on the tinted violation band.
+ * Appearance for a threshold annotation chip ("Alert" / "Warning").
+ * White text on a solid tint of the threshold color — readable on both the
+ * translucent violation band and light/dark chart backgrounds.
  */
-const thresholdAnnotationLabelProps = (color: ChartThresholdColor) => ({
-  fill: `var(--color-${color}-800)`,
-  fontSize: 12,
-  className: "font-bold",
-  // paintOrder draws the background stroke under the fill (text halo).
-  paintOrder: "stroke fill" as const,
-  stroke: "var(--color-background)",
-  strokeWidth: 3,
-  strokeLinejoin: "round" as const,
+const thresholdAnnotationChipAppearance = (color: ChartThresholdColor) => ({
+  background: `var(--color-${color}-600)`,
+  foreground: "#fff",
+  fontSize: 11,
+  paddingX: 5,
+  paddingY: 2,
+  /** Approx. average glyph width at `fontSize` for short Latin labels. */
+  glyphWidthFactor: 0.62,
+  gapFromLine: 4,
+  gapFromRight: 4,
+  cornerRadius: 3,
 });
+
+/** Layout for a chip anchored to the top-right of a horizontal reference line. */
+const layoutThresholdAnnotationChip = ({
+  label,
+  viewBox,
+  appearance,
+}: {
+  label: string;
+  viewBox: { x: number; y: number; width: number };
+  appearance: ReturnType<typeof thresholdAnnotationChipAppearance>;
+}) => {
+  const textWidth = Math.max(
+    label.length * appearance.fontSize * appearance.glyphWidthFactor,
+    appearance.fontSize,
+  );
+  const width = textWidth + appearance.paddingX * 2;
+  const height = appearance.fontSize + appearance.paddingY * 2;
+  const x = viewBox.x + viewBox.width - width - appearance.gapFromRight;
+  // Prefer above the line; if that would clip off the chart top, drop below.
+  const yAbove = viewBox.y - height - appearance.gapFromLine;
+  const y = yAbove < 0 ? viewBox.y + appearance.gapFromLine : yAbove;
+  return {
+    x,
+    y,
+    width,
+    height,
+    textX: x + width / 2,
+    textY: y + height / 2,
+  };
+};
+
+type ThresholdLabelViewBox = {
+  x?: number;
+  y?: number;
+  width?: number;
+};
+
+/** ThresholdAnnotationChip renders a solid high-contrast label at the line's top-right. */
+const ThresholdAnnotationChip = ({
+  viewBox,
+  value,
+  color,
+}: {
+  viewBox?: ThresholdLabelViewBox;
+  value?: string | number;
+  color: ChartThresholdColor;
+}) => {
+  if (
+    value == null ||
+    viewBox?.x == null ||
+    viewBox.y == null ||
+    viewBox.width == null
+  ) {
+    return null;
+  }
+  const label = String(value);
+  const appearance = thresholdAnnotationChipAppearance(color);
+  const layout = layoutThresholdAnnotationChip({
+    label,
+    viewBox: { x: viewBox.x, y: viewBox.y, width: viewBox.width },
+    appearance,
+  });
+
+  return (
+    <g data-testid="threshold-annotation-chip">
+      <rect
+        x={layout.x}
+        y={layout.y}
+        width={layout.width}
+        height={layout.height}
+        rx={appearance.cornerRadius}
+        ry={appearance.cornerRadius}
+        fill={appearance.background}
+      />
+      <text
+        x={layout.textX}
+        y={layout.textY}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill={appearance.foreground}
+        fontSize={appearance.fontSize}
+        className="font-bold"
+      >
+        {label}
+      </text>
+    </g>
+  );
+};
 
 /** ThresholdOverlay returns the ReferenceLine + (operator-derived) ReferenceArea recharts elements for a single ChartThreshold. */
 const ThresholdOverlay = ({
@@ -180,8 +270,13 @@ const ThresholdOverlay = ({
       {threshold.label && (
         <Label
           value={threshold.label}
-          position="insideTopRight"
-          {...thresholdAnnotationLabelProps(threshold.color)}
+          content={(props) => (
+            <ThresholdAnnotationChip
+              viewBox={props.viewBox as ThresholdLabelViewBox | undefined}
+              value={props.value}
+              color={threshold.color}
+            />
+          )}
         />
       )}
     </ReferenceLine>,
@@ -190,7 +285,10 @@ const ThresholdOverlay = ({
   return <>{elements}</>;
 };
 
-export const __test = { thresholdAnnotationLabelProps };
+export const __test = {
+  thresholdAnnotationChipAppearance,
+  layoutThresholdAnnotationChip,
+};
 
 /**
  * LineChartTimeSeries component


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16010.preview.langfuse.com](https://pr-16010.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Threshold annotation labels (`Alert` / `Warning`) on line time-series charts were bare `*-600` text at 11px, so they washed out against the tinted violation band on the monitor live preview (especially Alert).
- Labels now render as solid colored chips with white text (`fill-white font-bold` — required because chart ancestors set CSS `fill: currentColor`, which overrides SVG `fill` attributes).
- Chips anchor to the top-right of the threshold line and drop below the line when placing them above would clip the chart top.
- Added Storybook story `WithAlertAndWarningThresholds` and client tests for appearance + layout.

## Impacted packages

- `web`

## Test plan

- [x] `pnpm --filter web run test-client src/features/widgets/chart-library/LineChartTimeSeries.clienttest.ts` — `Tests  4 passed (4)`
- [x] Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- [x] Storybook visual review (light + dark): chips with white text are clearly legible

[Threshold chips with white text](https://cursor.com/agents/bc-35aa47e8-8ec2-49f9-ba7b-8cdc811cdad1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fthreshold-chips-white-text.webp)

## Notes

Only `LineChartTimeSeries` renders monitor `thresholds` today (`MonitorChartPreview` → `Chart` → line time series).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-10314](https://linear.app/clickhouse/issue/LFE-10314/monitor-chart-alert-annotation-text-is-barely-visible)

<div><a href="https://cursor.com/agents/bc-35aa47e8-8ec2-49f9-ba7b-8cdc811cdad1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35aa47e8-8ec2-49f9-ba7b-8cdc811cdad1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

