### PR TITLE
fix(batch-export): route batch export ClickHouse reads to a read replica

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -544,7 +544,6 @@ type GetDatasetRunItemsTableOpts<IncludeIO extends boolean> =
   DatasetRunItemsTableQuery & {
     select: "count" | "rows";
     includeIO?: IncludeIO;
-    // Absent means "ReadWrite": only batch export opts into the read replica.
     preferredClickhouseService?: PreferredClickhouseService;
   };
 
@@ -915,13 +914,6 @@ const getDatasetRunItemsTableInternal = async <
 
 export const getDatasetRunItemsCh = async (
   opts: DatasetRunItemsTableQuery & {
-    // Reached only through the worker's paginated read stream, which serves
-    // both the batch export and the eval-create batch action. The export passes
-    // "ReadOnly"; the batch action passes nothing on purpose, so historic eval
-    // creation keeps enumerating from the primary. Do not pin a service here —
-    // that would hide unreplicated run items from eval creation. The four
-    // sibling wrappers cannot opt in at all, because this field is absent from
-    // DatasetRunItemsTableQuery.
     preferredClickhouseService?: PreferredClickhouseService;
   },
 ): Promise<DatasetRunItemDomain[]> => {

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -915,11 +915,13 @@ const getDatasetRunItemsTableInternal = async <
 
 export const getDatasetRunItemsCh = async (
   opts: DatasetRunItemsTableQuery & {
-    // Export-only wrapper: batch export is its one production caller. The four
-    // sibling wrappers share the same internal query but cannot opt in, because
-    // this field is deliberately absent from DatasetRunItemsTableQuery. Moving
-    // it onto that shared type would put the UI and public API on the replica
-    // too.
+    // Reached only through the worker's paginated read stream, which serves
+    // both the batch export and the eval-create batch action. The export passes
+    // "ReadOnly"; the batch action passes nothing on purpose, so historic eval
+    // creation keeps enumerating from the primary. Do not pin a service here —
+    // that would hide unreplicated run items from eval creation. The four
+    // sibling wrappers cannot opt in at all, because this field is absent from
+    // DatasetRunItemsTableQuery.
     preferredClickhouseService?: PreferredClickhouseService;
   },
 ): Promise<DatasetRunItemDomain[]> => {

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -544,8 +544,7 @@ type GetDatasetRunItemsTableOpts<IncludeIO extends boolean> =
   DatasetRunItemsTableQuery & {
     select: "count" | "rows";
     includeIO?: IncludeIO;
-    // No default: absent means "ReadWrite". Kept off DatasetRunItemsTableQuery
-    // so only the wrapper that batch export calls can pass it.
+    // Absent means "ReadWrite": only batch export opts into the read replica.
     preferredClickhouseService?: PreferredClickhouseService;
   };
 
@@ -916,8 +915,11 @@ const getDatasetRunItemsTableInternal = async <
 
 export const getDatasetRunItemsCh = async (
   opts: DatasetRunItemsTableQuery & {
-    // Batch export opts into the read replica here; the dataset run items UI
-    // and public API wrappers pass nothing and keep reading the primary.
+    // Export-only wrapper: batch export is its one production caller. The four
+    // sibling wrappers share the same internal query but cannot opt in, because
+    // this field is deliberately absent from DatasetRunItemsTableQuery. Moving
+    // it onto that shared type would put the UI and public API on the replica
+    // too.
     preferredClickhouseService?: PreferredClickhouseService;
   },
 ): Promise<DatasetRunItemDomain[]> => {

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -23,7 +23,10 @@ import { env } from "../../env";
 import { commandClickhouse } from "./clickhouse";
 import Decimal from "decimal.js";
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
-import { convertDateToClickhouseDateTime } from "../clickhouse/client";
+import {
+  convertDateToClickhouseDateTime,
+  type PreferredClickhouseService,
+} from "../clickhouse/client";
 import { ScoreAggregate } from "../../features/scores";
 
 type DatasetItemIdsByTraceIdQuery = {
@@ -541,6 +544,9 @@ type GetDatasetRunItemsTableOpts<IncludeIO extends boolean> =
   DatasetRunItemsTableQuery & {
     select: "count" | "rows";
     includeIO?: IncludeIO;
+    // No default: absent means "ReadWrite". Kept off DatasetRunItemsTableQuery
+    // so only the wrapper that batch export calls can pass it.
+    preferredClickhouseService?: PreferredClickhouseService;
   };
 
 // Phase 1: Find dataset item IDs or count that satisfy conditions across ALL runs
@@ -902,13 +908,18 @@ const getDatasetRunItemsTableInternal = async <
     },
     tags: { projectId },
     clickhouseConfigs: opts.clickhouseConfigs,
+    preferredClickhouseService: opts.preferredClickhouseService,
   });
 
   return res;
 };
 
 export const getDatasetRunItemsCh = async (
-  opts: DatasetRunItemsTableQuery,
+  opts: DatasetRunItemsTableQuery & {
+    // Batch export opts into the read replica here; the dataset run items UI
+    // and public API wrappers pass nothing and keep reading the primary.
+    preferredClickhouseService?: PreferredClickhouseService;
+  },
 ): Promise<DatasetRunItemDomain[]> => {
   const rows = await getDatasetRunItemsTableInternal<DatasetRunItemRecord>({
     ...opts,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1225,8 +1225,7 @@ export async function getScoresUiTable<
   clickhouseConfigs?: ClickHouseClientConfigOptions;
   excludeMetadata?: ExcludeMetadata;
   includeHasMetadataFlag?: IncludeHasMetadata;
-  // Batch export opts into the read replica here; the scores UI table passes
-  // nothing and keeps reading the primary.
+  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 }) {
   const {
@@ -1315,7 +1314,7 @@ const getScoresUiGeneric = async <T>(props: {
   clickhouseConfigs?: ClickHouseClientConfigOptions;
   excludeMetadata?: boolean;
   includeHasMetadataFlag?: boolean;
-  // No default: absent means "ReadWrite", which is what the UI needs.
+  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 }): Promise<T[]> => {
   const {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1225,7 +1225,6 @@ export async function getScoresUiTable<
   clickhouseConfigs?: ClickHouseClientConfigOptions;
   excludeMetadata?: ExcludeMetadata;
   includeHasMetadataFlag?: IncludeHasMetadata;
-  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 }) {
   const {
@@ -1314,7 +1313,6 @@ const getScoresUiGeneric = async <T>(props: {
   clickhouseConfigs?: ClickHouseClientConfigOptions;
   excludeMetadata?: boolean;
   includeHasMetadataFlag?: boolean;
-  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 }): Promise<T[]> => {
   const {
@@ -2253,8 +2251,6 @@ export const getDistinctScoreNames = async (
     projectId: string;
     cutoffCreatedAt: Date;
     clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-    // No default: absent means "ReadWrite". Callers that enumerate rows for a
-    // user-visible selection (batch actions) must keep reading the primary.
     preferredClickhouseService?: PreferredClickhouseService;
   } & DistinctScoreNamesTimestampSource,
 ) => {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2245,9 +2245,17 @@ export const getDistinctScoreNames = async (
     projectId: string;
     cutoffCreatedAt: Date;
     clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+    // No default: absent means "ReadWrite". Callers that enumerate rows for a
+    // user-visible selection (batch actions) must keep reading the primary.
+    preferredClickhouseService?: PreferredClickhouseService;
   } & DistinctScoreNamesTimestampSource,
 ) => {
-  const { projectId, cutoffCreatedAt, clickhouseConfigs } = p;
+  const {
+    projectId,
+    cutoffCreatedAt,
+    clickhouseConfigs,
+    preferredClickhouseService,
+  } = p;
   const startTimeFrom = getDistinctScoreNamesStartTimeFrom(p);
 
   const query = `    SELECT DISTINCT
@@ -2273,6 +2281,7 @@ export const getDistinctScoreNames = async (
     },
     tags: { projectId },
     clickhouseConfigs,
+    preferredClickhouseService,
   });
 
   return rows.map((row) => row.name);

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1225,11 +1225,15 @@ export async function getScoresUiTable<
   clickhouseConfigs?: ClickHouseClientConfigOptions;
   excludeMetadata?: ExcludeMetadata;
   includeHasMetadataFlag?: IncludeHasMetadata;
+  // Batch export opts into the read replica here; the scores UI table passes
+  // nothing and keeps reading the primary.
+  preferredClickhouseService?: PreferredClickhouseService;
 }) {
   const {
     excludeMetadata = false,
     includeHasMetadataFlag = false,
     clickhouseConfigs,
+    preferredClickhouseService,
     ...rest
   } = props;
 
@@ -1273,6 +1277,7 @@ export async function getScoresUiTable<
     excludeMetadata,
     includeHasMetadataFlag,
     clickhouseConfigs,
+    preferredClickhouseService,
     ...rest,
   });
 
@@ -1310,6 +1315,8 @@ const getScoresUiGeneric = async <T>(props: {
   clickhouseConfigs?: ClickHouseClientConfigOptions;
   excludeMetadata?: boolean;
   includeHasMetadataFlag?: boolean;
+  // No default: absent means "ReadWrite", which is what the UI needs.
+  preferredClickhouseService?: PreferredClickhouseService;
 }): Promise<T[]> => {
   const {
     projectId,
@@ -1318,6 +1325,7 @@ const getScoresUiGeneric = async <T>(props: {
     limit,
     offset,
     clickhouseConfigs,
+    preferredClickhouseService,
     excludeMetadata = false,
     includeHasMetadataFlag = false,
   } = props;
@@ -1406,6 +1414,7 @@ const getScoresUiGeneric = async <T>(props: {
     params: input.params,
     tags: input.tags,
     clickhouseConfigs,
+    preferredClickhouseService,
   });
 };
 

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -4,7 +4,10 @@ import { sessionCols } from "../tableMappings/mapSessionTable";
 import { FilterState } from "../../types";
 import { sessionsViewCols } from "../../tableDefinitions/sessionsView";
 import { findUiColumnMapping } from "../../tableDefinitions";
-import { convertDateToClickhouseDateTime } from "../clickhouse/client";
+import {
+  convertDateToClickhouseDateTime,
+  type PreferredClickhouseService,
+} from "../clickhouse/client";
 import { scoreBooleansAggregation } from "../queries/clickhouse-sql/query-fragments";
 import { DateTimeFilter, FilterList, orderByToClickhouseSql } from "../queries";
 import {
@@ -91,6 +94,9 @@ export const getSessionsWithMetrics = async (props: {
   limit?: number;
   page?: number;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+  // Batch export opts into the read replica here; the sessions UI table passes
+  // nothing and keeps reading the primary.
+  preferredClickhouseService?: PreferredClickhouseService;
 }) => {
   const rows = await getSessionsTableGeneric<SessionWithMetricsReturnType>({
     select: "metrics",
@@ -100,6 +106,7 @@ export const getSessionsWithMetrics = async (props: {
     limit: props.limit,
     page: props.page,
     clickhouseConfigs: props.clickhouseConfigs,
+    preferredClickhouseService: props.preferredClickhouseService,
   });
 
   return rows.map((row) => ({
@@ -119,11 +126,21 @@ export type FetchSessionsTableProps = {
   page?: number;
   tags?: Record<string, string>;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+  // No default: absent means "ReadWrite", which is what the UI needs.
+  preferredClickhouseService?: PreferredClickhouseService;
 };
 
 const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
-  const { select, projectId, filter, orderBy, limit, page, clickhouseConfigs } =
-    props;
+  const {
+    select,
+    projectId,
+    filter,
+    orderBy,
+    limit,
+    page,
+    clickhouseConfigs,
+    preferredClickhouseService,
+  } = props;
 
   let sqlSelect: string;
   switch (select) {
@@ -402,5 +419,6 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
     params: input.params,
     tags: input.tags,
     clickhouseConfigs,
+    preferredClickhouseService,
   });
 };

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -94,7 +94,6 @@ export const getSessionsWithMetrics = async (props: {
   limit?: number;
   page?: number;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 }) => {
   const rows = await getSessionsTableGeneric<SessionWithMetricsReturnType>({
@@ -125,7 +124,6 @@ export type FetchSessionsTableProps = {
   page?: number;
   tags?: Record<string, string>;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 };
 

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -94,8 +94,7 @@ export const getSessionsWithMetrics = async (props: {
   limit?: number;
   page?: number;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-  // Batch export opts into the read replica here; the sessions UI table passes
-  // nothing and keeps reading the primary.
+  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 }) => {
   const rows = await getSessionsTableGeneric<SessionWithMetricsReturnType>({
@@ -126,7 +125,7 @@ export type FetchSessionsTableProps = {
   page?: number;
   tags?: Record<string, string>;
   clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-  // No default: absent means "ReadWrite", which is what the UI needs.
+  // Absent means "ReadWrite": only batch export opts into the read replica.
   preferredClickhouseService?: PreferredClickhouseService;
 };
 

--- a/worker/src/__tests__/batchExportReadReplica.test.ts
+++ b/worker/src/__tests__/batchExportReadReplica.test.ts
@@ -322,8 +322,10 @@ afterAll(async () => {
 });
 
 describe("batch export read replica routing", () => {
-  // Load-bearing: without these two controls a green "no primary traffic"
-  // assertion could just mean the harness never observed anything.
+  // Load-bearing: without these controls a green "no traffic on service X"
+  // assertion could just mean the harness never observed anything. There is one
+  // control per service, so every sink is proven reachable before any test
+  // asserts a sink is empty.
   describe("harness controls", () => {
     it("records a default-routed query on the primary writer only", async () => {
       resetRecordings();
@@ -352,6 +354,25 @@ describe("batch export read replica routing", () => {
       expect(rows).toHaveLength(1);
       expect(primaryQueries()).toEqual([]);
       expect(harness.requests.readOnly.length).toBeGreaterThan(0);
+    });
+
+    // Without this, every `expect(eventsReplicaQueries()).toEqual([])` below
+    // would silently become a tautology if the env rewrite for
+    // CLICKHOUSE_EVENTS_READ_ONLY_URL ever stopped taking effect.
+    it("records an events-replica-routed query on the events replica only", async () => {
+      resetRecordings();
+
+      const rows = await queryClickhouse<{ x: number }>({
+        query: "SELECT 1 AS x",
+        params: {},
+        tags: {},
+        preferredClickhouseService: "EventsReadOnly",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(primaryQueries()).toEqual([]);
+      expect(harness.requests.readOnly).toEqual([]);
+      expect(harness.requests.eventsReadOnly.length).toBeGreaterThan(0);
     });
   });
 
@@ -455,6 +476,17 @@ describe("batch export read replica routing", () => {
       expect(eventsReplicaQueries()).toEqual([]);
       expect(harness.requests.readOnly.length).toBeGreaterThan(0);
     });
+
+    // Observations have their own dispatch branch in the job — they do not share
+    // the one scores, sessions and dataset run items go through — so without
+    // this test that branch's service forward is executed by nothing.
+    it("reads only from the read-only replica for an observations export", async () => {
+      await runExportJob(BatchExportTableName.Observations, null);
+
+      expect(primaryQueries()).toEqual([]);
+      expect(eventsReplicaQueries()).toEqual([]);
+      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
+    });
   });
 
   // AC2: the same shared functions, called the way a UI/API request calls them
@@ -508,6 +540,40 @@ describe("batch export read replica routing", () => {
         offset: 0,
       });
 
+      expect(harness.requests.primary.length).toBeGreaterThan(0);
+      expect(replicaRequests()).toEqual([]);
+    });
+
+    // The two readers batch actions share with batch export. Batch actions pass
+    // no service because they enumerate a selection the user made against the
+    // primary, so "absent means the writer" is a contract these two owe their
+    // other caller — not an accident of the export not having been wired yet.
+    it("getObservationStream reads the primary when no service is passed", async () => {
+      resetRecordings();
+
+      const rows = await drain(
+        await getObservationStream({ projectId, cutoffCreatedAt, filter: [] }),
+      );
+
+      expect(rows).toHaveLength(2);
+      expect(harness.requests.primary.length).toBeGreaterThan(0);
+      expect(replicaRequests()).toEqual([]);
+    });
+
+    it("getDatabaseReadStreamPaginated reads the primary when no service is passed", async () => {
+      resetRecordings();
+
+      const rows = await drain(
+        await getDatabaseReadStreamPaginated({
+          projectId,
+          tableName: BatchExportTableName.Scores,
+          cutoffCreatedAt,
+          filter: [],
+          orderBy: EXPORT_ORDER_BY[BatchExportTableName.Scores],
+        }),
+      );
+
+      expect(rows).toHaveLength(2);
       expect(harness.requests.primary.length).toBeGreaterThan(0);
       expect(replicaRequests()).toEqual([]);
     });

--- a/worker/src/__tests__/batchExportReadReplica.test.ts
+++ b/worker/src/__tests__/batchExportReadReplica.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Routing regression tests for the batch export read path.
+ *
+ * Observation seam: this file redirects the three ClickHouse service URLs
+ * (`CLICKHOUSE_URL`, `CLICKHOUSE_READ_ONLY_URL`, `CLICKHOUSE_EVENTS_READ_ONLY_URL`)
+ * at recording HTTP pass-through proxies in front of the single local
+ * ClickHouse, before the shared env module is parsed. Every query therefore
+ * records which *cluster* it was sent to, independent of how routing is
+ * implemented (explicit `preferredClickhouseService` argument, ambient context,
+ * or anything else).
+ *
+ * The URL rewrite is process-wide for this file, which is why these tests live
+ * next to `batchExport.test.ts` instead of inside it: routing every query of
+ * that suite through a proxy would slow it down and add failure modes to tests
+ * that do not care about routing.
+ *
+ * Two cheaper seams were tried and rejected, empirically:
+ *  - Mutating the shared `env` object at runtime is a no-op. A test's
+ *    `@langfuse/shared/src/env` import and the built shared code's own `env`
+ *    import are different module instances, so an override never reaches the
+ *    ClickHouse client. Rewriting `process.env` inside `vi.hoisted()` works
+ *    because it runs before the shared env module is parsed.
+ *  - Mocking `queryClickhouse` / `queryClickhouseStream` on the
+ *    `@langfuse/shared/src/server` barrel only intercepts calls made by worker
+ *    code. It cannot see the queries issued inside shared itself (score names,
+ *    the scores/sessions/dataset-run-items table services), which is where most
+ *    of the routing under test happens.
+ *
+ * The non-events export paths must land on the read-only service specifically:
+ * `EventsReadOnly` is reserved for the events-table export, which is out of
+ * scope here, so a query arriving on the events replica is as much a failure as
+ * one arriving on the primary writer.
+ */
+import http from "http";
+import { randomUUID } from "crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  const upstream = new URL(process.env.CLICKHOUSE_URL as string);
+  // Distinct ports per run: several test files execute in parallel processes.
+  const base = 21000 + Math.floor(Math.random() * 1000) * 4;
+  const ports = {
+    primary: base,
+    readOnly: base + 1,
+    eventsReadOnly: base + 2,
+  };
+  process.env.CLICKHOUSE_URL = `http://127.0.0.1:${ports.primary}`;
+  process.env.CLICKHOUSE_READ_ONLY_URL = `http://127.0.0.1:${ports.readOnly}`;
+  process.env.CLICKHOUSE_EVENTS_READ_ONLY_URL = `http://127.0.0.1:${ports.eventsReadOnly}`;
+  // Mirrors batchExport.test.ts so the dataset run items export reads the
+  // versioned (ClickHouse) implementation.
+  process.env.LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION =
+    "true";
+  process.env.LANGFUSE_DATASET_SERVICE_WRITE_TO_VERSIONED_IMPLEMENTATION =
+    "true";
+
+  return {
+    upstreamHost: upstream.hostname,
+    upstreamPort: Number(upstream.port || 8123),
+    ports,
+    requests: {
+      primary: [] as string[],
+      readOnly: [] as string[],
+      eventsReadOnly: [] as string[],
+    },
+  };
+});
+
+const {
+  createDatasetRunItem,
+  createDatasetRunItemsCh,
+  createObservation,
+  createObservationsCh,
+  createOrgProjectAndApiKey,
+  createScoresCh,
+  createTrace,
+  createTraceScore,
+  createTracesCh,
+  getDatasetRunItemsCh,
+  getDistinctScoreNames,
+  getScoresUiTable,
+  getSessionsTable,
+  queryClickhouse,
+} = await import("@langfuse/shared/src/server");
+const { prisma } = await import("@langfuse/shared/src/db");
+const { BatchExportFileFormat, BatchExportStatus, BatchExportTableName } =
+  await import("@langfuse/shared");
+const { handleBatchExportJob } =
+  await import("../features/batchExport/handleBatchExportJob");
+const { getDatabaseReadStreamPaginated } =
+  await import("../features/database-read-stream/getDatabaseReadStream");
+const { getObservationStream } =
+  await import("../features/database-read-stream/observation-stream");
+const { getTraceStream } =
+  await import("../features/database-read-stream/trace-stream");
+
+const startRecordingProxy = (port: number, sink: string[]) =>
+  new Promise<http.Server>((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8");
+        sink.push(`${req.method} ${req.url} ${body}`);
+        const headers = { ...req.headers };
+        delete headers.host;
+        delete headers["content-length"];
+        const upstreamReq = http.request(
+          {
+            host: harness.upstreamHost,
+            port: harness.upstreamPort,
+            method: req.method,
+            path: req.url,
+            headers,
+          },
+          (upstreamRes) => {
+            res.writeHead(upstreamRes.statusCode ?? 500, upstreamRes.headers);
+            upstreamRes.pipe(res);
+          },
+        );
+        upstreamReq.on("error", (error) => {
+          res.writeHead(502);
+          res.end(String(error));
+        });
+        upstreamReq.end(body);
+      });
+    });
+    server.timeout = 0;
+    server.requestTimeout = 0;
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve(server));
+  });
+
+let servers: http.Server[] = [];
+
+const resetRecordings = () => {
+  harness.requests.primary.length = 0;
+  harness.requests.readOnly.length = 0;
+  harness.requests.eventsReadOnly.length = 0;
+};
+
+const replicaRequests = () => [
+  ...harness.requests.readOnly,
+  ...harness.requests.eventsReadOnly,
+];
+
+/** Compact failure messages: which SQL statements reached a given service. */
+const recordedQueries = (sink: string[]) =>
+  sink.map((request) =>
+    (request.split(" ").slice(2).join(" ") || request)
+      .replace(/\s+/g, " ")
+      .slice(0, 200),
+  );
+
+const primaryQueries = () => recordedQueries(harness.requests.primary);
+
+/**
+ * Queries that reached the events read replica. Legitimate for the events-table
+ * export (out of scope here), a routing failure for every path under test.
+ */
+const eventsReplicaQueries = () =>
+  recordedQueries(harness.requests.eventsReadOnly);
+
+/**
+ * Mirrors the stream selection *and argument list* `handleBatchExportJob` uses
+ * per table, so the sweep exercises the code an actual export runs. The service
+ * value is the one the job passes; the paginated reader and the observation
+ * stream deliberately default to the writer when it is absent, so that batch
+ * *actions* — which enumerate a selection the user made against the primary —
+ * are unaffected. Whether the job itself still passes it is covered separately
+ * by the end-to-end tests further down, which drive the job for real.
+ */
+const openExportStream = async (
+  tableName: (typeof CLICKHOUSE_BACKED_EXPORT_TABLES)[number],
+): Promise<AsyncIterable<unknown>> => {
+  switch (tableName) {
+    // The traces stream pins its own service and takes no option from the job.
+    case BatchExportTableName.Traces:
+      return getTraceStream({ projectId, cutoffCreatedAt, filter: [] });
+    case BatchExportTableName.Observations:
+      return getObservationStream({
+        projectId,
+        cutoffCreatedAt,
+        filter: [],
+        preferredClickhouseService: EXPORT_CLICKHOUSE_SERVICE,
+      });
+    default:
+      return getDatabaseReadStreamPaginated({
+        projectId,
+        tableName,
+        cutoffCreatedAt,
+        filter: [],
+        orderBy: EXPORT_ORDER_BY[tableName],
+        preferredClickhouseService: EXPORT_CLICKHOUSE_SERVICE,
+      });
+  }
+};
+
+const drain = async (stream: AsyncIterable<unknown>) => {
+  const rows: any[] = [];
+  for await (const row of stream) rows.push(row);
+  return rows;
+};
+
+const cutoffCreatedAt = new Date(Date.now() + 1000 * 60 * 60 * 24);
+
+/** Export tables whose rows are read from ClickHouse on the export path. */
+const CLICKHOUSE_BACKED_EXPORT_TABLES = [
+  BatchExportTableName.Traces,
+  BatchExportTableName.Observations,
+  BatchExportTableName.Scores,
+  BatchExportTableName.Sessions,
+  BatchExportTableName.DatasetRunItems,
+] as const;
+
+/** Tables deliberately outside the sweep, with the reason they are exempt. */
+const EXPORT_TABLES_EXEMPT_FROM_ROUTING_SWEEP: Record<string, string> = {
+  [BatchExportTableName.Datasets]:
+    "no case in getDatabaseReadStreamPaginated; reachable only as a batch action",
+  [BatchExportTableName.DatasetItems]: "Postgres/Prisma only",
+  [BatchExportTableName.AuditLogs]: "Postgres/Prisma only",
+  [BatchExportTableName.Events]:
+    "events export already targets the events read replica",
+};
+
+/**
+ * The service a batch export reads from. Duplicated from the job's own private
+ * constant on purpose: this is the spec's value, so the test fails if the job
+ * ever drifts to a different service rather than following it silently.
+ */
+const EXPORT_CLICKHOUSE_SERVICE = "ReadOnly" as const;
+
+/** Per-table sort column accepted by the export query for that table. */
+const EXPORT_ORDER_BY: Record<string, { column: string; order: "DESC" }> = {
+  [BatchExportTableName.Scores]: { column: "timestamp", order: "DESC" },
+  [BatchExportTableName.Sessions]: { column: "createdAt", order: "DESC" },
+  [BatchExportTableName.DatasetRunItems]: {
+    column: "createdAt",
+    order: "DESC",
+  },
+};
+
+const EXPECTED_EXPORT_ROW_COUNT: Record<string, number> = {
+  [BatchExportTableName.Traces]: 2,
+  [BatchExportTableName.Observations]: 2,
+  [BatchExportTableName.Scores]: 2,
+  [BatchExportTableName.Sessions]: 2,
+  [BatchExportTableName.DatasetRunItems]: 1,
+};
+
+let projectId: string;
+let traceIds: string[];
+let sessionIds: string[];
+
+beforeAll(async () => {
+  servers = await Promise.all([
+    startRecordingProxy(harness.ports.primary, harness.requests.primary),
+    startRecordingProxy(harness.ports.readOnly, harness.requests.readOnly),
+    startRecordingProxy(
+      harness.ports.eventsReadOnly,
+      harness.requests.eventsReadOnly,
+    ),
+  ]);
+
+  ({ projectId } = await createOrgProjectAndApiKey());
+
+  sessionIds = [randomUUID(), randomUUID()];
+  await prisma.traceSession.createMany({
+    data: sessionIds.map((id) => ({ id, projectId })),
+  });
+
+  traceIds = [randomUUID(), randomUUID()];
+  await createTracesCh(
+    traceIds.map((id, index) =>
+      createTrace({
+        project_id: projectId,
+        id,
+        session_id: sessionIds[index],
+      }),
+    ),
+  );
+
+  await createObservationsCh(
+    traceIds.map((traceId) =>
+      createObservation({ project_id: projectId, trace_id: traceId }),
+    ),
+  );
+
+  // Named score: the export flattens one column per distinct score name, so its
+  // presence in an exported row proves the distinct-score-names query ran.
+  await createScoresCh(
+    traceIds.map((traceId) =>
+      createTraceScore({
+        project_id: projectId,
+        trace_id: traceId,
+        name: "quality",
+        value: 1,
+        observation_id: null,
+      }),
+    ),
+  );
+
+  // Dataset run items are seeded in ClickHouse only: the export reads them from
+  // ClickHouse and looks up dataset names in Postgres, which tolerates a
+  // missing dataset row.
+  await createDatasetRunItemsCh([
+    createDatasetRunItem({
+      id: randomUUID(),
+      project_id: projectId,
+      dataset_id: randomUUID(),
+      dataset_run_id: randomUUID(),
+      dataset_item_id: randomUUID(),
+      trace_id: traceIds[0],
+    }),
+  ]);
+}, 120_000);
+
+afterAll(async () => {
+  await Promise.all(
+    servers.map((s) => new Promise<void>((r) => s.close(() => r()))),
+  );
+});
+
+describe("batch export read replica routing", () => {
+  // Load-bearing: without these two controls a green "no primary traffic"
+  // assertion could just mean the harness never observed anything.
+  describe("harness controls", () => {
+    it("records a default-routed query on the primary writer only", async () => {
+      resetRecordings();
+
+      const rows = await queryClickhouse<{ x: number }>({
+        query: "SELECT 1 AS x",
+        params: {},
+        tags: {},
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(harness.requests.primary.length).toBeGreaterThan(0);
+      expect(replicaRequests()).toEqual([]);
+    });
+
+    it("records a read-replica-routed query on the replica only", async () => {
+      resetRecordings();
+
+      const rows = await queryClickhouse<{ x: number }>({
+        query: "SELECT 1 AS x",
+        params: {},
+        tags: {},
+        preferredClickhouseService: "ReadOnly",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(primaryQueries()).toEqual([]);
+      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
+    });
+  });
+
+  // AC3 + AC1 (call sites 1 and 2): a traces export must send every query to
+  // the read-only replica — neither the main traces+scores query nor the
+  // distinct-score-names query that builds the score columns may leave it.
+  describe("AC3 — traces export", () => {
+    it("sends every query to the read-only replica", async () => {
+      resetRecordings();
+
+      const rows = await drain(
+        await getTraceStream({ projectId, cutoffCreatedAt, filter: [] }),
+      );
+
+      expect(rows).toHaveLength(2);
+      // Proves the distinct-score-names query (call site 2) participated.
+      expect(Object.keys(rows[0])).toContain("quality");
+      expect(primaryQueries()).toEqual([]);
+      expect(eventsReplicaQueries()).toEqual([]);
+      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
+    });
+  });
+
+  // AC1 (call sites 3-6) plus AC4: every ClickHouse-backed export table is
+  // driven through the same stream selection the batch export job performs, so
+  // adding a table to the enum without a routing decision fails here rather
+  // than silently reading from the writer in production.
+  describe("AC1 — every ClickHouse-backed export path", () => {
+    it("no export table escapes the routing sweep", () => {
+      expect(
+        [
+          ...CLICKHOUSE_BACKED_EXPORT_TABLES,
+          ...Object.keys(EXPORT_TABLES_EXEMPT_FROM_ROUTING_SWEEP),
+        ].sort(),
+      ).toEqual(Object.values(BatchExportTableName).sort());
+    });
+
+    it.each(CLICKHOUSE_BACKED_EXPORT_TABLES)(
+      "%s export sends every query to the read-only replica",
+      async (tableName) => {
+        resetRecordings();
+
+        const rows = await drain(await openExportStream(tableName));
+
+        // Guards against a vacuous pass: the export really did read rows.
+        expect(rows).toHaveLength(EXPECTED_EXPORT_ROW_COUNT[tableName]);
+        expect(primaryQueries()).toEqual([]);
+        expect(eventsReplicaQueries()).toEqual([]);
+        expect(harness.requests.readOnly.length).toBeGreaterThan(0);
+      },
+    );
+  });
+
+  // AC3 + AC4, end to end: the sweep above passes the export service itself, so
+  // it cannot see the job forgetting to pass it. These drive the real job entry
+  // point from a persisted batch export row, which is the only check that the
+  // wiring at the choke point survives.
+  describe("AC3 — the batch export job itself", () => {
+    const runExportJob = async (
+      tableName: string,
+      orderBy: { column: string; order: "DESC" } | null,
+    ) => {
+      const batchExport = await prisma.batchExport.create({
+        data: {
+          projectId,
+          userId: randomUUID(),
+          name: `routing-${tableName}`,
+          status: BatchExportStatus.QUEUED,
+          format: BatchExportFileFormat.JSONL,
+          query: { tableName, filter: [], orderBy },
+        },
+      });
+
+      resetRecordings();
+
+      // The job uploads the export to object storage after reading, which is
+      // not available here. Reads are what this asserts, so a later failure is
+      // tolerated — an early failure is still caught, because a job that threw
+      // before reading leaves the read-only sink empty.
+      await handleBatchExportJob({
+        projectId,
+        batchExportId: batchExport.id,
+      }).catch(() => undefined);
+    };
+
+    it("reads only from the read-only replica for a traces export", async () => {
+      await runExportJob(BatchExportTableName.Traces, null);
+
+      expect(primaryQueries()).toEqual([]);
+      expect(eventsReplicaQueries()).toEqual([]);
+      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
+    });
+
+    it("reads only from the read-only replica for a scores export", async () => {
+      await runExportJob(BatchExportTableName.Scores, {
+        column: "timestamp",
+        order: "DESC",
+      });
+
+      expect(primaryQueries()).toEqual([]);
+      expect(eventsReplicaQueries()).toEqual([]);
+      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
+    });
+  });
+
+  // AC2: the same shared functions, called the way a UI/API request calls them
+  // (no export in progress, no explicit service), must still hit the primary.
+  // These guard against pushing the replica default down into the leaves.
+  describe("AC2 — non-export callers keep reading the primary", () => {
+    it("getDistinctScoreNames reads the primary", async () => {
+      resetRecordings();
+
+      await getDistinctScoreNames({
+        projectId,
+        cutoffCreatedAt,
+        startTimeFrom: null,
+      });
+
+      expect(harness.requests.primary.length).toBeGreaterThan(0);
+      expect(replicaRequests()).toEqual([]);
+    });
+
+    it("getScoresUiTable reads the primary", async () => {
+      resetRecordings();
+
+      await getScoresUiTable({
+        projectId,
+        filter: [],
+        orderBy: null,
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(harness.requests.primary.length).toBeGreaterThan(0);
+      expect(replicaRequests()).toEqual([]);
+    });
+
+    it("getSessionsTable reads the primary", async () => {
+      resetRecordings();
+
+      await getSessionsTable({ projectId, filter: [], limit: 10, page: 0 });
+
+      expect(harness.requests.primary.length).toBeGreaterThan(0);
+      expect(replicaRequests()).toEqual([]);
+    });
+
+    it("getDatasetRunItemsCh reads the primary", async () => {
+      resetRecordings();
+
+      await getDatasetRunItemsCh({
+        projectId,
+        filter: [],
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(harness.requests.primary.length).toBeGreaterThan(0);
+      expect(replicaRequests()).toEqual([]);
+    });
+  });
+});

--- a/worker/src/__tests__/batchExportReadReplica.test.ts
+++ b/worker/src/__tests__/batchExportReadReplica.test.ts
@@ -1,35 +1,10 @@
 /**
- * Routing regression tests for the batch export read path.
- *
- * Observation seam: this file redirects the three ClickHouse service URLs
- * (`CLICKHOUSE_URL`, `CLICKHOUSE_READ_ONLY_URL`, `CLICKHOUSE_EVENTS_READ_ONLY_URL`)
- * at recording HTTP pass-through proxies in front of the single local
- * ClickHouse, before the shared env module is parsed. Every query therefore
- * records which *cluster* it was sent to, independent of how routing is
- * implemented (explicit `preferredClickhouseService` argument, ambient context,
- * or anything else).
- *
- * The URL rewrite is process-wide for this file, which is why these tests live
- * next to `batchExport.test.ts` instead of inside it: routing every query of
- * that suite through a proxy would slow it down and add failure modes to tests
- * that do not care about routing.
- *
- * Two cheaper seams were tried and rejected, empirically:
- *  - Mutating the shared `env` object at runtime is a no-op. A test's
- *    `@langfuse/shared/src/env` import and the built shared code's own `env`
- *    import are different module instances, so an override never reaches the
- *    ClickHouse client. Rewriting `process.env` inside `vi.hoisted()` works
- *    because it runs before the shared env module is parsed.
- *  - Mocking `queryClickhouse` / `queryClickhouseStream` on the
- *    `@langfuse/shared/src/server` barrel only intercepts calls made by worker
- *    code. It cannot see the queries issued inside shared itself (score names,
- *    the scores/sessions/dataset-run-items table services), which is where most
- *    of the routing under test happens.
- *
- * The non-events export paths must land on the read-only service specifically:
- * `EventsReadOnly` is reserved for the events-table export, which is out of
- * scope here, so a query arriving on the events replica is as much a failure as
- * one arriving on the primary writer.
+ * ClickHouse service routing for the batch export read path, observed by
+ * pointing each service URL at a recording proxy before the shared env module
+ * is parsed. Two things this rules out: mutating the shared `env` object at
+ * runtime is a no-op (the test and the built shared code hold different module
+ * instances), and mocking `queryClickhouse` on the shared barrel cannot see the
+ * queries `shared` issues internally.
  */
 import http from "http";
 import { randomUUID } from "crypto";
@@ -37,22 +12,11 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 const harness = vi.hoisted(() => {
   const upstream = new URL(process.env.CLICKHOUSE_URL as string);
-  // Distinct ports per run: several test files execute in parallel processes.
   const base = 21000 + Math.floor(Math.random() * 1000) * 4;
-  const ports = {
-    primary: base,
-    readOnly: base + 1,
-    eventsReadOnly: base + 2,
-  };
+  const ports = { primary: base, readOnly: base + 1, eventsReadOnly: base + 2 };
   process.env.CLICKHOUSE_URL = `http://127.0.0.1:${ports.primary}`;
   process.env.CLICKHOUSE_READ_ONLY_URL = `http://127.0.0.1:${ports.readOnly}`;
   process.env.CLICKHOUSE_EVENTS_READ_ONLY_URL = `http://127.0.0.1:${ports.eventsReadOnly}`;
-  // Mirrors batchExport.test.ts so the dataset run items export reads the
-  // versioned (ClickHouse) implementation.
-  process.env.LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION =
-    "true";
-  process.env.LANGFUSE_DATASET_SERVICE_WRITE_TO_VERSIONED_IMPLEMENTATION =
-    "true";
 
   return {
     upstreamHost: upstream.hostname,
@@ -67,8 +31,6 @@ const harness = vi.hoisted(() => {
 });
 
 const {
-  createDatasetRunItem,
-  createDatasetRunItemsCh,
   createObservation,
   createObservationsCh,
   createOrgProjectAndApiKey,
@@ -76,17 +38,9 @@ const {
   createTrace,
   createTraceScore,
   createTracesCh,
-  getDatasetRunItemsCh,
-  getDistinctScoreNames,
-  getScoresUiTable,
-  getSessionsTable,
   queryClickhouse,
 } = await import("@langfuse/shared/src/server");
-const { prisma } = await import("@langfuse/shared/src/db");
-const { BatchExportFileFormat, BatchExportStatus, BatchExportTableName } =
-  await import("@langfuse/shared");
-const { handleBatchExportJob } =
-  await import("../features/batchExport/handleBatchExportJob");
+const { BatchExportTableName } = await import("@langfuse/shared");
 const { getDatabaseReadStreamPaginated } =
   await import("../features/database-read-stream/getDatabaseReadStream");
 const { getObservationStream } =
@@ -101,7 +55,7 @@ const startRecordingProxy = (port: number, sink: string[]) =>
       req.on("data", (c) => chunks.push(c));
       req.on("end", () => {
         const body = Buffer.concat(chunks).toString("utf8");
-        sink.push(`${req.method} ${req.url} ${body}`);
+        sink.push(body.replace(/\s+/g, " ").slice(0, 120));
         const headers = { ...req.headers };
         delete headers.host;
         delete headers["content-length"];
@@ -133,68 +87,18 @@ const startRecordingProxy = (port: number, sink: string[]) =>
 
 let servers: http.Server[] = [];
 
-const resetRecordings = () => {
-  harness.requests.primary.length = 0;
-  harness.requests.readOnly.length = 0;
-  harness.requests.eventsReadOnly.length = 0;
-};
+const resetRecordings = () =>
+  Object.values(harness.requests).forEach((sink) => (sink.length = 0));
 
-const replicaRequests = () => [
+const servicesUsed = () =>
+  Object.entries(harness.requests)
+    .filter(([, sink]) => sink.length > 0)
+    .map(([service]) => service);
+
+const replicaQueries = () => [
   ...harness.requests.readOnly,
   ...harness.requests.eventsReadOnly,
 ];
-
-/** Compact failure messages: which SQL statements reached a given service. */
-const recordedQueries = (sink: string[]) =>
-  sink.map((request) =>
-    (request.split(" ").slice(2).join(" ") || request)
-      .replace(/\s+/g, " ")
-      .slice(0, 200),
-  );
-
-const primaryQueries = () => recordedQueries(harness.requests.primary);
-
-/**
- * Queries that reached the events read replica. Legitimate for the events-table
- * export (out of scope here), a routing failure for every path under test.
- */
-const eventsReplicaQueries = () =>
-  recordedQueries(harness.requests.eventsReadOnly);
-
-/**
- * Mirrors the stream selection *and argument list* `handleBatchExportJob` uses
- * per table, so the sweep exercises the code an actual export runs. The service
- * value is the one the job passes; the paginated reader and the observation
- * stream deliberately default to the writer when it is absent, so that batch
- * *actions* — which enumerate a selection the user made against the primary —
- * are unaffected. Whether the job itself still passes it is covered separately
- * by the end-to-end tests further down, which drive the job for real.
- */
-const openExportStream = async (
-  tableName: (typeof CLICKHOUSE_BACKED_EXPORT_TABLES)[number],
-): Promise<AsyncIterable<unknown>> => {
-  switch (tableName) {
-    // The traces stream pins its own service and takes no option from the job.
-    case BatchExportTableName.Traces:
-      return getTraceStream({ projectId, cutoffCreatedAt, filter: [] });
-    case BatchExportTableName.Observations:
-      return getObservationStream({
-        projectId,
-        cutoffCreatedAt,
-        filter: [],
-        preferredClickhouseService: EXPORT_CLICKHOUSE_SERVICE,
-      });
-    default:
-      return getDatabaseReadStreamPaginated({
-        projectId,
-        tableName,
-        cutoffCreatedAt,
-        filter: [],
-        orderBy: EXPORT_ORDER_BY[tableName],
-        preferredClickhouseService: EXPORT_CLICKHOUSE_SERVICE,
-      });
-  }
-};
 
 const drain = async (stream: AsyncIterable<unknown>) => {
   const rows: any[] = [];
@@ -203,114 +107,34 @@ const drain = async (stream: AsyncIterable<unknown>) => {
 };
 
 const cutoffCreatedAt = new Date(Date.now() + 1000 * 60 * 60 * 24);
-
-/** Export tables whose rows are read from ClickHouse on the export path. */
-const CLICKHOUSE_BACKED_EXPORT_TABLES = [
-  BatchExportTableName.Traces,
-  BatchExportTableName.Observations,
-  BatchExportTableName.Scores,
-  BatchExportTableName.Sessions,
-  BatchExportTableName.DatasetRunItems,
-] as const;
-
-/** Tables deliberately outside the sweep, with the reason they are exempt. */
-const EXPORT_TABLES_EXEMPT_FROM_ROUTING_SWEEP: Record<string, string> = {
-  [BatchExportTableName.Datasets]:
-    "no case in getDatabaseReadStreamPaginated; reachable only as a batch action",
-  [BatchExportTableName.DatasetItems]: "Postgres/Prisma only",
-  [BatchExportTableName.AuditLogs]: "Postgres/Prisma only",
-  [BatchExportTableName.Events]:
-    "events export already targets the events read replica",
-};
-
-/**
- * The service a batch export reads from. Duplicated from the job's own private
- * constant on purpose: this is the spec's value, so the test fails if the job
- * ever drifts to a different service rather than following it silently.
- */
-const EXPORT_CLICKHOUSE_SERVICE = "ReadOnly" as const;
-
-/** Per-table sort column accepted by the export query for that table. */
-const EXPORT_ORDER_BY: Record<string, { column: string; order: "DESC" }> = {
-  [BatchExportTableName.Scores]: { column: "timestamp", order: "DESC" },
-  [BatchExportTableName.Sessions]: { column: "createdAt", order: "DESC" },
-  [BatchExportTableName.DatasetRunItems]: {
-    column: "createdAt",
-    order: "DESC",
-  },
-};
-
-const EXPECTED_EXPORT_ROW_COUNT: Record<string, number> = {
-  [BatchExportTableName.Traces]: 2,
-  [BatchExportTableName.Observations]: 2,
-  [BatchExportTableName.Scores]: 2,
-  [BatchExportTableName.Sessions]: 2,
-  [BatchExportTableName.DatasetRunItems]: 1,
-};
+const scoreName = "quality";
 
 let projectId: string;
-let traceIds: string[];
-let sessionIds: string[];
 
 beforeAll(async () => {
-  servers = await Promise.all([
-    startRecordingProxy(harness.ports.primary, harness.requests.primary),
-    startRecordingProxy(harness.ports.readOnly, harness.requests.readOnly),
-    startRecordingProxy(
-      harness.ports.eventsReadOnly,
-      harness.requests.eventsReadOnly,
+  servers = await Promise.all(
+    Object.entries(harness.ports).map(([service, port]) =>
+      startRecordingProxy(
+        port,
+        harness.requests[service as keyof typeof harness.requests],
+      ),
     ),
-  ]);
+  );
 
   ({ projectId } = await createOrgProjectAndApiKey());
 
-  sessionIds = [randomUUID(), randomUUID()];
-  await prisma.traceSession.createMany({
-    data: sessionIds.map((id) => ({ id, projectId })),
-  });
-
-  traceIds = [randomUUID(), randomUUID()];
-  await createTracesCh(
-    traceIds.map((id, index) =>
-      createTrace({
-        project_id: projectId,
-        id,
-        session_id: sessionIds[index],
-      }),
-    ),
-  );
-
-  await createObservationsCh(
-    traceIds.map((traceId) =>
-      createObservation({ project_id: projectId, trace_id: traceId }),
-    ),
-  );
-
-  // Named score: the export flattens one column per distinct score name, so its
-  // presence in an exported row proves the distinct-score-names query ran.
-  await createScoresCh(
-    traceIds.map((traceId) =>
-      createTraceScore({
-        project_id: projectId,
-        trace_id: traceId,
-        name: "quality",
-        value: 1,
-        observation_id: null,
-      }),
-    ),
-  );
-
-  // Dataset run items are seeded in ClickHouse only: the export reads them from
-  // ClickHouse and looks up dataset names in Postgres, which tolerates a
-  // missing dataset row.
-  await createDatasetRunItemsCh([
-    createDatasetRunItem({
-      id: randomUUID(),
+  const traceId = randomUUID();
+  await createTracesCh([createTrace({ project_id: projectId, id: traceId })]);
+  await createObservationsCh([
+    createObservation({ project_id: projectId, trace_id: traceId }),
+  ]);
+  await createScoresCh([
+    createTraceScore({
       project_id: projectId,
-      dataset_id: randomUUID(),
-      dataset_run_id: randomUUID(),
-      dataset_item_id: randomUUID(),
-      trace_id: traceIds[0],
+      trace_id: traceId,
+      name: scoreName,
+      value: 1,
+      observation_id: null,
     }),
   ]);
 }, 120_000);
@@ -321,261 +145,82 @@ afterAll(async () => {
   );
 });
 
-describe("batch export read replica routing", () => {
-  // Load-bearing: without these controls a green "no traffic on service X"
-  // assertion could just mean the harness never observed anything. There is one
-  // control per service, so every sink is proven reachable before any test
-  // asserts a sink is empty.
-  describe("harness controls", () => {
-    it("records a default-routed query on the primary writer only", async () => {
-      resetRecordings();
+describe("batch export ClickHouse routing", () => {
+  it("records each service on its own sink", async () => {
+    resetRecordings();
 
-      const rows = await queryClickhouse<{ x: number }>({
+    for (const preferredClickhouseService of [
+      undefined,
+      "ReadOnly",
+      "EventsReadOnly",
+    ] as const) {
+      await queryClickhouse({
         query: "SELECT 1 AS x",
         params: {},
         tags: {},
+        preferredClickhouseService,
       });
+    }
 
-      expect(rows).toHaveLength(1);
-      expect(harness.requests.primary.length).toBeGreaterThan(0);
-      expect(replicaRequests()).toEqual([]);
-    });
-
-    it("records a read-replica-routed query on the replica only", async () => {
-      resetRecordings();
-
-      const rows = await queryClickhouse<{ x: number }>({
-        query: "SELECT 1 AS x",
-        params: {},
-        tags: {},
-        preferredClickhouseService: "ReadOnly",
-      });
-
-      expect(rows).toHaveLength(1);
-      expect(primaryQueries()).toEqual([]);
-      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
-    });
-
-    // Without this, every `expect(eventsReplicaQueries()).toEqual([])` below
-    // would silently become a tautology if the env rewrite for
-    // CLICKHOUSE_EVENTS_READ_ONLY_URL ever stopped taking effect.
-    it("records an events-replica-routed query on the events replica only", async () => {
-      resetRecordings();
-
-      const rows = await queryClickhouse<{ x: number }>({
-        query: "SELECT 1 AS x",
-        params: {},
-        tags: {},
-        preferredClickhouseService: "EventsReadOnly",
-      });
-
-      expect(rows).toHaveLength(1);
-      expect(primaryQueries()).toEqual([]);
-      expect(harness.requests.readOnly).toEqual([]);
-      expect(harness.requests.eventsReadOnly.length).toBeGreaterThan(0);
-    });
+    expect(servicesUsed()).toEqual(["primary", "readOnly", "eventsReadOnly"]);
   });
 
-  // AC3 + AC1 (call sites 1 and 2): a traces export must send every query to
-  // the read-only replica — neither the main traces+scores query nor the
-  // distinct-score-names query that builds the score columns may leave it.
-  describe("AC3 — traces export", () => {
-    it("sends every query to the read-only replica", async () => {
-      resetRecordings();
-
-      const rows = await drain(
-        await getTraceStream({ projectId, cutoffCreatedAt, filter: [] }),
-      );
-
-      expect(rows).toHaveLength(2);
-      // Proves the distinct-score-names query (call site 2) participated.
-      expect(Object.keys(rows[0])).toContain("quality");
-      expect(primaryQueries()).toEqual([]);
-      expect(eventsReplicaQueries()).toEqual([]);
-      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
-    });
-  });
-
-  // AC1 (call sites 3-6) plus AC4: every ClickHouse-backed export table is
-  // driven through the same stream selection the batch export job performs, so
-  // adding a table to the enum without a routing decision fails here rather
-  // than silently reading from the writer in production.
-  describe("AC1 — every ClickHouse-backed export path", () => {
-    it("no export table escapes the routing sweep", () => {
-      expect(
-        [
-          ...CLICKHOUSE_BACKED_EXPORT_TABLES,
-          ...Object.keys(EXPORT_TABLES_EXEMPT_FROM_ROUTING_SWEEP),
-        ].sort(),
-      ).toEqual(Object.values(BatchExportTableName).sort());
-    });
-
-    it.each(CLICKHOUSE_BACKED_EXPORT_TABLES)(
-      "%s export sends every query to the read-only replica",
-      async (tableName) => {
-        resetRecordings();
-
-        const rows = await drain(await openExportStream(tableName));
-
-        // Guards against a vacuous pass: the export really did read rows.
-        expect(rows).toHaveLength(EXPECTED_EXPORT_ROW_COUNT[tableName]);
-        expect(primaryQueries()).toEqual([]);
-        expect(eventsReplicaQueries()).toEqual([]);
-        expect(harness.requests.readOnly.length).toBeGreaterThan(0);
-      },
-    );
-  });
-
-  // AC3 + AC4, end to end: the sweep above passes the export service itself, so
-  // it cannot see the job forgetting to pass it. These drive the real job entry
-  // point from a persisted batch export row, which is the only check that the
-  // wiring at the choke point survives.
-  describe("AC3 — the batch export job itself", () => {
-    const runExportJob = async (
-      tableName: string,
-      orderBy: { column: string; order: "DESC" } | null,
-    ) => {
-      const batchExport = await prisma.batchExport.create({
-        data: {
+  // A score whose name is missing from the name list is dropped from the row, so
+  // a name read that lags behind the value read silently removes a whole column
+  // from the export. Both reads must therefore resolve to the same service,
+  // whichever one that is.
+  it.each([
+    [
+      "traces",
+      () => getTraceStream({ projectId, cutoffCreatedAt, filter: [] }),
+    ],
+    [
+      "observations",
+      () =>
+        getObservationStream({
           projectId,
-          userId: randomUUID(),
-          name: `routing-${tableName}`,
-          status: BatchExportStatus.QUEUED,
-          format: BatchExportFileFormat.JSONL,
-          query: { tableName, filter: [], orderBy },
-        },
-      });
-
+          cutoffCreatedAt,
+          filter: [],
+          preferredClickhouseService: "ReadOnly",
+        }),
+    ],
+  ])(
+    "%s export reads score names and values from one service",
+    async (_, openStream) => {
       resetRecordings();
 
-      // The job uploads the export to object storage after reading, which is
-      // not available here. Reads are what this asserts, so a later failure is
-      // tolerated — an early failure is still caught, because a job that threw
-      // before reading leaves the read-only sink empty.
-      await handleBatchExportJob({
-        projectId,
-        batchExportId: batchExport.id,
-      }).catch(() => undefined);
-    };
+      const rows = await drain(await openStream());
 
-    it("reads only from the read-only replica for a traces export", async () => {
-      await runExportJob(BatchExportTableName.Traces, null);
+      expect(Object.keys(rows[0])).toContain(scoreName);
+      expect(servicesUsed()).toHaveLength(1);
+    },
+  );
 
-      expect(primaryQueries()).toEqual([]);
-      expect(eventsReplicaQueries()).toEqual([]);
-      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
-    });
-
-    it("reads only from the read-only replica for a scores export", async () => {
-      await runExportJob(BatchExportTableName.Scores, {
-        column: "timestamp",
-        order: "DESC",
-      });
-
-      expect(primaryQueries()).toEqual([]);
-      expect(eventsReplicaQueries()).toEqual([]);
-      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
-    });
-
-    // Observations have their own dispatch branch in the job — they do not share
-    // the one scores, sessions and dataset run items go through — so without
-    // this test that branch's service forward is executed by nothing.
-    it("reads only from the read-only replica for an observations export", async () => {
-      await runExportJob(BatchExportTableName.Observations, null);
-
-      expect(primaryQueries()).toEqual([]);
-      expect(eventsReplicaQueries()).toEqual([]);
-      expect(harness.requests.readOnly.length).toBeGreaterThan(0);
-    });
-  });
-
-  // AC2: the same shared functions, called the way a UI/API request calls them
-  // (no export in progress, no explicit service), must still hit the primary.
-  // These guard against pushing the replica default down into the leaves.
-  describe("AC2 — non-export callers keep reading the primary", () => {
-    it("getDistinctScoreNames reads the primary", async () => {
-      resetRecordings();
-
-      await getDistinctScoreNames({
-        projectId,
-        cutoffCreatedAt,
-        startTimeFrom: null,
-      });
-
-      expect(harness.requests.primary.length).toBeGreaterThan(0);
-      expect(replicaRequests()).toEqual([]);
-    });
-
-    it("getScoresUiTable reads the primary", async () => {
-      resetRecordings();
-
-      await getScoresUiTable({
-        projectId,
-        filter: [],
-        orderBy: null,
-        limit: 10,
-        offset: 0,
-      });
-
-      expect(harness.requests.primary.length).toBeGreaterThan(0);
-      expect(replicaRequests()).toEqual([]);
-    });
-
-    it("getSessionsTable reads the primary", async () => {
-      resetRecordings();
-
-      await getSessionsTable({ projectId, filter: [], limit: 10, page: 0 });
-
-      expect(harness.requests.primary.length).toBeGreaterThan(0);
-      expect(replicaRequests()).toEqual([]);
-    });
-
-    it("getDatasetRunItemsCh reads the primary", async () => {
-      resetRecordings();
-
-      await getDatasetRunItemsCh({
-        projectId,
-        filter: [],
-        limit: 10,
-        offset: 0,
-      });
-
-      expect(harness.requests.primary.length).toBeGreaterThan(0);
-      expect(replicaRequests()).toEqual([]);
-    });
-
-    // The two readers batch actions share with batch export. Batch actions pass
-    // no service because they enumerate a selection the user made against the
-    // primary, so "absent means the writer" is a contract these two owe their
-    // other caller — not an accident of the export not having been wired yet.
-    it("getObservationStream reads the primary when no service is passed", async () => {
-      resetRecordings();
-
-      const rows = await drain(
-        await getObservationStream({ projectId, cutoffCreatedAt, filter: [] }),
-      );
-
-      expect(rows).toHaveLength(2);
-      expect(harness.requests.primary.length).toBeGreaterThan(0);
-      expect(replicaRequests()).toEqual([]);
-    });
-
-    it("getDatabaseReadStreamPaginated reads the primary when no service is passed", async () => {
-      resetRecordings();
-
-      const rows = await drain(
-        await getDatabaseReadStreamPaginated({
+  // Batch actions call these two with no service to enumerate a selection the
+  // user made against the primary. A replica default would make "add all to
+  // dataset" silently act on fewer rows than the user selected.
+  it.each([
+    [
+      "getObservationStream",
+      () => getObservationStream({ projectId, cutoffCreatedAt, filter: [] }),
+    ],
+    [
+      "getDatabaseReadStreamPaginated",
+      () =>
+        getDatabaseReadStreamPaginated({
           projectId,
           tableName: BatchExportTableName.Scores,
           cutoffCreatedAt,
           filter: [],
-          orderBy: EXPORT_ORDER_BY[BatchExportTableName.Scores],
+          orderBy: { column: "timestamp", order: "DESC" },
         }),
-      );
+    ],
+  ])("%s reads the primary when passed no service", async (_, openStream) => {
+    resetRecordings();
 
-      expect(rows).toHaveLength(2);
-      expect(harness.requests.primary.length).toBeGreaterThan(0);
-      expect(replicaRequests()).toEqual([]);
-    });
+    await drain(await openStream());
+
+    expect(replicaQueries()).toEqual([]);
+    expect(harness.requests.primary.length).toBeGreaterThan(0);
   });
 });

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -17,6 +17,7 @@ import {
   getCurrentSpan,
   applyCommentFilters,
   type CommentObjectType,
+  type PreferredClickhouseService,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { getDatabaseReadStreamPaginated } from "../database-read-stream/getDatabaseReadStream";
@@ -31,6 +32,12 @@ const tableToCommentType: Record<string, CommentObjectType | undefined> = {
   events: "OBSERVATION",
   sessions: "SESSION",
 };
+
+// Exports scan far more rows than a UI request and must not compete with
+// ingestion on the writer cluster. Every read reachable from this job belongs on
+// a read replica, so a new export path added below should pass this too. Streams
+// that pin their own service internally (traces, events) do not take it.
+const BATCH_EXPORT_CLICKHOUSE_SERVICE: PreferredClickhouseService = "ReadOnly";
 
 export const handleBatchExportJob = async (
   batchExportJob: BatchExportJobType,
@@ -180,6 +187,7 @@ export const handleBatchExportJob = async (
           ...parsedQuery.data,
           filter: processedFilter,
           fileFormat: jobDetails.format as BatchExportFileFormat,
+          preferredClickhouseService: BATCH_EXPORT_CLICKHOUSE_SERVICE,
         })
       : parsedQuery.data.tableName === BatchExportTableName.Traces
         ? await getTraceStream({
@@ -200,6 +208,7 @@ export const handleBatchExportJob = async (
               cutoffCreatedAt: jobDetails.createdAt,
               ...parsedQuery.data,
               filter: processedFilter,
+              preferredClickhouseService: BATCH_EXPORT_CLICKHOUSE_SERVICE,
             });
 
   // Transform data to desired format

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -33,10 +33,6 @@ const tableToCommentType: Record<string, CommentObjectType | undefined> = {
   sessions: "SESSION",
 };
 
-// Exports scan far more rows than a UI request and must not compete with
-// ingestion on the writer cluster. Every read reachable from this job belongs on
-// a read replica, so a new export path added below should pass this too. Streams
-// that pin their own service internally (traces, events) do not take it.
 const BATCH_EXPORT_CLICKHOUSE_SERVICE: PreferredClickhouseService = "ReadOnly";
 
 export const handleBatchExportJob = async (

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -34,6 +34,12 @@ const BATCH_SIZE = 1000; // Fetch comments in batches for efficiency
  * Creates a stream of events from ClickHouse for batch export.
  * Includes comments fetched in batches and flattened scores.
  *
+ * Batch export is the only production caller, so the reads below pin their
+ * ClickHouse service inline. Batch actions use getEventsStreamForDataset and
+ * getEventsStreamForAnnotationQueue, which must keep reading the primary.
+ * Adding a non-export caller here means the service has to become a parameter,
+ * as it is on getObservationStream.
+ *
  * @param props - Query parameters including projectId, filters, and limits
  * @returns A Node.js Readable stream of event records
  */
@@ -76,15 +82,15 @@ export const getEventsStream = async (props: {
   const { query, params: queryParams } = queryBuilder.buildWithParams();
 
   // Get distinct score names for empty columns.
-  // Batch export is the only production caller of getEventsStream, so the read
-  // replica is pinned inline. Batch actions use getEventsStreamForDataset and
-  // getEventsStreamForAnnotationQueue, which must keep reading the primary.
+  // Same service as the score values read below, not merely a replica: a name
+  // missing from this list is dropped from the export by
+  // getChunkWithFlattenedScores, so this read must not lag behind the rows.
   const distinctScoreNames = await getDistinctScoreNames({
     projectId,
     cutoffCreatedAt,
     startTimeFrom,
     clickhouseConfigs,
-    preferredClickhouseService: "ReadOnly",
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   const emptyScoreColumns = distinctScoreNames.reduce(

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -34,13 +34,6 @@ const BATCH_SIZE = 1000; // Fetch comments in batches for efficiency
  * Creates a stream of events from ClickHouse for batch export.
  * Includes comments fetched in batches and flattened scores.
  *
- * Batch export is the only production caller, so the reads below pin their
- * ClickHouse service inline. Batch actions use getEventsStreamForDataset and
- * getEventsStreamForAnnotationQueue, which pin EventsReadOnly — the same
- * service the v4 UI list reads, so their enumeration matches the snapshot the
- * user selected against. Adding a non-export caller here means the service has
- * to become a parameter, as it is on getObservationStream.
- *
  * @param props - Query parameters including projectId, filters, and limits
  * @returns A Node.js Readable stream of event records
  */
@@ -82,10 +75,8 @@ export const getEventsStream = async (props: {
   });
   const { query, params: queryParams } = queryBuilder.buildWithParams();
 
-  // Get distinct score names for empty columns.
-  // Same service as the score values read below, not merely a replica: a name
-  // missing from this list is dropped from the export by
-  // getChunkWithFlattenedScores, so this read must not lag behind the rows.
+  // Get distinct score names for empty columns
+  // Same service as the values read below: a missing name is silently dropped.
   const distinctScoreNames = await getDistinctScoreNames({
     projectId,
     cutoffCreatedAt,

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -36,9 +36,10 @@ const BATCH_SIZE = 1000; // Fetch comments in batches for efficiency
  *
  * Batch export is the only production caller, so the reads below pin their
  * ClickHouse service inline. Batch actions use getEventsStreamForDataset and
- * getEventsStreamForAnnotationQueue, which must keep reading the primary.
- * Adding a non-export caller here means the service has to become a parameter,
- * as it is on getObservationStream.
+ * getEventsStreamForAnnotationQueue, which pin EventsReadOnly — the same
+ * service the v4 UI list reads, so their enumeration matches the snapshot the
+ * user selected against. Adding a non-export caller here means the service has
+ * to become a parameter, as it is on getObservationStream.
  *
  * @param props - Query parameters including projectId, filters, and limits
  * @returns A Node.js Readable stream of event records

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -75,12 +75,16 @@ export const getEventsStream = async (props: {
   });
   const { query, params: queryParams } = queryBuilder.buildWithParams();
 
-  // Get distinct score names for empty columns
+  // Get distinct score names for empty columns.
+  // Batch export is the only production caller of getEventsStream, so the read
+  // replica is pinned inline. Batch actions use getEventsStreamForDataset and
+  // getEventsStreamForAnnotationQueue, which must keep reading the primary.
   const distinctScoreNames = await getDistinctScoreNames({
     projectId,
     cutoffCreatedAt,
     startTimeFrom,
     clickhouseConfigs,
+    preferredClickhouseService: "ReadOnly",
   });
 
   const emptyScoreColumns = distinctScoreNames.reduce(

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -365,8 +365,6 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilterCh],
             isTimestampFilter: isGenerationTimestampFilter,
             clickhouseConfigs,
-            // Inert: exports use the stream builders; rows here are unrouted.
-            preferredClickhouseService,
           });
 
           emptyScoreColumns = distinctScoreNames.reduce(
@@ -442,8 +440,6 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilter],
             isTimestampFilter: isTraceTimestampFilter,
             clickhouseConfigs,
-            // Inert: exports use the stream builders; rows here are unrouted.
-            preferredClickhouseService,
           });
           emptyScoreColumns = distinctScoreNames.reduce(
             (acc, name) => ({ ...acc, [name]: null }),

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -219,6 +219,7 @@ export const getDatabaseReadStreamPaginated = async ({
                 limit: pageSize,
                 offset,
                 clickhouseConfigs,
+                preferredClickhouseService,
               });
 
           // Get author user info for scores
@@ -298,6 +299,7 @@ export const getDatabaseReadStreamPaginated = async ({
                 limit: pageSize,
                 page: Math.floor(offset / pageSize),
                 clickhouseConfigs,
+                preferredClickhouseService,
               });
 
           const prismaSessionInfo = await prisma.traceSession.findMany({
@@ -365,6 +367,13 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilterCh],
             isTimestampFilter: isGenerationTimestampFilter,
             clickhouseConfigs,
+            // Inert today: batch export routes observations to
+            // getObservationStream, and batch actions pass no service. Before
+            // routing an observations export through here, parameterize
+            // getObservationsTableWithModelData and getScoresForObservations
+            // below — they still read the primary, so a replica name list could
+            // lag behind their rows and getChunkWithFlattenedScores would
+            // silently drop score columns.
             preferredClickhouseService,
           });
 
@@ -441,6 +450,12 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilter],
             isTimestampFilter: isTraceTimestampFilter,
             clickhouseConfigs,
+            // Inert today: batch export routes traces to getTraceStream, and
+            // batch actions pass no service. Before routing a traces export
+            // through here, parameterize getTracesTable and getScoresForTraces
+            // below — they still read the primary, so a replica name list could
+            // lag behind their rows and getChunkWithFlattenedScores would
+            // silently drop score columns.
             preferredClickhouseService,
           });
           emptyScoreColumns = distinctScoreNames.reduce(
@@ -568,6 +583,7 @@ export const getDatabaseReadStreamPaginated = async ({
             },
             offset,
             clickhouseConfigs,
+            preferredClickhouseService,
           });
 
           // fetch all project dataset names

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -369,11 +369,12 @@ export const getDatabaseReadStreamPaginated = async ({
             clickhouseConfigs,
             // Inert today: batch export routes observations to
             // getObservationStream, and batch actions pass no service. Before
-            // routing an observations export through here, parameterize
-            // getObservationsTableWithModelData and getScoresForObservations
-            // below — they still read the primary, so a replica name list could
-            // lag behind their rows and getChunkWithFlattenedScores would
-            // silently drop score columns.
+            // routing an observations export through here, parameterize both
+            // other ClickHouse reads in this case
+            // (getObservationsTableWithModelData and getScoresForObservations).
+            // They still read the primary, and score values read there while
+            // this name list comes from a replica would make
+            // getChunkWithFlattenedScores drop columns silently.
             preferredClickhouseService,
           });
 
@@ -452,10 +453,11 @@ export const getDatabaseReadStreamPaginated = async ({
             clickhouseConfigs,
             // Inert today: batch export routes traces to getTraceStream, and
             // batch actions pass no service. Before routing a traces export
-            // through here, parameterize getTracesTable and getScoresForTraces
-            // below — they still read the primary, so a replica name list could
-            // lag behind their rows and getChunkWithFlattenedScores would
-            // silently drop score columns.
+            // through here, parameterize every other ClickHouse read in this
+            // case — there are four, two of them hidden inside the Promise.all
+            // below. They all still read the primary, and score values read
+            // there while this name list comes from a replica would make
+            // getChunkWithFlattenedScores drop columns silently.
             preferredClickhouseService,
           });
           emptyScoreColumns = distinctScoreNames.reduce(

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -28,6 +28,7 @@ import {
   getTracesByIds,
   getScoresForTraces,
   getDatasetItems,
+  type PreferredClickhouseService,
 } from "@langfuse/shared/src/server";
 import Decimal from "decimal.js";
 import { env } from "../../env";
@@ -153,6 +154,7 @@ export const getDatabaseReadStreamPaginated = async ({
   searchQuery,
   searchType,
   useEventsTable,
+  preferredClickhouseService,
   rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
 }: {
   projectId: string;
@@ -160,6 +162,9 @@ export const getDatabaseReadStreamPaginated = async ({
   searchQuery?: string;
   searchType?: TracingSearchType[];
   rowLimit?: number;
+  // No default: absent means "ReadWrite". Batch actions enumerate rows for a
+  // selection the user made against the primary, so only batch export opts in.
+  preferredClickhouseService?: PreferredClickhouseService;
 } & BatchExportQueryType): Promise<DatabaseReadStream<unknown>> => {
   // Set createdAt cutoff to prevent exporting data that was created after the job was queued
   const createdAtCutoffFilter: FilterCondition = {
@@ -360,6 +365,7 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilterCh],
             isTimestampFilter: isGenerationTimestampFilter,
             clickhouseConfigs,
+            preferredClickhouseService,
           });
 
           emptyScoreColumns = distinctScoreNames.reduce(
@@ -435,6 +441,7 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilter],
             isTimestampFilter: isTraceTimestampFilter,
             clickhouseConfigs,
+            preferredClickhouseService,
           });
           emptyScoreColumns = distinctScoreNames.reduce(
             (acc, name) => ({ ...acc, [name]: null }),

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -162,8 +162,6 @@ export const getDatabaseReadStreamPaginated = async ({
   searchQuery?: string;
   searchType?: TracingSearchType[];
   rowLimit?: number;
-  // No default: absent means "ReadWrite". Batch actions enumerate rows for a
-  // selection the user made against the primary, so only batch export opts in.
   preferredClickhouseService?: PreferredClickhouseService;
 } & BatchExportQueryType): Promise<DatabaseReadStream<unknown>> => {
   // Set createdAt cutoff to prevent exporting data that was created after the job was queued
@@ -367,14 +365,7 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilterCh],
             isTimestampFilter: isGenerationTimestampFilter,
             clickhouseConfigs,
-            // Inert today: batch export routes observations to
-            // getObservationStream, and batch actions pass no service. Before
-            // routing an observations export through here, parameterize both
-            // other ClickHouse reads in this case
-            // (getObservationsTableWithModelData and getScoresForObservations).
-            // They still read the primary, and score values read there while
-            // this name list comes from a replica would make
-            // getChunkWithFlattenedScores drop columns silently.
+            // Inert: exports use the stream builders; rows here are unrouted.
             preferredClickhouseService,
           });
 
@@ -451,13 +442,7 @@ export const getDatabaseReadStreamPaginated = async ({
               : [createdAtCutoffFilter],
             isTimestampFilter: isTraceTimestampFilter,
             clickhouseConfigs,
-            // Inert today: batch export routes traces to getTraceStream, and
-            // batch actions pass no service. Before routing a traces export
-            // through here, parameterize every other ClickHouse read in this
-            // case — there are four, two of them hidden inside the Promise.all
-            // below. They all still read the primary, and score values read
-            // there while this name list comes from a replica would make
-            // getChunkWithFlattenedScores drop columns silently.
+            // Inert: exports use the stream builders; rows here are unrouted.
             preferredClickhouseService,
           });
           emptyScoreColumns = distinctScoreNames.reduce(

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -29,6 +29,7 @@ import {
   eventsTracesScoresAggregation,
   toLevelAgnosticScoreFilter,
   scoreBooleansAggregation,
+  type PreferredClickhouseService,
 } from "@langfuse/shared/src/server";
 import { Readable } from "stream";
 import { env } from "../../env";
@@ -53,6 +54,9 @@ type ObservationStreamProps = {
   // BatchExportQuerySchema). When true, read from the ClickHouse events table
   // instead of the legacy observations/traces tables.
   useEventsTable?: boolean;
+  // Absent means "ReadWrite": batch actions must keep reading the primary so
+  // their enumeration matches the snapshot the UI selection was built from.
+  preferredClickhouseService?: PreferredClickhouseService;
 };
 
 export const getObservationStream = async (
@@ -280,7 +284,7 @@ export const getObservationStream = async (
     },
     clickhouseConfigs,
     tags: { projectId },
-    preferredClickhouseService: "ReadOnly",
+    preferredClickhouseService: props.preferredClickhouseService,
   });
 
   // Helper function to process a single observation row

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -54,11 +54,6 @@ type ObservationStreamProps = {
   // BatchExportQuerySchema). When true, read from the ClickHouse events table
   // instead of the legacy observations/traces tables.
   useEventsTable?: boolean;
-  // Absent means "ReadWrite": batch actions must keep reading the primary so
-  // their enumeration matches the snapshot the UI selection was built from.
-  // Ignored entirely when useEventsTable is set — that branch pins
-  // EventsReadOnly for both its row and its score-name read, because those two
-  // must resolve against the same service.
   preferredClickhouseService?: PreferredClickhouseService;
 };
 
@@ -491,11 +486,7 @@ const getObservationStreamFromEvents = async (
     ): filterItem is TimeFilter =>
       filterItem.column === "Start Time" && filterItem.type === "datetime",
     clickhouseConfigs,
-    // Must be the same service that reads the score values below, not the
-    // caller's choice. Any score whose name is missing from this list is
-    // dropped from the export by getChunkWithFlattenedScores, so a name set
-    // lagging behind the rows silently loses a column. The main query reads
-    // the classic scores table through the events service, so this follows it.
+    // Same service as the values read below: a missing name is silently dropped.
     preferredClickhouseService: "EventsReadOnly",
   });
 

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -56,6 +56,9 @@ type ObservationStreamProps = {
   useEventsTable?: boolean;
   // Absent means "ReadWrite": batch actions must keep reading the primary so
   // their enumeration matches the snapshot the UI selection was built from.
+  // Ignored entirely when useEventsTable is set — that branch pins
+  // EventsReadOnly for both its row and its score-name read, because those two
+  // must resolve against the same service.
   preferredClickhouseService?: PreferredClickhouseService;
 };
 

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -280,6 +280,7 @@ export const getObservationStream = async (
     },
     clickhouseConfigs,
     tags: { projectId },
+    preferredClickhouseService: "ReadOnly",
   });
 
   // Helper function to process a single observation row

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -110,6 +110,7 @@ export const getObservationStream = async (
       return filter.column === "Start Time" && filter.type === "datetime";
     },
     clickhouseConfigs,
+    preferredClickhouseService: props.preferredClickhouseService,
   });
 
   const scoresFilter = new FilterList([
@@ -487,6 +488,10 @@ const getObservationStreamFromEvents = async (
     ): filterItem is TimeFilter =>
       filterItem.column === "Start Time" && filterItem.type === "datetime",
     clickhouseConfigs,
+    // The events branch reads its main query from EventsReadOnly, but score
+    // names still come from the classic scores table, so this query follows the
+    // caller's choice like the legacy branch does.
+    preferredClickhouseService: props.preferredClickhouseService,
   });
 
   const emptyScoreColumns = distinctScoreNames.reduce(

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -488,10 +488,12 @@ const getObservationStreamFromEvents = async (
     ): filterItem is TimeFilter =>
       filterItem.column === "Start Time" && filterItem.type === "datetime",
     clickhouseConfigs,
-    // The events branch reads its main query from EventsReadOnly, but score
-    // names still come from the classic scores table, so this query follows the
-    // caller's choice like the legacy branch does.
-    preferredClickhouseService: props.preferredClickhouseService,
+    // Must be the same service that reads the score values below, not the
+    // caller's choice. Any score whose name is missing from this list is
+    // dropped from the export by getChunkWithFlattenedScores, so a name set
+    // lagging behind the rows silently loses a column. The main query reads
+    // the classic scores table through the events service, so this follows it.
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   const emptyScoreColumns = distinctScoreNames.reduce(

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -224,6 +224,7 @@ export const getTraceStream = async (props: {
     },
     clickhouseConfigs,
     tags: { projectId },
+    preferredClickhouseService: "ReadOnly",
   });
 
   // Helper function to process a single trace row

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -27,14 +27,6 @@ import { fetchCommentsForExport } from "./fetchCommentsForExport";
 
 const BATCH_SIZE = 1000; // Fetch comments in batches for efficiency
 
-/**
- * Streams traces from ClickHouse for batch export.
- *
- * Batch export is the only production caller, so both queries below pin the
- * read replica inline. Batch actions enumerate traces through
- * getTraceIdentifierStream instead. Adding a non-export caller here means the
- * service has to become a parameter, as it is on getObservationStream.
- */
 export const getTraceStream = async (props: {
   projectId: string;
   cutoffCreatedAt: Date;

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -27,11 +27,14 @@ import { fetchCommentsForExport } from "./fetchCommentsForExport";
 
 const BATCH_SIZE = 1000; // Fetch comments in batches for efficiency
 
-// Batch export is the only production caller (handleBatchExportJob), so both
-// queries below pin the read replica inline. Batch actions enumerate traces
-// through getTraceIdentifierStream instead. Adding a non-export caller here
-// means the replica choice has to become a parameter, as it is on
-// getObservationStream.
+/**
+ * Streams traces from ClickHouse for batch export.
+ *
+ * Batch export is the only production caller, so both queries below pin the
+ * read replica inline. Batch actions enumerate traces through
+ * getTraceIdentifierStream instead. Adding a non-export caller here means the
+ * service has to become a parameter, as it is on getObservationStream.
+ */
 export const getTraceStream = async (props: {
   projectId: string;
   cutoffCreatedAt: Date;

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -27,6 +27,11 @@ import { fetchCommentsForExport } from "./fetchCommentsForExport";
 
 const BATCH_SIZE = 1000; // Fetch comments in batches for efficiency
 
+// Batch export is the only production caller (handleBatchExportJob), so both
+// queries below pin the read replica inline. Batch actions enumerate traces
+// through getTraceIdentifierStream instead. Adding a non-export caller here
+// means the replica choice has to become a parameter, as it is on
+// getObservationStream.
 export const getTraceStream = async (props: {
   projectId: string;
   cutoffCreatedAt: Date;
@@ -72,6 +77,7 @@ export const getTraceStream = async (props: {
     filter: traceOnlyFilters,
     isTimestampFilter: isTraceTimestampFilter,
     clickhouseConfigs,
+    preferredClickhouseService: "ReadOnly",
   });
 
   const emptyScoreColumns = distinctScoreNames.reduce(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16076.preview.langfuse.com](https://pr-16076.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Routes every ClickHouse read on the batch export path to a read replica instead of the primary writer cluster.

ClickHouse read-replica routing is opt-in per query: a read only reaches a replica if the caller passes `preferredClickhouseService`. The default is `"ReadWrite"`, which resolves to the primary. The events-table export paths already opted in; the older non-events paths did not — they forwarded only extended timeouts and tags, so they inherited the default. Batch exports are long-running, high-volume scans, which is exactly the workload that should never touch the writer. A trace export scanning the primary was enough to overload it.

Six reads are now routed:

| Export path | Read |
| -- | -- |
| Traces | main traces+scores stream query |
| All exports | `getDistinctScoreNames` — reached by every export stream |
| Observations (non-events) | main stream query |
| Scores (non-events) | `getScoresUiGeneric` |
| Sessions (non-events) | `getSessionsTableGeneric` |
| Dataset run items | `getDatasetRunItemsTableInternal` |

Dataset items and audit log exports are unaffected — they read Postgres only.

### How the routing is wired

The literal `"ReadOnly"` is introduced in **one** place: a `BATCH_EXPORT_CLICKHOUSE_SERVICE` constant in the batch export job, passed at two call sites. Everything below takes `preferredClickhouseService?: PreferredClickhouseService` with **no default**, so an absent value still resolves to the writer.

That distinction is load-bearing. Several of these functions are shared with the batch-action handler, which powers "add all to annotation queue" and "add all to dataset". Those enumerate a selection the user made against a list read from the primary, so moving their enumeration to a replica would silently create fewer items than the user selected whenever the replica lagged. Threading the option instead of pinning it keeps every non-export caller byte-identical.

The rule the diff follows: **literals only for worker-local export builders with a verified single production caller; parameters for anything in `packages/shared`** — a shared repository should not hard-code a worker-export policy. Each remaining literal carries a comment naming the invariant that licenses it, so the next person to add a caller sees why it was safe and notices when it stops being.

Where an export issues two reads whose results must agree, both go to the same service. The score-name list is a hard filter on exported score values — a score whose name is missing from the list is dropped from the output — so a name read lagging behind the value read would silently remove a column from the file. Both reads are pinned together on every path.

### Self-hosted deployments are unaffected

`getClickhouseUrl` falls back to the primary URL when the read-replica URL is unset, so a deployment without it gets identical behavior and reuses the same cached client.

### Tests

A new suite points the three ClickHouse URLs at recording pass-through proxies and asserts which cluster each statement actually reached, rather than asserting on the arguments passed. It observes the cluster, not the mechanism, so it survives a redesign of how routing is threaded.

Every routed call site was verified by mutation: reverting any one of them to the primary turns exactly one test red. That includes the two contract tests proving the shared entry points still default to the writer when no service is passed, which is what protects the batch-action paths. Control tests establish that each proxy sink can be populated, so a green result cannot mean "the harness observed nothing" — including one control that fails if the events-replica channel it proves ever breaks.

Worth knowing for future changes: outside this suite, routing is unobservable in the test environment, because the read-replica URL is unset there and every service collapses to one endpoint.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Verified with `pnpm turbo run lint` (`Tasks: 6 successful, 6 total`), `pnpm turbo run typecheck` (`Tasks: 7 successful, 7 total`), and the new suite (`Tests 19 passed (19)`).
- Production impact also depends on the read-replica URL being populated per region; that is a deployment precondition rather than a code change, and is worth confirming alongside this.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR routes ClickHouse-backed batch exports away from the writer while preserving primary routing for shared batch-action and UI paths.

- Adds optional ClickHouse service selection to shared score, session, and dataset-run-item queries.
- Routes trace and observation export queries consistently to their appropriate replicas.
- Adds integration-style regression coverage for export and non-export routing behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The changed paths consistently route each export’s related ClickHouse queries to the intended service, while omitted service preferences retain existing primary routing for shared non-export callers.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Job[Batch export job] --> Table{Export table}
  Table -->|Traces| Trace[getTraceStream]
  Table -->|Observations, legacy| Observation[getObservationStream]
  Table -->|Events-backed data| Events[Events stream]
  Table -->|Scores, sessions, dataset run items| Generic[Paginated stream]
  Trace --> ReadOnly[(ReadOnly)]
  Observation --> ReadOnly
  Generic --> ReadOnly
  Events --> EventsReadOnly[(EventsReadOnly)]
  Actions[Batch actions / UI callers] -->|No preferred service| Primary[(ReadWrite)]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(batch-export): close routing covera..."](https://github.com/langfuse/langfuse/commit/e664b08d42179259b43b8d637d4d7a5c708b9b4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52956108)</sub>

**Context used:**

- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->