### PR TITLE
feat(v4-migration): add v4 features pitch with docs links to upgrade sidebar header

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1030,7 +1030,7 @@ describe("V4MigrationHeaderContent", () => {
     expect(screen.getByText("Upgrade to v4")).toBeInTheDocument();
     expect(screen.queryByText(/Project 1/)).not.toBeInTheDocument();
     expect(screen.getByText(/Langfuse v4 is live/)).toHaveTextContent(
-      "Langfuse v4 is live: a re-architecture of our data model and database tables that is up to 165× more performant in the UI and on APIs. It also enables new features such as full-text search, a new filter search bar, alerts, code evaluators, and the Langfuse Assistant. Complete the action items below to switch this project over. See docs.",
+      "Langfuse v4 is live: a re-architecture of our data model and database tables. It is up to 165× more performant in UI and on APIs. It also enables new features such as full-text search, a new filter search bar, alerts, code evaluators, and the Langfuse Assistant. Complete the action items below to switch this project over. See docs.",
     );
     expect(
       screen.getByRole("link", { name: "full-text search" }),

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1029,11 +1029,34 @@ describe("V4MigrationHeaderContent", () => {
 
     expect(screen.getByText("Upgrade to v4")).toBeInTheDocument();
     expect(screen.queryByText(/Project 1/)).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/Complete the action items below/),
-    ).toHaveTextContent(
-      "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. Complete the action items below to switch this project over. See docs.",
+    expect(screen.getByText(/Langfuse v4 is live/)).toHaveTextContent(
+      "Langfuse v4 is live: a re-architecture of our data model and database tables that is up to 165× more performant in the UI and on APIs. It also enables new features such as full-text search, a new filter search bar, alerts, code evaluators, and the Langfuse Assistant. Complete the action items below to switch this project over. See docs.",
     );
+    expect(
+      screen.getByRole("link", { name: "full-text search" }),
+    ).toHaveAttribute(
+      "href",
+      "https://langfuse.com/docs/observability/features/full-text-search",
+    );
+    expect(
+      screen.getByRole("link", { name: "new filter search bar" }),
+    ).toHaveAttribute(
+      "href",
+      "https://langfuse.com/docs/observability/features/filter-search-bar",
+    );
+    expect(screen.getByRole("link", { name: "alerts" })).toHaveAttribute(
+      "href",
+      "https://langfuse.com/docs/metrics/features/alerts",
+    );
+    expect(
+      screen.getByRole("link", { name: "code evaluators" }),
+    ).toHaveAttribute(
+      "href",
+      "https://langfuse.com/docs/evaluation/evaluation-methods/code-evaluators",
+    );
+    expect(
+      screen.getByRole("link", { name: "Langfuse Assistant" }),
+    ).toHaveAttribute("href", "https://langfuse.com/docs/langfuse-assistant");
     expect(screen.getByRole("link", { name: "See docs." })).toHaveAttribute(
       "href",
       "https://langfuse.com/docs/v4",
@@ -1069,9 +1092,7 @@ describe("V4MigrationHeaderContent", () => {
       expect(
         screen.queryByText(/Complete the action items below/),
       ).not.toBeInTheDocument();
-      expect(
-        screen.getByText(/Langfuse v4 is here: real-time ingestion/),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Langfuse v4 is live/)).toBeInTheDocument();
       expect(
         screen.queryByText(/some features may stop working/),
       ).not.toBeInTheDocument();

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1008,8 +1008,8 @@ export function V4MigrationHeaderContent({
       <div className="text-muted-foreground flex flex-col gap-2 text-sm leading-relaxed">
         <p>
           Langfuse v4 is live: a re-architecture of our data model and database
-          tables that is up to 165× more performant in the UI and on APIs. It
-          also enables new features such as{" "}
+          tables. It is up to 165× more performant in UI and on APIs. It also
+          enables new features such as{" "}
           <ExternalLink
             href={FULL_TEXT_SEARCH_URL}
             analytics={{ section: "header", link: "full_text_search_docs" }}

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -99,6 +99,15 @@ const EXPERIMENT_OTEL_INGESTION_URL =
 const SDK_OVERVIEW_URL = "https://langfuse.com/docs/observability/sdk/overview";
 const OTEL_INTEGRATION_URL =
   "https://langfuse.com/integrations/native/opentelemetry";
+// v4 feature docs linked from the upgrade header pitch.
+const FULL_TEXT_SEARCH_URL =
+  "https://langfuse.com/docs/observability/features/full-text-search";
+const FILTER_SEARCH_BAR_URL =
+  "https://langfuse.com/docs/observability/features/filter-search-bar";
+const ALERTS_URL = "https://langfuse.com/docs/metrics/features/alerts";
+const CODE_EVALUATORS_URL =
+  "https://langfuse.com/docs/evaluation/evaluation-methods/code-evaluators";
+const LANGFUSE_ASSISTANT_URL = "https://langfuse.com/docs/langfuse-assistant";
 
 // Copies the agent migration prompt to the clipboard with toast + analytics;
 // shared by the panel/modal header CTA and the status page.
@@ -998,9 +1007,47 @@ export function V4MigrationHeaderContent({
       </div>
       <div className="text-muted-foreground flex flex-col gap-2 text-sm leading-relaxed">
         <p>
+          Langfuse v4 is live: a re-architecture of our data model and database
+          tables that is up to 165× more performant in the UI and on APIs. It
+          also enables new features such as{" "}
+          <ExternalLink
+            href={FULL_TEXT_SEARCH_URL}
+            analytics={{ section: "header", link: "full_text_search_docs" }}
+          >
+            full-text search
+          </ExternalLink>
+          , a{" "}
+          <ExternalLink
+            href={FILTER_SEARCH_BAR_URL}
+            analytics={{ section: "header", link: "filter_search_bar_docs" }}
+          >
+            new filter search bar
+          </ExternalLink>
+          ,{" "}
+          <ExternalLink
+            href={ALERTS_URL}
+            analytics={{ section: "header", link: "alerts_docs" }}
+          >
+            alerts
+          </ExternalLink>
+          ,{" "}
+          <ExternalLink
+            href={CODE_EVALUATORS_URL}
+            analytics={{ section: "header", link: "code_evaluators_docs" }}
+          >
+            code evaluators
+          </ExternalLink>
+          , and the{" "}
+          <ExternalLink
+            href={LANGFUSE_ASSISTANT_URL}
+            analytics={{ section: "header", link: "langfuse_assistant_docs" }}
+          >
+            Langfuse Assistant
+          </ExternalLink>
+          .
           {actionNeeded
-            ? "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. Complete the action items below to switch this project over. "
-            : "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. "}
+            ? " Complete the action items below to switch this project over."
+            : ""}{" "}
           <ExternalLink
             href={V4_DOCS_URL}
             analytics={{ section: "header", link: "v4_docs" }}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16087.preview.langfuse.com](https://pr-16087.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds the requested v4 marketing copy to the top of the "Upgrade to v4" sidebar header (`V4MigrationHeaderContent`), directly below the "Upgrade to v4" title, with hyperlinks to the relevant docs.

The new lead paragraph reads:

> Langfuse v4 is live: a re-architecture of our data model and database tables. It is up to 165× more performant in UI and on APIs. It also enables new features such as **full-text search**, a **new filter search bar**, **alerts**, **code evaluators**, and the **Langfuse Assistant**. [Complete the action items below to switch this project over.] **See docs.**

The bolded phrases are external links:

- full-text search → `https://langfuse.com/docs/observability/features/full-text-search`
- new filter search bar → `https://langfuse.com/docs/observability/features/filter-search-bar`
- alerts → `https://langfuse.com/docs/metrics/features/alerts`
- code evaluators → `https://langfuse.com/docs/evaluation/evaluation-methods/code-evaluators`
- Langfuse Assistant → `https://langfuse.com/docs/langfuse-assistant`
- See docs → `https://langfuse.com/docs/v4` (existing `V4_DOCS_URL`)

Because this component is the single source of truth for the migration copy, both the sidebar panel and the modal pick up the new text. The existing `November 16, 2026` deadline line (with its timeline link) and the action-needed "Complete the action items below" clause are preserved.

### Implementation notes

- The previous lead sentence ("Langfuse v4 is here: real-time ingestion and up to 165× faster queries.") is replaced by the richer feature pitch, which supersedes it and keeps a single `See docs.` link (avoids duplicate copy and a duplicate-link collision in tests).
- Each feature link emits the existing `v4_migration:section_link_clicked` analytics event with a `header` section and a per-feature `link` dimension, matching the established pattern for links in this component.
- URLs were verified against the live Langfuse docs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Testing

- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx` — 37 tests pass (updated the header-copy assertions and added href assertions for all five new feature links).
- `pnpm --filter web run lint` — passes.
- `pnpm --filter web run typecheck` — passes.
- Rendered the `V4MigrationHeaderContent` "ActionNeeded" Storybook story and confirmed the copy and links display correctly.

[Updated Upgrade to v4 sidebar header with feature links](https://cursor.com/agents/bc-9a4caef0-1532-443e-8c1e-172b7c1d58a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv4_sidebar_header_copy_v2.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a4caef0-1532-443e-8c1e-172b7c1d58a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a4caef0-1532-443e-8c1e-172b7c1d58a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a richer Langfuse v4 feature pitch to the migration header used by both the upgrade sidebar and modal.
- Links five highlighted v4 features to their documentation.
- Adds per-feature header analytics metadata.
- Updates component tests to verify the new copy and destinations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new links follow the existing ExternalLink navigation and analytics contract, and the readiness-dependent migration messaging remains covered by the updated tests.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(v4-migration): add v4 features pitc..."](https://github.com/langfuse/langfuse/commit/a53b5dbc1a19cb4cafaf91fdc684125e1883270c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52999814)</sub>

<!-- /greptile_comment -->