### PR TITLE
fix(scim): ignore password attribute in user provisioning (v3 backport of #15997)

### DIFF
--- a/fern/apis/server/definition/scim.yml
+++ b/fern/apis/server/definition/scim.yml
@@ -63,8 +63,17 @@ service:
               docs: Whether the user is active
               type: optional<boolean>
             password:
-              docs: Initial password for the user
+              docs: >-
+                Ignored. Accepted only for compatibility with identity
+                providers that always send a password on user creation (Okta
+                sends a placeholder value even when password sync is disabled).
+                No credential is created for the user; provisioned users
+                authenticate via SSO or set a password themselves through the
+                password reset flow.
               type: optional<string>
+              availability:
+                status: deprecated
+                message: "This attribute is ignored. SCIM provisioning never sets a password; provisioned users authenticate via SSO or the password reset flow."
       response: ScimUser
 
     getUser:

--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -9,7 +9,6 @@ import {
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
-import { verifyPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
 
 // Schema for SCIM User response
 const ScimUserSchema = z.object({
@@ -224,9 +223,17 @@ describe("SCIM API", () => {
         "urn:ietf:params:scim:api:messages:2.0:ListResponse",
       );
       expect(response.body.Resources.length).toBeGreaterThan(0);
+      // RFC 7644 3.4.2: `totalResults` must match what was actually returned.
+      expect(response.body.totalResults).toBe(response.body.Resources.length);
       expect(response.body.Resources[0].id).toContain(
         "urn:ietf:params:scim:schemas:core:2.0:User",
       );
+      // `password` must not be advertised: schema discovery is how a SCIM
+      // client learns the attribute is unsupported.
+      const attributeNames = response.body.Resources[0].attributes.map(
+        (attribute) => (attribute as { name: string }).name,
+      );
+      expect(attributeNames).not.toContain("password");
     });
 
     it("should return 401 when invalid API keys are provided", async () => {
@@ -473,7 +480,7 @@ describe("SCIM API", () => {
         expect(user?.name).toBe("Test User");
       });
 
-      it("should create a new user with password", async () => {
+      it("accepts a password attribute but never sets a credential", async () => {
         const uniqueEmail = `test.user.${randomUUID().substring(0, 8)}@example.com`;
         const password = `password-${randomUUID().substring(0, 8)}`;
         const response = await makeZodVerifiedAPICall(
@@ -517,9 +524,11 @@ describe("SCIM API", () => {
         expect(user).not.toBeNull();
         expect(user?.email).toBe(uniqueEmail);
         expect(user?.name).toBe("Test User With Password");
-        // Verify password was created
-        expect(user?.password).not.toBeNull();
-        expect(await verifyPassword(password, user?.password ?? "")).toBe(true);
+        // The password attribute is ignored, so the account has no usable
+        // credential and cannot be signed into with the supplied value. Okta
+        // sends a placeholder password on every create, so the request must
+        // still succeed rather than 4xx.
+        expect(user?.password).toBeNull();
       });
 
       it("should return 400 when userName is missing", async () => {

--- a/web/src/pages/api/public/scim/Schemas.ts
+++ b/web/src/pages/api/public/scim/Schemas.ts
@@ -52,7 +52,10 @@ export default async function handler(
   // Return the schemas
   return res.status(200).json({
     schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    totalResults: 2,
+    // Only the User schema is advertised; `Resources` has one entry, and RFC
+    // 7644 3.4.2 wants `totalResults` to match what was returned. Sibling
+    // `/ResourceTypes` already gets this right.
+    totalResults: 1,
     Resources: [
       // User Schema
       {
@@ -148,17 +151,6 @@ export default async function handler(
             ],
             mutability: "readWrite",
             returned: "default",
-            uniqueness: "none",
-          },
-          {
-            name: "password",
-            type: "string",
-            multiValued: false,
-            description: "The user's password",
-            required: false,
-            caseExact: false,
-            mutability: "writeOnly",
-            returned: "never",
             uniqueness: "none",
           },
           {

--- a/web/src/pages/api/public/scim/ServiceProviderConfig.ts
+++ b/web/src/pages/api/public/scim/ServiceProviderConfig.ts
@@ -52,7 +52,8 @@ export default async function handler(
   // Return the service provider configuration
   return res.status(200).json({
     schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
-    documentationUri: "https://docs.langfuse.com/scim",
+    documentationUri:
+      "https://langfuse.com/docs/administration/scim-and-org-api",
     patch: {
       supported: false,
     },

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -4,7 +4,6 @@ import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 
 import { type NextApiRequest, type NextApiResponse } from "next";
-import { hashPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
 import { z } from "zod";
 import { type Role } from "@langfuse/shared";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
@@ -173,7 +172,17 @@ export default async function handler(
         }
       }
 
-      const { userName, name, password, displayName, roles } = body;
+      // A `password` in the request body is accepted and ignored. Setting it
+      // created a usable login credential for an email address nobody had
+      // verified, so an org-scoped key could pre-register an account for
+      // someone else's address. Ignoring rather than rejecting is deliberate:
+      // RFC 7644 3.3 lets a service provider ignore POSTed content, the
+      // attribute is `returned: "never"` so no conformant client can observe
+      // the difference, and Okta sends a placeholder password on every create
+      // even when password sync is disabled — rejecting it would break those
+      // syncs. Users authenticate via SSO, or claim the account through the
+      // password-reset flow.
+      const { userName, name, displayName, roles } = body;
 
       if (!userName) {
         logger.warn("[SCIM] userName is required for user creation");
@@ -235,7 +244,6 @@ export default async function handler(
         create: {
           email: normalizedEmail,
           name: name?.formatted || displayName,
-          password: password ? await hashPassword(password) : undefined,
         },
         update: {},
       });


### PR DESCRIPTION
Backport of #15997 (main commit `b27fdec22`) to `v3`. Cherry-picked with `-x`; the applied diff is line-for-line identical to main's patch.

> ⚠️ Security fix (account-takeover risk). Please review before merging; do not auto-merge.

## Problem

SCIM `POST /Users` hashed and stored a `password` supplied in the request body, creating a **usable login credential for an email address whose ownership nobody had verified**. An org-scoped API key with the `admin-api` entitlement could therefore pre-register an account for someone else's address and choose its password — and then sign in as that account once the real owner was expected to arrive.

## Change

The attribute is now **accepted and ignored** rather than rejected:

- `hashPassword` and the `password:` field are dropped from the `prisma.user.upsert` in `web/src/pages/api/public/scim/Users/index.ts`; `password` is no longer destructured from the body.
- `password` is removed from the `/Schemas` User attribute list, which is how a SCIM client discovers the attribute is unsupported.
- The fern definition documents it as ignored and marks it `deprecated`.

Ignoring rather than rejecting is deliberate, and the reasoning is worth keeping in view for a maintenance branch:

- RFC 7644 3.3 permits a service provider to ignore POSTed content, and the attribute is `returned: "never"` (RFC 7643 4.1.1), so no conformant client can observe whether the value was stored.
- Okta sends a placeholder password on every user create even when password sync is disabled, and documents that value as not sensitive. Rejecting it would break those syncs outright and force admins to retune their Okta password policy — a hard failure for existing provisioning setups on an OSS maintenance line.

Provisioned users authenticate via SSO, or claim the account through the password-reset flow, which confirms control of the email address.

Two non-security fixes ride along in the same commit, both already reviewed on main:

- `/Schemas` `totalResults` corrected from `2` to `1` to match the single entry actually returned in `Resources` (RFC 7644 3.4.2).
- A stale `documentationUri` in `/ServiceProviderConfig` that pointed at `docs.langfuse.com/scim`.

## Why this matters on v3

v3 carries the identical pre-fix handler. The endpoint requires an organization-scoped API key (`accessLevel !== "organization"` is rejected) plus the `admin-api` entitlement, so this is a privileged-caller issue rather than an anonymous one — but the whole point of SCIM provisioning is that an IdP admin drives it, and the pre-fix behaviour let that role mint credentials for unverified addresses.

The revert-check below reproduces the credential write against v3's own code, so this is a live vulnerability on this branch, not a theoretical one.

## Known gap inherited from main

Main's commit updated the fern source but did **not** re-export the checked-in `web/public/generated/api/openapi.yml`, so the published API reference still reads `description: Initial password for the user` (`web/public/generated/api/openapi.yml:5098`) on both `main` and this branch. I deliberately did not fix it here — regenerating would break the line-for-line-identical-to-main property that makes this backport reviewable, and the fix belongs on `main` first. Happy to open that as a separate PR against `main`.

## Verification

Run against `v3` locally, Postgres on v3's own migration set (424 migrations on disk, 424 applied — no drift):

- `pnpm --filter web run test scim-api.servertest.ts` → `Tests  52 passed (52)`
- `pnpm run typecheck` → `Tasks:    7 successful, 7 total`
- `pnpm run lint` → `Tasks:    7 successful, 7 total`
- **Revert-check:** restored only the three production files (`scim/Users/index.ts`, `scim/Schemas.ts`, `scim/ServiceProviderConfig.ts`) to v3's pre-fix state, left the tests in place, re-ran → `Tests  2 failed | 50 passed (52)`:

  ```
  × accepts a password attribute but never sets a credential
      AssertionError: expected '$2a$12$jkwwP0vQsu.DzKzaDauH6e1Qhh/vYm…' to be null
  × should return schemas with valid organization API key
      AssertionError: expected 2 to be 1 // Object.is equality
  ```

  The first failure is the vulnerability itself: a real bcrypt cost-12 hash of the SCIM-supplied password sitting in `users.password` on unpatched v3. The second is `/Schemas` still advertising `password`. Both catch v3's actual behaviour rather than restating the new code. Restored afterwards; `git status --porcelain` empty before push.

Note on the local environment: these are HTTP servertests, so they ran against a v3 dev server pinned to the same `langfuse_test` database as vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport prevents SCIM provisioning from creating a login credential from a request-supplied password while preserving compatibility with identity providers that send placeholder passwords.

- Removes password hashing and persistence from SCIM user creation.
- Updates Fern and SCIM schema discovery to describe the unsupported password behavior.
- Corrects the schema result count and service-provider documentation URL.
- Adds server-test coverage confirming password-bearing requests succeed without storing credentials.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no unacknowledged actionable defects identified in the changed code.

The SCIM handler continues accepting password-bearing requests but omits the password from the database write, and the accompanying schema and tests consistently enforce that behavior.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant IdP as Identity Provider
  participant SCIM as POST /SCIM/Users
  participant DB as Postgres
  participant User as Provisioned User
  IdP->>SCIM: Create user (possibly with placeholder password)
  SCIM->>SCIM: Authenticate org API key and validate entitlement
  SCIM->>SCIM: Ignore password attribute
  SCIM->>DB: Upsert user without credential
  SCIM-->>IdP: 201 SCIM User
  User->>User: Authenticate via SSO or password setup flow
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scim): ignore password attribute in ..."](https://github.com/langfuse/langfuse/commit/6b2769857e6c5cf1fdcbf9ff96fa856d6f790f2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52534217)</sub>

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)
- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->