### PR TITLE
fix(playground): keep blank messages when replaying a conversation

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/messages.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/messages.test.ts
@@ -53,11 +53,75 @@ describe("mapChatMessagesToModelMessages", () => {
     }
   });
 
-  it("drops a lone empty message", () => {
+  it("keeps a lone empty message", () => {
     expect(
       mapChatMessagesToModelMessages([{ ...systemMessage, content: "" }], {
         adapter: LLMAdapter.Anthropic,
       }),
-    ).toEqual([]);
+    ).toEqual([{ role: "user", content: "" }]);
+  });
+
+  it("keeps blank messages so a replayed conversation keeps its shape", () => {
+    expect(
+      mapChatMessagesToModelMessages([
+        systemMessage,
+        { ...userMessage, content: "" },
+        { ...userMessage, content: "   " },
+        {
+          type: ChatMessageType.AssistantText,
+          role: ChatMessageRole.Assistant,
+          content: "",
+        },
+        userMessage,
+      ]),
+    ).toEqual([
+      { role: "system", content: "You are terse." },
+      { role: "user", content: "" },
+      { role: "user", content: "   " },
+      { role: "assistant", content: "" },
+      { role: "user", content: "Hi" },
+    ]);
+  });
+
+  it("keeps a tool result with empty output", () => {
+    expect(
+      mapChatMessagesToModelMessages([
+        {
+          type: ChatMessageType.AssistantToolCall,
+          role: ChatMessageRole.Assistant,
+          content: "",
+          toolCalls: [{ id: "call_1", name: "search", args: {} }],
+        },
+        {
+          type: ChatMessageType.ToolResult,
+          role: ChatMessageRole.Tool,
+          content: "",
+          toolCallId: "call_1",
+        },
+      ]),
+    ).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "search",
+            input: {},
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "search",
+            output: { type: "text", value: "" },
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/packages/shared/src/server/llm/ai-sdk/messages.ts
+++ b/packages/shared/src/server/llm/ai-sdk/messages.ts
@@ -27,7 +27,9 @@ const toSafeContent = (content: unknown): string =>
  * `ModelMessage[]`:
  * - the first system/developer message becomes `system`, later ones `user`
  * - non-string content is safely JSON-stringified
- * - messages with empty content are dropped unless they carry tool calls
+ * - blank content is preserved: a conversation replayed from a trace keeps the
+ *   exact turns it was recorded with, so an empty or whitespace-only message is
+ *   sent as-is rather than silently disappearing from the request
  * - tool results resolve their `toolName` from the preceding assistant
  *   tool-call messages; orphan tool results fail fast as a non-retryable
  *   error instead of a provider-side 400
@@ -43,10 +45,7 @@ export function mapChatMessagesToModelMessages(
     options?.adapter !== undefined &&
     PROVIDERS_WITH_REQUIRED_USER_MESSAGE.includes(options.adapter)
   ) {
-    const safeContent = toSafeContent(messages[0].content);
-    return safeContent.length > 0
-      ? [{ role: "user", content: safeContent }]
-      : [];
+    return [{ role: "user", content: toSafeContent(messages[0].content) }];
   }
 
   const toolCallIdToName = new Map<string, string>();
@@ -64,18 +63,22 @@ export function mapChatMessagesToModelMessages(
     const safeContent = toSafeContent(message.content);
 
     if (message.type === ChatMessageType.AssistantToolCall) {
-      const content: AssistantContent = [
-        ...(safeContent.length > 0
-          ? [{ type: "text" as const, text: safeContent }]
-          : []),
-        ...(message.toolCalls as LLMToolCall[]).map((toolCall) => ({
+      const toolCalls = (message.toolCalls as LLMToolCall[]).map(
+        (toolCall) => ({
           type: "tool-call" as const,
           toolCallId: toolCall.id,
           toolName: toolCall.name,
           input: toolCall.args,
-        })),
-      ];
-      if (content.length === 0) return; // mirror empty-content filter
+        }),
+      );
+
+      // An assistant turn that only selected tools has no text to send; keep
+      // the empty text part only when there is nothing else in the message.
+      const content: AssistantContent =
+        safeContent.length > 0 || toolCalls.length === 0
+          ? [{ type: "text" as const, text: safeContent }, ...toolCalls]
+          : toolCalls;
+
       modelMessages.push({ role: "assistant", content });
 
       return;
@@ -91,8 +94,6 @@ export function mapChatMessagesToModelMessages(
         });
       }
 
-      if (safeContent.length === 0) return; // mirror empty-content filter
-
       modelMessages.push({
         role: "tool",
         content: [
@@ -107,8 +108,6 @@ export function mapChatMessagesToModelMessages(
 
       return;
     }
-
-    if (safeContent.length === 0) return; // mirror empty-content filter
 
     if (message.role === ChatMessageRole.User) {
       modelMessages.push({ role: "user", content: safeContent });

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -361,7 +361,7 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
           messagePlaceholders,
         );
 
-        if (finalMessages.length === 0) {
+        if (finalMessages.every(isBlankMessage)) {
           throw new Error("Please add at least one message with content.");
         }
 
@@ -610,16 +610,15 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
 
     const handleGlobalExecute = () => {
       if (!isStreamingRef.current) {
-        // Check if this window has any content at all (including placeholders)
-        const hasAnyContent = messages.some((message) => {
-          if (message.type === ChatMessageType.Placeholder) {
-            return true; // Placeholders are considered content
-          }
-          if (typeof message.content === "string") {
-            return message.content.trim().length > 0;
-          }
-          return true; // Non-string content (tool calls, etc.) is considered valid
-        });
+        // Check if this window has any content at all (including placeholders).
+        // Whitespace counts as content: a window replayed from a trace may
+        // consist of a whitespace-only turn, and skipping it would drop the
+        // very thing being reproduced.
+        const hasAnyContent = messages.some(
+          (message) =>
+            message.type === ChatMessageType.Placeholder ||
+            !isBlankMessage(message),
+        );
 
         if (hasAnyContent) {
           // Read streaming preference from localStorage (same key as SubmitButton in Messages.tsx)
@@ -989,28 +988,22 @@ function getFinalMessages(
     {} as Record<string, string>,
   );
 
-  const compiledMessages = compileChatMessagesWithIds(
-    messages,
-    placeholderValues,
-    textVariables,
+  // Blank messages are kept: a conversation opened from a trace must be sent
+  // with the turns it was recorded with, and a blank turn is often the very
+  // thing being reproduced. Placeholders left unfilled are already rejected
+  // above, so there is nothing left here that is safe to silently drop.
+  return compileChatMessagesWithIds(messages, placeholderValues, textVariables);
+}
+
+function isBlankMessage(message: ChatMessageWithIdNoPlaceholders): boolean {
+  if (typeof message.content !== "string") return false;
+  if (message.content.length > 0) return false;
+
+  return !(
+    "toolCalls" in message &&
+    Array.isArray(message.toolCalls) &&
+    message.toolCalls.length > 0
   );
-
-  // Filter empty messages (except tool calls), e.g. if placeholder value was empty
-  return compiledMessages.filter((m) => {
-    // Standard ChatMessage filtering
-    if (typeof m.content === "string") {
-      return (
-        m.content.length > 0 ||
-        ("toolCalls" in m &&
-          m.toolCalls &&
-          Array.isArray(m.toolCalls) &&
-          m.toolCalls.length > 0)
-      );
-    }
-
-    // For arbitrary objects, keep them (assume they have meaningful content)
-    return true;
-  });
 }
 
 function getOutputJson(


### PR DESCRIPTION
## Problem

Opening a generation with **Test in playground** silently drops every message whose content is an empty string. The replayed request no longer matches the recorded call, which defeats the purpose of the playground for debugging: a blank turn is often the exact thing you are trying to reproduce.

Note for anyone who reported this as a "trim": there is no whitespace trimming in the parse path. `normalizeInput` → `convertChatMlToPlayground` preserves `"   "` and `"\n\n"` end to end. The omission is a strict empty-string check, plus one `trim()` in the Run All gate (below).

## Cause

Two mirrored filters:

1. `getFinalMessages` (`web/src/features/playground/page/context/index.tsx`) filtered compiled messages down to `content.length > 0 || toolCalls.length > 0` before submitting.
2. `mapChatMessagesToModelMessages` (`packages/shared/src/server/llm/ai-sdk/messages.ts`) dropped them again server-side — so this affected every caller of `generateLLMText` / `streamLLMText` (playground, evals, experiments, in-app agent), not just the playground.

The client filter was introduced to guard against an unfilled placeholder expanding to nothing, but that case is already rejected by the missing-placeholder error thrown earlier in the same function, so the filter was redundant for its stated purpose.

## Change

- Blank turns are forwarded as recorded, in order.
- An assistant message that only selected tools still omits its empty text part (no change in provider-visible shape there).
- Submitting nothing but blank messages still shows the friendly "Please add at least one message with content" error instead of a provider 400.
- The Run All content gate no longer uses `content.trim().length > 0`, so a window whose only turn is whitespace executes instead of being skipped silently. It now uses the same blank-message notion as the submit guard.

### Tradeoff

Empty text blocks now reach the provider, so Anthropic/Google can return a 400 where the request previously succeeded with the blank turn quietly removed (e.g. a filled system message plus a trailing blank row). That is deliberate: a visible provider error is better than silently reshaping the user's conversation.

## Tests

Regression coverage added to `packages/shared/src/server/llm/ai-sdk/messages.test.ts` (the suite that owns the empty-content contract): blank + whitespace-only turns keep their position and order, a lone empty message is kept, and a tool result with empty output survives.

## Verification

- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter @langfuse/shared run test src/server/llm` — `Tests  158 passed (158)`
- `pnpm --filter web run test-client src/utils/chatml` — `Tests  21 passed (21)`
- `pnpm --filter worker run test src/features/evaluation/__tests__/evalExecutionDeps.test.ts` — `Tests  2 passed (2)`

Draft because web server tests and browser signoff of the playground flow were not run locally (no Postgres/ClickHouse available here) — happy to validate on the PR preview.