### PR TITLE
fix(server): handle empty array options

### DIFF
--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -352,6 +352,58 @@ describe("evals trpc", () => {
       );
       expect(response.totalCount).toBe(2);
     });
+
+    // A Time Scope filter with no selected values is a reachable UI state
+    // (the facet's operator toggle can be flipped before any checkbox is
+    // checked). It must not crash the query — passing an empty value list
+    // into the Postgres array literal throws (`Prisma.join([])`), so the
+    // router treats an empty-value arrayOptions filter as no filter on that
+    // column. Only "all of"/"none of" can carry an empty value at all — the
+    // arrayOptionsFilter zod schema itself rejects "any of" with an empty
+    // value before this ever runs.
+    it.each(["all of", "none of"] as const)(
+      "does not throw and does not filter on an empty time scope value list ('%s')",
+      async (operator) => {
+        const { project, caller } = await prepare();
+
+        const evaluator = await prisma.jobConfiguration.create({
+          data: {
+            projectId: project.id,
+            jobType: "EVAL",
+            scoreName: "unfiltered-score",
+            filter: [],
+            targetObject: EvalTargetObject.TRACE,
+            variableMapping: [],
+            sampling: 1,
+            delay: 0,
+            status: "ACTIVE",
+            timeScope: ["NEW"],
+          },
+        });
+
+        const response = await caller.evals.allConfigs({
+          projectId: project.id,
+          filter: [
+            {
+              column: "timeScope",
+              type: "arrayOptions",
+              operator,
+              value: [],
+            },
+          ],
+          orderBy: {
+            column: "createdAt",
+            order: "DESC",
+          },
+          limit: 10,
+          page: 0,
+        });
+
+        expect(response.configs.map((config) => config.id)).toEqual([
+          evaluator.id,
+        ]);
+      },
+    );
   });
 
   describe("evals.templateNames", () => {

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -520,9 +520,18 @@ export const evalRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "evalJob:read",
       });
+      // Passing in empty arrayOptions is a no-op, so we exclude it
+      const sanitizedFilter = input.filter.filter(
+        (f) =>
+          !(
+            f.type === "arrayOptions" &&
+            f.value.length === 0 &&
+            f.operator !== "any of"
+          ),
+      );
 
       const filterCondition = tableColumnsToSqlFilterAndPrefix(
-        input.filter,
+        sanitizedFilter,
         evalConfigFilterColumns,
         "job_configurations",
       );

--- a/web/src/features/filters/lib/sidebar-filter-actions.ts
+++ b/web/src/features/filters/lib/sidebar-filter-actions.ts
@@ -257,14 +257,11 @@ export function applySelection(
     finalOperator = operator;
     finalValues = values;
 
-    // An empty "none of" and "all of" excludes nothing: since deselecting from the
+    // An empty "none of" excludes nothing: since deselecting from the
     // all-checked default now enters NONE mode by itself, toggling NONE
     // without a selection is a no-op rather than a persisted vacuous
     // filter (which would light the badge while matching everything).
-    if (
-      (finalOperator === "none of" || finalOperator === "all of") &&
-      finalValues.length === 0
-    ) {
+    if (finalOperator === "none of" && finalValues.length === 0) {
       return other;
     }
   } else {

--- a/web/src/features/filters/lib/sidebar-filter-actions.ts
+++ b/web/src/features/filters/lib/sidebar-filter-actions.ts
@@ -257,11 +257,14 @@ export function applySelection(
     finalOperator = operator;
     finalValues = values;
 
-    // An empty "none of" excludes nothing: since deselecting from the
+    // An empty "none of" and "all of" excludes nothing: since deselecting from the
     // all-checked default now enters NONE mode by itself, toggling NONE
     // without a selection is a no-op rather than a persisted vacuous
     // filter (which would light the badge while matching everything).
-    if (finalOperator === "none of" && finalValues.length === 0) {
+    if (
+      (finalOperator === "none of" || finalOperator === "all of") &&
+      finalValues.length === 0
+    ) {
       return other;
     }
   } else {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16086.preview.langfuse.com](https://pr-16086.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes sidebar filter handling so empty `all of` selections are discarded like empty `none of` selections.
- Extends the empty-selection early return to the `all of` operator.
- This prevents the UI from retaining `all of` while waiting for the first selected value.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until selecting “All of” before choosing values retains that operator.

The changed early return clears a reachable and explicitly valid waiting-for-selection state, causing subsequent selections to use “Any of” instead of the operator the user chose.

**Files Needing Attention:** web/src/features/filters/lib/sidebar-filter-actions.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/filters/lib/sidebar-filter-actions.ts:264-267
**Empty all-of state is discarded**

When a user selects “All of” before choosing any facet values, this branch removes the valid waiting-for-selection state and resets the operator to “Any of,” causing subsequent selections to use the wrong operator.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): handle empty array options"](https://github.com/langfuse/langfuse/commit/c866a15f441e309dab208e18d0582ced963ed964) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52992253)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->