### PR TITLE
fix(filters): let viewer-role users use Ask AI (LFE-14412)

### DIFF
--- a/web/src/__tests__/server/ai-filter-access.servertest.ts
+++ b/web/src/__tests__/server/ai-filter-access.servertest.ts
@@ -1,0 +1,122 @@
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { prisma, type Role } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import type { Session } from "next-auth";
+
+// Both Ask AI endpoints only generate a filter over data the caller can
+// already read, so they are gated on `project:read` — a VIEWER must get in.
+const NO_ACCESS = "User does not have access to this resource or action";
+
+const __orgIds: string[] = [];
+
+async function prepare(projectRole: Role) {
+  const { project, org } = await createOrgProjectAndApiKey();
+  __orgIds.push(org.id);
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: false,
+      name: "Demo User",
+      admin: false,
+      organizations: [
+        {
+          id: org.id,
+          name: org.name,
+          role: "MEMBER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: false,
+          aiTelemetryEnabled: false,
+          projects: [
+            {
+              id: project.id,
+              role: projectRole,
+              retentionDays: 30,
+              deletedAt: null,
+              hasTraces: false,
+              name: project.name,
+              metadata: {},
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: false,
+        searchBar: true,
+        v4BetaToggleVisible: false,
+        observationEvals: false,
+        experimentsV4Enabled: false,
+      },
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: "cloud:hobby",
+    },
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  return { project, caller: appRouter.createCaller({ ...ctx, prisma }) };
+}
+
+/** Message of a rejection, or "" when the call resolved. */
+const failureMessage = (promise: Promise<unknown>) =>
+  promise.then(
+    () => "",
+    (error: unknown) =>
+      error instanceof Error ? error.message : String(error),
+  );
+
+describe("Ask AI filter generation access", () => {
+  afterAll(async () => {
+    await prisma.organization.deleteMany({ where: { id: { in: __orgIds } } });
+  });
+
+  // The org's `aiFeaturesEnabled` is off, so both calls still fail on the
+  // org-level AI gate (or the self-hosted precondition) right after the RBAC
+  // check — no LLM is reached. Only the RBAC verdict is asserted here.
+  it("lets a VIEWER through the RBAC gate on both endpoints", async () => {
+    const { project, caller } = await prepare("VIEWER");
+
+    expect(
+      await failureMessage(
+        caller.naturalLanguageFilters.createCompletion({
+          projectId: project.id,
+          prompt: "traces from today",
+        }),
+      ),
+    ).not.toContain(NO_ACCESS);
+
+    expect(
+      await failureMessage(
+        caller.searchBar.generateFilter({
+          projectId: project.id,
+          prompt: "traces from today",
+        }),
+      ),
+    ).not.toContain(NO_ACCESS);
+  });
+
+  it("rejects a project role without project:read on both endpoints", async () => {
+    const { project, caller } = await prepare("NONE");
+
+    await expect(
+      caller.naturalLanguageFilters.createCompletion({
+        projectId: project.id,
+        prompt: "traces from today",
+      }),
+    ).rejects.toThrow(NO_ACCESS);
+
+    await expect(
+      caller.searchBar.generateFilter({
+        projectId: project.id,
+        prompt: "traces from today",
+      }),
+    ).rejects.toThrow(NO_ACCESS);
+  });
+});

--- a/web/src/features/natural-language-filters/server/router.ts
+++ b/web/src/features/natural-language-filters/server/router.ts
@@ -23,10 +23,13 @@ export const naturalLanguageFilterRouter = createTRPCRouter({
     .input(CreateNaturalLanguageFilterCompletion)
     .mutation(async ({ input, ctx }) => {
       try {
+        // Generating a filter reads nothing a project member cannot already
+        // read by hand, so membership is the right bar; whether the org uses
+        // AI at all is governed by `aiFeaturesEnabled` below.
         throwIfNoProjectAccess({
           session: ctx.session,
           projectId: input.projectId,
-          scope: "prompts:CUD",
+          scope: "project:read",
         });
 
         if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {

--- a/web/src/features/search-bar/server/router.ts
+++ b/web/src/features/search-bar/server/router.ts
@@ -80,10 +80,13 @@ export const searchBarRouter = createTRPCRouter({
     .input(GenerateFilterInput)
     .mutation(async ({ input, ctx }) => {
       try {
+        // Generating a filter reads nothing a project member cannot already
+        // read by hand, so membership is the right bar; whether the org uses
+        // AI at all is governed by `aiFeaturesEnabled` below.
         throwIfNoProjectAccess({
           session: ctx.session,
           projectId: input.projectId,
-          scope: "prompts:CUD",
+          scope: "project:read",
         });
 
         if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16042.preview.langfuse.com](https://pr-16042.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

**TL;DR** — Ask AI ("generate a filter from a sentence") was gated on `prompts:CUD`, so read-only project members got `User does not have access to this resource or action`. Both AI-filter endpoints now gate on `project:read`, which every project role holds. No UI change, no new data access.

## Why

A customer reported that viewer-role users cannot use Ask AI in tracing. The gate was a copy-paste: generating a filter has nothing to do with creating prompts, and Ask AI is really just a search helper.

It was wrong in **two** live routers, both reachable from the product:

| Endpoint | Surface |
|---|---|
| `naturalLanguageFilters.createCompletion` | the tables' "Ask AI" filter button (traces/observations) |
| `searchBar.generateFilter` | the v4 search bar's Ask AI prompt |

## What

Both gates become `scope: "project:read"`. Everything else in the two procedures is untouched: the self-hosted precondition, the org-level `aiFeaturesEnabled` / `aiTelemetryEnabled` checks, the LLM plumbing.

Why `project:read` is the right bar:

- There is **no traces/observations scope in the RBAC model at all** — reading trace data is gated by project membership, not by a scope. A filter *generator* over that data has no stricter home.
- AI features already have their control surface at the **organization** level (`aiFeaturesEnabled`, checked a few lines below each gate). Role is the wrong axis for "should this org use AI".
- `protectedProjectProcedure` already establishes membership, so `project:read` is the explicit, self-documenting version of "any member of this project".

## Result

A `VIEWER` can use Ask AI on both surfaces. `MEMBER`/`ADMIN`/`OWNER` are unchanged; a role without `project:read` (or a non-member) is still rejected.

<details>
<summary>Does this widen any privilege? No — and why</summary>

- **Input** is the user's own typed sentence (capped at 2048 chars) plus, for the search bar, the current query text and client-side context the caller already has on screen.
- **The prompt carries no request data**: `search-bar/server/buildFilterPrompt.ts` is a column catalog plus the bar's grammar, with an explicit note that it deliberately holds no per-request data.
- **Output** is a filter object applied to a query the viewer could already build by hand with the filter dropdowns. The search-bar path additionally round-trips the model output through the bar grammar, so an unknown column can never reach the client.

So a viewer using Ask AI reads exactly what they could already read, by an easier route. The only marginal cost is LLM tokens — governed at the organization level by `aiFeaturesEnabled`.

**No UI gate was added or removed.** There is no `useHasProjectAccess` on the Ask AI button today; once the server allows viewers, the visible button is correct.

**Tests** — `web/src/__tests__/server/ai-filter-access.servertest.ts`: a `VIEWER` gets past the RBAC gate on both procedures (each assertion was verified red against the old scope, one endpoint at a time), and a project role without `project:read` is still rejected with the exact message the customer saw. The org's `aiFeaturesEnabled` stays off, so the calls stop at the org gate and no LLM is reached.

**Not fixed here, flagged for a follow-up:** `web/src/pages/project/[projectId]/widgets/index.tsx` gates the widgets page's CUD affordances on `prompts:CUD` too — a third instance of the same copy-paste that should probably be `dashboards:CUD`. Different feature, different blast radius; kept out of this PR.

Checks: `pnpm run lint` — `Tasks: 7 successful, 7 total`; `pnpm run typecheck` — `Tasks: 7 successful, 7 total`; `pnpm --filter web run test src/__tests__/server/ai-filter-access.servertest.ts` — `Tests 2 passed (2)`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes both Ask AI filter-generation procedures from the unrelated `prompts:CUD` permission to `project:read`, allowing project viewers to use them while preserving project membership and organization-level AI gates.

- Updates authorization on the natural-language filter and v4 search-bar endpoints.
- Adds server tests covering VIEWER and NONE roles on both procedures.
- Introduces no UI or filter-generation logic changes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking opportunity to make the VIEWER regression test assert the expected downstream failure rather than merely the absence of one error message.

The authorization change uses a valid scope granted to all intended project roles, while protected project membership and organization-level AI controls remain intact; only the test’s permissive negative assertion weakens regression detection.

**Files Needing Attention:** web/src/__tests__/server/ai-filter-access.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/ai-filter-access.servertest.ts:94-102
**Viewer assertion accepts unrelated failures**

This assertion accepts any rejection whose message differs from `NO_ACCESS`, as well as a successful response, so a middleware change that still blocks VIEWER users with another error can leave the regression test green. Assert the specific downstream deployment or organization gate to demonstrate that both calls passed RBAC.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filters): let viewers use Ask AI fil..."](https://github.com/langfuse/langfuse/commit/ed2d8601042783606f2acd6e17b1150607b5cca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52622722)</sub>

<!-- /greptile_comment -->