### PR TITLE
fix(web): reduce default columns in scores table

### DIFF
--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -658,6 +658,7 @@ export default function ScoresTable({
       id: "traceName",
       enableHiding: true,
       enableSorting: true,
+      defaultHidden: true,
       size: 150,
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -494,6 +494,162 @@ export default function ScoresTable({
       },
     },
     {
+      accessorKey: "timestamp",
+      header: "Timestamp",
+      id: "timestamp",
+      enableHiding: true,
+      enableSorting: true,
+      size: 150,
+      cell: ({ row }) => {
+        const value: ScoresTableRow["timestamp"] = row.getValue("timestamp");
+        return value ? <LocalIsoDate date={value} /> : undefined;
+      },
+    },
+    {
+      accessorKey: "name",
+      header: "Name",
+      id: "name",
+      enableHiding: true,
+      enableSorting: true,
+      size: 150,
+    },
+    {
+      accessorKey: "value",
+      header: "Value",
+      id: "value",
+      enableHiding: true,
+      enableSorting: true,
+      size: 100,
+    },
+    {
+      accessorKey: "dataType",
+      header: "Data Type",
+      id: "dataType",
+      enableHiding: true,
+      enableSorting: true,
+      size: 100,
+    },
+    {
+      accessorKey: "source",
+      header: "Source",
+      id: "source",
+      enableHiding: true,
+      enableSorting: true,
+      size: 100,
+    },
+    {
+      accessorKey: "level",
+      header: "Level",
+      id: "level",
+      enableHiding: true,
+      // Derived client-side from the score's context ids — not a sortable
+      // backend column.
+      enableSorting: false,
+      size: 110,
+      cell: ({ row }) => {
+        // Level tag (LFE-10596): trace- vs observation- (vs session-) level
+        // scores look identical here otherwise.
+        const level: ScoresTableRow["level"] = row.getValue("level");
+        return <ScoreTag level={level} />;
+      },
+    },
+    {
+      accessorKey: "comment",
+      header: "Comment",
+      id: "comment",
+      enableHiding: true,
+      size: 400,
+      loadingCell: () => (
+        <IOTableCell
+          isLoading
+          data={undefined}
+          singleLine={rowHeight === "s"}
+        />
+      ),
+      cell: ({ row }) => {
+        const value = row.getValue("comment") as ScoresTableRow["comment"];
+        return (
+          !!value && <IOTableCell data={value} singleLine={rowHeight === "s"} />
+        );
+      },
+    },
+    {
+      accessorKey: "environment",
+      header: "Environment",
+      id: "environment",
+      size: 150,
+      enableHiding: true,
+      loadingCell: <TableBadgeLoadingCell />,
+      cell: ({ row }) => {
+        const value = row.getValue("environment") as string | undefined;
+        return value ? (
+          <Badge
+            variant="secondary"
+            className="max-w-fit truncate rounded-sm px-1 font-normal"
+            title={value}
+          >
+            {value}
+          </Badge>
+        ) : null;
+      },
+    },
+    {
+      accessorKey: "traceTags",
+      id: "traceTags",
+      header: "Trace Tags",
+      size: 250,
+      enableHiding: true,
+      defaultHidden: true,
+      loadingCell: <TableTextLoadingCell />,
+      cell: ({ row }) => {
+        if (isBetaEnabled && !scoreMetrics.data)
+          return <TableTextLoadingCell />;
+        const traceTags: string[] | undefined = row.getValue("traceTags");
+        return (
+          traceTags &&
+          traceTags.length > 0 && (
+            <div
+              className={cn(
+                "flex gap-x-2 gap-y-1",
+                rowHeight !== "s" && "flex-wrap",
+              )}
+            >
+              <TagList selectedTags={traceTags} isLoading={false} viewOnly />
+            </div>
+          )
+        );
+      },
+    },
+    {
+      accessorKey: "metadata",
+      header: "Metadata",
+      id: "metadata",
+      size: 400,
+      loadingCell: () => (
+        <IOTableCell
+          isLoading
+          data={undefined}
+          singleLine={rowHeight === "s"}
+        />
+      ),
+      headerTooltip: {
+        description: "Add metadata to scores to track additional information.",
+        // TODO: docs for metadata on scores
+        href: "https://langfuse.com/docs/observability/features/metadata",
+      },
+      cell: ({ row }) => {
+        const scoreId: ScoresTableRow["id"] = row.getValue("id");
+        return (
+          <ScoresMetadataCell
+            scoreId={scoreId}
+            projectId={projectId}
+            singleLine={rowHeight === "s"}
+          />
+        );
+      },
+      enableHiding: true,
+    },
+    {
       accessorKey: "traceName",
       header: "Trace Name",
       id: "traceName",
@@ -536,24 +692,6 @@ export default function ScoresTable({
       },
     },
     {
-      accessorKey: "executionTraceId",
-      id: "executionTraceId",
-      header: "Execution Trace",
-      enableSorting: false,
-      enableHiding: true,
-      defaultHidden: true,
-      size: 100,
-      cell: ({ row }) => {
-        const value = row.getValue("executionTraceId");
-        return typeof value === "string" ? (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(value)}`}
-            value={value}
-          />
-        ) : undefined;
-      },
-    },
-    {
       accessorKey: "observationId",
       id: "observationId",
       header: "Observation",
@@ -568,6 +706,24 @@ export default function ScoresTable({
           <TableLink
             path={`/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(observationId)}`}
             value={observationId}
+          />
+        ) : undefined;
+      },
+    },
+    {
+      accessorKey: "executionTraceId",
+      id: "executionTraceId",
+      header: "Execution Trace",
+      enableSorting: false,
+      enableHiding: true,
+      defaultHidden: true,
+      size: 100,
+      cell: ({ row }) => {
+        const value = row.getValue("executionTraceId");
+        return typeof value === "string" ? (
+          <TableLink
+            path={`/project/${projectId}/traces/${encodeURIComponent(value)}`}
+            value={value}
           />
         ) : undefined;
       },
@@ -590,26 +746,6 @@ export default function ScoresTable({
       },
     },
     {
-      accessorKey: "environment",
-      header: "Environment",
-      id: "environment",
-      size: 150,
-      enableHiding: true,
-      loadingCell: <TableBadgeLoadingCell />,
-      cell: ({ row }) => {
-        const value = row.getValue("environment") as string | undefined;
-        return value ? (
-          <Badge
-            variant="secondary"
-            className="max-w-fit truncate rounded-sm px-1 font-normal"
-            title={value}
-          >
-            {value}
-          </Badge>
-        ) : null;
-      },
-    },
-    {
       accessorKey: "userId",
       header: "User",
       id: "userId",
@@ -619,6 +755,7 @@ export default function ScoresTable({
       },
       enableHiding: true,
       enableSorting: true,
+      defaultHidden: true,
       size: 100,
       loadingCell: <TableTextLoadingCell />,
       cell: ({ row }) => {
@@ -633,115 +770,6 @@ export default function ScoresTable({
             />
           </>
         ) : undefined;
-      },
-    },
-    {
-      accessorKey: "timestamp",
-      header: "Timestamp",
-      id: "timestamp",
-      enableHiding: true,
-      enableSorting: true,
-      size: 150,
-      cell: ({ row }) => {
-        const value: ScoresTableRow["timestamp"] = row.getValue("timestamp");
-        return value ? <LocalIsoDate date={value} /> : undefined;
-      },
-    },
-    {
-      accessorKey: "source",
-      header: "Source",
-      id: "source",
-      enableHiding: true,
-      enableSorting: true,
-      size: 100,
-    },
-    {
-      accessorKey: "name",
-      header: "Name",
-      id: "name",
-      enableHiding: true,
-      enableSorting: true,
-      size: 150,
-    },
-    {
-      accessorKey: "level",
-      header: "Level",
-      id: "level",
-      enableHiding: true,
-      // Derived client-side from the score's context ids — not a sortable
-      // backend column.
-      enableSorting: false,
-      size: 110,
-      cell: ({ row }) => {
-        // Level tag (LFE-10596): trace- vs observation- (vs session-) level
-        // scores look identical here otherwise.
-        const level: ScoresTableRow["level"] = row.getValue("level");
-        return <ScoreTag level={level} />;
-      },
-    },
-    {
-      accessorKey: "dataType",
-      header: "Data Type",
-      id: "dataType",
-      enableHiding: true,
-      enableSorting: true,
-      size: 100,
-    },
-    {
-      accessorKey: "value",
-      header: "Value",
-      id: "value",
-      enableHiding: true,
-      enableSorting: true,
-      size: 100,
-    },
-    {
-      accessorKey: "metadata",
-      header: "Metadata",
-      id: "metadata",
-      size: 400,
-      loadingCell: () => (
-        <IOTableCell
-          isLoading
-          data={undefined}
-          singleLine={rowHeight === "s"}
-        />
-      ),
-      headerTooltip: {
-        description: "Add metadata to scores to track additional information.",
-        // TODO: docs for metadata on scores
-        href: "https://langfuse.com/docs/observability/features/metadata",
-      },
-      cell: ({ row }) => {
-        const scoreId: ScoresTableRow["id"] = row.getValue("id");
-        return (
-          <ScoresMetadataCell
-            scoreId={scoreId}
-            projectId={projectId}
-            singleLine={rowHeight === "s"}
-          />
-        );
-      },
-      enableHiding: true,
-    },
-    {
-      accessorKey: "comment",
-      header: "Comment",
-      id: "comment",
-      enableHiding: true,
-      size: 400,
-      loadingCell: () => (
-        <IOTableCell
-          isLoading
-          data={undefined}
-          singleLine={rowHeight === "s"}
-        />
-      ),
-      cell: ({ row }) => {
-        const value = row.getValue("comment") as ScoresTableRow["comment"];
-        return (
-          !!value && <IOTableCell data={value} singleLine={rowHeight === "s"} />
-        );
       },
     },
     {
@@ -777,6 +805,7 @@ export default function ScoresTable({
       },
       enableHiding: true,
       enableSorting: false,
+      defaultHidden: true,
       size: 150,
       cell: ({ row }) => {
         const value = row.getValue("jobConfigurationId");
@@ -788,33 +817,6 @@ export default function ScoresTable({
             />
           </>
         ) : undefined;
-      },
-    },
-    {
-      accessorKey: "traceTags",
-      id: "traceTags",
-      header: "Trace Tags",
-      size: 250,
-      enableHiding: true,
-      defaultHidden: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        if (isBetaEnabled && !scoreMetrics.data)
-          return <TableTextLoadingCell />;
-        const traceTags: string[] | undefined = row.getValue("traceTags");
-        return (
-          traceTags &&
-          traceTags.length > 0 && (
-            <div
-              className={cn(
-                "flex gap-x-2 gap-y-1",
-                rowHeight !== "s" && "flex-wrap",
-              )}
-            >
-              <TagList selectedTags={traceTags} isLoading={false} viewOnly />
-            </div>
-          )
-        );
       },
     },
   ];

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -651,6 +651,7 @@ export default function ScoresTable({
         );
       },
       enableHiding: true,
+      defaultHidden: true,
     },
     {
       accessorKey: "traceName",

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -535,6 +535,7 @@ export default function ScoresTable({
       id: "source",
       enableHiding: true,
       enableSorting: true,
+      defaultHidden: true,
       size: 100,
     },
     {
@@ -542,6 +543,7 @@ export default function ScoresTable({
       header: "Level",
       id: "level",
       enableHiding: true,
+      defaultHidden: true,
       // Derived client-side from the score's context ids — not a sortable
       // backend column.
       enableSorting: false,
@@ -579,6 +581,7 @@ export default function ScoresTable({
       id: "environment",
       size: 150,
       enableHiding: true,
+      defaultHidden: true,
       loadingCell: <TableBadgeLoadingCell />,
       cell: ({ row }) => {
         const value = row.getValue("environment") as string | undefined;

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -527,6 +527,7 @@ export default function ScoresTable({
       id: "dataType",
       enableHiding: true,
       enableSorting: true,
+      defaultHidden: true,
       size: 100,
     },
     {
@@ -782,6 +783,7 @@ export default function ScoresTable({
       id: "author",
       header: "Author",
       enableHiding: true,
+      defaultHidden: true,
       size: 150,
       cell: ({ row }) => {
         const { userId, name, image } = row.getValue(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16074.preview.langfuse.com](https://pr-16074.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What
Reduce the default columns shown in the scores table:
- Hide the eval configuration ID column by default
- Hide the trace tags column by default (already hidden)
- Hide the user column by default
- Reorder columns to roughly align with the tracing table's column order

Users who already customized their column layout are unaffected — this only changes the default for users without a saved layout.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the scores table’s default layout while preserving existing user customization.
- Reorders score columns to align more closely with tracing tables.
- Hides the User and Evaluation Configuration ID columns by default.
- Keeps Trace Tags hidden by default.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

Persisted column visibility and ordering continue to take precedence, while the new hidden defaults apply only to users without saved layout state.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): reduce default columns in scor..."](https://github.com/langfuse/langfuse/commit/0bd10c23797be5bfe335cfe0a018c2582401cda0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52948849)</sub>

<!-- /greptile_comment -->