### PR TITLE
feat(sessions): show existing annotation counts

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -1437,6 +1437,7 @@ const LoadedSessionEventsPage: React.FC<{
                     environment: session.environment,
                   }}
                   buttonVariant="outline"
+                  showAnnotationCount={isModernSessionEnabled}
                 />
                 <CreateNewAnnotationQueueItem
                   projectId={projectId}
@@ -1521,6 +1522,7 @@ const LoadedSessionEventsPage: React.FC<{
                 }}
                 buttonVariant="outline"
                 layout="menu"
+                showAnnotationCount={isModernSessionEnabled}
               />
               <CreateNewAnnotationQueueItem
                 projectId={projectId}

--- a/web/src/components/ui/action-button-count-badge.stories.tsx
+++ b/web/src/components/ui/action-button-count-badge.stories.tsx
@@ -1,0 +1,13 @@
+import preview from "../../../.storybook/preview";
+import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
+
+const meta = preview.meta({
+  component: ActionButtonCountBadge,
+  parameters: { a11y: { test: "error" } },
+});
+
+export default meta;
+
+export const Default = meta.story({ args: { count: 3 } });
+
+export const Overflow = meta.story({ args: { count: 120 } });

--- a/web/src/components/ui/action-button-count-badge.tsx
+++ b/web/src/components/ui/action-button-count-badge.tsx
@@ -1,19 +1,6 @@
-import { cn } from "@/src/utils/tailwind";
-
-export function ActionButtonCountBadge({
-  count,
-  className,
-}: {
-  count: number;
-  className?: string;
-}) {
+export function ActionButtonCountBadge({ count }: { count: number }) {
   return (
-    <span
-      className={cn(
-        "bg-primary/50 text-primary-foreground flex h-3.5 w-fit items-center justify-center rounded-sm px-1 text-xs shadow-xs",
-        className,
-      )}
-    >
+    <span className="bg-primary/50 text-primary-foreground flex h-3.5 w-fit items-center justify-center rounded-sm px-1 text-xs shadow-xs">
       {count > 99 ? "99+" : count}
     </span>
   );

--- a/web/src/components/ui/action-button-count-badge.tsx
+++ b/web/src/components/ui/action-button-count-badge.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/src/utils/tailwind";
+
+export function ActionButtonCountBadge({
+  count,
+  className,
+}: {
+  count: number;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "bg-primary/50 text-primary-foreground flex h-3.5 w-fit items-center justify-center rounded-sm px-1 text-xs shadow-xs",
+        className,
+      )}
+    >
+      {count > 99 ? "99+" : count}
+    </span>
+  );
+}

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @repo/no-style-props */
 import Header from "@/src/components/layouts/header";
+import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button, type ButtonProps } from "@/src/components/ui/button";
 import {
   Drawer,
@@ -192,9 +193,7 @@ export function CommentDrawerButton({
             />
             <span className={isMenu ? "text-sm" : undefined}>Add comment</span>
             {!!count ? (
-              <span className="bg-primary/50 text-primary-foreground flex h-3.5 w-fit items-center justify-center rounded-sm px-1 text-xs shadow-xs">
-                {count > 99 ? "99+" : count}
-              </span>
+              <ActionButtonCountBadge count={count} />
             ) : null}
           </div>
         </Button>

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -192,9 +192,7 @@ export function CommentDrawerButton({
               }
             />
             <span className={isMenu ? "text-sm" : undefined}>Add comment</span>
-            {!!count ? (
-              <ActionButtonCountBadge count={count} />
-            ) : null}
+            {!!count ? <ActionButtonCountBadge count={count} /> : null}
           </div>
         </Button>
       </DrawerTrigger>

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -83,7 +83,9 @@ export function AnnotateDrawer<Target extends ScoreTarget>({
           )}
           <span className={isMenu ? "text-sm" : undefined}>Annotate</span>
           {showAnnotationCount && annotationCount > 0 ? (
-            <ActionButtonCountBadge className="ml-1" count={annotationCount} />
+            <span className="ml-1">
+              <ActionButtonCountBadge count={annotationCount} />
+            </span>
           ) : null}
         </Button>
       </DrawerTrigger>

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button } from "@/src/components/ui/button";
 import { LockIcon, SquarePen } from "lucide-react";
 import {
@@ -24,6 +25,7 @@ export function AnnotateDrawer<Target extends ScoreTarget>({
   buttonVariant = "secondary",
   size = "default",
   layout = "toolbar",
+  showAnnotationCount = false,
 }: AnnotateDrawerProps<Target> & {
   size?: "default" | "sm" | "xs" | "lg" | "icon" | "icon-xs" | "icon-sm";
   /**
@@ -31,6 +33,7 @@ export function AnnotateDrawer<Target extends ScoreTarget>({
    * trigger as a full-width labeled row for the mobile header overflow popover.
    */
   layout?: "toolbar" | "menu";
+  showAnnotationCount?: boolean;
 }) {
   const isMenu = layout === "menu";
   const capture = usePostHogClientCapture();
@@ -42,6 +45,9 @@ export function AnnotateDrawer<Target extends ScoreTarget>({
   const hasNonAnnotationScores = scores.some(
     (score) => score.source !== "ANNOTATION",
   );
+  const annotationCount = scores.filter(
+    (score) => score.source === "ANNOTATION",
+  ).length;
 
   return (
     <Drawer>
@@ -76,6 +82,9 @@ export function AnnotateDrawer<Target extends ScoreTarget>({
             />
           )}
           <span className={isMenu ? "text-sm" : undefined}>Annotate</span>
+          {showAnnotationCount && annotationCount > 0 ? (
+            <ActionButtonCountBadge className="ml-1" count={annotationCount} />
+          ) : null}
         </Button>
       </DrawerTrigger>
       <DrawerContent className="p-3">


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16062.preview.langfuse.com](https://pr-16062.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- show existing counts on modern session comment and annotation actions
- count only manual `ANNOTATION` scores for annotations
- use a shared capped count badge, with Storybook coverage

## Impacted package

- `web`

## Verification

- Targeted Storybook test: 1 passed
- Targeted ESLint: passed
- Targeted Prettier: passed
- Full typecheck: unrelated existing failures outside the touched files

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds existing manual-annotation counts to modern session annotation actions and extracts the existing comment count styling into a reusable capped badge.

- Counts session scores whose source is `ANNOTATION`.
- Enables the count in the modern session toolbar and mobile menu actions.
- Reuses the badge for comment counts and adds default and overflow Storybook states.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable issues identified.

The count is derived from the same session score collection used by the annotation drawer, both responsive actions receive identical data and gating, and the comment badge extraction preserves existing behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(sessions): show existing annotation..."](https://github.com/langfuse/langfuse/commit/af26eb8c358637b28336d0fd6d1e36135a9f2bfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52900034)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->