### PR TITLE
fix(web): pin new Cloud analytics integrations to the enriched export source

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -70,6 +70,9 @@ NEXT_PUBLIC_LANGFUSE_CLOUD_REGION="DEV"
 # Same, for the integration-level cutoff applied to the blob storage
 # integration row's creation date instead of the project's.
 # NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF=
+# Same, for the integration-level cutoff applied to the PostHog/Mixpanel
+# integration row's creation date.
+# NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF=
 
 # Langfuse experimental features
 LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES="false"

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -37,6 +37,8 @@ const EnvSchema = z.object({
   NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
   // Same, for the integration-level cutoff (BlobStorageIntegration.createdAt).
   NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF: z.iso.datetime().optional(),
+  // Same, for the integration-level cutoff applied to PostHog/Mixpanel rows.
+  NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF: z.iso.datetime().optional(),
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
@@ -7,6 +7,7 @@ import {
   getAvailableExportSources,
   isEnrichedBlobExportSource,
   isLegacyBlobExportSource,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   LEGACY_BLOB_EXPORT_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
   validateExportSource,
@@ -174,13 +175,26 @@ describe("validateExportSource matrix", () => {
 // PostHog) get a later one. The policy takes it from the context so both
 // families share one implementation.
 describe("exporterCutoff parameterization", () => {
-  // Spec dates, written literally so these behaviour tests do not depend on
-  // the constant existing yet; the constants test below pins the exports.
-  const ANALYTICS_CUTOFF = new Date("2026-08-15T00:00:00.000Z");
-  // Deliberately between the two cutoffs: past blob's 2026-06-22, before
-  // analytics' 2026-08-15. Any assertion using it distinguishes "the context's
-  // cutoff was honoured" from "the blob default was hard-coded".
-  const ROW_BETWEEN_CUTOFFS = new Date("2026-07-01T00:00:00.000Z");
+  // Every date is derived from a cutoff constant, never written literally: both
+  // constants are overridable via NEXT_PUBLIC_LANGFUSE_*_CUTOFF for local
+  // testing, and this branch documents those overrides in .env.dev.example. A
+  // literal would turn a supported override into a suite failure.
+  const ANALYTICS_ROW_PRE = new Date(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+  );
+  const ANALYTICS_ROW_AT = LEGACY_ANALYTICS_EXPORTER_CUTOFF;
+  const ANALYTICS_ROW_POST = new Date(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+  );
+  // For the absent-vs-supplied contrast, both dates hang off the blob cutoff so
+  // the comparison holds whatever the two constants are set to: the row is one
+  // day past the blob boundary, and the supplied cutoff is far beyond it.
+  const ROW_JUST_PAST_BLOB_CUTOFF = new Date(
+    LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+  );
+  const CUTOFF_WELL_PAST_BLOB = new Date(
+    LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + 60 * MS_PER_DAY,
+  );
 
   type Ctx = ExportSourceContext & { exporterCutoff?: Date };
 
@@ -199,33 +213,33 @@ describe("exporterCutoff parameterization", () => {
     expect(
       reasonOf(
         "TRACES_OBSERVATIONS",
-        cloud({ integrationCreatedAt: ROW_BETWEEN_CUTOFFS }),
+        cloud({ integrationCreatedAt: ROW_JUST_PAST_BLOB_CUTOFF }),
       ),
     ).toBe("cloud-cutoff");
-    // Analytics call sites pass the later cutoff, so the same row is still
-    // grandfathered.
+    // A later supplied cutoff grandfathers the very same row.
     expect(
       reasonOf(
         "TRACES_OBSERVATIONS",
         cloud({
-          integrationCreatedAt: ROW_BETWEEN_CUTOFFS,
-          exporterCutoff: ANALYTICS_CUTOFF,
+          integrationCreatedAt: ROW_JUST_PAST_BLOB_CUTOFF,
+          exporterCutoff: CUTOFF_WELL_PAST_BLOB,
         }),
       ),
     ).toBeUndefined();
   });
 
-  it("the supplied cutoff keeps >= semantics on the row's creation date", () => {
+  it("the analytics cutoff keeps >= semantics on the row's creation date", () => {
     const at = (integrationCreatedAt: Date) =>
       reasonOf(
         "TRACES_OBSERVATIONS",
-        cloud({ integrationCreatedAt, exporterCutoff: ANALYTICS_CUTOFF }),
+        cloud({
+          integrationCreatedAt,
+          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+        }),
       );
-    expect(at(new Date(ANALYTICS_CUTOFF.getTime() - 1))).toBeUndefined();
-    expect(at(ANALYTICS_CUTOFF)).toBe("cloud-cutoff");
-    expect(at(new Date(ANALYTICS_CUTOFF.getTime() + MS_PER_DAY))).toBe(
-      "cloud-cutoff",
-    );
+    expect(at(ANALYTICS_ROW_PRE)).toBeUndefined();
+    expect(at(ANALYTICS_ROW_AT)).toBe("cloud-cutoff");
+    expect(at(ANALYTICS_ROW_POST)).toBe("cloud-cutoff");
   });
 
   it("a brand-new Cloud row (null createdAt) is pinned to enriched even before the cutoff date passes", () => {
@@ -233,7 +247,7 @@ describe("exporterCutoff parameterization", () => {
     // new-customer rules, it is not a date comparison.
     const brandNew = cloud({
       integrationCreatedAt: null,
-      exporterCutoff: ANALYTICS_CUTOFF,
+      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
     });
     expect(reasonOf("TRACES_OBSERVATIONS", brandNew)).toBe("cloud-cutoff");
     expect(reasonOf("TRACES_OBSERVATIONS_EVENTS", brandNew)).toBe(
@@ -249,7 +263,7 @@ describe("exporterCutoff parameterization", () => {
         enrichedAvailable: true,
         legacyWritesActive: true,
         integrationCreatedAt: null,
-        exporterCutoff: ANALYTICS_CUTOFF,
+        exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
       } as Ctx),
     ).toBeUndefined();
   });
@@ -259,7 +273,7 @@ describe("exporterCutoff parameterization", () => {
       getAvailableExportSources(
         cloud({
           integrationCreatedAt: null,
-          exporterCutoff: ANALYTICS_CUTOFF,
+          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
         }),
       ),
     ).toEqual([
@@ -269,19 +283,18 @@ describe("exporterCutoff parameterization", () => {
     ]);
   });
 
-  it("exports both cutoff constants; the blob one is unchanged", () => {
-    // Moving LEGACY_BLOB_EXPORTER_CUTOFF instead of adding a second constant
-    // would silently re-open legacy sources for blob rows created between the
-    // two dates, so both values are pinned.
-    expect(LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()).toBe(
-      "2026-06-22T00:00:00.000Z",
+  it("exports the analytics cutoff as its own valid constant, separate from the blob one", () => {
+    // The value is deliberately NOT pinned: both constants are overridable for
+    // local testing, so asserting an ISO string here would fail on a supported
+    // override rather than on a regression. What must hold is that the analytics
+    // cutoff is a real, separately-held Date — repurposing the blob constant
+    // instead of adding one would silently move the blob boundary.
+    expect(LEGACY_ANALYTICS_EXPORTER_CUTOFF).toBeInstanceOf(Date);
+    expect(Number.isNaN(LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime())).toBe(
+      false,
     );
-    const analyticsCutoff = (exportSourcePolicy as unknown as Record<string, unknown>)
-      .LEGACY_ANALYTICS_EXPORTER_CUTOFF;
-    expect(analyticsCutoff).toBeInstanceOf(Date);
-    expect((analyticsCutoff as Date | undefined)?.toISOString()).toBe(
-      ANALYTICS_CUTOFF.toISOString(),
-    );
+    expect(LEGACY_BLOB_EXPORTER_CUTOFF).toBeInstanceOf(Date);
+    expect(Number.isNaN(LEGACY_BLOB_EXPORTER_CUTOFF.getTime())).toBe(false);
   });
 });
 

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
@@ -169,6 +169,122 @@ describe("validateExportSource matrix", () => {
   });
 });
 
+// The integration-level ("exporter") cutoff is per-integration-kind: blob
+// storage keeps its own date, product-analytics integrations (Mixpanel,
+// PostHog) get a later one. The policy takes it from the context so both
+// families share one implementation.
+describe("exporterCutoff parameterization", () => {
+  // Spec dates, written literally so these behaviour tests do not depend on
+  // the constant existing yet; the constants test below pins the exports.
+  const ANALYTICS_CUTOFF = new Date("2026-08-15T00:00:00.000Z");
+  // Deliberately between the two cutoffs: past blob's 2026-06-22, before
+  // analytics' 2026-08-15. Any assertion using it distinguishes "the context's
+  // cutoff was honoured" from "the blob default was hard-coded".
+  const ROW_BETWEEN_CUTOFFS = new Date("2026-07-01T00:00:00.000Z");
+
+  type Ctx = ExportSourceContext & { exporterCutoff?: Date };
+
+  // projectCreatedAt is pinned pre-project-cutoff throughout so the only Cloud
+  // gate in play is the integration-level one.
+  const cloud = (over: Partial<Ctx>): Ctx => ({
+    isCloud: true,
+    enrichedAvailable: true,
+    legacyWritesActive: true,
+    projectCreatedAt: PROJECT_PRE,
+    ...over,
+  });
+
+  it("absent exporterCutoff keeps the blob constant as the boundary; supplying one moves it", () => {
+    // Blob call sites pass no exporterCutoff and must be unaffected.
+    expect(
+      reasonOf(
+        "TRACES_OBSERVATIONS",
+        cloud({ integrationCreatedAt: ROW_BETWEEN_CUTOFFS }),
+      ),
+    ).toBe("cloud-cutoff");
+    // Analytics call sites pass the later cutoff, so the same row is still
+    // grandfathered.
+    expect(
+      reasonOf(
+        "TRACES_OBSERVATIONS",
+        cloud({
+          integrationCreatedAt: ROW_BETWEEN_CUTOFFS,
+          exporterCutoff: ANALYTICS_CUTOFF,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("the supplied cutoff keeps >= semantics on the row's creation date", () => {
+    const at = (integrationCreatedAt: Date) =>
+      reasonOf(
+        "TRACES_OBSERVATIONS",
+        cloud({ integrationCreatedAt, exporterCutoff: ANALYTICS_CUTOFF }),
+      );
+    expect(at(new Date(ANALYTICS_CUTOFF.getTime() - 1))).toBeUndefined();
+    expect(at(ANALYTICS_CUTOFF)).toBe("cloud-cutoff");
+    expect(at(new Date(ANALYTICS_CUTOFF.getTime() + MS_PER_DAY))).toBe(
+      "cloud-cutoff",
+    );
+  });
+
+  it("a brand-new Cloud row (null createdAt) is pinned to enriched even before the cutoff date passes", () => {
+    // Create pins regardless of wall-clock: "no existing row" follows
+    // new-customer rules, it is not a date comparison.
+    const brandNew = cloud({
+      integrationCreatedAt: null,
+      exporterCutoff: ANALYTICS_CUTOFF,
+    });
+    expect(reasonOf("TRACES_OBSERVATIONS", brandNew)).toBe("cloud-cutoff");
+    expect(reasonOf("TRACES_OBSERVATIONS_EVENTS", brandNew)).toBe(
+      "cloud-cutoff",
+    );
+    expect(reasonOf("EVENTS", brandNew)).toBeUndefined();
+  });
+
+  it("self-hosted ignores exporterCutoff entirely", () => {
+    expect(
+      reasonOf("TRACES_OBSERVATIONS", {
+        isCloud: false,
+        enrichedAvailable: true,
+        legacyWritesActive: true,
+        integrationCreatedAt: null,
+        exporterCutoff: ANALYTICS_CUTOFF,
+      } as Ctx),
+    ).toBeUndefined();
+  });
+
+  it("leaves EVENTS as the only selectable source for a brand-new Cloud analytics integration", () => {
+    expect(
+      getAvailableExportSources(
+        cloud({
+          integrationCreatedAt: null,
+          exporterCutoff: ANALYTICS_CUTOFF,
+        }),
+      ),
+    ).toEqual([
+      { source: "TRACES_OBSERVATIONS", blockedReason: "cloud-cutoff" },
+      { source: "TRACES_OBSERVATIONS_EVENTS", blockedReason: "cloud-cutoff" },
+      { source: "EVENTS" },
+    ]);
+  });
+
+  it("exports both cutoff constants; the blob one is unchanged", () => {
+    // Moving LEGACY_BLOB_EXPORTER_CUTOFF instead of adding a second constant
+    // would silently re-open legacy sources for blob rows created between the
+    // two dates, so both values are pinned.
+    expect(LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()).toBe(
+      "2026-06-22T00:00:00.000Z",
+    );
+    const analyticsCutoff = (exportSourcePolicy as unknown as Record<string, unknown>)
+      .LEGACY_ANALYTICS_EXPORTER_CUTOFF;
+    expect(analyticsCutoff).toBeInstanceOf(Date);
+    expect((analyticsCutoff as Date | undefined)?.toISOString()).toBe(
+      ANALYTICS_CUTOFF.toISOString(),
+    );
+  });
+});
+
 describe("getAvailableExportSources", () => {
   it("returns all sources in UI order with per-source reasons", () => {
     const sources = getAvailableExportSources(

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.ts
@@ -9,8 +9,8 @@
 // The reasoning, in one place:
 //
 // - CLOUD DATE CUTOFFS ("cloud-cutoff"): Cloud projects created on or after
-//   LEGACY_BLOB_EXPORT_CUTOFF, and Cloud blob storage integration rows created
-//   on or after LEGACY_BLOB_EXPORTER_CUTOFF (including brand-new rows), cannot
+//   LEGACY_BLOB_EXPORT_CUTOFF, and Cloud integration rows created on or after
+//   their family's exporter cutoff (including brand-new rows), cannot
 //   use legacy export sources. These cutoffs are Cloud-only by design,
 //   permanently: their dates are arbitrary from a self-hosted operator's
 //   perspective (LFE-10065, LFE-10148). They apply to newly chosen values
@@ -46,8 +46,8 @@
 
 import { AnalyticsIntegrationExportSource } from "@prisma/client";
 
-// NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF / _EXPORTER_CUTOFF override the
-// defaults for local dev testing.
+// NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF / _BLOB_EXPORTER_CUTOFF /
+// _ANALYTICS_EXPORTER_CUTOFF override the defaults for local dev testing.
 const _override = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
   ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
   : null;
@@ -63,6 +63,15 @@ export const LEGACY_BLOB_EXPORTER_CUTOFF =
   _exporterOverride && !isNaN(_exporterOverride.getTime())
     ? _exporterOverride
     : new Date("2026-06-22T00:00:00.000Z");
+
+const _analyticsExporterOverride = process.env
+  .NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF
+  ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF)
+  : null;
+export const LEGACY_ANALYTICS_EXPORTER_CUTOFF =
+  _analyticsExporterOverride && !isNaN(_analyticsExporterOverride.getTime())
+    ? _analyticsExporterOverride
+    : new Date("2026-08-15T00:00:00.000Z");
 
 // satisfies ensures each element remains a valid enum member — catches renames
 // at compile time. A new enum variant does NOT automatically error here; the
@@ -107,8 +116,8 @@ export function isLegacyBlobExportSource(
 }
 
 /**
- * Whether a blob storage integration row counts as legacy — i.e. may still use
- * legacy export sources. Applied to `BlobStorageIntegration.createdAt`.
+ * Whether an integration row counts as legacy — i.e. may still use legacy
+ * export sources. Applied to the integration row's `createdAt`.
  *
  * - `!isCloud` → `true`: self-hosted is exempt (cutoff does not apply).
  * - `null` createdAt → `false`: no existing row means a brand-new integration,
@@ -122,10 +131,11 @@ export function isLegacyBlobExportSource(
 export function isLegacyBlobExporter(
   integrationCreatedAt: Date | null,
   isCloud: boolean,
+  exporterCutoff: Date = LEGACY_BLOB_EXPORTER_CUTOFF,
 ): boolean {
   if (!isCloud) return true;
   if (integrationCreatedAt == null) return false;
-  return integrationCreatedAt < LEGACY_BLOB_EXPORTER_CUTOFF;
+  return integrationCreatedAt < exporterCutoff;
 }
 
 /**
@@ -152,9 +162,10 @@ export function areEnrichedWritesActive(
  * skip their check when absent:
  * - projectCreatedAt: omit to skip the project-level Cloud cutoff (e.g. when
  *   the caller has no project in scope).
- * - integrationCreatedAt: omit to skip the integration-level Cloud cutoff
- *   (PostHog/Mixpanel have no such cutoff); pass null for "no existing row",
- *   which follows new-customer rules on Cloud.
+ * - integrationCreatedAt: omit to skip the integration-level Cloud cutoff; pass
+ *   null for "no existing row", which follows new-customer rules on Cloud.
+ * - exporterCutoff: the integration-level cutoff date. Each integration family
+ *   has its own; defaults to LEGACY_BLOB_EXPORTER_CUTOFF.
  */
 export type ExportSourceContext = {
   isCloud: boolean;
@@ -162,6 +173,7 @@ export type ExportSourceContext = {
   legacyWritesActive: boolean;
   projectCreatedAt?: Date;
   integrationCreatedAt?: Date | null;
+  exporterCutoff?: Date;
 };
 
 export type ExportSourceBlockedReason =
@@ -180,8 +192,10 @@ const ENRICHED_UNAVAILABLE_MESSAGE =
 // counted separately in logs. Customer-facing via the public REST PUT.
 const PROJECT_CUTOFF_MESSAGE =
   "Legacy export sources are not available for Cloud projects created on or after 2026-05-20. Use 'OBSERVATIONS_V2' instead.";
-const exporterCutoffMessage = () =>
-  `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`;
+const exporterCutoffMessage = (
+  exporterCutoff: Date = LEGACY_BLOB_EXPORTER_CUTOFF,
+) =>
+  `Legacy export sources are not available for integrations created on or after ${exporterCutoff.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`;
 
 // Self-hosted-operator-facing: naming the env var is intentional. Worded
 // integration-neutrally since blob storage, PostHog, and Mixpanel all surface
@@ -215,12 +229,16 @@ export function validateExportSource(
     }
     if (
       ctx.integrationCreatedAt !== undefined &&
-      !isLegacyBlobExporter(ctx.integrationCreatedAt, ctx.isCloud)
+      !isLegacyBlobExporter(
+        ctx.integrationCreatedAt,
+        ctx.isCloud,
+        ctx.exporterCutoff,
+      )
     ) {
       return {
         ok: false,
         reason: "cloud-cutoff",
-        message: exporterCutoffMessage(),
+        message: exporterCutoffMessage(ctx.exporterCutoff),
       };
     }
   }

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.ts
@@ -192,10 +192,13 @@ const ENRICHED_UNAVAILABLE_MESSAGE =
 // counted separately in logs. Customer-facing via the public REST PUT.
 const PROJECT_CUTOFF_MESSAGE =
   "Legacy export sources are not available for Cloud projects created on or after 2026-05-20. Use 'OBSERVATIONS_V2' instead.";
+// Covers both integration-level rejections: a brand-new integration (which
+// follows new-customer rules whatever today's date is) and an existing one that
+// postdates the cutoff.
 const exporterCutoffMessage = (
   exporterCutoff: Date = LEGACY_BLOB_EXPORTER_CUTOFF,
 ) =>
-  `Legacy export sources are not available for integrations created on or after ${exporterCutoff.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`;
+  `Legacy export sources are not available on Cloud for new integrations, or for integrations created on or after ${exporterCutoff.toISOString()}. Use 'OBSERVATIONS_V2' instead.`;
 
 // Self-hosted-operator-facing: naming the env var is intentional. Worded
 // integration-neutrally since blob storage, PostHog, and Mixpanel all surface

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
   "globalDependencies": [".env"],
   "globalEnv": [
     "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF",
-    "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF"
+    "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF",
+    "NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF"
   ],
   "envMode": "loose",
   "tasks": {

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -202,6 +202,11 @@ Sentry instrumentation skill first and decide whether it should capture at all
   unique test data over global reset helpers.
 - Put pure server unit tests that do not need Postgres bootstrap under
   `src/__tests__/server/unit/**` so they skip the shared DB setup hook.
+- Server tests that drive the public REST API over HTTP need a web server on
+  port 3000 using the _test_ database: `.env.test` overrides `DATABASE_URL`, so a
+  plain `pnpm run dev:web` serves a different database and every authenticated
+  call fails with 401. Start it with
+  `pnpm exec dotenv -e .env.test -e .env -- pnpm --filter web run dev`.
 - Preserve the server-test project split in `vitest.config.mts`. Most tests
   consume the built `@langfuse/shared` package; only tests importing
   `@langfuse/shared/in-app-agent` or `@langfuse/shared/src/env` use the

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1774,9 +1774,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(result.status).toBe(400);
-      expect(result.body.message).toContain(
-        "blob storage integrations created on or after",
-      );
+      expect(result.body.message).toContain("integrations created on or after");
       expect(result.body.message).toContain(
         LEGACY_BLOB_EXPORTER_CUTOFF.toISOString(),
       );
@@ -1814,9 +1812,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(result.status).toBe(400);
-      expect(result.body.message).toContain(
-        "blob storage integrations created on or after",
-      );
+      expect(result.body.message).toContain("integrations created on or after");
     });
 
     it("post-cutoff existing row + legacy source → 400", async () => {
@@ -1832,9 +1828,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(result.status).toBe(400);
-      expect(result.body.message).toContain(
-        "blob storage integrations created on or after",
-      );
+      expect(result.body.message).toContain("integrations created on or after");
     });
 
     it("no existing row + OBSERVATIONS_V2 → 200", async () => {

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -115,7 +115,11 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
     return { project, caller };
   };
 
-  it("Cloud + pre-cutoff project + legacy source → allow", async () => {
+  // A pre-cutoff project no longer buys a *new* integration the right to a
+  // legacy source: brand-new Cloud integrations are pinned to enriched events.
+  // The project cutoff is still grandfathered for integrations that already
+  // exist — covered in "Cloud new-integration enriched pin" below.
+  it("Cloud + pre-cutoff project + legacy source on create → BAD_REQUEST", async () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
     try {
@@ -130,7 +134,7 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS" as const,
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
     }
@@ -455,19 +459,21 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
+    it("Cloud + post-cutoff project + create without exportSource → persists EVENTS", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
         data: { createdAt: POST_CUTOFF },
       });
-      await expect(
-        caller.mixpanelIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-        }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
     });
 
     it("raced delete between read and write: mis-created legacy row is rolled back (post-cutoff Cloud)", async () => {
@@ -504,6 +510,50 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       ).toBeNull();
     });
 
+    it("raced delete: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      const { caller, project } = await prepare();
+      // Pre-cutoff project, so the project-level gate cannot fire. The only
+      // thing left that can reject is the backstop judging the CREATE on its
+      // own terms.
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      // The pre-flight read sees a row old enough to be grandfathered under
+      // either exporter cutoff, so the pre-flight assert allows the legacy
+      // source it carries. If the backstop then re-used this stale createdAt
+      // instead of treating the resulting CREATE as a brand-new row, the legacy
+      // row would be persisted and the guard would do nothing until the
+      // analytics cutoff date passes.
+      const spy = vi
+        .spyOn(prisma.mixpanelIntegration, "findUnique")
+        .mockResolvedValueOnce({
+          exportSource: "TRACES_OBSERVATIONS",
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+        } as never);
+      try {
+        await expect(
+          caller.mixpanelIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+          }),
+        ).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+          // Pins the cutoff path: an unrelated BAD_REQUEST (credentials,
+          // validation) must not satisfy this test.
+          message: expect.stringContaining("created on or after"),
+        });
+      } finally {
+        spy.mockRestore();
+      }
+      expect(
+        await prisma.mixpanelIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    });
+
     it("create without exportSource defaults to EVENTS on events_only", async () => {
       (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
       const { caller, project } = await prepare();
@@ -515,6 +565,177 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
+    });
+  });
+
+  // New Cloud analytics integrations land on the enriched events source and
+  // cannot be moved off it. Integrations that already existed before the
+  // analytics exporter cutoff are grandfathered: they keep their legacy source
+  // and may opt into enriched, but are never rewritten behind the user's back.
+  describe("Cloud new-integration enriched pin", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    // Written literally rather than imported so the expectation is the spec
+    // date, not whatever the implementation happens to export.
+    const ROW_PRE_ANALYTICS_CUTOFF = new Date("2026-07-01T00:00:00.000Z");
+    const ROW_POST_ANALYTICS_CUTOFF = new Date("2026-09-01T00:00:00.000Z");
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      // dual keeps legacy writes active, so any rejection below comes from the
+      // Cloud cutoff rather than the write-mode capability gate.
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    });
+
+    // Pre-cutoff project so the only Cloud gate in play is the
+    // integration-level one.
+    const prepareOldProject = async () => {
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      return { caller, project };
+    };
+
+    // Seeds a legacy row of a chosen age: created while self-hosted (where
+    // legacy is still selectable), then backdated.
+    const seedLegacyRow = async (
+      caller: Awaited<ReturnType<typeof prepare>>["caller"],
+      projectId: string,
+      createdAt: Date,
+      exportSource: "TRACES_OBSERVATIONS" | "EVENTS" = "TRACES_OBSERVATIONS",
+    ) => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      try {
+        await caller.mixpanelIntegration.update({
+          projectId,
+          ...baseConfig,
+          exportSource,
+        });
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      }
+      await prisma.mixpanelIntegration.update({
+        where: { projectId },
+        data: { createdAt },
+      });
+    };
+
+    it("create with no existing row persists EVENTS", async () => {
+      const { caller, project } = await prepareOldProject();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("create with an explicit legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(
+        await prisma.mixpanelIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    });
+
+    it("pre-cutoff row with a persisted legacy source: omitted source is preserved, not rewritten", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          enabled: false,
+        }),
+      ).resolves.not.toThrow();
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(result.config?.enabled).toBe(false);
+    });
+
+    it("pre-cutoff row may re-assert its legacy source and may switch to enriched", async () => {
+      const { caller, project } = await prepareOldProject();
+      // The row predates the analytics cutoff but postdates the blob one, so
+      // this also catches an adapter that forwards the blob cutoff by mistake.
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(
+        caller,
+        project.id,
+        ROW_POST_ANALYTICS_CUTOFF,
+        "EVENTS",
+      );
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("self-hosted on the legacy write mode is untouched by the pin", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      const { caller, project } = await prepareOldProject();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const created = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
     });
   });
 

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -510,7 +510,14 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       ).toBeNull();
     });
 
-    it("raced delete: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+    // Both raced-CREATE cases below share one shape and differ only in whether
+    // the caller sent an explicit exportSource. That single difference is the
+    // point: the real settings form always sends one (it lives in the form's
+    // defaultValues and onSubmit spreads every value), so a backstop that only
+    // runs when the field is omitted never runs in production.
+    const expectRacedCreateRejected = async (
+      extraInput: { exportSource?: "TRACES_OBSERVATIONS" } = {},
+    ) => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
       // Pre-cutoff project, so the project-level gate cannot fire. The only
@@ -522,10 +529,10 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       });
       // The pre-flight read sees a row old enough to be grandfathered under
       // either exporter cutoff, so the pre-flight assert allows the legacy
-      // source it carries. If the backstop then re-used this stale createdAt
-      // instead of treating the resulting CREATE as a brand-new row, the legacy
-      // row would be persisted and the guard would do nothing until the
-      // analytics cutoff date passes.
+      // source it carries and cannot be the thing that rejects. Meanwhile the
+      // DB genuinely holds no row, so the upsert lands as a CREATE — the race.
+      // If the backstop re-used this stale createdAt, or skipped itself
+      // entirely, the legacy row would be persisted.
       const spy = vi
         .spyOn(prisma.mixpanelIntegration, "findUnique")
         .mockResolvedValueOnce({
@@ -537,6 +544,7 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
           caller.mixpanelIntegration.update({
             projectId: project.id,
             ...baseConfig,
+            ...extraInput,
           }),
         ).rejects.toMatchObject({
           code: "BAD_REQUEST",
@@ -552,6 +560,16 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
           where: { projectId: project.id },
         }),
       ).toBeNull();
+    };
+
+    it("raced delete with the source omitted: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+      await expectRacedCreateRejected();
+    });
+
+    it("raced delete with the source explicitly present: the backstop still re-validates as a brand-new row", async () => {
+      await expectRacedCreateRejected({
+        exportSource: "TRACES_OBSERVATIONS",
+      });
     });
 
     it("create without exportSource defaults to EVENTS on events_only", async () => {

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -3,13 +3,36 @@ import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
-import { LEGACY_BLOB_EXPORT_CUTOFF } from "@langfuse/shared";
+import {
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
+} from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
+// Integration row ages derive from the cutoff constants, never from literals, so
+// the NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides this branch documents cannot
+// turn a supported override into a suite failure.
+const ROW_PRE_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+);
+const ROW_POST_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+);
+// The raced-CREATE pre-flight row must be grandfathered under BOTH exporter
+// cutoffs, so the pre-flight assert provably cannot be the thing that rejects
+// and only the in-transaction backstop can.
+const RACED_PREFLIGHT_CREATED_AT = new Date(
+  Math.min(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime(),
+    LEGACY_BLOB_EXPORTER_CUTOFF.getTime(),
+  ) -
+    30 * MS_PER_DAY,
+);
 
 const buildSession = (orgId: string, projectId: string): Session => ({
   expires: "1",
@@ -537,7 +560,7 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         .spyOn(prisma.mixpanelIntegration, "findUnique")
         .mockResolvedValueOnce({
           exportSource: "TRACES_OBSERVATIONS",
-          createdAt: new Date("2026-01-01T00:00:00Z"),
+          createdAt: RACED_PREFLIGHT_CREATED_AT,
         } as never);
       try {
         await expect(
@@ -593,11 +616,6 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
   describe("Cloud new-integration enriched pin", () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-
-    // Written literally rather than imported so the expectation is the spec
-    // date, not whatever the implementation happens to export.
-    const ROW_PRE_ANALYTICS_CUTOFF = new Date("2026-07-01T00:00:00.000Z");
-    const ROW_POST_ANALYTICS_CUTOFF = new Date("2026-09-01T00:00:00.000Z");
 
     beforeEach(() => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -3,13 +3,36 @@ import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
-import { LEGACY_BLOB_EXPORT_CUTOFF } from "@langfuse/shared";
+import {
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
+} from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
+// Integration row ages derive from the cutoff constants, never from literals, so
+// the NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides this branch documents cannot
+// turn a supported override into a suite failure.
+const ROW_PRE_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+);
+const ROW_POST_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+);
+// The raced-CREATE pre-flight row must be grandfathered under BOTH exporter
+// cutoffs, so the pre-flight assert provably cannot be the thing that rejects
+// and only the in-transaction backstop can.
+const RACED_PREFLIGHT_CREATED_AT = new Date(
+  Math.min(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime(),
+    LEGACY_BLOB_EXPORTER_CUTOFF.getTime(),
+  ) -
+    30 * MS_PER_DAY,
+);
 
 const buildSession = (orgId: string, projectId: string): Session => ({
   expires: "1",
@@ -581,7 +604,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         .spyOn(prisma.posthogIntegration, "findUnique")
         .mockResolvedValueOnce({
           exportSource: "TRACES_OBSERVATIONS",
-          createdAt: new Date("2026-01-01T00:00:00Z"),
+          createdAt: RACED_PREFLIGHT_CREATED_AT,
         } as never);
       try {
         await expect(
@@ -637,11 +660,6 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
   describe("Cloud new-integration enriched pin", () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-
-    // Written literally rather than imported so the expectation is the spec
-    // date, not whatever the implementation happens to export.
-    const ROW_PRE_ANALYTICS_CUTOFF = new Date("2026-07-01T00:00:00.000Z");
-    const ROW_POST_ANALYTICS_CUTOFF = new Date("2026-09-01T00:00:00.000Z");
 
     beforeEach(() => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -554,7 +554,14 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       ).toBeNull();
     });
 
-    it("raced delete: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+    // Both raced-CREATE cases below share one shape and differ only in whether
+    // the caller sent an explicit exportSource. That single difference is the
+    // point: the real settings form always sends one (it lives in the form's
+    // defaultValues and onSubmit spreads every value), so a backstop that only
+    // runs when the field is omitted never runs in production.
+    const expectRacedCreateRejected = async (
+      extraInput: { exportSource?: "TRACES_OBSERVATIONS" } = {},
+    ) => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
       // Pre-cutoff project, so the project-level gate cannot fire. The only
@@ -566,10 +573,10 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       });
       // The pre-flight read sees a row old enough to be grandfathered under
       // either exporter cutoff, so the pre-flight assert allows the legacy
-      // source it carries. If the backstop then re-used this stale createdAt
-      // instead of treating the resulting CREATE as a brand-new row, the legacy
-      // row would be persisted and the guard would do nothing until the
-      // analytics cutoff date passes.
+      // source it carries and cannot be the thing that rejects. Meanwhile the
+      // DB genuinely holds no row, so the upsert lands as a CREATE — the race.
+      // If the backstop re-used this stale createdAt, or skipped itself
+      // entirely, the legacy row would be persisted.
       const spy = vi
         .spyOn(prisma.posthogIntegration, "findUnique")
         .mockResolvedValueOnce({
@@ -581,6 +588,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
           caller.posthogIntegration.update({
             projectId: project.id,
             ...baseConfig,
+            ...extraInput,
           }),
         ).rejects.toMatchObject({
           code: "BAD_REQUEST",
@@ -596,6 +604,16 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
           where: { projectId: project.id },
         }),
       ).toBeNull();
+    };
+
+    it("raced delete with the source omitted: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+      await expectRacedCreateRejected();
+    });
+
+    it("raced delete with the source explicitly present: the backstop still re-validates as a brand-new row", async () => {
+      await expectRacedCreateRejected({
+        exportSource: "TRACES_OBSERVATIONS",
+      });
     });
 
     it("create without exportSource defaults to EVENTS on events_only", async () => {

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -159,7 +159,11 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     return { project, caller };
   };
 
-  it("Cloud + pre-cutoff project + legacy source → allow", async () => {
+  // A pre-cutoff project no longer buys a *new* integration the right to a
+  // legacy source: brand-new Cloud integrations are pinned to enriched events.
+  // The project cutoff is still grandfathered for integrations that already
+  // exist — covered in "Cloud new-integration enriched pin" below.
+  it("Cloud + pre-cutoff project + legacy source on create → BAD_REQUEST", async () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
     try {
@@ -174,7 +178,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS" as const,
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
     }
@@ -499,19 +503,21 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
+    it("Cloud + post-cutoff project + create without exportSource → persists EVENTS", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
         data: { createdAt: POST_CUTOFF },
       });
-      await expect(
-        caller.posthogIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-        }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
     });
 
     it("raced delete between read and write: mis-created legacy row is rolled back (post-cutoff Cloud)", async () => {
@@ -548,6 +554,50 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       ).toBeNull();
     });
 
+    it("raced delete: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      const { caller, project } = await prepare();
+      // Pre-cutoff project, so the project-level gate cannot fire. The only
+      // thing left that can reject is the backstop judging the CREATE on its
+      // own terms.
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      // The pre-flight read sees a row old enough to be grandfathered under
+      // either exporter cutoff, so the pre-flight assert allows the legacy
+      // source it carries. If the backstop then re-used this stale createdAt
+      // instead of treating the resulting CREATE as a brand-new row, the legacy
+      // row would be persisted and the guard would do nothing until the
+      // analytics cutoff date passes.
+      const spy = vi
+        .spyOn(prisma.posthogIntegration, "findUnique")
+        .mockResolvedValueOnce({
+          exportSource: "TRACES_OBSERVATIONS",
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+        } as never);
+      try {
+        await expect(
+          caller.posthogIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+          }),
+        ).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+          // Pins the cutoff path: an unrelated BAD_REQUEST (credentials,
+          // validation) must not satisfy this test.
+          message: expect.stringContaining("created on or after"),
+        });
+      } finally {
+        spy.mockRestore();
+      }
+      expect(
+        await prisma.posthogIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    });
+
     it("create without exportSource defaults to EVENTS on events_only", async () => {
       (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
       const { caller, project } = await prepare();
@@ -559,6 +609,177 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
+    });
+  });
+
+  // New Cloud analytics integrations land on the enriched events source and
+  // cannot be moved off it. Integrations that already existed before the
+  // analytics exporter cutoff are grandfathered: they keep their legacy source
+  // and may opt into enriched, but are never rewritten behind the user's back.
+  describe("Cloud new-integration enriched pin", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    // Written literally rather than imported so the expectation is the spec
+    // date, not whatever the implementation happens to export.
+    const ROW_PRE_ANALYTICS_CUTOFF = new Date("2026-07-01T00:00:00.000Z");
+    const ROW_POST_ANALYTICS_CUTOFF = new Date("2026-09-01T00:00:00.000Z");
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      // dual keeps legacy writes active, so any rejection below comes from the
+      // Cloud cutoff rather than the write-mode capability gate.
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    });
+
+    // Pre-cutoff project so the only Cloud gate in play is the
+    // integration-level one.
+    const prepareOldProject = async () => {
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      return { caller, project };
+    };
+
+    // Seeds a row of a chosen age: created while self-hosted (where legacy is
+    // still selectable), then backdated.
+    const seedLegacyRow = async (
+      caller: Awaited<ReturnType<typeof prepare>>["caller"],
+      projectId: string,
+      createdAt: Date,
+      exportSource: "TRACES_OBSERVATIONS" | "EVENTS" = "TRACES_OBSERVATIONS",
+    ) => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      try {
+        await caller.posthogIntegration.update({
+          projectId,
+          ...baseConfig,
+          exportSource,
+        });
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      }
+      await prisma.posthogIntegration.update({
+        where: { projectId },
+        data: { createdAt },
+      });
+    };
+
+    it("create with no existing row persists EVENTS", async () => {
+      const { caller, project } = await prepareOldProject();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("create with an explicit legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(
+        await prisma.posthogIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    });
+
+    it("pre-cutoff row with a persisted legacy source: omitted source is preserved, not rewritten", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          enabled: false,
+        }),
+      ).resolves.not.toThrow();
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(result.config?.enabled).toBe(false);
+    });
+
+    it("pre-cutoff row may re-assert its legacy source and may switch to enriched", async () => {
+      const { caller, project } = await prepareOldProject();
+      // The row predates the analytics cutoff but postdates the blob one, so
+      // this also catches an adapter that forwards the blob cutoff by mistake.
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(
+        caller,
+        project.id,
+        ROW_POST_ANALYTICS_CUTOFF,
+        "EVENTS",
+      );
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("self-hosted on the legacy write mode is untouched by the pin", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      const { caller, project } = await prepareOldProject();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const created = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
     });
   });
 

--- a/web/src/__tests__/server/unit/assertExportSourceAllowed.servertest.ts
+++ b/web/src/__tests__/server/unit/assertExportSourceAllowed.servertest.ts
@@ -137,6 +137,28 @@ describe("assertExportSourceAllowed", () => {
     });
   });
 
+  // Forwarding guard: analytics adapters override the integration-level cutoff
+  // through the context. A destructuring assert that drops the field would
+  // silently fall back to the blob cutoff and reject a grandfathered row.
+  it("forwards a context-supplied exporterCutoff instead of the blob default", () => {
+    const ctx: ExportSourceContext & { exporterCutoff?: Date } = {
+      isCloud: true,
+      enrichedAvailable: true,
+      legacyWritesActive: true,
+      // Between the blob cutoff (2026-06-22) and the analytics one
+      // (2026-08-15): blocked under the default, grandfathered under the
+      // override.
+      integrationCreatedAt: new Date("2026-07-01T00:00:00.000Z"),
+      exporterCutoff: new Date("2026-08-15T00:00:00.000Z"),
+    };
+    expect(() =>
+      assertExportSourceAllowed({
+        nextExportSource: "TRACES_OBSERVATIONS",
+        ctx,
+      }),
+    ).not.toThrow();
+  });
+
   it("omitted source without a persisted row is a no-op", () => {
     expect(() =>
       assertExportSourceAllowed({

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -575,6 +575,7 @@ export const env = createEnv({
       .optional(),
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF: z.iso.datetime().optional(),
+    NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF: z.iso.datetime().optional(),
     NEXT_PUBLIC_DEMO_PROJECT_ID: z.string().optional(),
     NEXT_PUBLIC_DEMO_ORG_ID: z.string().optional(),
     NEXT_PUBLIC_SIGN_UP_DISABLED: z.enum(["true", "false"]).default("false"),
@@ -630,6 +631,8 @@ export const env = createEnv({
       process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF,
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF:
       process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF,
+    NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF:
+      process.env.NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF,
     NEXT_PUBLIC_SIGN_UP_DISABLED: process.env.NEXT_PUBLIC_SIGN_UP_DISABLED,
     NEXT_PUBLIC_PREVIEW_PR_URL: process.env.NEXT_PUBLIC_PREVIEW_PR_URL,
     NEXT_PUBLIC_PREVIEW_PR_AUTHOR: process.env.NEXT_PUBLIC_PREVIEW_PR_AUTHOR,

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -1,5 +1,6 @@
 import {
   AnalyticsIntegrationExportSource,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   LEGACY_BLOB_EXPORT_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
   type BlobExportWriteMode,
@@ -8,11 +9,13 @@ import {
 
 import {
   buildExportSourceContext,
+  getDefaultExportSource,
   getExportSourceFormValue,
   getExportSourceOptions,
   getExportSourceUnavailableMessage,
   isExportSourceSelectable,
   shouldHideExportSourceSelector,
+  shouldShowExportSourceField,
 } from "./exportSource";
 
 // UI-adapter tests. The policy matrix itself lives with the policy
@@ -56,7 +59,9 @@ const selfHostedEventsOnly: ExportSourceContext = {
   legacyWritesActive: false,
 };
 
-describe("getExportSourceFormValue", () => {
+// Only the blob-storage form calls getExportSourceFormValue; the analytics
+// pages use getDefaultExportSource (covered further down).
+describe("getExportSourceFormValue (blob storage form)", () => {
   it("keeps any persisted value regardless of deployment state (LFE-10296)", () => {
     for (const persisted of Object.values(AnalyticsIntegrationExportSource)) {
       for (const ctx of [
@@ -402,57 +407,111 @@ describe("write mode drives the settings-page selector", () => {
   );
 });
 
-// Product-analytics integrations (Mixpanel/PostHog) carry a later
-// integration-level cutoff than blob storage, supplied through the context.
-describe("analytics integrations: exporterCutoff-driven selector state", () => {
+// The two derivations the Mixpanel and PostHog settings pages actually call:
+// shouldShowExportSourceField and getDefaultExportSource. Contexts below mirror
+// what those pages build (enrichedAvailable from the write mode, the analytics
+// exporter cutoff supplied), so these assertions cover shipped behaviour.
+describe("analytics integrations: settings-page field visibility and default", () => {
   type Ctx = ExportSourceContext & { exporterCutoff?: Date };
 
-  // Spec dates written literally: the analytics cutoff, and a row age that sits
-  // between the blob cutoff (2026-06-22) and it.
-  const ANALYTICS_CUTOFF = new Date("2026-08-15T00:00:00.000Z");
-  const ROW_BETWEEN_CUTOFFS = new Date("2026-07-01T00:00:00.000Z");
+  // Derived from the constant, never a literal: the cutoff is overridable via
+  // NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF for local testing.
+  const ROW_PRE_ANALYTICS_CUTOFF = new Date(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+  );
+  const ROW_POST_ANALYTICS_CUTOFF = new Date(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+  );
 
-  const newCloudIntegration: Ctx = {
+  const cloudCtx = (integrationCreatedAt: Date | null): Ctx => ({
     isCloud: true,
     enrichedAvailable: true,
     legacyWritesActive: true,
+    // Pre-cutoff project, so only the integration-level gate is in play.
     projectCreatedAt: PROJECT_PRE,
-    integrationCreatedAt: null,
-    exporterCutoff: ANALYTICS_CUTOFF,
-  };
-  const grandfatheredCloudIntegration: Ctx = {
-    ...newCloudIntegration,
-    integrationCreatedAt: ROW_BETWEEN_CUTOFFS,
-  };
-
-  it("hides the selector for a brand-new Cloud integration, pinned to EVENTS", () => {
-    const options = getExportSourceOptions(undefined, newCloudIntegration);
-    expect(options.map((o) => o.value)).toEqual([
-      AnalyticsIntegrationExportSource.EVENTS,
-    ]);
-    expect(shouldHideExportSourceSelector(options)).toBe(true);
-    expect(getExportSourceFormValue(undefined, newCloudIntegration)).toBe(
-      AnalyticsIntegrationExportSource.EVENTS,
-    );
+    integrationCreatedAt,
+    exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   });
 
-  it("keeps the selector visible and legacy selectable for a grandfathered Cloud integration", () => {
-    const options = getExportSourceOptions(
-      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-      grandfatheredCloudIntegration,
-    );
-    expect(shouldHideExportSourceSelector(options)).toBe(false);
+  const derive = (
+    persisted: AnalyticsIntegrationExportSource | null | undefined,
+    ctx: Ctx,
+    isBetaEnabled: boolean,
+  ) => ({
+    show: shouldShowExportSourceField({
+      persisted,
+      ctx,
+      isBetaEnabled,
+      options: getExportSourceOptions(persisted ?? null, ctx),
+    }),
+    defaulted: getDefaultExportSource({ persisted, ctx, isBetaEnabled }),
+  });
+
+  it("brand-new Cloud integration: field hidden and default pinned to EVENTS, regardless of the beta opt-in", () => {
+    for (const isBetaEnabled of [false, true]) {
+      expect(derive(undefined, cloudCtx(null), isBetaEnabled)).toEqual({
+        show: false,
+        defaulted: AnalyticsIntegrationExportSource.EVENTS,
+      });
+    }
+  });
+
+  it("grandfathered pre-cutoff Cloud integration: field shown without the beta opt-in, default keeps the persisted legacy source", () => {
+    const ctx = cloudCtx(ROW_PRE_ANALYTICS_CUTOFF);
+    expect(
+      derive(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS, ctx, false),
+    ).toEqual({
+      show: true,
+      defaulted: AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    });
+    // The legacy source stays a real choice, so the user can opt into enriched
+    // without being forced and without being rewritten.
     expect(
       isExportSourceSelectable(
         AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-        grandfatheredCloudIntegration,
+        ctx,
       ),
     ).toBe(true);
     expect(
-      isExportSourceSelectable(
-        AnalyticsIntegrationExportSource.EVENTS,
-        grandfatheredCloudIntegration,
-      ),
+      isExportSourceSelectable(AnalyticsIntegrationExportSource.EVENTS, ctx),
+    ).toBe(true);
+  });
+
+  it("post-cutoff Cloud integration: field hidden and pinned even with a persisted legacy source", () => {
+    const ctx = cloudCtx(ROW_POST_ANALYTICS_CUTOFF);
+    expect(
+      derive(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS, ctx, false),
+    ).toEqual({
+      show: false,
+      defaulted: AnalyticsIntegrationExportSource.EVENTS,
+    });
+  });
+
+  it("self-hosted without the beta opt-in: field hidden, default legacy (unchanged)", () => {
+    expect(derive(undefined, selfHostedWithPreview, false)).toEqual({
+      show: false,
+      defaulted: AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    });
+  });
+
+  it("self-hosted with the beta opt-in: field shown, default EVENTS", () => {
+    // Guards the self-hosted arm of `isCloud || isBetaEnabled`: making the
+    // selector Cloud-unconditional must not have dropped the opt-in path.
+    expect(derive(undefined, selfHostedWithPreview, true)).toEqual({
+      show: true,
+      defaulted: AnalyticsIntegrationExportSource.EVENTS,
+    });
+  });
+
+  it("self-hosted events_only with a persisted legacy source: field forced visible so the blocked-save alert has a target", () => {
+    // Not a cutoff case — capability. Without this arm the user would be left
+    // with a blocked save and no control to change.
+    expect(
+      derive(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        selfHostedEventsOnly,
+        false,
+      ).show,
     ).toBe(true);
   });
 });

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -402,6 +402,61 @@ describe("write mode drives the settings-page selector", () => {
   );
 });
 
+// Product-analytics integrations (Mixpanel/PostHog) carry a later
+// integration-level cutoff than blob storage, supplied through the context.
+describe("analytics integrations: exporterCutoff-driven selector state", () => {
+  type Ctx = ExportSourceContext & { exporterCutoff?: Date };
+
+  // Spec dates written literally: the analytics cutoff, and a row age that sits
+  // between the blob cutoff (2026-06-22) and it.
+  const ANALYTICS_CUTOFF = new Date("2026-08-15T00:00:00.000Z");
+  const ROW_BETWEEN_CUTOFFS = new Date("2026-07-01T00:00:00.000Z");
+
+  const newCloudIntegration: Ctx = {
+    isCloud: true,
+    enrichedAvailable: true,
+    legacyWritesActive: true,
+    projectCreatedAt: PROJECT_PRE,
+    integrationCreatedAt: null,
+    exporterCutoff: ANALYTICS_CUTOFF,
+  };
+  const grandfatheredCloudIntegration: Ctx = {
+    ...newCloudIntegration,
+    integrationCreatedAt: ROW_BETWEEN_CUTOFFS,
+  };
+
+  it("hides the selector for a brand-new Cloud integration, pinned to EVENTS", () => {
+    const options = getExportSourceOptions(undefined, newCloudIntegration);
+    expect(options.map((o) => o.value)).toEqual([
+      AnalyticsIntegrationExportSource.EVENTS,
+    ]);
+    expect(shouldHideExportSourceSelector(options)).toBe(true);
+    expect(getExportSourceFormValue(undefined, newCloudIntegration)).toBe(
+      AnalyticsIntegrationExportSource.EVENTS,
+    );
+  });
+
+  it("keeps the selector visible and legacy selectable for a grandfathered Cloud integration", () => {
+    const options = getExportSourceOptions(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      grandfatheredCloudIntegration,
+    );
+    expect(shouldHideExportSourceSelector(options)).toBe(false);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        grandfatheredCloudIntegration,
+      ),
+    ).toBe(true);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.EVENTS,
+        grandfatheredCloudIntegration,
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("getExportSourceUnavailableMessage", () => {
   it("names the write mode for enriched-unavailable (self-hosted operator-facing)", () => {
     const message = getExportSourceUnavailableMessage("enriched-unavailable");

--- a/web/src/features/analytics-integrations/exportSource.ts
+++ b/web/src/features/analytics-integrations/exportSource.ts
@@ -89,6 +89,66 @@ export function getExportSourceOptions(
   });
 }
 
+/**
+ * Selector visibility and initial form value for the PostHog and Mixpanel
+ * settings forms, which derive both identically. `isBetaEnabled` is the V4
+ * preview opt-in; on Cloud the selector does not depend on it, because enriched
+ * export is always available there.
+ */
+
+// Post-cutoff Cloud: the selector is hidden and the form value is pinned to
+// EVENTS. Brand-new Cloud rows land here too — they follow new-customer rules.
+function isPostCutoffCloud(ctx: ExportSourceContext): boolean {
+  const legacyValidation = validateExportSource(
+    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    ctx,
+  );
+  return !legacyValidation.ok && legacyValidation.reason === "cloud-cutoff";
+}
+
+export function shouldShowExportSourceField({
+  persisted,
+  ctx,
+  isBetaEnabled,
+  options,
+}: {
+  persisted: AnalyticsIntegrationExportSource | null | undefined;
+  ctx: ExportSourceContext;
+  isBetaEnabled: boolean;
+  options: SelectableExportSourceOption[];
+}): boolean {
+  const postCutoffCloud = isPostCutoffCloud(ctx);
+  // A persisted source blocked by capability forces the field visible so the
+  // blocked-save alert has something to point at.
+  const persistedBlockedByCapability =
+    persisted != null &&
+    !postCutoffCloud &&
+    !isExportSourceSelectable(persisted, ctx);
+  return (
+    (((ctx.isCloud || isBetaEnabled) && !postCutoffCloud) ||
+      persistedBlockedByCapability) &&
+    !shouldHideExportSourceSelector(options)
+  );
+}
+
+export function getDefaultExportSource({
+  persisted,
+  ctx,
+  isBetaEnabled,
+}: {
+  persisted: AnalyticsIntegrationExportSource | null | undefined;
+  ctx: ExportSourceContext;
+  isBetaEnabled: boolean;
+}): AnalyticsIntegrationExportSource {
+  if (isPostCutoffCloud(ctx)) return AnalyticsIntegrationExportSource.EVENTS;
+  return (
+    persisted ??
+    (ctx.isCloud || isBetaEnabled || !ctx.legacyWritesActive
+      ? AnalyticsIntegrationExportSource.EVENTS
+      : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS)
+  );
+}
+
 // Blocked-save alert body per policy reason.
 const EXPORT_SOURCE_UNAVAILABLE_MESSAGES: Record<
   ExportSourceBlockedReason,

--- a/web/src/features/analytics-integrations/server/analyticsExportSource.ts
+++ b/web/src/features/analytics-integrations/server/analyticsExportSource.ts
@@ -1,0 +1,142 @@
+import {
+  AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
+  areLegacyWritesActive,
+  InvalidRequestError,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  validateExportSource,
+  type ExportSourceContext,
+} from "@langfuse/shared";
+import { type Prisma } from "@langfuse/shared/src/db";
+
+import { env } from "@/src/env.mjs";
+import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+
+/**
+ * Write-time export-source handling for the PostHog and Mixpanel routers, whose
+ * upserts are otherwise identical here. Assembles the ExportSourceContext both
+ * routers need — see export-source-policy.ts for the policy itself.
+ */
+
+type ExistingAnalyticsIntegration = {
+  exportSource: AnalyticsIntegrationExportSource;
+  createdAt: Date;
+};
+
+type Deployment = {
+  isCloud: boolean;
+  enrichedAvailable: boolean;
+  legacyWritesActive: boolean;
+};
+
+function readDeployment(): Deployment {
+  const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+  return {
+    isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+    enrichedAvailable: areEnrichedWritesActive(writeMode),
+    legacyWritesActive: areLegacyWritesActive(writeMode),
+  };
+}
+
+function buildContext(
+  deployment: Deployment,
+  projectCreatedAt: Date | undefined,
+  integrationCreatedAt: Date | null,
+): ExportSourceContext {
+  return {
+    ...deployment,
+    projectCreatedAt,
+    integrationCreatedAt,
+    exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  };
+}
+
+/**
+ * Validates the requested source (throwing InvalidRequestError when blocked)
+ * and returns the value the upsert's CREATE branch should carry.
+ *
+ * That value prefers the persisted source over the new-row default, because a
+ * concurrent delete can turn the upsert into a CREATE that was meant as an
+ * UPDATE; assertRacedCreateAllowed then judges whatever landed.
+ */
+export async function resolveAnalyticsExportSource({
+  tx,
+  projectId,
+  requestedExportSource,
+  existingIntegration,
+}: {
+  tx: Prisma.TransactionClient;
+  projectId: string;
+  requestedExportSource: AnalyticsIntegrationExportSource | undefined;
+  existingIntegration: ExistingAnalyticsIntegration | null | undefined;
+}): Promise<AnalyticsIntegrationExportSource> {
+  const deployment = readDeployment();
+  const createDefaultExportSource =
+    deployment.isCloud || !deployment.legacyWritesActive
+      ? AnalyticsIntegrationExportSource.EVENTS
+      : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
+
+  const nextExportSource =
+    requestedExportSource ??
+    (existingIntegration ? undefined : createDefaultExportSource);
+  // The Cloud cutoffs need the project only for explicitly chosen (or
+  // create-defaulted) sources.
+  const projectCreatedAt = nextExportSource
+    ? (
+        await tx.project.findUniqueOrThrow({
+          where: { id: projectId },
+          select: { createdAt: true },
+        })
+      ).createdAt
+    : undefined;
+
+  assertExportSourceAllowed({
+    nextExportSource,
+    persistedExportSource: existingIntegration?.exportSource,
+    ctx: buildContext(
+      deployment,
+      projectCreatedAt,
+      existingIntegration?.createdAt ?? null,
+    ),
+  });
+
+  return (
+    requestedExportSource ??
+    existingIntegration?.exportSource ??
+    createDefaultExportSource
+  );
+}
+
+/**
+ * In-transaction backstop (mirrors blob storage's service.ts). The pre-flight
+ * read is racy: a concurrent delete can flip the expected UPDATE into a CREATE.
+ * A changed createdAt detects that, and the row is then re-validated as the
+ * brand-new row it is — not as the grandfathered one the pre-flight read saw.
+ */
+export async function assertRacedCreateAllowed({
+  tx,
+  projectId,
+  existingIntegration,
+  result,
+}: {
+  tx: Prisma.TransactionClient;
+  projectId: string;
+  existingIntegration: ExistingAnalyticsIntegration | null | undefined;
+  result: ExistingAnalyticsIntegration;
+}): Promise<void> {
+  if (
+    !existingIntegration ||
+    result.createdAt.getTime() === existingIntegration.createdAt.getTime()
+  ) {
+    return;
+  }
+  const project = await tx.project.findUniqueOrThrow({
+    where: { id: projectId },
+    select: { createdAt: true },
+  });
+  const validation = validateExportSource(
+    result.exportSource,
+    buildContext(readDeployment(), project.createdAt, null),
+  );
+  if (!validation.ok) throw new InvalidRequestError(validation.message);
+}

--- a/web/src/features/analytics-integrations/server/analyticsExportSource.ts
+++ b/web/src/features/analytics-integrations/server/analyticsExportSource.ts
@@ -60,12 +60,12 @@ function buildContext(
  * UPDATE; assertRacedCreateAllowed then judges whatever landed.
  */
 export async function resolveAnalyticsExportSource({
-  tx,
+  db,
   projectId,
   requestedExportSource,
   existingIntegration,
 }: {
-  tx: Prisma.TransactionClient;
+  db: Prisma.TransactionClient;
   projectId: string;
   requestedExportSource: AnalyticsIntegrationExportSource | undefined;
   existingIntegration: ExistingAnalyticsIntegration | null | undefined;
@@ -83,7 +83,7 @@ export async function resolveAnalyticsExportSource({
   // create-defaulted) sources.
   const projectCreatedAt = nextExportSource
     ? (
-        await tx.project.findUniqueOrThrow({
+        await db.project.findUniqueOrThrow({
           where: { id: projectId },
           select: { createdAt: true },
         })

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+import {
+  assertRacedCreateAllowed,
+  resolveAnalyticsExportSource,
+} from "@/src/features/analytics-integrations/server/analyticsExportSource";
 import { isPrismaRecordNotFoundError } from "@/src/features/analytics-integrations/server/isPrismaRecordNotFoundError";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -15,12 +18,7 @@ import { env } from "@/src/env.mjs";
 import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
-  areEnrichedWritesActive,
-  areLegacyWritesActive,
-  InvalidRequestError,
   LangfuseNotFoundError,
-  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-  validateExportSource,
 } from "@langfuse/shared";
 
 export const mixpanelIntegrationRouter = createTRPCRouter({
@@ -96,9 +94,6 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         }
       }
 
-      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-      const legacyWritesActive = areLegacyWritesActive(writeMode);
-      const enrichedAvailable = areEnrichedWritesActive(writeMode);
       const existingIntegration =
         await ctx.prisma.mixpanelIntegration.findUnique({
           where: { projectId: input.projectId },
@@ -120,35 +115,11 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           message: "Mixpanel Project Token is required",
         });
       }
-      const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
-      const createDefaultExportSource =
-        isCloud || !legacyWritesActive
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
-      const nextExportSource =
-        input.exportSource ??
-        (existingIntegration ? undefined : createDefaultExportSource);
-      // The Cloud cutoffs need the project only for explicitly chosen (or
-      // create-defaulted) sources.
-      const projectCreatedAt = nextExportSource
-        ? (
-            await ctx.prisma.project.findUniqueOrThrow({
-              where: { id: input.projectId },
-              select: { createdAt: true },
-            })
-          ).createdAt
-        : undefined;
-      assertExportSourceAllowed({
-        nextExportSource,
-        persistedExportSource: existingIntegration?.exportSource,
-        ctx: {
-          isCloud,
-          enrichedAvailable,
-          legacyWritesActive,
-          projectCreatedAt,
-          integrationCreatedAt: existingIntegration?.createdAt ?? null,
-          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-        },
+      const createExportSource = await resolveAnalyticsExportSource({
+        tx: ctx.prisma,
+        projectId: input.projectId,
+        requestedExportSource: input.exportSource,
+        existingIntegration,
       });
 
       await auditLog({
@@ -169,12 +140,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
             mixpanelRegion: config.mixpanelRegion,
             encryptedMixpanelProjectToken,
             enabled: config.enabled,
-            // Persisted value before the new-row default: a concurrent delete
-            // can turn this upsert into a CREATE that was meant as an UPDATE.
-            exportSource:
-              config.exportSource ??
-              existingIntegration?.exportSource ??
-              createDefaultExportSource,
+            exportSource: createExportSource,
           },
           update: {
             encryptedMixpanelProjectToken,
@@ -186,29 +152,12 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           },
         });
 
-        // Race backstop (mirrors blob storage's service.ts): a concurrent
-        // delete between the pre-flight read and this upsert can flip the
-        // expected UPDATE into a CREATE. Detectable as a createdAt change;
-        // re-validate the row that landed as a brand-new one and roll back on
-        // failure.
-        if (
-          existingIntegration &&
-          result.createdAt.getTime() !== existingIntegration.createdAt.getTime()
-        ) {
-          const project = await tx.project.findUniqueOrThrow({
-            where: { id: input.projectId },
-            select: { createdAt: true },
-          });
-          const validation = validateExportSource(result.exportSource, {
-            isCloud,
-            enrichedAvailable,
-            legacyWritesActive,
-            projectCreatedAt: project.createdAt,
-            integrationCreatedAt: null,
-            exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-          });
-          if (!validation.ok) throw new InvalidRequestError(validation.message);
-        }
+        await assertRacedCreateAllowed({
+          tx,
+          projectId: input.projectId,
+          existingIntegration,
+          result,
+        });
       });
     }),
   delete: protectedProjectProcedure

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -116,7 +116,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         });
       }
       const createExportSource = await resolveAnalyticsExportSource({
-        tx: ctx.prisma,
+        db: ctx.prisma,
         projectId: input.projectId,
         requestedExportSource: input.exportSource,
         existingIntegration,

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -19,6 +19,7 @@ import {
   areLegacyWritesActive,
   InvalidRequestError,
   LangfuseNotFoundError,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
 } from "@langfuse/shared";
 
@@ -119,9 +120,11 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           message: "Mixpanel Project Token is required",
         });
       }
-      const createDefaultExportSource = legacyWritesActive
-        ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-        : AnalyticsIntegrationExportSource.EVENTS;
+      const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+      const createDefaultExportSource =
+        isCloud || !legacyWritesActive
+          ? AnalyticsIntegrationExportSource.EVENTS
+          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
       const nextExportSource =
         input.exportSource ??
         (existingIntegration ? undefined : createDefaultExportSource);
@@ -139,10 +142,12 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         nextExportSource,
         persistedExportSource: existingIntegration?.exportSource,
         ctx: {
-          isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+          isCloud,
           enrichedAvailable,
           legacyWritesActive,
           projectCreatedAt,
+          integrationCreatedAt: existingIntegration?.createdAt ?? null,
+          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
         },
       });
 
@@ -164,7 +169,12 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
             mixpanelRegion: config.mixpanelRegion,
             encryptedMixpanelProjectToken,
             enabled: config.enabled,
-            exportSource: config.exportSource ?? createDefaultExportSource,
+            // Persisted value before the new-row default: a concurrent delete
+            // can turn this upsert into a CREATE that was meant as an UPDATE.
+            exportSource:
+              config.exportSource ??
+              existingIntegration?.exportSource ??
+              createDefaultExportSource,
           },
           update: {
             encryptedMixpanelProjectToken,
@@ -178,9 +188,9 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
 
         // Race backstop (mirrors blob storage's service.ts): a concurrent
         // delete between the pre-flight read and this upsert can flip the
-        // expected UPDATE into a CREATE carrying the unvalidated legacy
-        // default. Detectable as a createdAt change; re-validate the persisted
-        // row as an explicit choice and roll back on failure.
+        // expected UPDATE into a CREATE. Detectable as a createdAt change;
+        // re-validate the row that landed as a brand-new one and roll back on
+        // failure.
         if (
           input.exportSource === undefined &&
           existingIntegration &&
@@ -191,10 +201,12 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
             select: { createdAt: true },
           });
           const validation = validateExportSource(result.exportSource, {
-            isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+            isCloud,
             enrichedAvailable,
             legacyWritesActive,
             projectCreatedAt: project.createdAt,
+            integrationCreatedAt: null,
+            exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
           });
           if (!validation.ok) throw new InvalidRequestError(validation.message);
         }

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -192,7 +192,6 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         // re-validate the row that landed as a brand-new one and roll back on
         // failure.
         if (
-          input.exportSource === undefined &&
           existingIntegration &&
           result.createdAt.getTime() !== existingIntegration.createdAt.getTime()
         ) {

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -20,6 +20,7 @@ import {
   areLegacyWritesActive,
   InvalidRequestError,
   LangfuseNotFoundError,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
 } from "@langfuse/shared";
 
@@ -132,9 +133,11 @@ export const posthogIntegrationRouter = createTRPCRouter({
           message: "PostHog Project API Key is required",
         });
       }
-      const createDefaultExportSource = legacyWritesActive
-        ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-        : AnalyticsIntegrationExportSource.EVENTS;
+      const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+      const createDefaultExportSource =
+        isCloud || !legacyWritesActive
+          ? AnalyticsIntegrationExportSource.EVENTS
+          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
       const nextExportSource =
         input.exportSource ??
         (existingIntegration ? undefined : createDefaultExportSource);
@@ -152,10 +155,12 @@ export const posthogIntegrationRouter = createTRPCRouter({
         nextExportSource,
         persistedExportSource: existingIntegration?.exportSource,
         ctx: {
-          isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+          isCloud,
           enrichedAvailable,
           legacyWritesActive,
           projectCreatedAt,
+          integrationCreatedAt: existingIntegration?.createdAt ?? null,
+          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
         },
       });
 
@@ -177,7 +182,12 @@ export const posthogIntegrationRouter = createTRPCRouter({
             posthogHostName: config.posthogHostname,
             encryptedPosthogApiKey,
             enabled: config.enabled,
-            exportSource: config.exportSource ?? createDefaultExportSource,
+            // Persisted value before the new-row default: a concurrent delete
+            // can turn this upsert into a CREATE that was meant as an UPDATE.
+            exportSource:
+              config.exportSource ??
+              existingIntegration?.exportSource ??
+              createDefaultExportSource,
           },
           update: {
             encryptedPosthogApiKey,
@@ -193,9 +203,9 @@ export const posthogIntegrationRouter = createTRPCRouter({
 
         // Race backstop (mirrors blob storage's service.ts): a concurrent
         // delete between the pre-flight read and this upsert can flip the
-        // expected UPDATE into a CREATE carrying the unvalidated legacy
-        // default. Detectable as a createdAt change; re-validate the persisted
-        // row as an explicit choice and roll back on failure.
+        // expected UPDATE into a CREATE. Detectable as a createdAt change;
+        // re-validate the row that landed as a brand-new one and roll back on
+        // failure.
         if (
           input.exportSource === undefined &&
           existingIntegration &&
@@ -206,10 +216,12 @@ export const posthogIntegrationRouter = createTRPCRouter({
             select: { createdAt: true },
           });
           const validation = validateExportSource(result.exportSource, {
-            isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+            isCloud,
             enrichedAvailable,
             legacyWritesActive,
             projectCreatedAt: project.createdAt,
+            integrationCreatedAt: null,
+            exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
           });
           if (!validation.ok) throw new InvalidRequestError(validation.message);
         }

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -129,7 +129,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
         });
       }
       const createExportSource = await resolveAnalyticsExportSource({
-        tx: ctx.prisma,
+        db: ctx.prisma,
         projectId: input.projectId,
         requestedExportSource: input.exportSource,
         existingIntegration,

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -207,7 +207,6 @@ export const posthogIntegrationRouter = createTRPCRouter({
         // re-validate the row that landed as a brand-new one and roll back on
         // failure.
         if (
-          input.exportSource === undefined &&
           existingIntegration &&
           result.createdAt.getTime() !== existingIntegration.createdAt.getTime()
         ) {

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+import {
+  assertRacedCreateAllowed,
+  resolveAnalyticsExportSource,
+} from "@/src/features/analytics-integrations/server/analyticsExportSource";
 import { isPrismaRecordNotFoundError } from "@/src/features/analytics-integrations/server/isPrismaRecordNotFoundError";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -16,12 +19,7 @@ import { validateWebhookURL } from "@langfuse/shared/src/server";
 import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
-  areEnrichedWritesActive,
-  areLegacyWritesActive,
-  InvalidRequestError,
   LangfuseNotFoundError,
-  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-  validateExportSource,
 } from "@langfuse/shared";
 
 export const posthogIntegrationRouter = createTRPCRouter({
@@ -109,9 +107,6 @@ export const posthogIntegrationRouter = createTRPCRouter({
         });
       }
 
-      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-      const legacyWritesActive = areLegacyWritesActive(writeMode);
-      const enrichedAvailable = areEnrichedWritesActive(writeMode);
       const existingIntegration =
         await ctx.prisma.posthogIntegration.findUnique({
           where: { projectId: input.projectId },
@@ -133,35 +128,11 @@ export const posthogIntegrationRouter = createTRPCRouter({
           message: "PostHog Project API Key is required",
         });
       }
-      const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
-      const createDefaultExportSource =
-        isCloud || !legacyWritesActive
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
-      const nextExportSource =
-        input.exportSource ??
-        (existingIntegration ? undefined : createDefaultExportSource);
-      // The Cloud cutoffs need the project only for explicitly chosen (or
-      // create-defaulted) sources.
-      const projectCreatedAt = nextExportSource
-        ? (
-            await ctx.prisma.project.findUniqueOrThrow({
-              where: { id: input.projectId },
-              select: { createdAt: true },
-            })
-          ).createdAt
-        : undefined;
-      assertExportSourceAllowed({
-        nextExportSource,
-        persistedExportSource: existingIntegration?.exportSource,
-        ctx: {
-          isCloud,
-          enrichedAvailable,
-          legacyWritesActive,
-          projectCreatedAt,
-          integrationCreatedAt: existingIntegration?.createdAt ?? null,
-          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-        },
+      const createExportSource = await resolveAnalyticsExportSource({
+        tx: ctx.prisma,
+        projectId: input.projectId,
+        requestedExportSource: input.exportSource,
+        existingIntegration,
       });
 
       await auditLog({
@@ -182,12 +153,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
             posthogHostName: config.posthogHostname,
             encryptedPosthogApiKey,
             enabled: config.enabled,
-            // Persisted value before the new-row default: a concurrent delete
-            // can turn this upsert into a CREATE that was meant as an UPDATE.
-            exportSource:
-              config.exportSource ??
-              existingIntegration?.exportSource ??
-              createDefaultExportSource,
+            exportSource: createExportSource,
           },
           update: {
             encryptedPosthogApiKey,
@@ -201,29 +167,12 @@ export const posthogIntegrationRouter = createTRPCRouter({
           },
         });
 
-        // Race backstop (mirrors blob storage's service.ts): a concurrent
-        // delete between the pre-flight read and this upsert can flip the
-        // expected UPDATE into a CREATE. Detectable as a createdAt change;
-        // re-validate the row that landed as a brand-new one and roll back on
-        // failure.
-        if (
-          existingIntegration &&
-          result.createdAt.getTime() !== existingIntegration.createdAt.getTime()
-        ) {
-          const project = await tx.project.findUniqueOrThrow({
-            where: { id: input.projectId },
-            select: { createdAt: true },
-          });
-          const validation = validateExportSource(result.exportSource, {
-            isCloud,
-            enrichedAvailable,
-            legacyWritesActive,
-            projectCreatedAt: project.createdAt,
-            integrationCreatedAt: null,
-            exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-          });
-          if (!validation.ok) throw new InvalidRequestError(validation.message);
-        }
+        await assertRacedCreateAllowed({
+          tx,
+          projectId: input.projectId,
+          existingIntegration,
+          result,
+        });
       });
     }),
   delete: protectedProjectProcedure

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -33,7 +33,6 @@ import {
   type MixpanelRegion,
 } from "@/src/features/mixpanel-integration/types";
 import {
-  AnalyticsIntegrationExportSource,
   LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
   type BlobExportWriteMode,
@@ -43,10 +42,11 @@ import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 // Shared export-source UI adapters; policy in export-source-policy.ts.
 import {
   buildExportSourceContext,
+  getDefaultExportSource,
   getExportSourceOptions,
   getExportSourceUnavailableMessage,
   isExportSourceSelectable,
-  shouldHideExportSourceSelector,
+  shouldShowExportSourceField,
 } from "@/src/features/analytics-integrations/exportSource";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
@@ -189,29 +189,16 @@ const MixpanelIntegrationSettingsForm = ({
     }),
     [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
-  const legacyValidation = validateExportSource(
-    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-    exportSourceCtx,
-  );
-  // Post-cutoff Cloud projects: field hidden, form value pinned to EVENTS via
-  // the default below (LFE-9688 / 9830 behavior, unchanged).
-  const isPostCutoffCloud =
-    !legacyValidation.ok && legacyValidation.reason === "cloud-cutoff";
   const exportSourceOptions = getExportSourceOptions(
     state?.exportSource ?? null,
     exportSourceCtx,
   );
-  // Selector is beta-gated off Cloud, except a persisted source blocked by
-  // capability forces it visible so the blocked-save alert has something to
-  // point at.
-  const persistedBlockedByCapability =
-    state?.exportSource != null &&
-    !isPostCutoffCloud &&
-    !isExportSourceSelectable(state.exportSource, exportSourceCtx);
-  const showExportSourceField =
-    (((isLangfuseCloud || isBetaEnabled) && !isPostCutoffCloud) ||
-      persistedBlockedByCapability) &&
-    !shouldHideExportSourceSelector(exportSourceOptions);
+  const showExportSourceField = shouldShowExportSourceField({
+    persisted: state?.exportSource,
+    ctx: exportSourceCtx,
+    isBetaEnabled,
+    options: exportSourceOptions,
+  });
 
   // Blocked-save validation instead of silent rewrite (LFE-10296).
   const formSchema = useMemo(
@@ -238,12 +225,11 @@ const MixpanelIntegrationSettingsForm = ({
     [exportSourceCtx, state],
   );
 
-  const defaultExportSource = isPostCutoffCloud
-    ? AnalyticsIntegrationExportSource.EVENTS
-    : (state?.exportSource ??
-      (isLangfuseCloud || isBetaEnabled || !exportSourceCtx.legacyWritesActive
-        ? AnalyticsIntegrationExportSource.EVENTS
-        : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
+  const defaultExportSource = getDefaultExportSource({
+    persisted: state?.exportSource,
+    ctx: exportSourceCtx,
+    isBetaEnabled,
+  });
 
   const mixpanelForm = useForm({
     resolver: zodResolver(formSchema),

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/src/features/mixpanel-integration/types";
 import {
   AnalyticsIntegrationExportSource,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
   type BlobExportWriteMode,
   type ExportSourceContext,
@@ -173,14 +174,20 @@ const MixpanelIntegrationSettingsForm = ({
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const integrationCreatedAt = state?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () =>
-      buildExportSourceContext({
+    () => ({
+      ...buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
         projectCreatedAt: new Date(projectCreatedAt),
+        integrationCreatedAt: integrationCreatedAt
+          ? new Date(integrationCreatedAt)
+          : null,
       }),
-    [writeMode, isLangfuseCloud, projectCreatedAt],
+      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+    }),
+    [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
   const legacyValidation = validateExportSource(
     AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
@@ -194,14 +201,16 @@ const MixpanelIntegrationSettingsForm = ({
     state?.exportSource ?? null,
     exportSourceCtx,
   );
-  // Selector is beta-gated, except a persisted source blocked by capability
-  // forces it visible so the blocked-save alert has something to point at.
+  // Selector is beta-gated off Cloud, except a persisted source blocked by
+  // capability forces it visible so the blocked-save alert has something to
+  // point at.
   const persistedBlockedByCapability =
     state?.exportSource != null &&
     !isPostCutoffCloud &&
     !isExportSourceSelectable(state.exportSource, exportSourceCtx);
   const showExportSourceField =
-    ((isBetaEnabled && !isPostCutoffCloud) || persistedBlockedByCapability) &&
+    (((isLangfuseCloud || isBetaEnabled) && !isPostCutoffCloud) ||
+      persistedBlockedByCapability) &&
     !shouldHideExportSourceSelector(exportSourceOptions);
 
   // Blocked-save validation instead of silent rewrite (LFE-10296).
@@ -232,7 +241,7 @@ const MixpanelIntegrationSettingsForm = ({
   const defaultExportSource = isPostCutoffCloud
     ? AnalyticsIntegrationExportSource.EVENTS
     : (state?.exportSource ??
-      (isBetaEnabled || !exportSourceCtx.legacyWritesActive
+      (isLangfuseCloud || isBetaEnabled || !exportSourceCtx.legacyWritesActive
         ? AnalyticsIntegrationExportSource.EVENTS
         : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
 

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -32,6 +32,7 @@ import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration
 import { PostHogStatusSection } from "@/src/features/posthog-integration/components/PostHogStatusSection";
 import {
   AnalyticsIntegrationExportSource,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
   type BlobExportWriteMode,
   type ExportSourceContext,
@@ -167,14 +168,20 @@ const PostHogIntegrationSettings = ({
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const integrationCreatedAt = state?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () =>
-      buildExportSourceContext({
+    () => ({
+      ...buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
         projectCreatedAt: new Date(projectCreatedAt),
+        integrationCreatedAt: integrationCreatedAt
+          ? new Date(integrationCreatedAt)
+          : null,
       }),
-    [writeMode, isLangfuseCloud, projectCreatedAt],
+      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+    }),
+    [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
   const legacyValidation = validateExportSource(
     AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
@@ -188,14 +195,16 @@ const PostHogIntegrationSettings = ({
     state?.exportSource ?? null,
     exportSourceCtx,
   );
-  // Selector is beta-gated, except a persisted source blocked by capability
-  // forces it visible so the blocked-save alert has something to point at.
+  // Selector is beta-gated off Cloud, except a persisted source blocked by
+  // capability forces it visible so the blocked-save alert has something to
+  // point at.
   const persistedBlockedByCapability =
     state?.exportSource != null &&
     !isPostCutoffCloud &&
     !isExportSourceSelectable(state.exportSource, exportSourceCtx);
   const showExportSourceField =
-    ((isBetaEnabled && !isPostCutoffCloud) || persistedBlockedByCapability) &&
+    (((isLangfuseCloud || isBetaEnabled) && !isPostCutoffCloud) ||
+      persistedBlockedByCapability) &&
     !shouldHideExportSourceSelector(exportSourceOptions);
 
   // Blocked-save validation instead of silent rewrite (LFE-10296).
@@ -226,7 +235,7 @@ const PostHogIntegrationSettings = ({
   const defaultExportSource = isPostCutoffCloud
     ? AnalyticsIntegrationExportSource.EVENTS
     : (state?.exportSource ??
-      (isBetaEnabled || !exportSourceCtx.legacyWritesActive
+      (isLangfuseCloud || isBetaEnabled || !exportSourceCtx.legacyWritesActive
         ? AnalyticsIntegrationExportSource.EVENTS
         : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
 

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -31,7 +31,6 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration/types";
 import { PostHogStatusSection } from "@/src/features/posthog-integration/components/PostHogStatusSection";
 import {
-  AnalyticsIntegrationExportSource,
   LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
   type BlobExportWriteMode,
@@ -41,10 +40,11 @@ import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 // Shared export-source UI adapters; policy in export-source-policy.ts.
 import {
   buildExportSourceContext,
+  getDefaultExportSource,
   getExportSourceOptions,
   getExportSourceUnavailableMessage,
   isExportSourceSelectable,
-  shouldHideExportSourceSelector,
+  shouldShowExportSourceField,
 } from "@/src/features/analytics-integrations/exportSource";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
@@ -183,29 +183,16 @@ const PostHogIntegrationSettings = ({
     }),
     [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
-  const legacyValidation = validateExportSource(
-    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-    exportSourceCtx,
-  );
-  // Post-cutoff Cloud projects: field hidden, form value pinned to EVENTS via
-  // the default below (LFE-9688 / 9830 behavior, unchanged).
-  const isPostCutoffCloud =
-    !legacyValidation.ok && legacyValidation.reason === "cloud-cutoff";
   const exportSourceOptions = getExportSourceOptions(
     state?.exportSource ?? null,
     exportSourceCtx,
   );
-  // Selector is beta-gated off Cloud, except a persisted source blocked by
-  // capability forces it visible so the blocked-save alert has something to
-  // point at.
-  const persistedBlockedByCapability =
-    state?.exportSource != null &&
-    !isPostCutoffCloud &&
-    !isExportSourceSelectable(state.exportSource, exportSourceCtx);
-  const showExportSourceField =
-    (((isLangfuseCloud || isBetaEnabled) && !isPostCutoffCloud) ||
-      persistedBlockedByCapability) &&
-    !shouldHideExportSourceSelector(exportSourceOptions);
+  const showExportSourceField = shouldShowExportSourceField({
+    persisted: state?.exportSource,
+    ctx: exportSourceCtx,
+    isBetaEnabled,
+    options: exportSourceOptions,
+  });
 
   // Blocked-save validation instead of silent rewrite (LFE-10296).
   const formSchema = useMemo(
@@ -232,12 +219,11 @@ const PostHogIntegrationSettings = ({
     [exportSourceCtx, state],
   );
 
-  const defaultExportSource = isPostCutoffCloud
-    ? AnalyticsIntegrationExportSource.EVENTS
-    : (state?.exportSource ??
-      (isLangfuseCloud || isBetaEnabled || !exportSourceCtx.legacyWritesActive
-        ? AnalyticsIntegrationExportSource.EVENTS
-        : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
+  const defaultExportSource = getDefaultExportSource({
+    persisted: state?.exportSource,
+    ctx: exportSourceCtx,
+    isBetaEnabled,
+  });
 
   const posthogForm = useForm({
     resolver: zodResolver(formSchema),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16097.preview.langfuse.com](https://pr-16097.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Pins newly created Mixpanel and PostHog integrations on Langfuse Cloud to the
enriched events export source, and stops the export-source selector depending on
the V4 beta opt-in when running on Cloud.

Two problems existed:

1. **New integrations could still be created on the legacy export source.**
   Unlike blob storage, the analytics adapters never fed the integration row's
   `createdAt` into `ExportSourceContext`, so the integration-level ("exporter")
   cutoff never ran. A brand-new integration on an older Cloud project therefore
   defaulted to, and permitted, legacy `TRACES_OBSERVATIONS`.
2. **The selector was gated behind the V4 beta flag even on Cloud**, where
   dual-write has been live for a while and the enriched path is always
   available. That flag is a UI rollout gate and has nothing to do with data
   availability.

### Approach

The exporter cutoff is now **parameterized per integration family** rather than
hard-coded to blob storage's. `ExportSourceContext` gained an optional
`exporterCutoff`, defaulting to the existing blob constant so every blob call
site keeps its current behaviour unchanged; the analytics adapters pass their own
constant. `isLegacyBlobExporter` and the rejection message were both threaded
with the same value, so a rejection can never state a cutoff that was not the one
used for the decision.

On the server, both routers now pass the row's `createdAt` (and `null` for a
brand-new row, which follows new-customer rules) and default new Cloud rows to
the enriched source — the analytics equivalent of blob's `forceEventsOnCreate`.
On the client, both settings pages feed the same context in, which reuses the
existing hide-selector-and-pin path rather than introducing a second pinning
mechanism.

Grandfathered rows created before the cutoff keep their persisted source, keep a
visible selector, and are never silently rewritten.

### Behaviour worth a reviewer's attention

- **Create-pinning is deliberately date-independent.** A row with no prior
  existence is pinned on Cloud regardless of the wall-clock date; the cutoff
  governs *existing* rows only. A `now >= cutoff` reading would make the change
  inert until the cutoff date passes.
- **One self-hosted behaviour delta, contrary to a strict "unchanged" reading.**
  The upsert's CREATE payload now prefers the persisted source over the legacy
  new-row default. Under `LANGFUSE_MIGRATION_V4_WRITE_MODE=legacy` with a
  persisted enriched row, a save that omits the source and races a concurrent
  delete used to recreate the row on the legacy source; it now recreates it on
  the persisted enriched one. This is intentional — recreating a row with a value
  the caller never asked for silently rewrites their configuration — and it is
  only reachable under a concurrent delete. Called out explicitly rather than
  left implicit.
- **Grandfathered Cloud rows can now reach the selector without the beta flag.**
  For a row created before the cutoff, legacy sources remain selectable, so a
  Cloud project already on the enriched source can move back to a legacy one.
  The write was already permitted before this change (the cutoff was being
  skipped entirely); what changes is that the control is now visible. This is the
  intended grandfathering policy and is the one genuinely user-visible behaviour
  change here.
- The in-transaction race backstop now runs whenever the source is sent
  explicitly, not only when it is omitted. Because the settings form always
  submits the field, the previous condition meant the backstop never ran for any
  save made through the UI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Blob storage behaviour is unchanged: every existing call site omits the new
  `exporterCutoff` and so keeps the blob cutoff. Verified by re-running the blob
  tRPC, public REST, and status suites (118 tests) plus the worker blob
  processing suite (33 tests).
- Self-hosted behaviour is unchanged in the `legacy`, `dual` + preview opt-in,
  and `events_only` write modes, with the single documented exception above.
  `(isLangfuseCloud || isBetaEnabled)` collapses to the previous expression when
  not on Cloud.
- Tests cover the new create-default and the write-time assert for new versus
  grandfathered Cloud rows, for both Mixpanel and PostHog; the raced-create
  backstop on both the omitted and explicit source paths; and the settings-page
  field-visibility and default derivations. Cutoff dates in tests are derived
  from the constants so the documented local-dev override cannot break them.
- Both settings pages were exercised in a browser against a backdated project
  with the beta flag off: a new integration shows no selector and persists the
  enriched source, and a grandfathered row shows the selector with legacy
  selectable.
- `pnpm run lint` and `pnpm run typecheck` both pass (7/7 tasks each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gives Blob Storage and PostHog/Mixpanel integrations separate exporter cutoff dates and centralizes analytics export-source validation across their routers and settings forms.

- Adds the analytics-specific cutoff environment override and shared policy parameter.
- Applies the analytics cutoff consistently to PostHog and Mixpanel creation/update paths.
- Expands policy, server, and client coverage for cutoff behavior and concurrent-delete handling.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The persisted-source rewrite should be fixed before merging because saving an existing post-cutoff analytics integration can silently change which data it exports.

The new integration-level cutoff reaches form initialization before the persisted value is considered, while the selector is hidden, so an unrelated settings save can persist EVENTS over an existing legacy source.

**Files Needing Attention:** web/src/features/analytics-integrations/exportSource.ts and the PostHog/Mixpanel settings pages
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[PostHog or Mixpanel settings] --> Context[Build export-source context]
  Context --> Policy[Shared export-source policy]
  Policy -->|Analytics family| AnalyticsCutoff[Analytics exporter cutoff]
  Policy -->|Blob family| BlobCutoff[Blob exporter cutoff]
  Policy --> Validation[Router validation]
  Validation --> Upsert[Persist integration configuration]
  Upsert --> Worker[Worker exports selected streams]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/analytics-integrations/exportSource.ts:118
**Persisted export source gets replaced**

If an existing Cloud PostHog or Mixpanel row created on or after the analytics cutoff still stores a legacy export source, this branch initializes and resets the hidden field to `EVENTS` before consulting `persisted`. Saving any integration setting then silently changes which streams subsequent exports include, instead of preserving and surfacing the blocked persisted value.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web,shared): cover the client expor..."](https://github.com/langfuse/langfuse/commit/b19522ecb245b620f4137902225c0bae13f28999) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53036553)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->