### PR TITLE
fix(web): tidy up the blob storage integration save UI

### DIFF
--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/src/components/ui/button";
+import { ConfirmDialog } from "@/src/components/ui/confirm-dialog";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
@@ -38,6 +39,8 @@ export const BlobStorageIntegrationContainer = ({
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { project } = useQueryProject();
+  const [runNowConfirmOpen, setRunNowConfirmOpen] = useState(false);
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
 
   // Policy context for the export-source selector; the policy itself lives in
   // export-source-policy.ts. null integrationCreatedAt = new row.
@@ -131,6 +134,28 @@ export const BlobStorageIntegrationContainer = ({
       persistedExportSource={config?.exportSource}
       isSaving={mut.isPending}
       onSubmit={handleSubmit}
+      destructiveAction={
+        <ConfirmDialog
+          open={resetConfirmOpen}
+          onOpenChange={setResetConfirmOpen}
+          trigger={
+            <Button
+              variant="destructive-secondary"
+              loading={mutDelete.isPending}
+              disabled={!config}
+            >
+              Reset
+            </Button>
+          }
+          title="Reset blob storage integration?"
+          description="This deletes the blob storage configuration for this project and stops all scheduled exports. Files already written to your bucket are not removed."
+          confirmLabel="Reset integration"
+          onConfirm={() => {
+            mutDelete.mutate({ projectId });
+            setResetConfirmOpen(false);
+          }}
+        />
+      }
     >
       <Button
         variant="secondary"
@@ -143,37 +168,28 @@ export const BlobStorageIntegrationContainer = ({
       >
         Validate
       </Button>
-      <Button
-        variant="secondary"
-        loading={mutRunNow.isPending}
-        disabled={!config?.enabled}
-        title="Trigger an immediate export of all data since the last sync"
-        onClick={() => {
-          if (
-            confirm(
-              "Are you sure you want to run the blob storage export now? This will export all data since the last sync.",
-            )
-          )
-            mutRunNow.mutate({ projectId });
+      <ConfirmDialog
+        open={runNowConfirmOpen}
+        onOpenChange={setRunNowConfirmOpen}
+        trigger={
+          <Button
+            variant="secondary"
+            loading={mutRunNow.isPending}
+            disabled={!config?.enabled}
+            title="Trigger an immediate export of all data since the last sync"
+          >
+            Run Now
+          </Button>
+        }
+        title="Run export now?"
+        description="This exports all data since the last sync to your blob storage."
+        confirmLabel="Run now"
+        confirmVariant="default"
+        onConfirm={() => {
+          mutRunNow.mutate({ projectId });
+          setRunNowConfirmOpen(false);
         }}
-      >
-        Run Now
-      </Button>
-      <Button
-        variant="ghost"
-        loading={mutDelete.isPending}
-        disabled={!config}
-        onClick={() => {
-          if (
-            confirm(
-              "Are you sure you want to reset the Blob Storage integration for this project?",
-            )
-          )
-            mutDelete.mutate({ projectId });
-        }}
-      >
-        Reset
-      </Button>
+      />
     </BlobStorageIntegrationForm>
   );
 };

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -71,6 +71,12 @@ export const BlobStorageIntegrationContainer = ({
   const mut = api.blobStorageIntegration.update.useMutation({
     onSuccess: () => {
       utils.blobStorageIntegration.invalidate();
+      // A save otherwise completes silently: the form keeps the values the
+      // user just typed, so nothing on screen confirms the write landed.
+      showSuccessToast({
+        title: "Integration saved",
+        description: "Scheduled exports now use the updated configuration.",
+      });
     },
     onError: (error) => {
       showErrorToast("Failed to save integration", error.message);
@@ -84,6 +90,14 @@ export const BlobStorageIntegrationContainer = ({
   const mutRunNow = api.blobStorageIntegration.runNow.useMutation({
     onSuccess: () => {
       utils.blobStorageIntegration.invalidate();
+      showSuccessToast({
+        title: "Export queued",
+        description:
+          "The export runs in the background; the status above updates when it completes.",
+      });
+    },
+    onError: (error) => {
+      showErrorToast("Failed to start export", error.message);
     },
   });
   const mutValidate = api.blobStorageIntegration.validate.useMutation({

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
   BlobStorageIntegrationFileType,
@@ -37,6 +38,7 @@ const ui = (
   key: string,
   initialValues: BlobStorageFormValues,
   onSubmit: (values: unknown) => void = () => {},
+  slots?: { children?: ReactNode; destructiveAction?: ReactNode },
 ) => (
   <TooltipProvider>
     <BlobStorageIntegrationForm
@@ -46,7 +48,10 @@ const ui = (
       persistedExportSource={null}
       isSaving={false}
       onSubmit={onSubmit}
-    />
+      destructiveAction={slots?.destructiveAction}
+    >
+      {slots?.children}
+    </BlobStorageIntegrationForm>
   </TooltipProvider>
 );
 
@@ -171,5 +176,53 @@ describe("BlobStorageIntegrationForm draft lifetime (keyed remount)", () => {
       }),
       expect.anything(),
     );
+  });
+});
+
+describe("BlobStorageIntegrationForm action bar", () => {
+  it("Save is the form's submit button, so a native form submit saves the draft", async () => {
+    const onSubmit = vi.fn();
+    render(
+      ui(
+        "p1:new",
+        buildBlobStorageFormValues(undefined, exportSourceCtx),
+        onSubmit,
+      ),
+    );
+
+    fireEvent.change(bucketInput(), { target: { value: "my-new-bucket" } });
+
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save).toHaveAttribute("type", "submit");
+
+    // Submitting the form itself (e.g. Enter in a text field) must save,
+    // which only works while Save lives inside the <form>.
+    fireEvent.submit(save.closest("form")!);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the destructive action out of the Save/secondary action group", () => {
+    render(
+      ui(
+        "p1:configured",
+        buildBlobStorageFormValues(savedConfig, exportSourceCtx),
+        () => {},
+        {
+          children: <button type="button">Validate</button>,
+          destructiveAction: <button type="button">Reset</button>,
+        },
+      ),
+    );
+
+    const save = screen.getByRole("button", { name: "Save" });
+    const validate = screen.getByRole("button", { name: "Validate" });
+    const reset = screen.getByRole("button", { name: "Reset" });
+
+    // Save and the secondary actions share the action bar directly; the
+    // destructive action is wrapped in its own separated slot.
+    expect(validate.parentElement).toBe(save.parentElement);
+    expect(reset.parentElement).not.toBe(save.parentElement);
+    expect(reset.parentElement).toHaveClass("ml-auto");
   });
 });

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
@@ -40,16 +40,20 @@ export const BlobStorageIntegrationForm = ({
   isSaving,
   onSubmit,
   children,
+  destructiveAction,
 }: {
   initialValues: BlobStorageFormValues;
   exportSourceCtx: ExportSourceContext;
   persistedExportSource: AnalyticsIntegrationExportSource | null | undefined;
   isSaving: boolean;
   onSubmit: (values: BlobStorageIntegrationFormSchema) => void;
-  // Entity-scoped action buttons (Validate / Run Now / Reset) rendered by
-  // the container next to Save — they act on the persisted entity, not on
-  // this draft.
+  // Entity-scoped action buttons (Validate / Run Now) rendered by the
+  // container next to Save — they act on the persisted entity, not on this
+  // draft.
   children?: ReactNode;
+  // Entity-scoped destructive action (Reset). Separated from the other
+  // actions in the bar below so it cannot be hit while reaching for Save.
+  destructiveAction?: ReactNode;
 }) => {
   // Block the save when the persisted source is no longer selectable rather
   // than silently rewriting it (LFE-10296). The policy context is fixed for
@@ -79,47 +83,48 @@ export const BlobStorageIntegrationForm = ({
 
   return (
     <Form {...blobStorageForm}>
-      <form
-        className="space-y-3"
-        onSubmit={blobStorageForm.handleSubmit(onSubmit)}
-      >
-        <StorageProviderFields control={control} />
-        <ExportScheduleFields control={control} />
-        <ExportSourceField
-          control={control}
-          persistedExportSource={persistedExportSource}
-          exportSourceCtx={exportSourceCtx}
-        />
-        <ExportFieldGroupsField control={control} />
-        <GzipCompressionField control={control} />
-        <FormField
-          control={control}
-          name="enabled"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Enabled</FormLabel>
-              <FormControl>
-                <div className="mt-1 ml-4">
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                  />
-                </div>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+      <form onSubmit={blobStorageForm.handleSubmit(onSubmit)}>
+        <div className="space-y-3">
+          <StorageProviderFields control={control} />
+          <ExportScheduleFields control={control} />
+          <ExportSourceField
+            control={control}
+            persistedExportSource={persistedExportSource}
+            exportSourceCtx={exportSourceCtx}
+          />
+          <ExportFieldGroupsField control={control} />
+          <GzipCompressionField control={control} />
+          <FormField
+            control={control}
+            name="enabled"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Enabled</FormLabel>
+                <FormControl>
+                  <div className="mt-1 ml-4">
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        {/* Action bar. Inside the form so Save is a real submit button:
+            keyboard submit works and the draft has a single submit path. */}
+        <div className="mt-8 flex items-center gap-2 border-t pt-4">
+          <Button type="submit" loading={isSaving}>
+            Save
+          </Button>
+          {children}
+          {destructiveAction ? (
+            <div className="ml-auto">{destructiveAction}</div>
+          ) : null}
+        </div>
       </form>
-      <div className="mt-8 flex gap-2">
-        <Button
-          loading={isSaving}
-          onClick={blobStorageForm.handleSubmit(onSubmit)}
-        >
-          Save
-        </Button>
-        {children}
-      </div>
     </Form>
   );
 };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16078.preview.langfuse.com](https://pr-16078.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Cleans up the action bar at the bottom of **Project Settings → Integrations → Blob Storage**, which had accumulated a few rough edges.

### Before

[Action bar before: Save, Validate, Run Now and Reset all crammed together on the left with no divider, Reset styled as plain text](https://cursor.com/agents/bc-e63ffdce-a31b-43ca-90d3-2e98622100de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsave_ui_before.png)

1. **Save was not the form's submit button.** It sat *outside* the `<form>` and submitted through an `onClick` handler, so the form had no submit button at all and keyboard submit did nothing.
2. **`Reset` deletes the integration but looked harmless.** It sat flush against `Run Now` with identical spacing and a `ghost` style that reads as plain text — easy to hit while reaching for a neighbouring button.
3. **`Run Now` and `Reset` confirmed via `window.confirm()`**, producing an unstyled `localhost:3000 says` browser dialog.
4. **Save and Run Now completed silently.** The form keeps the values already on screen, so nothing confirmed the write landed or the job was queued. A failed manual export was swallowed entirely.

### After

[Action bar after: divider above the row, Save/Validate/Run Now grouped left, Reset pushed right with a red destructive outline, and a green ](https://cursor.com/agents/bc-e63ffdce-a31b-43ca-90d3-2e98622100de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsave_ui_after_full.png)

- Action bar moved inside the `<form>`; `Save` is a real `type="submit"` button, so there is one submit path and keyboard submit works.
- A divider separates the action bar from the fields.
- `Reset` moved to the opposite end of the bar via a dedicated `destructiveAction` slot and restyled `destructive-secondary`.
- Both native confirms replaced with the shared `ConfirmDialog`, with wording that says what actually happens (e.g. that files already written to the bucket are not removed).
- `Save` and `Run Now` now raise a success toast, and a failed manual export reports its error.

Behaviour of the underlying mutations is unchanged.

Walkthrough of the new action bar and both confirmation dialogs:

[blob_storage_save_ui_after.mp4](https://cursor.com/agents/bc-e63ffdce-a31b-43ca-90d3-2e98622100de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblob_storage_save_ui_after.mp4)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Verified in a browser against the full local stack (real MinIO-backed integration, exports actually running): divider and button grouping, both styled confirm dialogs, cancelling `Reset` leaves the integration intact, and both success toasts.
- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-client src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx` → `Tests 7 passed (7)`, including two new cases covering the submit-button wiring and the separated destructive slot.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15096](https://linear.app/clickhouse/issue/LFE-15096/record-video-for-upgrading-legacy-s3-integrations)

<div><a href="https://cursor.com/agents/bc-e63ffdce-a31b-43ca-90d3-2e98622100de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e63ffdce-a31b-43ca-90d3-2e98622100de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

