### PR TITLE
ci: switch pipelines back to GitHub-hosted runners

### DIFF
--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -21,7 +21,7 @@ on:
         required: false
 jobs:
   ecs-deploy:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
       contents: read

--- a/.github/workflows/build-sandbox-microvm-image.yml
+++ b/.github/workflows/build-sandbox-microvm-image.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     name: Build & Publish (${{ matrix.environment }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ matrix.environment }}
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ concurrency:
 name: Deploy to ECS
 jobs:
   affected-services:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.affected-services.outputs.result }}
     steps:
@@ -67,7 +67,7 @@ jobs:
             console.log('Services', `${process.env.services}` ?? 'n/a');
 
   affected-environments:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       environments: ${{ steps.affected-environments.outputs.result }}
     steps:
@@ -120,7 +120,7 @@ jobs:
   notify-slack-on-failure:
     needs: [affected-services, affected-environments, ecs-deploy]
     if: failure()
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -51,7 +51,7 @@ env:
 jobs:
   audit:
     if: github.repository == 'langfuse/langfuse'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
       has_changes: ${{ steps.prepare.outputs.has_changes }}
@@ -711,7 +711,7 @@ jobs:
   publish:
     needs: audit
     if: needs.audit.outputs.has_changes == 'true' && needs.audit.outputs.dry_run_mode == 'disabled'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Download pull request artifact

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,7 +47,7 @@ jobs:
   # it instantly and their jobs start without waiting for it (~45-100s of
   # wall clock per run).
   pre-job:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'push'
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -76,7 +76,7 @@ jobs:
           fi
 
   llm-connections-filter:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.llm_connections }}
     timeout-minutes: 15
@@ -101,7 +101,7 @@ jobs:
               - 'worker/src/__tests__/llmConnections.test.ts'
 
   lint:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -167,7 +167,7 @@ jobs:
         run: pnpm run typecheck
 
   knip:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -201,7 +201,7 @@ jobs:
         run: pnpm exec knip
 
   prettier-check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -262,7 +262,7 @@ jobs:
           fi
 
   tests-eslint-plugin:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -298,7 +298,7 @@ jobs:
         run: pnpm --filter @repo/eslint-plugin run test
 
   tests-storybook:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -353,7 +353,7 @@ jobs:
 
   tests-shared:
     timeout-minutes: 15
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -411,11 +411,11 @@ jobs:
         include:
           - component: web
             service: langfuse-web
-            runner: blacksmith-8vcpu-ubuntu-2404
+            runner: ubuntu-latest
             health_url: http://localhost:3000/api/public/health
           - component: worker
             service: langfuse-worker
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-latest
             health_url: http://localhost:3030/api/health
     steps:
       - name: Checkout
@@ -487,7 +487,7 @@ jobs:
           if-no-files-found: ignore
   tests-web:
     timeout-minutes: 30
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -656,7 +656,7 @@ jobs:
 
   tests-web-client:
     timeout-minutes: 10
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
@@ -695,7 +695,7 @@ jobs:
 
   tests-worker:
     timeout-minutes: 20
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -794,7 +794,7 @@ jobs:
           LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT: ${{ matrix.deploy-mode == '' && 'http://localhost:4566' || '' }}
   test-worker-llm-connections:
     timeout-minutes: 20
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
       - llm-connections-filter
@@ -875,7 +875,7 @@ jobs:
           LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY: ${{ secrets.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY }}
 
   e2e-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -998,7 +998,7 @@ jobs:
         run: pnpm --filter=web run test:e2e
 
   e2e-server-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -1101,7 +1101,7 @@ jobs:
 
   all-ci-passed:
     # This allows us to have a branch protection rule for tests and deploys with matrix
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       [
         lint,
@@ -1302,7 +1302,7 @@ jobs:
             image_name: langfuse
           - component: worker
             image_name: langfuse-worker
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
@@ -1451,7 +1451,7 @@ jobs:
       - build-docker-image-release
       - publish-docker-image-release
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -155,7 +155,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.state == 'open' &&
       (github.event.action != 'labeled' || github.event.label.name == 'preview')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: "protected branches"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +42,7 @@ jobs:
   notify-slack-on-failure:
     needs: release
     if: failure()
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   generate-sdk-api-specs:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       python_has_changes: ${{ steps.prepare-python-sdk.outputs.has_changes }}
       python_branch_name: ${{ steps.prepare-python-sdk.outputs.branch_name }}
@@ -170,7 +170,7 @@ jobs:
   push-python-sdk:
     needs: generate-sdk-api-specs
     if: needs.generate-sdk-api-specs.outputs.python_has_changes == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Download Python SDK update
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -227,7 +227,7 @@ jobs:
   push-typescript-sdk:
     needs: generate-sdk-api-specs
     if: needs.generate-sdk-api-specs.outputs.typescript_has_changes == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Download TypeScript SDK update
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -287,7 +287,7 @@ jobs:
       - push-python-sdk
       - push-typescript-sdk
     if: failure()
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Storybook preview
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'push' && github.ref_name == 'main') ||
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Blacksmith is experiencing a partial outage, which is blocking CI pipelines. This moves the general-purpose CI, lint, test, build, deploy, and release-orchestration jobs off the `blacksmith-*-ubuntu-2404` runners and back onto GitHub-hosted `ubuntu-latest` (the label these jobs used before the Blacksmith migration).

Changed workflows:
- `pipeline.yml` (CI: pre-job, lint, knip, prettier, tests, e2e, docker-build smoke, orchestration jobs)
- `deploy.yml`, `_deploy_ecs_service.yml`, `release.yml`, `preview-build.yml`
- `sdk-api-spec.yml`, `storybook-preview.yml`, `model-price-audit.yml`, `build-sandbox-microvm-image.yml`

### Intentionally left on Blacksmith runners

Two jobs are coupled to Blacksmith infrastructure and cannot function on GitHub-hosted runners, so they are unchanged:

- **`pipeline.yml` → `build-docker-image-release`** (amd64 + arm64 matrix): uses the `useblacksmith/setup-docker-builder` and `useblacksmith/build-push-action` actions plus Blacksmith's Docker layer cache. This job only runs on tag pushes; per the existing in-file comment, a Blacksmith outage is expected to block releases rather than silently degrade them.
- **`warm-caches.yml`**: warms Blacksmith's own Actions cache backend, which only works when run from a Blacksmith runner.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Notes on verification

Runner-label-only substitutions (indentation preserved). The repo pre-commit hook ran `prettier --check` and `turbo run lint` successfully (`Tasks: 7 successful, 7 total`). Full end-to-end validation happens when the workflows execute on GitHub-hosted runners for this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15105](https://linear.app/clickhouse/issue/LFE-15105/switch-pipelines-back-to-github-runners)

<div><a href="https://cursor.com/agents/bc-03de9240-3e89-4799-947c-4c08746946b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03de9240-3e89-4799-947c-4c08746946b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves general-purpose CI, deployment, preview, SDK-generation, audit, and release-orchestration jobs from Blacksmith runners to GitHub-hosted `ubuntu-latest` while retaining Blacksmith-coupled image builds.

- Updates runner labels in nine GitHub Actions workflows.
- Leaves the architecture-specific release image build on Blacksmith.
- Retains an eight-worker web-test configuration that was calibrated for the previous eight-vCPU runner.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking concern that the web test job now oversubscribes its smaller runner.

The Blacksmith-specific image build remains correctly isolated, and the migrated jobs otherwise use standard runner capabilities; only the fixed eight-worker web-test configuration conflicts with the newly selected runner capacity.

**Files Needing Attention:** .github/workflows/pipeline.yml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/pipeline.yml:490
**Eight workers oversubscribe runner**

The `tests-web` job still starts eight database-heavy Vitest workers after moving off its eight-vCPU runner, conflicting with the workflow's one-vCPU-per-worker requirement and increasing contention, runtime, and test flakiness against the 30-minute timeout.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: switch pipelines back to GitHub-host..."](https://github.com/langfuse/langfuse/commit/29a6f5c04658e215f5295e9593f56e79790a896d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52985025)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->