### PR TITLE
fix(ui-migration): exclude annotation scores from discovery query

### DIFF
--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -854,6 +854,7 @@ ORDER BY bucket_time ASC, score_name ASC
     AND timestamp <= {toTimestamp: DateTime64(3)}
     AND NOT startsWith(environment, 'langfuse-')
     AND execution_trace_id IS NULL
+    AND source != 'ANNOTATION'
     AND ingestion_sdk_name NOT IN {internalSdkNames: Array(String)}
     AND is_deleted = 0`;
 
@@ -954,6 +955,7 @@ ORDER BY ${bucketTimeSql} ASC, sdk_name ASC, sdk_version ASC, public_key ASC
     AND timestamp <= {toTimestamp: DateTime64(3)}
     AND NOT startsWith(environment, 'langfuse-')
     AND execution_trace_id IS NULL
+    AND source != 'ANNOTATION'
     AND ingestion_sdk_name NOT IN {internalSdkNames: Array(String)}
     AND is_deleted = 0`;
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR excludes annotation-originated scores from both v4 SDK usage discovery queries so human annotation activity does not influence migration status.

- Adds the source filter to SDK usage time-series discovery.
- Applies the same filter to per-project SDK usage summaries.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking gap in regression coverage for the new SQL predicates.

The new filter matches the non-nullable canonical score-source schema and is consistently applied to both migration discovery queries; the remaining concern is that existing tests do not protect this fix from regression.

**Files Needing Attention:** web/src/features/v4/server/v4TransitionRouter.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4/server/v4TransitionRouter.ts:857
**Cover annotation discovery filters**

The new annotation-source predicates in both SDK discovery queries lack focused regression assertions, so a later SQL refactor can silently reintroduce annotation scores and incorrect migration guidance. Add tests that verify the predicate in both generated queries.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui-migration): exclude annotation sc..."](https://github.com/langfuse/langfuse/commit/b46b402c3d7999db5ed5880f22d4e71ae04f0bf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52720165)</sub>

<!-- /greptile_comment -->