### PR TITLE
docs(v4-migration): restyle badges and make sure assistant upgrade is opened in v4 content modal 

### DIFF
--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -61,13 +61,11 @@ import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeU
 import { V4MigrationBadgeContent } from "@/src/features/v4-migration/V4MigrationBadgeContent";
 import { buildEvaluatorUpgradeUrl } from "@/src/features/v4-migration/evaluatorMigrationUrls";
 
-function DeprecatedChipCell() {
+function DeprecatedChip() {
   return (
-    <div className="flex items-center gap-1.5">
-      <span className="bg-light-yellow text-dark-yellow inline-flex w-fit shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-bold whitespace-nowrap">
-        Deprecated
-      </span>
-    </div>
+    <span className="bg-light-yellow text-dark-yellow inline-flex w-fit shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-bold whitespace-nowrap">
+      Deprecated
+    </span>
   );
 }
 
@@ -182,7 +180,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("scoreName", {
       id: "scoreName",
       header: "Generated Score Name",
-      size: v4UpgradeUiEnabled ? 320 : 200,
+      size: 320,
       cell: (row) => {
         const scoreName = row.getValue();
         if (!scoreName) return undefined;
@@ -190,14 +188,18 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
         return (
           <div className="flex w-[calc(var(--col-scoreName-size)*1px-0.75rem)] items-center gap-2">
             <TableIdOrName value={scoreName} className="min-w-[4px] flex-1" />
-            {v4UpgradeUiEnabled && row.row.original.isLegacy ? (
+            {row.row.original.isLegacy ? (
               <span className="ml-auto justify-self-end">
-                <V4MigrationBadgeContent
-                  onClick={() => openEvaluatorUpgrade(row.row.original.id)}
-                  title="Upgrade now"
-                  showChevron={false}
-                  compact
-                />
+                {v4UpgradeUiEnabled ? (
+                  <V4MigrationBadgeContent
+                    onClick={() => openEvaluatorUpgrade(row.row.original.id)}
+                    title="Upgrade now"
+                    showChevron={false}
+                    compact
+                  />
+                ) : (
+                  <DeprecatedChip />
+                )}
               </span>
             ) : null}
           </div>
@@ -216,20 +218,6 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
             <StatusBadge type={status.toLowerCase()} />
           </div>
         );
-      },
-    }),
-    columnHelper.accessor("isLegacy", {
-      id: "isLegacy",
-      header: "Eval Version",
-      size: 180,
-      enableHiding: true,
-      loadingCell: <TableBadgeLoadingCell />,
-      cell: (row) => {
-        // Set by useEvaluatorTableData only for active legacy evaluators with
-        // a NEW time scope — the ones that actually require migration.
-        if (!row.row.original.isLegacy) return null;
-
-        return <DeprecatedChipCell />;
       },
     }),
     columnHelper.accessor("totalCost", {

--- a/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
+++ b/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
@@ -158,9 +158,8 @@ export function EvaluatorMigrationDialog({
                         "Open the evaluator upgrade form."
                       ) : (
                         <>
-                          Click evaluators with the Deprecated label to review{" "}
-                          <br />
-                          them and start each upgrade individually.
+                          Click the Upgrade now button on an evaluator to <br />
+                          review it and start each upgrade individually.
                         </>
                       )}
                     </span>

--- a/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
+++ b/web/src/features/v4-migration/EvaluatorMigrationDialog.tsx
@@ -27,6 +27,10 @@ type EvaluatorMigrationDialogProps = {
   assistantPrompt: string;
   onManualUpgrade: () => void;
   onAssistantStarted: () => void;
+  /** Opens the dialog with this action already selected, skipping the
+   *  choice screen. Only honored while AI features are enabled — otherwise
+   *  the choice screen keeps owning the enable-AI and admin-handoff flows. */
+  initialAction?: SelectedMigrationAction;
 };
 
 type SelectedMigrationAction = "assistant";
@@ -41,6 +45,7 @@ export function EvaluatorMigrationDialog({
   assistantPrompt,
   onManualUpgrade,
   onAssistantStarted,
+  initialAction,
 }: EvaluatorMigrationDialogProps) {
   const canUseAssistant = useCanUseInAppAgent();
   const { organization } = useQueryProjectOrOrganization();
@@ -56,6 +61,14 @@ export function EvaluatorMigrationDialog({
   const aiFeaturesEnabled = Boolean(organization?.aiFeaturesEnabled);
   const isSingleEvaluator = scope.type === "single";
   const showAssistantOption = canUseAssistant;
+  // With AI features disabled, the choice screen's assistant option owns the
+  // enable-AI and admin-handoff side effects, so the preselect only applies
+  // once the assistant can actually start.
+  const effectiveAction =
+    selectedAction ??
+    (initialAction === "assistant" && showAssistantOption && aiFeaturesEnabled
+      ? "assistant"
+      : null);
 
   const capture = usePostHogClientCapture();
   const startAssistant = async () => {
@@ -108,7 +121,7 @@ export function EvaluatorMigrationDialog({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {selectedAction === "assistant"
+              {effectiveAction === "assistant"
                 ? "Ready to start your evaluator upgrade?"
                 : isSingleEvaluator
                   ? "How would you like to upgrade this evaluator?"
@@ -116,7 +129,7 @@ export function EvaluatorMigrationDialog({
             </DialogTitle>
           </DialogHeader>
           <DialogBody className="gap-3">
-            {selectedAction === "assistant" ? (
+            {effectiveAction === "assistant" ? (
               <p className="text-muted-foreground text-sm">
                 {aiFeaturesEnabled
                   ? "The Assistant will review your deprecated evaluators and suggest upgrading all of them at once."
@@ -168,17 +181,21 @@ export function EvaluatorMigrationDialog({
               </>
             )}
           </DialogBody>
-          {selectedAction ? (
+          {effectiveAction ? (
             <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  setSelectedAction(null);
-                }}
-              >
-                Back
-              </Button>
+              {/* Back returns to the choice screen; when the dialog opened
+                  preselected there is no choice screen to go back to. */}
+              {selectedAction ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setSelectedAction(null);
+                  }}
+                >
+                  Back
+                </Button>
+              ) : null}
               <Button
                 type="button"
                 onClick={startAssistant}

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -320,16 +320,17 @@ describe("V4MigrationDetailsContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("uses Retarget consistently for affected evals", () => {
+  it("uses Update consistently for affected evals", () => {
     mocks.migrationData.evals = { status: "loaded", count: 2 };
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Retarget Evals/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Update Evals/ }));
     expect(
-      screen.getByText(/Retarget them at observations/),
+      screen.getByText(/Update them to target observations/),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Repoint them/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Retarget them/)).not.toBeInTheDocument();
   });
 
   it("shows the experiment instrumentation upgrade requirement", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -299,7 +299,7 @@ describe("V4MigrationDetailsContent", () => {
         "Evals, experiments, APIs and integrations are up to date.",
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Repoint Evals")).not.toBeInTheDocument();
+    expect(screen.queryByText("Update Evals")).not.toBeInTheDocument();
     expect(screen.queryByText("Experiments")).not.toBeInTheDocument();
     expect(screen.queryByText("Migrate APIs")).not.toBeInTheDocument();
     expect(screen.queryByText("Migrate Integrations")).not.toBeInTheDocument();
@@ -315,7 +315,7 @@ describe("V4MigrationDetailsContent", () => {
       screen.getByText("Evals and experiments are up to date."),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("Repoint Evals", { exact: true }),
+      screen.queryByText("Update Evals", { exact: true }),
     ).not.toBeInTheDocument();
   });
 
@@ -851,12 +851,18 @@ describe("V4MigrationDetailsContent", () => {
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
+    // The panel entry point preselects the assistant: no choice screen.
     const migrationDialog = screen.getByRole("dialog");
-    fireEvent.click(
-      within(migrationDialog).getByRole("button", {
+    expect(
+      within(migrationDialog).getByRole("heading", {
+        name: "Ready to start your evaluator upgrade?",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(migrationDialog).queryByRole("button", {
         name: /^Use Assistant/,
       }),
-    );
+    ).not.toBeInTheDocument();
     fireEvent.click(
       within(migrationDialog).getByRole("button", {
         name: "Start upgrade now",
@@ -872,6 +878,33 @@ describe("V4MigrationDetailsContent", () => {
     );
   });
 
+  it("keeps the choice screen when AI features are disabled", () => {
+    mocks.migrationData.evals = { status: "loaded", count: 1 };
+    mocks.aiFeaturesEnabled = false;
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    // Without AI features the button drops the assistant branding …
+    expect(
+      screen.queryByRole("button", { name: "Use Assistant" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Update evals" }));
+
+    // … and the dialog does not preselect the assistant, so the choice
+    // screen keeps owning the enable-AI flow.
+    const migrationDialog = screen.getByRole("dialog");
+    expect(
+      within(migrationDialog).getByRole("heading", {
+        name: "How would you like to upgrade your evaluators?",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(migrationDialog).getByRole("button", {
+        name: /^Use Assistant/,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("shows the admin handoff after a non-admin chooses the Assistant", () => {
     mocks.migrationData.evals = { status: "loaded", count: 1 };
     mocks.canUpdateOrgSettings = false;
@@ -879,7 +912,7 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update evals" }));
     const migrationDialog = screen.getByRole("dialog");
     fireEvent.click(
       within(migrationDialog).getByRole("button", {

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -850,11 +850,11 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
+    fireEvent.click(screen.getByRole("button", { name: "Repoint evals" }));
     const migrationDialog = screen.getByRole("dialog");
     fireEvent.click(
       within(migrationDialog).getByRole("button", {
-        name: /^Use Assistant/,
+        name: /^Repoint evals/,
       }),
     );
     fireEvent.click(
@@ -879,11 +879,11 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
+    fireEvent.click(screen.getByRole("button", { name: "Repoint evals" }));
     const migrationDialog = screen.getByRole("dialog");
     fireEvent.click(
       within(migrationDialog).getByRole("button", {
-        name: /^Use Assistant/,
+        name: /^Repoint evals/,
       }),
     );
 

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -850,11 +850,11 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Repoint evals" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
     const migrationDialog = screen.getByRole("dialog");
     fireEvent.click(
       within(migrationDialog).getByRole("button", {
-        name: /^Repoint evals/,
+        name: /^Use Assistant/,
       }),
     );
     fireEvent.click(
@@ -879,11 +879,11 @@ describe("V4MigrationDetailsContent", () => {
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Repoint evals" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use Assistant" }));
     const migrationDialog = screen.getByRole("dialog");
     fireEvent.click(
       within(migrationDialog).getByRole("button", {
-        name: /^Repoint evals/,
+        name: /^Use Assistant/,
       }),
     );
 

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -2,14 +2,7 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import {
-  Bot,
-  BotMessageSquare,
-  Check,
-  ChevronRight,
-  Copy,
-  Info,
-} from "lucide-react";
+import { Bot, Check, ChevronRight, Copy, Info } from "lucide-react";
 import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { Button } from "@/src/components/ui/button";
@@ -667,8 +660,7 @@ export function V4MigrationEvalsSection({
           </p>
           {assistant && (
             <Button variant="outline" size="sm" onClick={assistant.onMigrate}>
-              <BotMessageSquare className="mr-1.5 h-4 w-4" />
-              Use Assistant
+              Repoint evals
             </Button>
           )}
         </>

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -52,7 +52,10 @@ import {
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { numberFormatter } from "@/src/utils/numbers";
 import { formatCompactRelativeTime } from "@/src/utils/dates";
-import { useProject } from "@/src/features/projects/hooks";
+import {
+  useProject,
+  useQueryProjectOrOrganization,
+} from "@/src/features/projects/hooks";
 import { V4PreviewToggleRow } from "@/src/features/events/components/V4SidebarToggle";
 import {
   useEvalUpgradeAssistantPlan,
@@ -607,8 +610,10 @@ export function V4MigrationEvalsSection({
   defaultOpen,
 }: {
   state: MigrationCountState;
-  /** Assistant CTA; null hides the button. */
-  assistant: { onMigrate: () => void } | null;
+  /** Upgrade CTA; null hides the button. Assistant branding only while AI
+   *  features are on — otherwise the dialog opens on its choice screen, so
+   *  the button must not promise the assistant. */
+  assistant: { onMigrate: () => void; aiFeaturesEnabled?: boolean } | null;
   evalsUrl?: string;
   onNavigate?: () => void;
   defaultOpen?: boolean;
@@ -616,7 +621,7 @@ export function V4MigrationEvalsSection({
   const capture = usePostHogClientCapture();
   return (
     <Section
-      title="Repoint Evals"
+      title="Update Evals"
       analyticsSection="evals"
       count={state.status === "loaded" ? state.count : undefined}
       meta={
@@ -662,13 +667,19 @@ export function V4MigrationEvalsSection({
                 input/output
               </>
             )}
-            , which v4 no longer sets. Repoint{" "}
-            {state.count === 1 ? "it" : "them"} at observations.
+            , which v4 no longer sets. Update{" "}
+            {state.count === 1 ? "it" : "them"} to target observations.
           </p>
           {assistant && (
             <Button variant="outline" size="sm" onClick={assistant.onMigrate}>
-              <BotMessageSquare className="mr-1.5 h-4 w-4" />
-              Use Assistant
+              {assistant.aiFeaturesEnabled !== false ? (
+                <>
+                  <BotMessageSquare className="mr-1.5 h-4 w-4" />
+                  Use Assistant
+                </>
+              ) : (
+                "Update evals"
+              )}
             </Button>
           )}
         </>
@@ -1269,6 +1280,10 @@ export function V4MigrationDetailsContent({
     openSupportDrawerWithMode("form", { topic: "V4 Migration" });
   };
   const canUseAssistant = useCanUseInAppAgent();
+  // Same org source as EvaluatorMigrationDialog's gating, so the button
+  // branding and the dialog's preselect can't disagree.
+  const { organization: routeOrganization } = useQueryProjectOrOrganization();
+  const aiFeaturesEnabled = Boolean(routeOrganization?.aiFeaturesEnabled);
   const [evalMigrationDialogOpen, setEvalMigrationDialogOpen] = useState(false);
   const upgradePlan = useEvalUpgradeAssistantPlan({
     projectId,
@@ -1320,7 +1335,10 @@ export function V4MigrationDetailsContent({
               state={migrationData.evals}
               assistant={
                 canUseAssistant
-                  ? { onMigrate: handleMigrateEvalsWithAgent }
+                  ? {
+                      onMigrate: handleMigrateEvalsWithAgent,
+                      aiFeaturesEnabled,
+                    }
                   : null
               }
               evalsUrl={evalsUrl}
@@ -1440,6 +1458,7 @@ export function V4MigrationDetailsContent({
           open={evalMigrationDialogOpen}
           onOpenChange={setEvalMigrationDialogOpen}
           scope={{ type: "all" }}
+          initialAction="assistant"
           assistantPrompt={upgradePlan.assistantPrompt}
           onManualUpgrade={handleManualEvalUpgrade}
           onAssistantStarted={() => onNavigate?.()}

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -2,7 +2,14 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { Bot, Check, ChevronRight, Copy, Info } from "lucide-react";
+import {
+  Bot,
+  BotMessageSquare,
+  Check,
+  ChevronRight,
+  Copy,
+  Info,
+} from "lucide-react";
 import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { Button } from "@/src/components/ui/button";
@@ -660,7 +667,8 @@ export function V4MigrationEvalsSection({
           </p>
           {assistant && (
             <Button variant="outline" size="sm" onClick={assistant.onMigrate}>
-              Repoint evals
+              <BotMessageSquare className="mr-1.5 h-4 w-4" />
+              Use Assistant
             </Button>
           )}
         </>

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -540,8 +540,8 @@ function V4MigrationStatusPageContent() {
           >
             one prompt
           </button>
-          : the agent updates your SDK, repoints your evals, and migrates your
-          API calls, checking with you before it changes anything.
+          : the agent updates your SDK and evals, and migrates your API calls,
+          checking with you before it changes anything.
         </>
       ),
     },


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16070.preview.langfuse.com](https://pr-16070.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR renames the V4 evaluations migration action and updates its client tests, but uses copy that differs from the requested label.
- Removes the assistant icon from the migration action.
- Changes the button and dialog test selectors from “Use Assistant” to “Update evals”.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The copy mismatch should be corrected before merging so the UI and tests implement the requested “Upgrade evals” label.

The changed component renders “Repoint evals” while the stated change requires “Upgrade evals”, and the tests reinforce the incorrect label.

**Files Needing Attention:** web/src/features/v4-migration/V4MigrationContent.tsx; web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4-migration/V4MigrationContent.tsx:661
**Migration action uses wrong label**

When the migration assistant is available, this button renders “Repoint evals” instead of the requested “Upgrade evals”, causing the UI and updated test expectations to encode the wrong product copy.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(v4-migration): rename &quot;Use Assi..."](https://github.com/langfuse/langfuse/commit/6b1545eb4096589d6c43455387267fde777842b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52916390)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->