### PR TITLE
fix(datasets): update versioning documentation link

### DIFF
--- a/web/src/features/datasets/components/DatasetVersionHistoryPanel.tsx
+++ b/web/src/features/datasets/components/DatasetVersionHistoryPanel.tsx
@@ -90,7 +90,7 @@ export function DatasetVersionHistoryPanel({
 
   const openDocumentation = () => {
     window.open(
-      "https://langfuse.com/docs/datasets/dataset-versioning",
+      "https://langfuse.com/docs/evaluation/experiments/datasets#run-experiments-on-versioned-datasets",
       "_blank",
     );
   };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16069.preview.langfuse.com](https://pr-16069.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- replace the stale dataset versioning documentation URL with the current versioned experiments section

## Verification
- Not run per request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the dataset version-history panel’s documentation action to point directly to the current guidance for running experiments on versioned datasets.
- Replaces the stale dataset-versioning URL with the current experiments documentation route and section anchor.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the updated documentation link targets the intended current section.

The only behavioral change replaces a stale external documentation URL with a valid route and section that match the existing “How to use in experiments” action.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): update versioning documen..."](https://github.com/langfuse/langfuse/commit/6f1cb3bc4a1f5f95d4f222686c841e4fc064e995) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52912339)</sub>

<!-- /greptile_comment -->