### PR TITLE
fix(web): expand the v4 delay badge hover text to its full width

### DIFF
--- a/web/src/features/v4-migration/V4MigrationBadgeContent.stories.tsx
+++ b/web/src/features/v4-migration/V4MigrationBadgeContent.stories.tsx
@@ -1,0 +1,65 @@
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+
+import preview from "../../../.storybook/preview";
+import { V4MigrationBadgeContent } from "./V4MigrationBadgeContent";
+
+// The longest copy the delay badge renders (V4MigrationDelayBadge); the
+// hover reveal must expand to whatever width this needs (LF-90).
+const OTEL_DESCRIPTION =
+  "Your setup is outdated. Update OTel instrumentation for real-time data";
+
+const meta = preview.meta({
+  component: V4MigrationBadgeContent,
+});
+
+export const Default = meta.story({
+  args: {
+    onClick: fn(),
+    title: "New data in ~15 min",
+    description: "Your setup is outdated. Update SDK for real-time data",
+  },
+});
+
+export const LongestDescription = meta.story({
+  args: {
+    onClick: fn(),
+    title: "New data in ~15 min",
+    description: OTEL_DESCRIPTION,
+  },
+});
+
+export const Compact = meta.story({
+  args: {
+    onClick: fn(),
+    title: "Action required",
+    compact: true,
+  },
+});
+
+export const TestFocusRevealsLongestDescription = meta.story({
+  name: "(Test) Focus Reveals Longest Description",
+  args: {
+    onClick: fn(),
+    title: "New data in ~15 min",
+    description: OTEL_DESCRIPTION,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = await canvas.findByRole("button");
+    // Synthetic hover cannot activate CSS :hover; the badge also reveals on
+    // focus-visible, which keyboard focus does trigger.
+    await userEvent.tab();
+    await expect(button).toHaveFocus();
+    // The description sits in an overflow-hidden wrapper that animates open;
+    // once expanded it must fit the whole text (no clipping mid-word).
+    const text = within(button).getByText(
+      /Update OTel instrumentation for real-time data/,
+    );
+    const clipBox = text.parentElement;
+    if (!clipBox) throw new Error("description wrapper not found");
+    await waitFor(() => {
+      expect(clipBox.clientWidth).toBeGreaterThan(0);
+      expect(clipBox.scrollWidth).toBeLessThanOrEqual(clipBox.clientWidth + 1);
+    });
+  },
+});

--- a/web/src/features/v4-migration/V4MigrationBadgeContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationBadgeContent.tsx
@@ -79,8 +79,12 @@ export function V4MigrationBadgeContent({
         <span className="flex items-center">
           {title}
           {description ? (
-            <span className="flex max-w-0 items-center overflow-hidden transition-[max-width] duration-300 ease-out group-hover:max-w-96 group-focus-visible:max-w-96">
-              <span className="whitespace-nowrap">.&nbsp;{description}.</span>
+            // 0fr -> 1fr animates to the intrinsic text width; a max-width cap
+            // would clip any description longer than the magic number (LF-90).
+            <span className="grid grid-cols-[0fr] transition-[grid-template-columns] duration-300 ease-out group-hover:grid-cols-[1fr] group-focus-visible:grid-cols-[1fr]">
+              <span className="min-w-0 overflow-hidden">
+                <span className="whitespace-nowrap">.&nbsp;{description}.</span>
+              </span>
             </span>
           ) : null}
           {showChevron ? (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16065.preview.langfuse.com](https://pr-16065.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Fixes [LF-90](https://linear.app/clickhouse/issue/LF-90/fix-text-is-cut-of-for-data-delay-badge).

## What changed

| Change | Ticket | Before | After |
| --- | --- | --- | --- |
| The "New data in ~15 min" badge's hover reveal animated `max-width` to a fixed 384px cap, so the longest copy variant (OTel, 403px at `text-xs` bold) was clipped mid-word before the chevron. The reveal now animates `grid-template-columns: 0fr → 1fr`, which expands to the intrinsic text width for any copy length — no magic number to outgrow. | [LF-90](https://linear.app/clickhouse/issue/LF-90/fix-text-is-cut-of-for-data-delay-badge) | ![before: hover text clipped at "real-time da"](https://raw.githubusercontent.com/langfuse/langfuse/9bad79ebddae5ad02b9030453e5e5bd5fccaa813/.screenshots-review/v4-migration-panel/lf-90-delay-badge-clip-v1/01-before-hover-otel-copy-clipped.png) | ![after: full sentence and chevron visible](https://raw.githubusercontent.com/langfuse/langfuse/9bad79ebddae5ad02b9030453e5e5bd5fccaa813/.screenshots-review/v4-migration-panel/lf-90-delay-badge-clip-v1/02-after-hover-otel-copy-full.png) |
| New Storybook coverage for `V4MigrationBadgeContent`: showcase stories for the badge copy variants plus a focus-driven play test asserting the longest description fits its reveal container. The test fails against the previous cap (`expected 403 to be less than or equal to 385`) and passes with this fix. | [LF-90](https://linear.app/clickhouse/issue/LF-90/fix-text-is-cut-of-for-data-delay-badge) | — | — |

The collapsed state is unchanged:

![collapsed badge unchanged](https://raw.githubusercontent.com/langfuse/langfuse/9bad79ebddae5ad02b9030453e5e5bd5fccaa813/.screenshots-review/v4-migration-panel/lf-90-delay-badge-clip-v1/03-after-collapsed-unchanged.png)

Impacted packages: `web` only.

## Verification

- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationDelayBadge.clienttest.tsx` — `Tests  8 passed (8)`
- `pnpm --filter web run test-storybook src/features/v4-migration/V4MigrationBadgeContent.stories.tsx` — `Tests  4 passed (4)`; the play test confirmed failing against the pre-fix component (`expected 403 to be less than or equal to 385`)
- `pnpm --filter web run lint` — exit 0 (pre-commit `turbo run lint`: `Tasks: 7 successful, 7 total`)
- `pnpm --filter web run typecheck` — exit 0
- Browser-verified on localhost with the OTel copy variant: reveal now opens to the full 403px text width (was capped at 384px), hover animation and collapsed state intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the delay badge’s fixed max-width reveal with an intrinsic-width grid animation and adds Storybook examples plus a focus-driven clipping test.
- Reveals the full OTel description instead of clipping it at 384px.
- Adds stories for default, longest-description, compact, and focus-test states.
- The unconstrained intrinsic width can overflow mobile viewports.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The mobile overflow caused by unconstrained intrinsic expansion should be fixed before merging.

The longest description is wider than common mobile viewports, while the changed reveal, badge, and mobile badge container provide no shrinking, wrapping, or viewport-width constraint.

**Files Needing Attention:** web/src/features/v4-migration/V4MigrationBadgeContent.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4-migration/V4MigrationBadgeContent.tsx:84-86
**Intrinsic reveal overflows mobile viewports**

When the long OTel badge is focused on a 375–390px mobile viewport, the non-shrinking `1fr` track expands the nowrap description to its approximately 403px intrinsic width, causing horizontal page overflow or placing part of the badge off-screen.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): storybook coverage for the v4..."](https://github.com/langfuse/langfuse/commit/981fe303a5fc36678726046ffbbb6efe073ab75c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52930312)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->