### PR TITLE
fix(web): reframe the v4 upgrade copy away from "your setup is outdated"

### DIFF
--- a/web/src/features/v4-migration/V4MigrationBadgeContent.stories.tsx
+++ b/web/src/features/v4-migration/V4MigrationBadgeContent.stories.tsx
@@ -5,8 +5,7 @@ import { V4MigrationBadgeContent } from "./V4MigrationBadgeContent";
 
 // The longest copy the delay badge renders (V4MigrationDelayBadge); the
 // hover reveal must expand to whatever width this needs (LF-90).
-const OTEL_DESCRIPTION =
-  "Your setup is outdated. Update OTel instrumentation for real-time data";
+const OTEL_DESCRIPTION = "Update your OTel instrumentation for real-time data";
 
 const meta = preview.meta({
   component: V4MigrationBadgeContent,
@@ -16,7 +15,7 @@ export const Default = meta.story({
   args: {
     onClick: fn(),
     title: "New data in ~15 min",
-    description: "Your setup is outdated. Update SDK for real-time data",
+    description: "Update your SDK for real-time data",
   },
 });
 
@@ -53,7 +52,7 @@ export const TestFocusRevealsLongestDescription = meta.story({
     // The description sits in an overflow-hidden wrapper that animates open;
     // once expanded it must fit the whole text (no clipping mid-word).
     const text = within(button).getByText(
-      /Update OTel instrumentation for real-time data/,
+      /Update your OTel instrumentation for real-time data/,
     );
     const clipBox = text.parentElement;
     if (!clipBox) throw new Error("description wrapper not found");

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -996,9 +996,9 @@ describe("V4MigrationHeaderContent", () => {
     expect(screen.getByText("Upgrade to v4")).toBeInTheDocument();
     expect(screen.queryByText(/Project 1/)).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Your project setup is outdated/),
+      screen.getByText(/Complete the action items below/),
     ).toHaveTextContent(
-      "Your project setup is outdated. Upgrade to v4 now for real-time ingestion and up to 165x faster queries. See docs.",
+      "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. Complete the action items below to switch this project over. See docs.",
     );
     expect(screen.getByRole("link", { name: "See docs." })).toHaveAttribute(
       "href",
@@ -1021,7 +1021,7 @@ describe("V4MigrationHeaderContent", () => {
     expect(screen.getByText("Upgrade to v4").parentElement).toHaveClass("pr-6");
   });
 
-  it("does not call ready or unresolved projects outdated", () => {
+  it("keeps the pitch but drops the action ask for ready or unresolved projects", () => {
     for (const readiness of [
       "ready",
       "checking",
@@ -1033,10 +1033,10 @@ describe("V4MigrationHeaderContent", () => {
       );
 
       expect(
-        screen.queryByText(/Your project setup is outdated/),
+        screen.queryByText(/Complete the action items below/),
       ).not.toBeInTheDocument();
       expect(
-        screen.getByText(/Langfuse v4 offers real-time ingestion/),
+        screen.getByText(/Langfuse v4 is here: real-time ingestion/),
       ).toBeInTheDocument();
       expect(
         screen.queryByText(/some features may stop working/),

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -988,8 +988,8 @@ export function V4MigrationHeaderContent({
       <div className="text-muted-foreground flex flex-col gap-2 text-sm leading-relaxed">
         <p>
           {actionNeeded
-            ? "Your project setup is outdated. Upgrade to v4 now for real-time ingestion and up to 165x faster queries. "
-            : "Langfuse v4 offers real-time ingestion and up to 165x faster queries. "}
+            ? "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. Complete the action items below to switch this project over. "
+            : "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. "}
           <ExternalLink
             href={V4_DOCS_URL}
             analytics={{ section: "header", link: "v4_docs" }}

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.clienttest.tsx
@@ -148,7 +148,7 @@ describe("V4MigrationDelayBadge", () => {
       0,
     );
     expect(
-      screen.getAllByText(/Update SDK for real-time data/).length,
+      screen.getAllByText(/Update your SDK for real-time data/).length,
     ).toBeGreaterThan(0);
   });
 
@@ -156,7 +156,7 @@ describe("V4MigrationDelayBadge", () => {
     setSdk("otel_header_required", [delayedOtelSeries()]);
     render(<V4MigrationDelayBadge />);
     expect(
-      screen.getAllByText(/Update OTel instrumentation for real-time data/)
+      screen.getAllByText(/Update your OTel instrumentation for real-time data/)
         .length,
     ).toBeGreaterThan(0);
   });
@@ -165,7 +165,8 @@ describe("V4MigrationDelayBadge", () => {
     setSdk("unknown", [customIngestionSeries()]);
     render(<V4MigrationDelayBadge />);
     expect(
-      screen.getAllByText(/Upgrade instrumentation for real-time data/).length,
+      screen.getAllByText(/Upgrade your instrumentation for real-time data/)
+        .length,
     ).toBeGreaterThan(0);
   });
 
@@ -173,11 +174,11 @@ describe("V4MigrationDelayBadge", () => {
     setSdk("legacy", [outdatedSdkSeries(), delayedOtelSeries()]);
     render(<V4MigrationDelayBadge />);
     expect(
-      screen.getAllByText(/Upgrade for real-time data/).length,
+      screen.getAllByText(/Upgrade to v4 for real-time data/).length,
     ).toBeGreaterThan(0);
-    expect(screen.queryAllByText(/Update SDK for real-time data/)).toHaveLength(
-      0,
-    );
+    expect(
+      screen.queryAllByText(/Update your SDK for real-time data/),
+    ).toHaveLength(0);
   });
 
   it("stays hidden when an SDK version is merely unrecognized", () => {

--- a/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
+++ b/web/src/features/v4-migration/V4MigrationDelayBadge.tsx
@@ -75,12 +75,12 @@ export function V4MigrationDelayBadge() {
   // multiple delayed paths get the generic clause.
   const description =
     actionablePaths > 1
-      ? "Your setup is outdated. Upgrade for real-time data"
+      ? "Upgrade to v4 for real-time data"
       : sdkActionable
-        ? "Your setup is outdated. Update SDK for real-time data"
+        ? "Update your SDK for real-time data"
         : otelActionable
-          ? "Your setup is outdated. Update OTel instrumentation for real-time data"
-          : "Your setup is outdated. Upgrade instrumentation for real-time data";
+          ? "Update your OTel instrumentation for real-time data"
+          : "Upgrade your instrumentation for real-time data";
 
   return (
     <V4MigrationBadgeContent

--- a/web/src/features/v4-migration/V4MigrationHeaderContent.stories.tsx
+++ b/web/src/features/v4-migration/V4MigrationHeaderContent.stories.tsx
@@ -1,0 +1,30 @@
+import preview from "../../../.storybook/preview";
+import { V4MigrationHeaderContent } from "./V4MigrationContent";
+
+// The panel takes ~40% of a desktop viewport; this width keeps the line breaks
+// representative of what users actually read.
+const PANEL_WIDTH = "w-[520px]";
+
+const meta = preview.meta({
+  component: V4MigrationHeaderContent,
+  decorators: [
+    (Story) => (
+      <div className={PANEL_WIDTH}>
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+// What a project with remaining upgrade steps sees, opened from the sidebar.
+export const ActionNeeded = meta.story({
+  args: { readiness: "action-needed" },
+});
+
+export const Ready = meta.story({
+  args: { readiness: "ready" },
+});
+
+export const Checking = meta.story({
+  args: { readiness: "checking" },
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16075.preview.langfuse.com](https://pr-16075.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The v4 upgrade panel opened with a verdict on the user's work:

> Your project setup is outdated. Upgrade to v4 now for real-time ingestion and up to 165x faster queries.

Three problems: it judges the reader rather than describing a state, the first clause carries no information the surrounding UI does not already give (the sidebar pill says "Action required", the panel title says "Upgrade to v4"), and it is off-voice with the org banner and status page, which both open with "Langfuse v4 is here".

This changes the header to lead with the benefit and then point at the checklist rendered immediately below, and drops the same "Your setup is outdated." prefix from the four delay-badge hover strings.

**Panel header, action needed**

- Before: `Your project setup is outdated. Upgrade to v4 now for real-time ingestion and up to 165x faster queries. See docs.`
- After: `Langfuse v4 is here: real-time ingestion and up to 165× faster queries. Complete the action items below to switch this project over. See docs.`

**Panel header, no action needed**

- Before: `Langfuse v4 offers real-time ingestion and up to 165x faster queries. See docs.`
- After: `Langfuse v4 is here: real-time ingestion and up to 165× faster queries. See docs.`

Both readiness states now share one opening sentence and differ only in the action clause. This also settles the `165x` / `165×` split — the banner and status page already used `×`.

**Delay badge hover** (traces, observations, experiments tables)

| Before | After |
|---|---|
| Your setup is outdated. Upgrade for real-time data | Upgrade to v4 for real-time data |
| Your setup is outdated. Update SDK for real-time data | Update your SDK for real-time data |
| Your setup is outdated. Update OTel instrumentation for real-time data | Update your OTel instrumentation for real-time data |
| Your setup is outdated. Upgrade instrumentation for real-time data | Upgrade your instrumentation for real-time data |

The badge title already states the observable fact ("New data in ~15 min"), so the hover clause only needs the fix. Leading with the action also shortens the longest string the hover reveal has to expand to.

The deadline sentence ("After November 16, 2026 some features may stop working without a v4 upgrade.") is unchanged — it is hedged deliberately, and rewording it would change what we commit to.

Also adds `V4MigrationHeaderContent.stories.tsx`, which had no story, so header copy is reviewable per readiness state.

## Alternatives considered

Two other directions were rendered in the real component before picking this one; both are a one-line swap if preferred.

- **Neutral status:** `This project is still on v3. Upgrade for real-time ingestion and up to 165× faster queries.` — shortest, states a fact about the project rather than about the user, but drops the pitch.
- **Effort first:** `Most of this upgrade is one prompt away. Move this project to v4 for real-time ingestion and up to 165× faster queries.` — lowest perceived effort, leans on the agent-prompt section further down the panel.

[Current copy compared with the three proposals, rendered in the panel header component](https://cursor.com/agents/bc-2b56853c-6107-40a2-ab4c-4355e8358031/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv4_panel_copy_proposals.png)

## Impacted package

- `web`

## Verification

- `pnpm --filter web run test-client src/features/v4-migration` — `Tests  99 passed (99)`
- `pnpm --filter web run test-storybook src/features/v4-migration` — `Tests  19 passed (19)`
- `pnpm --filter web run lint` — clean, and the pre-commit hook ran `turbo run lint` with `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` — clean
- Screenshots captured from Storybook against the running components

### Implemented copy, both readiness states

[Panel header for a project needing action and for a project already on v4](https://cursor.com/agents/bc-2b56853c-6107-40a2-ab4c-4355e8358031/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv4_panel_header_states.png)

### Delay badge hover

[Delay badge hover copy before and after](https://cursor.com/agents/bc-2b56853c-6107-40a2-ab4c-4355e8358031/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv4_delay_badge_before_after.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b56853c-6107-40a2-ab4c-4355e8358031?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b56853c-6107-40a2-ab4c-4355e8358031&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR revises the v4 migration UI to use benefit-led, neutral language and adds Storybook coverage for each header readiness state.

- Replaces “setup is outdated” messaging in the migration header and delay badges.
- Standardizes the performance claim as “165× faster queries.”
- Updates client tests and stories to cover the revised copy.
- Adds header stories for action-needed, ready, and checking states.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with copy, tests, and stories updated consistently.

The changes are presentational, preserve existing readiness behavior, and introduce no accepted functional, security, or quality defects.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): drop the &quot;setup is outdated&quot; v..."](https://github.com/langfuse/langfuse/commit/72964299498c46f98faa99ea264ac3fcc37cec0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52951994)</sub>

<!-- /greptile_comment -->