### PR TITLE
fix(v4): round estimated API call counts

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -360,6 +360,26 @@ describe("V4MigrationDetailsContent", () => {
     }
   });
 
+  it("rounds estimated API call counts to the nearest integer", () => {
+    mocks.migrationData.apiUsage = [
+      {
+        endpoint: "GET /api/public/traces",
+        count: 56.5,
+        lastSeen: "2026-07-23T10:37:00Z",
+      },
+      {
+        endpoint: "GET /api/public/observations",
+        count: 4.5,
+        lastSeen: "2026-07-22T10:37:00Z",
+      },
+    ];
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    expect(screen.getByText(/57 calls · last seen/)).toBeInTheDocument();
+    expect(screen.getByText(/5 calls · last seen/)).toBeInTheDocument();
+  });
+
   it("collapses clean sections into one up-to-date summary", () => {
     mocks.migrationData.apis = { status: "loaded", count: 0 };
     mocks.migrationData.exports = { status: "loaded", count: 0 };

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -360,7 +360,7 @@ describe("V4MigrationDetailsContent", () => {
     }
   });
 
-  it("rounds estimated API call counts to the nearest integer", () => {
+  it("rounds estimated API call counts and keeps positive usage visible", () => {
     mocks.migrationData.apiUsage = [
       {
         endpoint: "GET /api/public/traces",
@@ -372,12 +372,18 @@ describe("V4MigrationDetailsContent", () => {
         count: 4.5,
         lastSeen: "2026-07-22T10:37:00Z",
       },
+      {
+        endpoint: "GET /api/public/traces/{id}",
+        count: 1 / 3,
+        lastSeen: "2026-07-21T10:37:00Z",
+      },
     ];
 
     render(<V4MigrationDetailsContent projectId="project-1" />);
 
     expect(screen.getByText(/57 calls · last seen/)).toBeInTheDocument();
     expect(screen.getByText(/5 calls · last seen/)).toBeInTheDocument();
+    expect(screen.getByText(/1 call · last seen/)).toBeInTheDocument();
   });
 
   it("collapses clean sections into one up-to-date summary", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -922,7 +922,7 @@ export function V4MigrationApisSection({
                   className="text-muted-foreground text-sm whitespace-nowrap"
                   title={`Last seen at ${row.lastSeen}`}
                 >
-                  {numberFormatter(row.count, 0, 2)} calls · last seen{" "}
+                  {numberFormatter(row.count, 0)} calls · last seen{" "}
                   {formatCompactRelativeTime(new Date(row.lastSeen))}
                 </span>
               </div>

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -906,27 +906,35 @@ export function V4MigrationApisSection({
             maps each endpoint to its replacement.
           </p>
           <div className="flex flex-col">
-            {usage.map((row) => (
-              <div
-                key={row.endpoint}
-                className="text-muted-foreground flex flex-wrap items-baseline justify-between gap-x-2 py-0.5"
-              >
-                <ExternalLink
-                  href={DEPRECATED_API_MIGRATION_URL}
-                  className="text-sm"
-                  analytics={{ section: "apis", link: "deprecated_api_docs" }}
+            {usage.map((row) => {
+              const roundedCount = Math.max(1, Math.round(row.count));
+
+              return (
+                <div
+                  key={row.endpoint}
+                  className="text-muted-foreground flex flex-wrap items-baseline justify-between gap-x-2 py-0.5"
                 >
-                  {row.endpoint}
-                </ExternalLink>
-                <span
-                  className="text-muted-foreground text-sm whitespace-nowrap"
-                  title={`Last seen at ${row.lastSeen}`}
-                >
-                  {numberFormatter(row.count, 0)} calls · last seen{" "}
-                  {formatCompactRelativeTime(new Date(row.lastSeen))}
-                </span>
-              </div>
-            ))}
+                  <ExternalLink
+                    href={DEPRECATED_API_MIGRATION_URL}
+                    className="text-sm"
+                    analytics={{
+                      section: "apis",
+                      link: "deprecated_api_docs",
+                    }}
+                  >
+                    {row.endpoint}
+                  </ExternalLink>
+                  <span
+                    className="text-muted-foreground text-sm whitespace-nowrap"
+                    title={`Last seen at ${row.lastSeen}`}
+                  >
+                    {numberFormatter(roundedCount, 0)}{" "}
+                    {roundedCount === 1 ? "call" : "calls"} · last seen{" "}
+                    {formatCompactRelativeTime(new Date(row.lastSeen))}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </>
       ) : (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16104.preview.langfuse.com](https://pr-16104.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- round estimated legacy API usage counts to the nearest whole number
- add regression coverage for fractional trace and observation call estimates

## Why

The migration API usage query estimates request counts from ClickHouse query-log rows. That estimate can be fractional, but the UI labels the value as a number of API calls. Showing values such as `56.5 calls` is misleading; the presentation should use the nearest integer.

## Impact

Fractional estimates now render as whole call counts, for example `56.5` as `57` and `4.5` as `5`.

## Verification

- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx` — `Tests 40 passed (40)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR rounds estimated legacy API usage counts for display while ensuring positive usage remains visible.
- Rounds fractional trace and observation call estimates to whole numbers.
- Uses singular and plural call labels based on the displayed count.
- Adds regression coverage for fractional and sub-one estimates.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(v4): keep positive API usage visible"](https://github.com/langfuse/langfuse/commit/3acbf0827a2f90782ea6dbcdb421403ad7570733) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53097545)</sub>

<!-- /greptile_comment -->