### PR TITLE
fix(evals): show actionable evaluators in migration view

### DIFF
--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -288,6 +288,61 @@ describe("evals trpc", () => {
         { id: inactiveEvaluator.id, displayStatus: "INACTIVE" },
       ]);
     });
+
+    it("filters evaluator configurations by time scope", async () => {
+      const { project, caller } = await prepare();
+
+      const createEvaluator = (scoreName: string, timeScope: string[]) =>
+        prisma.jobConfiguration.create({
+          data: {
+            projectId: project.id,
+            jobType: "EVAL",
+            scoreName,
+            filter: [],
+            targetObject: EvalTargetObject.TRACE,
+            variableMapping: [],
+            sampling: 1,
+            delay: 0,
+            status: "ACTIVE",
+            timeScope,
+          },
+        });
+
+      const newEvaluator = await createEvaluator("new-score", ["NEW"]);
+      const newAndExistingEvaluator = await createEvaluator(
+        "new-and-existing-score",
+        ["NEW", "EXISTING"],
+      );
+      const existingEvaluator = await createEvaluator("existing-score", [
+        "EXISTING",
+      ]);
+
+      const response = await caller.evals.allConfigs({
+        projectId: project.id,
+        filter: [
+          {
+            column: "timeScope",
+            type: "arrayOptions",
+            operator: "any of",
+            value: ["NEW"],
+          },
+        ],
+        orderBy: {
+          column: "createdAt",
+          order: "DESC",
+        },
+        limit: 10,
+        page: 0,
+      });
+
+      expect(response.configs.map((config) => config.id)).toEqual(
+        expect.arrayContaining([newEvaluator.id, newAndExistingEvaluator.id]),
+      );
+      expect(response.configs.map((config) => config.id)).not.toContain(
+        existingEvaluator.id,
+      );
+      expect(response.totalCount).toBe(2);
+    });
   });
 
   describe("evals.templateNames", () => {

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -26,7 +26,10 @@ import TableIdOrName from "@/src/components/table/table-id";
 import { ExternalLinkIcon, Pen } from "lucide-react";
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
 import { TablePeekViewEvaluatorConfigDetail } from "@/src/components/table/peek/peek-evaluator-config-detail";
-import { evalConfigTargetValues } from "@/src/server/api/definitions/evalConfigsTable";
+import {
+  evalConfigTargetValues,
+  evalConfigTimeScopeValues,
+} from "@/src/server/api/definitions/evalConfigsTable";
 import { Button } from "@/src/components/ui/button";
 import { IconOnlyButton } from "@/src/components/IconOnlyButton";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
@@ -92,6 +95,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
   const newFilterOptions = {
     status: ["ACTIVE", "PAUSED", "INACTIVE"],
     target: evalConfigTargetValues,
+    timeScope: evalConfigTimeScopeValues,
   };
 
   const queryFilter = useSidebarFilterState(

--- a/web/src/features/filters/config/evaluators-config.ts
+++ b/web/src/features/filters/config/evaluators-config.ts
@@ -21,5 +21,10 @@ export const evaluatorFilterConfig: FilterConfig = {
       column: "target",
       label: "Target",
     },
+    {
+      type: "categorical" as const,
+      column: "timeScope",
+      label: "Time Scope",
+    },
   ],
 };

--- a/web/src/features/v4-migration/evaluatorMigrationUrls.clienttest.ts
+++ b/web/src/features/v4-migration/evaluatorMigrationUrls.clienttest.ts
@@ -1,0 +1,37 @@
+import { decodeFiltersGeneric } from "@langfuse/shared";
+import { describe, expect, it } from "vitest";
+
+import { buildDeprecatedEvaluatorsUrl } from "./evaluatorMigrationUrls";
+
+describe("buildDeprecatedEvaluatorsUrl", () => {
+  it("shows actionable active and paused legacy evaluators", () => {
+    const url = new URL(
+      buildDeprecatedEvaluatorsUrl("project-1"),
+      "https://langfuse.local",
+    );
+
+    expect(url.pathname).toBe("/project/project-1/evals");
+    expect(decodeFiltersGeneric(url.searchParams.get("filter") ?? "")).toEqual(
+      [
+        {
+          column: "status",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["ACTIVE", "PAUSED"],
+        },
+        {
+          column: "target",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["trace", "dataset"],
+        },
+        {
+          column: "timeScope",
+          type: "arrayOptions",
+          operator: "any of",
+          value: ["NEW"],
+        },
+      ],
+    );
+  });
+});

--- a/web/src/features/v4-migration/evaluatorMigrationUrls.clienttest.ts
+++ b/web/src/features/v4-migration/evaluatorMigrationUrls.clienttest.ts
@@ -11,27 +11,25 @@ describe("buildDeprecatedEvaluatorsUrl", () => {
     );
 
     expect(url.pathname).toBe("/project/project-1/evals");
-    expect(decodeFiltersGeneric(url.searchParams.get("filter") ?? "")).toEqual(
-      [
-        {
-          column: "status",
-          type: "stringOptions",
-          operator: "any of",
-          value: ["ACTIVE", "PAUSED"],
-        },
-        {
-          column: "target",
-          type: "stringOptions",
-          operator: "any of",
-          value: ["trace", "dataset"],
-        },
-        {
-          column: "timeScope",
-          type: "arrayOptions",
-          operator: "any of",
-          value: ["NEW"],
-        },
-      ],
-    );
+    expect(decodeFiltersGeneric(url.searchParams.get("filter") ?? "")).toEqual([
+      {
+        column: "status",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["ACTIVE", "PAUSED"],
+      },
+      {
+        column: "target",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["trace", "dataset"],
+      },
+      {
+        column: "timeScope",
+        type: "arrayOptions",
+        operator: "any of",
+        value: ["NEW"],
+      },
+    ]);
   });
 });

--- a/web/src/features/v4-migration/evaluatorMigrationUrls.ts
+++ b/web/src/features/v4-migration/evaluatorMigrationUrls.ts
@@ -5,7 +5,7 @@ const DEPRECATED_EVALUATOR_FILTERS: FilterState = [
     column: "status",
     type: "stringOptions",
     operator: "any of",
-    value: ["ACTIVE"],
+    value: ["ACTIVE", "PAUSED"],
   },
   {
     column: "target",

--- a/web/src/features/v4-migration/evaluatorMigrationUrls.ts
+++ b/web/src/features/v4-migration/evaluatorMigrationUrls.ts
@@ -13,6 +13,12 @@ const DEPRECATED_EVALUATOR_FILTERS: FilterState = [
     operator: "any of",
     value: ["trace", "dataset"],
   },
+  {
+    column: "timeScope",
+    type: "arrayOptions",
+    operator: "any of",
+    value: ["NEW"],
+  },
 ];
 
 const MODERN_EVALUATOR_FILTERS: FilterState = [

--- a/web/src/server/api/definitions/evalConfigsTable.ts
+++ b/web/src/server/api/definitions/evalConfigsTable.ts
@@ -2,6 +2,7 @@ import {
   EvalTargetObject,
   type ColumnDefinition,
   JobConfigState,
+  JobTimeScopeZod,
 } from "@langfuse/shared";
 
 export const evalConfigTargetOptions = Object.values(EvalTargetObject).map(
@@ -13,6 +14,8 @@ export const evalConfigTargetOptions = Object.values(EvalTargetObject).map(
 export const evalConfigTargetValues = evalConfigTargetOptions.map(
   (option) => option.value,
 );
+
+export const evalConfigTimeScopeValues = JobTimeScopeZod.options;
 
 const evaluatorDisplayStatusSql = `CASE
   WHEN jc."status" = 'INACTIVE' THEN 'INACTIVE'
@@ -43,6 +46,13 @@ export const evalConfigFilterColumns: ColumnDefinition[] = [
     internal: 'jc."target_object"',
     options: evalConfigTargetOptions,
   },
+  {
+    name: "Time Scope",
+    id: "timeScope",
+    type: "arrayOptions",
+    internal: 'jc."time_scope"',
+    options: evalConfigTimeScopeValues.map((value) => ({ value })),
+  },
 ];
 
 export const evalConfigsTableCols: ColumnDefinition[] = [
@@ -51,6 +61,7 @@ export const evalConfigsTableCols: ColumnDefinition[] = [
     internal: evaluatorStatusSortRankSql,
   },
   evalConfigFilterColumns[1],
+  evalConfigFilterColumns[2],
   {
     name: "Updated At",
     id: "updatedAt",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16053.preview.langfuse.com](https://pr-16053.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- include active and paused legacy evaluators in the upgrade view
- exclude evaluators that only run on existing traces by filtering for the `NEW` time scope
- expose time scope as a regular evaluator table filter
- keep the existing evaluator-list route and encoded `filter` query parameter

## Verification

- Added URL-contract and server-filter regression tests.
- Tests and lint were not run to avoid interfering with an active local server.
- `git diff --cached --check` passed before commit.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the legacy evaluator migration view to show active and paused evaluators that process new data.

- Adds `timeScope` as a supported evaluator table filter and sidebar facet.
- Filters migration links to trace and dataset evaluators whose scope includes `NEW`.
- Adds regression coverage for URL encoding and server-side array filtering.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The URL contract, filter configuration, array-overlap server filtering, and intended exclusion of EXISTING-only evaluators are consistent across the changed implementation and regression tests.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(tests): improve formatting of f..."](https://github.com/langfuse/langfuse/commit/04bb3b146ae17bf3c418b3ade4f27d9eff605709) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52795944)</sub>

<!-- /greptile_comment -->