### PR TITLE
fix(api): validate authorUserId on public comment creation (v3 backport of #15900)

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -61,7 +61,7 @@ types:
         docs: The content of the comment. May include markdown. Currently limited to 5000 characters.
       authorUserId:
         type: optional<string>
-        docs: The id of the user who created the comment.
+        docs: The id of the user who created the comment. Must be a member of the organization that owns the project, otherwise an error will be thrown.
   CreateCommentResponse:
     properties:
       id:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8855,7 +8855,10 @@ components:
         authorUserId:
           type: string
           nullable: true
-          description: The id of the user who created the comment.
+          description: >-
+            The id of the user who created the comment. Must be a member of the
+            organization that owns the project, otherwise an error will be
+            thrown.
       required:
         - projectId
         - objectType

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -1,4 +1,8 @@
-import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
+import { randomUUID } from "crypto";
+import {
+  makeAPICall,
+  makeZodVerifiedAPICall,
+} from "@/src/__tests__/test-utils";
 import {
   GetCommentsV1Response,
   GetCommentV1Response,
@@ -11,6 +15,41 @@ import {
   createTracesCh,
 } from "@langfuse/shared/src/server";
 import { createObservation, createTrace } from "@langfuse/shared/src/server";
+
+const seedProjectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+// POST /api/public/comments only accepts an authorUserId that belongs to a
+// member of the project's organization. CI provisions the seed project through
+// LANGFUSE_INIT_* instead of the Postgres seeder, so seeded ids such as
+// "user-1" do not exist there. Create a member of the project's organization
+// and use its id wherever a valid comment author is needed.
+let orgMemberUserId: string;
+
+beforeAll(async () => {
+  const project = await prisma.project.findUniqueOrThrow({
+    where: { id: seedProjectId },
+    select: { orgId: true },
+  });
+
+  const user = await prisma.user.create({
+    data: {
+      name: "Comments API Author",
+      email: `comments-api-author-${randomUUID()}@langfuse.com`,
+    },
+  });
+  orgMemberUserId = user.id;
+
+  await prisma.organizationMembership.create({
+    data: { orgId: project.orgId, userId: orgMemberUserId, role: "MEMBER" },
+  });
+});
+
+afterAll(async () => {
+  await prisma.organizationMembership.deleteMany({
+    where: { userId: orgMemberUserId },
+  });
+  await prisma.user.delete({ where: { id: orgMemberUserId } });
+});
 
 describe("Create and get comments", () => {
   beforeAll(async () => {
@@ -35,7 +74,7 @@ describe("Create and get comments", () => {
         objectId: "1234",
         objectType: "TRACE",
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        authorUserId: "user-1",
+        authorUserId: orgMemberUserId,
       },
     );
 
@@ -54,7 +93,7 @@ describe("Create and get comments", () => {
       objectId: "1234",
       objectType: "TRACE",
       content: "hello",
-      authorUserId: "user-1",
+      authorUserId: orgMemberUserId,
     });
   });
 
@@ -366,7 +405,7 @@ describe("Public API does NOT process mentions", () => {
         objectId: "no-mention-processing-trace",
         objectType: "TRACE",
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        authorUserId: "user-1",
+        authorUserId: orgMemberUserId,
       },
     );
 
@@ -383,5 +422,142 @@ describe("Public API does NOT process mentions", () => {
     expect(response.body.content).toBe(
       "Hey @[FakeAdmin](user:user-1) and @[InvalidUser](user:invalid-id), check this!",
     );
+  });
+});
+
+describe("POST /api/public/comments authorUserId scoping", () => {
+  const projectId = seedProjectId;
+  const objectId = "author-scoping-trace";
+  let otherOrgId: string;
+  let otherOrgUserId: string;
+
+  beforeAll(async () => {
+    await createTracesCh([
+      createTrace({
+        name: "trace-for-author-scoping",
+        project_id: projectId,
+        id: objectId,
+      }),
+    ]);
+
+    const otherOrg = await prisma.organization.create({
+      data: { name: `Comment Author Scoping Org ${randomUUID()}` },
+    });
+    otherOrgId = otherOrg.id;
+
+    const otherOrgUser = await prisma.user.create({
+      data: {
+        name: "Other Org User",
+        email: `comment-author-scoping-${randomUUID()}@langfuse.com`,
+      },
+    });
+    otherOrgUserId = otherOrgUser.id;
+
+    await prisma.organizationMembership.create({
+      data: { orgId: otherOrgId, userId: otherOrgUserId, role: "MEMBER" },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.comment.deleteMany({ where: { projectId, objectId } });
+    await prisma.organizationMembership.deleteMany({
+      where: { userId: otherOrgUserId },
+    });
+    await prisma.organization.delete({ where: { id: otherOrgId } });
+    await prisma.user.delete({ where: { id: otherOrgUserId } });
+  });
+
+  it("should reject an authorUserId that is not a member of the project's organization", async () => {
+    const response = await makeAPICall<{ message: string; error: string }>(
+      "POST",
+      "/api/public/comments",
+      {
+        content: "spoofed comment",
+        objectId,
+        objectType: "TRACE",
+        projectId,
+        authorUserId: otherOrgUserId,
+      },
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("InvalidRequestError");
+
+    const comments = await prisma.comment.findMany({
+      where: { projectId, authorUserId: otherOrgUserId },
+    });
+    expect(comments).toHaveLength(0);
+  });
+
+  it("should not disclose whether a rejected authorUserId exists", async () => {
+    const crossOrgResponse = await makeAPICall<{ message: string }>(
+      "POST",
+      "/api/public/comments",
+      {
+        content: "spoofed comment",
+        objectId,
+        objectType: "TRACE",
+        projectId,
+        authorUserId: otherOrgUserId,
+      },
+    );
+
+    const unknownUserResponse = await makeAPICall<{ message: string }>(
+      "POST",
+      "/api/public/comments",
+      {
+        content: "spoofed comment",
+        objectId,
+        objectType: "TRACE",
+        projectId,
+        authorUserId: `does-not-exist-${randomUUID()}`,
+      },
+    );
+
+    expect(crossOrgResponse.status).toBe(400);
+    expect(unknownUserResponse.status).toBe(400);
+    expect(crossOrgResponse.body.message).toBe(
+      unknownUserResponse.body.message,
+    );
+  });
+
+  it("should accept an authorUserId of an organization member without project-level ownership", async () => {
+    // orgMemberUserId has an organization membership but no project membership.
+    const commentResponse = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "comment by org member",
+        objectId,
+        objectType: "TRACE",
+        projectId,
+        authorUserId: orgMemberUserId,
+      },
+    );
+
+    const comment = await prisma.comment.findUnique({
+      where: { id: commentResponse.body.id },
+    });
+    expect(comment?.authorUserId).toBe(orgMemberUserId);
+  });
+
+  it("should still create comments without an authorUserId", async () => {
+    const commentResponse = await makeZodVerifiedAPICall(
+      PostCommentsV1Response,
+      "POST",
+      "/api/public/comments",
+      {
+        content: "comment without author",
+        objectId,
+        objectType: "TRACE",
+        projectId,
+      },
+    );
+
+    const comment = await prisma.comment.findUnique({
+      where: { id: commentResponse.body.id },
+    });
+    expect(comment?.authorUserId).toBeNull();
   });
 });

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -8,7 +8,7 @@ import type {
   GetCommentsV1Query,
   PostCommentsV1Body,
 } from "@/src/features/public-api/types/comments";
-import { LangfuseNotFoundError } from "@langfuse/shared";
+import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 
 type CommentAuditScope = {
@@ -71,10 +71,41 @@ export const getCommentRecordOrThrow = async ({
   return comment;
 };
 
+// The public API accepts a client-supplied authorUserId, so we must verify that
+// the author is a member of the authenticated project's organization. Otherwise
+// any project write key could attribute comments to arbitrary users.
+// The message is identical for unknown and out-of-scope users so that the
+// endpoint does not disclose whether a given user id exists.
+const throwIfAuthorNotInOrganization = async ({
+  authorUserId,
+  orgId,
+}: {
+  authorUserId: string;
+  orgId: string;
+}) => {
+  const membership = await prisma.organizationMembership.findFirst({
+    where: { orgId, userId: authorUserId },
+    select: { id: true },
+  });
+
+  if (!membership) {
+    throw new InvalidRequestError(
+      "authorUserId must belong to a member of the organization that owns the authenticated project.",
+    );
+  }
+};
+
 export const createCommentForApi = async ({
   input,
   auditScope,
 }: CreateCommentInput) => {
+  if (input.authorUserId != null) {
+    await throwIfAuthorNotInOrganization({
+      authorUserId: input.authorUserId,
+      orgId: auditScope.orgId,
+    });
+  }
+
   const result = await validateCommentReferenceObject({
     ctx: { prisma, auth: { scope: { projectId: auditScope.projectId } } },
     input: {


### PR DESCRIPTION
Backport of #15900 (main commit `89956fd0a`) to `v3`. Cherry-picked with `-x`; the applied diff is line-for-line identical to main's patch.

> ⚠️ Security fix. Please review before merging; do not auto-merge.

## Problem

`POST /api/public/comments` persisted the client-supplied `authorUserId` without checking it. The route is `createAuthedProjectAPIRoute`, so **any project API key** could attribute a comment to an arbitrary user id — including a user id belonging to a different organization. Nothing tied the claimed author to the authenticated project's org.

The impact is comment attribution forgery plus a cross-tenant user-id oracle: the response echoed the stored `authorUserId`, so a caller could confirm which ids exist.

## Change

- `createCommentForApi` now calls a new `throwIfAuthorNotInOrganization` helper whenever `authorUserId` is non-null, checking for an `organizationMembership` row matching `auditScope.orgId` + the supplied user id.
- Unknown and out-of-scope ids share one `InvalidRequestError` (400) message, so the endpoint does not disclose whether a given user id exists.
- Omitting `authorUserId` still creates an unattributed comment.
- The tRPC path is unchanged — it always uses the session user and never accepted a client-supplied author.

Also in the cherry-pick: the `CreateCommentRequest.authorUserId` docstring in `fern/apis/server/definition/comments.yml` and the regenerated `web/public/generated/api/openapi.yml` that powers the online API reference. Both came across from main verbatim; neither was hand-edited here.

## Why this matters on v3

v3 carries the identical pre-fix `createCommentForApi`, reachable from the same single call site:

- `web/src/pages/api/public/comments/index.ts:15` — `POST` via `createAuthedProjectAPIRoute({ name: "Create Comment" })`, passing `auth.scope` straight through as the audit scope.

The dependency surface the fix needs is already on this branch: `InvalidRequestError` is exported from `packages/shared/src/errors/InvalidRequestError.ts`, and `auditScope` already carries `orgId`, so the membership lookup needed no adaptation. Confirmed by the revert-check below, which reproduces the vulnerability against v3's own code.

## Verification

Run against `v3` locally, Postgres on v3's own migration set (424 migrations on disk, 424 applied — no drift):

- `pnpm --filter web run test comments-api.servertest.ts` → `Tests  16 passed (16)`
- `pnpm run typecheck` → `Tasks:    7 successful, 7 total`
- `pnpm run lint` → `Tasks:    7 successful, 7 total`
- **Revert-check:** restored only the production file (`web/src/features/comments/server/publicCommentService.ts`) to v3's pre-fix state, left the tests in place, re-ran → `Tests  2 failed | 14 passed (16)`:

  ```
  × should reject an authorUserId that is not a member of the project's organization
      AssertionError: expected 200 to be 400 // Object.is equality
  × should not disclose whether a rejected authorUserId exists
      AssertionError: expected 200 to be 400 // Object.is equality
  ```

  The `200` is unpatched v3 accepting a cross-organization `authorUserId` and storing it, so the tests catch v3's actual behaviour rather than restating the new code. Restored afterwards; `git status --porcelain` empty before push.

Note on the local environment: these are HTTP servertests, so they ran against a v3 dev server pinned to the same `langfuse_test` database as vitest. The ClickHouse `default` database also carried main-only `events_*` tables from a sibling worktree; that is inert for this suite, which writes and reads only `traces`/`observations` via the shared helpers — and those paths are exercised by the passing reference-object tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport prevents public comment clients from attributing comments to users outside the authenticated project’s organization while preserving unattributed comments.
- Validates non-null `authorUserId` values against organization membership before persistence.
- Uses an indistinguishable error response for unknown and cross-organization user IDs.
- Adds server tests covering rejection, non-disclosure, valid organization members, and omitted authors.
- Updates Fern and generated OpenAPI documentation with the membership requirement.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the author identity now constrained to the authenticated project’s organization and no actionable regressions identified.

The membership lookup uses the authenticated organization scope, rejects unknown and cross-organization IDs uniformly before persistence, and preserves valid organization-member and unattributed comment creation.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API as Public Comments API
  participant Membership as OrganizationMembership
  participant Comments as Comment Store
  Client->>API: POST /api/public/comments
  alt authorUserId is provided
    API->>Membership: Lookup auditScope.orgId + authorUserId
    alt Membership exists
      Membership-->>API: Member confirmed
      API->>Comments: Create attributed comment
      Comments-->>Client: Comment ID
    else Membership absent
      Membership-->>API: No membership
      API-->>Client: 400 InvalidRequestError
    end
  else authorUserId is omitted
    API->>Comments: Create unattributed comment
    Comments-->>Client: Comment ID
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): validate authorUserId on publi..."](https://github.com/langfuse/langfuse/commit/c42e21a446952fe615f891a26006374a83d336af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52534165)</sub>

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->