### PR TITLE
fix(admin-webhook): retry after failed delivery and bound the request timeout

### DIFF
--- a/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
+++ b/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
@@ -78,6 +78,7 @@ describe("sendAdminAccessWebhook", () => {
       headers: {
         "Content-Type": "application/json",
       },
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -181,5 +182,135 @@ describe("sendAdminAccessWebhook", () => {
         orgId: "org-1",
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("should retry on the next event after a non-ok response", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    // A failed delivery must not consume the 24h dedupe window.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should retry on the next event after fetch rejects", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should still dedupe a successful delivery within the window", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should abort a hung endpoint instead of awaiting it indefinitely", async () => {
+    vi.useFakeTimers();
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    // Never settles on its own — only the abort signal can end it.
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal;
+          signal?.addEventListener("abort", () =>
+            reject(signal.reason ?? new Error("aborted")),
+          );
+        }),
+    );
+
+    const pending = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("should retry after a hung endpoint times out", async () => {
+    vi.useFakeTimers();
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            const signal = (init as RequestInit | undefined)?.signal;
+            signal?.addEventListener("abort", () =>
+              reject(signal.reason ?? new Error("aborted")),
+            );
+          }),
+      )
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const pending = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await pending;
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/server/adminAccessWebhook.ts
+++ b/web/src/server/adminAccessWebhook.ts
@@ -10,23 +10,42 @@ type AdminAccessWebhookPayload = {
 };
 
 const DEDUPE_WINDOW_MS = 24 * 60 * 60_000;
+// Callers await this helper on user-facing request paths (tRPC procedures,
+// dashboard query streaming, trace export). Without a deadline, an
+// unresponsive webhook endpoint stalls those requests for as long as it takes
+// the connection to die, so cap every delivery attempt.
+const DELIVERY_TIMEOUT_MS = 5_000;
 const lastWebhookByKey = new Map<string, number>();
 
 export const resetAdminAccessWebhookCacheForTests = () => {
   lastWebhookByKey.clear();
 };
 
-const shouldSkipDueToRecentDuplicate = (payload: AdminAccessWebhookPayload) => {
-  const dedupeKey = [payload.email, payload.project, payload.org].join(":");
+const getDedupeKey = (payload: AdminAccessWebhookPayload) =>
+  [payload.email, payload.project, payload.org].join(":");
+
+// Claims the dedupe slot up front so concurrent callers collapse onto a single
+// delivery, and returns false when a recent delivery already covers this key.
+// The claim is provisional: `releaseDeliverySlot` hands it back when delivery
+// fails, so the reservation only becomes a real 24h suppression once the
+// webhook has actually been delivered.
+const claimDeliverySlot = (dedupeKey: string) => {
   const nowMs = Date.now();
   const lastSentMs = lastWebhookByKey.get(dedupeKey);
 
   if (lastSentMs && nowMs - lastSentMs < DEDUPE_WINDOW_MS) {
-    return true;
+    return false;
   }
 
   lastWebhookByKey.set(dedupeKey, nowMs);
-  return false;
+  return true;
+};
+
+// Deleting is enough to restore the previous state: reaching a delivery
+// attempt means there was either no entry for this key, or one that had
+// already aged out of the dedupe window, and both are equivalent to absent.
+const releaseDeliverySlot = (dedupeKey: string) => {
+  lastWebhookByKey.delete(dedupeKey);
 };
 
 export const sendAdminAccessWebhook = async (params: {
@@ -51,7 +70,19 @@ export const sendAdminAccessWebhook = async (params: {
     region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? "self-hosted",
   };
 
-  if (shouldSkipDueToRecentDuplicate(payload)) return;
+  const dedupeKey = getDedupeKey(payload);
+  if (!claimDeliverySlot(dedupeKey)) return;
+
+  // An explicit controller rather than `AbortSignal.timeout`, so the deadline
+  // runs on the ambient `setTimeout` and stays observable to tests.
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort(
+      new Error(
+        `Admin access webhook timed out after ${DELIVERY_TIMEOUT_MS}ms`,
+      ),
+    );
+  }, DELIVERY_TIMEOUT_MS);
 
   try {
     const response = await fetch(env.LANGFUSE_ADMIN_ACCESS_WEBHOOK, {
@@ -60,9 +91,13 @@ export const sendAdminAccessWebhook = async (params: {
       headers: {
         "Content-Type": "application/json",
       },
+      signal: abortController.signal,
     });
 
     if (!response.ok) {
+      // Hand the slot back: a rejected delivery must not suppress the next
+      // attempt for the full dedupe window.
+      releaseDeliverySlot(dedupeKey);
       logger.warn("Failed to send admin access webhook", {
         status: response.status,
         statusText: response.statusText,
@@ -72,11 +107,14 @@ export const sendAdminAccessWebhook = async (params: {
       });
     }
   } catch (error) {
+    releaseDeliverySlot(dedupeKey);
     logger.warn("Error while sending admin access webhook", {
       error,
       email: payload.email,
       project: payload.project,
       org: payload.org,
     });
+  } finally {
+    clearTimeout(timeout);
   }
 };


### PR DESCRIPTION
Fixes langfuse/langfuse#15957

## Problem

`sendAdminAccessWebhook` recorded the 24h dedupe timestamp **before** attempting delivery:

```ts
if (shouldSkipDueToRecentDuplicate(payload)) return; // <- writes the timestamp
await fetch(env.LANGFUSE_ADMIN_ACCESS_WEBHOOK, { ... });
```

So any failed delivery — a 500, a network error — still consumed the dedupe window, and every subsequent admin access event for the same `email:project:org` was suppressed for a full day. The notification was silently lost.

The `fetch` also had no deadline. Callers `await` this helper on user-facing request paths (5 call sites in `server/api/trpc.ts`, `pages/api/dashboard/execute-query-stream.ts`, `features/traces/server/buildTraceExport.ts`), so an unresponsive endpoint stalled those requests for as long as the connection took to die.

## Fix

* **Claim the dedupe slot up front, release it on failure.** Keeping the up-front claim preserves the existing behaviour where concurrent callers collapse onto a single delivery; releasing it on failure means a transient outage no longer suppresses the next attempt. Deleting the key is sufficient to restore the prior state — reaching a delivery attempt implies there was either no entry or one already outside the window, and both are equivalent to absent.
* **Bound each attempt at 5s** with an `AbortController`, so a hung endpoint cannot block a user-facing request.

I used `AbortController` + `setTimeout` rather than `AbortSignal.timeout()` so the deadline runs on the ambient `setTimeout` and stays controllable from fake timers — otherwise the hung-endpoint behaviour the issue asks for isn't testable.

## Tests

5 new cases in `web/src/__tests__/server/async/admin-access-webhook.servertest.ts`:

* retries on the next event after a non-ok response
* retries on the next event after `fetch` rejects
* still dedupes a **successful** delivery within the window (guards against over-correcting)
* aborts a hung endpoint instead of awaiting it indefinitely
* retries after a hung endpoint times out

All 5 were confirmed to fail against the current implementation before the fix — the two hung-endpoint cases fail by hanging until Vitest's 30s timeout, which is the bug. The existing payload assertion gained `signal: expect.any(AbortSignal)`.

## Verification

```
Tests  21 passed (21)
```

(`admin-access-webhook.servertest.ts` + `admin-access-webhook-middleware.servertest.ts`)

`pnpm --filter web run typecheck` exited 0, and `eslint` / `prettier --check` are clean on both changed files.

## Scope

No behaviour change when the webhook is unset or delivery succeeds. No new env vars, no contract changes.

<details><summary>Greptile Summary</summary>

The PR fixes admin-access webhook delivery by releasing provisional dedupe reservations after unsuccessful attempts and bounding outbound requests to five seconds.

* Refactors deduplication into explicit claim and release operations while retaining concurrent-delivery collapse.
* Adds an abortable delivery timeout and clears the timer after completion.
* Adds coverage for HTTP failures, rejected requests, successful deduplication, hung endpoints, and retries after timeouts.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge, with the failure retry and bounded timeout behavior implemented consistently for the supported server runtime.

Failed deliveries now release their provisional dedupe reservation, successful deliveries retain it, and every awaited outbound request is bounded and cleaned up without introducing a concrete blocking failure.

</details>

Reviews (1): Last reviewed commit: ["fix(admin-webhook): retry after failed d..."](<https://github.com/langfuse/langfuse/commit/aa7ba76d0837a261c320ee3a14beb4d8b2c7ca4e>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=52562316>)

**Context used:**

* Knowledge Base — [Web App (`web/`)](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md>)