### PR TITLE
feat(trace): raise the observation load cap to 20k, measured (LFE-14994)

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -360,6 +360,13 @@ const EnvSchema = z.object({
   LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES: z.coerce
     .number()
     .default(80e6), // 80MB
+  // How many observations the trace detail view loads (startTime ASC, so the
+  // chronological tail is what a bigger trace loses). Also a crash guard: the
+  // client builds one node per observation before it renders.
+  LANGFUSE_MAX_OBSERVATIONS_PER_TRACE: z.coerce
+    .number()
+    .positive()
+    .default(20_000),
   LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS: z.coerce.number().default(600_000), // 10 minutes
   LANGFUSE_CLICKHOUSE_QUERY_MAX_ATTEMPTS: z.coerce.number().default(3), // Maximum attempts for socket hang up errors
   LANGFUSE_SKIP_S3_LIST_FOR_OBSERVATIONS_PROJECT_IDS: z.string().optional(),

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -365,6 +365,7 @@ const EnvSchema = z.object({
   // client builds one node per observation before it renders.
   LANGFUSE_MAX_OBSERVATIONS_PER_TRACE: z.coerce
     .number()
+    .int()
     .positive()
     .default(20_000),
   LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS: z.coerce.number().default(600_000), // 10 minutes

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -415,7 +415,8 @@ const TRACES_ORDER_BY_COLUMNS = TRACES_FROM_EVENTS_UI_COLUMN_DEFINITIONS.filter(
 }));
 
 // TODO: introduce pagination
-export const MAX_OBSERVATIONS_PER_TRACE = 10_000;
+export const MAX_OBSERVATIONS_PER_TRACE =
+  env.LANGFUSE_MAX_OBSERVATIONS_PER_TRACE;
 
 export const getObservationsForTraceFromEventsTable = async (params: {
   projectId: string;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16039.preview.langfuse.com](https://pr-16039.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The trace detail view loaded at most **10 000** observations per trace — a number nothing derived, and
one a customer's traces exceed. Measured what the load actually costs at 10k / 15k / 20k / 25k against
a production build, found the cost linear and the compute nowhere near a limit, and **raised the
default to 20 000**, now settable per deployment via `LANGFUSE_MAX_OBSERVATIONS_PER_TRACE`.

Two-file change. The measurement is the substance — it's below.

## Why not just bump it

The constant doubles as a crash guard: the client builds one tree node per observation before it can
render anything. Raising it blindly risks trading a truncated tree for an unresponsive tab on exactly
the traces that motivated the change. So: measure first, then pick.

## The numbers

Production build (`next build` + `next start`), Chrome, localhost — so transfer times exclude real
network latency. One 25 000-observation trace, the cap varied per server boot. Server split from
instrumenting the three phases of `getObservationsForTraceFromEventsTable`; client numbers from the
tab itself.

| cap | response (raw / gzip) | server: CH read / model enrich / trace fields | client: parse / dedupe+build | first tree row | long tasks (total / max) | JS heap |
| --- | --- | --- | --- | --- | --- | --- |
| 10 000 *(today)* | 15.6 MB / 0.82 MB | 83 / 41 / 11 ms | 18 / 18 ms | 1.25 s | 559 / 170 ms | 164 MB |
| 15 000 | 23.4 MB / 1.23 MB | 146 / 90 / 20 ms | 26 / 33 ms | 1.88 s | 681 / 181 ms | 152 MB |
| **20 000** *(new default)* | 31.2 MB / 1.63 MB | 147 / 72 / 23 ms | 40 / 44 ms | 2.49 s | 795 / 192 ms | 175 MB |
| 25 000 | 39.0 MB / 2.03 MB | 192 / 77 / 25 ms | 43 / 66 ms | 2.31 s | 895 / 212 ms | 209 MB |

**Firefox at 20 000** (checked separately — its smaller stack has previously exposed crashes Chrome
masked): first tree row 2.55 s, parse 78 ms, tree build 36 ms, no crash, 60 fps once settled. The tree
builder is iterative, so depth is not a factor.

What the numbers say:

- **Nothing is near a cliff.** Every measure is linear in row count. `buildTraceUiData` — the pass the
  ticket suspected — costs **44 ms at 20k**; heap moves from 164 MB to 209 MB against a 4.4 GB budget;
  the worst single long task grows 170 → 212 ms, so the tab jank is a blip, not a freeze. The tree,
  timeline, search list and log view are all virtualized: 33 rows stay mounted at any cap.
- **The response body is the binding cost**, at ~1.55 MB raw per 1 000 rows (1 381 bytes/row here).
  Next.js already logs `API response … exceeds 4MB` for this endpoint **at today's 10k cap** — the row
  cap is the only thing bounding it.
- **The graph is not affected**: it has its own 5 000-node ceiling
  (`MAX_NODES_FOR_GRAPH_UI`), so it is already unavailable for any trace anywhere near the cap.

## Why 20 000 and not 25 000

25 000 measured fine, so the deciding factor is the one thing the fixture can't tell me: **row width**.
These rows are lean — this path selects no I/O and no metadata — and 1 381 bytes/row is a
best case. A real trace with long span names, tags and status messages runs 2-3× wider, so its payload
at a given cap is 2-3× the table above. 20 000 keeps that plausible worst case near where 10 000 sits
today for wide traces, and doubles the headroom for the traces that prompted this.

Deployments that know their traces are lean (or that accept a slower load) can go further via the env
var without a code change — the number the UI reports is read from the server response, so the
truncation notice stays accurate at any value.

<details>
<summary>Method, payload breakdown, and what this implies for pagination</summary>

**Method.** Measurement-only instrumentation (reverted before this diff): `performance.now()` around
the ClickHouse read and the two enrichment passes server-side, and around `dedupeObservationsById` /
`buildTraceUiData` client-side. Client numbers collected from a fresh browser context per run
(long-task observer installed pre-navigation, RAF-gap sampling after settle), one server boot per cap
so the module-scope constant is re-read. Fixture: `trace-tree --observations 25000 --stride-ms 10 --v4`
(the `--stride-ms` flag from #16030 gives unique, strictly increasing start times so the
`startTime ASC` cut lands exactly where you expect).

**What is actually in those bytes** (10 000 rows, 13.8 MB before superjson):

- No dominant field — ~45 small ones. Largest: `projectId` 38 B/row (7%), `traceName` 29 B (5%),
  `traceTags` 28 B (5%), then six timestamps at ~26 B each.
- **~10% is trace-level constants repeated on every row** (`projectId`, `traceName`, `traceTags`,
  `userId`, `sessionId`, `release`). Hoisting those into the response envelope is the cheapest
  available win and needs no new fetching machinery.
- It compresses ~19× (13.8 MB → 0.68 MB gzip, 0.40 MB brotli), so the wire is not the problem — the
  cost is the JSON the server serializes and the object graph the tab holds.

**Implications for real pagination** (explicitly out of scope here):

1. Both sides are linear in *rows*, and the client's per-node cost is small. So the win from
   pagination is not compute, it's payload: page size should be chosen by bytes, not by nodes.
2. Paging by count would cut the tree at an arbitrary point, which is what today's truncation already
   does badly. The useful shape is windowing by *structure* — load the roots plus the subtree around
   the selection, fetch the rest on expand. The by-id fetch added in LFE-14992 (#16030) and reused by
   LFE-14993 (#16033) is the first primitive of exactly that.
3. Before any of that: trim the payload (point 2 above) and consider a leaner wire encoding for
   timestamps. Those two together are worth more than doubling the cap again.

A byte-budget cap (take rows until N bytes) was considered — the ticket allows it. Rejected for now:
the client's cost is per *node* (build, render, memory), so a row cap controls the thing that can
actually break the tab, and it keeps the tree size predictable for a given trace. A byte budget makes
sense as the page-size rule if the payload trimming above doesn't hold the line.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR raises the trace-detail observation cap from 10,000 to a configurable 20,000 default.

- Adds `LANGFUSE_MAX_OBSERVATIONS_PER_TRACE` to shared environment validation.
- Uses the configured value for events-table trace observation queries and truncation behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR needs its new cap configuration restricted to finite integers before merging, otherwise accepted deployment values can break trace-detail requests.

The configured value is validated only as positive but is subsequently bound to a ClickHouse Int32 limit, so positive decimals or Infinity pass startup validation and fail on the changed query path.

**Files Needing Attention:** packages/shared/src/env.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/env.ts:366-369
**Invalid integer query limit**

If a deployment sets `LANGFUSE_MAX_OBSERVATIONS_PER_TRACE` to a positive decimal or `Infinity`, this schema accepts it and the repository binds the resulting value as a ClickHouse `Int32` limit, causing trace-detail requests to fail.

```suggestion
  LANGFUSE_MAX_OBSERVATIONS_PER_TRACE: z.coerce
    .number()
    .int()
    .positive()
    .finite()
    .default(20_000),
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(trace): raise the observation load ..."](https://github.com/langfuse/langfuse/commit/e6e88b3403e6e048717f820d35961d39210550e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52586319)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->