### PR TITLE
fix(layout): stop drawer content from scrolling the whole page

### DIFF
--- a/web/src/__e2e__/app-shell-overflow.spec.ts
+++ b/web/src/__e2e__/app-shell-overflow.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * The app shell is fully height- and width-constrained: page content scrolls
+ * inside it, and the document itself must never scroll. These assertions need
+ * real layout, so they live here rather than in a jsdom client test.
+ */
+
+const SHORT_VIEWPORT = { width: 1190, height: 560 };
+
+async function signIn(page: Page) {
+  await page.goto("/auth/sign-in");
+  await page.fill('input[name="email"]', "demo@langfuse.com");
+  await page.fill('input[type="password"]', "password");
+  await page.click('button[data-testid="submit-email-password-sign-in-form"]');
+  await expect(page).toHaveURL("/");
+}
+
+/** Document overflow in CSS px, per axis. */
+function documentOverflow(page: Page) {
+  return page.evaluate(() => {
+    const de = document.documentElement;
+    return {
+      y: de.scrollHeight - de.clientHeight,
+      x: de.scrollWidth - de.clientWidth,
+    };
+  });
+}
+
+test("a right drawer's absolutely-positioned content does not scroll the document", async ({
+  page,
+}) => {
+  await page.setViewportSize(SHORT_VIEWPORT);
+  await signIn(page);
+  await page.getByRole("button", { name: "Support" }).click();
+  const drawerBody = page.locator("#secondary div.overflow-y-auto").first();
+  await expect(drawerBody).toBeVisible();
+
+  // Tailwind's `sr-only` box, appended below the fold of the drawer's own
+  // scroll area. With no positioned ancestor inside the drawer it resolves its
+  // containing block against the app shell, escapes the drawer's clip and
+  // grows the document instead of scrolling inside the drawer.
+  await drawerBody.evaluate((body) => {
+    const probe = document.createElement("span");
+    probe.dataset.testid = "overflow-probe";
+    probe.style.cssText =
+      "position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)";
+    const spacer = document.createElement("div");
+    spacer.style.height = "1200px";
+    body.append(spacer, probe);
+  });
+
+  expect(await documentOverflow(page)).toEqual({ y: 0, x: 0 });
+});

--- a/web/src/components/ui/resizable-split-layout.tsx
+++ b/web/src/components/ui/resizable-split-layout.tsx
@@ -7,6 +7,7 @@ import {
   useDefaultLayout,
   usePanelRef,
 } from "@/src/components/ui/resizable";
+import { cn } from "@/src/utils/tailwind";
 
 interface ResizableSplitLayoutProps {
   primaryContent: ReactNode;
@@ -130,13 +131,16 @@ export function ResizableSplitLayout({
       ? handleSecondaryResizeCallback
       : undefined;
 
+  // `relative` mirrors the primary panel's wrapper below: without a containing
+  // block here, absolutely-positioned secondary content (Tailwind's `sr-only`
+  // among it) resolves against the app shell, escapes this panel's scroll clip
+  // and grows the document instead.
   // In rail mode the collapsed panel stays visible (the caller renders a rail
   // in it) and keeps its handle so it can be dragged back open.
-  const secondaryPanelClassName = hasCollapsedRail
-    ? undefined
-    : open
-      ? "visible"
-      : "invisible";
+  const secondaryPanelClassName = cn(
+    "relative",
+    !hasCollapsedRail && (open ? "visible" : "invisible"),
+  );
   const showSecondaryHandle = showHandle && (open || hasCollapsedRail);
 
   return (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16080.preview.langfuse.com](https://pr-16080.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Opening the v4 upgrade panel in a short browser window gave the app a **second, global scrollbar** — and on Windows/Linux a horizontal one too. Cause: a 1px invisible `sr-only` span in the panel was positioned against the app shell instead of the panel, so it escaped the drawer's scroll clip and made the whole document taller than the viewport. One `relative` on the drawer panel fixes it for every drawer.

## Why

A user reported extra scrollbars — including one on the document — after opening the upgrade panel and resizing the window wide but not tall. It looked environment-specific and didn't reproduce on a Mac trackpad, so it was easy to write off as a local quirk. It isn't: the document overflows for **everyone** below a certain window height. macOS overlay scrollbars are 0px wide, so the same broken layout shows only a faint auto-hiding bar; with space-taking scrollbars (Windows/Linux always, macOS with *Show scroll bars: Always* or a mouse attached) it turns into four visible scrollbars and a page that scrolls.

Tailwind's `.sr-only` is `position: absolute` with auto insets. Every ancestor between it and `SidebarInset` was `position: static`, and `SidebarInset` is `relative` — so the span's containing block was the **app shell**. A scroll container only clips descendants for which it is in the containing-block chain, so neither the drawer's `overflow-y-auto` body nor the panel group's `overflow: hidden` clipped it. The span sat at its static position ~593px down the panel's content flow and extended the shell's scrollable overflow.

## What

`ResizableSplitLayout`'s secondary panel now carries `relative`, mirroring the `relative` its primary panel's wrapper already had. That asymmetry was the whole bug — one side of the split established a containing block and the other didn't. Fixing it at the shared layout covers all three drawer surfaces (support drawer, upgrade panel, filter sidebar) rather than patching the one panel where it surfaced.

## Result

Document overflow goes from 48px vertical + 15px horizontal to **0/0**, verified across the whole 520–600px viewport band at 1190 and 1440 wide with space-taking scrollbars forced. No visual change to any drawer.

<details>
<summary>Mechanism, measurements and verification</summary>

**The cascade, measured** (1190×560, panel open, space-taking scrollbars):

1. The escaped span puts `main.scrollHeight` at 594 against a `clientHeight` of 560 → vertical document scrollbar.
2. That scrollbar takes 15px of width, but `SidebarInset` is sized `w-[calc(100vw - var(--sidebar-width))]` and `100vw` ignores scrollbars by spec → 15px of horizontal overflow → horizontal scrollbar.
3. The horizontal scrollbar takes 15px of height, so the `h-dvh` / `100svh` boxes now exceed the client area and the vertical overflow grows 33 → 48px.

Step 2 is an independent defect and gets its own PR; this one removes the trigger.

**Proof it is the containing block, not geometry.** `overflow: hidden` on `SidebarInset` zeroes the document overflow while `main.scrollHeight` stays 594; clipping the panel group, the primary panel or the secondary panel changes nothing before this fix. A sweep of eight routes found exactly **one** clip-escaping absolutely-positioned box in the app — this span. The span does not move when the panel's own scroll area scrolls, because its containing block is outside that scroller.

**Trigger predicate**, verified to the pixel at three widths: the document overflows iff `documentElement.clientHeight` is below the toggle's static offset inside the panel's content flow — `h = ceil(offset)` clean, `h = ceil(offset) - 1` broken. That offset is 515px for a project with nothing outstanding, 593px with a few action items, 661px at a 1024px-wide window (narrower panel → more wrapping → taller content). So the more migration work a project has, the taller the window at which this bites. Independent of device pixel ratio (identical at 1, 1.25, 1.5, 1.75, 2) and of table state (columns, rows per page, chart expanded, filter sidebar) — the table lives inside `overflow-auto` and cannot push the document.

**Test.** `web/src/__e2e__/app-shell-overflow.spec.ts` asserts the shell invariant — with a right drawer open at a short viewport, an absolutely-positioned box in the drawer's scroll content must not make the document scroll. It appends the probe itself rather than depending on a project's migration state, so it is deterministic and pins the contract instead of this one span. Fails on `main` (`y: 1459` of document overflow), passes here. Layout can only be asserted in a real browser, hence e2e rather than a jsdom client test.

**Accessibility** is unchanged — the description element and its `aria-describedby` wiring are untouched.

Checks: `pnpm run lint` → `Tasks: 7 successful, 7 total`; `pnpm run typecheck` → `Tasks: 7 successful, 7 total`; e2e spec → `1 passed`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR establishes the secondary resizable panel as the containing block for absolutely positioned drawer content, preventing it from expanding the document. It also adds a browser-level regression test that opens the Support drawer, inserts an absolute-positioned overflow probe, and verifies that the document remains constrained on both axes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable regressions identified.

The containing-block change is consistent across left and right secondary panels, known absolute descendants already use local positioned ancestors, and the regression test reaches the intended Support drawer scroll container with established test credentials.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(layout): stop drawer content from sc..."](https://github.com/langfuse/langfuse/commit/24dbe5d3b2da45785cc637564ef058bc1a9374ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52971855)</sub>

<!-- /greptile_comment -->