### PR TITLE
build: limit storybook test run time

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -305,6 +305,7 @@ jobs:
     # at run creation, so this job starts immediately (!cancelled() lets the
     # condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
+    timeout-minutes: 10
     env:
       NODE_ENV: test
     steps:


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a ten-minute timeout to the Storybook CI job so unexpectedly long runs are cancelled instead of consuming runner time indefinitely.
- Applies the timeout to the complete Storybook test and static-build job.
- Leaves the job’s steps, conditions, environment, and required CI gating unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete defect established by the workflow-only timeout change.

The added timeout uses valid GitHub Actions job syntax and no repository evidence shows that healthy Storybook runs require more than ten minutes.
</details>

<sub>Reviews (1): Last reviewed commit: ["build: limit storybook test run time"](https://github.com/langfuse/langfuse/commit/ee8ce4b7a514a534182c81dd2ba69520b4e1bd35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52525436)</sub>

<!-- /greptile_comment -->