### PR TITLE
fix(web): close v4 migration panel on browser back/forward

### DIFF
--- a/web/src/features/v4-migration/V4MigrationPanelProvider.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanelProvider.clienttest.tsx
@@ -120,4 +120,25 @@ describe("V4MigrationPanelProvider", () => {
       source: "status_page_row",
     });
   });
+
+  it("closes the panel on browser back/forward navigation", () => {
+    flagState.enabled = true;
+    const { result } = renderHook(() => useV4MigrationPanel(), { wrapper });
+
+    act(() =>
+      result.current.openForProject(
+        { id: "project-id", name: "Project" },
+        "project_chip",
+      ),
+    );
+    expect(result.current.open).toBe(true);
+
+    // Browser back/forward emits popstate; the panel is a transient side
+    // surface and must not linger on the page the user lands on.
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(result.current.open).toBe(false);
+  });
 });

--- a/web/src/features/v4-migration/V4MigrationPanelProvider.tsx
+++ b/web/src/features/v4-migration/V4MigrationPanelProvider.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useState,
   type PropsWithChildren,
 } from "react";
@@ -76,6 +77,17 @@ export function V4MigrationPanelProvider({
     });
     setRequestedOpen(true);
   };
+
+  // The panel is a transient side surface that intentionally survives
+  // programmatic forward navigation (e.g. a status-page row opens it and then
+  // pushes to the project). Browser back/forward is different: landing on a
+  // page the user did not open the panel from — most visibly the org overview —
+  // with the panel still docked is confusing, so close it on popstate.
+  useEffect(() => {
+    const closeOnPopState = () => setRequestedOpen(false);
+    window.addEventListener("popstate", closeOnPopState);
+    return () => window.removeEventListener("popstate", closeOnPopState);
+  }, []);
 
   return (
     <V4MigrationPanelContext.Provider


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The V4 migration side panel is owned by an app-root provider (`V4MigrationPanelProvider`), so its `open` state persisted across route changes. When a user opened the panel (e.g. on the org overview or via the migration status page) and then used **browser back/forward**, they landed on a page where they never opened the panel — most visibly the org/projects overview after backing out of the user-level migration status page — with the panel still docked. This felt confusing and broken.

This closes the panel on the `popstate` event so browser back/forward dismisses the transient side surface. Intentional programmatic forward flows are unaffected (they use `router.push`, which does not emit `popstate`), so the designed behavior — e.g. a status-page row opening the panel and then pushing to the project, or the panel following the route's project — still works.

### Changes
- `V4MigrationPanelProvider`: add a `popstate` listener (browser back/forward external system, with proper add/remove cleanup) that closes the panel.
- Added a client test asserting the panel closes on a dispatched `popstate` event.

Fixes the reported issue: navigating back with browser navigation from the user-level migration status page left the overview with the sidebar still there.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Testing

- `pnpm --filter web run test-client src/features/v4-migration/` → `Test Files 13 passed (13)`, `Tests 105 passed (105)` (includes the new failing-first popstate test)
- `pnpm --filter web run lint` → `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` → passed

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15111](https://linear.app/clickhouse/issue/LFE-15111/upgrade-dollarproject-name-to-v4)

<div><a href="https://cursor.com/agents/bc-d166db33-72d9-4c32-9dcb-fb6a041f9e97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d166db33-72d9-4c32-9dcb-fb6a041f9e97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

