### PR TITLE
chore: reproduce clickhouse analyzer issues

### DIFF
--- a/scripts/clickhouse-analyzer-repro/README.md
+++ b/scripts/clickhouse-analyzer-repro/README.md
@@ -1,0 +1,182 @@
+# ClickHouse analyzer/query-plan reproductions
+
+This directory contains three self-contained optimizer reproductions extracted
+from Langfuse customer reports. Docker only selects and isolates ClickHouse
+versions; every database setup, trigger query, and mitigation is plain SQL.
+
+The version column below means **the highest official Docker build directly
+tested failing**, not an inferred affected range.
+
+| Issue class | Combinations of flags to mitigate, least broad impact first | Last ClickHouse version reproduced on |
+| --- | --- | --- |
+| `FINAL` + preserved-side `LEFT JOIN` + `ORDER BY/LIMIT`: `topKThroughJoin` and filter push-down leave lazy materialization with a dangling predicate input (`NOT_FOUND_COLUMN_IN_BLOCK`) | `query_plan_top_k_through_join=0` (recommended); or per query `query_plan_max_limit_for_lazy_materialization < LIMIT`; or `query_plan_filter_push_down=0`; or `query_plan_optimize_lazy_materialization=0`; or `query_plan_enable_optimizations=0`; broad fallback: `enable_analyzer=0` / `allow_experimental_analyzer=0` | **26.7.1.1315** (first tested working: 26.7.2.59) |
+| Lightweight-update patch parts + lazy materialization lose internal `_block_number` during an in-order read (`NOT_FOUND_COLUMN_IN_BLOCK`) | Per query `query_plan_max_limit_for_lazy_materialization < LIMIT`; or `query_plan_optimize_lazy_materialization=0`; broad fallback: `enable_analyzer=0` / `allow_experimental_analyzer=0` | **26.3.17.110** (first tested working: 26.4.1.1141) |
+| `Distributed` table + shared-subexpression `ALIAS` columns + `ORDER BY`: remote and initiator projection headers differ, then positional mapping casts a `UInt64` into `Map(String, Decimal(38,12))` (`TYPE_MISMATCH`) | No narrow flag found. Least-impact workaround is a query rewrite: project in an inner query, then apply `ORDER BY`/`LIMIT BY`/`LIMIT` in an outer query block. Flag fallback: `enable_analyzer=0` / `allow_experimental_analyzer=0` | **26.6.1.1193** (first tested working: 26.6.2.81) |
+
+## Run a reproduction
+
+Each command starts isolated official ClickHouse containers, runs a setup SQL
+file, verifies the baseline result, verifies every effective mitigation, and
+removes its containers again.
+
+```bash
+./scripts/clickhouse-analyzer-repro/run.sh scores 26.7.1.1315 fail
+./scripts/clickhouse-analyzer-repro/run.sh patch-parts 26.3.17.110 fail
+./scripts/clickhouse-analyzer-repro/run.sh distributed 26.6.1.1193 fail
+```
+
+Use `pass` instead of `fail` for a fixed-version control:
+
+```bash
+./scripts/clickhouse-analyzer-repro/run.sh scores 26.7.2.59 pass
+./scripts/clickhouse-analyzer-repro/run.sh patch-parts 26.4.1.1141 pass
+./scripts/clickhouse-analyzer-repro/run.sh distributed 26.6.2.81 pass
+```
+
+Run every version boundary used in this report:
+
+```bash
+./scripts/clickhouse-analyzer-repro/verify-matrix.sh
+```
+
+The SQL can also be run manually. For a single-node case, run its `*-setup.sql`
+and then `*-repro.sql` in the same server. For the distributed case, start two
+servers with `distributed-cluster.xml`, run `distributed-node2-setup.sql` on
+node 2, then `distributed-node1-setup.sql` and `distributed-repro.sql` on node
+1. The `*-mitigations.sql` files are passing controls.
+
+## Setting isolation
+
+### 1. Scores / top-K-through-join class
+
+The minimal SQL is `scores-setup.sql` + `scores-repro.sql`.
+
+All of these independently make the failing query succeed on 26.7.1.1315:
+
+| Option | Result | Scope |
+| --- | --- | --- |
+| `query_plan_top_k_through_join=0` | passes | Directly disables the optimization that creates the bad plan; narrowest robust setting. |
+| `query_plan_max_limit_for_lazy_materialization=4` with query `LIMIT 5` | passes | Avoids lazy materialization for this query shape; useful only as a per-query threshold. A value equal to the limit still fails. |
+| `query_plan_filter_push_down=0` | passes | Disables a broader plan transformation involved in the interaction. |
+| `query_plan_optimize_lazy_materialization=0` | passes | Disables lazy materialization for the whole query. |
+| `query_plan_enable_optimizations=0` | passes | Much broader than needed. |
+| `enable_analyzer=0` or `allow_experimental_analyzer=0` | passes | Broadest fallback. |
+
+Tested individually with **no effect**: `query_plan_read_in_order=0`,
+`optimize_read_in_order=0`, `query_plan_execute_functions_after_sorting=0`,
+`query_plan_push_down_limit=0`, `query_plan_merge_expressions=0`,
+`query_plan_merge_filters=0`, `query_plan_remove_unused_columns=0`,
+`query_plan_split_filter=0`, `optimize_move_to_prewhere=0`, and
+`query_plan_optimize_prewhere=0`. Changing join algorithm/strictness also did
+not remove the class.
+
+Removing any of `FINAL`, the `LEFT JOIN`, `ORDER BY`, or `LIMIT` avoids the
+failure; so does changing the join to `INNER`. Those are trigger-isolation
+controls, not generally equivalent application rewrites.
+
+Version observations:
+
+| Docker/server version | Baseline |
+| --- | --- |
+| 26.5.5.8 | fails |
+| 26.6.1.1193 | fails |
+| 26.6.2.81 | fails |
+| 26.7.1.1315 | fails |
+| 26.7.2.59 | passes |
+
+Upstream provenance:
+
+- [ClickHouse #109210](https://github.com/ClickHouse/ClickHouse/issues/109210)
+  is the exact minimized bug report.
+- [PR #104268](https://github.com/ClickHouse/ClickHouse/pull/104268)
+  introduced `query_plan_top_k_through_join` in 26.5.1.651.
+- [PR #110722](https://github.com/ClickHouse/ClickHouse/pull/110722) fixes
+  the dangling filter input. It landed in 26.7.1.1334 and was backported to
+  26.7.2.11, 26.6.2.108, and 26.5.6.70.
+
+### 2. Patch-parts class
+
+The minimal SQL is `patch-parts-setup.sql` + `patch-parts-repro.sql`.
+
+| Option | Result on 26.3.17.110 | Scope |
+| --- | --- | --- |
+| `query_plan_max_limit_for_lazy_materialization=4` with query `LIMIT 5` | passes | Least broad per-query setting. |
+| `query_plan_optimize_lazy_materialization=0` | passes | Robust setting workaround for all patch-part query shapes. |
+| `enable_analyzer=0` or `allow_experimental_analyzer=0` | passes | Broad fallback. |
+| `query_plan_enable_optimizations=0` | **still fails** | The lazy-materialization pass is not suppressed by this umbrella flag in the tested build. |
+| `query_plan_filter_push_down=0`, `query_plan_read_in_order=0`, or `optimize_read_in_order=0` | **still fails** | Not causal. |
+
+Version observations:
+
+| Docker/server version | Baseline |
+| --- | --- |
+| 25.12.11.4 | fails |
+| 26.2.19.43 | fails |
+| 26.3.17.110 | fails |
+| 26.4.1.1141 | passes |
+
+[ClickHouse PR #102904](https://github.com/ClickHouse/ClickHouse/pull/102904)
+is both the upstream reproduction and fix: skip lazy materialization whenever
+the mutation snapshot has patch parts. It merged in 26.4.1.1005. Automated
+backport PRs to [25.8](https://github.com/ClickHouse/ClickHouse/pull/106432)
+and [26.3](https://github.com/ClickHouse/ClickHouse/pull/106433) were closed
+without merging, consistent with the tested failures.
+
+### 3. Distributed output-column-order class
+
+The minimal two-node SQL is `distributed-node1-setup.sql`,
+`distributed-node2-setup.sql`, and `distributed-repro.sql`.
+
+| Option or rewrite | Result on 26.6.1.1193 |
+| --- | --- |
+| Move `ORDER BY` and the row limit/dedup operation to an outer query block | passes; recommended workaround because unrelated optimizer features stay enabled |
+| `enable_analyzer=0` or `allow_experimental_analyzer=0` | passes; broad fallback |
+| `query_plan_optimize_lazy_materialization=0` | **still fails** |
+| `query_plan_enable_optimizations=0` | **still fails** |
+| `distributed_push_down_limit=0` | **still fails** |
+| `query_plan_filter_push_down=0` | **still fails** |
+| `query_plan_read_in_order=0` or `optimize_read_in_order=0` | **still fails** |
+| `query_plan_execute_functions_after_sorting=0` | **still fails** |
+| `serialize_query_plan=0` or `serialize_query_plan=1` | **still fails** |
+
+Removing `ORDER BY`, reading the local table, or replacing the table `ALIAS`
+columns with ordinary SELECT expressions avoids the failure. Removing only
+`LIMIT` does **not** avoid it. Wrapping the already-sorted query also does not
+help: the sort must move into the outer query block.
+
+Version observations:
+
+| Docker/server version | Baseline |
+| --- | --- |
+| 25.12.8.9 | fails |
+| 26.6.1.1193 | fails |
+| 26.6.2.81 | passes |
+| 26.7.1.1315 | passes |
+
+The direct upstream lineage is
+[ClickHouse #79916](https://github.com/ClickHouse/ClickHouse/issues/79916),
+[#81631](https://github.com/ClickHouse/ClickHouse/issues/81631), and
+[#97899](https://github.com/ClickHouse/ClickHouse/issues/97899), fixed by
+[PR #107675](https://github.com/ClickHouse/ClickHouse/pull/107675). The fix
+preserves projection-output order before the initiator's positional mapping.
+It landed in 26.7.1.245 and was backported to 26.6.2.46, 26.5.6.28,
+26.4.5.115, 26.3.17.34, and 25.8.29.10. No 25.12 backport is listed.
+
+## Related Langfuse issues, classified
+
+| Langfuse issue/PR | Classification |
+| --- | --- |
+| [#13809](https://github.com/langfuse/langfuse/issues/13809), [#14065](https://github.com/langfuse/langfuse/issues/14065), [#14156](https://github.com/langfuse/langfuse/issues/14156), [#14349](https://github.com/langfuse/langfuse/issues/14349), [#14496](https://github.com/langfuse/langfuse/issues/14496), [#14792](https://github.com/langfuse/langfuse/issues/14792), [#15125](https://github.com/langfuse/langfuse/issues/15125), [#15977](https://github.com/langfuse/langfuse/issues/15977) | Same Scores/top-K/lazy-plan class. Reports blaming `none of`, serialized sets, or `and()` syntax are observing an internal analyzer expression in the exception, not malformed generated SQL. |
+| [PR #13693](https://github.com/langfuse/langfuse/pull/13693) | Added the global lazy-materialization workaround for the separate patch-parts class. It later happened to mitigate the Scores class too. |
+| [PR #14187](https://github.com/langfuse/langfuse/pull/14187) | Added automatic ClickHouse version detection, but models all affected versions as one open-ended lazy-materialization band. It cannot mitigate the Distributed class. |
+| [#14431](https://github.com/langfuse/langfuse/issues/14431) | Distributed projection-order class. The customer explicitly confirmed `query_plan_optimize_lazy_materialization=0` did not help. |
+| [#12545](https://github.com/langfuse/langfuse/issues/12545) / [PR #12546](https://github.com/langfuse/langfuse/pull/12546) | Performance issue and query-shape change that exposed #14431 by replacing `FINAL` with `ORDER BY ... LIMIT 1 BY`; not the ClickHouse defect itself. |
+| [PR #14432](https://github.com/langfuse/langfuse/pull/14432) | Open application-side workaround for #14431 that moves ordering/deduplication to an outer query block. The minimal SQL here validates that exact boundary. |
+| [#15529](https://github.com/langfuse/langfuse/issues/15529) | Intermittent timeout/load report. No deterministic analyzer exception or matching SQL trigger; excluded from these optimizer classes. |
+
+## Scope note
+
+The patch-parts setup intentionally uses two tiny inserts, a lightweight
+`UPDATE`, and `OPTIMIZE ... FINAL` solely to manufacture the internal storage
+state needed for the bug. It is a regression fixture, not production ingestion
+or mutation guidance.

--- a/scripts/clickhouse-analyzer-repro/distributed-cluster.xml
+++ b/scripts/clickhouse-analyzer-repro/distributed-cluster.xml
@@ -1,0 +1,18 @@
+<clickhouse>
+    <remote_servers>
+        <repro_cluster>
+            <shard>
+                <replica>
+                    <host>ch-analyzer-repro-node1</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>ch-analyzer-repro-node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </repro_cluster>
+    </remote_servers>
+</clickhouse>

--- a/scripts/clickhouse-analyzer-repro/distributed-mitigations.sql
+++ b/scripts/clickhouse-analyzer-repro/distributed-mitigations.sql
@@ -1,0 +1,36 @@
+-- There is no narrow optimizer flag for this class. Moving ORDER BY/LIMIT to
+-- an outer query block avoids the broken mergeable-stage output header without
+-- disabling unrelated optimizations.
+
+SELECT 'outer ORDER BY query block' AS mitigation;
+SELECT
+    cost_details,
+    observation_count,
+    raw_count,
+    another_count,
+    derived_count
+FROM
+(
+    SELECT
+        map('total', toDecimal128(1, 12)) AS cost_details,
+        observation_count,
+        raw_count,
+        another_count,
+        observation_count + 1 AS derived_count,
+        sort_key
+    FROM distributed_map_cast
+) AS result
+ORDER BY sort_key ASC
+LIMIT 1;
+
+SELECT 'enable_analyzer=0' AS mitigation;
+SELECT
+    map('total', toDecimal128(1, 12)) AS cost_details,
+    observation_count,
+    raw_count,
+    another_count,
+    observation_count + 1 AS derived_count
+FROM distributed_map_cast
+ORDER BY sort_key ASC
+LIMIT 1
+SETTINGS enable_analyzer = 0;

--- a/scripts/clickhouse-analyzer-repro/distributed-node1-setup.sql
+++ b/scripts/clickhouse-analyzer-repro/distributed-node1-setup.sql
@@ -1,0 +1,24 @@
+-- Setup for the initiator/data shard of the Distributed analyzer repro.
+
+DROP TABLE IF EXISTS distributed_map_cast;
+DROP TABLE IF EXISTS distributed_map_cast_local;
+
+CREATE TABLE distributed_map_cast_local
+(
+    sort_key Int32,
+    raw_count UInt64,
+    observation_count UInt64 ALIAS raw_count + 1,
+    another_count UInt64 ALIAS raw_count + 2
+)
+ENGINE = MergeTree
+ORDER BY sort_key;
+
+CREATE TABLE distributed_map_cast AS distributed_map_cast_local
+ENGINE = Distributed(
+    repro_cluster,
+    currentDatabase(),
+    distributed_map_cast_local,
+    rand()
+);
+
+INSERT INTO distributed_map_cast_local VALUES (10, 41), (20, 99);

--- a/scripts/clickhouse-analyzer-repro/distributed-node2-setup.sql
+++ b/scripts/clickhouse-analyzer-repro/distributed-node2-setup.sql
@@ -1,0 +1,13 @@
+-- The second shard has the same schema and deliberately remains empty.
+
+DROP TABLE IF EXISTS distributed_map_cast_local;
+
+CREATE TABLE distributed_map_cast_local
+(
+    sort_key Int32,
+    raw_count UInt64,
+    observation_count UInt64 ALIAS raw_count + 1,
+    another_count UInt64 ALIAS raw_count + 2
+)
+ENGINE = MergeTree
+ORDER BY sort_key;

--- a/scripts/clickhouse-analyzer-repro/distributed-repro.sql
+++ b/scripts/clickhouse-analyzer-repro/distributed-repro.sql
@@ -1,0 +1,19 @@
+-- Reproduces the class behind langfuse/langfuse#14431 and the upstream
+-- ClickHouse issues #79916, #81631 and #97899.
+--
+-- The remote and initiator output headers are ordered differently. Positional
+-- mapping then tries to put a UInt64 alias expression into cost_details.
+-- Expected failure:
+--   Code: 53 ... Unsupported types to CAST AS Map. Left type: UInt64 ...
+
+SELECT version() AS clickhouse_version;
+
+SELECT
+    map('total', toDecimal128(1, 12)) AS cost_details,
+    observation_count,
+    raw_count,
+    another_count,
+    observation_count + 1 AS derived_count
+FROM distributed_map_cast
+ORDER BY sort_key ASC
+LIMIT 1;

--- a/scripts/clickhouse-analyzer-repro/patch-parts-mitigations.sql
+++ b/scripts/clickhouse-analyzer-repro/patch-parts-mitigations.sql
@@ -1,0 +1,26 @@
+-- A per-query limit threshold is the least broad setting workaround when the
+-- query limit is known. Disabling lazy materialization is the robust fallback.
+
+SELECT 'query_plan_max_limit_for_lazy_materialization=4' AS mitigation;
+SELECT lazy
+FROM patch_parts_repro
+WHERE filt > 0
+ORDER BY id
+LIMIT 5
+SETTINGS query_plan_max_limit_for_lazy_materialization = 4;
+
+SELECT 'query_plan_optimize_lazy_materialization=0' AS mitigation;
+SELECT lazy
+FROM patch_parts_repro
+WHERE filt > 0
+ORDER BY id
+LIMIT 5
+SETTINGS query_plan_optimize_lazy_materialization = 0;
+
+SELECT 'enable_analyzer=0' AS mitigation;
+SELECT lazy
+FROM patch_parts_repro
+WHERE filt > 0
+ORDER BY id
+LIMIT 5
+SETTINGS enable_analyzer = 0;

--- a/scripts/clickhouse-analyzer-repro/patch-parts-repro.sql
+++ b/scripts/clickhouse-analyzer-repro/patch-parts-repro.sql
@@ -1,0 +1,10 @@
+-- Expected failure:
+--   Code: 10 ... Not found column _block_number ...
+
+SELECT version() AS clickhouse_version;
+
+SELECT lazy
+FROM patch_parts_repro
+WHERE filt > 0
+ORDER BY id
+LIMIT 5;

--- a/scripts/clickhouse-analyzer-repro/patch-parts-setup.sql
+++ b/scripts/clickhouse-analyzer-repro/patch-parts-setup.sql
@@ -1,0 +1,33 @@
+-- Setup for ClickHouse/ClickHouse#102904. Lightweight UPDATE creates patch
+-- parts; OPTIMIZE keeps a deterministic post-merge read shape.
+
+SET enable_lightweight_update = 1;
+
+DROP TABLE IF EXISTS patch_parts_repro;
+
+CREATE TABLE patch_parts_repro
+(
+    id UInt64,
+    filt UInt64,
+    lazy String
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    enable_block_number_column = 1,
+    enable_block_offset_column = 1,
+    apply_patches_on_merge = 0;
+
+INSERT INTO patch_parts_repro
+SELECT number, number % 10, repeat('a', number)
+FROM numbers(100);
+
+INSERT INTO patch_parts_repro
+SELECT number + 100, number % 10, repeat('b', number + 100)
+FROM numbers(100);
+
+UPDATE patch_parts_repro
+SET lazy = 'patched'
+WHERE filt < 3;
+
+OPTIMIZE TABLE patch_parts_repro FINAL;

--- a/scripts/clickhouse-analyzer-repro/run.sh
+++ b/scripts/clickhouse-analyzer-repro/run.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly CASE_NAME="${1:-}"
+readonly CLICKHOUSE_TAG="${2:-}"
+readonly EXPECTED_RESULT="${3:-either}"
+readonly IMAGE="clickhouse/clickhouse-server:${CLICKHOUSE_TAG}"
+readonly SINGLE_CONTAINER="ch-analyzer-repro-single"
+readonly NODE1_CONTAINER="ch-analyzer-repro-node1"
+readonly NODE2_CONTAINER="ch-analyzer-repro-node2"
+readonly NETWORK="ch-analyzer-repro-network"
+
+usage() {
+  echo "Usage: $0 <scores|patch-parts|distributed> <clickhouse-tag> [fail|pass|either]"
+}
+
+if [[ -z "${CASE_NAME}" || -z "${CLICKHOUSE_TAG}" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "${EXPECTED_RESULT}" != "fail" && "${EXPECTED_RESULT}" != "pass" && "${EXPECTED_RESULT}" != "either" ]]; then
+  usage
+  exit 2
+fi
+
+wait_for_clickhouse() {
+  local container="$1"
+  local attempt
+
+  for attempt in $(seq 1 45); do
+    if docker exec "${container}" clickhouse-client --query "SELECT 1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "ClickHouse did not become ready in ${container}" >&2
+  return 1
+}
+
+remove_container() {
+  local container="$1"
+  docker rm -f "${container}" >/dev/null 2>&1 || true
+}
+
+cleanup_single() {
+  remove_container "${SINGLE_CONTAINER}"
+}
+
+cleanup_distributed() {
+  remove_container "${NODE1_CONTAINER}"
+  remove_container "${NODE2_CONTAINER}"
+  docker network rm "${NETWORK}" >/dev/null 2>&1 || true
+}
+
+start_node() {
+  local container="$1"
+
+  docker run -d \
+    --name "${container}" \
+    --hostname "${container}" \
+    --ulimit nofile=262144:262144 \
+    -e CLICKHOUSE_SKIP_USER_SETUP=1 \
+    -v "${SCRIPT_DIR}:/repro:ro" \
+    "${@:2}" \
+    "${IMAGE}" >/dev/null
+}
+
+run_baseline() {
+  local container="$1"
+  local sql_file="$2"
+  local signature="$3"
+  local output
+  local status
+  local actual_result
+
+  set +e
+  output="$(docker exec "${container}" clickhouse-client --multiquery --queries-file "/repro/${sql_file}" 2>&1)"
+  status=$?
+  set -e
+
+  echo "${output}"
+
+  if [[ ${status} -eq 0 ]]; then
+    actual_result="pass"
+  else
+    actual_result="fail"
+    if [[ "${output}" != *"${signature}"* ]]; then
+      echo "Baseline failed, but not with the expected signature: ${signature}" >&2
+      return 1
+    fi
+  fi
+
+  echo "BASELINE case=${CASE_NAME} version=${ACTUAL_VERSION} result=${actual_result}"
+
+  if [[ "${EXPECTED_RESULT}" != "either" && "${actual_result}" != "${EXPECTED_RESULT}" ]]; then
+    echo "Expected ${EXPECTED_RESULT}, got ${actual_result}" >&2
+    return 1
+  fi
+}
+
+run_single_case() {
+  local setup_file="$1"
+  local repro_file="$2"
+  local mitigations_file="$3"
+  local signature="$4"
+
+  cleanup_single
+  trap cleanup_single EXIT
+
+  start_node "${SINGLE_CONTAINER}"
+  wait_for_clickhouse "${SINGLE_CONTAINER}"
+  ACTUAL_VERSION="$(docker exec "${SINGLE_CONTAINER}" clickhouse-client --query "SELECT version()")"
+  readonly ACTUAL_VERSION
+
+  docker exec "${SINGLE_CONTAINER}" clickhouse-client --multiquery --queries-file "/repro/${setup_file}"
+  run_baseline "${SINGLE_CONTAINER}" "${repro_file}" "${signature}"
+  docker exec "${SINGLE_CONTAINER}" clickhouse-client --multiquery --queries-file "/repro/${mitigations_file}"
+  echo "MITIGATIONS case=${CASE_NAME} version=${ACTUAL_VERSION} result=pass"
+}
+
+run_distributed_case() {
+  cleanup_distributed
+  trap cleanup_distributed EXIT
+
+  docker network create "${NETWORK}" >/dev/null
+  start_node "${NODE1_CONTAINER}" --network "${NETWORK}" -v "${SCRIPT_DIR}/distributed-cluster.xml:/etc/clickhouse-server/config.d/repro-cluster.xml:ro"
+  start_node "${NODE2_CONTAINER}" --network "${NETWORK}" -v "${SCRIPT_DIR}/distributed-cluster.xml:/etc/clickhouse-server/config.d/repro-cluster.xml:ro"
+  wait_for_clickhouse "${NODE1_CONTAINER}"
+  wait_for_clickhouse "${NODE2_CONTAINER}"
+  ACTUAL_VERSION="$(docker exec "${NODE1_CONTAINER}" clickhouse-client --query "SELECT version()")"
+  readonly ACTUAL_VERSION
+
+  docker exec "${NODE2_CONTAINER}" clickhouse-client --multiquery --queries-file /repro/distributed-node2-setup.sql
+  docker exec "${NODE1_CONTAINER}" clickhouse-client --multiquery --queries-file /repro/distributed-node1-setup.sql
+  run_baseline "${NODE1_CONTAINER}" distributed-repro.sql "Unsupported types to CAST AS Map"
+  docker exec "${NODE1_CONTAINER}" clickhouse-client --multiquery --queries-file /repro/distributed-mitigations.sql
+  echo "MITIGATIONS case=${CASE_NAME} version=${ACTUAL_VERSION} result=pass"
+}
+
+case "${CASE_NAME}" in
+  scores)
+    run_single_case scores-setup.sql scores-repro.sql scores-mitigations.sql NOT_FOUND_COLUMN_IN_BLOCK
+    ;;
+  patch-parts)
+    run_single_case patch-parts-setup.sql patch-parts-repro.sql patch-parts-mitigations.sql _block_number
+    ;;
+  distributed)
+    run_distributed_case
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/clickhouse-analyzer-repro/scores-mitigations.sql
+++ b/scripts/clickhouse-analyzer-repro/scores-mitigations.sql
@@ -1,0 +1,57 @@
+-- Each query must succeed on an affected build. The first setting is the
+-- narrowest robust mitigation because it disables only the optimization that
+-- introduced this plan shape.
+
+SELECT 'query_plan_top_k_through_join=0' AS mitigation;
+SELECT l.id, r.user_id
+FROM scores_repro_left AS l FINAL
+LEFT JOIN scores_repro_right AS r ON l.trace_id = r.id
+WHERE l.project_id = 2
+ORDER BY l.id DESC
+LIMIT 5
+SETTINGS query_plan_top_k_through_join = 0;
+
+SELECT 'query_plan_max_limit_for_lazy_materialization=4' AS mitigation;
+SELECT l.id, r.user_id
+FROM scores_repro_left AS l FINAL
+LEFT JOIN scores_repro_right AS r ON l.trace_id = r.id
+WHERE l.project_id = 2
+ORDER BY l.id DESC
+LIMIT 5
+SETTINGS query_plan_max_limit_for_lazy_materialization = 4;
+
+SELECT 'query_plan_filter_push_down=0' AS mitigation;
+SELECT l.id, r.user_id
+FROM scores_repro_left AS l FINAL
+LEFT JOIN scores_repro_right AS r ON l.trace_id = r.id
+WHERE l.project_id = 2
+ORDER BY l.id DESC
+LIMIT 5
+SETTINGS query_plan_filter_push_down = 0;
+
+SELECT 'query_plan_optimize_lazy_materialization=0' AS mitigation;
+SELECT l.id, r.user_id
+FROM scores_repro_left AS l FINAL
+LEFT JOIN scores_repro_right AS r ON l.trace_id = r.id
+WHERE l.project_id = 2
+ORDER BY l.id DESC
+LIMIT 5
+SETTINGS query_plan_optimize_lazy_materialization = 0;
+
+SELECT 'query_plan_enable_optimizations=0' AS mitigation;
+SELECT l.id, r.user_id
+FROM scores_repro_left AS l FINAL
+LEFT JOIN scores_repro_right AS r ON l.trace_id = r.id
+WHERE l.project_id = 2
+ORDER BY l.id DESC
+LIMIT 5
+SETTINGS query_plan_enable_optimizations = 0;
+
+SELECT 'enable_analyzer=0' AS mitigation;
+SELECT l.id, r.user_id
+FROM scores_repro_left AS l FINAL
+LEFT JOIN scores_repro_right AS r ON l.trace_id = r.id
+WHERE l.project_id = 2
+ORDER BY l.id DESC
+LIMIT 5
+SETTINGS enable_analyzer = 0;

--- a/scripts/clickhouse-analyzer-repro/scores-repro.sql
+++ b/scripts/clickhouse-analyzer-repro/scores-repro.sql
@@ -1,0 +1,12 @@
+-- Reproduces langfuse/langfuse#15125 and ClickHouse/ClickHouse#109210.
+-- Expected failure:
+--   Code: 10 ... NOT_FOUND_COLUMN_IN_BLOCK
+
+SELECT version() AS clickhouse_version;
+
+SELECT l.id, r.user_id
+FROM scores_repro_left AS l FINAL
+LEFT JOIN scores_repro_right AS r ON l.trace_id = r.id
+WHERE l.project_id = 2
+ORDER BY l.id DESC
+LIMIT 5;

--- a/scripts/clickhouse-analyzer-repro/scores-setup.sql
+++ b/scripts/clickhouse-analyzer-repro/scores-setup.sql
@@ -1,0 +1,25 @@
+-- Setup for the FINAL + LEFT JOIN + top-K/lazy-materialization repro.
+-- The query is data-independent, but one part must exist to build the failing
+-- ReadFromMergeTree plan.
+
+DROP TABLE IF EXISTS scores_repro_right;
+DROP TABLE IF EXISTS scores_repro_left;
+
+CREATE TABLE scores_repro_left
+(
+    id UInt64,
+    project_id UInt64,
+    trace_id UInt64
+)
+ENGINE = ReplacingMergeTree
+ORDER BY (project_id, id);
+
+CREATE TABLE scores_repro_right
+(
+    id UInt64,
+    user_id UInt64
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO scores_repro_left VALUES (1, 1, 1);

--- a/scripts/clickhouse-analyzer-repro/verify-matrix.sh
+++ b/scripts/clickhouse-analyzer-repro/verify-matrix.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+CASES=(
+  "scores 26.5.5.8 fail"
+  "scores 26.6.1.1193 fail"
+  "scores 26.6.2.81 fail"
+  "scores 26.7.1.1315 fail"
+  "scores 26.7.2.59 pass"
+  "patch-parts 25.12.11.4 fail"
+  "patch-parts 26.2.19.43 fail"
+  "patch-parts 26.3.17.110 fail"
+  "patch-parts 26.4.1.1141 pass"
+  "distributed 25.12.8.9 fail"
+  "distributed 26.6.1.1193 fail"
+  "distributed 26.6.2.81 pass"
+  "distributed 26.7.1.1315 pass"
+)
+
+for matrix_case in "${CASES[@]}"; do
+  read -r case_name clickhouse_tag expected_result <<<"${matrix_case}"
+  echo "MATRIX case=${case_name} tag=${clickhouse_tag} expected=${expected_result}"
+  "${SCRIPT_DIR}/run.sh" "${case_name}" "${clickhouse_tag}" "${expected_result}"
+done
+
+echo "MATRIX result=pass cases=${#CASES[@]}"


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16072.preview.langfuse.com](https://pr-16072.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Reproduction SQL scripts for a number of ClickHouse planner issues.

- [ClickHouse #109210](https://github.com/ClickHouse/ClickHouse/issues/109210)
  is the exact minimized bug report.
- [PR #104268](https://github.com/ClickHouse/ClickHouse/pull/104268)
  introduced `query_plan_top_k_through_join` in 26.5.1.651. Fixed in https://github.com/ClickHouse/ClickHouse/pull/110722
- [PR #110722](https://github.com/ClickHouse/ClickHouse/pull/110722) fixes
  the dangling filter input. It landed in 26.7.1.1334 and was backported to
  26.7.2.11, 26.6.2.108, and 26.5.6.70.