### PR TITLE
fix(v4): link keyless observation evidence

### DIFF
--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -368,26 +368,29 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
     },
   );
 
-  it("maps API key filters to the ingestion attribution column", () => {
-    const [filter] = createFilterFromFilterState(
-      [
-        {
-          column: "ingestionApiKey",
-          type: "stringOptions",
-          operator: "any of",
-          value: ["pk-lf-test"],
-        },
-      ],
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    );
+  it.each(["pk-lf-test", ""])(
+    "maps API key value %j to the ingestion attribution column",
+    (apiKey) => {
+      const [filter] = createFilterFromFilterState(
+        [
+          {
+            column: "ingestionApiKey",
+            type: "stringOptions",
+            operator: "any of",
+            value: [apiKey],
+          },
+        ],
+        eventsTableUiColumnDefinitions,
+        eventsTableCols,
+      );
 
-    expect(filter).toBeDefined();
-    if (!filter) throw new Error("expected filter");
-    const applied = filter.apply();
-    expect(applied.query).toContain('e."ingestion_api_key" IN');
-    expect(Object.values(applied.params)).toContainEqual(["pk-lf-test"]);
-  });
+      expect(filter).toBeDefined();
+      if (!filter) throw new Error("expected filter");
+      const applied = filter.apply();
+      expect(applied.query).toContain('e."ingestion_api_key" IN');
+      expect(Object.values(applied.params)).toContainEqual([apiKey]);
+    },
+  );
 
   it.each([
     ["ingestionSdkName", 'e."ingestion_sdk_name" IN', "python"],

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -1259,6 +1259,11 @@ describe("v4TransitionRouter", () => {
     expect(clickhouseQuery?.query).toContain("FROM events_core");
     expect(clickhouseQuery?.query).toContain("UNION ALL");
     expect(clickhouseQuery?.query).toContain("FROM scores FINAL");
+    const [eventsQuery, scoresQuery] = clickhouseQuery?.query.split(
+      "UNION ALL",
+    ) ?? ["", ""];
+    expect(eventsQuery).not.toContain("execution_trace_id IS NULL");
+    expect(scoresQuery).toContain("execution_trace_id IS NULL");
     expect(
       clickhouseQuery?.query.match(/project_id = \{projectId: String\}/g),
     ).toHaveLength(2);
@@ -1751,6 +1756,12 @@ describe("v4TransitionRouter", () => {
     expect(usageQuery?.query).toContain("FROM events_core");
     expect(usageQuery?.query).toContain("UNION ALL");
     expect(usageQuery?.query).toContain("FROM scores FINAL");
+    const [eventsQuery, scoresQuery] = usageQuery?.query.split("UNION ALL") ?? [
+      "",
+      "",
+    ];
+    expect(eventsQuery).not.toContain("execution_trace_id IS NULL");
+    expect(scoresQuery).toContain("execution_trace_id IS NULL");
     expect(usageQuery?.query).not.toContain("system.columns");
     expect(
       usageQuery?.query.match(/project_id IN \{projectIds: Array\(String\)\}/g),

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -473,26 +473,39 @@ describe("V4MigrationDetailsContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not link observations when an offender has no public key", () => {
+  it("links keyless raw OTel observations with an exact empty-key filter", () => {
     mocks.migrationData.sdk = {
-      status: "legacy",
+      status: "otel_header_required",
       sdkUsageSeries: [
         makeSdkUsageSeries({
-          sdkVersion: "2.60.3",
-          v4MigrationStatus: "upgrade_required",
+          sdkName: "openlit",
+          sdkVersion: "1.35.4",
+          canonicalSdkName: null,
+          v4MigrationStatus: "unknown",
+          hasDelayedOtelEvents: true,
           publicKey: "",
         }),
       ],
-      upgradeRequiredCount: 1,
-      delayedOtelIngestionCount: 0,
+      upgradeRequiredCount: 0,
+      delayedOtelIngestionCount: 1,
     };
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
     expect(screen.getByText("No API key")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "View observations" }),
-    ).not.toBeInTheDocument();
+    const evidenceLink = screen.getByRole("link", {
+      name: "View observations",
+    });
+    expect(evidenceLink).toHaveAttribute(
+      "href",
+      `/project/project-1/observations?filter=${encodeURIComponent(
+        "ingestionApiKey;stringOptions;;any of;," +
+          "ingestionSdkName;stringOptions;;any of;openlit," +
+          "ingestionSdkVersion;stringOptions;;any of;1.35.4",
+      )}&dateRange=14d`,
+    );
+    expect(evidenceLink).toHaveAttribute("target", "_blank");
+    expect(evidenceLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("captures panel_checks_loaded once when all checks settle", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -197,8 +197,9 @@ function ExternalLink({
 }
 
 // Evidence deep-link filter for one SDK usage series: always the exact public
-// key, plus the ingestion SDK name/version when the series carries exact
-// values — so two SDK versions on the same key link to distinct result sets.
+// key (including the empty value used by raw OTel ingestion), plus the
+// ingestion SDK name/version when the series carries exact values — so two SDK
+// versions on the same key link to distinct result sets.
 // "unknown" is the attribution fallback bucket, not an exact value, so those
 // dimensions fall back to key-only. The delayed-OTel `source` dimension is
 // deliberately not linked either: it is a prefix match, not an exact one.
@@ -332,7 +333,7 @@ function SdkUsageSeriesRows({
             ? `${usage.publicKey.slice(0, 9)}…${usage.publicKey.slice(-6)}`
             : usage.publicKey || "No API key";
         const evidenceHref =
-          projectId && usage.publicKey && usage.eventsCount > 0
+          projectId && usage.eventsCount > 0
             ? `/project/${projectId}/observations?filter=${encodeURIComponent(
                 buildSdkUsageEvidenceFilter(usage),
               )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`
@@ -360,9 +361,9 @@ function SdkUsageSeriesRows({
               </span>
               {/* Deep link to the exact evidence: the events table filtered by
                   this public key, plus SDK name and version when attributed,
-                  over the detection lookback. Rows without a public key and
-                  scores-only offenders stay unlinked because their target
-                  would be overly broad or empty. */}
+                  over the detection lookback. An empty public key is an exact
+                  filter value for raw OTel ingestion; scores-only offenders
+                  stay unlinked because their target would be empty. */}
               {evidenceHref ? (
                 <>
                   <span aria-hidden="true">·</span>

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -853,6 +853,7 @@ ORDER BY bucket_time ASC, score_name ASC
     AND timestamp >= {fromTimestamp: DateTime64(3)}
     AND timestamp <= {toTimestamp: DateTime64(3)}
     AND NOT startsWith(environment, 'langfuse-')
+    AND execution_trace_id IS NULL
     AND ingestion_sdk_name NOT IN {internalSdkNames: Array(String)}
     AND is_deleted = 0`;
 
@@ -952,6 +953,7 @@ ORDER BY ${bucketTimeSql} ASC, sdk_name ASC, sdk_version ASC, public_key ASC
     AND timestamp >= {fromTimestamp: DateTime64(3)}
     AND timestamp <= {toTimestamp: DateTime64(3)}
     AND NOT startsWith(environment, 'langfuse-')
+    AND execution_trace_id IS NULL
     AND ingestion_sdk_name NOT IN {internalSdkNames: Array(String)}
     AND is_deleted = 0`;
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16049.preview.langfuse.com](https://pr-16049.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- allow migration evidence links for observation series without an ingestion API key
- preserve an exact empty-key filter for raw OpenTelemetry observations
- exclude evaluator-generated score rows with an execution trace ID from SDK usage discovery
- keep scores-only and v3-preview link safeguards unchanged

## Verification

- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx`
- `pnpm --filter web run test src/__tests__/server/event-query-builder.servertest.ts`
- `pnpm --filter web run test src/__tests__/server/unit/v4TransitionRouter.servertest.ts`
- `pnpm --filter web run typecheck`
- `pnpm run lint`
- `git diff --check`

## Packages

- `web`