### PR TITLE
fix(v4-migration): update migration deadline to November 15

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -69,7 +69,7 @@ import { buildDeprecatedEvaluatorsUrl } from "@/src/features/v4-migration/evalua
 
 const V4_DOCS_URL = "https://langfuse.com/docs/v4";
 // Consumed by the status page deadline copy.
-export const V4_MIGRATION_DEADLINE = "Oct 9";
+export const V4_MIGRATION_DEADLINE = "Nov 15";
 const SDK_UPGRADE_URL =
   "https://langfuse.com/docs/observability/sdk/upgrade-path";
 const OTEL_V4_MIGRATION_URL =

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -67,7 +67,7 @@ vi.mock("@/src/features/in-app-agent/components/InAppAiAgentProvider", () => ({
 }));
 
 vi.mock("@/src/features/v4-migration/V4MigrationContent", () => ({
-  V4_MIGRATION_DEADLINE: "Oct 9",
+  V4_MIGRATION_DEADLINE: "Nov 15",
   useCopyMigrationPrompt: () => vi.fn(),
 }));
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16064.preview.langfuse.com](https://pr-16064.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the displayed v4 migration deadline from October 9 to November 15 and aligns the status-page test mock with the new date.
- Changes the exported migration deadline copy to `Nov 15`.
- Updates the corresponding client-test mock.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The production deadline copy and its corresponding test mock are updated consistently, with no behavioral, security, or contract failures identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4-migration): update migration dead..."](https://github.com/langfuse/langfuse/commit/fee31b9d5ba48587450890f3b2321d2d8620cadc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52901184)</sub>

<!-- /greptile_comment -->