### PR TITLE
chore(deps): bump nanoid to 3.3.17

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ overrides:
   esbuild: 0.28.1
   undici@7: 7.29.0
   zod: 4.3.6
-  nanoid: 3.3.16
+  nanoid: 3.3.17
   katex: ^0.16.21
   tar-fs: ^2.1.2
   rollup@^4.0.0: ^4.22.4
@@ -782,8 +782,8 @@ importers:
         specifier: ^0.552.0
         version: 0.552.0(react@19.2.4)
       nanoid:
-        specifier: 3.3.16
-        version: 3.3.16
+        specifier: 3.3.17
+        version: 3.3.17
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -9554,8 +9554,8 @@ packages:
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12244,7 +12244,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       secure-json-parse: 2.7.0
       zod: 4.3.6
 
@@ -21699,7 +21699,7 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -22333,7 +22333,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,7 @@ overrides:
   esbuild: "0.28.1"
   "undici@7": 7.29.0
   zod: 4.3.6
-  nanoid: 3.3.16
+  nanoid: 3.3.17
   katex: ^0.16.21
   tar-fs: ^2.1.2
   rollup@^4.0.0: ^4.22.4

--- a/web/package.json
+++ b/web/package.json
@@ -134,7 +134,7 @@
     "langfuse": "3.38.4",
     "lodash": "^4.18.1",
     "lucide-react": "^0.552.0",
-    "nanoid": "3.3.16",
+    "nanoid": "3.3.17",
     "next": "16.2.11",
     "next-auth": "^4.24.14",
     "next-query-params": "^5.1.0",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16029.preview.langfuse.com](https://pr-16029.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades `nanoid` from 3.3.16 to 3.3.17.
- Updates the web application's exact dependency version.
- Updates the workspace-wide override.
- Regenerates the lockfile with consistent 3.3.17 resolution and integrity metadata.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The exact dependency declaration, workspace override, and lockfile resolution are internally consistent, and existing callers and runtime targets remain compatible with the upgraded package.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump nanoid to 3.3.17"](https://github.com/langfuse/langfuse/commit/51f7f7c47edb8458aa9808a471deb05b4f9d71d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52553101)</sub>

<!-- /greptile_comment -->