### PR TITLE
feat(playground): run the same configuration N times (repetitions)

### DIFF
--- a/web/src/__tests__/playground-run-stats.clienttest.ts
+++ b/web/src/__tests__/playground-run-stats.clienttest.ts
@@ -72,6 +72,23 @@ describe("computeRunStats", () => {
     expect(stats.distinctOutputCount).toBe(2);
   });
 
+  it("treats argument key order as irrelevant when counting distinct outputs", () => {
+    const stats = computeRunStats([
+      completedRun(0, {
+        toolCalls: [
+          { id: "a", name: "generate_deal", args: { amount: 1, installments: 3 } },
+        ],
+      }),
+      completedRun(1, {
+        toolCalls: [
+          { id: "b", name: "generate_deal", args: { installments: 3, amount: 1 } },
+        ],
+      }),
+    ]);
+
+    expect(stats.distinctOutputCount).toBe(1);
+  });
+
   it("treats identical text with different tool calls as distinct outputs", () => {
     const stats = computeRunStats([
       completedRun(0, {

--- a/web/src/__tests__/playground-run-stats.clienttest.ts
+++ b/web/src/__tests__/playground-run-stats.clienttest.ts
@@ -1,0 +1,103 @@
+import { computeRunStats } from "@/src/features/playground/page/utils/runStats";
+import { type PlaygroundRunResult } from "@/src/features/playground/page/types";
+
+const completedRun = (
+  index: number,
+  overrides: Partial<PlaygroundRunResult> = {},
+): PlaygroundRunResult => ({
+  index,
+  status: "completed",
+  content: "hello",
+  toolCalls: [],
+  latencyMs: 100,
+  ...overrides,
+});
+
+describe("computeRunStats", () => {
+  it("counts completed and failed runs and aggregates latency", () => {
+    const stats = computeRunStats([
+      completedRun(0, { latencyMs: 100 }),
+      completedRun(1, { latencyMs: 300 }),
+      {
+        index: 2,
+        status: "error",
+        content: "",
+        toolCalls: [],
+        latencyMs: 50,
+        error: "boom",
+      },
+    ]);
+
+    expect(stats.totalCount).toBe(3);
+    expect(stats.completedCount).toBe(2);
+    expect(stats.errorCount).toBe(1);
+    expect(stats.latency).toEqual({ min: 100, avg: 200, max: 300 });
+  });
+
+  it("counts runs per tool-call signature including argument shape", () => {
+    const stats = computeRunStats([
+      completedRun(0, {
+        toolCalls: [
+          { id: "a", name: "validate_customer", args: { document: "1" } },
+        ],
+      }),
+      completedRun(1, {
+        toolCalls: [
+          { id: "b", name: "validate_customer", args: { document: "2" } },
+          // second call of the same signature within one run counts once
+          { id: "c", name: "validate_customer", args: { document: "3" } },
+        ],
+      }),
+      completedRun(2, {
+        toolCalls: [
+          { id: "d", name: "validate_customer", args: { birthday: "1990" } },
+        ],
+      }),
+      completedRun(3),
+    ]);
+
+    expect(stats.toolCallFrequencies).toEqual([
+      { signature: "validate_customer(document)", runCount: 2 },
+      { signature: "validate_customer(birthday)", runCount: 1 },
+    ]);
+  });
+
+  it("counts distinct outputs after whitespace normalization", () => {
+    const stats = computeRunStats([
+      completedRun(0, { content: "same  answer" }),
+      completedRun(1, { content: "same answer" }),
+      completedRun(2, { content: "different answer" }),
+    ]);
+
+    expect(stats.distinctOutputCount).toBe(2);
+  });
+
+  it("treats identical text with different tool calls as distinct outputs", () => {
+    const stats = computeRunStats([
+      completedRun(0, {
+        toolCalls: [{ id: "a", name: "generate_deal", args: { amount: 1 } }],
+      }),
+      completedRun(1, {
+        toolCalls: [{ id: "b", name: "generate_deal", args: { amount: 2 } }],
+      }),
+    ]);
+
+    expect(stats.distinctOutputCount).toBe(2);
+  });
+
+  it("returns null latency and empty frequencies when nothing completed", () => {
+    const stats = computeRunStats([
+      {
+        index: 0,
+        status: "running",
+        content: "",
+        toolCalls: [],
+        latencyMs: 0,
+      },
+    ]);
+
+    expect(stats.latency).toBeNull();
+    expect(stats.toolCallFrequencies).toEqual([]);
+    expect(stats.distinctOutputCount).toBe(0);
+  });
+});

--- a/web/src/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/features/playground/page/components/GenerationOutput.tsx
@@ -32,9 +32,54 @@ export const GenerationOutput = () => {
     runs,
   } = usePlaygroundContext();
 
+  const isMultiRun = runs.length > 1;
+  const [activeRunIndex, setActiveRunIndex] = useState(0);
+  const isRunning = runs.some((run) => run.status === "running");
+
+  // While executing, follow the most recently settled run so the carousel
+  // shows progress without requiring interaction; once the batch finishes,
+  // reset to the first run so review always starts from the beginning.
+  const wasRunningRef = useRef(false);
+  useEffect(() => {
+    if (isRunning) {
+      const lastSettled = runs.reduce(
+        (latest, run, index) => (run.status !== "running" ? index : latest),
+        0,
+      );
+      setActiveRunIndex(lastSettled);
+    } else if (wasRunningRef.current) {
+      setActiveRunIndex(0);
+    }
+    wasRunningRef.current = isRunning;
+  }, [runs, isRunning]);
+
+  // Copy and add-to-messages always act on what is visible: the active
+  // carousel run during repeated submissions, the legacy single output
+  // otherwise.
+  const activeRun = isMultiRun
+    ? runs[Math.min(activeRunIndex, runs.length - 1)]
+    : undefined;
+  const visibleContent = activeRun ? activeRun.content : output;
+  const visibleToolCalls = activeRun ? activeRun.toolCalls : outputToolCalls;
+
   const handleCopy = () => {
     setIsCopied(true);
-    const textToCopy = isJson ? outputJson : output;
+    const textToCopy = activeRun
+      ? isJson
+        ? JSON.stringify(
+            {
+              content: activeRun.content,
+              ...(activeRun.toolCalls.length > 0
+                ? { tool_calls: activeRun.toolCalls }
+                : {}),
+            },
+            null,
+            2,
+          )
+        : activeRun.content
+      : isJson
+        ? outputJson
+        : output;
     copyTextToClipboard(textToCopy);
     setTimeout(() => setIsCopied(false), 1000);
   };
@@ -42,17 +87,17 @@ export const GenerationOutput = () => {
   const handleAddAssistantMessage = () => {
     setIsAdded(true);
     const newMessage =
-      outputToolCalls.length > 0
+      visibleToolCalls.length > 0
         ? addMessage({
             type: ChatMessageType.AssistantToolCall,
             role: ChatMessageRole.Assistant,
-            content: output,
-            toolCalls: outputToolCalls,
+            content: visibleContent,
+            toolCalls: visibleToolCalls,
           })
         : addMessage({
             type: ChatMessageType.AssistantText,
             role: ChatMessageRole.Assistant,
-            content: output,
+            content: visibleContent,
           });
     // Scroll the appended row into view without stealing focus: this is a
     // programmatic add from the Output panel, so unlike the Add-message button
@@ -75,7 +120,7 @@ export const GenerationOutput = () => {
   const plusIcon = <Plus className="h-2 w-2" />;
 
   const copyButton =
-    output || outputToolCalls.length ? (
+    output || outputToolCalls.length || isMultiRun ? (
       <div className="absolute top-2 right-3 flex space-x-1 opacity-50">
         <Button
           size="icon"
@@ -92,7 +137,7 @@ export const GenerationOutput = () => {
           size="icon"
           variant="secondary"
           onClick={!isCopied ? handleCopy : undefined}
-          title="Copy output"
+          title={isMultiRun ? "Copy active run" : "Copy output"}
         >
           {isCopied ? checkIcon : copyIcon}
         </Button>
@@ -101,7 +146,11 @@ export const GenerationOutput = () => {
           className="flex items-center gap-1 p-0 px-1 whitespace-nowrap"
           variant="secondary"
           onClick={!isAdded ? handleAddAssistantMessage : undefined}
-          title="Add as assistant message"
+          title={
+            isMultiRun
+              ? "Add active run as assistant message"
+              : "Add as assistant message"
+          }
           disabled={isAdded}
         >
           {isAdded ? checkIcon : plusIcon}
@@ -123,8 +172,12 @@ export const GenerationOutput = () => {
           </div>
         </div>
         <div className="px-4">
-          {runs.length > 1 ? (
-            <MultiRunOutput runs={runs} />
+          {isMultiRun ? (
+            <MultiRunOutput
+              runs={runs}
+              activeIndex={activeRunIndex}
+              onNavigate={setActiveRunIndex}
+            />
           ) : (
             <>
               {outputReasoning && !isJson && (
@@ -154,29 +207,21 @@ export const GenerationOutput = () => {
  * Output panel for repeated ("Run xN") submissions: a carousel over the runs
  * (one run visible at a time, prev/next navigation) preceded by deterministic
  * consistency stats (counts, frequencies, and latency distribution only).
+ * Navigation state lives in the parent so copy/add actions target the run
+ * that is currently visible.
  */
-const MultiRunOutput = ({ runs }: { runs: PlaygroundRunResult[] }) => {
+const MultiRunOutput = ({
+  runs,
+  activeIndex,
+  onNavigate,
+}: {
+  runs: PlaygroundRunResult[];
+  activeIndex: number;
+  onNavigate: (index: number) => void;
+}) => {
   const stats = useMemo(() => computeRunStats(runs), [runs]);
-  const [activeIndex, setActiveIndex] = useState(0);
   const isRunning = runs.some((run) => run.status === "running");
   const activeRun = runs[Math.min(activeIndex, runs.length - 1)];
-
-  // While executing, follow the most recently settled run so the carousel
-  // shows progress without requiring interaction; once the batch finishes,
-  // reset to the first run so review always starts from the beginning.
-  const wasRunningRef = useRef(false);
-  useEffect(() => {
-    if (isRunning) {
-      const lastSettled = runs.reduce(
-        (latest, run, index) => (run.status !== "running" ? index : latest),
-        0,
-      );
-      setActiveIndex(lastSettled);
-    } else if (wasRunningRef.current) {
-      setActiveIndex(0);
-    }
-    wasRunningRef.current = isRunning;
-  }, [runs, isRunning]);
 
   if (!activeRun) return null;
 
@@ -186,7 +231,7 @@ const MultiRunOutput = ({ runs }: { runs: PlaygroundRunResult[] }) => {
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
           <span className="font-bold">
             {stats.completedCount}/{stats.totalCount} runs completed
-            {stats.errorCount > 0 ? ` \u00b7 ${stats.errorCount} failed` : ""}
+            {stats.errorCount > 0 ? ` · ${stats.errorCount} failed` : ""}
           </span>
           {stats.latency && (
             <span className="text-muted-foreground">
@@ -220,7 +265,7 @@ const MultiRunOutput = ({ runs }: { runs: PlaygroundRunResult[] }) => {
               variant="ghost"
               className="h-5 w-5"
               disabled={activeIndex === 0}
-              onClick={() => setActiveIndex((prev) => Math.max(prev - 1, 0))}
+              onClick={() => onNavigate(Math.max(activeIndex - 1, 0))}
               title="Previous run"
             >
               <ChevronLeft className="h-3 w-3" />
@@ -234,7 +279,7 @@ const MultiRunOutput = ({ runs }: { runs: PlaygroundRunResult[] }) => {
               className="h-5 w-5"
               disabled={activeIndex >= runs.length - 1}
               onClick={() =>
-                setActiveIndex((prev) => Math.min(prev + 1, runs.length - 1))
+                onNavigate(Math.min(activeIndex + 1, runs.length - 1))
               }
               title="Next run"
             >

--- a/web/src/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/features/playground/page/components/GenerationOutput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { usePlaygroundContext } from "../context";
 import { ChatMessageRole, ChatMessageType } from "@langfuse/shared";
@@ -6,6 +6,9 @@ import { BracesIcon, Check, Copy, Plus } from "lucide-react";
 import { ToolCallCard } from "@/src/components/ChatMessages/ToolCallCard";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { ThinkingBlock } from "@/src/features/traces";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { type PlaygroundRunResult } from "../types";
+import { computeRunStats } from "../utils/runStats";
 
 export const GenerationOutput = () => {
   const [isCopied, setIsCopied] = useState(false);
@@ -19,6 +22,7 @@ export const GenerationOutput = () => {
     addMessage,
     outputToolCalls,
     scrollToMessage,
+    runs,
   } = usePlaygroundContext();
 
   const handleCopy = () => {
@@ -112,23 +116,117 @@ export const GenerationOutput = () => {
           </div>
         </div>
         <div className="px-4">
-          {outputReasoning && !isJson && (
-            <div className="-ml-1">
-              <ThinkingBlock content={outputReasoning} />
-            </div>
-          )}
-          <pre className="text-xs wrap-break-word whitespace-break-spaces">
-            {isJson ? outputJson : output}
-          </pre>
-          {outputToolCalls.length > 0
-            ? outputToolCalls.map((toolCall) => (
-                <div className="mt-4" key={toolCall.id}>
-                  <ToolCallCard toolCall={toolCall} />
+          {runs.length > 1 ? (
+            <MultiRunOutput runs={runs} />
+          ) : (
+            <>
+              {outputReasoning && !isJson && (
+                <div className="-ml-1">
+                  <ThinkingBlock content={outputReasoning} />
                 </div>
-              ))
-            : null}
+              )}
+              <pre className="text-xs wrap-break-word whitespace-break-spaces">
+                {isJson ? outputJson : output}
+              </pre>
+              {outputToolCalls.length > 0
+                ? outputToolCalls.map((toolCall) => (
+                    <div className="mt-4" key={toolCall.id}>
+                      <ToolCallCard toolCall={toolCall} />
+                    </div>
+                  ))
+                : null}
+            </>
+          )}
         </div>
       </div>
+    </div>
+  );
+};
+
+/**
+ * Output panel for repeated ("Run xN") submissions: every run stacked with
+ * its own latency and tool calls, preceded by deterministic consistency
+ * stats (counts, frequencies, and latency distribution only).
+ */
+const MultiRunOutput = ({ runs }: { runs: PlaygroundRunResult[] }) => {
+  const stats = useMemo(() => computeRunStats(runs), [runs]);
+  const isRunning = runs.some((run) => run.status === "running");
+
+  return (
+    <div className="flex flex-col gap-3 pb-4">
+      <div className="bg-background/50 rounded-md border p-2 text-xs">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          <span className="font-bold">
+            {stats.completedCount}/{stats.totalCount} runs completed
+            {stats.errorCount > 0 ? ` \u00b7 ${stats.errorCount} failed` : ""}
+          </span>
+          {stats.latency && (
+            <span className="text-muted-foreground">
+              latency {stats.latency.min}–{stats.latency.max}ms (avg{" "}
+              {stats.latency.avg}ms)
+            </span>
+          )}
+          {stats.completedCount > 1 && (
+            <span className="text-muted-foreground">
+              {stats.distinctOutputCount} distinct output
+              {stats.distinctOutputCount === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
+        {stats.toolCallFrequencies.length > 0 && (
+          <div className="text-muted-foreground mt-1 flex flex-wrap gap-x-4 gap-y-1">
+            {stats.toolCallFrequencies.map(({ signature, runCount }) => (
+              <span key={signature}>
+                {signature}: {runCount}/{stats.completedCount} runs
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {runs.map((run) => (
+        <div key={run.index} className="rounded-md border">
+          <div className="bg-background/50 text-muted-foreground flex items-center justify-between border-b px-2 py-1 text-xs">
+            <span className="font-bold">Run {run.index + 1}</span>
+            <span className="flex items-center gap-1">
+              {run.status === "running" && <Spinner size="xxs" />}
+              {run.status === "error" && (
+                <span className="text-destructive">failed</span>
+              )}
+              {run.status === "completed" && `${run.latencyMs}ms`}
+            </span>
+          </div>
+          <div className="px-2 py-1.5">
+            {run.status === "error" ? (
+              <pre className="text-destructive text-xs wrap-break-word whitespace-break-spaces">
+                {run.error}
+              </pre>
+            ) : (
+              <>
+                {run.reasoning && (
+                  <div className="-ml-1">
+                    <ThinkingBlock content={run.reasoning} />
+                  </div>
+                )}
+                <pre className="text-xs wrap-break-word whitespace-break-spaces">
+                  {run.content}
+                </pre>
+                {run.toolCalls.map((toolCall) => (
+                  <div className="mt-2" key={toolCall.id}>
+                    <ToolCallCard toolCall={toolCall} />
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        </div>
+      ))}
+      {isRunning && (
+        <div className="text-muted-foreground flex items-center gap-2 text-xs">
+          <Spinner size="xxs" />
+          <span>Executing…</span>
+        </div>
+      )}
     </div>
   );
 };

--- a/web/src/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/features/playground/page/components/GenerationOutput.tsx
@@ -2,7 +2,14 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { usePlaygroundContext } from "../context";
 import { ChatMessageRole, ChatMessageType } from "@langfuse/shared";
-import { BracesIcon, Check, Copy, Plus } from "lucide-react";
+import {
+  BracesIcon,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Plus,
+} from "lucide-react";
 import { ToolCallCard } from "@/src/components/ChatMessages/ToolCallCard";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { ThinkingBlock } from "@/src/features/traces";
@@ -144,13 +151,34 @@ export const GenerationOutput = () => {
 };
 
 /**
- * Output panel for repeated ("Run xN") submissions: every run stacked with
- * its own latency and tool calls, preceded by deterministic consistency
- * stats (counts, frequencies, and latency distribution only).
+ * Output panel for repeated ("Run xN") submissions: a carousel over the runs
+ * (one run visible at a time, prev/next navigation) preceded by deterministic
+ * consistency stats (counts, frequencies, and latency distribution only).
  */
 const MultiRunOutput = ({ runs }: { runs: PlaygroundRunResult[] }) => {
   const stats = useMemo(() => computeRunStats(runs), [runs]);
+  const [activeIndex, setActiveIndex] = useState(0);
   const isRunning = runs.some((run) => run.status === "running");
+  const activeRun = runs[Math.min(activeIndex, runs.length - 1)];
+
+  // While executing, follow the most recently settled run so the carousel
+  // shows progress without requiring interaction; once the batch finishes,
+  // reset to the first run so review always starts from the beginning.
+  const wasRunningRef = useRef(false);
+  useEffect(() => {
+    if (isRunning) {
+      const lastSettled = runs.reduce(
+        (latest, run, index) => (run.status !== "running" ? index : latest),
+        0,
+      );
+      setActiveIndex(lastSettled);
+    } else if (wasRunningRef.current) {
+      setActiveIndex(0);
+    }
+    wasRunningRef.current = isRunning;
+  }, [runs, isRunning]);
+
+  if (!activeRun) return null;
 
   return (
     <div className="flex flex-col gap-3 pb-4">
@@ -184,43 +212,67 @@ const MultiRunOutput = ({ runs }: { runs: PlaygroundRunResult[] }) => {
         )}
       </div>
 
-      {runs.map((run) => (
-        <div key={run.index} className="rounded-md border">
-          <div className="bg-background/50 text-muted-foreground flex items-center justify-between border-b px-2 py-1 text-xs">
-            <span className="font-bold">Run {run.index + 1}</span>
-            <span className="flex items-center gap-1">
-              {run.status === "running" && <Spinner size="xxs" />}
-              {run.status === "error" && (
-                <span className="text-destructive">failed</span>
-              )}
-              {run.status === "completed" && `${run.latencyMs}ms`}
+      <div className="rounded-md border">
+        <div className="bg-background/50 flex items-center justify-between border-b px-2 py-1 text-xs">
+          <div className="flex items-center gap-1">
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-5 w-5"
+              disabled={activeIndex === 0}
+              onClick={() => setActiveIndex((prev) => Math.max(prev - 1, 0))}
+              title="Previous run"
+            >
+              <ChevronLeft className="h-3 w-3" />
+            </Button>
+            <span className="font-bold whitespace-nowrap">
+              Run {activeIndex + 1}/{runs.length}
             </span>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-5 w-5"
+              disabled={activeIndex >= runs.length - 1}
+              onClick={() =>
+                setActiveIndex((prev) => Math.min(prev + 1, runs.length - 1))
+              }
+              title="Next run"
+            >
+              <ChevronRight className="h-3 w-3" />
+            </Button>
           </div>
-          <div className="px-2 py-1.5">
-            {run.status === "error" ? (
-              <pre className="text-destructive text-xs wrap-break-word whitespace-break-spaces">
-                {run.error}
-              </pre>
-            ) : (
-              <>
-                {run.reasoning && (
-                  <div className="-ml-1">
-                    <ThinkingBlock content={run.reasoning} />
-                  </div>
-                )}
-                <pre className="text-xs wrap-break-word whitespace-break-spaces">
-                  {run.content}
-                </pre>
-                {run.toolCalls.map((toolCall) => (
-                  <div className="mt-2" key={toolCall.id}>
-                    <ToolCallCard toolCall={toolCall} />
-                  </div>
-                ))}
-              </>
+          <span className="text-muted-foreground flex items-center gap-1">
+            {activeRun.status === "running" && <Spinner size="xxs" />}
+            {activeRun.status === "error" && (
+              <span className="text-destructive">failed</span>
             )}
-          </div>
+            {activeRun.status === "completed" && `${activeRun.latencyMs}ms`}
+          </span>
         </div>
-      ))}
+        <div className="px-2 py-1.5">
+          {activeRun.status === "error" ? (
+            <pre className="text-destructive text-xs wrap-break-word whitespace-break-spaces">
+              {activeRun.error}
+            </pre>
+          ) : (
+            <>
+              {activeRun.reasoning && (
+                <div className="-ml-1">
+                  <ThinkingBlock content={activeRun.reasoning} />
+                </div>
+              )}
+              <pre className="text-xs wrap-break-word whitespace-break-spaces">
+                {activeRun.content}
+              </pre>
+              {activeRun.toolCalls.map((toolCall) => (
+                <div className="mt-2" key={toolCall.id}>
+                  <ToolCallCard toolCall={toolCall} />
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
       {isRunning && (
         <div className="text-muted-foreground flex items-center gap-2 text-xs">
           <Spinner size="xxs" />

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Button } from "@/src/components/ui/button";
 import { usePlaygroundContext } from "@/src/features/playground/page/context";
 import {
@@ -9,6 +10,7 @@ import {
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { Settings } from "lucide-react";
 import useLocalStorage from "@/src/components/useLocalStorage";
+import { useGlobalRunCount } from "@/src/features/playground/page/hooks/useWindowCoordination";
 import { env } from "@/src/env.mjs";
 import { STREAMING_PREF_KEY } from "@/src/features/playground/page/storage/keys";
 import { captureUnknownError } from "@/src/utils/captureUnknownError";
@@ -20,9 +22,23 @@ import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
+  usePanelRef,
 } from "@/src/components/ui/resizable";
 
 export const Messages: React.FC<MessagesContext> = (props) => {
+  const outputPanelRef = usePanelRef();
+  const { runs } = usePlaygroundContext();
+  const isMultiRun = runs.length > 1;
+
+  // Repeated runs render a stats bar plus a run carousel; the default 20%
+  // output panel forces a manual resize every submission, so grow it once
+  // per multi-run batch.
+  useEffect(() => {
+    if (isMultiRun) {
+      outputPanelRef.current?.resize("40%");
+    }
+  }, [isMultiRun, outputPanelRef]);
+
   return (
     <div className="flex h-full flex-col space-y-4 pt-2 pr-4">
       <ResizablePanelGroup orientation="vertical">
@@ -31,6 +47,7 @@ export const Messages: React.FC<MessagesContext> = (props) => {
         </ResizablePanel>
         <ResizableHandle withHandle className="bg-transparent" />
         <ResizablePanel
+          panelRef={outputPanelRef}
           minSize="20%"
           defaultSize="20%"
           className="flex flex-col space-y-4"
@@ -43,11 +60,9 @@ export const Messages: React.FC<MessagesContext> = (props) => {
   );
 };
 
-const REPETITION_OPTIONS = [1, 3, 5, 10];
-
 const SubmitButton = () => {
-  const { handleSubmit, isStreaming, runCount, setRunCount } =
-    usePlaygroundContext();
+  const { handleSubmit, isStreaming } = usePlaygroundContext();
+  const runCount = useGlobalRunCount();
   const defaultStreamingEnabled =
     env.NEXT_PUBLIC_LANGFUSE_PLAYGROUND_STREAMING_ENABLED_DEFAULT === "true";
   const [streamingEnabled, setStreamingEnabled] = useLocalStorage(
@@ -96,32 +111,6 @@ const SubmitButton = () => {
               checked={streamingEnabled}
               onCheckedChange={setStreamingEnabled}
             />
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="flex cursor-pointer items-center justify-between py-2.5"
-            onClick={(e) => e.preventDefault()}
-          >
-            <div className="flex flex-col">
-              <span className="font-bold">Repetitions</span>
-              <span className="text-muted-foreground text-xs">
-                {runCount > 1
-                  ? `Run ${runCount}\u00d7 to compare consistency`
-                  : "Run the same setup multiple times"}
-              </span>
-            </div>
-            <div className="flex items-center gap-1">
-              {REPETITION_OPTIONS.map((option) => (
-                <Button
-                  key={option}
-                  size="sm"
-                  variant={runCount === option ? "default" : "outline"}
-                  className="h-6 px-2 text-xs"
-                  onClick={() => setRunCount(option)}
-                >
-                  {option}
-                </Button>
-              ))}
-            </div>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -43,8 +43,11 @@ export const Messages: React.FC<MessagesContext> = (props) => {
   );
 };
 
+const REPETITION_OPTIONS = [1, 3, 5, 10];
+
 const SubmitButton = () => {
-  const { handleSubmit, isStreaming } = usePlaygroundContext();
+  const { handleSubmit, isStreaming, runCount, setRunCount } =
+    usePlaygroundContext();
   const defaultStreamingEnabled =
     env.NEXT_PUBLIC_LANGFUSE_PLAYGROUND_STREAMING_ENABLED_DEFAULT === "true";
   const [streamingEnabled, setStreamingEnabled] = useLocalStorage(
@@ -63,7 +66,7 @@ const SubmitButton = () => {
         }}
         loading={isStreaming}
       >
-        <p>Submit</p>
+        <p>{runCount > 1 ? `Submit \u00d7${runCount}` : "Submit"}</p>
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -93,6 +96,32 @@ const SubmitButton = () => {
               checked={streamingEnabled}
               onCheckedChange={setStreamingEnabled}
             />
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="flex cursor-pointer items-center justify-between py-2.5"
+            onClick={(e) => e.preventDefault()}
+          >
+            <div className="flex flex-col">
+              <span className="font-bold">Repetitions</span>
+              <span className="text-muted-foreground text-xs">
+                {runCount > 1
+                  ? `Run ${runCount}\u00d7 to compare consistency`
+                  : "Run the same setup multiple times"}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              {REPETITION_OPTIONS.map((option) => (
+                <Button
+                  key={option}
+                  size="sm"
+                  variant={runCount === option ? "default" : "outline"}
+                  className="h-6 px-2 text-xs"
+                  onClick={() => setRunCount(option)}
+                >
+                  {option}
+                </Button>
+              ))}
+            </div>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -45,6 +45,7 @@ import {
   MULTI_WINDOW_CONFIG,
 } from "@/src/features/playground/page/types";
 import {
+  getGlobalRunCount,
   getPlaygroundEventBus,
   useWindowCoordination,
 } from "@/src/features/playground/page/hooks/useWindowCoordination";
@@ -75,8 +76,6 @@ type PlaygroundContextType = {
   outputToolCalls: LLMToolCall[];
 
   runs: PlaygroundRunResult[];
-  runCount: number;
-  setRunCount: React.Dispatch<React.SetStateAction<number>>;
 
   handleSubmit: (streaming?: boolean) => Promise<void>;
   isStreaming: boolean;
@@ -127,7 +126,6 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
   const [outputToolCalls, setOutputToolCalls] = useState<LLMToolCall[]>([]);
   const [outputJson, setOutputJson] = useState("");
   const [runs, setRuns] = useState<PlaygroundRunResult[]>([]);
-  const [runCount, setRunCount] = useState(1);
   const [isStreaming, setIsStreaming] = useState(false);
   const isStreamingRef = useRef(isStreaming);
   const [tools, setTools] = useState<PlaygroundTool[]>([]);
@@ -393,6 +391,8 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
           );
         }
 
+        const runCount = getGlobalRunCount();
+
         let response = "";
         if (runCount > 1) {
           // Repetitions mode: execute the same configuration N times in
@@ -463,38 +463,53 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
             };
           };
 
-          const results = await Promise.all(
-            Array.from({ length: runCount }, async (_, index) => {
-              const startedAt = performance.now();
-              let run: PlaygroundRunResult;
-              try {
-                const result = await executeOnce();
-                run = {
-                  index,
-                  status: "completed",
-                  content: result.content,
-                  reasoning: result.reasoning,
-                  toolCalls: result.toolCalls,
-                  latencyMs: Math.round(performance.now() - startedAt),
-                };
-              } catch (err) {
-                run = {
-                  index,
-                  status: "error",
-                  content: "",
-                  toolCalls: [],
-                  latencyMs: Math.round(performance.now() - startedAt),
-                  error:
-                    err instanceof Error ? err.message : "An error occurred",
-                };
-              }
-              setRuns((prev) =>
-                prev.map((prevRun) =>
-                  prevRun.index === index ? run : prevRun,
-                ),
-              );
-              return run;
-            }),
+          // Bounded worker pool: with up to MAX_RUN_COUNT repetitions,
+          // firing everything at once would trip provider rate limits.
+          const CONCURRENT_RUNS = 5;
+          const results: PlaygroundRunResult[] = new Array(runCount);
+          let nextRunIndex = 0;
+
+          const executeRunAt = async (index: number) => {
+            const startedAt = performance.now();
+            let run: PlaygroundRunResult;
+            try {
+              const result = await executeOnce();
+              run = {
+                index,
+                status: "completed",
+                content: result.content,
+                reasoning: result.reasoning,
+                toolCalls: result.toolCalls,
+                latencyMs: Math.round(performance.now() - startedAt),
+              };
+            } catch (err) {
+              run = {
+                index,
+                status: "error",
+                content: "",
+                toolCalls: [],
+                latencyMs: Math.round(performance.now() - startedAt),
+                error:
+                  err instanceof Error ? err.message : "An error occurred",
+              };
+            }
+            results[index] = run;
+            setRuns((prev) =>
+              prev.map((prevRun) => (prevRun.index === index ? run : prevRun)),
+            );
+          };
+
+          await Promise.all(
+            Array.from(
+              { length: Math.min(CONCURRENT_RUNS, runCount) },
+              async () => {
+                while (nextRunIndex < runCount) {
+                  const index = nextRunIndex;
+                  nextRunIndex += 1;
+                  await executeRunAt(index);
+                }
+              },
+            ),
           );
 
           const firstCompleted = results.find(
@@ -614,7 +629,6 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
       setPlaygroundCache,
       structuredOutputSchema,
       projectId,
-      runCount,
     ],
   );
 
@@ -875,8 +889,6 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
         outputJson,
         outputToolCalls,
         runs,
-        runCount,
-        setRunCount,
         handleSubmit,
         isStreaming,
         scrollToMessage,

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -40,6 +40,7 @@ import {
   type PlaceholderMessageFillIn,
   type PlaygroundProviderProps,
   type PlaygroundHandle,
+  type PlaygroundRunResult,
   PLAYGROUND_EVENTS,
   MULTI_WINDOW_CONFIG,
 } from "@/src/features/playground/page/types";
@@ -72,6 +73,10 @@ type PlaygroundContextType = {
   outputReasoning: string;
   outputJson: string;
   outputToolCalls: LLMToolCall[];
+
+  runs: PlaygroundRunResult[];
+  runCount: number;
+  setRunCount: React.Dispatch<React.SetStateAction<number>>;
 
   handleSubmit: (streaming?: boolean) => Promise<void>;
   isStreaming: boolean;
@@ -121,6 +126,8 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
   const [outputReasoning, setOutputReasoning] = useState("");
   const [outputToolCalls, setOutputToolCalls] = useState<LLMToolCall[]>([]);
   const [outputJson, setOutputJson] = useState("");
+  const [runs, setRuns] = useState<PlaygroundRunResult[]>([]);
+  const [runCount, setRunCount] = useState(1);
   const [isStreaming, setIsStreaming] = useState(false);
   const isStreamingRef = useRef(isStreaming);
   const [tools, setTools] = useState<PlaygroundTool[]>([]);
@@ -354,6 +361,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
         setOutputReasoning("");
         setOutputJson("");
         setOutputToolCalls([]);
+        setRuns([]);
 
         const finalMessages = getFinalMessages(
           promptVariables,
@@ -386,7 +394,126 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
         }
 
         let response = "";
-        if (tools.length > 0) {
+        if (runCount > 1) {
+          // Repetitions mode: execute the same configuration N times in
+          // parallel (always non-streaming) so output variance across runs
+          // can be inspected in a single submission.
+          setRuns(
+            Array.from({ length: runCount }, (_, index) => ({
+              index,
+              status: "running" as const,
+              content: "",
+              toolCalls: [],
+              latencyMs: 0,
+            })),
+          );
+
+          const executeOnce = async (): Promise<{
+            content: string;
+            reasoning?: string;
+            toolCalls: LLMToolCall[];
+          }> => {
+            if (tools.length > 0) {
+              const completion = await getChatCompletionWithTools(
+                projectId,
+                finalMessages,
+                modelParams,
+                tools,
+                false,
+              );
+
+              const displayContent =
+                typeof completion.content === "string"
+                  ? completion.content
+                  : ((completion.content.find(
+                      (m): m is { type: "text"; text: string } =>
+                        "type" in m && m.type === "text",
+                    )?.text as string) ?? "");
+
+              return {
+                content: displayContent,
+                reasoning: completion.reasoning,
+                toolCalls: completion.tool_calls,
+              };
+            }
+
+            if (structuredOutputSchema) {
+              const structuredResponse =
+                await getChatCompletionWithStructuredOutput(
+                  projectId,
+                  finalMessages,
+                  modelParams,
+                  structuredOutputSchema,
+                  false,
+                );
+
+              return { content: structuredResponse, toolCalls: [] };
+            }
+
+            const result = await getChatCompletionNonStreaming(
+              projectId,
+              finalMessages,
+              modelParams,
+            );
+
+            return {
+              content: result.content,
+              reasoning: result.reasoning,
+              toolCalls: [],
+            };
+          };
+
+          const results = await Promise.all(
+            Array.from({ length: runCount }, async (_, index) => {
+              const startedAt = performance.now();
+              let run: PlaygroundRunResult;
+              try {
+                const result = await executeOnce();
+                run = {
+                  index,
+                  status: "completed",
+                  content: result.content,
+                  reasoning: result.reasoning,
+                  toolCalls: result.toolCalls,
+                  latencyMs: Math.round(performance.now() - startedAt),
+                };
+              } catch (err) {
+                run = {
+                  index,
+                  status: "error",
+                  content: "",
+                  toolCalls: [],
+                  latencyMs: Math.round(performance.now() - startedAt),
+                  error:
+                    err instanceof Error ? err.message : "An error occurred",
+                };
+              }
+              setRuns((prev) =>
+                prev.map((prevRun) =>
+                  prevRun.index === index ? run : prevRun,
+                ),
+              );
+              return run;
+            }),
+          );
+
+          const firstCompleted = results.find(
+            (run) => run.status === "completed",
+          );
+          if (!firstCompleted) {
+            throw new Error(
+              results.find((run) => run.error)?.error ?? "All runs failed",
+            );
+          }
+
+          // Keep the single-output state in sync with the first completed run
+          // so existing consumers (copy, add-to-messages, cache) keep working.
+          setOutput(firstCompleted.content);
+          setOutputToolCalls(firstCompleted.toolCalls);
+          if (firstCompleted.reasoning)
+            setOutputReasoning(firstCompleted.reasoning);
+          response = firstCompleted.content;
+        } else if (tools.length > 0) {
           const completion = await getChatCompletionWithTools(
             projectId,
             finalMessages,
@@ -467,6 +594,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
           outputLength: response.length,
           toolCount: tools.length,
           isStructuredOutput: Boolean(structuredOutputSchema),
+          runCount,
         });
       } catch (err) {
         const errorMessage =
@@ -486,6 +614,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
       setPlaygroundCache,
       structuredOutputSchema,
       projectId,
+      runCount,
     ],
   );
 
@@ -745,6 +874,9 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
         outputReasoning,
         outputJson,
         outputToolCalls,
+        runs,
+        runCount,
+        setRunCount,
         handleSubmit,
         isStreaming,
         scrollToMessage,

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -522,12 +522,27 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
           }
 
           // Keep the single-output state in sync with the first completed run
-          // so existing consumers (copy, add-to-messages, cache) keep working.
+          // so existing consumers (cache restore, output JSON) keep working.
+          // With tool calls, serialize the same shape as the single-run tools
+          // path so cache restoration preserves the tool-call cards.
           setOutput(firstCompleted.content);
           setOutputToolCalls(firstCompleted.toolCalls);
           if (firstCompleted.reasoning)
             setOutputReasoning(firstCompleted.reasoning);
-          response = firstCompleted.content;
+          response =
+            firstCompleted.toolCalls.length > 0
+              ? JSON.stringify(
+                  {
+                    content: firstCompleted.content,
+                    tool_calls: firstCompleted.toolCalls,
+                    ...(firstCompleted.reasoning
+                      ? { reasoning: firstCompleted.reasoning }
+                      : {}),
+                  },
+                  null,
+                  2,
+                )
+              : firstCompleted.content;
         } else if (tools.length > 0) {
           const completion = await getChatCompletionWithTools(
             projectId,

--- a/web/src/features/playground/page/hooks/useWindowCoordination.ts
+++ b/web/src/features/playground/page/hooks/useWindowCoordination.ts
@@ -7,6 +7,47 @@ import {
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 /**
+ * Global repetitions setting shared by all playground windows, LangSmith-style:
+ * a single control next to "Run All" instead of per-window state. Stored at
+ * module level (like the window registry below) and read at execution time so
+ * submissions never capture a stale value.
+ */
+export const MAX_RUN_COUNT = 50;
+export const DEFAULT_RUN_COUNT = 1;
+
+let globalRunCount = DEFAULT_RUN_COUNT;
+const RUN_COUNT_CHANGE_EVENT = "playground:run-count-change";
+
+export const getGlobalRunCount = (): number => globalRunCount;
+
+export const setGlobalRunCount = (runCount: number): void => {
+  globalRunCount = Math.min(
+    Math.max(Math.round(runCount) || 1, 1),
+    MAX_RUN_COUNT,
+  );
+  playgroundEventBus.dispatchEvent(
+    new CustomEvent(RUN_COUNT_CHANGE_EVENT, { detail: { runCount } }),
+  );
+};
+
+/** Reactive view of the global repetitions setting. */
+export const useGlobalRunCount = (): number => {
+  const [runCount, setRunCount] = useState(globalRunCount);
+
+  useEffect(() => {
+    const handleChange = () => setRunCount(globalRunCount);
+    playgroundEventBus.addEventListener(RUN_COUNT_CHANGE_EVENT, handleChange);
+    return () =>
+      playgroundEventBus.removeEventListener(
+        RUN_COUNT_CHANGE_EVENT,
+        handleChange,
+      );
+  }, []);
+
+  return runCount;
+};
+
+/**
  * Playground window registry for coordinating actions across multiple playground windows
  * This Map stores references to all active playground windows and their handles
  * Key: windowId, Value: PlaygroundHandle interface

--- a/web/src/features/playground/page/index.tsx
+++ b/web/src/features/playground/page/index.tsx
@@ -3,7 +3,21 @@ import { Button } from "@/src/components/ui/button";
 import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import { Play } from "lucide-react";
 import { ResetPlaygroundButton } from "@/src/features/playground/page/components/ResetPlaygroundButton";
-import { useWindowCoordination } from "@/src/features/playground/page/hooks/useWindowCoordination";
+import {
+  MAX_RUN_COUNT,
+  setGlobalRunCount,
+  useGlobalRunCount,
+  useWindowCoordination,
+} from "@/src/features/playground/page/hooks/useWindowCoordination";
+import { Input } from "@/src/components/ui/input";
+import { Slider } from "@/src/components/ui/slider";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { ChevronDown, Repeat } from "lucide-react";
 import { usePersistedWindowIds } from "@/src/features/playground/page/hooks/usePersistedWindowIds";
 import useCommandEnter from "@/src/features/playground/page/hooks/useCommandEnter";
 import { type MultiWindowState } from "@/src/features/playground/page/types";
@@ -46,6 +60,7 @@ export default function PlaygroundPage() {
   }, []);
 
   const projectId = useProjectIdFromURL();
+  const runCount = useGlobalRunCount();
   const { windowIds, isLoaded, addWindowWithCopy, removeWindowId } =
     usePersistedWindowIds();
 
@@ -171,6 +186,51 @@ export default function PlaygroundPage() {
                   </>
                 )}
               </div>
+
+              {/* Global repetitions selector, LangSmith-style: applies to
+                  every submission (Run All and per-window Submit alike) */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    disabled={globalIsExecutingAll}
+                    className="hidden shrink-0 gap-1 md:flex"
+                    title="Number of times each window runs per submission"
+                  >
+                    <Repeat className="h-3 w-3" />
+                    <span>{`\u00d7${runCount}`}</span>
+                    <ChevronDown className="h-3 w-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-60 p-3">
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-bold">Repetitions</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={MAX_RUN_COUNT}
+                        value={runCount}
+                        onChange={(e) =>
+                          setGlobalRunCount(Number(e.target.value))
+                        }
+                        onKeyDown={(e) => e.stopPropagation()}
+                        className="h-7 w-16 text-xs"
+                      />
+                    </div>
+                    <Slider
+                      min={1}
+                      max={MAX_RUN_COUNT}
+                      step={1}
+                      value={[runCount]}
+                      onValueChange={(value) => setGlobalRunCount(value[0])}
+                    />
+                    <span className="text-muted-foreground text-xs">
+                      Runs per submission (max {MAX_RUN_COUNT})
+                    </span>
+                  </div>
+                </DropdownMenuContent>
+              </DropdownMenu>
 
               {/* Multi-Window Controls - Hidden on mobile */}
               <Button

--- a/web/src/features/playground/page/types.ts
+++ b/web/src/features/playground/page/types.ts
@@ -3,11 +3,27 @@ import {
   type LLMJSONSchema,
   type LlmSchema,
   type LlmTool,
+  type LLMToolCall,
   type LLMToolDefinition,
   type PlaceholderMessage,
   type PromptVariable,
   type UIModelParams,
 } from "@langfuse/shared";
+
+/**
+ * Result of a single execution within a repeated ("Run xN") playground
+ * submission. Collected per run so the output panel can show every response
+ * alongside deterministic consistency stats.
+ */
+export interface PlaygroundRunResult {
+  index: number;
+  status: "running" | "completed" | "error";
+  content: string;
+  reasoning?: string;
+  toolCalls: LLMToolCall[];
+  latencyMs: number;
+  error?: string;
+}
 
 export type PlaygroundTool = LLMToolDefinition & {
   id: string;

--- a/web/src/features/playground/page/utils/runStats.ts
+++ b/web/src/features/playground/page/utils/runStats.ts
@@ -16,6 +16,21 @@ export interface RunStats {
   distinctOutputCount: number;
 }
 
+/** JSON.stringify with recursively sorted object keys so semantically equal
+ * values normalize identically regardless of key insertion order. */
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+  return `{${entries.join(",")}}`;
+};
+
 const toolCallSignature = (name: string, args: unknown): string => {
   if (args && typeof args === "object" && !Array.isArray(args)) {
     const keys = Object.keys(args as Record<string, unknown>).sort();
@@ -28,7 +43,7 @@ const normalizeOutput = (run: PlaygroundRunResult): string => {
   const content = run.content.trim().replace(/\s+/g, " ");
   const toolCalls = run.toolCalls
     .map((toolCall) =>
-      JSON.stringify({ name: toolCall.name, args: toolCall.args }),
+      stableStringify({ name: toolCall.name, args: toolCall.args }),
     )
     .sort()
     .join("|");

--- a/web/src/features/playground/page/utils/runStats.ts
+++ b/web/src/features/playground/page/utils/runStats.ts
@@ -1,0 +1,86 @@
+import { type PlaygroundRunResult } from "../types";
+
+export interface RunStats {
+  totalCount: number;
+  completedCount: number;
+  errorCount: number;
+  latency: { min: number; avg: number; max: number } | null;
+  /**
+   * Per tool-call signature (tool name + sorted argument keys), the number of
+   * completed runs in which it was called at least once. Argument keys are
+   * part of the signature so runs that call the same tool with a different
+   * argument shape are surfaced as distinct behavior.
+   */
+  toolCallFrequencies: { signature: string; runCount: number }[];
+  /** Number of distinct normalized outputs across completed runs. */
+  distinctOutputCount: number;
+}
+
+const toolCallSignature = (name: string, args: unknown): string => {
+  if (args && typeof args === "object" && !Array.isArray(args)) {
+    const keys = Object.keys(args as Record<string, unknown>).sort();
+    return `${name}(${keys.join(", ")})`;
+  }
+  return `${name}()`;
+};
+
+const normalizeOutput = (run: PlaygroundRunResult): string => {
+  const content = run.content.trim().replace(/\s+/g, " ");
+  const toolCalls = run.toolCalls
+    .map((toolCall) =>
+      JSON.stringify({ name: toolCall.name, args: toolCall.args }),
+    )
+    .sort()
+    .join("|");
+  return `${content}::${toolCalls}`;
+};
+
+/**
+ * Deterministic consistency stats over a set of repeated playground runs:
+ * counts, frequencies, and latency distribution only — no model-based scoring.
+ */
+export function computeRunStats(runs: PlaygroundRunResult[]): RunStats {
+  const completed = runs.filter((run) => run.status === "completed");
+  const errored = runs.filter((run) => run.status === "error");
+
+  const latencies = completed.map((run) => run.latencyMs);
+  const latency =
+    latencies.length > 0
+      ? {
+          min: Math.min(...latencies),
+          avg: Math.round(
+            latencies.reduce((sum, value) => sum + value, 0) /
+              latencies.length,
+          ),
+          max: Math.max(...latencies),
+        }
+      : null;
+
+  const signatureRunCounts = new Map<string, number>();
+  for (const run of completed) {
+    const signaturesInRun = new Set(
+      run.toolCalls.map((toolCall) =>
+        toolCallSignature(toolCall.name, toolCall.args),
+      ),
+    );
+    for (const signature of signaturesInRun) {
+      signatureRunCounts.set(
+        signature,
+        (signatureRunCounts.get(signature) ?? 0) + 1,
+      );
+    }
+  }
+
+  const distinctOutputs = new Set(completed.map(normalizeOutput));
+
+  return {
+    totalCount: runs.length,
+    completedCount: completed.length,
+    errorCount: errored.length,
+    latency,
+    toolCallFrequencies: Array.from(signatureRunCounts.entries())
+      .map(([signature, runCount]) => ({ signature, runCount }))
+      .sort((a, b) => b.runCount - a.runCount),
+    distinctOutputCount: distinctOutputs.size,
+  };
+}


### PR DESCRIPTION
## Summary

Implements the proposal from #16013: a **repetitions** option in the Playground so the same window configuration can be executed N times in one submission, surfacing output variance — the thing a single execution hides when iterating on production prompts (especially tool-calling consistency).

## What it does

- **Repetitions selector (1/3/5/10)** in the submit settings dropdown, next to the existing streaming toggle. Submit button shows `Submit ×N`.
- With N > 1, the same configuration runs **N times in parallel** (always non-streaming); each run lands progressively in the output panel with its own latency, content, reasoning, and tool calls.
- **Deterministic consistency stats** above the runs (following the direction suggested by @bobleer in the discussion — no LLM-judged scoring):
  - completed/failed counts and latency min–max (avg)
  - distinct normalized outputs count
  - per tool-call signature (tool name + sorted argument keys), the number of runs that called it — e.g. `validate_customer(document): 4/5 runs`
- **N=1 (default) is byte-for-byte the existing behavior**, streaming included. "Run All" composes naturally: each window respects its own repetitions setting.

## Implementation notes

- `context`: extracted a non-streaming `executeOnce` used by the repetitions path; the single-run path is untouched. Runs land in a new `runs` state; the legacy single-output state is synced from the first completed run so existing consumers (copy, add-to-messages, cache) keep working.
- `utils/runStats.ts`: pure stats helpers, covered by unit tests (`playground-run-stats.clienttest.ts`).
- No changes to server routes — repetitions reuse the existing `/api/chatCompletion` endpoint per run.

## Testing

- `pnpm run typecheck` (web): clean
- `pnpm run lint` (web): clean
- `pnpm run test-client`: 3168 passed (includes 5 new tests for the stats helpers)
- Functional testing: pending — opening as **draft** to validate UX direction with maintainers first (per #16013), happy to iterate on the design or scope (e.g. different N options, stats placement, or gating behind a flag).

Closes #16013 if accepted.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds configurable repeated Playground executions with bounded parallel requests, progressive per-run output, and deterministic comparison statistics.

- Introduces a global repetition selector shared by per-window Submit and Run All.
- Adds repeated-run execution state, carousel output, latency/output/tool-call statistics, and helper tests.
- Preserves the existing single-output state and session cache for legacy consumers.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until repeated-run actions target the selected result, tool-call cache data is preserved, and equivalent tool arguments produce stable consistency statistics.

The new repeated-run path can copy or append a different result than the one displayed, loses tool calls when persisting repeated tool outputs, and overcounts output variance when argument key order differs.

**Files Needing Attention:** web/src/features/playground/page/components/GenerationOutput.tsx, web/src/features/playground/page/context/index.tsx, web/src/features/playground/page/utils/runStats.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant P as Playground window
  participant W as Bounded worker pool
  participant API as /api/chatCompletion
  participant O as Output carousel
  U->>P: Submit ×N
  P->>W: Queue N executions
  par Up to 5 concurrent runs
    W->>API: Non-streaming completion
    API-->>W: Content / reasoning / tool calls
  end
  W-->>O: Update each run progressively
  O-->>U: Runs and consistency statistics
  W->>P: Sync first successful run to legacy output/cache
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/playground/page/components/GenerationOutput.tsx:126-127
**Actions target the wrong run**

When a user navigates to a run other than the first completed one, the carousel updates only its local `activeIndex`, while Copy and Add to messages continue reading the legacy `output`, `outputJson`, and `outputToolCalls` state. Those actions therefore copy or append a different response and tool calls than the run currently visible.

### Issue 2
web/src/features/playground/page/context/index.tsx:530
**Repeated runs drop tool calls**

When a repeated submission uses tools, assigning only `firstCompleted.content` to `response` omits the successful run's tool calls from `outputJson` and the persisted cache. After a refresh, cache restoration falls back to plain text, so the tool-call cards disappear and Add to messages creates an assistant-text message instead of preserving the tool call.

### Issue 3
web/src/features/playground/page/utils/runStats.ts:31-34
**Argument order inflates variance**

When two runs return semantically identical tool arguments with object keys in different insertion orders, direct `JSON.stringify` calls produce different normalized values. This causes `distinctOutputCount` to report multiple outputs even though the content and tool calls are equivalent.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(playground): global repetitions..."](https://github.com/langfuse/langfuse/commit/c5c37ddfe3f36fb49b1753fbb43e2c959e84f873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52812109)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Prompt Management and Playground](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground.md)

<!-- /greptile_comment -->