### PR TITLE
fix(web): always show the coding-agent prompt in the v4 migration sidebar

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -325,7 +325,6 @@ export const events = {
   // panel_opened carries the entry surface; panel_checks_loaded carries the
   // amount of work shown (counts only — never keys or SDK payload values).
   v4_migration: [
-    "coding_agent_prompt_viewed",
     "coding_agent_prompt_copied",
     "delay_badge_clicked",
     "project_chip_clicked",

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1056,24 +1056,25 @@ describe("V4MigrationHeaderContent", () => {
     expect(screen.queryByRole("separator")).not.toBeInTheDocument();
   });
 
-  it("does not create credentials when revealing or copying the prompt", () => {
+  it("shows the prompt without any click and copies it in a single click", () => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
     render(<V4MigrationAgentUpgradeSection projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
-
+    // The prompt is always visible; no reveal step required.
     expect(screen.getByText("coding-agent-prompt")).toBeInTheDocument();
     expect(mocks.createProjectApiKey).not.toHaveBeenCalled();
 
-    // Second click copies; still no credentials. (jsdom has no clipboard.)
-    Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
+    // A single CTA click copies; still no credentials. (jsdom has no clipboard.)
     fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "coding-agent-prompt",
+    );
     expect(mocks.createProjectApiKey).not.toHaveBeenCalled();
   });
 
   it("creates keys only on the explicit create action and shows an env block", async () => {
     render(<V4MigrationAgentUpgradeSection projectId="project-1" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
     const createButton = screen.getByRole("button", {
       name: "Create API keys",
     });
@@ -1110,7 +1111,6 @@ describe("V4MigrationHeaderContent", () => {
 
     const promptButton = screen.getByRole("button", { name: "Copy prompt" });
     expect(promptButton).toBeEnabled();
-    fireEvent.click(promptButton);
     expect(screen.getByText("coding-agent-prompt")).toBeInTheDocument();
 
     const createButton = screen.getByRole("button", {
@@ -1125,7 +1125,6 @@ describe("V4MigrationHeaderContent", () => {
     const { rerender } = render(
       <V4MigrationAgentUpgradeSection key="project-1" projectId="project-1" />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
     fireEvent.click(screen.getByRole("button", { name: "Create API keys" }));
 
     await waitFor(() =>
@@ -1141,7 +1140,6 @@ describe("V4MigrationHeaderContent", () => {
     expect(
       screen.queryByText(/LANGFUSE_PUBLIC_KEY=pk-lf-project-1/),
     ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
     fireEvent.click(screen.getByRole("button", { name: "Create API keys" }));
     await waitFor(() =>
       expect(

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -3,7 +3,6 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import {
-  Bot,
   BotMessageSquare,
   Check,
   ChevronRight,
@@ -1014,12 +1013,11 @@ export function V4MigrationHeaderContent({
   );
 }
 
-// The primary agent CTA as its own group. The CTA is two-step: the first
-// click reveals the prompt so users can see what they hand to their agent,
-// the second click copies it. Project API keys are NOT created as a side
-// effect: credentials only exist after an explicit click on the separate
-// "Create keys for project access" action, and secrets never enter the
-// agent prompt.
+// The primary agent CTA as its own group. The prompt is always visible so a
+// single click on the CTA (or the code block's corner button) copies it.
+// Project API keys are NOT created as a side effect: credentials only exist
+// after an explicit click on the separate "Create keys for project access"
+// action, and secrets never enter the agent prompt.
 export function V4MigrationAgentUpgradeSection({
   projectId,
 }: {
@@ -1027,7 +1025,6 @@ export function V4MigrationAgentUpgradeSection({
 }) {
   const capture = usePostHogClientCapture();
   const handleCopyPrompt = useCopyMigrationPrompt();
-  const [promptVisible, setPromptVisible] = useState(false);
 
   const [generatedKeys, setGeneratedKeys] = useState<{
     projectId: string;
@@ -1045,11 +1042,6 @@ export function V4MigrationAgentUpgradeSection({
     projectId,
     scope: "apiKeys:CUD",
   });
-
-  const handleShowPrompt = () => {
-    capture("v4_migration:coding_agent_prompt_viewed");
-    setPromptVisible(true);
-  };
 
   const handleCreateKeys = () => {
     // Guards double-clicks and re-creation once keys exist for this project.
@@ -1116,29 +1108,20 @@ export function V4MigrationAgentUpgradeSection({
         </p>
       </div>
       <div className="flex flex-col gap-2">
-        <RainbowButton
-          className="w-full"
-          onClick={promptVisible ? handleCopyPrompt : handleShowPrompt}
-        >
-          {promptVisible ? (
-            <Copy className="mr-1.5 h-4 w-4 shrink-0" />
-          ) : (
-            <Bot className="mr-1.5 h-4 w-4 shrink-0" />
-          )}
+        <RainbowButton className="w-full" onClick={handleCopyPrompt}>
+          <Copy className="mr-1.5 h-4 w-4 shrink-0" />
           <span className="min-w-0 truncate" title="Copy prompt">
             Copy prompt
           </span>
         </RainbowButton>
-        {promptVisible && (
-          <CodeBlockWithCopy
-            text={V4_CODING_AGENT_PROMPT}
-            copyLabel="Copy prompt to clipboard"
-            onCopy={() => capture("v4_migration:coding_agent_prompt_copied")}
-            scrollable
-            className="my-3"
-          />
-        )}
-        {promptVisible && projectId && (
+        <CodeBlockWithCopy
+          text={V4_CODING_AGENT_PROMPT}
+          copyLabel="Copy prompt to clipboard"
+          onCopy={() => capture("v4_migration:coding_agent_prompt_copied")}
+          scrollable
+          className="my-3"
+        />
+        {projectId && (
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between gap-2">
               <p className="text-muted-foreground min-w-0 text-sm leading-relaxed">


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16084.preview.langfuse.com](https://pr-16084.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The "Upgrade using coding agents" section in the v4 migration sidebar previously
hid the coding-agent prompt behind a two-step CTA: the first click revealed the
prompt, and only the second click copied it to the clipboard. This makes the
prompt always visible so copying it takes a single click.

Changes in `V4MigrationAgentUpgradeSection`:

- The prompt code block (and the "Create project API keys" helper) now render
  immediately instead of being gated behind a `promptVisible` toggle.
- The "Copy prompt" CTA copies in one click (previously it only revealed the
  prompt on the first click). The code block's corner copy button also remains
  as a one-click affordance.
- Removed the now-unused `promptVisible` state, `handleShowPrompt` handler, the
  `Bot` icon, and the `v4_migration:coding_agent_prompt_viewed` analytics event
  (there is no longer a separate reveal action).

Credentials are still only created on the explicit "Create API keys" action, and
the secret never enters the agent prompt — unchanged behavior.

Fixes the request to always show the prompt so it no longer takes two clicks to
copy.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Testing

Updated the colocated client tests to assert the prompt is visible without any
click and that a single CTA click copies it. Existing key-creation tests were
adjusted to drop the now-unnecessary reveal click.

- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx` → `Tests 36 passed (36)`
- `pnpm --filter web run lint` → passed (`Tasks: 7 successful, 7 total`)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15093](https://linear.app/clickhouse/issue/LFE-15093/always-show-prompt-in-the-v4-sidebar)

<div><a href="https://cursor.com/agents/bc-42d0f03f-20a2-408e-9673-c51f52334a3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d0f03f-20a2-408e-9673-c51f52334a3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes the v4 migration coding-agent prompt immediately visible and changes the primary copy action to work on the first click.

- Removes the obsolete prompt-visibility state, reveal handler, icon, and analytics event.
- Keeps project API-key creation behind its separate explicit action and permission check.
- Updates client tests for immediate visibility and one-click copying.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The prompt is rendered without side effects, both copy affordances remain direct user-initiated actions, and API-key creation retains its explicit permission-gated flow.
</details>

<sub>Reviews (1): Last reviewed commit: ["Always show the coding-agent prompt in t..."](https://github.com/langfuse/langfuse/commit/9904f8163305682c2814ed8c65003132a965f9ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52985742)</sub>

<!-- /greptile_comment -->