### PR TITLE
fix(web): add the v4 walkthrough video to the migration side panel

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -345,6 +345,7 @@ export const events = {
     "section_link_clicked",
     "project_keys_copied",
     "evals_manual_upgrade_clicked",
+    "walkthrough_video_clicked",
   ],
   // Filter/search-bar usage analytics (LFE-10781). METADATA ONLY — payloads
   // never carry a raw filter value, search text, or AI prompt (PII). Only

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1080,7 +1080,7 @@ describe("V4MigrationHeaderContent", () => {
     }
   });
 
-  it("labels the help footer and groups content with two separators", () => {
+  it("labels the help footer and groups content with three separators", () => {
     const { container } = render(
       <V4MigrationDetailsContent projectId="project-1" />,
     );

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -50,6 +50,11 @@ const cleanSdkState = (): V4MigrationSdkState => ({
 });
 
 const mocks = vi.hoisted(() => ({
+  // Mutable so tests can flip between Cloud and self-hosted; the component
+  // reads the env at render time.
+  env: { NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: "US" } as {
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: string | undefined;
+  },
   routerPush: vi.fn(),
   capture: vi.fn(),
   openAssistant: vi.fn(),
@@ -91,6 +96,8 @@ const mocks = vi.hoisted(() => ({
   aiFeaturesEnabled: true,
   createProjectApiKey: vi.fn(),
 }));
+
+vi.mock("@/src/env.mjs", () => ({ env: mocks.env }));
 
 vi.mock("next/router", () => ({
   useRouter: () => ({
@@ -215,6 +222,7 @@ vi.mock("@/src/components/ui/collapsible", () => {
 describe("V4MigrationDetailsContent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "US";
     mocks.routerPush.mockResolvedValue(true);
     mocks.submitAgentMessage.mockResolvedValue(undefined);
     mocks.migrationData.evals = { status: "loaded", count: 0 };
@@ -896,6 +904,33 @@ describe("V4MigrationDetailsContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("links the walkthrough video from the help footer on Cloud", () => {
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    const link = screen.getByRole("link", { name: "Walkthrough video" });
+    // Straight to YouTube in a new tab; the panel never embeds the player,
+    // so no iframe may render before or after the click.
+    expect(link).toHaveAttribute(
+      "href",
+      "https://www.youtube.com/watch?v=g3YbbqVGt4g",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(document.querySelector("iframe")).toBeNull();
+
+    fireEvent.click(link);
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "v4_migration:walkthrough_video_clicked",
+    );
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+
+  it("hides the walkthrough video link on self-hosted deployments", () => {
+    mocks.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(screen.queryByText("Walkthrough video")).not.toBeInTheDocument();
+  });
+
   it("shows the preview-toggle section only when the session can toggle v4", () => {
     const { unmount } = render(
       <V4MigrationDetailsContent projectId="project-1" />,
@@ -1045,15 +1080,22 @@ describe("V4MigrationHeaderContent", () => {
     }
   });
 
-  it("labels the help footer and renders no horizontal separators", () => {
-    render(<V4MigrationDetailsContent projectId="project-1" />);
+  it("labels the help footer and groups content with two separators", () => {
+    const { container } = render(
+      <V4MigrationDetailsContent projectId="project-1" />,
+    );
 
     expect(screen.getByText("Need help?")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
       "href",
       "https://langfuse.com/docs/v4",
     );
-    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
+    // One divider above Action items, one above the agent CTA, one above
+    // Need help. Decorative Radix separators render role="none", so query
+    // by data attribute.
+    expect(
+      container.querySelectorAll('[data-orientation="horizontal"]'),
+    ).toHaveLength(3);
   });
 
   it("does not create credentials when revealing or copying the prompt", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -10,6 +10,7 @@ import {
   Copy,
   Info,
 } from "lucide-react";
+import { env } from "@/src/env.mjs";
 import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { Button } from "@/src/components/ui/button";
@@ -20,6 +21,7 @@ import {
   HoverCardTrigger,
 } from "@/src/components/ui/hover-card";
 import { RainbowButton } from "@/src/components/magicui/rainbow-button";
+import { Separator } from "@/src/components/ui/separator";
 import {
   Collapsible,
   CollapsibleContent,
@@ -96,6 +98,11 @@ const EXPERIMENT_OTEL_INGESTION_URL =
 const SDK_OVERVIEW_URL = "https://langfuse.com/docs/observability/sdk/overview";
 const OTEL_INTEGRATION_URL =
   "https://langfuse.com/integrations/native/opentelemetry";
+// Hassieb's 2 minute walkthrough of the upgrade steps. Linked (not embedded)
+// from the Need help footer, so the panel stays free of YouTube player
+// chrome and the CSP frame-src stays untouched. Cloud only: the video covers
+// the steps as they apply to Langfuse Cloud projects.
+const WALKTHROUGH_VIDEO_URL = "https://www.youtube.com/watch?v=g3YbbqVGt4g";
 
 // Copies the agent migration prompt to the clipboard with toast + analytics;
 // shared by the panel/modal header CTA and the status page.
@@ -1316,6 +1323,8 @@ export function V4MigrationDetailsContent({
 
   return (
     <>
+      <Separator />
+
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-2 text-base font-bold">
           Action items
@@ -1379,6 +1388,8 @@ export function V4MigrationDetailsContent({
         </div>
       </div>
 
+      <Separator />
+
       <V4MigrationAgentUpgradeSection projectId={projectId} />
 
       {/* The toggle row hides itself when the session cannot toggle v4
@@ -1421,6 +1432,8 @@ export function V4MigrationDetailsContent({
         </>
       )}
 
+      <Separator />
+
       <div className="flex flex-col gap-2">
         <p className="text-base font-bold">Need help?</p>
         <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
@@ -1451,6 +1464,22 @@ export function V4MigrationDetailsContent({
           >
             Book a call
           </a>
+          {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION && (
+            <>
+              <span>·</span>
+              <a
+                href={WALKTHROUGH_VIDEO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() =>
+                  capture("v4_migration:walkthrough_video_clicked")
+                }
+                className="underline"
+              >
+                Walkthrough video
+              </a>
+            </>
+          )}
         </div>
       </div>
       {projectId ? (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16079.preview.langfuse.com](https://pr-16079.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Fixes [LF-107](https://linear.app/clickhouse/issue/LF-107/add-v4-walkthrough-video-to-the-migration-side-bar).

## What changed

| Change | Ticket |
| --- | --- |
| The migration panel's Need help footer row gains a Cloud-only "Walkthrough video" link (Docs · Email an engineer · Book a call · Walkthrough video) that opens Hassieb's 2 minute upgrade walkthrough on YouTube in a new tab. Deliberately understated: earlier iterations embedded the player and then a thumbnail card, but both pulled attention away from the panel's action items, so the video ships as a quiet footer link on purpose. Linked rather than embedded, so the panel stays free of YouTube player chrome and unrelated recommendations and the CSP frame-src stays untouched. Gated on `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` since the video covers the Cloud upgrade steps. Clicks fire the new `v4_migration:walkthrough_video_clicked` event. | [LF-107](https://linear.app/clickhouse/issue/LF-107/add-v4-walkthrough-video-to-the-migration-side-bar) |
| The panel's visual grouping returns: three inset separators, above Action items, above Upgrade using coding agents, and above Need help. | [LF-107](https://linear.app/clickhouse/issue/LF-107/add-v4-walkthrough-video-to-the-migration-side-bar) |

Impacted packages: `web` only.

## Verification

- `pnpm --filter web run test-client v4-migration` — `Tests  101 passed (101)` (13 files; includes two new tests: the link targets the watch page in a new tab with no iframe ever mounted, and hides on self-hosted)
- `pnpm run lint` — `Tasks: 7 successful, 7 total` (also enforced by the pre-commit hook)
- Browser-verified on localhost: panel opened via the "Action required" nav item, footer link renders in Need help, click opens `youtube.com/watch?v=g3YbbqVGt4g` in a new tab (checked via Playwright tab list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)