### PR TITLE
fix(in-app-agent): invoke sandbox lifecycle hooks

### DIFF
--- a/packages/shared/src/in-app-agent/server/sandbox/index.ts
+++ b/packages/shared/src/in-app-agent/server/sandbox/index.ts
@@ -1,6 +1,9 @@
 export { createLambdaMicrovmSandboxProvider } from "./providers/lambdaMicrovm";
 export { getDefaultInAppAgentSandboxProviderType } from "./config";
-export { createInAppAgentSandbox } from "./service";
+export {
+  createInAppAgentSandbox,
+  terminateInAppAgentSandboxSession,
+} from "./service";
 export type {
   InAppAgentSandbox,
   InAppAgentSandboxProviderType,

--- a/packages/shared/src/in-app-agent/server/sandbox/service.ts
+++ b/packages/shared/src/in-app-agent/server/sandbox/service.ts
@@ -1,5 +1,18 @@
 import type { InAppAgentSandbox, SandboxFile, SandboxProvider } from "./types";
 
+export async function terminateInAppAgentSandboxSession(params: {
+  provider: Pick<SandboxProvider, "terminateSession">;
+  providerSessionId?: string | null;
+}): Promise<void> {
+  if (!params.providerSessionId) {
+    return;
+  }
+
+  await params.provider.terminateSession?.({
+    sessionId: params.providerSessionId,
+  });
+}
+
 export async function createInAppAgentSandbox(params: {
   conversationId: string;
   projectId: string;
@@ -13,6 +26,8 @@ export async function createInAppAgentSandbox(params: {
 }> {
   let sessionId = params.providerSessionId ?? null;
   let sessionIsKnownActive = sessionId !== null;
+  let sessionIsSuspended = false;
+  let sessionSuspendPromise: Promise<void> | undefined;
 
   const persistState = async () => {
     await params.saveState({
@@ -23,12 +38,14 @@ export async function createInAppAgentSandbox(params: {
   const updateSessionState = async (nextSessionId: string) => {
     if (nextSessionId === sessionId) {
       sessionIsKnownActive = true;
+      sessionIsSuspended = false;
       return;
     }
 
     sessionId = nextSessionId;
     await persistState();
     sessionIsKnownActive = true;
+    sessionIsSuspended = false;
   };
 
   const ensureSession = async () => {
@@ -69,11 +86,26 @@ export async function createInAppAgentSandbox(params: {
   return {
     sandbox: createExecutionSandbox(),
     onTurnEnded: async () => {
-      if (!sessionId) {
+      if (!sessionId || sessionIsSuspended) {
         return;
       }
 
-      await persistState();
+      if (!sessionSuspendPromise) {
+        const sessionIdToSuspend = sessionId;
+        sessionSuspendPromise = (async () => {
+          await params.provider.suspendSession?.({
+            sessionId: sessionIdToSuspend,
+          });
+          await persistState();
+          sessionIsSuspended = true;
+        })();
+      }
+
+      try {
+        await sessionSuspendPromise;
+      } finally {
+        sessionSuspendPromise = undefined;
+      }
     },
   };
 }

--- a/web/src/__tests__/server/in-app-agent-router.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-router.servertest.ts
@@ -1,13 +1,47 @@
 import { randomUUID } from "crypto";
 import type { Session } from "next-auth";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { prisma } from "@langfuse/shared/src/db";
+import type {
+  createInAppAgentSandboxProvider,
+  getDefaultInAppAgentSandboxProviderType,
+} from "@langfuse/shared/in-app-agent/server/sandbox/config";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 
+const sandboxLifecycleMocks = vi.hoisted(() => ({
+  providerType: null as "dangerous-docker" | "lambda-microvm" | null,
+  terminateSession: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/in-app-agent/server/sandbox/config", async () => {
+  const actual = await vi.importActual<{
+    createInAppAgentSandboxProvider: typeof createInAppAgentSandboxProvider;
+    getDefaultInAppAgentSandboxProviderType: typeof getDefaultInAppAgentSandboxProviderType;
+  }>("@langfuse/shared/in-app-agent/server/sandbox/config");
+
+  return {
+    ...actual,
+    getDefaultInAppAgentSandboxProviderType: () =>
+      sandboxLifecycleMocks.providerType,
+    createInAppAgentSandboxProvider: async () => ({
+      ensureSession: async () => {
+        throw new Error("ensureSession should not be called by deletion");
+      },
+      terminateSession: sandboxLifecycleMocks.terminateSession,
+    }),
+  };
+});
+
+afterEach(() => {
+  sandboxLifecycleMocks.providerType = null;
+  sandboxLifecycleMocks.terminateSession.mockReset();
+});
+
 describe("in-app agent router", () => {
   it("soft-deletes an owned conversation", async () => {
+    sandboxLifecycleMocks.providerType = "lambda-microvm";
     const { caller, projectId, userId } = await createCaller();
     const conversation = await createConversation({
       projectId,
@@ -32,6 +66,42 @@ describe("in-app agent router", () => {
 
     expect(deletedConversation.deletedAt).toBeInstanceOf(Date);
     expect(deletedConversation.providerSessionId).toBeNull();
+    expect(sandboxLifecycleMocks.terminateSession).toHaveBeenCalledWith({
+      sessionId: "session-1",
+    });
+  });
+
+  it("keeps the provider session id when termination fails", async () => {
+    sandboxLifecycleMocks.providerType = "lambda-microvm";
+    sandboxLifecycleMocks.terminateSession.mockRejectedValueOnce(
+      new Error("provider unavailable"),
+    );
+    const { caller, projectId, userId } = await createCaller();
+    const conversation = await createConversation({
+      projectId,
+      userId,
+      providerSessionId: "session-1",
+    });
+
+    await expect(
+      caller.inAppAgent.deleteConversation({
+        projectId,
+        conversationId: conversation.id,
+      }),
+    ).rejects.toThrow("provider unavailable");
+
+    const persistedConversation =
+      await prisma.inAppAgentConversation.findUniqueOrThrow({
+        where: {
+          id_projectId: {
+            id: conversation.id,
+            projectId,
+          },
+        },
+      });
+
+    expect(persistedConversation.deletedAt).toBeInstanceOf(Date);
+    expect(persistedConversation.providerSessionId).toBe("session-1");
   });
 
   it("excludes deleted conversations from list and get", async () => {

--- a/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
@@ -9,7 +9,10 @@ import {
   getConversationMessagesForDisplay,
   getSandboxToolCallFiles,
 } from "@langfuse/shared/in-app-agent/server/persistence";
-import { createInAppAgentSandbox } from "@langfuse/shared/in-app-agent/server/sandbox";
+import {
+  createInAppAgentSandbox,
+  terminateInAppAgentSandboxSession,
+} from "@langfuse/shared/in-app-agent/server/sandbox";
 import { withOptionalSilentMcpOutput } from "@langfuse/shared/in-app-agent/server/tools";
 import { listObservationsTool } from "@/src/features/mcp/features/observations/tools/listObservations";
 
@@ -83,9 +86,13 @@ describe("in-app agent sandbox", () => {
         return { stdout: "", stderr: "", exitCode: 0 };
       },
     };
+    const suspendedSessionIds: string[] = [];
     const provider = {
       async ensureSession() {
         return { sessionId: "session-1", sandbox: sandboxSession };
+      },
+      async suspendSession({ sessionId }: { sessionId: string }) {
+        suspendedSessionIds.push(sessionId);
       },
     };
     const savedStates: Array<Record<string, unknown>> = [];
@@ -100,7 +107,7 @@ describe("in-app agent sandbox", () => {
     });
 
     await sandbox.sandbox.write({ path: "notes.txt", content: "hello" });
-    await sandbox.onTurnEnded();
+    await Promise.all([sandbox.onTurnEnded(), sandbox.onTurnEnded()]);
 
     expect(savedStates[0]).toEqual({
       providerSessionId: "session-1",
@@ -108,6 +115,63 @@ describe("in-app agent sandbox", () => {
     expect(savedStates[1]).toEqual({
       providerSessionId: "session-1",
     });
+    expect(suspendedSessionIds).toEqual(["session-1"]);
+  });
+
+  it("terminates a persisted provider session when requested", async () => {
+    const terminatedSessionIds: string[] = [];
+
+    await terminateInAppAgentSandboxSession({
+      provider: {
+        async terminateSession({ sessionId }) {
+          terminatedSessionIds.push(sessionId);
+        },
+      },
+      providerSessionId: "session-1",
+    });
+    await terminateInAppAgentSandboxSession({
+      provider: {},
+      providerSessionId: null,
+    });
+
+    expect(terminatedSessionIds).toEqual(["session-1"]);
+  });
+
+  it("suspends a persisted session when the turn ends", async () => {
+    const suspendedSessionIds: string[] = [];
+    const sandboxSession = {
+      async syncReadonlyFiles() {},
+      async read() {
+        return { path: "notes.txt", content: null };
+      },
+      async write() {
+        return { path: "notes.txt", bytesWritten: 0 };
+      },
+      async edit() {
+        return { path: "notes.txt", replaced: false };
+      },
+      async bash() {
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    };
+    const sandbox = await createInAppAgentSandbox({
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      providerSessionId: "session-1",
+      provider: {
+        async ensureSession() {
+          return { sessionId: "session-1", sandbox: sandboxSession };
+        },
+        async suspendSession({ sessionId }) {
+          suspendedSessionIds.push(sessionId);
+        },
+      },
+      getToolCallFiles: async () => [],
+      saveState: async () => undefined,
+    });
+
+    await sandbox.onTurnEnded();
+    expect(suspendedSessionIds).toEqual(["session-1"]);
   });
 
   it("syncs same-turn silent tool output into sandbox tool-call files", async () => {

--- a/web/src/features/in-app-agent/server/backgroundRunService.ts
+++ b/web/src/features/in-app-agent/server/backgroundRunService.ts
@@ -321,19 +321,23 @@ export async function deleteBackgroundConversation(params: {
       provider,
       providerSessionId,
     });
-  }
 
-  await params.prisma.inAppAgentConversation.update({
-    where: {
-      id_projectId: {
-        id: params.conversationId,
-        projectId: params.projectId,
+    // Only clear the persisted session id after a successful termination.
+    // If the provider could not be resolved (env unset or changed), keeping
+    // the id leaves a handle for a later cleanup attempt instead of
+    // orphaning the sandbox with no way to find it.
+    await params.prisma.inAppAgentConversation.update({
+      where: {
+        id_projectId: {
+          id: params.conversationId,
+          projectId: params.projectId,
+        },
       },
-    },
-    data: {
-      providerSessionId: null,
-    },
-  });
+      data: {
+        providerSessionId: null,
+      },
+    });
+  }
 
   return { success: true };
 }

--- a/web/src/features/in-app-agent/server/backgroundRunService.ts
+++ b/web/src/features/in-app-agent/server/backgroundRunService.ts
@@ -23,6 +23,11 @@ import {
   type AgUiRunAgentInput,
 } from "@langfuse/shared/in-app-agent";
 import { parseInAppAgentInterruptEvent } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
+import {
+  createInAppAgentSandboxProvider,
+  getDefaultInAppAgentSandboxProviderType,
+} from "@langfuse/shared/in-app-agent/server/sandbox/config";
+import { terminateInAppAgentSandboxSession } from "@langfuse/shared/in-app-agent/server/sandbox";
 import { getInAppAgentPrefixedToolName } from "@langfuse/shared/in-app-agent/server/tools";
 import {
   ensureOwnedConversation,
@@ -269,12 +274,20 @@ export async function deleteBackgroundConversation(params: {
   conversationId: string;
   userId: string;
 }) {
-  await getOwnedConversationOrThrow({
+  const conversation = await getOwnedConversationOrThrow({
     prisma: params.prisma,
     projectId: params.projectId,
     conversationId: params.conversationId,
     userId: params.userId,
   });
+
+  const providerSessionId = conversation.providerSessionId;
+  const providerType = providerSessionId
+    ? getDefaultInAppAgentSandboxProviderType()
+    : null;
+  const provider = providerType
+    ? await createInAppAgentSandboxProvider(providerType)
+    : undefined;
 
   const cancelledRunIds = await params.prisma.$transaction(async (tx) => {
     const cancelledImmediately = await cancelConversationRunsInTransaction({
@@ -291,7 +304,6 @@ export async function deleteBackgroundConversation(params: {
         },
       },
       data: {
-        providerSessionId: null,
         deletedAt: new Date(),
       },
     });
@@ -301,6 +313,27 @@ export async function deleteBackgroundConversation(params: {
 
   // Avoid spending a worker slot on jobs whose runs are already cancelled.
   await Promise.all(cancelledRunIds.map(removeInAppAgentRunJob));
+
+  // Keep provider cleanup outside the transaction. Provider calls can be
+  // remote and should never hold the conversation row lock while they run.
+  if (providerSessionId && provider) {
+    await terminateInAppAgentSandboxSession({
+      provider,
+      providerSessionId,
+    });
+  }
+
+  await params.prisma.inAppAgentConversation.update({
+    where: {
+      id_projectId: {
+        id: params.conversationId,
+        projectId: params.projectId,
+      },
+    },
+    data: {
+      providerSessionId: null,
+    },
+  });
 
   return { success: true };
 }

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -51,6 +51,7 @@ import {
   createInAppAgentSandboxProvider,
   getDefaultInAppAgentSandboxProviderType,
 } from "@langfuse/shared/in-app-agent/server/sandbox/config";
+import { terminateInAppAgentSandboxSession } from "@langfuse/shared/in-app-agent/server/sandbox";
 
 import { env } from "../../env";
 
@@ -325,7 +326,7 @@ export async function executeInAppAgentRun(params: {
           provider: sandboxProvider,
           getToolCallFiles: async () => sandboxToolCallFiles.getFiles(),
           saveState: async (state) => {
-            await prisma.inAppAgentConversation.updateMany({
+            const result = await prisma.inAppAgentConversation.updateMany({
               where: {
                 id: conversation.id,
                 projectId,
@@ -333,6 +334,16 @@ export async function executeInAppAgentRun(params: {
               },
               data: state,
             });
+            // The conversation was deleted between the session snapshot and
+            // this save: the update matched nothing, so the new sandbox
+            // session would be orphaned. Terminate it to release the
+            // provider resource instead of leaking it until provider expiry.
+            if (result.count === 0 && state.providerSessionId && sandboxProvider) {
+              await terminateInAppAgentSandboxSession({
+                provider: sandboxProvider,
+                providerSessionId: state.providerSessionId,
+              });
+            }
           },
         })
       : undefined;

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -325,8 +325,12 @@ export async function executeInAppAgentRun(params: {
           provider: sandboxProvider,
           getToolCallFiles: async () => sandboxToolCallFiles.getFiles(),
           saveState: async (state) => {
-            await prisma.inAppAgentConversation.update({
-              where: { id_projectId: { id: conversation.id, projectId } },
+            await prisma.inAppAgentConversation.updateMany({
+              where: {
+                id: conversation.id,
+                projectId,
+                deletedAt: null,
+              },
               data: state,
             });
           },


### PR DESCRIPTION
## What does this PR do?

Fixes #15953

Sandbox provider lifecycle hooks were defined but never reached from production code. This change:

- suspends provider sessions once when a turn finishes, while retaining the persisted session ID;
- terminates sessions from conversation deletion, outside the DB transaction;
- preserves the session ID when termination fails so a retry can clean it up;
- prevents a late worker cleanup from restoring a session ID after deletion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the diff.
- [x] Added regression coverage for suspend/terminate and retry behavior.
- [x] Checked formatting, lint, typecheck, and builds.

## Verification

- `11 tests passed` — `in-app-agent-sandbox.servertest.ts`
- `15 tests passed` — `in-app-agent-stream.servertest.ts`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter worker run build`
- `pnpm --filter worker run typecheck`
- `pnpm --filter web run typecheck`
- touched-file ESLint and Prettier checks passed
- DB-backed router/worker integration tests could not run in this checkout because PostgreSQL/Docker are unavailable (`localhost:5432` was unreachable).

AI assistance was used during investigation and implementation; the patch and tests were reviewed against the repository's contribution guidance.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires sandbox suspension into worker turn completion and termination into conversation deletion while retaining failed-cleanup IDs for retries.

- Adds shared sandbox termination and single-flight suspension behavior.
- Moves deletion cleanup outside the database transaction and guards worker state writes after soft deletion.
- Adds regression coverage for suspension, termination, and failed termination.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until a provider session created concurrently with deletion is terminated instead of having its persistence silently discarded.

A running worker can create a sandbox before observing cooperative cancellation, after which the deleted-row update guard loses the new session ID and only suspends the resource; provider configuration transitions can also discard persisted cleanup handles without successful termination.

**Files Needing Attention:** worker/src/features/in-app-agent/executeInAppAgentRun.ts, web/src/features/in-app-agent/server/backgroundRunService.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as Delete request
  participant DB as Postgres
  participant W as Running worker
  participant P as Sandbox provider
  U->>DB: Read providerSessionId
  U->>DB: Set deletedAt and request cancellation
  W->>P: ensureSession()
  P-->>W: New session ID
  W->>DB: updateMany where deletedAt is null
  DB-->>W: 0 rows updated
  U->>P: Terminate snapshotted session ID
  W->>P: Suspend new session
  Note over W,P: New session ID is no longer persisted
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/in-app-agent/executeInAppAgentRun.ts:327-335
**Late session cleanup is lost**

If a running worker creates a sandbox after deletion snapshots the previous session ID but before it observes cooperative cancellation, this `updateMany` silently discards the new session ID because `deletedAt` is already set. Deletion can only terminate the earlier snapshot and worker completion only suspends the new session, leaving the provider resource allocated until provider-side expiry.

### Issue 2
web/src/features/in-app-agent/server/backgroundRunService.ts:319-334
**Unresolved provider loses cleanup handle**

If `LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER` is unset or changed after a session was persisted, cleanup is skipped or sent to the wrong provider, but this code still clears `providerSessionId`. That orphans the MicroVM or container and removes the only persisted identifier available for a later cleanup attempt.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): invoke sandbox lifecy..."](https://github.com/langfuse/langfuse/commit/8caa18b23d1aef693cc366bf5df0ccc98b45a4d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52468200)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)
</details>

<!-- /greptile_comment -->