### PR TITLE
fix(admin-webhook): bound delivery at 5s and reuse the secure webhook fetch

### DIFF
--- a/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
+++ b/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
@@ -78,6 +78,7 @@ describe("sendAdminAccessWebhook", () => {
       headers: {
         "Content-Type": "application/json",
       },
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -181,5 +182,135 @@ describe("sendAdminAccessWebhook", () => {
         orgId: "org-1",
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("should retry on the next event after a non-ok response", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    // A failed delivery must not consume the 24h dedupe window.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should retry on the next event after fetch rejects", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should still dedupe a successful delivery within the window", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should abort a hung endpoint instead of awaiting it indefinitely", async () => {
+    vi.useFakeTimers();
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    // Never settles on its own — only the abort signal can end it.
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal;
+          signal?.addEventListener("abort", () =>
+            reject(signal.reason ?? new Error("aborted")),
+          );
+        }),
+    );
+
+    const pending = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("should retry after a hung endpoint times out", async () => {
+    vi.useFakeTimers();
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            const signal = (init as RequestInit | undefined)?.signal;
+            signal?.addEventListener("abort", () =>
+              reject(signal.reason ?? new Error("aborted")),
+            );
+          }),
+      )
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const pending = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await pending;
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
+++ b/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
@@ -1,16 +1,41 @@
+import { type Mock } from "vitest";
 import { env } from "@/src/env.mjs";
+import {
+  fetchWithSecureRedirects,
+  validateWebhookURL,
+} from "@langfuse/shared/src/server";
 import {
   resetAdminAccessWebhookCacheForTests,
   sendAdminAccessWebhook,
 } from "@/src/server/adminAccessWebhook";
 
+vi.mock("@langfuse/shared/src/server", async () => {
+  const actual = await vi.importActual("@langfuse/shared/src/server");
+
+  return {
+    ...actual,
+    fetchWithSecureRedirects: vi.fn(),
+    validateWebhookURL: vi.fn(),
+  };
+});
+
+const okResult = {
+  response: { ok: true } as Response,
+  redirectChain: [],
+  finalUrl: "https://example.com/hook",
+};
+
 describe("sendAdminAccessWebhook", () => {
   const originalWebhook = env.LANGFUSE_ADMIN_ACCESS_WEBHOOK;
   const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+  const fetchMock = fetchWithSecureRedirects as Mock;
+  const validateMock = validateWebhookURL as Mock;
 
   beforeEach(() => {
     resetAdminAccessWebhookCacheForTests();
-    vi.restoreAllMocks();
+    fetchMock.mockReset();
+    validateMock.mockReset();
+    validateMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -21,9 +46,7 @@ describe("sendAdminAccessWebhook", () => {
 
   it("should not send when webhook is not configured", async () => {
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = undefined;
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true } as Response);
+    fetchMock.mockResolvedValue(okResult);
 
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",
@@ -31,14 +54,12 @@ describe("sendAdminAccessWebhook", () => {
       orgId: "org-1",
     });
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("should not send when email is missing", async () => {
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true } as Response);
+    fetchMock.mockResolvedValue(okResult);
 
     await sendAdminAccessWebhook({
       email: null,
@@ -46,7 +67,7 @@ describe("sendAdminAccessWebhook", () => {
       orgId: "org-1",
     });
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("should send expected payload including project, org and region", async () => {
@@ -55,9 +76,7 @@ describe("sendAdminAccessWebhook", () => {
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "HIPAA";
 
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true } as Response);
+    fetchMock.mockResolvedValue(okResult);
 
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",
@@ -65,21 +84,37 @@ describe("sendAdminAccessWebhook", () => {
       orgId: "org-1",
     });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy).toHaveBeenCalledWith("https://example.com/hook", {
-      method: "POST",
-      body: JSON.stringify({
-        email: "admin@langfuse.com",
-        timestamp: "2026-02-19T19:39:37.000Z",
-        project: "project-1",
-        org: "org-1",
-        region: "HIPAA",
-      }),
-      headers: {
-        "Content-Type": "application/json",
+    expect(validateMock).toHaveBeenCalledWith(
+      "https://example.com/hook",
+      expect.any(Object),
+      { allowedPorts: "any" },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/hook",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          email: "admin@langfuse.com",
+          timestamp: "2026-02-19T19:39:37.000Z",
+          project: "project-1",
+          org: "org-1",
+          region: "HIPAA",
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        signal: expect.any(AbortSignal),
       },
-      signal: expect.any(AbortSignal),
-    });
+      {
+        maxRedirects: 10,
+        redirectValidation: {
+          validateUrl: expect.any(Function),
+          whitelist: expect.any(Object),
+          logContext: "Admin access webhook",
+        },
+      },
+    );
   });
 
   it("should dedupe repeated sends within 24 hours for same email/project/org", async () => {
@@ -87,9 +122,7 @@ describe("sendAdminAccessWebhook", () => {
     vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true } as Response);
+    fetchMock.mockResolvedValue(okResult);
 
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",
@@ -102,7 +135,7 @@ describe("sendAdminAccessWebhook", () => {
       orgId: "org-1",
     });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("should send again after dedupe window has passed", async () => {
@@ -110,9 +143,7 @@ describe("sendAdminAccessWebhook", () => {
     vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true } as Response);
+    fetchMock.mockResolvedValue(okResult);
 
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",
@@ -128,15 +159,13 @@ describe("sendAdminAccessWebhook", () => {
       orgId: "org-1",
     });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("should not dedupe when email/project/org differ", async () => {
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true } as Response);
+    fetchMock.mockResolvedValue(okResult);
 
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",
@@ -149,13 +178,42 @@ describe("sendAdminAccessWebhook", () => {
       orgId: "org-1",
     });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("should not throw when fetch rejects", async () => {
+  it("should collapse concurrent callers onto a single delivery", async () => {
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network error"));
+    let resolveDelivery: (result: typeof okResult) => void = () => {};
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<typeof okResult>((resolve) => {
+          resolveDelivery = resolve;
+        }),
+    );
+
+    const first = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    const second = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    await second;
+    resolveDelivery(okResult);
+    await first;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not throw when the request rejects", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    fetchMock.mockRejectedValue(new Error("network error"));
 
     await expect(
       sendAdminAccessWebhook({
@@ -166,102 +224,42 @@ describe("sendAdminAccessWebhook", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("should not throw when fetch returns non-ok response", async () => {
+  it("should not throw when the endpoint returns a non-ok response", async () => {
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-    } as Response);
-
-    await expect(
-      sendAdminAccessWebhook({
-        email: "admin@langfuse.com",
-        projectId: "project-1",
-        orgId: "org-1",
-      }),
-    ).resolves.toBeUndefined();
-  });
-
-  it("should retry on a later event after a non-ok response", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
-    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
-
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce({
+    fetchMock.mockResolvedValue({
+      ...okResult,
+      response: {
         ok: false,
         status: 500,
         statusText: "Internal Server Error",
-      } as Response)
-      .mockResolvedValueOnce({ ok: true } as Response);
-
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
+      } as Response,
     });
 
-    vi.setSystemTime(new Date("2026-02-19T19:40:38.000Z"));
-
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-
-    // A failed delivery must not consume the 24h dedupe window.
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    await expect(
+      sendAdminAccessWebhook({
+        email: "admin@langfuse.com",
+        projectId: "project-1",
+        orgId: "org-1",
+      }),
+    ).resolves.toBeUndefined();
   });
 
-  it("should retry on a later event after fetch rejects", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
-    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+  it("should not send and not throw when URL validation rejects", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://10.0.0.1/hook";
 
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockRejectedValueOnce(new Error("network error"))
-      .mockResolvedValueOnce({ ok: true } as Response);
+    validateMock.mockRejectedValue(new Error("Blocked IP address detected"));
+    fetchMock.mockResolvedValue(okResult);
 
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
+    await expect(
+      sendAdminAccessWebhook({
+        email: "admin@langfuse.com",
+        projectId: "project-1",
+        orgId: "org-1",
+      }),
+    ).resolves.toBeUndefined();
 
-    vi.setSystemTime(new Date("2026-02-19T19:40:38.000Z"));
-
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-  });
-
-  it("should still dedupe a successful delivery within the window", async () => {
-    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
-
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue({ ok: true } as Response);
-
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("should abort a hung endpoint instead of awaiting it indefinitely", async () => {
@@ -269,7 +267,7 @@ describe("sendAdminAccessWebhook", () => {
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
     // Never settles on its own — only the abort signal can end it.
-    vi.spyOn(globalThis, "fetch").mockImplementation(
+    fetchMock.mockImplementation(
       (_url, init) =>
         new Promise((_resolve, reject) => {
           const signal = (init as RequestInit | undefined)?.signal;
@@ -288,105 +286,5 @@ describe("sendAdminAccessWebhook", () => {
     await vi.advanceTimersByTimeAsync(5_000);
 
     await expect(pending).resolves.toBeUndefined();
-  });
-
-  it("should not retry again until the failure cooldown has elapsed", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
-    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
-
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockRejectedValue(new Error("network error"));
-
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-
-    // An unreachable endpoint must not put a delivery attempt — and its
-    // timeout — on every admin request that follows.
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-
-    vi.setSystemTime(new Date("2026-02-19T19:40:38.000Z"));
-
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-  });
-
-  it("should collapse concurrent callers onto a single delivery", async () => {
-    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
-
-    let resolveDelivery: (response: Response) => void = () => {};
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
-      () =>
-        new Promise<Response>((resolve) => {
-          resolveDelivery = resolve;
-        }),
-    );
-
-    const first = sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-    const second = sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-
-    await second;
-    resolveDelivery({ ok: true } as Response);
-    await first;
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("should retry after a hung endpoint times out", async () => {
-    vi.useFakeTimers();
-    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
-
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockImplementationOnce(
-        (_url, init) =>
-          new Promise((_resolve, reject) => {
-            const signal = (init as RequestInit | undefined)?.signal;
-            signal?.addEventListener("abort", () =>
-              reject(signal.reason ?? new Error("aborted")),
-            );
-          }),
-      )
-      .mockResolvedValueOnce({ ok: true } as Response);
-
-    const pending = sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-    await vi.advanceTimersByTimeAsync(5_000);
-    await pending;
-
-    await vi.advanceTimersByTimeAsync(60_001);
-
-    await sendAdminAccessWebhook({
-      email: "admin@langfuse.com",
-      projectId: "project-1",
-      orgId: "org-1",
-    });
-
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
+++ b/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
@@ -184,7 +184,9 @@ describe("sendAdminAccessWebhook", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("should retry on the next event after a non-ok response", async () => {
+  it("should retry on a later event after a non-ok response", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
     const fetchSpy = vi
@@ -201,6 +203,9 @@ describe("sendAdminAccessWebhook", () => {
       projectId: "project-1",
       orgId: "org-1",
     });
+
+    vi.setSystemTime(new Date("2026-02-19T19:40:38.000Z"));
+
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",
       projectId: "project-1",
@@ -211,7 +216,9 @@ describe("sendAdminAccessWebhook", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("should retry on the next event after fetch rejects", async () => {
+  it("should retry on a later event after fetch rejects", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
 
     const fetchSpy = vi
@@ -224,6 +231,9 @@ describe("sendAdminAccessWebhook", () => {
       projectId: "project-1",
       orgId: "org-1",
     });
+
+    vi.setSystemTime(new Date("2026-02-19T19:40:38.000Z"));
+
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",
       projectId: "project-1",
@@ -280,6 +290,70 @@ describe("sendAdminAccessWebhook", () => {
     await expect(pending).resolves.toBeUndefined();
   });
 
+  it("should not retry again until the failure cooldown has elapsed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("network error"));
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    // An unreachable endpoint must not put a delivery attempt — and its
+    // timeout — on every admin request that follows.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-02-19T19:40:38.000Z"));
+
+    await sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should collapse concurrent callers onto a single delivery", async () => {
+    (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
+
+    let resolveDelivery: (response: Response) => void = () => {};
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveDelivery = resolve;
+        }),
+    );
+
+    const first = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+    const second = sendAdminAccessWebhook({
+      email: "admin@langfuse.com",
+      projectId: "project-1",
+      orgId: "org-1",
+    });
+
+    await second;
+    resolveDelivery({ ok: true } as Response);
+    await first;
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("should retry after a hung endpoint times out", async () => {
     vi.useFakeTimers();
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
@@ -304,6 +378,8 @@ describe("sendAdminAccessWebhook", () => {
     });
     await vi.advanceTimersByTimeAsync(5_000);
     await pending;
+
+    await vi.advanceTimersByTimeAsync(60_001);
 
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",

--- a/web/src/server/adminAccessWebhook.ts
+++ b/web/src/server/adminAccessWebhook.ts
@@ -10,42 +10,46 @@ type AdminAccessWebhookPayload = {
 };
 
 const DEDUPE_WINDOW_MS = 24 * 60 * 60_000;
+// A failed delivery hands its slot back early so the notification is not lost
+// for a full day, but not immediately: an admin session emits one event per
+// tRPC procedure call, and every one of them awaits this helper. Retrying each
+// of them against a dead endpoint would charge DELIVERY_TIMEOUT_MS to every
+// admin request, so failures stay suppressed for a short cooldown instead.
+const FAILED_DELIVERY_COOLDOWN_MS = 60_000;
 // Callers await this helper on user-facing request paths (tRPC procedures,
 // dashboard query streaming, trace export). Without a deadline, an
 // unresponsive webhook endpoint stalls those requests for as long as it takes
-// the connection to die, so cap every delivery attempt.
+// the connection to die, so cap every delivery attempt. Matches the deadline
+// the web callout sender applies to its own outbound requests.
 const DELIVERY_TIMEOUT_MS = 5_000;
-const lastWebhookByKey = new Map<string, number>();
+const suppressedUntilByKey = new Map<string, number>();
 
 export const resetAdminAccessWebhookCacheForTests = () => {
-  lastWebhookByKey.clear();
+  suppressedUntilByKey.clear();
 };
 
 const getDedupeKey = (payload: AdminAccessWebhookPayload) =>
   [payload.email, payload.project, payload.org].join(":");
 
-// Claims the dedupe slot up front so concurrent callers collapse onto a single
-// delivery, and returns false when a recent delivery already covers this key.
-// The claim is provisional: `releaseDeliverySlot` hands it back when delivery
-// fails, so the reservation only becomes a real 24h suppression once the
-// webhook has actually been delivered.
+// Claims the delivery slot up front so concurrent callers collapse onto a
+// single delivery, and returns false while a recent delivery — or a recent
+// failed attempt — still suppresses this key. The claim is provisional:
+// `suppressAfterFailedDelivery` shortens it when delivery fails, so the full
+// 24h suppression only survives a webhook that was actually delivered.
 const claimDeliverySlot = (dedupeKey: string) => {
   const nowMs = Date.now();
-  const lastSentMs = lastWebhookByKey.get(dedupeKey);
+  const suppressedUntilMs = suppressedUntilByKey.get(dedupeKey);
 
-  if (lastSentMs && nowMs - lastSentMs < DEDUPE_WINDOW_MS) {
+  if (suppressedUntilMs !== undefined && nowMs < suppressedUntilMs) {
     return false;
   }
 
-  lastWebhookByKey.set(dedupeKey, nowMs);
+  suppressedUntilByKey.set(dedupeKey, nowMs + DEDUPE_WINDOW_MS);
   return true;
 };
 
-// Deleting is enough to restore the previous state: reaching a delivery
-// attempt means there was either no entry for this key, or one that had
-// already aged out of the dedupe window, and both are equivalent to absent.
-const releaseDeliverySlot = (dedupeKey: string) => {
-  lastWebhookByKey.delete(dedupeKey);
+const suppressAfterFailedDelivery = (dedupeKey: string) => {
+  suppressedUntilByKey.set(dedupeKey, Date.now() + FAILED_DELIVERY_COOLDOWN_MS);
 };
 
 export const sendAdminAccessWebhook = async (params: {
@@ -95,9 +99,9 @@ export const sendAdminAccessWebhook = async (params: {
     });
 
     if (!response.ok) {
-      // Hand the slot back: a rejected delivery must not suppress the next
-      // attempt for the full dedupe window.
-      releaseDeliverySlot(dedupeKey);
+      // A rejected delivery must not suppress the next attempt for the full
+      // dedupe window.
+      suppressAfterFailedDelivery(dedupeKey);
       logger.warn("Failed to send admin access webhook", {
         status: response.status,
         statusText: response.statusText,
@@ -107,7 +111,7 @@ export const sendAdminAccessWebhook = async (params: {
       });
     }
   } catch (error) {
-    releaseDeliverySlot(dedupeKey);
+    suppressAfterFailedDelivery(dedupeKey);
     logger.warn("Error while sending admin access webhook", {
       error,
       email: payload.email,

--- a/web/src/server/adminAccessWebhook.ts
+++ b/web/src/server/adminAccessWebhook.ts
@@ -1,5 +1,12 @@
 import { env } from "@/src/env.mjs";
-import { logger } from "@langfuse/shared/src/server";
+import {
+  fetchWithSecureRedirects,
+  logger,
+  type RedirectUrlValidator,
+  validateWebhookURL,
+  type WebhookValidationWhitelist,
+  whitelistFromEnv,
+} from "@langfuse/shared/src/server";
 
 type AdminAccessWebhookPayload = {
   email: string;
@@ -10,47 +17,66 @@ type AdminAccessWebhookPayload = {
 };
 
 const DEDUPE_WINDOW_MS = 24 * 60 * 60_000;
-// A failed delivery hands its slot back early so the notification is not lost
-// for a full day, but not immediately: an admin session emits one event per
-// tRPC procedure call, and every one of them awaits this helper. Retrying each
-// of them against a dead endpoint would charge DELIVERY_TIMEOUT_MS to every
-// admin request, so failures stay suppressed for a short cooldown instead.
-const FAILED_DELIVERY_COOLDOWN_MS = 60_000;
 // Callers await this helper on user-facing request paths (tRPC procedures,
 // dashboard query streaming, trace export). Without a deadline, an
 // unresponsive webhook endpoint stalls those requests for as long as it takes
 // the connection to die, so cap every delivery attempt. Matches the deadline
 // the web callout sender applies to its own outbound requests.
 const DELIVERY_TIMEOUT_MS = 5_000;
-const suppressedUntilByKey = new Map<string, number>();
+const MAX_REDIRECTS = 10;
+const URL_VALIDATION_LOG_CONTEXT = "Admin access webhook";
+const lastWebhookByKey = new Map<string, number>();
 
 export const resetAdminAccessWebhookCacheForTests = () => {
-  suppressedUntilByKey.clear();
+  lastWebhookByKey.clear();
 };
 
-const getDedupeKey = (payload: AdminAccessWebhookPayload) =>
-  [payload.email, payload.project, payload.org].join(":");
-
-// Claims the delivery slot up front so concurrent callers collapse onto a
-// single delivery, and returns false while a recent delivery — or a recent
-// failed attempt — still suppresses this key. The claim is provisional:
-// `suppressAfterFailedDelivery` shortens it when delivery fails, so the full
-// 24h suppression only survives a webhook that was actually delivered.
-const claimDeliverySlot = (dedupeKey: string) => {
+const shouldSkipDueToRecentDuplicate = (payload: AdminAccessWebhookPayload) => {
+  const dedupeKey = [payload.email, payload.project, payload.org].join(":");
   const nowMs = Date.now();
-  const suppressedUntilMs = suppressedUntilByKey.get(dedupeKey);
+  const lastSentMs = lastWebhookByKey.get(dedupeKey);
 
-  if (suppressedUntilMs !== undefined && nowMs < suppressedUntilMs) {
-    return false;
+  if (lastSentMs && nowMs - lastSentMs < DEDUPE_WINDOW_MS) {
+    return true;
   }
 
-  suppressedUntilByKey.set(dedupeKey, nowMs + DEDUPE_WINDOW_MS);
-  return true;
+  lastWebhookByKey.set(dedupeKey, nowMs);
+  return false;
 };
 
-const suppressAfterFailedDelivery = (dedupeKey: string) => {
-  suppressedUntilByKey.set(dedupeKey, Date.now() + FAILED_DELIVERY_COOLDOWN_MS);
+// The endpoint is operator-configured (env var), not tenant-supplied, so
+// internal targets are legitimate here: self-hosted deployments whitelist them
+// via LANGFUSE_WEBHOOK_WHITELISTED_*, and local development gets localhost for
+// free, mirroring the web callout sender.
+const LOCAL_DEVELOPMENT_WHITELIST: WebhookValidationWhitelist = {
+  hosts: ["localhost", "127.0.0.1", "[::1]"],
+  ips: ["127.0.0.1", "::1"],
+  ip_ranges: ["127.0.0.0/8", "::1/128"],
 };
+
+const adminAccessWebhookWhitelist = (): WebhookValidationWhitelist => {
+  const whitelist = whitelistFromEnv();
+
+  if (env.NODE_ENV !== "development") {
+    return whitelist;
+  }
+
+  return {
+    hosts: [...whitelist.hosts, ...LOCAL_DEVELOPMENT_WHITELIST.hosts],
+    ips: [...whitelist.ips, ...LOCAL_DEVELOPMENT_WHITELIST.ips],
+    ip_ranges: [
+      ...whitelist.ip_ranges,
+      ...LOCAL_DEVELOPMENT_WHITELIST.ip_ranges,
+    ],
+  };
+};
+
+// Operator-configured receivers commonly listen on custom ports, so unlike
+// tenant-facing webhooks the port is unrestricted.
+const validateAdminAccessWebhookUrl: RedirectUrlValidator = (
+  url,
+  whitelist = adminAccessWebhookWhitelist(),
+) => validateWebhookURL(url, whitelist, { allowedPorts: "any" });
 
 export const sendAdminAccessWebhook = async (params: {
   email: string | null | undefined;
@@ -74,8 +100,7 @@ export const sendAdminAccessWebhook = async (params: {
     region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? "self-hosted",
   };
 
-  const dedupeKey = getDedupeKey(payload);
-  if (!claimDeliverySlot(dedupeKey)) return;
+  if (shouldSkipDueToRecentDuplicate(payload)) return;
 
   // An explicit controller rather than `AbortSignal.timeout`, so the deadline
   // runs on the ambient `setTimeout` and stays observable to tests.
@@ -89,19 +114,36 @@ export const sendAdminAccessWebhook = async (params: {
   }, DELIVERY_TIMEOUT_MS);
 
   try {
-    const response = await fetch(env.LANGFUSE_ADMIN_ACCESS_WEBHOOK, {
-      method: "POST",
-      body: JSON.stringify(payload),
-      headers: {
-        "Content-Type": "application/json",
+    const whitelist = adminAccessWebhookWhitelist();
+    await validateAdminAccessWebhookUrl(
+      env.LANGFUSE_ADMIN_ACCESS_WEBHOOK,
+      whitelist,
+    );
+
+    const { response } = await fetchWithSecureRedirects(
+      env.LANGFUSE_ADMIN_ACCESS_WEBHOOK,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        signal: abortController.signal,
       },
-      signal: abortController.signal,
-    });
+      {
+        maxRedirects: MAX_REDIRECTS,
+        redirectValidation: {
+          validateUrl: validateAdminAccessWebhookUrl,
+          whitelist,
+          logContext: URL_VALIDATION_LOG_CONTEXT,
+        },
+      },
+    );
+
+    // Release the pooled connection; the receiver's body is never used.
+    await response.body?.cancel().catch(() => {});
 
     if (!response.ok) {
-      // A rejected delivery must not suppress the next attempt for the full
-      // dedupe window.
-      suppressAfterFailedDelivery(dedupeKey);
       logger.warn("Failed to send admin access webhook", {
         status: response.status,
         statusText: response.statusText,
@@ -111,7 +153,6 @@ export const sendAdminAccessWebhook = async (params: {
       });
     }
   } catch (error) {
-    suppressAfterFailedDelivery(dedupeKey);
     logger.warn("Error while sending admin access webhook", {
       error,
       email: payload.email,

--- a/web/src/server/adminAccessWebhook.ts
+++ b/web/src/server/adminAccessWebhook.ts
@@ -10,23 +10,42 @@ type AdminAccessWebhookPayload = {
 };
 
 const DEDUPE_WINDOW_MS = 24 * 60 * 60_000;
+// Callers await this helper on user-facing request paths (tRPC procedures,
+// dashboard query streaming, trace export). Without a deadline, an
+// unresponsive webhook endpoint stalls those requests for as long as it takes
+// the connection to die, so cap every delivery attempt.
+const DELIVERY_TIMEOUT_MS = 5_000;
 const lastWebhookByKey = new Map<string, number>();
 
 export const resetAdminAccessWebhookCacheForTests = () => {
   lastWebhookByKey.clear();
 };
 
-const shouldSkipDueToRecentDuplicate = (payload: AdminAccessWebhookPayload) => {
-  const dedupeKey = [payload.email, payload.project, payload.org].join(":");
+const getDedupeKey = (payload: AdminAccessWebhookPayload) =>
+  [payload.email, payload.project, payload.org].join(":");
+
+// Claims the dedupe slot up front so concurrent callers collapse onto a single
+// delivery, and returns false when a recent delivery already covers this key.
+// The claim is provisional: `releaseDeliverySlot` hands it back when delivery
+// fails, so the reservation only becomes a real 24h suppression once the
+// webhook has actually been delivered.
+const claimDeliverySlot = (dedupeKey: string) => {
   const nowMs = Date.now();
   const lastSentMs = lastWebhookByKey.get(dedupeKey);
 
   if (lastSentMs && nowMs - lastSentMs < DEDUPE_WINDOW_MS) {
-    return true;
+    return false;
   }
 
   lastWebhookByKey.set(dedupeKey, nowMs);
-  return false;
+  return true;
+};
+
+// Deleting is enough to restore the previous state: reaching a delivery
+// attempt means there was either no entry for this key, or one that had
+// already aged out of the dedupe window, and both are equivalent to absent.
+const releaseDeliverySlot = (dedupeKey: string) => {
+  lastWebhookByKey.delete(dedupeKey);
 };
 
 export const sendAdminAccessWebhook = async (params: {
@@ -51,7 +70,19 @@ export const sendAdminAccessWebhook = async (params: {
     region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? "self-hosted",
   };
 
-  if (shouldSkipDueToRecentDuplicate(payload)) return;
+  const dedupeKey = getDedupeKey(payload);
+  if (!claimDeliverySlot(dedupeKey)) return;
+
+  // An explicit controller rather than `AbortSignal.timeout`, so the deadline
+  // runs on the ambient `setTimeout` and stays observable to tests.
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort(
+      new Error(
+        `Admin access webhook timed out after ${DELIVERY_TIMEOUT_MS}ms`,
+      ),
+    );
+  }, DELIVERY_TIMEOUT_MS);
 
   try {
     const response = await fetch(env.LANGFUSE_ADMIN_ACCESS_WEBHOOK, {
@@ -60,9 +91,13 @@ export const sendAdminAccessWebhook = async (params: {
       headers: {
         "Content-Type": "application/json",
       },
+      signal: abortController.signal,
     });
 
     if (!response.ok) {
+      // Hand the slot back: a rejected delivery must not suppress the next
+      // attempt for the full dedupe window.
+      releaseDeliverySlot(dedupeKey);
       logger.warn("Failed to send admin access webhook", {
         status: response.status,
         statusText: response.statusText,
@@ -72,11 +107,14 @@ export const sendAdminAccessWebhook = async (params: {
       });
     }
   } catch (error) {
+    releaseDeliverySlot(dedupeKey);
     logger.warn("Error while sending admin access webhook", {
       error,
       email: payload.email,
       project: payload.project,
       org: payload.org,
     });
+  } finally {
+    clearTimeout(timeout);
   }
 };


### PR DESCRIPTION
🟡 **Live preview: [pr-16051.preview.langfuse.com](<https://pr-16051.preview.langfuse.com>)**

## What does this PR do?

Fixes langfuse/langfuse#15957 (supersedes the retry mechanics of langfuse/langfuse#16032 per maintainer review).

`sendAdminAccessWebhook` — the operator-configured admin-access audit notification — had no deadline, even though all eight call sites `await` it on user-facing request paths (tRPC middleware, dashboard query streaming, trace export). A hung endpoint stalled those requests for as long as the connection took to die.

Per review, the delivery semantics stay exactly as they are: this is a best-effort notification, so a failed delivery keeps its 24-hour dedupe slot and is simply dropped — no retry, no cooldown machinery (earlier iterations of this branch added those; the last commit removes them again).

What changes is how the request is made. Delivery now goes through the same secure fetch the webhook queue and web-callout sender use:

* `validateWebhookURL` + `fetchWithSecureRedirects` with connection-time DNS/IP validation and per-hop redirect validation, instead of a raw `fetch`.
* A five-second `AbortController` deadline (matching `WEB_CALLOUT_TIMEOUT_MS`), so a dead endpoint costs at most 5s once per dedupe key per day.
* Since the endpoint is operator-configured rather than tenant-supplied, ports are unrestricted (`allowedPorts: "any"`, like web callouts), internal receivers can be allowed via the existing `LANGFUSE_WEBHOOK_WHITELISTED_{HOST,IPS,IP_SEGMENTS}` env vars, and localhost is whitelisted in development (mirroring the web-callout sender).
* The unused response body is cancelled to release the pooled connection.

**Behavior note for self-hosters:** deployments pointing `LANGFUSE_ADMIN_ACCESS_WEBHOOK` at a private/internal address now need it whitelisted via `LANGFUSE_WEBHOOK_WHITELISTED_*`, otherwise delivery is blocked (warn log, request unaffected). Worth a line in the self-hosting docs if this lands.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code.

## Verification

Exercised end to end against the source-built stack: `demo@langfuse.com` flagged as a Langfuse admin, `LANGFUSE_ADMIN_ACCESS_WEBHOOK` pointed at a local receiver on a private IP, and each line below is one real project-scoped tRPC request whose middleware fires the webhook. Phase A shows SSRF validation blocking the non-whitelisted private target without stalling the request; B shows delivery + 24h dedupe once whitelisted; C shows a hung endpoint bounded at 5046 ms with the failure keeping its dedupe slot.

[Live stack transcript: unwhitelisted private receiver blocked at 45ms, whitelisted delivery and dedupe, hung endpoint bounded at 5046ms](<https://cursor.com/agents/bc-70a9302b-669b-4412-b8a1-aa93cb528eb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_webhook_secure_fetch_live_stack.png>)

Tests (`fetchWithSecureRedirects`/`validateWebhookURL` mocked, following the web-callouts test pattern) cover payload + secure-fetch options, dedupe, concurrent-caller collapse, non-ok/rejected/validation-blocked deliveries not throwing, and the hung-endpoint abort under fake timers:

```
 ✓ |server-isolated| src/__tests__/server/async/admin-access-webhook.servertest.ts (11 tests) 15ms
 ✓ |server-isolated| src/__tests__/server/admin-access-webhook-middleware.servertest.ts (8 tests) 24ms
```

`pnpm run lint` — `Tasks: 7 successful, 7 total` (plus `All matched files use Prettier code style!`); `pnpm --filter web run typecheck` exited 0.

## Notes for the reviewer, not changed here

* `sendAdminAccessWebhook` is still `await`ed on eight user-facing paths; the deeper fix remains not blocking requests on a best-effort notification.
* `lastWebhookByKey` has no eviction, as before this PR.
* The test file needs no Postgres, so `src/__tests__/server/unit/` would let it skip the database bootstrap (`web/AGENTS.md`). Left in place to keep the diff scoped.

To show artifacts inline, [enable](<https://cursor.com/dashboard/cloud-agents#team-pull-requests>) in settings.

Linear Issue: [LFE-15047](https://linear.app/clickhouse/issue/LFE-15047/gh-pr-fixadmin-webhook-retry-after-failed-delivery-and-bound-the)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

<details><summary>Greptile Summary</summary>

The PR changes admin-access webhook deduplication so failed deliveries become retryable after a bounded cooldown while successful deliveries remain suppressed for 24 hours.

* Claims the suppression slot before delivery to collapse concurrent callers.
* Applies a five-second AbortController deadline to outbound webhook requests.
* Shortens suppression to one minute after HTTP errors, network failures, or timeouts.
* Adds coverage for retries, cooldown behavior, timeout cancellation, successful deduplication, and concurrent callers.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The changed helper bounds awaited webhook requests, preserves successful-delivery deduplication, and makes failed attempts retryable at a controlled rate, with focused tests covering each new behavior.

</details>

<details><summary>Flowchart</summary>

%%{init: {'theme': 'neutral'}}%% flowchart TD A\[Admin-access event\] --> B{Key currently suppressed?} B -->|Yes| C\[Return without delivery\] B -->|No| D\[Claim provisional 24-hour slot\] D --> E\[Send webhook with 5-second timeout\] E -->|2xx response| F\[Keep 24-hour suppression\] E -->|Non-2xx, network error, or timeout| G\[Replace with 1-minute cooldown\] G --> H\[Later event may retry after cooldown\]

</details>

Reviews (1): Last reviewed commit: ["fix(admin-webhook): bound retry rate aft..."](<https://github.com/langfuse/langfuse/commit/b7acb7bcdc1f8d18165ac5abe94d039f11d26c25>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=52728724>)

**Context used:**

* Knowledge Base — [Web App (`web/`)](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md>)