### PR TITLE
refactor(models): define the pricing tier contract once

### DIFF
--- a/packages/shared/src/features/model-pricing/validation.ts
+++ b/packages/shared/src/features/model-pricing/validation.ts
@@ -72,8 +72,11 @@ export type PricingTierCondition = z.infer<typeof PricingTierConditionSchema>;
  * Used when creating new tiers via API or tRPC
  */
 export const PricingTierInputSchema = z.object({
+  // Trimmed before every later check, so a name differing only by whitespace
+  // cannot pass uniqueness and then render as an identical label.
   name: z
     .string()
+    .trim()
     .min(1, "Name cannot be empty")
     .max(100, "Name exceeds maximum length of 100 characters"),
   isDefault: z.boolean().default(false),
@@ -90,6 +93,35 @@ export const PricingTierInputSchema = z.object({
 });
 
 export type PricingTierInput = z.infer<typeof PricingTierInputSchema>;
+
+/**
+ * Indexes of entries whose name repeats an earlier one, with that name. The
+ * first occurrence is not reported — it is the later one that is the duplicate.
+ *
+ * Shared with the model form so a duplicate means the same thing in the UI and
+ * at the API boundary; the form needs the index to anchor a field error, the
+ * API only needs to know that one exists.
+ */
+export function duplicateNameIndexes(
+  entries: { name: string }[],
+): [number, string][] {
+  const seen = new Set<string>();
+  const duplicates: [number, string][] = [];
+  entries.forEach((entry, index) => {
+    if (seen.has(entry.name)) duplicates.push([index, entry.name]);
+    seen.add(entry.name);
+  });
+  return duplicates;
+}
+
+/** Indexes of non-default tiers with no condition, which can never match. */
+export function tiersMissingConditions(
+  tiers: { isDefault?: boolean; conditions: unknown[] }[],
+): number[] {
+  return tiers.flatMap((tier, index) =>
+    !tier.isDefault && tier.conditions.length === 0 ? [index] : [],
+  );
+}
 
 /**
  * Validates an array of pricing tiers
@@ -139,13 +171,12 @@ export function validatePricingTiers(
   }
 
   // Validate non-default tiers have at least 1 condition
-  for (const tier of tiers) {
-    if (!tier.isDefault && tier.conditions.length === 0) {
-      return {
-        valid: false,
-        error: `Non-default pricing tier "${tier.name}" must have at least one condition`,
-      };
-    }
+  const missingConditions = tiersMissingConditions(tiers);
+  if (missingConditions.length > 0) {
+    return {
+      valid: false,
+      error: `Non-default pricing tier "${tiers[missingConditions[0]].name}" must have at least one condition`,
+    };
   }
 
   // Check for unique priorities
@@ -159,9 +190,7 @@ export function validatePricingTiers(
   }
 
   // Check for unique names
-  const names = tiers.map((t) => t.name);
-  const uniqueNames = new Set(names);
-  if (names.length !== uniqueNames.size) {
+  if (duplicateNameIndexes(tiers).length > 0) {
     return { valid: false, error: "Pricing tier names must be unique" };
   }
 

--- a/web/src/__tests__/server/model-pricing-tiers.servertest.ts
+++ b/web/src/__tests__/server/model-pricing-tiers.servertest.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { z } from "zod";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   makeAPICall,
@@ -14,6 +15,7 @@ import {
   validateRegexPattern,
   validatePricingTiers,
   validatePricingMethod,
+  PricingTierInputSchema,
   type PricingTierInput,
 } from "@langfuse/shared";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
@@ -266,6 +268,40 @@ describe("validation methods", () => {
         },
       ];
 
+      const result = validatePricingTiers(tiers);
+      expect(result.valid).toBe(false);
+      expect(getValidationError(result)).toContain("names must be unique");
+    });
+
+    it("should reject names that differ only by whitespace, as the UI does", () => {
+      // The schema is what normalises: parsing trims, so the validator that
+      // runs after it cannot see "Standard " as a distinct name. Without that,
+      // a trailing space saved a second tier rendering an identical label.
+      const tiers = z.array(PricingTierInputSchema).parse([
+        {
+          name: "Standard",
+          isDefault: true,
+          priority: 0,
+          conditions: [],
+          prices: { input: 3.0 },
+        },
+        {
+          name: "Standard ",
+          isDefault: false,
+          priority: 1,
+          conditions: [
+            {
+              usageDetailPattern: "^input",
+              operator: "gt",
+              value: 100,
+              caseSensitive: false,
+            },
+          ],
+          prices: { input: 5.0 },
+        },
+      ]);
+
+      expect(tiers[1].name).toBe("Standard");
       const result = validatePricingTiers(tiers);
       expect(result.valid).toBe(false);
       expect(getValidationError(result)).toContain("names must be unique");

--- a/web/src/features/models/components/PricingSection/PricingSection.tsx
+++ b/web/src/features/models/components/PricingSection/PricingSection.tsx
@@ -60,6 +60,8 @@ export function PricingSection({ form }: PricingSectionProps) {
     });
   };
 
+  // These compare LIVE form values, which the schema has not parsed (and so not
+  // trimmed) yet — unlike the submitted payload, where the schema owns it.
   const prefillUsageTypes = (names: string[]) => {
     const existing = new Set(
       form.getValues("usageTypes").map((row) => row.name.trim()),

--- a/web/src/features/models/fns/toPricingTierInputs.ts
+++ b/web/src/features/models/fns/toPricingTierInputs.ts
@@ -11,7 +11,7 @@ export const toPricingTierInputs = (
   const priorities = derivePriorities(values.pricingTiers);
 
   return values.pricingTiers.map((tier, tierIndex) => ({
-    name: tier.name.trim(),
+    name: tier.name,
     isDefault: tier.isDefault,
     priority: priorities[tierIndex],
     conditions: tier.conditions.map((condition) => ({
@@ -21,7 +21,7 @@ export const toPricingTierInputs = (
     prices: Object.fromEntries(
       values.usageTypes.flatMap((row) => {
         const price = parsePriceInput(tier.prices[row.key]);
-        return price === null ? [] : [[row.name.trim(), price] as const];
+        return price === null ? [] : [[row.name, price] as const];
       }),
     ),
   }));

--- a/web/src/features/models/validation.ts
+++ b/web/src/features/models/validation.ts
@@ -2,8 +2,10 @@ import { z } from "zod";
 
 import { parsePriceInput } from "@/src/features/models/fns/parsePriceInput";
 import {
+  duplicateNameIndexes,
   PricingTierConditionSchema,
   PricingTierInputSchema,
+  tiersMissingConditions,
   validatePricingTiers,
 } from "@langfuse/shared";
 
@@ -40,7 +42,16 @@ export type PricingTier = z.infer<typeof PricingTierSchema>;
  */
 const FormUsageTypeSchema = z.object({
   key: z.string(),
-  name: z.string(),
+  // Trimmed here, so every later check and the submitted payload see one
+  // normalised name. The value in the input is untouched while typing.
+  name: z
+    .string()
+    .trim()
+    .min(1, "Usage type required")
+    .regex(
+      USAGE_TYPE_PATTERN,
+      "Only letters, numbers, hyphens and underscores",
+    ),
 });
 
 export type FormUsageType = z.infer<typeof FormUsageTypeSchema>;
@@ -48,7 +59,7 @@ export type FormUsageType = z.infer<typeof FormUsageTypeSchema>;
 // Form-level tier schema. Prices are keyed by usage type row key and held as
 // strings, so a half-typed "0." or "0.0000025" survives every keystroke.
 export const FormPricingTierSchema = z.object({
-  name: z.string().min(1, "Tier name is required"),
+  name: z.string().trim().min(1, "Tier name is required"),
   isDefault: z.boolean(),
   conditions: z.array(PricingTierConditionSchema),
   prices: z.record(z.string(), z.string()),
@@ -129,60 +140,35 @@ export const FormUpsertModelSchema = z
     usageTypes: z.array(FormUsageTypeSchema).min(1),
     pricingTiers: z.array(FormPricingTierSchema).min(1),
   })
+  // Only cross-field rules live here; anything about a single value is on the
+  // field itself, so there is one definition per rule.
   .superRefine(({ usageTypes, pricingTiers }, ctx) => {
-    const seenUsageTypes = new Set<string>();
-    usageTypes.forEach((row, index) => {
-      const path = ["usageTypes", index, "name"];
-      const name = row.name.trim();
+    duplicateNameIndexes(usageTypes).forEach(([index, name]) =>
+      ctx.addIssue({
+        code: "custom",
+        path: ["usageTypes", index, "name"],
+        message: `Duplicate usage type "${name}"`,
+      }),
+    );
 
-      if (!name) {
-        ctx.addIssue({ code: "custom", path, message: "Usage type required" });
-      } else if (!USAGE_TYPE_PATTERN.test(name)) {
-        ctx.addIssue({
-          code: "custom",
-          path,
-          message: "Only letters, numbers, hyphens and underscores",
-        });
-      } else if (seenUsageTypes.has(name)) {
-        ctx.addIssue({
-          code: "custom",
-          path,
-          message: `Duplicate usage type "${name}"`,
-        });
-      }
-      seenUsageTypes.add(name);
-    });
+    // The API's rule, reused rather than restated — the form's job is only to
+    // point at the offending field.
+    duplicateNameIndexes(pricingTiers).forEach(([index]) =>
+      ctx.addIssue({
+        code: "custom",
+        path: ["pricingTiers", index, "name"],
+        message: "Tier names must be unique",
+      }),
+    );
+    tiersMissingConditions(pricingTiers).forEach((index) =>
+      ctx.addIssue({
+        code: "custom",
+        path: ["pricingTiers", index, "conditions"],
+        message: "Non-default tiers need at least one condition",
+      }),
+    );
 
-    const seenTierNames = new Set<string>();
     pricingTiers.forEach((tier, tierIndex) => {
-      // Compared trimmed, like usage types: whitespace must not sneak a second
-      // tier past this check and render as an identical label.
-      const tierName = tier.name.trim();
-      const tierNamePath = ["pricingTiers", tierIndex, "name"];
-
-      if (!tierName) {
-        ctx.addIssue({
-          code: "custom",
-          path: tierNamePath,
-          message: "Tier name is required",
-        });
-      } else if (seenTierNames.has(tierName)) {
-        ctx.addIssue({
-          code: "custom",
-          path: tierNamePath,
-          message: "Tier names must be unique",
-        });
-      }
-      seenTierNames.add(tierName);
-
-      if (!tier.isDefault && tier.conditions.length === 0) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["pricingTiers", tierIndex, "conditions"],
-          message: "Non-default tiers need at least one condition",
-        });
-      }
-
       usageTypes.forEach((row) => {
         if (parsePriceInput(tier.prices[row.key]) === null) {
           ctx.addIssue({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16040.preview.langfuse.com](https://pr-16040.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

A pricing tier named `"Standard "` — one trailing space — saved next to an existing
`"Standard"` and rendered as an identical label, because three layers each defined
"tier names are unique" and none of them normalised the name. The schema now trims, so
every later check and the submitted payload see one value, and the two rules the form and
the API both need are shared predicates instead of two implementations.

## Why

The whitespace duplicate passed every gate:

- the form's `superRefine` compared raw `tier.name`, while the usage-type check two lines
  above compared `row.name.trim()`;
- `PricingTierInputSchema.name` was `z.string().min(1).max(100)`, no trim;
- `validatePricingTiers` deduped with `new Set(tiers.map((t) => t.name))`, no trim.

It was fixed once by trimming at three call sites. That is the actual problem — the same
rule stated in three places drifts, and "which of these is the contract?" has no answer.

## What

**Normalisation moved onto the field.** `z.string().trim()` on `pricingTiers[].name`,
`usageTypes[].name` and `PricingTierInputSchema.name`. Zod parses fields before
object-level refinements, so the duplicate check, the submitted payload and the API
validator all see the trimmed value without anyone remembering to trim. The three manual
`.trim()` calls on the payload are gone; the two that remain in `PricingSection` are on
*live, unparsed* form values (an `addTier` name collision and the prefill diff), which is
a different job and is commented as such.

**Single-value rules moved onto the field too**, so `superRefine` holds only genuinely
cross-field rules. `usageTypes[].name` carries its own `min(1)` and charset regex, which
removes two branches from the refinement and keeps the same error anchors.

**The two rules both sides need are now shared predicates** in
`packages/shared/src/features/model-pricing/validation.ts`:

- `duplicateNameIndexes(entries)` — indexes of later duplicates, with the name
- `tiersMissingConditions(tiers)` — non-default tiers that can never match

`validatePricingTiers` calls them for its string errors; the form calls them to anchor
field errors. One definition, two presentations — the form's job is only to point at the
offending field.

## Result

The failure is now identical whichever door it arrives at, and the behaviour tests from
the previous PR pass untouched.

<details>
<summary>Scope and verification</summary>

**Deliberately not in this PR:** usage-type *keys*. The form rejects anything outside
`[a-zA-Z0-9_-]`, but `PricingTierInputSchema.prices` accepts any string key — tightening
that is a breaking public-API change and deserves its own decision. Also not here:
splitting the dialog's `create | edit | clone` branches; that regression is already pinned
by a test, so it is worth doing opportunistically rather than as a dedicated pass.

**Verification**

- New server test beside the existing duplicate-names case: parsing
  `["Standard", "Standard "]` through `PricingTierInputSchema` yields `name === "Standard"`
  for the second tier, and `validatePricingTiers` then rejects it — proving the API path
  agrees with the UI. `✓ should reject names that differ only by whitespace, as the UI does`
- The 5 component tests from the price-editor PR pass **unchanged**: `Tests 5 passed (5)`.
  They encode behaviour, not structure, so they were the check that this refactor is
  behaviour-preserving.
- `pnpm run lint` → `Tasks: 7 successful, 7 total`; `web` and `@langfuse/shared` typecheck
  clean.
- The `/models` public-API cases in that file fail identically on unmodified `main` in this
  environment (14 failures either way — they need the API test harness), so they are
  untouched by this change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes pricing-tier normalization and reusable cross-field validation so the form and API apply the same contract.
- Trims tier and usage-type names at their Zod schema boundaries.
- Adds shared helpers for duplicate names and non-default tiers without conditions.
- Reuses those helpers in API and form validation.
- Removes redundant payload-level trimming and adds coverage for whitespace-equivalent tier names.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The form submission path supplies normalized resolver output, the server reparses pricing-tier inputs at its boundary, and the shared predicates preserve the existing duplicate-name and missing-condition behavior.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Input[Form or API input] --> Schema[Zod field schemas]
  Schema -->|trim names| Parsed[Normalized pricing tiers]
  Parsed --> Duplicate[duplicateNameIndexes]
  Parsed --> Conditions[tiersMissingConditions]
  Duplicate --> FormErrors[Form field errors]
  Conditions --> FormErrors
  Duplicate --> APIErrors[API validation errors]
  Conditions --> APIErrors
  Parsed --> Payload[Persisted payload]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(models): define the pricing tie..."](https://github.com/langfuse/langfuse/commit/72cebaf94d51b9d4693f6e67441934e5a59312c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52588144)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->