### PR TITLE
fix(worker): pin analytics export egress to connect-time SSRF validation

### DIFF
--- a/packages/shared/src/server/outbound-url/validation.ts
+++ b/packages/shared/src/server/outbound-url/validation.ts
@@ -28,6 +28,11 @@ export class OutboundUrlValidationError extends Error {
   }
 }
 
+// Prefix of the message thrown on DNS-resolution failure. Exported so consumers
+// can detect this failure by message when the typed `code` is lost — e.g. after
+// RedirectValidationError re-wraps the inner error by message text only.
+export const DNS_LOOKUP_FAILED_MESSAGE_PREFIX = "DNS lookup failed for";
+
 export interface OutboundUrlValidationWhitelist {
   hosts: string[];
   ips: string[];
@@ -78,7 +83,7 @@ export async function resolveHost(hostname: string): Promise<string[]> {
   if (!ips.size) {
     throw new OutboundUrlValidationError(
       "dns-lookup-failed",
-      `DNS lookup failed for ${hostname}`,
+      `${DNS_LOOKUP_FAILED_MESSAGE_PREFIX} ${hostname}`,
     );
   }
   return [...ips];

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -260,12 +260,43 @@ describe("outbound validation classification", () => {
   });
 });
 
+/**
+ * Everything a structured logger or tracer can pull off a thrown error: its
+ * enumerable own fields (winston copies those into the JSON log line), its
+ * message, its stack, and the same again for each `cause` a chain-walking
+ * reporter follows. A credential must appear in none of them.
+ */
+function serializableSurface(error: unknown): string {
+  const parts: string[] = [];
+  let current: any = error;
+  for (let depth = 0; depth < 6 && current; depth++) {
+    parts.push(JSON.stringify({ ...current }));
+    if (typeof current.message === "string") parts.push(current.message);
+    if (typeof current.stack === "string") parts.push(current.stack);
+    current = current.cause;
+  }
+  return parts.join("\n");
+}
+
+function captureRethrow(error: unknown): unknown {
+  try {
+    rethrowIfOutboundValidationFailure(error, {
+      logSubject: "Mixpanel outbound send",
+      jobSubject: "Mixpanel export",
+    });
+  } catch (caught) {
+    return caught;
+  }
+  return undefined;
+}
+
 describe("terminal outbound failure reporting", () => {
-  // The rejected redirect target is embedded verbatim in the validation error,
-  // so a credentialed Location header would otherwise reach the log line and
+  // The rejected redirect target is embedded verbatim in the validation error —
+  // in its message, its stack, and its enumerable `redirectUrl` field — so a
+  // credentialed Location header would otherwise reach the log line and
   // BullMQ's persisted failedReason.
-  it("redacts credentials from a rejected redirect target", () => {
-    const error = Object.assign(new TypeError("fetch failed"), {
+  const credentialedRedirect = () =>
+    Object.assign(new TypeError("fetch failed"), {
       cause: new RedirectValidationError(
         "Blocked IP address detected: 169.254.169.254",
         "http://exporter:hunter2@169.254.169.254/",
@@ -273,15 +304,8 @@ describe("terminal outbound failure reporting", () => {
       ),
     });
 
-    let thrown: unknown;
-    try {
-      rethrowIfOutboundValidationFailure(error, {
-        logSubject: "Mixpanel outbound send",
-        jobSubject: "Mixpanel export",
-      });
-    } catch (caught) {
-      thrown = caught;
-    }
+  it("redacts credentials from a rejected redirect target", () => {
+    const thrown = captureRethrow(credentialedRedirect());
 
     expect(isUnrecoverableError(thrown)).toBe(true);
     const message = (thrown as Error).message;
@@ -290,6 +314,29 @@ describe("terminal outbound failure reporting", () => {
     // The diagnostic reason must survive redaction, otherwise the operator
     // cannot tell a blocked IP from a rejected scheme.
     expect(message).toContain("Blocked IP address detected: 169.254.169.254");
+  });
+
+  it("keeps credentials out of every field a logger or tracer can serialize", () => {
+    const thrown = captureRethrow(credentialedRedirect());
+
+    // Redacting only the message is not enough: the queue's generic `failed`
+    // handler passes the whole error to the logger and to traceException, so a
+    // raw error retained as an enumerable `cause` leaks the URL anyway.
+    expect(serializableSurface(thrown)).not.toContain("hunter2");
+    expect(serializableSurface(thrown)).not.toContain(
+      "exporter:hunter2@169.254.169.254",
+    );
+    // Non-vacuous: the redacted reason really is reachable on that surface.
+    expect(serializableSurface(thrown)).toContain(
+      "Blocked IP address detected: 169.254.169.254",
+    );
+  });
+
+  it("does not expose the retained cause as an enumerable field", () => {
+    const thrown = captureRethrow(credentialedRedirect());
+
+    expect((thrown as Error).cause).toBeDefined();
+    expect(Object.keys(thrown as object)).not.toContain("cause");
   });
 
   it("leaves a credential-free message untouched and stays a no-op for other errors", () => {

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -48,6 +48,11 @@ afterEach(async () => {
 
 const h = vi.hoisted(() => {
   const posthogIntegrationUpdate = vi.fn();
+  // The atomic disable claim (enabled true->false) the PostHog handler makes
+  // once it classifies the fault as the customer's.
+  const posthogIntegrationUpdateMany = vi.fn(async () => ({ count: 1 }));
+  const recordIncrement = vi.fn();
+  const dispatchProjectNotification = vi.fn(async () => {});
   // Only scores yields, so the first flush attempts the blocked send and the
   // handler stops — bounding runtime.
   const oneRow = () =>
@@ -65,7 +70,16 @@ const h = vi.hoisted(() => {
     project: { name: "Test Project", createdAt: new Date("2023-01-01") },
   });
   const db = { integration: integration() as Record<string, unknown> };
-  return { posthogIntegrationUpdate, oneRow, noRows, integration, db };
+  return {
+    posthogIntegrationUpdate,
+    posthogIntegrationUpdateMany,
+    recordIncrement,
+    dispatchProjectNotification,
+    oneRow,
+    noRows,
+    integration,
+    db,
+  };
 });
 
 vi.mock("@langfuse/shared/src/db", () => ({
@@ -73,6 +87,7 @@ vi.mock("@langfuse/shared/src/db", () => ({
     posthogIntegration: {
       findFirst: vi.fn(async () => h.db.integration),
       update: h.posthogIntegrationUpdate,
+      updateMany: h.posthogIntegrationUpdateMany,
     },
   },
 }));
@@ -86,7 +101,8 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     ...actual,
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     getCurrentSpan: vi.fn(() => undefined),
-    recordIncrement: vi.fn(),
+    recordIncrement: h.recordIncrement,
+    dispatchProjectNotification: h.dispatchProjectNotification,
     validateWebhookURL: vi.fn(async () => {}),
     getTracesForAnalyticsIntegrations: vi.fn(() => h.noRows()),
     getGenerationsForAnalyticsIntegrations: vi.fn(() => h.noRows()),
@@ -130,7 +146,10 @@ vi.mock("../env", () => ({
 }));
 
 // Imported after mocks are registered.
-import { handlePostHogIntegrationProjectJob } from "../features/posthog/handlePostHogIntegrationProjectJob";
+import {
+  handlePostHogIntegrationProjectJob,
+  POSTHOG_INTEGRATION_DISABLED_METRIC,
+} from "../features/posthog/handlePostHogIntegrationProjectJob";
 import {
   OutboundUrlValidationError,
   RedirectValidationError,
@@ -159,10 +178,18 @@ function causeChainIncludes(error: unknown, needle: string): boolean {
 describe("PostHog integration project job — SSRF connect-time pinning", () => {
   beforeEach(() => {
     h.posthogIntegrationUpdate.mockClear();
+    h.posthogIntegrationUpdateMany.mockClear();
+    h.recordIncrement.mockClear();
+    h.dispatchProjectNotification.mockClear();
     h.db.integration = h.integration();
   });
 
-  it("rejects a validated host that connects to a blocked IP, before egress and terminally", async () => {
+  // A blocked resolved IP is a customer-config fault, so the handler's shared
+  // classifier owns the terminal decision: disable the integration, notify, and
+  // RESOLVE. What this test adds over the classifier's own suite is the source
+  // of the fault — a host that PASSED the string pre-check and only failed when
+  // the socket resolved, which is reachable solely through connect-time pinning.
+  it("blocks a validated host that resolves to a blocked IP before egress, and disables the integration", async () => {
     let requestCount = 0;
     const { nameUrl } = await startLoopbackServer(() => {
       requestCount++;
@@ -177,15 +204,20 @@ describe("PostHog integration project job — SSRF connect-time pinning", () => 
     }
 
     expect(requestCount).toBe(0);
-    expect(thrown).toBeDefined();
-    expect(isUnrecoverableError(thrown)).toBe(true);
-    // The terminal error must be caused BY the SSRF block; otherwise any
-    // UnrecoverableError raised before the first socket write would satisfy the
-    // assertions above and the test would go vacuous.
-    expect(causeChainIncludes(thrown, "Blocked IP address detected")).toBe(
-      true,
+    expect(thrown).toBeUndefined();
+
+    // Non-vacuous: only an OutboundUrlValidationError carrying `blocked-ip` (or
+    // `blocked-hostname`) produces this reason, and the pre-check is stubbed to
+    // pass, so the tag can only have come from the connect-time lookup.
+    expect(h.recordIncrement).toHaveBeenCalledWith(
+      POSTHOG_INTEGRATION_DISABLED_METRIC,
+      1,
+      { reason: "ssrf_blocked_endpoint" },
     );
-    expect(h.posthogIntegrationUpdate).not.toHaveBeenCalled();
+    expect(h.posthogIntegrationUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { enabled: false } }),
+    );
+    expect(h.dispatchProjectNotification).toHaveBeenCalled();
   }, 40_000);
 });
 

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Connect-time SSRF pinning for the PostHog and Mixpanel analytics exporters.
+ *
+ * Both senders used to validate the configured host once and then send over an
+ * unpinned fetch. That is a check-then-use (TOCTOU) gap: a host answering a
+ * public IP during validation can rebind to a private/loopback address by the
+ * time the socket connects. Egress now runs through the shared
+ * connect-time-pinned secure-outbound infra, and a block fails terminally.
+ *
+ * Both sender tests neutralise the string pre-check (that models "the host
+ * validated as public") and point the send at a `localhost` NAME, whose
+ * connect-time lookup re-resolves to 127.0.0.1 (that models "it rebinds at
+ * connect"). Pointing them at a statically-blocked host instead would pass even
+ * without connect-time pinning, which is why they are shaped this way.
+ */
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isUnrecoverableError } from "../errors/UnrecoverableError";
+import { findOutboundUrlValidationError } from "../errors/findOutboundUrlValidationError";
+
+// The senders read their allowlist from the environment, and vitest loads
+// ../.env. A developer who allowlists localhost for local webhook testing would
+// otherwise turn the block assertions below into mystery failures.
+vi.hoisted(() => {
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_HOST;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IPS;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IP_SEGMENTS;
+});
+
+const openServers: Server[] = [];
+
+async function startLoopbackServer(
+  onRequest: () => void,
+): Promise<{ nameUrl: string; port: number }> {
+  const server = createServer((_req, res) => {
+    onRequest();
+    res.end("{}");
+  });
+  openServers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return { nameUrl: `http://localhost:${port}`, port };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    openServers
+      .splice(0)
+      .map((s) => new Promise<void>((r) => s.close(() => r()))),
+  );
+  vi.restoreAllMocks();
+});
+
+const h = vi.hoisted(() => {
+  const posthogIntegrationUpdate = vi.fn();
+  // Only scores yields, so the first flush attempts the blocked send and the
+  // handler stops — bounding runtime.
+  const oneRow = () =>
+    (async function* () {
+      yield { langfuse_id: "row-1" };
+    })();
+  const noRows = () => (async function* () {})();
+  const integration = () => ({
+    projectId: "project-1",
+    enabled: true,
+    exportSource: "TRACES_OBSERVATIONS",
+    posthogHostName: "http://placeholder.invalid",
+    encryptedPosthogApiKey: "enc",
+    lastSyncAt: new Date("2024-01-01"),
+    project: { name: "Test Project", createdAt: new Date("2023-01-01") },
+  });
+  const db = { integration: integration() as Record<string, unknown> };
+  return { posthogIntegrationUpdate, oneRow, noRows, integration, db };
+});
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    posthogIntegration: {
+      findFirst: vi.fn(async () => h.db.integration),
+      update: h.posthogIntegrationUpdate,
+    },
+  },
+}));
+
+// Keep the REAL secure-outbound egress helpers; override only the data-stream
+// sources, the logger, and validateWebhookURL.
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getCurrentSpan: vi.fn(() => undefined),
+    recordIncrement: vi.fn(),
+    validateWebhookURL: vi.fn(async () => {}),
+    getTracesForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+    getGenerationsForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+    getScoresForAnalyticsIntegrations: vi.fn(() => h.oneRow()),
+    getEventsForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+  };
+});
+
+// Transformers must return a payload the real posthog-node capture() accepts.
+vi.mock("../features/posthog/transformers", () => {
+  const payload = () => ({
+    distinctId: "p",
+    event: "langfuse",
+    properties: {},
+  });
+  return {
+    transformTraceForPostHog: vi.fn(payload),
+    transformGenerationForPostHog: vi.fn(payload),
+    transformScoreForPostHog: vi.fn(payload),
+    transformEventForPostHog: vi.fn(payload),
+  };
+});
+
+vi.mock("@langfuse/shared/encryption", () => ({
+  decrypt: vi.fn(() => "phc_decrypted"),
+}));
+
+vi.mock("../env", () => ({
+  env: {
+    LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
+    LANGFUSE_POSTHOG_FLUSH_DELAY_MS: 0,
+    LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: 0,
+    // Must stay non-zero, else the Mixpanel abort timer fires at ~0ms and masks
+    // the SSRF block with a spurious timeout error.
+    LANGFUSE_MIXPANEL_TIMEOUT_MS: 30_000,
+  },
+  v4WritesToLegacyTables: (e: { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }) =>
+    e.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only",
+  v4WritesToEventsTable: (e: { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }) =>
+    e.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "legacy",
+}));
+
+// Imported after mocks are registered.
+import { handlePostHogIntegrationProjectJob } from "../features/posthog/handlePostHogIntegrationProjectJob";
+import { OutboundUrlValidationError } from "@langfuse/shared/src/server";
+import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
+import type { MixpanelEvent } from "../features/mixpanel/transformers";
+
+function makeJob() {
+  return {
+    data: { id: "job-1", payload: { projectId: "project-1" } },
+    attemptsMade: 0,
+  } as unknown as Parameters<typeof handlePostHogIntegrationProjectJob>[0];
+}
+
+function causeChainIncludes(error: unknown, needle: string): boolean {
+  let current: any = error;
+  for (let depth = 0; depth < 6 && current; depth++) {
+    if (typeof current.message === "string" && current.message.includes(needle))
+      return true;
+    current = current.cause;
+  }
+  return false;
+}
+
+describe("PostHog integration project job — SSRF connect-time pinning", () => {
+  beforeEach(() => {
+    h.posthogIntegrationUpdate.mockClear();
+    h.db.integration = h.integration();
+  });
+
+  it("rejects a validated host that connects to a blocked IP, before egress and terminally", async () => {
+    let requestCount = 0;
+    const { nameUrl } = await startLoopbackServer(() => {
+      requestCount++;
+    });
+    h.db.integration.posthogHostName = nameUrl;
+
+    let thrown: unknown;
+    try {
+      await handlePostHogIntegrationProjectJob(makeJob());
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(requestCount).toBe(0);
+    expect(thrown).toBeDefined();
+    expect(isUnrecoverableError(thrown)).toBe(true);
+    // The terminal error must be caused BY the SSRF block; otherwise any
+    // UnrecoverableError raised before the first socket write would satisfy the
+    // assertions above and the test would go vacuous.
+    expect(causeChainIncludes(thrown, "Blocked IP address detected")).toBe(
+      true,
+    );
+    expect(h.posthogIntegrationUpdate).not.toHaveBeenCalled();
+  }, 40_000);
+});
+
+describe("Mixpanel sender — SSRF connect-time pinning", () => {
+  it("rejects a validated host that connects to a blocked IP, before egress and terminally", async () => {
+    let requestCount = 0;
+    const { nameUrl, port } = await startLoopbackServer(() => {
+      requestCount++;
+    });
+
+    // Negative control: the pre-fix path (bare global fetch) reaches the server,
+    // so a later count of 0 proves the pinning blocked the send rather than the
+    // harness being unreachable.
+    await fetch(`http://localhost:${port}/import?strict=1`, {
+      method: "POST",
+      body: "[]",
+    });
+    expect(requestCount).toBe(1);
+
+    const client = new MixpanelClient({
+      projectToken: "t",
+      region: "api",
+      baseUrl: nameUrl,
+    });
+    client.addEvent({
+      event: "trace",
+      properties: { token: "t", distinct_id: "1", $insert_id: 1 },
+    } as unknown as MixpanelEvent);
+
+    let thrown: unknown;
+    try {
+      await client.flush();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(requestCount).toBe(1);
+    expect(thrown).toBeDefined();
+    expect(isUnrecoverableError(thrown)).toBe(true);
+    expect(causeChainIncludes(thrown, "Blocked IP address detected")).toBe(
+      true,
+    );
+  }, 40_000);
+});
+
+describe("outbound validation classification", () => {
+  it("treats a DNS lookup failure as retryable and a blocked IP as terminal", () => {
+    const wrap = (cause: Error) =>
+      Object.assign(new TypeError("fetch failed"), { cause });
+
+    expect(
+      findOutboundUrlValidationError(
+        wrap(
+          new OutboundUrlValidationError(
+            "dns-lookup-failed",
+            "DNS lookup failed for exporter.example.com",
+          ),
+        ),
+      ),
+    ).toBeUndefined();
+
+    expect(
+      findOutboundUrlValidationError(
+        wrap(
+          new OutboundUrlValidationError(
+            "blocked-ip",
+            "Blocked IP address detected: 127.0.0.1",
+          ),
+        ),
+      ),
+    ).toBeDefined();
+  });
+});

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -1,12 +1,6 @@
 /**
  * Connect-time SSRF pinning for the PostHog and Mixpanel analytics exporters.
  *
- * Both senders used to validate the configured host once and then send over an
- * unpinned fetch. That is a check-then-use (TOCTOU) gap: a host answering a
- * public IP during validation can rebind to a private/loopback address by the
- * time the socket connects. Egress now runs through the shared
- * connect-time-pinned secure-outbound infra, and a block fails terminally.
- *
  * Both sender tests neutralise the string pre-check (that models "the host
  * validated as public") and point the send at a `localhost` NAME, whose
  * connect-time lookup re-resolves to 127.0.0.1 (that models "it rebinds at

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -131,7 +131,11 @@ vi.mock("../env", () => ({
 
 // Imported after mocks are registered.
 import { handlePostHogIntegrationProjectJob } from "../features/posthog/handlePostHogIntegrationProjectJob";
-import { OutboundUrlValidationError } from "@langfuse/shared/src/server";
+import {
+  OutboundUrlValidationError,
+  RedirectValidationError,
+} from "@langfuse/shared/src/server";
+import { rethrowIfOutboundValidationFailure } from "../features/analyticsIntegrationEgress";
 import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
 import type { MixpanelEvent } from "../features/mixpanel/transformers";
 
@@ -253,5 +257,57 @@ describe("outbound validation classification", () => {
         ),
       ),
     ).toBeDefined();
+  });
+});
+
+describe("terminal outbound failure reporting", () => {
+  // The rejected redirect target is embedded verbatim in the validation error,
+  // so a credentialed Location header would otherwise reach the log line and
+  // BullMQ's persisted failedReason.
+  it("redacts credentials from a rejected redirect target", () => {
+    const error = Object.assign(new TypeError("fetch failed"), {
+      cause: new RedirectValidationError(
+        "Blocked IP address detected: 169.254.169.254",
+        "http://exporter:hunter2@169.254.169.254/",
+        0,
+      ),
+    });
+
+    let thrown: unknown;
+    try {
+      rethrowIfOutboundValidationFailure(error, {
+        logSubject: "Mixpanel outbound send",
+        jobSubject: "Mixpanel export",
+      });
+    } catch (caught) {
+      thrown = caught;
+    }
+
+    expect(isUnrecoverableError(thrown)).toBe(true);
+    const message = (thrown as Error).message;
+    expect(message).not.toContain("hunter2");
+    expect(message).toContain("http://***@169.254.169.254/");
+    // The diagnostic reason must survive redaction, otherwise the operator
+    // cannot tell a blocked IP from a rejected scheme.
+    expect(message).toContain("Blocked IP address detected: 169.254.169.254");
+  });
+
+  it("leaves a credential-free message untouched and stays a no-op for other errors", () => {
+    expect(() =>
+      rethrowIfOutboundValidationFailure(new Error("connection reset"), {
+        logSubject: "Mixpanel outbound send",
+        jobSubject: "Mixpanel export",
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      rethrowIfOutboundValidationFailure(
+        new OutboundUrlValidationError(
+          "blocked-ip",
+          "Blocked IP address detected: 127.0.0.1",
+        ),
+        { logSubject: "Mixpanel outbound send", jobSubject: "Mixpanel export" },
+      ),
+    ).toThrow("Blocked IP address detected: 127.0.0.1");
   });
 });

--- a/worker/src/errors/findOutboundUrlValidationError.ts
+++ b/worker/src/errors/findOutboundUrlValidationError.ts
@@ -1,0 +1,54 @@
+/**
+ * Walk an error's `cause` chain looking for a connect-time secure-outbound
+ * validation failure: a blocked resolved IP or a rejected redirect target.
+ * undici surfaces the connect-time block as a generic "fetch failed" TypeError
+ * whose `cause` holds the real validation error, and SDKs (e.g. posthog-node)
+ * may wrap it again, so the signal only shows up by walking the chain.
+ *
+ * Matched by error NAME rather than `instanceof`: importing the shared error
+ * classes as values breaks in tests that replace the
+ * `@langfuse/shared/src/server` barrel without `importOriginal`, and a
+ * classifier that throws would destroy the very error it is meant to describe.
+ */
+const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
+  "OutboundUrlValidationError",
+  "RedirectValidationError",
+]);
+
+// A resolver hiccup is not a policy block: the host may be legitimate and the
+// next attempt may succeed, so it must stay retryable. RedirectValidationError
+// re-wraps the inner failure by message only — no code, no cause — so a DNS
+// failure on a redirect hop is recognisable only by its message text.
+const isTransientDnsFailure = (error: Error): boolean =>
+  (error as { code?: unknown }).code === "dns-lookup-failed" ||
+  error.message.includes("DNS lookup failed for");
+
+/**
+ * The validation error, but only when the block is permanent. Returns undefined
+ * when nothing in the chain is a validation error, or when the failure is a
+ * transient DNS-resolution error that deserves a retry.
+ */
+export function findOutboundUrlValidationError(
+  error: unknown,
+): Error | undefined {
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== null && current !== undefined && !visited.has(current)) {
+    visited.add(current);
+
+    if (
+      current instanceof Error &&
+      OUTBOUND_VALIDATION_ERROR_NAMES.has(current.name)
+    ) {
+      return isTransientDnsFailure(current) ? undefined : current;
+    }
+
+    current =
+      typeof current === "object" && current !== null && "cause" in current
+        ? (current as { cause: unknown }).cause
+        : undefined;
+  }
+
+  return undefined;
+}

--- a/worker/src/errors/findOutboundUrlValidationError.ts
+++ b/worker/src/errors/findOutboundUrlValidationError.ts
@@ -10,6 +10,8 @@
  * `@langfuse/shared/src/server` barrel without `importOriginal`, and a
  * classifier that throws would destroy the very error it is meant to describe.
  */
+import { DNS_LOOKUP_FAILED_MESSAGE_PREFIX } from "@langfuse/shared/src/server";
+
 const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
   "OutboundUrlValidationError",
   "RedirectValidationError",
@@ -18,10 +20,11 @@ const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
 // A resolver hiccup is not a policy block: the host may be legitimate and the
 // next attempt may succeed, so it must stay retryable. RedirectValidationError
 // re-wraps the inner failure by message only — no code, no cause — so a DNS
-// failure on a redirect hop is recognisable only by its message text.
+// failure on a redirect hop is recognisable only by its message text. The
+// substring is imported from the throw site so the two stay in sync.
 const isTransientDnsFailure = (error: Error): boolean =>
   (error as { code?: unknown }).code === "dns-lookup-failed" ||
-  error.message.includes("DNS lookup failed for");
+  error.message.includes(DNS_LOOKUP_FAILED_MESSAGE_PREFIX);
 
 /**
  * The validation error, but only when the block is permanent. Returns undefined

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -1,4 +1,9 @@
-import { logger } from "@langfuse/shared/src/server";
+import {
+  logger,
+  validateWebhookURL,
+  whitelistFromEnv,
+  type RedirectOptions,
+} from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../errors/UnrecoverableError";
 import { findOutboundUrlValidationError } from "../errors/findOutboundUrlValidationError";
 
@@ -8,7 +13,23 @@ import { findOutboundUrlValidationError } from "../errors/findOutboundUrlValidat
  * budget stays generous enough not to break a self-hosted endpoint behind a
  * redirecting edge. Mirrors MAX_LLM_REDIRECTS on the LLM egress path.
  */
-export const ANALYTICS_INTEGRATION_MAX_REDIRECTS = 10;
+const ANALYTICS_INTEGRATION_MAX_REDIRECTS = 10;
+
+/**
+ * Connect-time-pinned egress settings shared by both analytics senders, so the
+ * redirect budget, the validator and the whitelist source cannot drift apart
+ * between them. `logContext` is the only per-sender part.
+ */
+export const buildAnalyticsRedirectOptions = (
+  logContext: string,
+): RedirectOptions => ({
+  maxRedirects: ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+  redirectValidation: {
+    validateUrl: validateWebhookURL,
+    whitelist: whitelistFromEnv(),
+    logContext,
+  },
+});
 
 // A rejected redirect target is reported with its URL embedded verbatim, and a
 // Location header may carry userinfo, so the message can hold a password.
@@ -18,14 +39,29 @@ const redactUrlCredentials = (text: string): string =>
   text.replace(URL_CREDENTIALS, "$1***@");
 
 /**
+ * A serialization-safe stand-in for the validation error. The original holds the
+ * offending URL three times over — in its message, in its stack, and, for a
+ * rejected redirect, in an enumerable `redirectUrl` field — and the generic
+ * queue failure handler both logs the thrown error and reports it to tracing,
+ * so everything reachable from `cause` is written out verbatim.
+ */
+const sanitizedCause = (validationError: Error): Error => {
+  const sanitized = new Error(redactUrlCredentials(validationError.message));
+  sanitized.name = validationError.name;
+  if (validationError.stack) {
+    sanitized.stack = redactUrlCredentials(validationError.stack);
+  }
+  return sanitized;
+};
+
+/**
  * Rethrow a connect-time SSRF block as terminal, so BullMQ stops re-attempting
  * a send that cannot succeed; no-op for anything else, which the caller keeps
  * handling as retryable.
  *
- * Both surfaces written here outlive the job — the log line, and the error
- * message BullMQ persists as the job's `failedReason` — so the reason is
- * credential-redacted. The raw error stays reachable as `cause` for tests and
- * in-process inspection, but is not handed to the logger.
+ * Nothing the thrown error carries may hold a credential: the message, the
+ * retained cause and that cause's own stack all outlive the job, via the log
+ * line and via the `failedReason` BullMQ persists.
  */
 export function rethrowIfOutboundValidationFailure(
   error: unknown,
@@ -42,6 +78,14 @@ export function rethrowIfOutboundValidationFailure(
   const unrecoverable = new UnrecoverableError(
     `${labels.jobSubject} blocked by SSRF protection: ${reason}`,
   );
-  unrecoverable.cause = error;
+  // Non-enumerable, because a structured logger handed this error copies every
+  // enumerable field into the log line — which is how the raw URL escaped a
+  // redacted message before.
+  Object.defineProperty(unrecoverable, "cause", {
+    value: sanitizedCause(validationError),
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
   throw unrecoverable;
 }

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -1,3 +1,7 @@
+import { logger } from "@langfuse/shared/src/server";
+import { UnrecoverableError } from "../errors/UnrecoverableError";
+import { findOutboundUrlValidationError } from "../errors/findOutboundUrlValidationError";
+
 /**
  * Redirect budget for the analytics integration exporters. Both senders
  * previously used a plain fetch, which auto-follows up to 20 redirects, so the
@@ -5,3 +9,39 @@
  * redirecting edge. Mirrors MAX_LLM_REDIRECTS on the LLM egress path.
  */
 export const ANALYTICS_INTEGRATION_MAX_REDIRECTS = 10;
+
+// A rejected redirect target is reported with its URL embedded verbatim, and a
+// Location header may carry userinfo, so the message can hold a password.
+const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^/?#\s@]*@/gi;
+
+const redactUrlCredentials = (text: string): string =>
+  text.replace(URL_CREDENTIALS, "$1***@");
+
+/**
+ * Rethrow a connect-time SSRF block as terminal, so BullMQ stops re-attempting
+ * a send that cannot succeed; no-op for anything else, which the caller keeps
+ * handling as retryable.
+ *
+ * Both surfaces written here outlive the job — the log line, and the error
+ * message BullMQ persists as the job's `failedReason` — so the reason is
+ * credential-redacted. The raw error stays reachable as `cause` for tests and
+ * in-process inspection, but is not handed to the logger.
+ */
+export function rethrowIfOutboundValidationFailure(
+  error: unknown,
+  labels: { logSubject: string; jobSubject: string },
+): void {
+  const validationError = findOutboundUrlValidationError(error);
+  if (!validationError) return;
+
+  const reason = redactUrlCredentials(validationError.message);
+  logger.error(`${labels.logSubject} blocked by SSRF protection: ${reason}`, {
+    errorName: validationError.name,
+  });
+
+  const unrecoverable = new UnrecoverableError(
+    `${labels.jobSubject} blocked by SSRF protection: ${reason}`,
+  );
+  unrecoverable.cause = error;
+  throw unrecoverable;
+}

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -1,0 +1,7 @@
+/**
+ * Redirect budget for the analytics integration exporters. Both senders
+ * previously used a plain fetch, which auto-follows up to 20 redirects, so the
+ * budget stays generous enough not to break a self-hosted endpoint behind a
+ * redirecting edge. Mirrors MAX_LLM_REDIRECTS on the LLM egress path.
+ */
+export const ANALYTICS_INTEGRATION_MAX_REDIRECTS = 10;

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -6,9 +6,10 @@ import {
 } from "@langfuse/shared/src/server";
 import { gzipSync } from "zlib";
 import { env } from "../../env";
-import { ANALYTICS_INTEGRATION_MAX_REDIRECTS } from "../analyticsIntegrationEgress";
-import { UnrecoverableError } from "../../errors/UnrecoverableError";
-import { findOutboundUrlValidationError } from "../../errors/findOutboundUrlValidationError";
+import {
+  ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+  rethrowIfOutboundValidationFailure,
+} from "../analyticsIntegrationEgress";
 import type { MixpanelEvent } from "./transformers";
 
 type MixpanelClientConfig = {
@@ -179,18 +180,10 @@ export class MixpanelClient {
       // A connect-time SSRF block is a permanent misconfiguration, not a
       // transient failure, so skip the remaining BullMQ attempts for this job
       // rather than re-running the same hopeless send.
-      const validationError = findOutboundUrlValidationError(error);
-      if (validationError) {
-        logger.error(
-          `Mixpanel outbound send blocked by SSRF protection: ${validationError.message}`,
-          error,
-        );
-        const unrecoverable = new UnrecoverableError(
-          `Mixpanel export blocked by SSRF protection: ${validationError.message}`,
-        );
-        unrecoverable.cause = error;
-        throw unrecoverable;
-      }
+      rethrowIfOutboundValidationFailure(error, {
+        logSubject: "Mixpanel outbound send",
+        jobSubject: "Mixpanel export",
+      });
       logger.error("Error sending batch to Mixpanel", error);
       throw error;
     } finally {

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -1,13 +1,8 @@
-import {
-  logger,
-  fetchWithSecureRedirects,
-  validateWebhookURL,
-  whitelistFromEnv,
-} from "@langfuse/shared/src/server";
+import { logger, fetchWithSecureRedirects } from "@langfuse/shared/src/server";
 import { gzipSync } from "zlib";
 import { env } from "../../env";
 import {
-  ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+  buildAnalyticsRedirectOptions,
   rethrowIfOutboundValidationFailure,
 } from "../analyticsIntegrationEgress";
 import type { MixpanelEvent } from "./transformers";
@@ -115,14 +110,7 @@ export class MixpanelClient {
           body: compressedBody as unknown as BodyInit,
           signal: abortController.signal,
         },
-        {
-          maxRedirects: ANALYTICS_INTEGRATION_MAX_REDIRECTS,
-          redirectValidation: {
-            validateUrl: validateWebhookURL,
-            whitelist: whitelistFromEnv(),
-            logContext: "Mixpanel integration",
-          },
-        },
+        buildAnalyticsRedirectOptions("Mixpanel integration"),
       );
 
       if (!response.ok) {

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -1,6 +1,14 @@
-import { logger } from "@langfuse/shared/src/server";
+import {
+  logger,
+  fetchWithSecureRedirects,
+  validateWebhookURL,
+  whitelistFromEnv,
+} from "@langfuse/shared/src/server";
 import { gzipSync } from "zlib";
 import { env } from "../../env";
+import { ANALYTICS_INTEGRATION_MAX_REDIRECTS } from "../analyticsIntegrationEgress";
+import { UnrecoverableError } from "../../errors/UnrecoverableError";
+import { findOutboundUrlValidationError } from "../../errors/findOutboundUrlValidationError";
 import type { MixpanelEvent } from "./transformers";
 
 type MixpanelClientConfig = {
@@ -10,6 +18,12 @@ type MixpanelClientConfig = {
    * Validated at API layer via MIXPANEL_REGIONS in web/src/features/mixpanel-integration/types.ts
    */
   region: string;
+  /**
+   * Overrides the Mixpanel API origin. Test-only seam, so the send can be
+   * pointed at a local server; production leaves it unset and derives the
+   * origin from `region`.
+   */
+  baseUrl?: string;
 };
 
 export class MixpanelClient {
@@ -63,7 +77,9 @@ export class MixpanelClient {
    * Send a batch of events to Mixpanel Import API
    */
   private async sendBatch(events: MixpanelEvent[]): Promise<void> {
-    const url = `https://${this.config.region}.mixpanel.com/import?strict=1`;
+    const origin =
+      this.config.baseUrl ?? `https://${this.config.region}.mixpanel.com`;
+    const url = `${origin}/import?strict=1`;
     const body = JSON.stringify(events);
 
     // Compress the body with gzip
@@ -82,16 +98,31 @@ export class MixpanelClient {
     }, env.LANGFUSE_MIXPANEL_TIMEOUT_MS);
 
     try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Content-Encoding": "gzip",
-          Authorization: authHeader,
+      // Re-resolve and re-validate the destination IP at socket connect time: a
+      // host that validated as public can rebind to a private/loopback address
+      // before the socket opens (TOCTOU). Redirect targets are re-validated
+      // with the same URL validator.
+      const { response } = await fetchWithSecureRedirects(
+        url,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+            Authorization: authHeader,
+          },
+          body: compressedBody as unknown as BodyInit,
+          signal: abortController.signal,
         },
-        body: compressedBody as unknown as BodyInit,
-        signal: abortController.signal,
-      });
+        {
+          maxRedirects: ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+          redirectValidation: {
+            validateUrl: validateWebhookURL,
+            whitelist: whitelistFromEnv(),
+            logContext: "Mixpanel integration",
+          },
+        },
+      );
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -144,6 +175,21 @@ export class MixpanelClient {
         );
         logger.error("Error sending batch to Mixpanel", timeoutError);
         throw timeoutError;
+      }
+      // A connect-time SSRF block is a permanent misconfiguration, not a
+      // transient failure, so skip the remaining BullMQ attempts for this job
+      // rather than re-running the same hopeless send.
+      const validationError = findOutboundUrlValidationError(error);
+      if (validationError) {
+        logger.error(
+          `Mixpanel outbound send blocked by SSRF protection: ${validationError.message}`,
+          error,
+        );
+        const unrecoverable = new UnrecoverableError(
+          `Mixpanel export blocked by SSRF protection: ${validationError.message}`,
+        );
+        unrecoverable.cause = error;
+        throw unrecoverable;
       }
       logger.error("Error sending batch to Mixpanel", error);
       throw error;

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -15,7 +15,10 @@ import {
   whitelistFromEnv,
   fetchWithSecureRedirects,
 } from "@langfuse/shared/src/server";
-import { ANALYTICS_INTEGRATION_MAX_REDIRECTS } from "../analyticsIntegrationEgress";
+import {
+  ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+  rethrowIfOutboundValidationFailure,
+} from "../analyticsIntegrationEgress";
 import {
   transformTraceForPostHog,
   transformGenerationForPostHog,
@@ -29,8 +32,6 @@ import { assertExportSourceWritable } from "../exportWriteModeGuard";
 import { classifyCustomerFault } from "../integrations/customerFaultClassification";
 import { isRecordNotFoundError } from "../integrations/prismaErrors";
 import { env, v4WritesToLegacyTables } from "../../env";
-import { UnrecoverableError } from "../../errors/UnrecoverableError";
-import { findOutboundUrlValidationError } from "../../errors/findOutboundUrlValidationError";
 
 // Counter for PostHog integrations auto-disabled after a deterministic
 // customer-config fault, tagged by `reason`. A classifier-regression
@@ -458,18 +459,10 @@ export const handlePostHogIntegrationProjectJob = async (
       // customer fault and disables the integration instead. The integration
       // stays enabled here, so the schedule re-enqueues the project next cycle,
       // which is what lets a fixed endpoint recover on its own.
-      const validationError = findOutboundUrlValidationError(error);
-      if (validationError) {
-        logger.error(
-          `[POSTHOG] Outbound send for project ${projectId} blocked by SSRF protection: ${validationError.message}`,
-          error,
-        );
-        const unrecoverable = new UnrecoverableError(
-          `PostHog integration for project ${projectId} blocked by SSRF protection: ${validationError.message}`,
-        );
-        unrecoverable.cause = error;
-        throw unrecoverable;
-      }
+      rethrowIfOutboundValidationFailure(error, {
+        logSubject: `[POSTHOG] Outbound send for project ${projectId}`,
+        jobSubject: `PostHog integration for project ${projectId}`,
+      });
 
       logger.error(
         `[POSTHOG] Error processing PostHog integration for project ${projectId}`,

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -12,11 +12,10 @@ import {
   validateWebhookURL,
   recordIncrement,
   dispatchProjectNotification,
-  whitelistFromEnv,
   fetchWithSecureRedirects,
 } from "@langfuse/shared/src/server";
 import {
-  ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+  buildAnalyticsRedirectOptions,
   rethrowIfOutboundValidationFailure,
 } from "../analyticsIntegrationEgress";
 import {
@@ -119,14 +118,7 @@ export const countingFetch =
     const { response } = await fetchWithSecureRedirects(
       url,
       options as RequestInit,
-      {
-        maxRedirects: ANALYTICS_INTEGRATION_MAX_REDIRECTS,
-        redirectValidation: {
-          validateUrl: validateWebhookURL,
-          whitelist: whitelistFromEnv(),
-          logContext: "PostHog integration",
-        },
-      },
+      buildAnalyticsRedirectOptions("PostHog integration"),
     );
     return response;
   };

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -12,7 +12,10 @@ import {
   validateWebhookURL,
   recordIncrement,
   dispatchProjectNotification,
+  whitelistFromEnv,
+  fetchWithSecureRedirects,
 } from "@langfuse/shared/src/server";
+import { ANALYTICS_INTEGRATION_MAX_REDIRECTS } from "../analyticsIntegrationEgress";
 import {
   transformTraceForPostHog,
   transformGenerationForPostHog,
@@ -26,6 +29,8 @@ import { assertExportSourceWritable } from "../exportWriteModeGuard";
 import { classifyCustomerFault } from "../integrations/customerFaultClassification";
 import { isRecordNotFoundError } from "../integrations/prismaErrors";
 import { env, v4WritesToLegacyTables } from "../../env";
+import { UnrecoverableError } from "../../errors/UnrecoverableError";
+import { findOutboundUrlValidationError } from "../../errors/findOutboundUrlValidationError";
 
 // Counter for PostHog integrations auto-disabled after a deterministic
 // customer-config fault, tagged by `reason`. A classifier-regression
@@ -88,7 +93,7 @@ type PostHogClientOptions = NonNullable<
 // mode uses /i/v1/analytics/events; feature-flag requests are excluded.
 export const countingFetch =
   (volume: { bytes: number }): PostHogClientOptions["fetch"] =>
-  (url, options) => {
+  async (url, options) => {
     // Extend the existing V0 counter to cover the additional capture mode
     // supported by newer posthog-node releases.
     if (url.endsWith("/batch/") || url.endsWith("/i/v1/analytics/events")) {
@@ -106,7 +111,23 @@ export const countingFetch =
         );
       }
     }
-    return globalThis.fetch(url, options as RequestInit);
+    // Re-resolve and re-validate the destination IP at socket connect time: a
+    // host that validated as public in the pre-check can rebind to a
+    // private/loopback address before the socket opens (TOCTOU). Redirect
+    // targets are re-validated with the same URL validator.
+    const { response } = await fetchWithSecureRedirects(
+      url,
+      options as RequestInit,
+      {
+        maxRedirects: ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+        redirectValidation: {
+          validateUrl: validateWebhookURL,
+          whitelist: whitelistFromEnv(),
+          logContext: "PostHog integration",
+        },
+      },
+    );
+    return response;
   };
 
 const processPostHogStream = async <T>(
@@ -430,6 +451,26 @@ export const handlePostHogIntegrationProjectJob = async (
     ).slice(0, 1000);
 
     if (reason === undefined) {
+      // A connect-time SSRF block is a permanent misconfiguration of the
+      // integration host, not a transient failure, so skip the remaining BullMQ
+      // attempts for this job. Only reached for blocks the classifier above does
+      // not own (e.g. a rejected redirect target): a blocked hostname/IP is a
+      // customer fault and disables the integration instead. The integration
+      // stays enabled here, so the schedule re-enqueues the project next cycle,
+      // which is what lets a fixed endpoint recover on its own.
+      const validationError = findOutboundUrlValidationError(error);
+      if (validationError) {
+        logger.error(
+          `[POSTHOG] Outbound send for project ${projectId} blocked by SSRF protection: ${validationError.message}`,
+          error,
+        );
+        const unrecoverable = new UnrecoverableError(
+          `PostHog integration for project ${projectId} blocked by SSRF protection: ${validationError.message}`,
+        );
+        unrecoverable.cause = error;
+        throw unrecoverable;
+      }
+
       logger.error(
         `[POSTHOG] Error processing PostHog integration for project ${projectId}`,
         error,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16091.preview.langfuse.com](https://pr-16091.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The PostHog and Mixpanel export workers validated the configured destination host **once**, then sent the data through an unpinned `fetch` that re-resolved DNS independently. That is check-then-use: a host answering a public IP during validation and rebinding to a private or loopback address at connect time bypassed the check entirely, and the exporter would POST customer trace data to whatever the second resolution returned.

Both senders now go through the shared connect-time-pinned egress path already used for webhooks, blob storage and LLM calls, so every resolved IP is re-validated at socket connect, before any bytes leave the worker.

A connect-time block fails terminally, so the queue stops re-attempting a send that cannot succeed. A transient DNS resolution failure is deliberately excluded from that — a resolver blip is not a permanent misconfiguration and must stay retryable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Checklist

- [x] Tests added/updated
- [x] `pnpm run lint` and `pnpm run typecheck` pass
- [ ] Documentation updated — not required; no external contract, env var or user-facing surface changes

## Notes for review

- **Redirect budget.** The shared helper requires an explicit budget where the platform previously followed redirects implicitly, so this sets 10. A redirect-budget exhaustion stays retryable, matching current behaviour.
- **Errors are matched by `name`, not `instanceof`.** This is deliberate and worth not "fixing" back: several worker suites replace the shared server barrel with a full mock, so `instanceof` against those imports dereferences `undefined` and the classifier's own `TypeError` replaces the real error. That broke six pre-existing tests in an earlier revision, invisibly to lint and typecheck.
- **The terminal error carries no credentials, anywhere.** A rejected redirect target is reported with its URL embedded verbatim, and a `Location` header may carry userinfo — so a redirect to `http://user:pass@blocked-host/` could put a password into the worker log line and into the `failedReason` BullMQ persists. Redacting the composed message alone was not sufficient: the queue's generic `failed` handler passes the whole error to both the logger and `traceException`, and under `LANGFUSE_LOG_FORMAT=json` winston copies every enumerable field into the log line — including a nested `cause` and its raw `redirectUrl`. The retained cause is therefore a sanitized stand-in, with the URL stripped from its message *and* its stack, attached non-enumerably. Tests assert the whole serializable surface rather than just the message.
- **Both senders share one egress module.** The redirect budget, the validator, the whitelist source and the classify-and-rethrow step all live in `analyticsIntegrationEgress.ts`, so the two exporters cannot drift apart.

## Follow-up hardening, intentionally not here

Kept out to keep this reviewable. None is exploitable today.

- An IP-literal destination check for Mixpanel — the connect-time DNS hook does not fire for literals.
- Redirect fault reporting.
- A wider negative-test matrix.
- Credential redaction on the *shared* outbound-url path, which this PR only narrows rather than closes: `fetchWithSecureRedirects`'s own `logger.warn` and the `MaxRedirectsExceededError` / `CircularRedirectError` chain messages still carry raw URLs for the webhook, blob-storage and LLM callers.

Branch: `chore/analytics-egress-hardening-deferred`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
