### PR TITLE
fix(web): instrument the v4 migration panel funnel

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -318,8 +318,11 @@ export const events = {
     "v4_beta_toggled",
     "v4_migration_card_clicked",
   ],
+  // Migration-funnel events answer "are people finding the panel, which
+  // action items do they engage with, and which CTA do they use?"
+  // panel_opened carries the entry surface; panel_checks_loaded carries the
+  // amount of work shown (counts only — never keys or SDK payload values).
   v4_migration: [
-    "in_app_agent_opened",
     "coding_agent_prompt_viewed",
     "coding_agent_prompt_copied",
     "delay_badge_clicked",
@@ -333,6 +336,13 @@ export const events = {
     "overview_banner_docs_clicked",
     "panel_docs_link_clicked",
     "create_project_keys_clicked",
+    "panel_opened",
+    "panel_checks_loaded",
+    "section_expanded",
+    "evidence_link_clicked",
+    "section_link_clicked",
+    "project_keys_copied",
+    "evals_manual_upgrade_clicked",
   ],
   // Filter/search-bar usage analytics (LFE-10781). METADATA ONLY — payloads
   // never carry a raw filter value, search text, or AI prompt (PII). Only

--- a/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
+++ b/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
@@ -14,6 +14,7 @@ import {
   useCanUseInAppAgent,
   useInAppAiAgent,
 } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 
@@ -56,6 +57,7 @@ export function EvaluatorMigrationDialog({
   const isSingleEvaluator = scope.type === "single";
   const showAssistantOption = canUseAssistant;
 
+  const capture = usePostHogClientCapture();
   const startAssistant = async () => {
     const opened = openAssistant("v4_migration");
     if (!opened) return;
@@ -79,10 +81,11 @@ export function EvaluatorMigrationDialog({
   };
 
   const handleManualClick = () => {
-    if (isSingleEvaluator) {
-      onManualUpgrade();
-      return;
-    }
+    // The assistant branch is covered by in_app_agent:new_chat_started
+    // (entryPoint "v4_migration"); this event completes the funnel fork.
+    capture("v4_migration:evals_manual_upgrade_clicked", {
+      scope: isSingleEvaluator ? "single" : "bulk",
+    });
     onManualUpgrade();
   };
 

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -512,12 +512,14 @@ describe("V4MigrationDetailsContent", () => {
     );
 
     fireEvent.click(screen.getByRole("link", { name: "pk-lf-123…abcdef" }));
+    // Only bounded values: the canonical SDK enum and status enums — never
+    // the raw client-supplied sdkName/sdkVersion header strings.
     expect(mocks.capture).toHaveBeenCalledWith(
       "v4_migration:evidence_link_clicked",
       {
         section: "sdk",
         sdkName: "python",
-        sdkVersion: "2.60.3",
+        v4MigrationStatus: "upgrade_required",
         attributionStatus: "attributed",
       },
     );

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -177,26 +177,35 @@ vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
 }));
 
 // Content stays rendered so section-body assertions need no expanding; the
-// trigger still reports an expansion so section_expanded stays testable.
+// trigger toggles like Radix (open ↔ closed, seeded from defaultOpen) so the
+// expand-only guard in Section is genuinely exercised.
 vi.mock("@/src/components/ui/collapsible", () => {
-  const OpenChangeContext = React.createContext<(open: boolean) => void>(
-    () => {},
-  );
+  const ToggleContext = React.createContext<() => void>(() => {});
   return {
     Collapsible: ({
       children,
+      defaultOpen,
       onOpenChange,
     }: {
       children: React.ReactNode;
+      defaultOpen?: boolean;
       onOpenChange?: (open: boolean) => void;
-    }) => (
-      <OpenChangeContext.Provider value={onOpenChange ?? (() => {})}>
-        <div>{children}</div>
-      </OpenChangeContext.Provider>
-    ),
+    }) => {
+      const [isOpen, setIsOpen] = React.useState(defaultOpen ?? false);
+      const toggle = () => {
+        const next = !isOpen;
+        setIsOpen(next);
+        onOpenChange?.(next);
+      };
+      return (
+        <ToggleContext.Provider value={toggle}>
+          <div>{children}</div>
+        </ToggleContext.Provider>
+      );
+    },
     CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => {
-      const onOpenChange = React.useContext(OpenChangeContext);
-      return <button onClick={() => onOpenChange(true)}>{children}</button>;
+      const toggle = React.useContext(ToggleContext);
+      return <button onClick={toggle}>{children}</button>;
     },
     CollapsibleContent: ({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
@@ -490,6 +499,29 @@ describe("V4MigrationDetailsContent", () => {
     );
   });
 
+  it("holds panel_checks_loaded when one check errors while another loads", () => {
+    // readiness collapses to "unavailable" on the first error, but the event
+    // must wait for the in-flight checks instead of locking in a mid-flight
+    // snapshot; errored counts then report null, not a clean-looking zero.
+    mocks.migrationData.evals = { status: "error", count: 0 };
+    mocks.migrationData.apis = { status: "loading", count: 0 };
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      "v4_migration:panel_checks_loaded",
+      expect.anything(),
+    );
+
+    mocks.migrationData.apis = { status: "loaded", count: 1 };
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "v4_migration:panel_checks_loaded",
+      expect.objectContaining({ readiness: "unavailable", evalsCount: null }),
+    );
+  });
+
   it("captures section_expanded and evidence_link_clicked in the SDK section", () => {
     mocks.migrationData.sdk = {
       status: "legacy",
@@ -510,6 +542,14 @@ describe("V4MigrationDetailsContent", () => {
       "v4_migration:section_expanded",
       { section: "sdk" },
     );
+
+    // Collapsing must not count as engagement.
+    fireEvent.click(screen.getByText("Update SDK").closest("button")!);
+    expect(
+      mocks.capture.mock.calls.filter(
+        ([name]) => name === "v4_migration:section_expanded",
+      ),
+    ).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("link", { name: "pk-lf-123…abcdef" }));
     // Only bounded values: the canonical SDK enum and status enums — never

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   fireEvent,
   render,
@@ -51,6 +52,7 @@ const cleanSdkState = (): V4MigrationSdkState => ({
 
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
+  capture: vi.fn(),
   openAssistant: vi.fn(),
   submitAgentMessage: vi.fn(),
   upgradePlan: {
@@ -103,7 +105,7 @@ vi.mock("@/src/features/support-chat/SupportDrawerProvider", () => ({
 }));
 
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
-  usePostHogClientCapture: () => vi.fn(),
+  usePostHogClientCapture: () => mocks.capture,
 }));
 
 vi.mock("@/src/utils/api", () => ({
@@ -174,17 +176,33 @@ vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
   }),
 }));
 
-vi.mock("@/src/components/ui/collapsible", () => ({
-  Collapsible: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => (
-    <button>{children}</button>
-  ),
-  CollapsibleContent: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-}));
+// Content stays rendered so section-body assertions need no expanding; the
+// trigger still reports an expansion so section_expanded stays testable.
+vi.mock("@/src/components/ui/collapsible", () => {
+  const OpenChangeContext = React.createContext<(open: boolean) => void>(
+    () => {},
+  );
+  return {
+    Collapsible: ({
+      children,
+      onOpenChange,
+    }: {
+      children: React.ReactNode;
+      onOpenChange?: (open: boolean) => void;
+    }) => (
+      <OpenChangeContext.Provider value={onOpenChange ?? (() => {})}>
+        <div>{children}</div>
+      </OpenChangeContext.Provider>
+    ),
+    CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => {
+      const onOpenChange = React.useContext(OpenChangeContext);
+      return <button onClick={() => onOpenChange(true)}>{children}</button>;
+    },
+    CollapsibleContent: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  };
+});
 
 describe("V4MigrationDetailsContent", () => {
   beforeEach(() => {
@@ -436,6 +454,79 @@ describe("V4MigrationDetailsContent", () => {
     expect(
       screen.queryByRole("link", { name: "pk-lf-123…abcdef" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("captures panel_checks_loaded once when all checks settle", () => {
+    const { rerender } = render(
+      <V4MigrationDetailsContent projectId="project-1" />,
+    );
+    rerender(<V4MigrationDetailsContent projectId="project-1" />);
+
+    const loadedCalls = mocks.capture.mock.calls.filter(
+      ([name]) => name === "v4_migration:panel_checks_loaded",
+    );
+    expect(loadedCalls).toHaveLength(1);
+    expect(loadedCalls[0]![1]).toEqual({
+      readiness: "action-needed",
+      sdkStatus: "latest",
+      sdkActionableCount: 0,
+      delayedOtelCount: 0,
+      customInstrumentationCount: 0,
+      evalsCount: 0,
+      apisCount: 1,
+      integrationsCount: 3,
+      experimentsResult: "not_required",
+    });
+  });
+
+  it("holds panel_checks_loaded while a check is still running", () => {
+    mocks.migrationData.evals = { status: "loading", count: 0 };
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      "v4_migration:panel_checks_loaded",
+      expect.anything(),
+    );
+  });
+
+  it("captures section_expanded and evidence_link_clicked in the SDK section", () => {
+    mocks.migrationData.sdk = {
+      status: "legacy",
+      sdkUsageSeries: [
+        makeSdkUsageSeries({
+          sdkVersion: "2.60.3",
+          v4MigrationStatus: "upgrade_required",
+        }),
+      ],
+      upgradeRequiredCount: 1,
+      delayedOtelIngestionCount: 0,
+    };
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    fireEvent.click(screen.getByText("Update SDK").closest("button")!);
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "v4_migration:section_expanded",
+      { section: "sdk" },
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "pk-lf-123…abcdef" }));
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "v4_migration:evidence_link_clicked",
+      {
+        section: "sdk",
+        sdkName: "python",
+        sdkVersion: "2.60.3",
+        attributionStatus: "attributed",
+      },
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "upgrade path" }));
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "v4_migration:section_link_clicked",
+      { section: "sdk", link: "sdk_upgrade_docs" },
+    );
   });
 
   it("shows delayed OTel exporters and hides the clean SDK section", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -116,6 +116,7 @@ function Section({
   meta,
   children,
   defaultOpen,
+  analyticsSection,
 }: {
   title: string;
   /** Number of affected items, shown muted after the title. */
@@ -124,9 +125,21 @@ function Section({
   meta?: ReactNode;
   children: ReactNode;
   defaultOpen?: boolean;
+  /** Funnel dimension for the section_expanded event (snake_case). */
+  analyticsSection: string;
 }) {
+  const capture = usePostHogClientCapture();
   return (
-    <Collapsible defaultOpen={defaultOpen}>
+    <Collapsible
+      defaultOpen={defaultOpen}
+      onOpenChange={(isOpen) => {
+        // User expansions only — defaultOpen does not fire onOpenChange.
+        if (isOpen)
+          capture("v4_migration:section_expanded", {
+            section: analyticsSection,
+          });
+      }}
+    >
       <CollapsibleTrigger className="group flex w-full items-center gap-2.5 py-2.5 text-left">
         {/* A rendered section always needs the user to act (clean ones hide
             themselves); same dot as the action-required badge. */}
@@ -157,17 +170,26 @@ function ExternalLink({
   href,
   children,
   className,
+  analytics,
 }: {
   href: string;
   children: ReactNode;
   className?: string;
+  /** Which guidance link in which section — for section_link_clicked. */
+  analytics?: { section: string; link: string };
 }) {
+  const capture = usePostHogClientCapture();
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       className={cn("underline", className)}
+      onClick={
+        analytics
+          ? () => capture("v4_migration:section_link_clicked", analytics)
+          : undefined
+      }
     >
       {children}
     </a>
@@ -280,6 +302,7 @@ function SdkUsageSeriesRows({
   unknownSeriesLabel = "OTLP exporter",
   projectId,
   onNavigate,
+  analyticsSection,
 }: {
   series: V4MigrationSdkUsageSeries[];
   /** Drives the per-row status emoji; the suffix carries the text meaning. */
@@ -290,7 +313,10 @@ function SdkUsageSeriesRows({
   /** Enables the evidence deep link on the public key. */
   projectId?: string;
   onNavigate?: () => void;
+  /** Funnel dimension for the evidence_link_clicked event (snake_case). */
+  analyticsSection: string;
 }) {
+  const capture = usePostHogClientCapture();
   if (series.length === 0) return null;
 
   return (
@@ -337,7 +363,16 @@ function SdkUsageSeriesRows({
                   href={`/project/${projectId}/observations?filter=${encodeURIComponent(
                     buildSdkUsageEvidenceFilter(usage),
                   )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`}
-                  onClick={onNavigate}
+                  onClick={() => {
+                    // sdkName is an SDK product identifier, not user content.
+                    capture("v4_migration:evidence_link_clicked", {
+                      section: analyticsSection,
+                      sdkName: usage.sdkName,
+                      sdkVersion: usage.sdkVersion,
+                      attributionStatus: usage.attributionStatus,
+                    });
+                    onNavigate?.();
+                  }}
                   className="underline"
                   title={usage.publicKey}
                 >
@@ -383,6 +418,7 @@ export function V4MigrationSdkSection({
   return (
     <Section
       title="Update SDK"
+      analyticsSection="sdk"
       count={isTransient ? undefined : section.actionableCount}
       meta={
         section.status === "checking"
@@ -405,7 +441,13 @@ export function V4MigrationSdkSection({
               ? "configuration needs"
               : "configurations need"}{" "}
             an update. See{" "}
-            <ExternalLink href={SDK_UPGRADE_URL}>upgrade path</ExternalLink>.
+            <ExternalLink
+              href={SDK_UPGRADE_URL}
+              analytics={{ section: "sdk", link: "sdk_upgrade_docs" }}
+            >
+              upgrade path
+            </ExternalLink>
+            .
           </>
         )}
       </p>
@@ -413,6 +455,7 @@ export function V4MigrationSdkSection({
         series={section.series}
         projectId={projectId}
         onNavigate={onNavigate}
+        analyticsSection="sdk"
         needsAction={(usage) =>
           (usage.v4MigrationStatus === "upgrade_required" &&
             !usage.upgradeCompleted) ||
@@ -458,6 +501,7 @@ export function V4MigrationOtelSection({
   return (
     <Section
       title="Update OTel Instrumentation"
+      analyticsSection="otel"
       count={section.delayedCount}
       defaultOpen={defaultOpen}
     >
@@ -466,7 +510,10 @@ export function V4MigrationOtelSection({
         <MonoValue>x-langfuse-ingestion-version</MonoValue> header to{" "}
         <MonoValue>4</MonoValue> on the OTLP exporter to use real-time
         ingestion.{" "}
-        <ExternalLink href={OTEL_V4_MIGRATION_URL}>
+        <ExternalLink
+          href={OTEL_V4_MIGRATION_URL}
+          analytics={{ section: "otel", link: "otel_migration_docs" }}
+        >
           OpenTelemetry migration guide
         </ExternalLink>
         .
@@ -475,6 +522,7 @@ export function V4MigrationOtelSection({
         series={section.series}
         projectId={projectId}
         onNavigate={onNavigate}
+        analyticsSection="otel"
         needsAction={(usage) => usage.hasDelayedOtelEvents === true}
         suffix={(usage) =>
           usage.hasDelayedOtelEvents === true ? (
@@ -513,6 +561,7 @@ export function V4MigrationCustomInstrumentationSection({
   return (
     <Section
       title="Upgrade Instrumentation"
+      analyticsSection="custom_instrumentation"
       count={section.series.length}
       defaultOpen={defaultOpen}
     >
@@ -520,9 +569,23 @@ export function V4MigrationCustomInstrumentationSection({
         Data is arriving through the ingestion API without a Langfuse SDK
         header, so this looks like custom instrumentation or a very old SDK
         version. Please upgrade to one of our latest{" "}
-        <ExternalLink href={SDK_OVERVIEW_URL}>Python or JS SDK</ExternalLink>{" "}
+        <ExternalLink
+          href={SDK_OVERVIEW_URL}
+          analytics={{
+            section: "custom_instrumentation",
+            link: "sdk_overview_docs",
+          }}
+        >
+          Python or JS SDK
+        </ExternalLink>{" "}
         versions, or use the{" "}
-        <ExternalLink href={OTEL_INTEGRATION_URL}>
+        <ExternalLink
+          href={OTEL_INTEGRATION_URL}
+          analytics={{
+            section: "custom_instrumentation",
+            link: "otel_integration_docs",
+          }}
+        >
           OpenTelemetry endpoint
         </ExternalLink>
         .
@@ -532,6 +595,7 @@ export function V4MigrationCustomInstrumentationSection({
         projectId={projectId}
         onNavigate={onNavigate}
         unknownSeriesLabel="Custom instrumentation"
+        analyticsSection="custom_instrumentation"
         needsAction={() => true}
         suffix={() => null}
       />
@@ -556,9 +620,11 @@ export function V4MigrationEvalsSection({
   onNavigate?: () => void;
   defaultOpen?: boolean;
 }) {
+  const capture = usePostHogClientCapture();
   return (
     <Section
       title="Repoint Evals"
+      analyticsSection="evals"
       count={state.status === "loaded" ? state.count : undefined}
       meta={
         state.status === "loading"
@@ -581,7 +647,17 @@ export function V4MigrationEvalsSection({
         <>
           <p className="text-muted-foreground mb-2 text-sm">
             {evalsUrl ? (
-              <Link href={evalsUrl} onClick={onNavigate} className="underline">
+              <Link
+                href={evalsUrl}
+                onClick={() => {
+                  capture("v4_migration:section_link_clicked", {
+                    section: "evals",
+                    link: "evals_table",
+                  });
+                  onNavigate?.();
+                }}
+                className="underline"
+              >
                 {state.count}{" "}
                 {state.count === 1 ? "eval targets" : "evals target"} trace
                 input/output
@@ -624,6 +700,7 @@ export function V4MigrationExperimentsSection({
   return (
     <Section
       title="Update Experiments"
+      analyticsSection="experiments"
       meta={
         state.status === "loading"
           ? "Checking…"
@@ -648,7 +725,13 @@ export function V4MigrationExperimentsSection({
               This project called the deprecated{" "}
               <MonoValue>POST /dataset-run-items</MonoValue>. Replace this
               direct API call with OTel experiment instrumentation. See the{" "}
-              <ExternalLink href={EXPERIMENT_OTEL_INGESTION_URL}>
+              <ExternalLink
+                href={EXPERIMENT_OTEL_INGESTION_URL}
+                analytics={{
+                  section: "experiments",
+                  link: "experiments_otel_docs",
+                }}
+              >
                 OTel experiment instrumentation guide
               </ExternalLink>{" "}
               for more details.
@@ -674,7 +757,10 @@ export function V4MigrationExperimentsSection({
             <>
               This project called <MonoValue>POST /dataset-run-items</MonoValue>{" "}
               with an outdated SDK.{" "}
-              <ExternalLink href={SDK_UPGRADE_URL}>
+              <ExternalLink
+                href={SDK_UPGRADE_URL}
+                analytics={{ section: "experiments", link: "sdk_upgrade_docs" }}
+              >
                 Upgrade the SDK
               </ExternalLink>{" "}
               and use the experiment runner method.
@@ -702,6 +788,7 @@ export function V4MigrationApisSection({
   return (
     <Section
       title="Migrate APIs"
+      analyticsSection="apis"
       count={state.status === "loaded" ? state.count : undefined}
       meta={
         state.status === "loading"
@@ -725,7 +812,10 @@ export function V4MigrationApisSection({
           <p className="text-muted-foreground mb-2 text-sm">
             You&apos;ve called these deprecated endpoints in the last{" "}
             {V4_MIGRATION_LOOKBACK_DAYS} days. They stop working soon; the{" "}
-            <ExternalLink href={DEPRECATED_API_MIGRATION_URL}>
+            <ExternalLink
+              href={DEPRECATED_API_MIGRATION_URL}
+              analytics={{ section: "apis", link: "deprecated_api_docs" }}
+            >
               migration guide
             </ExternalLink>{" "}
             maps each endpoint to its replacement.
@@ -739,6 +829,7 @@ export function V4MigrationApisSection({
                 <ExternalLink
                   href={DEPRECATED_API_MIGRATION_URL}
                   className="text-sm"
+                  analytics={{ section: "apis", link: "deprecated_api_docs" }}
                 >
                   {row.endpoint}
                 </ExternalLink>
@@ -776,9 +867,11 @@ export function V4MigrationIntegrationsSection({
   onNavigate?: () => void;
   defaultOpen?: boolean;
 }) {
+  const capture = usePostHogClientCapture();
   return (
     <Section
       title="Migrate Integrations"
+      analyticsSection="integrations"
       count={state.status === "loaded" ? state.count : undefined}
       meta={
         state.status === "loading"
@@ -811,7 +904,13 @@ export function V4MigrationIntegrationsSection({
                 {integrationsUrl ? (
                   <Link
                     href={integrationsUrl}
-                    onClick={onNavigate}
+                    onClick={() => {
+                      capture("v4_migration:section_link_clicked", {
+                        section: "integrations",
+                        link: "integrations_settings",
+                      });
+                      onNavigate?.();
+                    }}
                     className="text-sm underline"
                   >
                     {name}
@@ -825,6 +924,10 @@ export function V4MigrationIntegrationsSection({
                     DEPRECATED_INTEGRATION_MIGRATION_URLS[name] ?? V4_DOCS_URL
                   }
                   className="text-sm"
+                  analytics={{
+                    section: "integrations",
+                    link: "integration_migration_docs",
+                  }}
                 >
                   Migration guide
                 </ExternalLink>
@@ -885,8 +988,13 @@ export function V4MigrationHeaderContent({
         {/* Only claim the setup is outdated once the checks confirm it. */}
         {needsMigration && "Your setup is outdated. "}
         Upgrade to Langfuse v4 for{" "}
-        <ExternalLink href={V4_DOCS_URL}>real-time ingestion</ExternalLink> and
-        up to 165× faster queries.
+        <ExternalLink
+          href={V4_DOCS_URL}
+          analytics={{ section: "header", link: "v4_docs" }}
+        >
+          real-time ingestion
+        </ExternalLink>{" "}
+        and up to 165× faster queries.
       </p>
     </>
   );
@@ -1042,7 +1150,11 @@ export function V4MigrationAgentUpgradeSection({
                 ))}
             </div>
             {envBlock && (
-              <CodeBlockWithCopy text={envBlock} copyLabel="Copy keys" />
+              <CodeBlockWithCopy
+                text={envBlock}
+                copyLabel="Copy keys"
+                onCopy={() => capture("v4_migration:project_keys_copied")}
+              />
             )}
           </div>
         )}
@@ -1082,6 +1194,41 @@ export function V4MigrationDetailsContent({
   // ingestionApiKey filter — the link would open an unfiltered table. Keep
   // the key as plain text there instead of a misleading link.
   const evidenceProjectId = isBetaEnabled ? projectId : undefined;
+
+  // PostHog is the external system here: the panel's checks resolve
+  // asynchronously after open, so the "how much work was shown" event can
+  // only fire once they settle; the ref guards refetch-driven re-settles.
+  const readiness = getProjectMigrationReadiness(migrationData);
+  const checksLoadedCaptured = useRef(false);
+  useEffect(() => {
+    if (checksLoadedCaptured.current || readiness === "checking") return;
+    checksLoadedCaptured.current = true;
+    const sdkSection = getSdkSectionState(migrationData.sdk);
+    const otelSection = getOtelSectionState(migrationData.sdk);
+    const customSection = getCustomInstrumentationSectionState(
+      migrationData.sdk,
+    );
+    // Counts only — never keys, versions, or other row contents.
+    capture("v4_migration:panel_checks_loaded", {
+      readiness,
+      sdkStatus: migrationData.sdk.status,
+      sdkActionableCount: sdkSection.actionableCount,
+      delayedOtelCount: otelSection.delayedCount,
+      customInstrumentationCount: customSection.series.length,
+      evalsCount:
+        migrationData.evals.status === "loaded" ? migrationData.evals.count : 0,
+      apisCount:
+        migrationData.apis.status === "loaded" ? migrationData.apis.count : 0,
+      integrationsCount:
+        migrationData.exports.status === "loaded"
+          ? migrationData.exports.count
+          : 0,
+      experimentsResult:
+        migrationData.experiments.status === "loaded"
+          ? migrationData.experiments.result
+          : migrationData.experiments.status,
+    });
+  }, [readiness, migrationData, capture]);
 
   // Sections in a good state collapse into one summary sentence instead of
   // rendering their own (green) rows. Loading and error states keep the row.
@@ -1234,7 +1381,13 @@ export function V4MigrationDetailsContent({
                 <HoverCardPortal>
                   <HoverCardContent className="w-80 text-sm">
                     The latest SDK no longer sets trace input and output;{" "}
-                    <ExternalLink href={OBSERVATIONS_DATA_MODEL_URL}>
+                    <ExternalLink
+                      href={OBSERVATIONS_DATA_MODEL_URL}
+                      analytics={{
+                        section: "compare_row",
+                        link: "observations_data_model_docs",
+                      }}
+                    >
                       v4 infers them from observations
                     </ExternalLink>
                     .

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -364,11 +364,13 @@ function SdkUsageSeriesRows({
                     buildSdkUsageEvidenceFilter(usage),
                   )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`}
                   onClick={() => {
-                    // sdkName is an SDK product identifier, not user content.
+                    // Bounded values only: raw sdkName/sdkVersion are
+                    // client-supplied ingestion headers (user-controlled,
+                    // unbounded cardinality) and must not reach PostHog.
                     capture("v4_migration:evidence_link_clicked", {
                       section: analyticsSection,
-                      sdkName: usage.sdkName,
-                      sdkVersion: usage.sdkVersion,
+                      sdkName: usage.canonicalSdkName ?? "other",
+                      v4MigrationStatus: usage.v4MigrationStatus,
                       attributionStatus: usage.attributionStatus,
                     });
                     onNavigate?.();

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1200,17 +1200,27 @@ export function V4MigrationDetailsContent({
   // PostHog is the external system here: the panel's checks resolve
   // asynchronously after open, so the "how much work was shown" event can
   // only fire once they settle; the ref guards refetch-driven re-settles.
+  // Settled means no check is still in flight — readiness alone would report
+  // "unavailable" the moment one check errors while others are loading, and
+  // the event would lock in a mid-flight snapshot.
   const readiness = getProjectMigrationReadiness(migrationData);
+  const checksSettled =
+    migrationData.sdk.status !== "checking" &&
+    migrationData.experiments.status !== "loading" &&
+    migrationData.evals.status !== "loading" &&
+    migrationData.apis.status !== "loading" &&
+    migrationData.exports.status !== "loading";
   const checksLoadedCaptured = useRef(false);
   useEffect(() => {
-    if (checksLoadedCaptured.current || readiness === "checking") return;
+    if (checksLoadedCaptured.current || !checksSettled) return;
     checksLoadedCaptured.current = true;
     const sdkSection = getSdkSectionState(migrationData.sdk);
     const otelSection = getOtelSectionState(migrationData.sdk);
     const customSection = getCustomInstrumentationSectionState(
       migrationData.sdk,
     );
-    // Counts only — never keys, versions, or other row contents.
+    // Counts only — never keys, versions, or other row contents. Errored
+    // checks report null so they stay distinguishable from a clean zero.
     capture("v4_migration:panel_checks_loaded", {
       readiness,
       sdkStatus: migrationData.sdk.status,
@@ -1218,19 +1228,23 @@ export function V4MigrationDetailsContent({
       delayedOtelCount: otelSection.delayedCount,
       customInstrumentationCount: customSection.series.length,
       evalsCount:
-        migrationData.evals.status === "loaded" ? migrationData.evals.count : 0,
+        migrationData.evals.status === "loaded"
+          ? migrationData.evals.count
+          : null,
       apisCount:
-        migrationData.apis.status === "loaded" ? migrationData.apis.count : 0,
+        migrationData.apis.status === "loaded"
+          ? migrationData.apis.count
+          : null,
       integrationsCount:
         migrationData.exports.status === "loaded"
           ? migrationData.exports.count
-          : 0,
+          : null,
       experimentsResult:
         migrationData.experiments.status === "loaded"
           ? migrationData.experiments.result
           : migrationData.experiments.status,
     });
-  }, [readiness, migrationData, capture]);
+  }, [checksSettled, readiness, migrationData, capture]);
 
   // Sections in a good state collapse into one summary sentence instead of
   // rendering their own (green) rows. Loading and error states keep the row.

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -55,7 +55,7 @@ export function V4MigrationDelayBadge() {
 
   const handleClick = () => {
     capture("v4_migration:delay_badge_clicked");
-    openMigrationPanel({ id: project.id, name: project.name });
+    openMigrationPanel({ id: project.id, name: project.name }, "delay_badge");
   };
 
   // The hover's action clause echoes the panel section the click opens;

--- a/web/src/features/v4-migration/V4MigrationNavItem.tsx
+++ b/web/src/features/v4-migration/V4MigrationNavItem.tsx
@@ -47,7 +47,10 @@ export function V4MigrationNavItem() {
     }
     setTimeout(() => {
       // push to next tick to avoid flickering when hiding sidebar on mobile
-      openMigrationPanel({ id: project.id, name: project.name });
+      openMigrationPanel(
+        { id: project.id, name: project.name },
+        "sidebar_card",
+      );
     }, 1);
   };
 

--- a/web/src/features/v4-migration/V4MigrationPanel.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanel.tsx
@@ -59,6 +59,10 @@ export const V4MigrationPanel = ({
 
         <div className="flex flex-col gap-6 px-4 pt-6 pb-16">
           <V4MigrationDetailsContent
+            // Keyed like the header: a project switch while the panel stays
+            // open remounts the content, so per-open analytics (the
+            // panel_checks_loaded fire-once ref) reset for the new project.
+            key={project?.id}
             onNavigate={() => setOpen(false)}
             projectId={project?.id}
           />

--- a/web/src/features/v4-migration/V4MigrationPanelProvider.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanelProvider.clienttest.tsx
@@ -9,9 +9,14 @@ import {
 } from "./V4MigrationPanelProvider";
 
 const flagState = vi.hoisted(() => ({ enabled: false }));
+const captureMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./useV4UpgradeUiEnabled", () => ({
   useV4UpgradeUiEnabled: () => flagState.enabled,
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => captureMock,
 }));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -21,18 +26,23 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 describe("V4MigrationPanelProvider", () => {
   beforeEach(() => {
     flagState.enabled = false;
+    captureMock.mockClear();
   });
 
   it("refuses to open when the user flag is disabled", () => {
     const { result } = renderHook(() => useV4MigrationPanel(), { wrapper });
 
     act(() =>
-      result.current.openForProject({ id: "project-id", name: "Project" }),
+      result.current.openForProject(
+        { id: "project-id", name: "Project" },
+        "delay_badge",
+      ),
     );
     act(() => result.current.setOpen(true));
 
     expect(result.current.open).toBe(false);
     expect(result.current.targetProject).toBeNull();
+    expect(captureMock).not.toHaveBeenCalled();
   });
 
   it("opens for a project when the user flag is enabled", () => {
@@ -40,13 +50,56 @@ describe("V4MigrationPanelProvider", () => {
     const { result } = renderHook(() => useV4MigrationPanel(), { wrapper });
 
     act(() =>
-      result.current.openForProject({ id: "project-id", name: "Project" }),
+      result.current.openForProject(
+        { id: "project-id", name: "Project" },
+        "delay_badge",
+      ),
     );
 
     expect(result.current.open).toBe(true);
     expect(result.current.targetProject).toEqual({
       id: "project-id",
       name: "Project",
+    });
+    expect(captureMock).toHaveBeenCalledExactlyOnceWith(
+      "v4_migration:panel_opened",
+      { source: "delay_badge" },
+    );
+  });
+
+  it("reports one panel_opened per closed-to-open transition", () => {
+    flagState.enabled = true;
+    const { result } = renderHook(() => useV4MigrationPanel(), { wrapper });
+
+    act(() =>
+      result.current.openForProject(
+        { id: "project-id", name: "Project" },
+        "delay_badge",
+      ),
+    );
+    // Redundant open from another surface while already open: no new entry.
+    act(() =>
+      result.current.openForProject(
+        { id: "project-id", name: "Project" },
+        "sidebar_card",
+      ),
+    );
+
+    const openedCalls = captureMock.mock.calls.filter(
+      ([name]) => name === "v4_migration:panel_opened",
+    );
+    expect(openedCalls).toHaveLength(1);
+
+    // Close and reopen: a fresh funnel entry with the new source.
+    act(() => result.current.setOpen(false));
+    act(() =>
+      result.current.openForProject(
+        { id: "project-id", name: "Project" },
+        "status_page_row",
+      ),
+    );
+    expect(captureMock).toHaveBeenCalledWith("v4_migration:panel_opened", {
+      source: "status_page_row",
     });
   });
 });

--- a/web/src/features/v4-migration/V4MigrationPanelProvider.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanelProvider.clienttest.tsx
@@ -77,7 +77,7 @@ describe("V4MigrationPanelProvider", () => {
         "delay_badge",
       ),
     );
-    // Redundant open from another surface while already open: no new entry.
+    // Redundant open of the SAME project from another surface: no new entry.
     act(() =>
       result.current.openForProject(
         { id: "project-id", name: "Project" },
@@ -89,6 +89,19 @@ describe("V4MigrationPanelProvider", () => {
       ([name]) => name === "v4_migration:panel_opened",
     );
     expect(openedCalls).toHaveLength(1);
+
+    // Retargeting the open panel to a DIFFERENT project is a new entry.
+    act(() =>
+      result.current.openForProject(
+        { id: "project-2", name: "Other project" },
+        "status_page_row",
+      ),
+    );
+    expect(
+      captureMock.mock.calls.filter(
+        ([name]) => name === "v4_migration:panel_opened",
+      ),
+    ).toHaveLength(2);
 
     // Close and reopen: a fresh funnel entry with the new source.
     act(() => result.current.setOpen(false));

--- a/web/src/features/v4-migration/V4MigrationPanelProvider.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanelProvider.tsx
@@ -50,14 +50,16 @@ export function V4MigrationPanelProvider({
     setRequestedOpen(v4UpgradeUiEnabled && nextOpen);
   };
   // Every open path goes through here (setOpen callers only ever close), so
-  // this is the single funnel-entry event; the closed→open guard keeps
-  // redundant opens from double-counting.
+  // this is the single funnel-entry event. A redundant open of the same
+  // project does not double-count, but retargeting the open panel to a
+  // different project is a new funnel entry.
   const openForProject = (
     project: V4MigrationTargetProject,
     source: V4MigrationPanelOpenSource,
   ) => {
     if (!v4UpgradeUiEnabled) return;
-    if (!open) capture("v4_migration:panel_opened", { source });
+    if (!open || project.id !== targetProject?.id)
+      capture("v4_migration:panel_opened", { source });
     setTargetProject(project);
     setRequestedOpen(true);
   };

--- a/web/src/features/v4-migration/V4MigrationPanelProvider.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanelProvider.tsx
@@ -4,16 +4,27 @@ import {
   useState,
   type PropsWithChildren,
 } from "react";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 
 export type V4MigrationTargetProject = { id: string; name: string };
+
+/** Which surface opened the panel; the funnel's entry dimension. */
+export type V4MigrationPanelOpenSource =
+  | "delay_badge"
+  | "status_page_row"
+  | "sidebar_card"
+  | "project_chip";
 
 type V4MigrationPanelContextType = {
   open: boolean;
   setOpen: (v: boolean) => void;
   /** Project the panel content is about; set by whichever surface opened it. */
   targetProject: V4MigrationTargetProject | null;
-  openForProject: (project: V4MigrationTargetProject) => void;
+  openForProject: (
+    project: V4MigrationTargetProject,
+    source: V4MigrationPanelOpenSource,
+  ) => void;
 };
 
 const V4MigrationPanelContext =
@@ -29,6 +40,7 @@ export function V4MigrationPanelProvider({
   defaultOpen = false,
 }: V4MigrationPanelProviderProps) {
   const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
+  const capture = usePostHogClientCapture();
   const [requestedOpen, setRequestedOpen] = useState(defaultOpen);
   const [targetProject, setTargetProject] =
     useState<V4MigrationTargetProject | null>(null);
@@ -37,8 +49,15 @@ export function V4MigrationPanelProvider({
   const setOpen = (nextOpen: boolean) => {
     setRequestedOpen(v4UpgradeUiEnabled && nextOpen);
   };
-  const openForProject = (project: V4MigrationTargetProject) => {
+  // Every open path goes through here (setOpen callers only ever close), so
+  // this is the single funnel-entry event; the closed→open guard keeps
+  // redundant opens from double-counting.
+  const openForProject = (
+    project: V4MigrationTargetProject,
+    source: V4MigrationPanelOpenSource,
+  ) => {
     if (!v4UpgradeUiEnabled) return;
+    if (!open) capture("v4_migration:panel_opened", { source });
     setTargetProject(project);
     setRequestedOpen(true);
   };

--- a/web/src/features/v4-migration/V4MigrationProjectChip.tsx
+++ b/web/src/features/v4-migration/V4MigrationProjectChip.tsx
@@ -30,7 +30,7 @@ export function V4MigrationProjectChip({
 
   const handleClick = () => {
     capture("v4_migration:project_chip_clicked");
-    openMigrationPanel(project);
+    openMigrationPanel(project, "project_chip");
   };
 
   return (

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -144,10 +144,10 @@ describe("V4MigrationStatusPage", () => {
     });
     fireEvent.click(projectLink);
 
-    expect(mocks.openForProject).toHaveBeenCalledWith({
-      id: "project-1",
-      name: "Test project",
-    });
+    expect(mocks.openForProject).toHaveBeenCalledWith(
+      { id: "project-1", name: "Test project" },
+      "status_page_row",
+    );
     expect(mocks.capture).toHaveBeenCalledWith(
       "v4_migration:status_row_clicked",
     );
@@ -163,10 +163,10 @@ describe("V4MigrationStatusPage", () => {
 
     fireEvent.click(projectRow!);
 
-    expect(mocks.openForProject).toHaveBeenCalledWith({
-      id: "project-1",
-      name: "Test project",
-    });
+    expect(mocks.openForProject).toHaveBeenCalledWith(
+      { id: "project-1", name: "Test project" },
+      "status_page_row",
+    );
     expect(mocks.routerPush).toHaveBeenCalledWith("/project/project-1/traces");
   });
 

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -172,7 +172,7 @@ function OrgStatusSection({
 
   const openProjectMigration = (row: { id: string; name: string }) => {
     capture("v4_migration:status_row_clicked");
-    openMigrationPanel({ id: row.id, name: row.name });
+    openMigrationPanel({ id: row.id, name: row.name }, "status_page_row");
   };
 
   const handleRowClick = (row: { id: string; name: string }) => {

--- a/web/src/features/v4-migration/hooks/useOpenV4MigrationPanel.ts
+++ b/web/src/features/v4-migration/hooks/useOpenV4MigrationPanel.ts
@@ -2,6 +2,7 @@ import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiA
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import {
   useV4MigrationPanel,
+  type V4MigrationPanelOpenSource,
   type V4MigrationTargetProject,
 } from "@/src/features/v4-migration/V4MigrationPanelProvider";
 
@@ -10,9 +11,12 @@ export function useOpenV4MigrationPanel() {
   const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
   const { setOpen: setAiAgentOpen } = useInAppAiAgent();
 
-  return (project: V4MigrationTargetProject) => {
+  return (
+    project: V4MigrationTargetProject,
+    source: V4MigrationPanelOpenSource,
+  ) => {
     setAiAgentOpen(false);
     setSupportDrawerOpen(false);
-    openForProject(project);
+    openForProject(project, source);
   };
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16021.preview.langfuse.com](https://pr-16021.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Instruments the v4 migration panel so we can see whether and how people move through the migration. Stacked on #15898.

## What changed

| Question | Event | Properties | Where |
|---|---|---|---|
| Are people finding the panel? | `v4_migration:panel_opened` | `source` (`delay_badge` / `status_page_row` / `sidebar_card` / `project_chip`) | Fired once per closed→open transition in `V4MigrationPanelProvider.openForProject` — all four open surfaces route through it |
| How much work were they shown? | `v4_migration:panel_checks_loaded` | `readiness`, per-section counts, `experimentsResult` | Fires once per panel open when all checks settle (`V4MigrationDetailsContent`) |
| Which action items get attention? | `v4_migration:section_expanded` | `section` | All 7 checklist sections |
| Do they inspect evidence? | `v4_migration:evidence_link_clicked` | `section`, `sdkName`, `sdkVersion`, `attributionStatus` | Offender deep links in SDK / OTel / custom-instrumentation rows |
| Which guidance do they follow? | `v4_migration:section_link_clicked` | `section`, `link` | Every docs/table/settings link inside sections, header, and compare row |
| Create→copy key drop-off | `v4_migration:project_keys_copied` | — | The `.env` block corner copy |
| Evals: manual vs assistant | `v4_migration:evals_manual_upgrade_clicked` | `scope` | Dialog manual branch (assistant branch already covered by `in_app_agent:new_chat_started` `entryPoint=v4_migration`) |

Also removes the never-fired `in_app_agent_opened` registry entry.

**Privacy:** all payloads are metadata-only — enums, counts, SDK identifiers. No API keys, no filter values, no user content.

## Verification

`pnpm --filter web run test-client src/features/v4-migration` → **Tests 79 passed (79)** (4 new: panel_opened dedup across sources, checks-loaded fire-once + hold-while-loading, section/evidence/docs-link captures) · `tsc --noEmit` → 0 errors · pre-commit Prettier + turbo lint → passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds PostHog instrumentation across the v4 migration-panel funnel, from panel entry through loaded checks, section engagement, guidance links, key copying, and evaluator upgrade choices.
- Adds typed migration analytics events and source attribution for all panel entry surfaces.
- Captures checklist results and interactions throughout the migration content.
- Extends client tests for event timing, deduplication, and click payloads.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until raw ingestion-controlled SDK values are removed or safely normalized before being sent to PostHog.

The new evidence-click instrumentation crosses the analytics privacy boundary by forwarding arbitrary strings sourced from ingestion headers to a third-party service.

**Files Needing Attention:** web/src/features/v4-migration/V4MigrationContent.tsx
</details>

<details open><summary><h3>Security Review</h3></summary>

The evidence-link event sends raw SDK name and version values to PostHog. Because these values originate from unvalidated ingestion headers, arbitrary caller-provided content can cross the analytics boundary. **How this was verified:** The raw header values were traced through ingestion storage and the migration summary into the changed PostHog capture call without normalization.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant P as Migration panel
  participant C as Migration checks
  participant A as PostHog
  U->>P: Open from entry surface
  P->>A: panel_opened(source)
  P->>C: Load project migration checks
  C-->>P: Settled readiness and counts
  P->>A: panel_checks_loaded(counts)
  U->>P: Expand section / follow guidance
  P->>A: section_expanded / link_clicked
  U->>P: Click SDK evidence
  P->>A: evidence_link_clicked(raw SDK fields)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4-migration/V4MigrationContent.tsx:367-372
**Raw SDK fields cross analytics boundary**

When an ingestion client supplies arbitrary `x-langfuse-sdk-name` or `x-langfuse-sdk-version` values and a user follows the evidence link, this handler forwards those unvalidated strings to PostHog, causing user-controlled content to leave the project despite the metadata-only privacy guarantee. **How this was verified:** The raw header values were traced through ingestion storage and the migration summary into this capture call without normalization.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): instrument the v4 migration pa..."](https://github.com/langfuse/langfuse/commit/c58a43a4ca30a8ec1008db95cb1f92258a8ca69e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52512642)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->