### PR TITLE
fix: conditionally use default filter depending on v4/v3 settings

### DIFF
--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -362,7 +362,7 @@ export default function RemapEvaluatorPage() {
                   evalCapabilities={evalCapabilities}
                   showPreviewTargetBadge={false}
                   oldConfigId={evalConfigId}
-                  hideRootObservationFilter={sdk.status === "legacy"}
+                  hideRootObservationFilter={!isV4BetaEnabled}
                   renderFooter={({ isLoading, isSaveDisabled }) => (
                     <div className="flex w-full flex-col items-end gap-4">
                       <div className="flex items-center">


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16044.preview.langfuse.com](https://pr-16044.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns root-observation filter visibility with the v4 beta setting used to select the remapping form’s default filter.

- Shows the root-observation filter for users with v4 beta enabled.
- Hides the filter when the legacy v3 default is selected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable changed-code defects identified.

The visibility condition is now aligned with the existing v4/v3 default-filter selection, and the change does not alter persisted filter state by itself.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: conditionally use default filter de..."](https://github.com/langfuse/langfuse/commit/7c787a7ecf2a5f67dee9f3d70444435aecdc1782) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52637826)</sub>

<!-- /greptile_comment -->