### PR TITLE
refactor(integrations): derive export-source availability from the v4 write mode

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -80,7 +80,7 @@ types:
       - `OBSERVATIONS_V2`: same data model as the `/api/public/v2/observations` endpoint, plus scores. Columns are controlled by `exportFieldGroups`.
       - `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: both sets. Observation columns of both portions are controlled by `exportFieldGroups`.
 
-      **Note:** `OBSERVATIONS_V2` and the enriched-observations portion of `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` rely on the enriched observations table (Langfuse Fast Preview / v4), which is currently available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
+      **Note:** which sources a deployment accepts depends on how far it has moved to the v4 data model. `OBSERVATIONS_V2` and the enriched-observations portion of `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` read the enriched observations table, so they require a deployment that already populates it. `LEGACY_TRACES_OBSERVATIONS` and the legacy portion of `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` read the legacy traces and observations tables, so they require a deployment that still populates those. A deployment part-way through the migration populates both and accepts every source. Selecting a source the deployment cannot serve is rejected with `400`, rather than exporting an empty result. See https://langfuse.com/docs/v4.
     enum:
       - LEGACY_TRACES_OBSERVATIONS
       - OBSERVATIONS_V2

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -143,7 +143,7 @@ types:
       exportSource:
         type: optional<BlobStorageExportSource>
         docs: |
-          Data to export. When omitted on update, the existing value is preserved. When omitted on create: integrations on Langfuse Cloud default to `OBSERVATIONS_V2`; self-hosted deployments fall back to `LEGACY_TRACES_OBSERVATIONS`. Required when `exportFieldGroups` is provided.
+          Data to export. When omitted on update, the existing value is preserved. When omitted on create, the default is `OBSERVATIONS_V2` on Langfuse Cloud, and on self-hosted deployments `LEGACY_TRACES_OBSERVATIONS` — or `OBSERVATIONS_V2` where the deployment no longer populates the legacy tables. The default is never a source the deployment cannot serve. Required when `exportFieldGroups` is provided.
 
           **Cloud-only project deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP 400. Use `OBSERVATIONS_V2` for all new integrations. Self-hosted deployments are unaffected.
 

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 
+import * as exportSourcePolicy from "./export-source-policy";
 import {
+  areEnrichedWritesActive,
+  areLegacyWritesActive,
   getAvailableExportSources,
   isEnrichedBlobExportSource,
   isLegacyBlobExportSource,
   LEGACY_BLOB_EXPORT_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
   validateExportSource,
+  type BlobExportWriteMode,
   type ExportSourceContext,
 } from "./export-source-policy";
 
@@ -183,6 +187,121 @@ describe("getAvailableExportSources", () => {
       { source: "TRACES_OBSERVATIONS_EVENTS" },
       { source: "EVENTS" },
     ]);
+  });
+});
+
+// The active write mode is the single source of truth for which export
+// sources hold data. Neither the V4 frontend preview flag nor a per-user beta
+// opt-in may re-enter this decision.
+describe("write mode drives export-source availability", () => {
+  const WRITE_MODES: readonly BlobExportWriteMode[] = [
+    "legacy",
+    "dual",
+    "events_only",
+  ];
+
+  const ctxFor = (
+    writeMode: BlobExportWriteMode,
+    over: Partial<ExportSourceContext> = {},
+  ): ExportSourceContext => ({
+    isCloud: false,
+    enrichedAvailable: areEnrichedWritesActive(writeMode),
+    legacyWritesActive: areLegacyWritesActive(writeMode),
+    ...over,
+  });
+
+  it("areEnrichedWritesActive: enriched rows exist in every mode but legacy", () => {
+    expect(areEnrichedWritesActive("legacy")).toBe(false);
+    expect(areEnrichedWritesActive("dual")).toBe(true);
+    expect(areEnrichedWritesActive("events_only")).toBe(true);
+  });
+
+  it("areLegacyWritesActive: legacy rows exist in every mode but events_only", () => {
+    expect(areLegacyWritesActive("legacy")).toBe(true);
+    expect(areLegacyWritesActive("dual")).toBe(true);
+    expect(areLegacyWritesActive("events_only")).toBe(false);
+  });
+
+  // The whole selector, per mode: legacy → legacy sources only, events_only →
+  // events only, dual → both. Anything else means a surface offers a source
+  // whose data is not being written.
+  it.each([
+    [
+      "legacy",
+      [
+        { source: "TRACES_OBSERVATIONS" },
+        {
+          source: "TRACES_OBSERVATIONS_EVENTS",
+          blockedReason: "enriched-unavailable",
+        },
+        { source: "EVENTS", blockedReason: "enriched-unavailable" },
+      ],
+    ],
+    [
+      "dual",
+      [
+        { source: "TRACES_OBSERVATIONS" },
+        { source: "TRACES_OBSERVATIONS_EVENTS" },
+        { source: "EVENTS" },
+      ],
+    ],
+    [
+      "events_only",
+      [
+        {
+          source: "TRACES_OBSERVATIONS",
+          blockedReason: "legacy-writes-disabled",
+        },
+        {
+          source: "TRACES_OBSERVATIONS_EVENTS",
+          blockedReason: "legacy-writes-disabled",
+        },
+        { source: "EVENTS" },
+      ],
+    ],
+  ] as const)(
+    "write mode %s yields exactly this availability",
+    (mode, expected) => {
+      expect(getAvailableExportSources(ctxFor(mode))).toEqual(expected);
+    },
+  );
+
+  // No special case: the combined source needs both halves, so only dual can
+  // offer it. A hand-rolled rule for it would drift from the two predicates.
+  it("TRACES_OBSERVATIONS_EVENTS requires dual, purely from the two rules", () => {
+    const ok = (mode: BlobExportWriteMode) =>
+      validateExportSource("TRACES_OBSERVATIONS_EVENTS", ctxFor(mode)).ok;
+    expect(ok("legacy")).toBe(false);
+    expect(ok("dual")).toBe(true);
+    expect(ok("events_only")).toBe(false);
+    // …and the combination is exactly "legacy AND enriched".
+    for (const mode of WRITE_MODES) {
+      expect(ok(mode)).toBe(
+        areLegacyWritesActive(mode) && areEnrichedWritesActive(mode),
+      );
+    }
+  });
+
+  // The per-user beta opt-in and the Cloud deployment flag are gone from this
+  // decision: a pre-cutoff Cloud project sees exactly what self-hosted sees.
+  it("availability is deployment-agnostic for pre-cutoff Cloud projects", () => {
+    for (const mode of WRITE_MODES) {
+      expect(
+        getAvailableExportSources(
+          ctxFor(mode, {
+            isCloud: true,
+            projectCreatedAt: PROJECT_PRE,
+            integrationCreatedAt: ROW_PRE,
+          }),
+        ),
+      ).toEqual(getAvailableExportSources(ctxFor(mode)));
+    }
+  });
+
+  // Deletion guard: the old preview-flag helper must not survive as a second,
+  // divergent answer to "is enriched available?".
+  it("no longer exports isEnrichedBlobExportAvailable", () => {
+    expect("isEnrichedBlobExportAvailable" in exportSourcePolicy).toBe(false);
   });
 });
 

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.ts
@@ -26,8 +26,8 @@
 //   written, so a legacy source would silently export stale/empty data.
 //
 //   Both are data capability, deployment-agnostic, on Cloud and self-hosted
-//   alike (LFE-10148), and derived from the one write mode via
-//   areEnrichedWritesActive / areLegacyWritesActive. Unlike the date cutoffs
+//   alike, and derived from the one write mode via areEnrichedWritesActive /
+//   areLegacyWritesActive. Unlike the date cutoffs
 //   they also apply to persisted values: keeping one would not grandfather
 //   anything, it would export nothing. TRACES_OBSERVATIONS_EVENTS is both
 //   families at once, so it needs dual — that falls out of the two rules

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.ts
@@ -145,6 +145,13 @@ export function areLegacyWritesActive(writeMode: BlobExportWriteMode): boolean {
   return writeMode !== "events_only";
 }
 
+/** Whether the deployment already writes the v4 events table. */
+export function areEnrichedWritesActive(
+  writeMode: BlobExportWriteMode,
+): boolean {
+  return writeMode !== "legacy";
+}
+
 /**
  * Everything the policy needs to know about a deployment/project/integration.
  * Adapters assemble it (env reads stay server/worker-side); optional fields

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.ts
@@ -17,19 +17,21 @@
 //   only — a persisted legacy value on an old row is grandfathered, which is
 //   why the cutoffs key on creation dates rather than the write path.
 // - ENRICHED AVAILABILITY ("enriched-unavailable"): sources that include the
-//   enriched observations path (EVENTS, TRACES_OBSERVATIONS_EVENTS) need the
-//   enriched read path — available on Cloud, or on self-hosted via the V4
-//   preview opt-in. A persisted enriched value left behind by a preview
-//   rollback is rejected too, instead of silently driving exports against
-//   unpopulated tables (LFE-10296).
+//   enriched observations path (EVENTS, TRACES_OBSERVATIONS_EVENTS) read the v4
+//   events table. Under LANGFUSE_MIGRATION_V4_WRITE_MODE=legacy that table is
+//   not written, so such a source would export nothing.
 // - LEGACY WRITE CAPABILITY ("legacy-writes-disabled"): legacy sources read
 //   the v3 traces/observations tables. Under
 //   LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only those tables are no longer
-//   written, so a legacy source would silently export stale/empty data —
-//   blocked by data capability, deployment-agnostic, on Cloud and self-hosted
-//   alike (LFE-10148). Unlike the date cutoffs this also applies to persisted
-//   values: keeping one would not grandfather anything, it would export
-//   nothing.
+//   written, so a legacy source would silently export stale/empty data.
+//
+//   Both are data capability, deployment-agnostic, on Cloud and self-hosted
+//   alike (LFE-10148), and derived from the one write mode via
+//   areEnrichedWritesActive / areLegacyWritesActive. Unlike the date cutoffs
+//   they also apply to persisted values: keeping one would not grandfather
+//   anything, it would export nothing. TRACES_OBSERVATIONS_EVENTS is both
+//   families at once, so it needs dual — that falls out of the two rules
+//   rather than being special-cased.
 // - PERSISTED VALUES ARE NEVER SILENTLY REWRITTEN (LFE-10296): the UI keeps a
 //   persisted-but-blocked source visible as an unavailable option and blocks
 //   the save; forms and servers must not substitute a different source behind
@@ -124,14 +126,6 @@ export function isLegacyBlobExporter(
   if (!isCloud) return true;
   if (integrationCreatedAt == null) return false;
   return integrationCreatedAt < LEGACY_BLOB_EXPORTER_CUTOFF;
-}
-
-/** Enriched export path availability: Cloud, or self-hosted V4 preview opt-in. */
-export function isEnrichedBlobExportAvailable(
-  isCloud: boolean,
-  isV4PreviewEnabled?: boolean,
-): boolean {
-  return isCloud || isV4PreviewEnabled === true;
 }
 
 /**

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8744,10 +8744,18 @@ components:
         columns of both portions are controlled by `exportFieldGroups`.
 
 
-        **Note:** `OBSERVATIONS_V2` and the enriched-observations portion of
-        `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` rely on the enriched
-        observations table (Langfuse Fast Preview / v4), which is currently
-        available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
+        **Note:** which sources a deployment accepts depends on how far it has
+        moved to the v4 data model. `OBSERVATIONS_V2` and the
+        enriched-observations portion of
+        `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` read the enriched observations
+        table, so they require a deployment that already populates it.
+        `LEGACY_TRACES_OBSERVATIONS` and the legacy portion of
+        `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` read the legacy traces and
+        observations tables, so they require a deployment that still populates
+        those. A deployment part-way through the migration populates both and
+        accepts every source. Selecting a source the deployment cannot serve is
+        rejected with `400`, rather than exporting an empty result. See
+        https://langfuse.com/docs/v4.
     BlobStorageExportFieldGroup:
       title: BlobStorageExportFieldGroup
       type: string
@@ -8836,10 +8844,12 @@ components:
           nullable: true
           description: >-
             Data to export. When omitted on update, the existing value is
-            preserved. When omitted on create: integrations on Langfuse Cloud
-            default to `OBSERVATIONS_V2`; self-hosted deployments fall back to
-            `LEGACY_TRACES_OBSERVATIONS`. Required when `exportFieldGroups` is
-            provided.
+            preserved. When omitted on create, the default is `OBSERVATIONS_V2`
+            on Langfuse Cloud, and on self-hosted deployments
+            `LEGACY_TRACES_OBSERVATIONS` — or `OBSERVATIONS_V2` where the
+            deployment no longer populates the legacy tables. The default is
+            never a source the deployment cannot serve. Required when
+            `exportFieldGroups` is provided.
 
 
             **Cloud-only project deprecation gate (effective 2026-05-20):** For

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -718,28 +718,14 @@ describe("Blob Storage Integration tRPC Router", () => {
   });
 
   describe("get: isEnrichedExportAvailable flag", () => {
-    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
 
     afterEach(() => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
-        originalV4Preview;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
     });
 
-    it("returns true for Cloud deployments regardless of V4 flag", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
-      const { caller, project } = await prepare();
-      const result = await caller.blobStorageIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.isEnrichedExportAvailable).toBe(true);
-    });
-
-    it("returns false for self-hosted without V4 preview opt-in", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+    it("returns false under the legacy write mode", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       const result = await caller.blobStorageIntegration.get({
         projectId: project.id,
@@ -747,9 +733,17 @@ describe("Blob Storage Integration tRPC Router", () => {
       expect(result.isEnrichedExportAvailable).toBe(false);
     });
 
-    it("returns true for self-hosted with V4 preview opt-in enabled", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+    it("returns true under the dual write mode", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      const { caller, project } = await prepare();
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.isEnrichedExportAvailable).toBe(true);
+    });
+
+    it("returns true under the events_only write mode", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
       const { caller, project } = await prepare();
       const result = await caller.blobStorageIntegration.get({
         projectId: project.id,
@@ -760,17 +754,16 @@ describe("Blob Storage Integration tRPC Router", () => {
 
   describe("update: enriched export source guard", () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
 
     afterEach(() => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
-        originalV4Preview;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
     });
 
-    it("rejects EVENTS on self-hosted without V4 preview opt-in", async () => {
+    it("rejects EVENTS under the legacy write mode", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await expect(
         caller.blobStorageIntegration.update({
@@ -781,9 +774,9 @@ describe("Blob Storage Integration tRPC Router", () => {
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     });
 
-    it("rejects TRACES_OBSERVATIONS_EVENTS on self-hosted without V4 preview opt-in", async () => {
+    it("rejects TRACES_OBSERVATIONS_EVENTS under the legacy write mode", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
@@ -798,9 +791,43 @@ describe("Blob Storage Integration tRPC Router", () => {
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     });
 
-    it("allows EVENTS on self-hosted with V4 preview opt-in", async () => {
+    it("rejects TRACES_OBSERVATIONS_EVENTS under the events_only write mode", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("allows TRACES_OBSERVATIONS_EVENTS under the dual write mode", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("allows EVENTS under the events_only write mode", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
       const { caller, project } = await prepare();
       await expect(
         caller.blobStorageIntegration.update({
@@ -811,9 +838,9 @@ describe("Blob Storage Integration tRPC Router", () => {
       ).resolves.not.toThrow();
     });
 
-    it("allows EVENTS on Cloud regardless of V4 flag", async () => {
+    it("allows EVENTS on Cloud under the dual write mode", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
       const { caller, project } = await prepare();
       await expect(
         caller.blobStorageIntegration.update({
@@ -939,19 +966,18 @@ describe("Blob Storage Integration tRPC Router", () => {
   // enriched source alive on a deployment without the enriched export path.
   describe("update: omitted exportSource", () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
 
     afterEach(() => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
-        originalV4Preview;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
     });
 
     const { exportSource: _ignored, ...configWithoutExportSource } = baseConfig;
 
     it("preserves a persisted enriched source when enriched export is available", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
       const { caller, project } = await prepare();
       await createIntegration({
         projectId: project.id,
@@ -969,9 +995,9 @@ describe("Blob Storage Integration tRPC Router", () => {
       expect(row.exportSource).toBe("EVENTS");
     });
 
-    it("rejects an omitted exportSource over a stale enriched row on rolled-back self-hosted", async () => {
+    it("rejects an omitted exportSource over a stale enriched row on a legacy-write-mode deployment", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await createIntegration({
         projectId: project.id,
@@ -991,9 +1017,9 @@ describe("Blob Storage Integration tRPC Router", () => {
       expect(row.exportSource).toBe("EVENTS");
     });
 
-    it("preserves a persisted legacy source on rolled-back self-hosted", async () => {
+    it("preserves a persisted legacy source on a legacy-write-mode deployment", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await createIntegration({
         projectId: project.id,
@@ -1017,7 +1043,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       // default (TRACES_OBSERVATIONS) — mirror of the REST handler's
       // forceEventsOnCreate behavior.
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
@@ -1035,9 +1061,9 @@ describe("Blob Storage Integration tRPC Router", () => {
       expect(row.exportSource).toBe("EVENTS");
     });
 
-    it("still allows an explicit downgrade to a legacy source on rolled-back self-hosted", async () => {
+    it("still allows an explicit downgrade to a legacy source on a legacy-write-mode deployment", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await createIntegration({
         projectId: project.id,

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -755,10 +755,41 @@ describe("Blob Storage Integration tRPC Router", () => {
   describe("update: enriched export source guard", () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    const originalPreviewOptIn = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
 
     afterEach(() => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
       (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalPreviewOptIn;
+    });
+
+    it("rejects EVENTS under the legacy write mode even with the preview opt-in enabled", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("allows EVENTS under the dual write mode even with the preview opt-in disabled", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
     });
 
     it("rejects EVENTS under the legacy write mode", async () => {

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -717,39 +717,34 @@ describe("Blob Storage Integration tRPC Router", () => {
     });
   });
 
-  describe("get: isEnrichedExportAvailable flag", () => {
+  // The write mode is server-only, so the settings page can only learn it
+  // from this response. This is the durable half of the contract — the
+  // derived booleans next to it go away once their consumers read writeMode.
+  describe("get: writeMode", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    const originalPreviewOptIn = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
 
     afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
       (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalPreviewOptIn;
     });
 
-    it("returns false under the legacy write mode", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-      const { caller, project } = await prepare();
-      const result = await caller.blobStorageIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.isEnrichedExportAvailable).toBe(false);
-    });
-
-    it("returns true under the dual write mode", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
-      const { caller, project } = await prepare();
-      const result = await caller.blobStorageIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.isEnrichedExportAvailable).toBe(true);
-    });
-
-    it("returns true under the events_only write mode", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
-      const { caller, project } = await prepare();
-      const result = await caller.blobStorageIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.isEnrichedExportAvailable).toBe(true);
-    });
+    it.each(["legacy", "dual", "events_only"] as const)(
+      "returns the active write mode %s, independent of the preview opt-in",
+      async (writeMode) => {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+        (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = writeMode;
+        (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+        const { caller, project } = await prepare();
+        const result = await caller.blobStorageIntegration.get({
+          projectId: project.id,
+        });
+        expect(result.writeMode).toBe(writeMode);
+      },
+    );
   });
 
   describe("update: enriched export source guard", () => {

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -258,28 +258,12 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       ).resolves.not.toThrow();
     });
 
-    it("get returns legacyWritesActive=false on events_only", async () => {
+    it("get returns a null config when the project has no integration", async () => {
       const { caller, project } = await prepare();
       const result = await caller.mixpanelIntegration.get({
         projectId: project.id,
       });
-      expect(result.legacyWritesActive).toBe(false);
       expect(result.config).toBeNull();
-    });
-
-    it("get returns legacyWritesActive=true on dual, with config", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
-      const { caller, project } = await prepare();
-      await caller.mixpanelIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-        exportSource: "EVENTS" as const,
-      });
-      const result = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.legacyWritesActive).toBe(true);
-      expect(result.config?.exportSource).toBe("EVENTS");
     });
   });
 
@@ -370,13 +354,7 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
     });
 
     // The write mode is server-only, so the settings page can only learn it
-    // from this response. This is the durable half of the contract — the
-    // derived booleans next to it go away once their consumers read writeMode.
-    // Read untyped only because the router does not return the field yet;
-    // the property name itself is asserted exactly.
-    const writeModeOf = (result: object) =>
-      (result as Record<string, unknown>).writeMode;
-
+    // from this response.
     it.each(["legacy", "dual", "events_only"] as const)(
       "get returns the active write mode %s, independent of the preview opt-in",
       async (writeMode) => {
@@ -386,7 +364,7 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         const result = await caller.mixpanelIntegration.get({
           projectId: project.id,
         });
-        expect(writeModeOf(result)).toBe(writeMode);
+        expect(result.writeMode).toBe(writeMode);
       },
     );
   });
@@ -448,9 +426,11 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
-    // dual writes both, so the enriched source is the recommended default —
-    // no per-user beta opt-in involved any more.
-    it("create without exportSource defaults to EVENTS on dual", async () => {
+    // Router default for an omitted exportSource: legacy writes active ?
+    // TRACES_OBSERVATIONS : EVENTS. It deliberately differs from the
+    // settings-page default (EVENTS on dual) — a pre-existing divergence this
+    // change does not touch, pinned here so a later fix has to flip it.
+    it("create without exportSource defaults to TRACES_OBSERVATIONS on dual", async () => {
       const { caller, project } = await prepare();
       await caller.mixpanelIntegration.update({
         projectId: project.id,
@@ -459,7 +439,7 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       const result = await caller.mixpanelIntegration.get({
         projectId: project.id,
       });
-      expect(result.config?.exportSource).toBe("EVENTS");
+      expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
     it("create without exportSource defaults to TRACES_OBSERVATIONS on legacy", async () => {
@@ -475,30 +455,8 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    // Post-cutoff Cloud keeps the events source pinned; on dual that default
-    // is now valid, so the create succeeds instead of being refused.
-    it("Cloud + post-cutoff project + create without exportSource pins EVENTS on dual", async () => {
+    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
-      const { caller, project } = await prepare();
-      await prisma.project.update({
-        where: { id: project.id },
-        data: { createdAt: POST_CUTOFF },
-      });
-      await caller.mixpanelIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-      });
-      const result = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.config?.exportSource).toBe("EVENTS");
-    });
-
-    // legacy write mode leaves a post-cutoff Cloud project with no writable
-    // source at all: the default must be validated, not silently persisted.
-    it("Cloud + post-cutoff project + legacy write mode + create without exportSource → BAD_REQUEST", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -369,30 +369,26 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       ).resolves.not.toThrow();
     });
 
-    // The write mode is server-only, so the settings page can only learn
-    // enriched availability from this response. Field name is the
-    // implementer's call; the signal has to be there and has to track the mode.
-    const enrichedSignal = (result: Record<string, unknown>) =>
-      result.isEnrichedExportAvailable ??
-      result.enrichedWritesActive ??
-      result.enrichedAvailable;
+    // The write mode is server-only, so the settings page can only learn it
+    // from this response. This is the durable half of the contract — the
+    // derived booleans next to it go away once their consumers read writeMode.
+    // Read untyped only because the router does not return the field yet;
+    // the property name itself is asserted exactly.
+    const writeModeOf = (result: object) =>
+      (result as Record<string, unknown>).writeMode;
 
-    it("get reports enriched availability derived from the write mode", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
-      const { caller, project } = await prepare();
-      const onDual = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(enrichedSignal(onDual)).toBe(true);
-
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
-      const onLegacy = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(enrichedSignal(onLegacy)).toBe(false);
-    });
+    it.each(["legacy", "dual", "events_only"] as const)(
+      "get returns the active write mode %s, independent of the preview opt-in",
+      async (writeMode) => {
+        (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = writeMode;
+        (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+        const { caller, project } = await prepare();
+        const result = await caller.mixpanelIntegration.get({
+          projectId: project.id,
+        });
+        expect(writeModeOf(result)).toBe(writeMode);
+      },
+    );
   });
 
   // LFE-10148 review: the form schema's zod default must not be injected into

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -283,6 +283,118 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
     });
   });
 
+  // The active write mode is the only input to export-source availability.
+  // The V4 frontend preview flag and the per-user beta opt-in no longer
+  // participate, which makes two previously-unreachable combinations behave.
+  describe("enriched export sources follow the write mode alone", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    const originalPreview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = originalPreview;
+    });
+
+    // dual writes enriched rows, so the source works — it was hidden only
+    // because the frontend preview flag was off.
+    it("dual + preview opt-in disabled → EVENTS accepted", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("dual + preview opt-in disabled → TRACES_OBSERVATIONS_EVENTS accepted", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    // legacy writes no enriched rows: accepting the source here only defers
+    // the failure to export time.
+    it("legacy + preview opt-in enabled → EVENTS rejected", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("legacy + preview opt-in enabled → TRACES_OBSERVATIONS_EVENTS rejected", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("legacy → TRACES_OBSERVATIONS accepted", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    // The write mode is server-only, so the settings page can only learn
+    // enriched availability from this response. Field name is the
+    // implementer's call; the signal has to be there and has to track the mode.
+    const enrichedSignal = (result: Record<string, unknown>) =>
+      result.isEnrichedExportAvailable ??
+      result.enrichedWritesActive ??
+      result.enrichedAvailable;
+
+    it("get reports enriched availability derived from the write mode", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      const onDual = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(enrichedSignal(onDual)).toBe(true);
+
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const onLegacy = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(enrichedSignal(onLegacy)).toBe(false);
+    });
+  });
+
   // LFE-10148 review: the form schema's zod default must not be injected into
   // partial updates — an omitted exportSource preserves the persisted value
   // (capability-checked only), and CREATE picks an explicit, validated default.
@@ -340,7 +452,22 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
-    it("create without exportSource defaults to TRACES_OBSERVATIONS on dual", async () => {
+    // dual writes both, so the enriched source is the recommended default —
+    // no per-user beta opt-in involved any more.
+    it("create without exportSource defaults to EVENTS on dual", async () => {
+      const { caller, project } = await prepare();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("create without exportSource defaults to TRACES_OBSERVATIONS on legacy", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await caller.mixpanelIntegration.update({
         projectId: project.id,
@@ -352,8 +479,30 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
+    // Post-cutoff Cloud keeps the events source pinned; on dual that default
+    // is now valid, so the create succeeds instead of being refused.
+    it("Cloud + post-cutoff project + create without exportSource pins EVENTS on dual", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: POST_CUTOFF },
+      });
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    // legacy write mode leaves a post-cutoff Cloud project with no writable
+    // source at all: the default must be validated, not silently persisted.
+    it("Cloud + post-cutoff project + legacy write mode + create without exportSource → BAD_REQUEST", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -327,6 +327,118 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     });
   });
 
+  // The active write mode is the only input to export-source availability.
+  // The V4 frontend preview flag and the per-user beta opt-in no longer
+  // participate, which makes two previously-unreachable combinations behave.
+  describe("enriched export sources follow the write mode alone", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    const originalPreview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = originalPreview;
+    });
+
+    // dual writes enriched rows, so the source works — it was hidden only
+    // because the frontend preview flag was off.
+    it("dual + preview opt-in disabled → EVENTS accepted", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("dual + preview opt-in disabled → TRACES_OBSERVATIONS_EVENTS accepted", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    // legacy writes no enriched rows: accepting the source here only defers
+    // the failure to export time.
+    it("legacy + preview opt-in enabled → EVENTS rejected", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("legacy + preview opt-in enabled → TRACES_OBSERVATIONS_EVENTS rejected", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("legacy → TRACES_OBSERVATIONS accepted", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    // The write mode is server-only, so the settings page can only learn
+    // enriched availability from this response. Field name is the
+    // implementer's call; the signal has to be there and has to track the mode.
+    const enrichedSignal = (result: Record<string, unknown>) =>
+      result.isEnrichedExportAvailable ??
+      result.enrichedWritesActive ??
+      result.enrichedAvailable;
+
+    it("get reports enriched availability derived from the write mode", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      const onDual = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(enrichedSignal(onDual)).toBe(true);
+
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const onLegacy = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(enrichedSignal(onLegacy)).toBe(false);
+    });
+  });
+
   // LFE-10148 review: the form schema's zod default must not be injected into
   // partial updates — an omitted exportSource preserves the persisted value
   // (capability-checked only), and CREATE picks an explicit, validated default.
@@ -384,7 +496,22 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
-    it("create without exportSource defaults to TRACES_OBSERVATIONS on dual", async () => {
+    // dual writes both, so the enriched source is the recommended default —
+    // no per-user beta opt-in involved any more.
+    it("create without exportSource defaults to EVENTS on dual", async () => {
+      const { caller, project } = await prepare();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("create without exportSource defaults to TRACES_OBSERVATIONS on legacy", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await caller.posthogIntegration.update({
         projectId: project.id,
@@ -396,8 +523,30 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
+    // Post-cutoff Cloud keeps the events source pinned; on dual that default
+    // is now valid, so the create succeeds instead of being refused.
+    it("Cloud + post-cutoff project + create without exportSource pins EVENTS on dual", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: POST_CUTOFF },
+      });
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    // legacy write mode leaves a post-cutoff Cloud project with no writable
+    // source at all: the default must be validated, not silently persisted.
+    it("Cloud + post-cutoff project + legacy write mode + create without exportSource → BAD_REQUEST", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -413,30 +413,26 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       ).resolves.not.toThrow();
     });
 
-    // The write mode is server-only, so the settings page can only learn
-    // enriched availability from this response. Field name is the
-    // implementer's call; the signal has to be there and has to track the mode.
-    const enrichedSignal = (result: Record<string, unknown>) =>
-      result.isEnrichedExportAvailable ??
-      result.enrichedWritesActive ??
-      result.enrichedAvailable;
+    // The write mode is server-only, so the settings page can only learn it
+    // from this response. This is the durable half of the contract — the
+    // derived booleans next to it go away once their consumers read writeMode.
+    // Read untyped only because the router does not return the field yet;
+    // the property name itself is asserted exactly.
+    const writeModeOf = (result: object) =>
+      (result as Record<string, unknown>).writeMode;
 
-    it("get reports enriched availability derived from the write mode", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
-      const { caller, project } = await prepare();
-      const onDual = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(enrichedSignal(onDual)).toBe(true);
-
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
-      const onLegacy = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(enrichedSignal(onLegacy)).toBe(false);
-    });
+    it.each(["legacy", "dual", "events_only"] as const)(
+      "get returns the active write mode %s, independent of the preview opt-in",
+      async (writeMode) => {
+        (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = writeMode;
+        (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+        const { caller, project } = await prepare();
+        const result = await caller.posthogIntegration.get({
+          projectId: project.id,
+        });
+        expect(writeModeOf(result)).toBe(writeMode);
+      },
+    );
   });
 
   // LFE-10148 review: the form schema's zod default must not be injected into

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -302,28 +302,12 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       ).resolves.not.toThrow();
     });
 
-    it("get returns legacyWritesActive=false on events_only", async () => {
+    it("get returns a null config when the project has no integration", async () => {
       const { caller, project } = await prepare();
       const result = await caller.posthogIntegration.get({
         projectId: project.id,
       });
-      expect(result.legacyWritesActive).toBe(false);
       expect(result.config).toBeNull();
-    });
-
-    it("get returns legacyWritesActive=true on dual, with config", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
-      const { caller, project } = await prepare();
-      await caller.posthogIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-        exportSource: "EVENTS" as const,
-      });
-      const result = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.legacyWritesActive).toBe(true);
-      expect(result.config?.exportSource).toBe("EVENTS");
     });
   });
 
@@ -414,13 +398,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     });
 
     // The write mode is server-only, so the settings page can only learn it
-    // from this response. This is the durable half of the contract — the
-    // derived booleans next to it go away once their consumers read writeMode.
-    // Read untyped only because the router does not return the field yet;
-    // the property name itself is asserted exactly.
-    const writeModeOf = (result: object) =>
-      (result as Record<string, unknown>).writeMode;
-
+    // from this response.
     it.each(["legacy", "dual", "events_only"] as const)(
       "get returns the active write mode %s, independent of the preview opt-in",
       async (writeMode) => {
@@ -430,7 +408,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         const result = await caller.posthogIntegration.get({
           projectId: project.id,
         });
-        expect(writeModeOf(result)).toBe(writeMode);
+        expect(result.writeMode).toBe(writeMode);
       },
     );
   });
@@ -492,9 +470,11 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
-    // dual writes both, so the enriched source is the recommended default —
-    // no per-user beta opt-in involved any more.
-    it("create without exportSource defaults to EVENTS on dual", async () => {
+    // Router default for an omitted exportSource: legacy writes active ?
+    // TRACES_OBSERVATIONS : EVENTS. It deliberately differs from the
+    // settings-page default (EVENTS on dual) — a pre-existing divergence this
+    // change does not touch, pinned here so a later fix has to flip it.
+    it("create without exportSource defaults to TRACES_OBSERVATIONS on dual", async () => {
       const { caller, project } = await prepare();
       await caller.posthogIntegration.update({
         projectId: project.id,
@@ -503,7 +483,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       const result = await caller.posthogIntegration.get({
         projectId: project.id,
       });
-      expect(result.config?.exportSource).toBe("EVENTS");
+      expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
     it("create without exportSource defaults to TRACES_OBSERVATIONS on legacy", async () => {
@@ -519,30 +499,8 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    // Post-cutoff Cloud keeps the events source pinned; on dual that default
-    // is now valid, so the create succeeds instead of being refused.
-    it("Cloud + post-cutoff project + create without exportSource pins EVENTS on dual", async () => {
+    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
-      const { caller, project } = await prepare();
-      await prisma.project.update({
-        where: { id: project.id },
-        data: { createdAt: POST_CUTOFF },
-      });
-      await caller.posthogIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-      });
-      const result = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.config?.exportSource).toBe("EVENTS");
-    });
-
-    // legacy write mode leaves a post-cutoff Cloud project with no writable
-    // source at all: the default must be validated, not silently persisted.
-    it("Cloud + post-cutoff project + legacy write mode + create without exportSource → BAD_REQUEST", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },

--- a/web/src/__tests__/server/unit/assertExportSourceAllowed.servertest.ts
+++ b/web/src/__tests__/server/unit/assertExportSourceAllowed.servertest.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
 import {
+  areEnrichedWritesActive,
+  areLegacyWritesActive,
   InvalidRequestError,
   LEGACY_BLOB_EXPORT_CUTOFF,
+  type BlobExportWriteMode,
   type ExportSourceContext,
 } from "@langfuse/shared";
 
@@ -77,6 +80,61 @@ describe("assertExportSourceAllowed", () => {
         },
       }),
     ).toThrow(/events_only/);
+  });
+
+  // The write-mode gate every save path funnels through (tRPC routers and the
+  // public REST PUT). It must accept exactly what the UI offers for the mode.
+  describe("write mode gate", () => {
+    const ctxFor = (writeMode: BlobExportWriteMode): ExportSourceContext => ({
+      isCloud: false,
+      enrichedAvailable: areEnrichedWritesActive(writeMode),
+      legacyWritesActive: areLegacyWritesActive(writeMode),
+    });
+
+    const attempt = (
+      writeMode: BlobExportWriteMode,
+      nextExportSource:
+        | "TRACES_OBSERVATIONS"
+        | "TRACES_OBSERVATIONS_EVENTS"
+        | "EVENTS",
+    ) =>
+      assertExportSourceAllowed({ nextExportSource, ctx: ctxFor(writeMode) });
+
+    const cases: Array<
+      [
+        BlobExportWriteMode,
+        "TRACES_OBSERVATIONS" | "TRACES_OBSERVATIONS_EVENTS" | "EVENTS",
+        boolean,
+      ]
+    > = [
+      ["legacy", "TRACES_OBSERVATIONS", true],
+      ["legacy", "TRACES_OBSERVATIONS_EVENTS", false],
+      ["legacy", "EVENTS", false],
+      ["dual", "TRACES_OBSERVATIONS", true],
+      ["dual", "TRACES_OBSERVATIONS_EVENTS", true],
+      ["dual", "EVENTS", true],
+      ["events_only", "TRACES_OBSERVATIONS", false],
+      ["events_only", "TRACES_OBSERVATIONS_EVENTS", false],
+      ["events_only", "EVENTS", true],
+    ];
+
+    it.each(cases)("%s + %s → allowed=%s", (writeMode, source, allowed) => {
+      if (allowed) {
+        expect(() => attempt(writeMode, source)).not.toThrow();
+      } else {
+        expect(() => attempt(writeMode, source)).toThrow(InvalidRequestError);
+      }
+    });
+
+    it("keeps a persisted-but-blocked source rejected on an omitted update", () => {
+      expect(() =>
+        assertExportSourceAllowed({
+          nextExportSource: undefined,
+          persistedExportSource: "EVENTS",
+          ctx: ctxFor("legacy"),
+        }),
+      ).toThrow(InvalidRequestError);
+    });
   });
 
   it("omitted source without a persisted row is a no-op", () => {

--- a/web/src/features/analytics-integrations/components/IntegrationSettingsSkeleton.tsx
+++ b/web/src/features/analytics-integrations/components/IntegrationSettingsSkeleton.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/src/components/ui/skeleton";
+
+// Placeholder for an integration settings form that is not mounted yet. The
+// forms capture their defaults on first render, so each settings page holds
+// this until every async input has resolved.
+export const IntegrationSettingsSkeleton = () => (
+  <div className="space-y-3">
+    <Skeleton className="h-9 w-full" />
+    <Skeleton className="h-9 w-full" />
+    <Skeleton className="h-9 w-full" />
+  </div>
+);

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -1,7 +1,5 @@
 import {
   AnalyticsIntegrationExportSource,
-  areEnrichedWritesActive,
-  areLegacyWritesActive,
   LEGACY_BLOB_EXPORT_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
   type BlobExportWriteMode,
@@ -9,6 +7,7 @@ import {
 } from "@langfuse/shared";
 
 import {
+  buildExportSourceContext,
   getExportSourceFormValue,
   getExportSourceOptions,
   getExportSourceUnavailableMessage,
@@ -256,21 +255,20 @@ describe("shouldHideExportSourceSelector", () => {
 });
 
 // The settings pages (blob storage, PostHog, Mixpanel) build their context
-// from the write mode the integration router reports — not from the session's
-// beta flag and not from a frontend preview env var. These cases pin what each
-// write mode must render, identically for all three pages.
+// through buildExportSourceContext from the write mode the integration router
+// reports — not from the session's beta flag and not from a frontend preview
+// env var. Driving these cases through the real builder is what covers that
+// wiring; the builder takes no session or beta input at all.
 describe("write mode drives the settings-page selector", () => {
   const WRITE_MODES: BlobExportWriteMode[] = ["legacy", "dual", "events_only"];
 
   const ctxFor = (
     writeMode: BlobExportWriteMode,
-    over: Partial<ExportSourceContext> = {},
-  ): ExportSourceContext => ({
-    isCloud: false,
-    enrichedAvailable: areEnrichedWritesActive(writeMode),
-    legacyWritesActive: areLegacyWritesActive(writeMode),
-    ...over,
-  });
+    over: Partial<
+      Omit<ExportSourceContext, "enrichedAvailable" | "legacyWritesActive">
+    > = {},
+  ): ExportSourceContext =>
+    buildExportSourceContext({ writeMode, isCloud: false, ...over });
 
   const selectableValues = (ctx: ExportSourceContext) =>
     getExportSourceOptions(undefined, ctx)
@@ -307,12 +305,53 @@ describe("write mode drives the settings-page selector", () => {
     ["events_only", AnalyticsIntegrationExportSource.EVENTS],
   ];
 
+  // The settings-page create default: areEnrichedWritesActive(writeMode)
+  // ? EVENTS : TRACES_OBSERVATIONS. The tRPC/REST routers keep their own,
+  // older default for an omitted exportSource (TRACES_OBSERVATIONS on dual);
+  // that divergence predates this change and is tracked separately.
   it.each(defaults)(
-    "write mode %s picks %s as the create default",
+    "write mode %s picks %s as the settings-page create default",
     (mode, expected) => {
       expect(getExportSourceFormValue(undefined, ctxFor(mode))).toBe(expected);
     },
   );
+
+  // Precedence: when legacy is blocked by the Cloud cutoff, the page pins
+  // EVENTS even though the general rule would pick TRACES_OBSERVATIONS for a
+  // write mode without enriched writes. Only this ordering distinguishes the
+  // two rules; every other combination agrees.
+  it("post-cutoff Cloud pins EVENTS ahead of the write-mode rule", () => {
+    const ctx = ctxFor("legacy", {
+      isCloud: true,
+      projectCreatedAt: PROJECT_POST,
+      integrationCreatedAt: ROW_PRE,
+    });
+    expect(ctx.enrichedAvailable).toBe(false);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        ctx,
+      ),
+    ).toBe(false);
+    expect(getExportSourceFormValue(undefined, ctx)).toBe(
+      AnalyticsIntegrationExportSource.EVENTS,
+    );
+  });
+
+  // Same pinning on the reachable Cloud configuration, where the write-mode
+  // rule already agrees — this is the case real Cloud projects hit.
+  it("post-cutoff Cloud on dual pins EVENTS", () => {
+    expect(
+      getExportSourceFormValue(
+        undefined,
+        ctxFor("dual", {
+          isCloud: true,
+          projectCreatedAt: PROJECT_POST,
+          integrationCreatedAt: ROW_PRE,
+        }),
+      ),
+    ).toBe(AnalyticsIntegrationExportSource.EVENTS);
+  });
 
   // A source that was legal when it was saved must never silently vanish: the
   // user has to see why their save is blocked and what to switch to.
@@ -364,10 +403,13 @@ describe("write mode drives the settings-page selector", () => {
 });
 
 describe("getExportSourceUnavailableMessage", () => {
-  it("names the enriched path for enriched-unavailable", () => {
+  it("names the write mode for enriched-unavailable (self-hosted operator-facing)", () => {
     const message = getExportSourceUnavailableMessage("enriched-unavailable");
     expect(message).toContain("enriched observations");
-    expect(message).toContain("V4 preview opt-in");
+    expect(message).toContain("LANGFUSE_MIGRATION_V4_WRITE_MODE=legacy");
+    // The preview opt-in no longer affects enriched availability, so pointing
+    // an operator at it during a blocked save sends them to a dead end.
+    expect(message).not.toContain("preview opt-in");
   });
 
   it("describes the Cloud cutoff for cloud-cutoff", () => {

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -1,7 +1,10 @@
 import {
   AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
+  areLegacyWritesActive,
   LEGACY_BLOB_EXPORT_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
+  type BlobExportWriteMode,
   type ExportSourceContext,
 } from "@langfuse/shared";
 
@@ -250,6 +253,114 @@ describe("shouldHideExportSourceSelector", () => {
     expect(options[0].unavailable).toBe(true);
     expect(shouldHideExportSourceSelector(options)).toBe(false);
   });
+});
+
+// The settings pages (blob storage, PostHog, Mixpanel) build their context
+// from the write mode the integration router reports — not from the session's
+// beta flag and not from a frontend preview env var. These cases pin what each
+// write mode must render, identically for all three pages.
+describe("write mode drives the settings-page selector", () => {
+  const WRITE_MODES: BlobExportWriteMode[] = ["legacy", "dual", "events_only"];
+
+  const ctxFor = (
+    writeMode: BlobExportWriteMode,
+    over: Partial<ExportSourceContext> = {},
+  ): ExportSourceContext => ({
+    isCloud: false,
+    enrichedAvailable: areEnrichedWritesActive(writeMode),
+    legacyWritesActive: areLegacyWritesActive(writeMode),
+    ...over,
+  });
+
+  const selectableValues = (ctx: ExportSourceContext) =>
+    getExportSourceOptions(undefined, ctx)
+      .filter((o) => !o.unavailable)
+      .map((o) => o.value);
+
+  const offered: Array<
+    [BlobExportWriteMode, AnalyticsIntegrationExportSource[]]
+  > = [
+    ["legacy", [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS]],
+    [
+      "dual",
+      [
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+        AnalyticsIntegrationExportSource.EVENTS,
+      ],
+    ],
+    ["events_only", [AnalyticsIntegrationExportSource.EVENTS]],
+  ];
+
+  it.each(offered)(
+    "write mode %s offers exactly the sources it still writes",
+    (mode, expected) => {
+      expect(selectableValues(ctxFor(mode))).toEqual(expected);
+    },
+  );
+
+  const defaults: Array<
+    [BlobExportWriteMode, AnalyticsIntegrationExportSource]
+  > = [
+    ["legacy", AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS],
+    ["dual", AnalyticsIntegrationExportSource.EVENTS],
+    ["events_only", AnalyticsIntegrationExportSource.EVENTS],
+  ];
+
+  it.each(defaults)(
+    "write mode %s picks %s as the create default",
+    (mode, expected) => {
+      expect(getExportSourceFormValue(undefined, ctxFor(mode))).toBe(expected);
+    },
+  );
+
+  // A source that was legal when it was saved must never silently vanish: the
+  // user has to see why their save is blocked and what to switch to.
+  const blockedPersisted: Array<
+    [BlobExportWriteMode, AnalyticsIntegrationExportSource]
+  > = [
+    ["legacy", AnalyticsIntegrationExportSource.EVENTS],
+    ["legacy", AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS],
+    ["events_only", AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS],
+    [
+      "events_only",
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+    ],
+  ];
+
+  it.each(blockedPersisted)(
+    "write mode %s keeps a persisted %s visible and greyed out",
+    (mode, persisted) => {
+      const ctx = ctxFor(mode);
+      const options = getExportSourceOptions(persisted, ctx);
+      expect(options.map((o) => o.value)).toContain(persisted);
+      expect(options.find((o) => o.value === persisted)?.unavailable).toBe(
+        true,
+      );
+      // The form keeps the persisted value, so the blocked-save alert has a
+      // selected option to point at.
+      expect(getExportSourceFormValue(persisted, ctx)).toBe(persisted);
+      expect(shouldHideExportSourceSelector(options)).toBe(false);
+    },
+  );
+
+  // No per-user beta gate and no Cloud-specific enriched path remain, so a
+  // pre-cutoff Cloud project renders exactly what self-hosted renders.
+  it.each(WRITE_MODES)(
+    "pre-cutoff Cloud renders the same options as self-hosted on %s",
+    (mode) => {
+      expect(
+        getExportSourceOptions(
+          undefined,
+          ctxFor(mode, {
+            isCloud: true,
+            projectCreatedAt: PROJECT_PRE,
+            integrationCreatedAt: ROW_PRE,
+          }),
+        ),
+      ).toEqual(getExportSourceOptions(undefined, ctxFor(mode)));
+    },
+  );
 });
 
 describe("getExportSourceUnavailableMessage", () => {

--- a/web/src/features/analytics-integrations/exportSource.ts
+++ b/web/src/features/analytics-integrations/exportSource.ts
@@ -1,8 +1,11 @@
 import {
   AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
+  areLegacyWritesActive,
   EXPORT_SOURCE_OPTIONS,
   getAvailableExportSources,
   validateExportSource,
+  type BlobExportWriteMode,
   type ExportSourceBlockedReason,
   type ExportSourceContext,
   type ExportSourceOption,
@@ -11,6 +14,28 @@ import {
 // UI adapters over the export-source policy, shared by the blob-storage,
 // PostHog, and Mixpanel settings forms. Policy and rationale live in
 // packages/shared/.../export-source-policy.ts.
+
+// The write mode is server-only, so every settings page receives it from its
+// tRPC get response and derives both capabilities here.
+export function buildExportSourceContext({
+  writeMode,
+  isCloud,
+  projectCreatedAt,
+  integrationCreatedAt,
+}: {
+  writeMode: BlobExportWriteMode;
+  isCloud: boolean;
+  projectCreatedAt?: Date;
+  integrationCreatedAt?: Date | null;
+}): ExportSourceContext {
+  return {
+    isCloud,
+    enrichedAvailable: areEnrichedWritesActive(writeMode),
+    legacyWritesActive: areLegacyWritesActive(writeMode),
+    projectCreatedAt,
+    integrationCreatedAt,
+  };
+}
 
 export function isExportSourceSelectable(
   source: AnalyticsIntegrationExportSource,

--- a/web/src/features/analytics-integrations/exportSource.ts
+++ b/web/src/features/analytics-integrations/exportSource.ts
@@ -95,7 +95,7 @@ const EXPORT_SOURCE_UNAVAILABLE_MESSAGES: Record<
   string
 > = {
   "enriched-unavailable":
-    "This integration is configured to export enriched observations, but enriched export is not available on this deployment. Saving is blocked until you select an available export source above. To keep the current configuration instead, re-enable enriched export (V4 preview opt-in) on your deployment.",
+    "This integration is configured to export enriched observations, but this deployment runs LANGFUSE_MIGRATION_V4_WRITE_MODE=legacy and does not write the enriched observations table. Saving is blocked until you select an available export source above.",
   "cloud-cutoff":
     "This integration is configured to export legacy traces and observations, which is no longer available for this project. Saving is blocked until you select an available export source above.",
   // Self-hosted-operator-facing: naming the env var is intentional.

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -27,11 +27,11 @@ import { randomUUID } from "crypto";
 import { decrypt } from "@langfuse/shared/encryption";
 import {
   AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
   areLegacyWritesActive,
   BlobStorageIntegrationType,
   BlobStorageIntegrationFileType,
   InvalidRequestError,
-  isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 
 const getAuditLogErrorType = (error: unknown) =>
@@ -74,15 +74,8 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         scope: "integrations:CRUD",
       });
       try {
-        const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
-        const isEnrichedExportAvailable = isEnrichedBlobExportAvailable(
-          isCloud,
-          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
-        );
-        // Data capability for legacy sources (see export-source-policy.ts).
-        const legacyWritesActive = areLegacyWritesActive(
-          env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
-        );
+        // Data capability for both source families (see export-source-policy.ts).
+        const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
 
         const config = await ctx.prisma.blobStorageIntegration.findFirst({
           where: {
@@ -95,8 +88,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
 
         return {
           config: config ?? null,
-          isEnrichedExportAvailable,
-          legacyWritesActive,
+          writeMode,
+          isEnrichedExportAvailable: areEnrichedWritesActive(writeMode),
+          legacyWritesActive: areLegacyWritesActive(writeMode),
         };
       } catch (e) {
         logger.error(`Failed to get blob storage integration`, e);
@@ -131,8 +125,6 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         });
 
         const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
-        const isV4PreviewEnabled =
-          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
 
         const existingIntegration =
           await ctx.prisma.blobStorageIntegration.findUnique({
@@ -156,9 +148,8 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           persistedExportSource: existingIntegration?.exportSource,
           ctx: {
             isCloud,
-            enrichedAvailable: isEnrichedBlobExportAvailable(
-              isCloud,
-              isV4PreviewEnabled,
+            enrichedAvailable: areEnrichedWritesActive(
+              env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
             ),
             legacyWritesActive: areLegacyWritesActive(
               env.LANGFUSE_MIGRATION_V4_WRITE_MODE,

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -74,9 +74,6 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         scope: "integrations:CRUD",
       });
       try {
-        // Data capability for both source families (see export-source-policy.ts).
-        const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-
         const config = await ctx.prisma.blobStorageIntegration.findFirst({
           where: {
             projectId: input.projectId,
@@ -86,11 +83,11 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           },
         });
 
+        // The client derives export-source availability from this via the
+        // shared policy helpers (see export-source-policy.ts).
         return {
           config: config ?? null,
-          writeMode,
-          isEnrichedExportAvailable: areEnrichedWritesActive(writeMode),
-          legacyWritesActive: areLegacyWritesActive(writeMode),
+          writeMode: env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
         };
       } catch (e) {
         logger.error(`Failed to get blob storage integration`, e);

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -83,8 +83,6 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           },
         });
 
-        // The client derives export-source availability from this via the
-        // shared policy helpers (see export-source-policy.ts).
         return {
           config: config ?? null,
           writeMode: env.LANGFUSE_MIGRATION_V4_WRITE_MODE,

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -6,6 +6,9 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { api } from "@/src/utils/api";
 import {
+  areEnrichedWritesActive,
+  areLegacyWritesActive,
+  type BlobExportWriteMode,
   type BlobStorageIntegration,
   type ExportSourceContext,
 } from "@langfuse/shared";
@@ -26,14 +29,12 @@ export const BlobStorageIntegrationContainer = ({
   config,
   projectId,
   isLoading,
-  isEnrichedExportAvailable,
-  legacyWritesActive,
+  writeMode,
 }: {
   config: Partial<BlobStorageIntegration> | null;
   projectId: string;
   isLoading: boolean;
-  isEnrichedExportAvailable: boolean;
-  legacyWritesActive: boolean;
+  writeMode: BlobExportWriteMode;
 }) => {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
@@ -46,8 +47,8 @@ export const BlobStorageIntegrationContainer = ({
   const exportSourceCtx: ExportSourceContext = useMemo(
     () => ({
       isCloud: isLangfuseCloud,
-      enrichedAvailable: isEnrichedExportAvailable,
-      legacyWritesActive,
+      enrichedAvailable: areEnrichedWritesActive(writeMode),
+      legacyWritesActive: areLegacyWritesActive(writeMode),
       projectCreatedAt: projectCreatedAt
         ? new Date(projectCreatedAt)
         : undefined,
@@ -55,13 +56,7 @@ export const BlobStorageIntegrationContainer = ({
         ? new Date(integrationCreatedAt)
         : null,
     }),
-    [
-      isLangfuseCloud,
-      isEnrichedExportAvailable,
-      legacyWritesActive,
-      projectCreatedAt,
-      integrationCreatedAt,
-    ],
+    [isLangfuseCloud, writeMode, projectCreatedAt, integrationCreatedAt],
   );
 
   const utils = api.useUtils();

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Button } from "@/src/components/ui/button";
-import { Skeleton } from "@/src/components/ui/skeleton";
+import { IntegrationSettingsSkeleton } from "@/src/features/analytics-integrations/components/IntegrationSettingsSkeleton";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
@@ -27,12 +27,10 @@ import { BlobStorageIntegrationForm } from "@/src/features/blobstorage-integrati
 export const BlobStorageIntegrationContainer = ({
   config,
   projectId,
-  isLoading,
   writeMode,
 }: {
   config: Partial<BlobStorageIntegration> | null;
   projectId: string;
-  isLoading: boolean;
   writeMode: BlobExportWriteMode;
 }) => {
   const capture = usePostHogClientCapture();
@@ -90,15 +88,10 @@ export const BlobStorageIntegrationContainer = ({
   });
 
   // The form is never mounted before its inputs resolve, so there is no
-  // mid-flight reset to protect a draft from.
-  if (isLoading || !project) {
-    return (
-      <div className="space-y-3">
-        <Skeleton className="h-9 w-full" />
-        <Skeleton className="h-9 w-full" />
-        <Skeleton className="h-9 w-full" />
-      </div>
-    );
+  // mid-flight reset to protect a draft from. The page already gates on the
+  // integration query; only the separate project query can still be pending.
+  if (!project) {
+    return <IntegrationSettingsSkeleton />;
   }
 
   const handleSubmit = (values: BlobStorageIntegrationFormSchema) => {

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer.tsx
@@ -6,12 +6,11 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { api } from "@/src/utils/api";
 import {
-  areEnrichedWritesActive,
-  areLegacyWritesActive,
   type BlobExportWriteMode,
   type BlobStorageIntegration,
   type ExportSourceContext,
 } from "@langfuse/shared";
+import { buildExportSourceContext } from "@/src/features/analytics-integrations/exportSource";
 import { type BlobStorageIntegrationFormSchema } from "@/src/features/blobstorage-integration/types";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -45,17 +44,17 @@ export const BlobStorageIntegrationContainer = ({
   const projectCreatedAt = project?.createdAt;
   const integrationCreatedAt = config?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () => ({
-      isCloud: isLangfuseCloud,
-      enrichedAvailable: areEnrichedWritesActive(writeMode),
-      legacyWritesActive: areLegacyWritesActive(writeMode),
-      projectCreatedAt: projectCreatedAt
-        ? new Date(projectCreatedAt)
-        : undefined,
-      integrationCreatedAt: integrationCreatedAt
-        ? new Date(integrationCreatedAt)
-        : null,
-    }),
+    () =>
+      buildExportSourceContext({
+        writeMode,
+        isCloud: isLangfuseCloud,
+        projectCreatedAt: projectCreatedAt
+          ? new Date(projectCreatedAt)
+          : undefined,
+        integrationCreatedAt: integrationCreatedAt
+          ? new Date(integrationCreatedAt)
+          : null,
+      }),
     [isLangfuseCloud, writeMode, projectCreatedAt, integrationCreatedAt],
   );
 

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -4,6 +4,7 @@ import {
   BlobStorageIntegrationType,
   InvalidRequestError,
   AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
   areLegacyWritesActive,
   validateExportSource,
   BlobStorageIntegrationFileType,
@@ -149,9 +150,8 @@ export async function upsertBlobStorageIntegration(params: {
     // Under events_only a new row must never fall back to the legacy Prisma
     // column default; force EVENTS in-transaction, deployment-agnostic
     // (see export-source-policy.ts).
-    const legacyWritesActive = areLegacyWritesActive(
-      env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
-    );
+    const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    const legacyWritesActive = areLegacyWritesActive(writeMode);
     const createExportSource =
       data.exportSource ??
       (params.forceEventsOnCreate || !legacyWritesActive
@@ -200,7 +200,7 @@ export async function upsertBlobStorageIntegration(params: {
     // transaction back. See export-source-policy.ts.
     const backstop = validateExportSource(result.exportSource, {
       isCloud: !isSelfHosted,
-      enrichedAvailable: true,
+      enrichedAvailable: areEnrichedWritesActive(writeMode),
       legacyWritesActive,
       integrationCreatedAt: params.refuseLegacyOnCreate
         ? result.createdAt

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -15,6 +15,7 @@ import { env } from "@/src/env.mjs";
 import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
   areLegacyWritesActive,
   InvalidRequestError,
   LangfuseNotFoundError,
@@ -97,13 +98,12 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         }
       }
 
-      // EVENTS is always accepted by this router, hence enrichedAvailable:
-      // true. An omitted source preserves the persisted row; on CREATE it
-      // falls back to a default that is validated like an explicit choice
-      // (LFE-9688 / LFE-10148). See export-source-policy.ts.
-      const legacyWritesActive = areLegacyWritesActive(
-        env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
-      );
+      // An omitted source preserves the persisted row; on CREATE it falls back
+      // to a default that is validated like an explicit choice. See
+      // export-source-policy.ts.
+      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+      const legacyWritesActive = areLegacyWritesActive(writeMode);
+      const enrichedAvailable = areEnrichedWritesActive(writeMode);
       const existingIntegration =
         await ctx.prisma.mixpanelIntegration.findUnique({
           where: { projectId: input.projectId },
@@ -146,7 +146,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         persistedExportSource: existingIntegration?.exportSource,
         ctx: {
           isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-          enrichedAvailable: true,
+          enrichedAvailable,
           legacyWritesActive,
           projectCreatedAt,
         },
@@ -198,7 +198,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           });
           const validation = validateExportSource(result.exportSource, {
             isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-            enrichedAvailable: true,
+            enrichedAvailable,
             legacyWritesActive,
             projectCreatedAt: project.createdAt,
           });

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -31,8 +31,6 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "integrations:CRUD",
       });
-      // The client derives export-source availability from this via the
-      // shared policy helpers (see export-source-policy.ts).
       const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
       try {
         const dbConfig = await ctx.prisma.mixpanelIntegration.findFirst({
@@ -97,9 +95,6 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         }
       }
 
-      // An omitted source preserves the persisted row; on CREATE it falls back
-      // to a default that is validated like an explicit choice. See
-      // export-source-policy.ts.
       const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
       const legacyWritesActive = areLegacyWritesActive(writeMode);
       const enrichedAvailable = areEnrichedWritesActive(writeMode);

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -31,10 +31,9 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "integrations:CRUD",
       });
-      // Data capability for legacy sources (see export-source-policy.ts).
-      const legacyWritesActive = areLegacyWritesActive(
-        env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
-      );
+      // The client derives export-source availability from this via the
+      // shared policy helpers (see export-source-policy.ts).
+      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
       try {
         const dbConfig = await ctx.prisma.mixpanelIntegration.findFirst({
           where: {
@@ -43,7 +42,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         });
 
         if (!dbConfig) {
-          return { config: null, legacyWritesActive };
+          return { config: null, writeMode };
         }
 
         const { encryptedMixpanelProjectToken, exportSource, ...config } =
@@ -58,7 +57,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
               decrypt(encryptedMixpanelProjectToken),
             ),
           },
-          legacyWritesActive,
+          writeMode,
         };
       } catch (e) {
         console.error("mixpanel integration get", e);

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -16,6 +16,7 @@ import { validateWebhookURL } from "@langfuse/shared/src/server";
 import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
   areLegacyWritesActive,
   InvalidRequestError,
   LangfuseNotFoundError,
@@ -110,13 +111,12 @@ export const posthogIntegrationRouter = createTRPCRouter({
         });
       }
 
-      // EVENTS is always accepted by this router, hence enrichedAvailable:
-      // true. An omitted source preserves the persisted row; on CREATE it
-      // falls back to a default that is validated like an explicit choice
-      // (LFE-9688 / LFE-10148). See export-source-policy.ts.
-      const legacyWritesActive = areLegacyWritesActive(
-        env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
-      );
+      // An omitted source preserves the persisted row; on CREATE it falls back
+      // to a default that is validated like an explicit choice. See
+      // export-source-policy.ts.
+      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+      const legacyWritesActive = areLegacyWritesActive(writeMode);
+      const enrichedAvailable = areEnrichedWritesActive(writeMode);
       const existingIntegration =
         await ctx.prisma.posthogIntegration.findUnique({
           where: { projectId: input.projectId },
@@ -159,7 +159,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
         persistedExportSource: existingIntegration?.exportSource,
         ctx: {
           isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-          enrichedAvailable: true,
+          enrichedAvailable,
           legacyWritesActive,
           projectCreatedAt,
         },
@@ -213,7 +213,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
           });
           const validation = validateExportSource(result.exportSource, {
             isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-            enrichedAvailable: true,
+            enrichedAvailable,
             legacyWritesActive,
             projectCreatedAt: project.createdAt,
           });

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -32,10 +32,9 @@ export const posthogIntegrationRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "integrations:CRUD",
       });
-      // Data capability for legacy sources (see export-source-policy.ts).
-      const legacyWritesActive = areLegacyWritesActive(
-        env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
-      );
+      // The client derives export-source availability from this via the
+      // shared policy helpers (see export-source-policy.ts).
+      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
       try {
         const dbConfig = await ctx.prisma.posthogIntegration.findFirst({
           where: {
@@ -44,7 +43,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
         });
 
         if (!dbConfig) {
-          return { config: null, legacyWritesActive };
+          return { config: null, writeMode };
         }
 
         const { encryptedPosthogApiKey, exportSource, ...config } = dbConfig;
@@ -58,7 +57,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
               decrypt(encryptedPosthogApiKey),
             ),
           },
-          legacyWritesActive,
+          writeMode,
         };
       } catch (e) {
         console.error("posthog integration get", e);

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -32,8 +32,6 @@ export const posthogIntegrationRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "integrations:CRUD",
       });
-      // The client derives export-source availability from this via the
-      // shared policy helpers (see export-source-policy.ts).
       const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
       try {
         const dbConfig = await ctx.prisma.posthogIntegration.findFirst({
@@ -110,9 +108,6 @@ export const posthogIntegrationRouter = createTRPCRouter({
         });
       }
 
-      // An omitted source preserves the persisted row; on CREATE it falls back
-      // to a default that is validated like an explicit choice. See
-      // export-source-policy.ts.
       const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
       const legacyWritesActive = areLegacyWritesActive(writeMode);
       const enrichedAvailable = areEnrichedWritesActive(writeMode);

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -19,8 +19,8 @@ import {
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
 import {
+  areEnrichedWritesActive,
   areLegacyWritesActive,
-  isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { env } from "@/src/env.mjs";
@@ -162,8 +162,6 @@ async function handleUpsertBlobStorageIntegration(
 
   const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
-  const isV4PreviewEnabled =
-    env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
   const internalExportSource =
     validatedData.exportSource != null
       ? toInternalExportSource(validatedData.exportSource)
@@ -185,9 +183,8 @@ async function handleUpsertBlobStorageIntegration(
     persistedExportSource: existingIntegration?.exportSource,
     ctx: {
       isCloud,
-      enrichedAvailable: isEnrichedBlobExportAvailable(
-        isCloud,
-        isV4PreviewEnabled,
+      enrichedAvailable: areEnrichedWritesActive(
+        env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
       ),
       legacyWritesActive: areLegacyWritesActive(
         env.LANGFUSE_MIGRATION_V4_WRITE_MODE,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -3,6 +3,7 @@ import ContainerPage from "@/src/components/layouts/container-page";
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
+import { Skeleton } from "@/src/components/ui/skeleton";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -106,12 +107,20 @@ export default function BlobStorageIntegrationSettings() {
         <>
           <Header title="Configuration" className="mt-8" />
           <Card className="p-3">
-            <BlobStorageIntegrationContainer
-              config={state.data?.config ?? null}
-              projectId={projectId}
-              isLoading={state.isLoading}
-              writeMode={state.data?.writeMode ?? "legacy"}
-            />
+            {!state.data ? (
+              <div className="space-y-3">
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+              </div>
+            ) : (
+              <BlobStorageIntegrationContainer
+                config={state.data.config ?? null}
+                projectId={projectId}
+                isLoading={state.isLoading}
+                writeMode={state.data.writeMode}
+              />
+            )}
           </Card>
         </>
       )}

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -110,10 +110,7 @@ export default function BlobStorageIntegrationSettings() {
               config={state.data?.config ?? null}
               projectId={projectId}
               isLoading={state.isLoading}
-              isEnrichedExportAvailable={
-                state.data?.isEnrichedExportAvailable ?? false
-              }
-              legacyWritesActive={state.data?.legacyWritesActive ?? true}
+              writeMode={state.data?.writeMode ?? "legacy"}
             />
           </Card>
         </>

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -3,7 +3,7 @@ import ContainerPage from "@/src/components/layouts/container-page";
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
-import { Skeleton } from "@/src/components/ui/skeleton";
+import { IntegrationSettingsSkeleton } from "@/src/features/analytics-integrations/components/IntegrationSettingsSkeleton";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -108,16 +108,11 @@ export default function BlobStorageIntegrationSettings() {
           <Header title="Configuration" className="mt-8" />
           <Card className="p-3">
             {!state.data ? (
-              <div className="space-y-3">
-                <Skeleton className="h-9 w-full" />
-                <Skeleton className="h-9 w-full" />
-                <Skeleton className="h-9 w-full" />
-              </div>
+              <IntegrationSettingsSkeleton />
             ) : (
               <BlobStorageIntegrationContainer
                 config={state.data.config ?? null}
                 projectId={projectId}
-                isLoading={state.isLoading}
                 writeMode={state.data.writeMode}
               />
             )}

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -35,11 +35,13 @@ import {
 import {
   AnalyticsIntegrationExportSource,
   validateExportSource,
+  type BlobExportWriteMode,
   type ExportSourceContext,
 } from "@langfuse/shared";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 // Shared export-source UI adapters; policy in export-source-policy.ts.
 import {
+  buildExportSourceContext,
   getExportSourceOptions,
   getExportSourceUnavailableMessage,
   isExportSourceSelectable,
@@ -125,7 +127,7 @@ export default function MixpanelIntegrationSettings() {
               state={state.data?.config ?? undefined}
               projectId={projectId}
               isLoading={state.isLoading}
-              legacyWritesActive={state.data?.legacyWritesActive ?? true}
+              writeMode={state.data?.writeMode ?? "legacy"}
             />
           </Card>
         </>
@@ -149,31 +151,29 @@ const MixpanelIntegrationSettingsForm = ({
   state,
   projectId,
   isLoading,
-  legacyWritesActive,
+  writeMode,
 }: {
   state?: NonNullable<RouterOutput["mixpanelIntegration"]["get"]["config"]>;
   projectId: string;
   isLoading: boolean;
-  legacyWritesActive: boolean;
+  writeMode: BlobExportWriteMode;
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { project } = useQueryProject();
 
-  // Policy context; EVENTS is always accepted by this router, hence
-  // enrichedAvailable: true (see export-source-policy.ts).
   const projectCreatedAt = project?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () => ({
-      isCloud: isLangfuseCloud,
-      enrichedAvailable: true,
-      legacyWritesActive,
-      projectCreatedAt: projectCreatedAt
-        ? new Date(projectCreatedAt)
-        : undefined,
-    }),
-    [isLangfuseCloud, legacyWritesActive, projectCreatedAt],
+    () =>
+      buildExportSourceContext({
+        writeMode,
+        isCloud: isLangfuseCloud,
+        projectCreatedAt: projectCreatedAt
+          ? new Date(projectCreatedAt)
+          : undefined,
+      }),
+    [writeMode, isLangfuseCloud, projectCreatedAt],
   );
   const legacyValidation = validateExportSource(
     AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
@@ -225,7 +225,7 @@ const MixpanelIntegrationSettingsForm = ({
   const defaultExportSource = isPostCutoffCloud
     ? AnalyticsIntegrationExportSource.EVENTS
     : (state?.exportSource ??
-      (isBetaEnabled || !legacyWritesActive
+      (isBetaEnabled || !exportSourceCtx.legacyWritesActive
         ? AnalyticsIntegrationExportSource.EVENTS
         : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
 

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -55,7 +55,7 @@ import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Card } from "@/src/components/ui/card";
-import { Skeleton } from "@/src/components/ui/skeleton";
+import { IntegrationSettingsSkeleton } from "@/src/features/analytics-integrations/components/IntegrationSettingsSkeleton";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
@@ -127,11 +127,7 @@ export default function MixpanelIntegrationSettings() {
           <Card className="p-3">
             <MixpanelLogo className="text-foreground mb-4 w-20" />
             {!state.data || !project ? (
-              <div className="space-y-3">
-                <Skeleton className="h-9 w-full" />
-                <Skeleton className="h-9 w-full" />
-                <Skeleton className="h-9 w-full" />
-              </div>
+              <IntegrationSettingsSkeleton />
             ) : (
               <MixpanelIntegrationSettingsForm
                 // Draft lifetime = entity identity, so background refetches
@@ -140,7 +136,7 @@ export default function MixpanelIntegrationSettings() {
                 state={state.data.config ?? undefined}
                 projectId={projectId}
                 writeMode={state.data.writeMode}
-                projectCreatedAt={new Date(project.createdAt)}
+                projectCreatedAt={project.createdAt}
               />
             )}
           </Card>
@@ -170,7 +166,9 @@ const MixpanelIntegrationSettingsForm = ({
   state?: NonNullable<RouterOutput["mixpanelIntegration"]["get"]["config"]>;
   projectId: string;
   writeMode: BlobExportWriteMode;
-  projectCreatedAt: Date;
+  // Raw ISO string, not a Date: a Date built in the parent's JSX would be a new
+  // reference on every render and would defeat the memo below.
+  projectCreatedAt: string;
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
@@ -180,7 +178,7 @@ const MixpanelIntegrationSettingsForm = ({
       buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
-        projectCreatedAt,
+        projectCreatedAt: new Date(projectCreatedAt),
       }),
     [writeMode, isLangfuseCloud, projectCreatedAt],
   );

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -55,9 +55,10 @@ import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Card } from "@/src/components/ui/card";
+import { Skeleton } from "@/src/components/ui/skeleton";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { type z } from "zod";
 import { Info, ExternalLink } from "lucide-react";
@@ -76,6 +77,8 @@ export default function MixpanelIntegrationSettings() {
       enabled: hasAccess,
     },
   );
+
+  const { project } = useQueryProject();
 
   const status =
     state.isLoading || !hasAccess
@@ -123,12 +126,23 @@ export default function MixpanelIntegrationSettings() {
           <Header title="Configuration" />
           <Card className="p-3">
             <MixpanelLogo className="text-foreground mb-4 w-20" />
-            <MixpanelIntegrationSettingsForm
-              state={state.data?.config ?? undefined}
-              projectId={projectId}
-              isLoading={state.isLoading}
-              writeMode={state.data?.writeMode ?? "legacy"}
-            />
+            {!state.data || !project ? (
+              <div className="space-y-3">
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+              </div>
+            ) : (
+              <MixpanelIntegrationSettingsForm
+                // Draft lifetime = entity identity, so background refetches
+                // cannot reset a draft in progress.
+                key={`${projectId}:${state.data.config ? "configured" : "new"}`}
+                state={state.data.config ?? undefined}
+                projectId={projectId}
+                writeMode={state.data.writeMode}
+                projectCreatedAt={new Date(project.createdAt)}
+              />
+            )}
           </Card>
         </>
       )}
@@ -150,28 +164,23 @@ export default function MixpanelIntegrationSettings() {
 const MixpanelIntegrationSettingsForm = ({
   state,
   projectId,
-  isLoading,
   writeMode,
+  projectCreatedAt,
 }: {
   state?: NonNullable<RouterOutput["mixpanelIntegration"]["get"]["config"]>;
   projectId: string;
-  isLoading: boolean;
   writeMode: BlobExportWriteMode;
+  projectCreatedAt: Date;
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
-  const { project } = useQueryProject();
-
-  const projectCreatedAt = project?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
     () =>
       buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
-        projectCreatedAt: projectCreatedAt
-          ? new Date(projectCreatedAt)
-          : undefined,
+        projectCreatedAt,
       }),
     [writeMode, isLangfuseCloud, projectCreatedAt],
   );
@@ -239,20 +248,7 @@ const MixpanelIntegrationSettingsForm = ({
       enabled: state?.enabled ?? false,
       exportSource: defaultExportSource,
     },
-    disabled: isLoading,
   });
-
-  useEffect(() => {
-    mixpanelForm.reset({
-      mixpanelRegion:
-        (state?.mixpanelRegion as MixpanelRegion) ??
-        MIXPANEL_REGIONS[0].subdomain,
-      mixpanelProjectToken: "",
-      enabled: state?.enabled ?? false,
-      exportSource: defaultExportSource,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
 
   const watchedExportSource = mixpanelForm.watch("exportSource");
   const watchedValidation =
@@ -437,14 +433,13 @@ const MixpanelIntegrationSettingsForm = ({
         <Button
           loading={mut.isPending}
           onClick={mixpanelForm.handleSubmit(onSubmit)}
-          disabled={isLoading}
         >
           Save
         </Button>
         <Button
           variant="ghost"
           loading={mutDelete.isPending}
-          disabled={isLoading || !!!state}
+          disabled={!state}
           onClick={() => {
             if (
               confirm(

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -53,7 +53,7 @@ import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Card } from "@/src/components/ui/card";
-import { Skeleton } from "@/src/components/ui/skeleton";
+import { IntegrationSettingsSkeleton } from "@/src/features/analytics-integrations/components/IntegrationSettingsSkeleton";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
@@ -129,11 +129,7 @@ export default function PosthogIntegrationSettings() {
           <Card className="p-3">
             <PostHogLogo className="text-foreground mb-4 w-36" />
             {!state.data || !project ? (
-              <div className="space-y-3">
-                <Skeleton className="h-9 w-full" />
-                <Skeleton className="h-9 w-full" />
-                <Skeleton className="h-9 w-full" />
-              </div>
+              <IntegrationSettingsSkeleton />
             ) : (
               <PostHogIntegrationSettings
                 // Draft lifetime = entity identity, so background refetches
@@ -142,7 +138,7 @@ export default function PosthogIntegrationSettings() {
                 state={state.data.config ?? undefined}
                 projectId={projectId}
                 writeMode={state.data.writeMode}
-                projectCreatedAt={new Date(project.createdAt)}
+                projectCreatedAt={project.createdAt}
               />
             )}
           </Card>
@@ -164,7 +160,9 @@ const PostHogIntegrationSettings = ({
   state?: NonNullable<RouterOutput["posthogIntegration"]["get"]["config"]>;
   projectId: string;
   writeMode: BlobExportWriteMode;
-  projectCreatedAt: Date;
+  // Raw ISO string, not a Date: a Date built in the parent's JSX would be a new
+  // reference on every render and would defeat the memo below.
+  projectCreatedAt: string;
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
@@ -174,7 +172,7 @@ const PostHogIntegrationSettings = ({
       buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
-        projectCreatedAt,
+        projectCreatedAt: new Date(projectCreatedAt),
       }),
     [writeMode, isLangfuseCloud, projectCreatedAt],
   );

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -53,9 +53,10 @@ import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Card } from "@/src/components/ui/card";
+import { Skeleton } from "@/src/components/ui/skeleton";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { type z } from "zod";
 import { Info, ExternalLink } from "lucide-react";
@@ -74,6 +75,8 @@ export default function PosthogIntegrationSettings() {
       enabled: hasAccess,
     },
   );
+
+  const { project } = useQueryProject();
 
   // A persisted fault outranks active/inactive: it is the state the admin has
   // to act on, and it is cleared by the next successful sync.
@@ -125,12 +128,23 @@ export default function PosthogIntegrationSettings() {
           <Header title="Configuration" />
           <Card className="p-3">
             <PostHogLogo className="text-foreground mb-4 w-36" />
-            <PostHogIntegrationSettings
-              state={state.data?.config ?? undefined}
-              projectId={projectId}
-              isLoading={state.isLoading}
-              writeMode={state.data?.writeMode ?? "legacy"}
-            />
+            {!state.data || !project ? (
+              <div className="space-y-3">
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+              </div>
+            ) : (
+              <PostHogIntegrationSettings
+                // Draft lifetime = entity identity, so background refetches
+                // cannot reset a draft in progress.
+                key={`${projectId}:${state.data.config ? "configured" : "new"}`}
+                state={state.data.config ?? undefined}
+                projectId={projectId}
+                writeMode={state.data.writeMode}
+                projectCreatedAt={new Date(project.createdAt)}
+              />
+            )}
           </Card>
         </>
       )}
@@ -144,28 +158,23 @@ export default function PosthogIntegrationSettings() {
 const PostHogIntegrationSettings = ({
   state,
   projectId,
-  isLoading,
   writeMode,
+  projectCreatedAt,
 }: {
   state?: NonNullable<RouterOutput["posthogIntegration"]["get"]["config"]>;
   projectId: string;
-  isLoading: boolean;
   writeMode: BlobExportWriteMode;
+  projectCreatedAt: Date;
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
-  const { project } = useQueryProject();
-
-  const projectCreatedAt = project?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
     () =>
       buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
-        projectCreatedAt: projectCreatedAt
-          ? new Date(projectCreatedAt)
-          : undefined,
+        projectCreatedAt,
       }),
     [writeMode, isLangfuseCloud, projectCreatedAt],
   );
@@ -231,18 +240,7 @@ const PostHogIntegrationSettings = ({
       enabled: state?.enabled ?? false,
       exportSource: defaultExportSource,
     },
-    disabled: isLoading,
   });
-
-  useEffect(() => {
-    posthogForm.reset({
-      posthogHostname: state?.posthogHostName ?? "",
-      posthogProjectApiKey: "",
-      enabled: state?.enabled ?? false,
-      exportSource: defaultExportSource,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
 
   const watchedExportSource = posthogForm.watch("exportSource");
   const watchedValidation =
@@ -414,14 +412,13 @@ const PostHogIntegrationSettings = ({
         <Button
           loading={mut.isPending}
           onClick={posthogForm.handleSubmit(onSubmit)}
-          disabled={isLoading}
         >
           Save
         </Button>
         <Button
           variant="ghost"
           loading={mutDelete.isPending}
-          disabled={isLoading || !!!state}
+          disabled={!state}
           onClick={() => {
             if (
               confirm(

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -33,11 +33,13 @@ import { PostHogStatusSection } from "@/src/features/posthog-integration/compone
 import {
   AnalyticsIntegrationExportSource,
   validateExportSource,
+  type BlobExportWriteMode,
   type ExportSourceContext,
 } from "@langfuse/shared";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 // Shared export-source UI adapters; policy in export-source-policy.ts.
 import {
+  buildExportSourceContext,
   getExportSourceOptions,
   getExportSourceUnavailableMessage,
   isExportSourceSelectable,
@@ -127,7 +129,7 @@ export default function PosthogIntegrationSettings() {
               state={state.data?.config ?? undefined}
               projectId={projectId}
               isLoading={state.isLoading}
-              legacyWritesActive={state.data?.legacyWritesActive ?? true}
+              writeMode={state.data?.writeMode ?? "legacy"}
             />
           </Card>
         </>
@@ -143,31 +145,29 @@ const PostHogIntegrationSettings = ({
   state,
   projectId,
   isLoading,
-  legacyWritesActive,
+  writeMode,
 }: {
   state?: NonNullable<RouterOutput["posthogIntegration"]["get"]["config"]>;
   projectId: string;
   isLoading: boolean;
-  legacyWritesActive: boolean;
+  writeMode: BlobExportWriteMode;
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { project } = useQueryProject();
 
-  // Policy context; EVENTS is always accepted by this router, hence
-  // enrichedAvailable: true (see export-source-policy.ts).
   const projectCreatedAt = project?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () => ({
-      isCloud: isLangfuseCloud,
-      enrichedAvailable: true,
-      legacyWritesActive,
-      projectCreatedAt: projectCreatedAt
-        ? new Date(projectCreatedAt)
-        : undefined,
-    }),
-    [isLangfuseCloud, legacyWritesActive, projectCreatedAt],
+    () =>
+      buildExportSourceContext({
+        writeMode,
+        isCloud: isLangfuseCloud,
+        projectCreatedAt: projectCreatedAt
+          ? new Date(projectCreatedAt)
+          : undefined,
+      }),
+    [writeMode, isLangfuseCloud, projectCreatedAt],
   );
   const legacyValidation = validateExportSource(
     AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
@@ -219,7 +219,7 @@ const PostHogIntegrationSettings = ({
   const defaultExportSource = isPostCutoffCloud
     ? AnalyticsIntegrationExportSource.EVENTS
     : (state?.exportSource ??
-      (isBetaEnabled || !legacyWritesActive
+      (isBetaEnabled || !exportSourceCtx.legacyWritesActive
         ? AnalyticsIntegrationExportSource.EVENTS
         : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
 

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -132,19 +132,18 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     s3Prefix = null;
   });
 
-  // LFE-10296: a persisted enriched export source on a deployment without the
-  // enriched export path (e.g. after a V4-preview rollback) must fail the job
-  // loudly instead of silently exporting from unpopulated tables.
+  // A persisted enriched export source on a deployment that does not write the
+  // v4 events table must fail the job loudly instead of silently exporting
+  // from unpopulated tables.
   describe("enriched export source guard", () => {
-    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
 
     afterEach(() => {
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
-        originalV4Preview;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
     });
 
-    it("fails the job and persists lastError when the enriched export path is unavailable", async () => {
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+    it("fails the job and persists lastError when an enriched source runs on legacy", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { projectId } = await createOrgProjectAndApiKey();
       s3Prefix = projectId;
 
@@ -242,11 +241,10 @@ describe("BlobStorageIntegrationProcessingJob", () => {
   // After BullMQ exhausts its retries, a customer-fault error disables the
   // integration; everything else keeps retrying as before.
   describe("customer-fault disable", () => {
-    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
 
     afterEach(() => {
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
-        originalV4Preview;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
     });
 
     // Minimal AWS SDK v3 S3 AccessDenied shape (high-confidence customer fault).
@@ -337,9 +335,9 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     });
 
     it("does not disable on the final attempt of a non-customer-fault ('other') error", async () => {
-      // Enriched source + V4 preview off => the guard throws a plain Error,
-      // which the classifier treats as "other".
-      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      // Enriched source on the legacy write mode => the guard throws a plain
+      // Error, which the classifier treats as "other".
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
       const { projectId } = await createOrgProjectAndApiKey();
       s3Prefix = projectId;
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -60,8 +60,6 @@ import {
   BlobStorageExportMode,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
-  isEnrichedBlobExportAvailable,
-  isEnrichedBlobExportSource,
   isLegacyBlobExportSource,
   isLegacyBlobExporter,
   resolveBlobExportTuning,
@@ -72,7 +70,7 @@ import { decrypt } from "@langfuse/shared/encryption";
 import { env as sharedEnv } from "@langfuse/shared/src/env";
 import { randomUUID } from "crypto";
 import { SpanKind } from "@opentelemetry/api";
-import { env, v4AllowPreviewOptIn } from "../../env";
+import { env } from "../../env";
 import { assertExportSourceWritable } from "../exportWriteModeGuard";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
 import {
@@ -1267,27 +1265,13 @@ export const handleBlobStorageIntegrationProjectJob = async (
     return;
   }
 
-  // Legacy-source deprecation is a Cloud policy (see blob-export-gate.ts:
-  // isLegacyBlobExportAllowed / isLegacyBlobExporter both exempt self-hosted),
-  // so the deprecation notice below is Cloud-only too.
+  // Legacy-source deprecation is a Cloud policy (isLegacyBlobExporter exempts
+  // self-hosted), so the deprecation notice below is Cloud-only too.
   const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
   try {
-    // Fail loudly rather than export from unpopulated tables when an enriched
-    // source survives on a deployment without the enriched path, e.g. after a
-    // V4-preview rollback. The catch persists lastError and notifies admins
-    // (LFE-10296).
-    if (
-      isEnrichedBlobExportSource(blobStorageIntegration.exportSource) &&
-      !isEnrichedBlobExportAvailable(isCloud, v4AllowPreviewOptIn(env))
-    ) {
-      throw new Error(
-        "The configured export source includes enriched observations, but enriched export is not available on this deployment. Select a different export source in the blob storage integration settings, or re-enable enriched export (V4 preview opt-in) on this deployment.",
-      );
-    }
-
-    // Write-mode guard, both directions (LFE-10148, LFE-11009); the catch
-    // persists lastError and notifies admins.
+    // Write-mode guard, both directions; the catch persists lastError and
+    // notifies admins.
     assertExportSourceWritable(
       blobStorageIntegration.exportSource,
       "Select the enriched export source (OBSERVATIONS_V2) in the blob storage integration settings.",

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1270,8 +1270,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
   const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
   try {
-    // Write-mode guard, both directions; the catch persists lastError and
-    // notifies admins.
+    // The catch persists lastError and notifies admins.
     assertExportSourceWritable(
       blobStorageIntegration.exportSource,
       "Select the enriched export source (OBSERVATIONS_V2) in the blob storage integration settings.",

--- a/worker/src/features/exportWriteModeGuard.ts
+++ b/worker/src/features/exportWriteModeGuard.ts
@@ -1,9 +1,10 @@
 import {
+  areEnrichedWritesActive,
   areLegacyWritesActive,
   validateExportSource,
   type AnalyticsIntegrationExportSource,
 } from "@langfuse/shared";
-import { env, v4WritesToEventsTable } from "../env";
+import { env } from "../env";
 
 /**
  * Write-mode guard for the export workers (blob storage, PostHog, Mixpanel);
@@ -22,7 +23,9 @@ export function assertExportSourceWritable(
   const validation = validateExportSource(exportSource, {
     // No dates: the Cloud cutoffs gate writes, not running exports.
     isCloud: false,
-    enrichedAvailable: v4WritesToEventsTable(env),
+    enrichedAvailable: areEnrichedWritesActive(
+      env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
+    ),
     legacyWritesActive: areLegacyWritesActive(
       env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
     ),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16093.preview.langfuse.com](https://pr-16093.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Export-source availability was decided in several places from several inputs. The PostHog and Mixpanel settings pages hardcoded `enrichedAvailable: true`, asserting the enriched events tables are always readable — so on a deployment that does not write them, the pages offered an export source the exporter cannot serve.

This derives availability from the one thing that actually determines it: the deployment's v4 write mode.

- `areEnrichedWritesActive` joins `areLegacyWritesActive` in the shared policy, so "is this source's data being written" has a single definition.
- Both analytics `get` procedures return the raw write mode instead of a pre-derived `legacyWritesActive` boolean, and every settings page builds its policy context through one `buildExportSourceContext`.
- The blob storage PUT endpoint, the worker's export guard, and the in-transaction race backstops all read from the same predicate rather than their own copies.
- The blocked-save alert for an unavailable enriched source pointed operators at the V4 preview opt-in, which no longer governs availability. It now names the setting that does.

**The per-user V4 beta gate is deliberately left in place here.** It is a policy decision with Cloud-visible consequences, so it is split into the stacked PR on top of this one and can be reviewed and accepted separately. This PR is the mechanical half.

### Also fixed: forms could mount before their inputs resolved

The write mode, the project and the integration row all arrive asynchronously, while `useForm` captures `defaultValues` once at first render. The pages fell back to a fabricated context (`?? true`, and an `isLoading`-only gate that lets a query *error* through with `data === undefined`), so a draft could be seeded from a value the deployment never had.

All three pages now render a skeleton until every input has resolved and mount the form keyed on entity identity, so background refetches cannot reset a draft in progress. This was latent before this PR and is fixed here because the following PR removes the synchronous session value that happened to mask it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

Behaviour changes only where the previous code was factually wrong: a deployment that does not write the enriched tables no longer offers enriched export sources.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Reviewing this

Roughly 60% of the diff is tests. Production code is a net reduction.

The served OpenAPI spec (`web/public/generated/api/openapi.yml`) is regenerated with `fern-api export`, not hand-edited. Note that nothing in CI runs that export, so the tracked spec can drift from its Fern source independently of this PR.

## Verification

- `pnpm turbo run typecheck lint` — 9 successful, 9 total
- `pnpm --filter web run test-client` — 3269 passed, 51 skipped
- `pnpm --filter @langfuse/shared run test` — 913 passed, 2 skipped

Server tests that assert REST behaviour under a specific write mode and region cannot be exercised locally; those are left to CI.
