### PR TITLE
fix(dashboards): read events_full for truncation-sensitive metadata filters

### DIFF
--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -4,6 +4,7 @@ import { convertDateToClickhouseDateTime } from "../../../server/clickhouse/clie
 import { shouldSkipObservationsFinal } from "../../../server/queries/clickhouse-sql/query-options";
 import {
   FilterList,
+  filtersRequireEventsFull,
   type Filter,
 } from "../../../server/queries/clickhouse-sql/clickhouse-filter";
 import { createFilterFromFilterState } from "../../../server/queries/clickhouse-sql/factory";
@@ -1583,10 +1584,23 @@ export class QueryBuilder {
     }
 
     // Create filters: normal WHERE filters + raw WHERE parts (filterSql pruning + exact match)
-    const { whereFilters, whereRawParts } = this.mapFilters(
-      query.filters,
-      view,
-    );
+    let mappedFilters = this.mapFilters(query.filters, view);
+
+    // events_core stores metadata_values truncated to 200 chars (events_core_mv);
+    // truncation-sensitive filters must read events_full or matches beyond the
+    // truncation point are silently dropped. Re-map so filter prefixes follow.
+    if (
+      this.actualTableName(view) === "events_core" &&
+      filtersRequireEventsFull(new FilterList(mappedFilters.whereFilters))
+    ) {
+      view = {
+        ...view,
+        baseCte: view.baseCte.replace("events_core", "events_full"),
+      };
+      mappedFilters = this.mapFilters(query.filters, view);
+    }
+
+    const { whereFilters, whereRawParts } = mappedFilters;
     let filterList = new FilterList(whereFilters);
 
     // Add standard filters (project_id, timestamps)

--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -5097,6 +5097,116 @@ describe("query builder measure-aggregation validation", () => {
     );
   });
 
+  describe("metadata filters on events views (v2)", () => {
+    // events_core stores metadata_values truncated to 200 chars
+    // (events_core_mv); metadata filters must read events_full or matches
+    // beyond the truncation point are silently dropped.
+    const isEventsTableV2Enabled =
+      env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true" ? it : it.skip;
+
+    const metadataFilterQuery = (
+      view: "traces" | "observations",
+    ): QueryType => ({
+      view,
+      dimensions: [{ field: "name" }],
+      metrics: [{ measure: "count", aggregation: "count" }],
+      filters: [
+        {
+          column: "metadata",
+          operator: "contains",
+          key: "experiments",
+          value: "HAGTI=B",
+          type: "stringObject",
+        },
+      ],
+      timeDimension: null,
+      fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+      toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+      orderBy: null,
+    });
+
+    it("reads events_full when a metadata filter is present (traces view)", async () => {
+      const builder = new QueryBuilder(undefined, "v2");
+      const { query: sql } = await builder.build(
+        metadataFilterQuery("traces"),
+        randomUUID(),
+      );
+
+      expect(sql).toContain("FROM events_full events_traces");
+      expect(sql).not.toContain("events_core");
+    });
+
+    it("reads events_full when a metadata filter is present (observations view)", async () => {
+      const builder = new QueryBuilder(undefined, "v2");
+      const { query: sql } = await builder.build(
+        metadataFilterQuery("observations"),
+        randomUUID(),
+      );
+
+      expect(sql).toContain("FROM events_full events_observations");
+      expect(sql).not.toContain("events_core");
+    });
+
+    it("keeps reading events_core without truncation-sensitive filters", async () => {
+      const builder = new QueryBuilder(undefined, "v2");
+      const query = metadataFilterQuery("traces");
+      query.filters = [
+        {
+          column: "environment",
+          operator: "=",
+          value: "production",
+          type: "string",
+        },
+      ];
+      const { query: sql } = await builder.build(query, randomUUID());
+
+      expect(sql).toContain("FROM events_core events_traces");
+      expect(sql).not.toContain("events_full");
+    });
+
+    isEventsTableV2Enabled(
+      "metadata 'contains' matches a value beyond the 200-char truncation point",
+      async () => {
+        const projectId = randomUUID();
+        const traceId = randomUUID();
+        const needle = `HAGTI=B-${randomUUID()}`;
+        const longValue = JSON.stringify([
+          ...Array.from({ length: 20 }, (_, i) => `experiment-${i}`),
+          needle,
+        ]);
+        expect(longValue.length).toBeGreaterThan(200);
+
+        await createEventsCh([
+          createEvent({
+            project_id: projectId,
+            trace_id: traceId,
+            trace_name: "trace-with-long-metadata",
+            name: "root-op",
+            parent_span_id: "",
+            metadata_names: ["experiments"],
+            metadata_values: [longValue],
+            start_time: Date.now() * 1000,
+          }),
+        ]);
+
+        const query = metadataFilterQuery("traces");
+        query.filters = [
+          {
+            column: "metadata",
+            operator: "contains",
+            key: "experiments",
+            value: needle,
+            type: "stringObject",
+          },
+        ];
+        const result = await executeQuery(projectId, query, "v2");
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("trace-with-long-metadata");
+      },
+    );
+  });
+
   describe("useFinal flag on events_core joins", () => {
     it("should join the parentless trace event without FINAL in v2 scores-numeric view", async () => {
       const projectId = randomUUID();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16088.preview.langfuse.com](https://pr-16088.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Dashboard widgets on the v4 data model returned no data for metadata `contains`/`=` filters whose values sit beyond the first 200 characters, while the same filter worked on the tracing table.

The dashboard `QueryBuilder`'s v2 views are hardcoded to `events_core`, whose `metadata_values` entries are truncated to 200 characters by `events_core_mv`, so predicates on long values (e.g. large JSON-serialized metadata arrays) silently matched nothing. The tracing table already handles this by swapping truncation-sensitive filters onto `events_full` (#15069); this PR reuses the same predicate (`filtersRequireEventsFull`) in the dashboard query builder to swap the view's base table and re-map filter prefixes accordingly. Queries without truncation-sensitive filters keep reading `events_core`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Added regression tests: SQL-level table selection for v2 traces/observations views, plus an end-to-end test matching a metadata value beyond the 200-char truncation point
- [x] `pnpm turbo run lint --filter=@langfuse/shared --filter=web`, `typecheck`, targeted web/worker/shared tests pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR routes v2 trace and observation dashboard queries to `events_full` when metadata filters require values beyond `events_core`’s truncation limit.

- Detects truncation-sensitive mapped filters and rebuilds them against `events_full`.
- Keeps ordinary filters on the smaller `events_core` table.
- Adds SQL-generation and integration coverage for long metadata values.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The source-table switch preserves aliases and schema contracts, remaps affected filters after switching, and is limited to currently supported metadata filters that require untruncated values.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): read events\_full for tr..."](https://github.com/langfuse/langfuse/commit/2bb35b054e8779aa40dbb43b102f312653e6a7dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53009083)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->