### PR TITLE
fix(chatml): parse AI SDK v7 parts[] messages in the aisdk adapter

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/aisdk.ts
+++ b/packages/shared/src/utils/chatml/adapters/aisdk.ts
@@ -10,16 +10,19 @@ import {
 import { z } from "zod";
 
 /**
- * AI SDK v5 Adapter
+ * AI SDK v5/v7 Adapter
  *
- * Handles traces from Vercel AI SDK v5 with any model provider
+ * Handles traces from Vercel AI SDK v5/v7 with any model provider
  *
  * Key characteristics:
  * - Observation names: ai.generateText.doGenerate, ai.generateObject.doGenerate
  * - Metadata: ai.operationId, ai.model.provider, ai.model.id
- * - Message structure: {role, content: [{type, text/toolCallId/...}]}
- * - Tool calls: {type: "tool-call", toolCallId, toolName, input|args}
- * - Tool results: {type: "tool-result", toolCallId, toolName, output|result}
+ * - Message structure (v5): {role, content: [{type, text/toolCallId/...}]}
+ * - Tool calls (v5): {type: "tool-call", toolCallId, toolName, input|args}
+ * - Tool results (v5): {type: "tool-result", toolCallId, toolName, output|result}
+ * - Message structure (v7 / OTel GenAI semconv): {role, parts: [{type, ...}]}
+ *   with part types "text" ({content}), "tool_call" ({id, name, arguments}),
+ *   and "tool_call_response" ({id, response})
  */
 
 // Message with AI SDK v5 tool-call content structure
@@ -105,6 +108,44 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
   working = withoutProviderFields;
 
   let normalized = removeNullFields(working);
+
+  // Normalize AI SDK v7 / OTel GenAI semconv `parts[]` messages to the v5
+  // `content[]` shape so the rest of this function can handle both:
+  // - text part: {type: "text", content} → {type: "text", text}
+  // - tool call part: {type: "tool_call", id, name, arguments} → {type: "tool-call", toolCallId, toolName, input}
+  // - tool result part: {type: "tool_call_response", id, response} → {type: "tool-result", toolCallId, output}
+  if (
+    !normalized.content &&
+    Array.isArray(normalized.parts) &&
+    normalized.parts.length > 0
+  ) {
+    normalized.content = normalized.parts.map((part: unknown) => {
+      if (!part || typeof part !== "object") return part;
+      const p = part as Record<string, unknown>;
+
+      if (p.type === "text" && typeof p.content === "string") {
+        return { type: "text", text: p.content };
+      }
+      if (p.type === "tool_call") {
+        return {
+          type: "tool-call",
+          toolCallId: p.id,
+          toolName: p.name,
+          input: p.arguments,
+        };
+      }
+      if (p.type === "tool_call_response") {
+        return {
+          type: "tool-result",
+          toolCallId: p.id,
+          toolName: p.name,
+          output: p.response,
+        };
+      }
+      return p;
+    });
+    delete normalized.parts;
+  }
 
   // Normalize content: [{type: "text", text: "..."}] → string
   if (

--- a/worker/src/__tests__/chatml/adapters/aisdk.test.ts
+++ b/worker/src/__tests__/chatml/adapters/aisdk.test.ts
@@ -449,6 +449,74 @@ describe("AI SDK Adapter", () => {
     });
   });
 
+  describe("AI SDK v7 / OTel GenAI semconv `parts[]` messages", () => {
+    it("should extract text from a `parts[]` text message", () => {
+      const input = {
+        messages: [
+          {
+            role: "user",
+            parts: [
+              { type: "text", content: "What is the weather in Berlin?" },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("What is the weather in Berlin?");
+      expect(result.data?.[0]).not.toHaveProperty("parts");
+    });
+
+    it("should normalize a `parts[]` tool_call message into tool_calls", () => {
+      const input = {
+        messages: [
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                id: "call_1",
+                name: "get_weather",
+                arguments: { city: "Berlin" },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].tool_calls?.[0].id).toBe("call_1");
+      expect(result.data?.[0].tool_calls?.[0].name).toBe("get_weather");
+      expect(result.data?.[0].tool_calls?.[0].arguments).toBe(
+        '{"city":"Berlin"}',
+      );
+    });
+
+    it("should normalize a `parts[]` tool_call_response message into a tool result", () => {
+      const input = {
+        messages: [
+          {
+            role: "tool",
+            parts: [
+              {
+                type: "tool_call_response",
+                id: "call_1",
+                response: { city: "Berlin", tempC: 18, sky: "clear" },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].tool_call_id).toBe("call_1");
+      expect(result.data?.[0].content).toContain("Berlin");
+    });
+  });
+
   describe("array handling", () => {
     it("should handle array of messages without wrapper", () => {
       const input = [


### PR DESCRIPTION
## What does this PR do?

Fixes #15952.

On the officially supported AI SDK 7 path (`@langfuse/vercel-ai-sdk` +
`registerTelemetry`), chat messages arrive as `role` + `parts[]` — the shape
specified by the OTel GenAI semantic conventions the AI SDK's own telemetry
follows. The `aisdk` ChatML adapter (`packages/shared/src/utils/chatml/adapters/aisdk.ts`)
only normalized AI SDK v5's `content: [...]` message shape, so `parts[]`
messages fell through `normalizeMessage` unchanged and rendered as a raw
`parts -> 0 -> {...}` tree in the Formatted view instead of a readable
conversation.

### Cause

`normalizeMessage` in `aisdk.ts` only looks at `message.content`. AI SDK 7
messages carry the same information under `message.parts`, with different
item shapes:

| | v5 (`content[]`) | v7 / OTel GenAI (`parts[]`) |
|---|---|---|
| text | `{type: "text", text}` | `{type: "text", content}` |
| tool call | `{type: "tool-call", toolCallId, toolName, input\|args}` | `{type: "tool_call", id, name, arguments}` |
| tool result | `{type: "tool-result", toolCallId, toolName, output\|result}` | `{type: "tool_call_response", id, response}` |

Since none of this was recognized, `content` was never populated and the raw
message (including `parts`) was passed straight through to the renderer.

### Fix

Before the existing `content[]` normalization logic runs, map a message's
`parts[]` (when present and `content` is absent) into the same `content[]`
item shapes the rest of `normalizeMessage` already understands
(`tool-call`/`tool-result`), then delete `parts`. This reuses all the
existing text-extraction, tool-call, and tool-result handling instead of
duplicating it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Added tests to `worker/src/__tests__/chatml/adapters/aisdk.test.ts` using the
message shapes from the issue's repro (`role: "user"` text part,
`role: "assistant"` `tool_call` part, `role: "tool"` `tool_call_response`
part). Verified the new tests fail without the fix
(`git checkout HEAD~1 -- packages/shared/src/utils/chatml/adapters/aisdk.ts`):

```
FAIL  ... > should extract text from a `parts[]` text message
FAIL  ... > should normalize a `parts[]` tool_call message into tool_calls
FAIL  ... > should normalize a `parts[]` tool_call_response message into a tool result
 Test Files  1 failed (1)
      Tests  3 failed | 19 passed (22)
```

With the fix restored, the full aisdk suite and the broader chatml suite
both pass:

```
$ pnpm --filter worker run test src/__tests__/chatml/adapters/aisdk.test.ts
 Test Files  1 passed (1)
      Tests  22 passed (22)

$ pnpm --filter worker run test src/__tests__/chatml
 Test Files  9 passed (9)
      Tests  135 passed (135)
```

Lint (shared + worker):

```
$ pnpm --filter @langfuse/shared run lint
$ pnpm --filter worker run lint
```
Both clean, no warnings.

## AI disclosure

This PR, including the diagnosis, fix, and tests, was produced by an AI
coding agent (Claude Code) working autonomously from the linked issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends the AI SDK ChatML adapter to normalize AI SDK v7 and OTel `parts[]` messages through the existing legacy-content pipeline.
- Converts text parts into normalized message content.
- Converts tool calls and responses into existing tool-call and tool-result shapes.
- Adds regression coverage for text, tool-call, and tool-response messages.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the supported message shapes.

The new mapping feeds text and tool parts into existing normalization behavior, and the added tests cover each newly supported conversion.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chatml): parse AI SDK v7 parts\[\] mes..."](https://github.com/langfuse/langfuse/commit/a82c18256a253358a73159f35c3a1c4f0786d086) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52455651)</sub>

<!-- /greptile_comment -->