### PR TITLE
fix(web): unstick v4 migration panel header so it scrolls on small screens

### DIFF
--- a/web/src/features/v4-migration/V4MigrationPanel.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanel.tsx
@@ -52,7 +52,7 @@ export const V4MigrationPanel = ({
         </div>
       </div>
       <div className="flex-1 overflow-y-auto border-t">
-        <div className="bg-background sticky top-0 z-[1] px-4 pt-4">
+        <div className="px-4 pt-4">
           <V4MigrationHeaderContent
             key={project?.id}
             projectName={project?.name}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16035.preview.langfuse.com](https://pr-16035.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The v4 migration side panel (`V4MigrationPanel`) pinned its top section — the "Migrate to v4" heading, the coding-agent prompt CTA, and the generated Public/Secret API key fields — with `sticky top-0 z-[1]` inside the panel's scroll container.

That header grows once the user reveals the prompt and API keys. On smaller/short screens the sticky header can be taller than the viewport, so it stays pinned and covers the content below it, making the rest of the panel ("What happens if I don't update?", the status sections, and the "Contact us" / "Book a call" / "Email an Engineer" block) unreachable — i.e. scrolling appears broken (LFE-14916).

The fix removes the `sticky top-0 z-[1]` positioning from the header wrapper so the whole panel body scrolls naturally as one column. This also matches the modal variant (`V4MigrationModal`), which already scrolls its header and details together. The panel's fixed "Update" title bar (with the close button) lives outside the scroll container and is unchanged.

Fixes LFE-14916

### Verification

Ran locally against the full Docker stack (web built from this branch, confirmed the built client chunk contains the new `px-4 pt-4` class and no longer contains `sticky top-0 z-[1]`). Signed in, enabled the `v4UpgradeUi` feature preview, opened the panel, revealed the prompt + API keys, and zoomed the page to force the panel content to overflow a short viewport. The entire panel scrolls smoothly from the "Migrate to v4" heading down to the "Contact us" / "Book a call" / "Email an Engineer" buttons and back; the header scrolls away with the content instead of staying pinned.

[v4_migration_panel_scroll_fixed.mp4](https://cursor.com/agents/bc-57b0f728-b7c9-4556-94de-7c3eebce0d37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv4_migration_panel_scroll_fixed.mp4)

[v4 migration panel scrolled to the bottom on a small viewport, showing the Contact us / Book a call / Email an Engineer section reachable](https://cursor.com/agents/bc-57b0f728-b7c9-4556-94de-7c3eebce0d37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv4_migration_panel_scrolled_to_bottom.webp)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14916](https://linear.app/clickhouse/issue/LFE-14916/v4-sidebar-scroll-behavior)

<div><a href="https://cursor.com/agents/bc-57b0f728-b7c9-4556-94de-7c3eebce0d37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57b0f728-b7c9-4556-94de-7c3eebce0d37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

