### PR TITLE
fix(v4): merge legacy API usage across ClickHouse services

### DIFF
--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -99,6 +99,13 @@ const sharedServerMock = vi.hoisted(() => ({
   },
 }));
 
+const sharedEnvMock = vi.hoisted(() => ({
+  CLICKHOUSE_URL: "https://clickhouse-main.example.com",
+  CLICKHOUSE_READ_ONLY_URL: "https://clickhouse-read.example.com",
+}));
+
+vi.mock("@langfuse/shared/src/env", () => ({ env: sharedEnvMock }));
+
 vi.mock("@langfuse/shared/src/server", async () => {
   const { ROOT_CONTEXT } = await import("@opentelemetry/api");
 
@@ -370,6 +377,8 @@ const accessibleProjectsFindManyArgs = {
 
 describe("v4TransitionRouter", () => {
   beforeEach(() => {
+    sharedEnvMock.CLICKHOUSE_READ_ONLY_URL =
+      "https://clickhouse-read.example.com";
     mockedQueryClickhouse.mockResolvedValue([
       {
         projectId,
@@ -385,6 +394,36 @@ describe("v4TransitionRouter", () => {
   });
 
   it("summarizes legacy public API usage for a project with route classification", async () => {
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: "0.6666666666666666",
+          lastSeen: "2026-06-24T12:34:56.789123Z",
+        },
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/datasets/{datasetName}/runs",
+          count: "1",
+          lastSeen: "2026-06-24T14:00:00.000000Z",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: "1.3333333333333335",
+          lastSeen: "2026-06-24T15:00:00.000000Z",
+        },
+        {
+          projectId,
+          entrypoint:
+            "publicapi: DELETE /api/public/datasets/{datasetName}/runs/{runName}",
+          count: "2",
+          lastSeen: "2026-06-24T16:00:00.000000Z",
+        },
+      ]);
     const caller = createCaller();
 
     const rows = await caller.legacyApiUsageSummary({
@@ -396,13 +435,26 @@ describe("v4TransitionRouter", () => {
     expect(rows).toEqual([
       {
         projectId,
+        entrypoint:
+          "publicapi: DELETE /api/public/datasets/{datasetName}/runs/{runName}",
+        count: 2,
+        lastSeen: "2026-06-24T16:00:00.000000Z",
+      },
+      {
+        projectId,
+        entrypoint: "publicapi: GET /api/public/datasets/{datasetName}/runs",
+        count: 1,
+        lastSeen: "2026-06-24T14:00:00.000000Z",
+      },
+      {
+        projectId,
         entrypoint: "publicapi: GET /api/public/traces/{id}",
-        count: 0.6666666666666666,
-        lastSeen: "2026-06-24T12:34:56.789123Z",
+        count: 2,
+        lastSeen: "2026-06-24T15:00:00.000000Z",
       },
     ]);
 
-    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(1);
+    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(2);
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
     expect(clickhouseQuery?.query).toContain(
       "FROM clusterAllReplicas('test-cluster', 'system.query_log')",
@@ -443,6 +495,12 @@ describe("v4TransitionRouter", () => {
     expect(clickhouseQuery?.clickhouseSettings).toEqual({
       skip_unavailable_shards: 1,
     });
+    expect(mockedQueryClickhouse.mock.calls[0]?.[0]).toMatchObject({
+      preferredClickhouseService: "ReadOnly",
+    });
+    expect(mockedQueryClickhouse.mock.calls[1]?.[0]).toMatchObject({
+      preferredClickhouseService: "ReadWrite",
+    });
 
     [
       "GET /api/public/spans",
@@ -463,10 +521,18 @@ describe("v4TransitionRouter", () => {
       "GET /api/public/observations/{id}",
       "GET /api/public/scores/{id}",
       "GET /api/public/v2/scores/{id}",
+      "GET /api/public/datasets/{datasetName}/runs",
       "GET /api/public/datasets/{datasetName}/runs/{runName}",
+      "DELETE /api/public/datasets/{datasetName}/runs/{runName}",
     ].forEach((route) => expect(clickhouseQuery?.query).toContain(route));
     expect(clickhouseQuery?.query).toContain(
+      "match(route_path, '^GET /api/public/datasets/[^/?#]+/runs$'), 'GET /api/public/datasets/{datasetName}/runs'",
+    );
+    expect(clickhouseQuery?.query).toContain(
       "match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1",
+    );
+    expect(clickhouseQuery?.query).toContain(
+      "match(route_path, '^DELETE /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1",
     );
 
     expect(clickhouseQuery?.query).toContain(
@@ -492,6 +558,22 @@ describe("v4TransitionRouter", () => {
     ).rejects.toThrow("30 days");
 
     expect(mockedQueryClickhouse).not.toHaveBeenCalled();
+  });
+
+  it("queries the main service once when no separate read replica is configured", async () => {
+    sharedEnvMock.CLICKHOUSE_READ_ONLY_URL = sharedEnvMock.CLICKHOUSE_URL;
+    const caller = createCaller();
+
+    await caller.legacyApiUsageSummary({
+      projectId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+    });
+
+    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(1);
+    expect(mockedQueryClickhouse).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredClickhouseService: "ReadWrite" }),
+    );
   });
 
   it("queries SDK usage for only the authorized project", async () => {
@@ -1562,20 +1644,35 @@ describe("v4TransitionRouter", () => {
   });
 
   it("summarizes legacy public API usage by organization project", async () => {
-    mockedQueryClickhouse.mockResolvedValue([
-      {
-        projectId,
-        entrypoint: "publicapi: GET /api/public/traces/{id}",
-        count: "0.6666666666666666",
-        lastSeen: "2026-06-24T12:34:56.789123Z",
-      },
-      {
-        projectId: secondProjectId,
-        entrypoint: "publicapi: GET /api/public/metrics",
-        count: 3,
-        lastSeen: "2026-06-24T15:00:00.000000Z",
-      },
-    ]);
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: "0.6666666666666666",
+          lastSeen: "2026-06-24T12:34:56.789123Z",
+        },
+        {
+          projectId: secondProjectId,
+          entrypoint: "publicapi: GET /api/public/metrics",
+          count: 3,
+          lastSeen: "2026-06-24T15:00:00.000000Z",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: "0.3333333333333334",
+          lastSeen: "2026-06-24T14:00:00.000000Z",
+        },
+        {
+          projectId: secondProjectId,
+          entrypoint: "publicapi: GET /api/public/metrics",
+          count: 2,
+          lastSeen: "2026-06-24T16:00:00.000000Z",
+        },
+      ]);
     const mockPrisma = {
       project: {
         findMany: vi.fn().mockResolvedValue([
@@ -1596,21 +1693,21 @@ describe("v4TransitionRouter", () => {
       {
         projectId,
         entrypoint: "publicapi: GET /api/public/traces/{id}",
-        count: 0.6666666666666666,
-        lastSeen: "2026-06-24T12:34:56.789123Z",
+        count: 1,
+        lastSeen: "2026-06-24T14:00:00.000000Z",
       },
       {
         projectId: secondProjectId,
         entrypoint: "publicapi: GET /api/public/metrics",
-        count: 3,
-        lastSeen: "2026-06-24T15:00:00.000000Z",
+        count: 5,
+        lastSeen: "2026-06-24T16:00:00.000000Z",
       },
     ]);
 
     expect(mockPrisma.project.findMany).toHaveBeenCalledWith(
       accessibleProjectsFindManyArgs,
     );
-    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(1);
+    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(2);
     const clickhouseQuery = mockedQueryClickhouse.mock.calls[0]?.[0];
     expect(clickhouseQuery?.query).not.toContain("toStartOfInterval");
     expect(clickhouseQuery?.query).not.toContain("bucket_time");
@@ -1632,6 +1729,12 @@ describe("v4TransitionRouter", () => {
     });
     expect(clickhouseQuery?.tags).toEqual({
       route: "v4-legacy-api-usage-summary",
+    });
+    expect(mockedQueryClickhouse.mock.calls[0]?.[0]).toMatchObject({
+      preferredClickhouseService: "ReadOnly",
+    });
+    expect(mockedQueryClickhouse.mock.calls[1]?.[0]).toMatchObject({
+      preferredClickhouseService: "ReadWrite",
     });
   });
 });

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -102,6 +102,7 @@ const sharedServerMock = vi.hoisted(() => ({
 const sharedEnvMock = vi.hoisted(() => ({
   CLICKHOUSE_URL: "https://clickhouse-main.example.com",
   CLICKHOUSE_READ_ONLY_URL: "https://clickhouse-read.example.com",
+  CLICKHOUSE_EVENTS_READ_ONLY_URL: "https://clickhouse-main.example.com",
 }));
 
 vi.mock("@langfuse/shared/src/env", () => ({ env: sharedEnvMock }));
@@ -379,12 +380,15 @@ describe("v4TransitionRouter", () => {
   beforeEach(() => {
     sharedEnvMock.CLICKHOUSE_READ_ONLY_URL =
       "https://clickhouse-read.example.com";
+    sharedEnvMock.CLICKHOUSE_EVENTS_READ_ONLY_URL =
+      sharedEnvMock.CLICKHOUSE_URL;
     mockedQueryClickhouse.mockResolvedValue([
       {
         projectId,
         entrypoint: "publicapi: GET /api/public/traces/{id}",
         count: "0.6666666666666666",
         lastSeen: "2026-06-24T12:34:56.789123Z",
+        clickhouseHost: "read-host",
       },
     ]);
   });
@@ -401,12 +405,14 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "0.6666666666666666",
           lastSeen: "2026-06-24T12:34:56.789123Z",
+          clickhouseHost: "read-host",
         },
         {
           projectId,
           entrypoint: "publicapi: GET /api/public/datasets/{datasetName}/runs",
           count: "1",
           lastSeen: "2026-06-24T14:00:00.000000Z",
+          clickhouseHost: "read-host",
         },
       ])
       .mockResolvedValueOnce([
@@ -415,13 +421,7 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "1.3333333333333335",
           lastSeen: "2026-06-24T15:00:00.000000Z",
-        },
-        {
-          projectId,
-          entrypoint:
-            "publicapi: DELETE /api/public/datasets/{datasetName}/runs/{runName}",
-          count: "2",
-          lastSeen: "2026-06-24T16:00:00.000000Z",
+          clickhouseHost: "main-host",
         },
       ]);
     const caller = createCaller();
@@ -433,13 +433,6 @@ describe("v4TransitionRouter", () => {
     });
 
     expect(rows).toEqual([
-      {
-        projectId,
-        entrypoint:
-          "publicapi: DELETE /api/public/datasets/{datasetName}/runs/{runName}",
-        count: 2,
-        lastSeen: "2026-06-24T16:00:00.000000Z",
-      },
       {
         projectId,
         entrypoint: "publicapi: GET /api/public/datasets/{datasetName}/runs",
@@ -484,8 +477,9 @@ describe("v4TransitionRouter", () => {
       "JSONExtractString(log_comment, 'projectId') IN {projectIds: Array(String)}",
     );
     expect(clickhouseQuery?.query).toContain(
-      "GROUP BY project_id, legacy_route",
+      "GROUP BY project_id, legacy_route, clickhouse_host",
     );
+    expect(clickhouseQuery?.query).toContain("hostName() AS clickhouse_host");
     expect(clickhouseQuery?.params).toMatchObject({
       projectIds: [projectId],
     });
@@ -523,7 +517,6 @@ describe("v4TransitionRouter", () => {
       "GET /api/public/v2/scores/{id}",
       "GET /api/public/datasets/{datasetName}/runs",
       "GET /api/public/datasets/{datasetName}/runs/{runName}",
-      "DELETE /api/public/datasets/{datasetName}/runs/{runName}",
     ].forEach((route) => expect(clickhouseQuery?.query).toContain(route));
     expect(clickhouseQuery?.query).toContain(
       "match(route_path, '^GET /api/public/datasets/[^/?#]+/runs$'), 'GET /api/public/datasets/{datasetName}/runs'",
@@ -531,10 +524,7 @@ describe("v4TransitionRouter", () => {
     expect(clickhouseQuery?.query).toContain(
       "match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1",
     );
-    expect(clickhouseQuery?.query).toContain(
-      "match(route_path, '^DELETE /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1",
-    );
-
+    expect(clickhouseQuery?.query).not.toContain("DELETE /api/public/datasets");
     expect(clickhouseQuery?.query).toContain(
       "'GET /api/public/traces',\n        'GET /api/public/observations',\n        'GET /api/public/scores',\n        'GET /api/public/v2/scores',\n        'GET /api/public/metrics/daily',\n        'GET /api/public/dataset-run-items'\n      ), 2",
     );
@@ -585,6 +575,7 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "1",
           lastSeen: "2026-06-24T15:00:00.000000Z",
+          clickhouseHost: "main-host",
         },
       ]);
     const caller = createCaller();
@@ -605,6 +596,44 @@ describe("v4TransitionRouter", () => {
     ]);
 
     expect(mockedQueryClickhouse).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not double-count the same ClickHouse host through two services", async () => {
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: "2",
+          lastSeen: "2026-06-24T14:00:00.000000Z",
+          clickhouseHost: "shared-host",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: "2",
+          lastSeen: "2026-06-24T15:00:00.000000Z",
+          clickhouseHost: "shared-host",
+        },
+      ]);
+    const caller = createCaller();
+
+    await expect(
+      caller.legacyApiUsageSummary({
+        projectId,
+        fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+        toTimestamp: new Date("2026-06-25T00:00:00Z"),
+      }),
+    ).resolves.toEqual([
+      {
+        projectId,
+        entrypoint: "publicapi: GET /api/public/traces/{id}",
+        count: 2,
+        lastSeen: "2026-06-24T15:00:00.000000Z",
+      },
+    ]);
   });
 
   it("queries SDK usage for only the authorized project", async () => {
@@ -1154,7 +1183,9 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T03:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([{ projectId, count: "1" }]);
+      .mockResolvedValueOnce([
+        { projectId, count: "1", clickhouseHost: "main-host" },
+      ]);
     const mockPrisma = {
       project: {
         findMany: vi.fn().mockResolvedValue([
@@ -1384,6 +1415,9 @@ describe("v4TransitionRouter", () => {
     expect(experimentUsageQuery?.query).toContain(
       "event_date >= toDate({fromTimestamp: DateTime64(3)})",
     );
+    expect(experimentUsageQuery?.query).toContain(
+      "hostName() AS clickhouseHost",
+    );
     expect(experimentUsageQuery?.params).toMatchObject({
       projectIds: [projectId, secondProjectId],
       fromTimestamp: "2026-06-24 00:00:00.000",
@@ -1391,6 +1425,47 @@ describe("v4TransitionRouter", () => {
     });
     expect(experimentUsageQuery?.tags).toEqual({
       route: "v4-experiment-instrumentation-summary",
+    });
+  });
+
+  it("finds dataset-run-items POST usage when only the main service has it", async () => {
+    sharedEnvMock.CLICKHOUSE_EVENTS_READ_ONLY_URL =
+      "https://clickhouse-events-read.example.com";
+    mockedQueryClickhouse
+      .mockResolvedValueOnce([
+        mockSdkUsageRow({
+          projectId,
+          source: "otel",
+          sdkName: "unknown",
+          sdkVersion: "unknown",
+        }),
+      ])
+      .mockRejectedValueOnce(new Error("events read replica unavailable"))
+      .mockResolvedValueOnce([
+        { projectId, count: "1", clickhouseHost: "main-host" },
+      ]);
+    const caller = createCaller({
+      project: {
+        findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
+      },
+    });
+
+    const [summary] = await caller.sdkUsageSummaryByProject({
+      orgId,
+      fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+      toTimestamp: new Date("2026-06-25T00:00:00Z"),
+    });
+
+    expect(summary?.experimentInstrumentationMigration).toEqual({
+      status: "required",
+      upgradePath: "api",
+    });
+    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(3);
+    expect(mockedQueryClickhouse.mock.calls[1]?.[0]).toMatchObject({
+      preferredClickhouseService: "EventsReadOnly",
+    });
+    expect(mockedQueryClickhouse.mock.calls[2]?.[0]).toMatchObject({
+      preferredClickhouseService: "ReadWrite",
     });
   });
 
@@ -1544,7 +1619,9 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T04:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([{ projectId, count: "1" }]);
+      .mockResolvedValueOnce([
+        { projectId, count: "1", clickhouseHost: "main-host" },
+      ]);
     const caller = createCaller({
       project: {
         findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
@@ -1623,7 +1700,9 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T04:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([{ projectId, count: "1" }]);
+      .mockResolvedValueOnce([
+        { projectId, count: "1", clickhouseHost: "main-host" },
+      ]);
     const caller = createCaller({
       project: {
         findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
@@ -1655,7 +1734,9 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T04:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([{ projectId, count: "1" }]);
+      .mockResolvedValueOnce([
+        { projectId, count: "1", clickhouseHost: "main-host" },
+      ]);
     const caller = createCaller({
       project: {
         findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
@@ -1682,12 +1763,14 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "0.6666666666666666",
           lastSeen: "2026-06-24T12:34:56.789123Z",
+          clickhouseHost: "read-host",
         },
         {
           projectId: secondProjectId,
           entrypoint: "publicapi: GET /api/public/metrics",
           count: 3,
           lastSeen: "2026-06-24T15:00:00.000000Z",
+          clickhouseHost: "read-host",
         },
       ])
       .mockResolvedValueOnce([
@@ -1696,12 +1779,14 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "0.3333333333333334",
           lastSeen: "2026-06-24T14:00:00.000000Z",
+          clickhouseHost: "main-host",
         },
         {
           projectId: secondProjectId,
           entrypoint: "publicapi: GET /api/public/metrics",
           count: 2,
           lastSeen: "2026-06-24T16:00:00.000000Z",
+          clickhouseHost: "main-host",
         },
       ]);
     const mockPrisma = {
@@ -1753,7 +1838,7 @@ describe("v4TransitionRouter", () => {
       "formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen",
     );
     expect(clickhouseQuery?.query).toContain(
-      "GROUP BY project_id, legacy_route",
+      "GROUP BY project_id, legacy_route, clickhouse_host",
     );
     expect(clickhouseQuery?.params).toMatchObject({
       projectIds: [projectId, secondProjectId],

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -576,6 +576,37 @@ describe("v4TransitionRouter", () => {
     );
   });
 
+  it("returns legacy API usage when one ClickHouse service is unavailable", async () => {
+    mockedQueryClickhouse
+      .mockRejectedValueOnce(new Error("read replica unavailable"))
+      .mockResolvedValueOnce([
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: "1",
+          lastSeen: "2026-06-24T15:00:00.000000Z",
+        },
+      ]);
+    const caller = createCaller();
+
+    await expect(
+      caller.legacyApiUsageSummary({
+        projectId,
+        fromTimestamp: new Date("2026-06-24T00:00:00Z"),
+        toTimestamp: new Date("2026-06-25T00:00:00Z"),
+      }),
+    ).resolves.toEqual([
+      {
+        projectId,
+        entrypoint: "publicapi: GET /api/public/traces/{id}",
+        count: 1,
+        lastSeen: "2026-06-24T15:00:00.000000Z",
+      },
+    ]);
+
+    expect(mockedQueryClickhouse).toHaveBeenCalledTimes(2);
+  });
+
   it("queries SDK usage for only the authorized project", async () => {
     mockedQueryClickhouse
       .mockResolvedValueOnce([

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -388,7 +388,6 @@ describe("v4TransitionRouter", () => {
         entrypoint: "publicapi: GET /api/public/traces/{id}",
         count: "0.6666666666666666",
         lastSeen: "2026-06-24T12:34:56.789123Z",
-        clickhouseHost: "read-host",
       },
     ]);
   });
@@ -405,14 +404,12 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "0.6666666666666666",
           lastSeen: "2026-06-24T12:34:56.789123Z",
-          clickhouseHost: "read-host",
         },
         {
           projectId,
           entrypoint: "publicapi: GET /api/public/datasets/{datasetName}/runs",
           count: "1",
           lastSeen: "2026-06-24T14:00:00.000000Z",
-          clickhouseHost: "read-host",
         },
       ])
       .mockResolvedValueOnce([
@@ -421,7 +418,6 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "1.3333333333333335",
           lastSeen: "2026-06-24T15:00:00.000000Z",
-          clickhouseHost: "main-host",
         },
       ]);
     const caller = createCaller();
@@ -477,9 +473,9 @@ describe("v4TransitionRouter", () => {
       "JSONExtractString(log_comment, 'projectId') IN {projectIds: Array(String)}",
     );
     expect(clickhouseQuery?.query).toContain(
-      "GROUP BY project_id, legacy_route, clickhouse_host",
+      "GROUP BY project_id, legacy_route",
     );
-    expect(clickhouseQuery?.query).toContain("hostName() AS clickhouse_host");
+    expect(clickhouseQuery?.query).not.toContain("hostName()");
     expect(clickhouseQuery?.params).toMatchObject({
       projectIds: [projectId],
     });
@@ -575,7 +571,6 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "1",
           lastSeen: "2026-06-24T15:00:00.000000Z",
-          clickhouseHost: "main-host",
         },
       ]);
     const caller = createCaller();
@@ -598,7 +593,7 @@ describe("v4TransitionRouter", () => {
     expect(mockedQueryClickhouse).toHaveBeenCalledTimes(2);
   });
 
-  it("does not double-count the same ClickHouse host through two services", async () => {
+  it("does not double-count identical results from two ClickHouse services", async () => {
     mockedQueryClickhouse
       .mockResolvedValueOnce([
         {
@@ -606,7 +601,6 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "2",
           lastSeen: "2026-06-24T14:00:00.000000Z",
-          clickhouseHost: "shared-host",
         },
       ])
       .mockResolvedValueOnce([
@@ -614,8 +608,7 @@ describe("v4TransitionRouter", () => {
           projectId,
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "2",
-          lastSeen: "2026-06-24T15:00:00.000000Z",
-          clickhouseHost: "shared-host",
+          lastSeen: "2026-06-24T14:00:00.000000Z",
         },
       ]);
     const caller = createCaller();
@@ -631,7 +624,7 @@ describe("v4TransitionRouter", () => {
         projectId,
         entrypoint: "publicapi: GET /api/public/traces/{id}",
         count: 2,
-        lastSeen: "2026-06-24T15:00:00.000000Z",
+        lastSeen: "2026-06-24T14:00:00.000000Z",
       },
     ]);
   });
@@ -1183,9 +1176,7 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T03:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([
-        { projectId, count: "1", clickhouseHost: "main-host" },
-      ]);
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
     const mockPrisma = {
       project: {
         findMany: vi.fn().mockResolvedValue([
@@ -1415,9 +1406,7 @@ describe("v4TransitionRouter", () => {
     expect(experimentUsageQuery?.query).toContain(
       "event_date >= toDate({fromTimestamp: DateTime64(3)})",
     );
-    expect(experimentUsageQuery?.query).toContain(
-      "hostName() AS clickhouseHost",
-    );
+    expect(experimentUsageQuery?.query).not.toContain("hostName()");
     expect(experimentUsageQuery?.params).toMatchObject({
       projectIds: [projectId, secondProjectId],
       fromTimestamp: "2026-06-24 00:00:00.000",
@@ -1441,9 +1430,7 @@ describe("v4TransitionRouter", () => {
         }),
       ])
       .mockRejectedValueOnce(new Error("events read replica unavailable"))
-      .mockResolvedValueOnce([
-        { projectId, count: "1", clickhouseHost: "main-host" },
-      ]);
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
     const caller = createCaller({
       project: {
         findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
@@ -1619,9 +1606,7 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T04:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([
-        { projectId, count: "1", clickhouseHost: "main-host" },
-      ]);
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
     const caller = createCaller({
       project: {
         findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
@@ -1700,9 +1685,7 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T04:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([
-        { projectId, count: "1", clickhouseHost: "main-host" },
-      ]);
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
     const caller = createCaller({
       project: {
         findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
@@ -1734,9 +1717,7 @@ describe("v4TransitionRouter", () => {
           lastSeen: "2026-06-24T04:00:00Z",
         }),
       ])
-      .mockResolvedValueOnce([
-        { projectId, count: "1", clickhouseHost: "main-host" },
-      ]);
+      .mockResolvedValueOnce([{ projectId, count: "1" }]);
     const caller = createCaller({
       project: {
         findMany: vi.fn().mockResolvedValue([{ id: projectId }]),
@@ -1763,14 +1744,12 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "0.6666666666666666",
           lastSeen: "2026-06-24T12:34:56.789123Z",
-          clickhouseHost: "read-host",
         },
         {
           projectId: secondProjectId,
           entrypoint: "publicapi: GET /api/public/metrics",
           count: 3,
           lastSeen: "2026-06-24T15:00:00.000000Z",
-          clickhouseHost: "read-host",
         },
       ])
       .mockResolvedValueOnce([
@@ -1779,14 +1758,12 @@ describe("v4TransitionRouter", () => {
           entrypoint: "publicapi: GET /api/public/traces/{id}",
           count: "0.3333333333333334",
           lastSeen: "2026-06-24T14:00:00.000000Z",
-          clickhouseHost: "main-host",
         },
         {
           projectId: secondProjectId,
           entrypoint: "publicapi: GET /api/public/metrics",
           count: 2,
           lastSeen: "2026-06-24T16:00:00.000000Z",
-          clickhouseHost: "main-host",
         },
       ]);
     const mockPrisma = {
@@ -1838,7 +1815,7 @@ describe("v4TransitionRouter", () => {
       "formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen",
     );
     expect(clickhouseQuery?.query).toContain(
-      "GROUP BY project_id, legacy_route, clickhouse_host",
+      "GROUP BY project_id, legacy_route",
     );
     expect(clickhouseQuery?.params).toMatchObject({
       projectIds: [projectId, secondProjectId],

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -104,6 +104,7 @@ type LegacyApiUsageSummaryByProjectRow = {
   entrypoint: string;
   count: string | number;
   lastSeen: string;
+  clickhouseHost: string;
 };
 
 type LegacyApiUsageSummaryByProjectResultRow = {
@@ -112,6 +113,11 @@ type LegacyApiUsageSummaryByProjectResultRow = {
   count: number;
   lastSeen: string;
 };
+
+type LegacyApiUsageSummaryByProjectServiceRow =
+  LegacyApiUsageSummaryByProjectResultRow & {
+    clickhouseHost: string;
+  };
 
 type SdkUsageSummaryByProjectRow = {
   projectId: string;
@@ -174,6 +180,60 @@ type SdkUsageSummaryByProjectResultRow = {
 type DatasetRunItemsPostUsageByProjectRow = {
   projectId: string;
   count: string | number;
+  clickhouseHost: string;
+};
+
+type SystemQueryLogReadService = "ReadOnly" | "EventsReadOnly";
+
+const getSystemQueryLogServices = ({
+  readService,
+  readUrl,
+}: {
+  readService: SystemQueryLogReadService;
+  readUrl: string | undefined;
+}): PreferredClickhouseService[] =>
+  readUrl &&
+  new URL(readUrl).toString() !== new URL(env.CLICKHOUSE_URL).toString()
+    ? [readService, "ReadWrite"]
+    : ["ReadWrite"];
+
+const querySystemQueryLogAcrossServices = async <T>({
+  preferredClickhouseServices,
+  queryService,
+  failureMessage,
+}: {
+  preferredClickhouseServices: PreferredClickhouseService[];
+  queryService: (service: PreferredClickhouseService) => Promise<T[]>;
+  failureMessage: string;
+}): Promise<T[]> => {
+  const settledServiceRows = await Promise.allSettled(
+    preferredClickhouseServices.map(queryService),
+  );
+  const firstSuccessfulResult = settledServiceRows.find(
+    (result) => result.status === "fulfilled",
+  );
+  if (!firstSuccessfulResult) {
+    const firstFailure = settledServiceRows.find(
+      (result) => result.status === "rejected",
+    );
+    throw firstFailure?.reason ?? new Error("ClickHouse services unavailable");
+  }
+
+  settledServiceRows.forEach((result, index) => {
+    if (result.status === "rejected") {
+      logger.warn(failureMessage, {
+        preferredClickhouseService: preferredClickhouseServices[index],
+        error:
+          result.reason instanceof Error
+            ? result.reason.message
+            : "Unknown error",
+      });
+    }
+  });
+
+  return settledServiceRows.flatMap((result) =>
+    result.status === "fulfilled" ? result.value : [],
+  );
 };
 
 const toBoolean = (value: boolean | string | number): boolean =>
@@ -356,6 +416,12 @@ const getSdkUsageSummaries = async ({
 }): Promise<SdkUsageSummaryByProjectResultRow[]> => {
   if (projectIds.length === 0) return [];
 
+  const systemQueryLogServices = getSystemQueryLogServices({
+    readService: "EventsReadOnly",
+    readUrl:
+      env.CLICKHOUSE_EVENTS_READ_ONLY_URL ?? env.CLICKHOUSE_READ_ONLY_URL,
+  });
+
   const [rows, datasetRunItemsPostUsageResult] = await Promise.all([
     queryClickhouse<SdkUsageSummaryByProjectRow>({
       query: `
@@ -484,11 +550,15 @@ ORDER BY
       tags: { route: "v4-sdk-usage-summary" },
       preferredClickhouseService: "EventsReadOnly",
     }),
-    queryClickhouse<DatasetRunItemsPostUsageByProjectRow>({
-      query: `
+    querySystemQueryLogAcrossServices({
+      preferredClickhouseServices: systemQueryLogServices,
+      queryService: (preferredClickhouseService) =>
+        queryClickhouse<DatasetRunItemsPostUsageByProjectRow>({
+          query: `
 SELECT
   JSONExtractString(log_comment, 'projectId') AS projectId,
-  count() AS count
+  count() AS count,
+  hostName() AS clickhouseHost
 FROM ${systemTableRef("system.query_log")}
 WHERE
   event_time >= {fromTimestamp: DateTime64(3)}
@@ -500,17 +570,20 @@ WHERE
   AND JSONExtractString(log_comment, 'surface') = 'publicapi'
   AND JSONExtractString(log_comment, 'projectId') IN {projectIds: Array(String)}
   AND splitByChar('?', JSONExtractString(log_comment, 'route'))[1] = 'POST /api/public/dataset-run-items'
-GROUP BY projectId
+GROUP BY projectId, clickhouseHost
 SETTINGS skip_unavailable_shards = 1
       `,
-      params: {
-        projectIds,
-        fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp),
-        toTimestamp: convertDateToClickhouseDateTime(toTimestamp),
-      },
-      tags: { route: "v4-experiment-instrumentation-summary" },
-      preferredClickhouseService: "EventsReadOnly",
-      clickhouseSettings: { skip_unavailable_shards: 1 },
+          params: {
+            projectIds,
+            fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp),
+            toTimestamp: convertDateToClickhouseDateTime(toTimestamp),
+          },
+          tags: { route: "v4-experiment-instrumentation-summary" },
+          preferredClickhouseService,
+          clickhouseSettings: { skip_unavailable_shards: 1 },
+        }),
+      failureMessage:
+        "Failed to query dataset-run-items POST usage from ClickHouse service",
     })
       .then((rows) => ({ status: "success" as const, rows }))
       .catch((error: unknown) => {
@@ -616,7 +689,7 @@ const getLegacyApiUsageSummariesForService = async ({
   fromTimestamp: Date;
   toTimestamp: Date;
   preferredClickhouseService: PreferredClickhouseService;
-}): Promise<LegacyApiUsageSummaryByProjectResultRow[]> => {
+}): Promise<LegacyApiUsageSummaryByProjectServiceRow[]> => {
   if (projectIds.length === 0) return [];
 
   const rows = await queryClickhouse<LegacyApiUsageSummaryByProjectRow>({
@@ -625,6 +698,7 @@ WITH selected AS (
   SELECT
     JSONExtractString(log_comment, 'projectId') AS project_id,
     event_time_microseconds,
+    hostName() AS clickhouse_host,
     splitByChar('?', JSONExtractString(log_comment, 'route'))[1] AS route_path
   FROM ${systemTableRef("system.query_log")}
   WHERE
@@ -641,6 +715,7 @@ classified AS (
   SELECT
     project_id,
     event_time_microseconds,
+    clickhouse_host,
     multiIf(
       route_path IN (
         'GET /api/public/spans',
@@ -661,7 +736,6 @@ classified AS (
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 'GET /api/public/v2/scores/{id}',
       match(route_path, '^GET /api/public/datasets/[^/?#]+/runs$'), 'GET /api/public/datasets/{datasetName}/runs',
       match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 'GET /api/public/datasets/{datasetName}/runs/{runName}',
-      match(route_path, '^DELETE /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 'DELETE /api/public/datasets/{datasetName}/runs/{runName}',
       NULL
     ) AS legacy_route,
     multiIf(
@@ -686,7 +760,6 @@ classified AS (
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 1,
       match(route_path, '^GET /api/public/datasets/[^/?#]+/runs$'), 1,
       match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1,
-      match(route_path, '^DELETE /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1,
       NULL
     ) AS clickhouse_queries_per_api_call
   FROM selected
@@ -696,12 +769,13 @@ SELECT
   project_id AS projectId,
   concat('publicapi: ', legacy_route) AS entrypoint,
   sum(1.0 / clickhouse_queries_per_api_call) AS count,
-  formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen
+  formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen,
+  clickhouse_host AS clickhouseHost
 FROM classified
 WHERE legacy_route IS NOT NULL
   AND clickhouse_queries_per_api_call IS NOT NULL
-GROUP BY project_id, legacy_route
-ORDER BY project_id ASC, legacy_route ASC
+GROUP BY project_id, legacy_route, clickhouse_host
+ORDER BY project_id ASC, legacy_route ASC, clickhouse_host ASC
 SETTINGS skip_unavailable_shards = 1
     `,
     params: {
@@ -719,6 +793,7 @@ SETTINGS skip_unavailable_shards = 1
     entrypoint: row.entrypoint,
     count: Number(row.count),
     lastSeen: row.lastSeen,
+    clickhouseHost: row.clickhouseHost,
   }));
 };
 
@@ -733,52 +808,50 @@ const getLegacyApiUsageSummaries = async ({
 }): Promise<LegacyApiUsageSummaryByProjectResultRow[]> => {
   if (projectIds.length === 0) return [];
 
-  const preferredClickhouseServices: PreferredClickhouseService[] =
-    env.CLICKHOUSE_READ_ONLY_URL &&
-    new URL(env.CLICKHOUSE_READ_ONLY_URL).toString() !==
-      new URL(env.CLICKHOUSE_URL).toString()
-      ? ["ReadOnly", "ReadWrite"]
-      : ["ReadWrite"];
-  const settledServiceRows = await Promise.allSettled(
-    preferredClickhouseServices.map((preferredClickhouseService) =>
+  const preferredClickhouseServices = getSystemQueryLogServices({
+    readService: "ReadOnly",
+    readUrl: env.CLICKHOUSE_READ_ONLY_URL,
+  });
+  const serviceRows = await querySystemQueryLogAcrossServices({
+    preferredClickhouseServices,
+    queryService: (preferredClickhouseService) =>
       getLegacyApiUsageSummariesForService({
         projectIds,
         fromTimestamp,
         toTimestamp,
         preferredClickhouseService,
       }),
-    ),
-  );
-  const firstSuccessfulResult = settledServiceRows.find(
-    (result) => result.status === "fulfilled",
-  );
-  if (!firstSuccessfulResult) {
-    const firstFailure = settledServiceRows.find(
-      (result) => result.status === "rejected",
+    failureMessage: "Failed to query legacy API usage from ClickHouse service",
+  });
+
+  const rowsByProjectEntrypointAndHost = new Map<
+    string,
+    LegacyApiUsageSummaryByProjectServiceRow
+  >();
+  for (const row of serviceRows) {
+    const key = `${row.projectId}\u0000${row.entrypoint}\u0000${row.clickhouseHost}`;
+    const existing = rowsByProjectEntrypointAndHost.get(key);
+    rowsByProjectEntrypointAndHost.set(
+      key,
+      existing
+        ? {
+            ...existing,
+            count: Math.max(existing.count, row.count),
+            lastSeen:
+              existing.lastSeen > row.lastSeen
+                ? existing.lastSeen
+                : row.lastSeen,
+          }
+        : row,
     );
-    throw firstFailure?.reason ?? new Error("ClickHouse services unavailable");
   }
 
-  settledServiceRows.forEach((result, index) => {
-    if (result.status === "rejected") {
-      logger.warn("Failed to query legacy API usage from ClickHouse service", {
-        preferredClickhouseService: preferredClickhouseServices[index],
-        error:
-          result.reason instanceof Error
-            ? result.reason.message
-            : "Unknown error",
-      });
-    }
-  });
-  const serviceRows = settledServiceRows.flatMap((result) =>
-    result.status === "fulfilled" ? [result.value] : [],
-  );
   const rowsByProjectAndEntrypoint = new Map<
     string,
     LegacyApiUsageSummaryByProjectResultRow
   >();
 
-  for (const row of serviceRows.flat()) {
+  for (const row of rowsByProjectEntrypointAndHost.values()) {
     const key = `${row.projectId}\u0000${row.entrypoint}`;
     const existing = rowsByProjectAndEntrypoint.get(key);
     rowsByProjectAndEntrypoint.set(
@@ -792,7 +865,12 @@ const getLegacyApiUsageSummaries = async ({
                 ? existing.lastSeen
                 : row.lastSeen,
           }
-        : row,
+        : {
+            projectId: row.projectId,
+            entrypoint: row.entrypoint,
+            count: row.count,
+            lastSeen: row.lastSeen,
+          },
     );
   }
 

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -104,7 +104,6 @@ type LegacyApiUsageSummaryByProjectRow = {
   entrypoint: string;
   count: string | number;
   lastSeen: string;
-  clickhouseHost: string;
 };
 
 type LegacyApiUsageSummaryByProjectResultRow = {
@@ -113,11 +112,6 @@ type LegacyApiUsageSummaryByProjectResultRow = {
   count: number;
   lastSeen: string;
 };
-
-type LegacyApiUsageSummaryByProjectServiceRow =
-  LegacyApiUsageSummaryByProjectResultRow & {
-    clickhouseHost: string;
-  };
 
 type SdkUsageSummaryByProjectRow = {
   projectId: string;
@@ -180,7 +174,6 @@ type SdkUsageSummaryByProjectResultRow = {
 type DatasetRunItemsPostUsageByProjectRow = {
   projectId: string;
   count: string | number;
-  clickhouseHost: string;
 };
 
 type SystemQueryLogReadService = "ReadOnly" | "EventsReadOnly";
@@ -205,7 +198,7 @@ const querySystemQueryLogAcrossServices = async <T>({
   preferredClickhouseServices: PreferredClickhouseService[];
   queryService: (service: PreferredClickhouseService) => Promise<T[]>;
   failureMessage: string;
-}): Promise<T[]> => {
+}): Promise<T[][]> => {
   const settledServiceRows = await Promise.allSettled(
     preferredClickhouseServices.map(queryService),
   );
@@ -232,7 +225,7 @@ const querySystemQueryLogAcrossServices = async <T>({
   });
 
   return settledServiceRows.flatMap((result) =>
-    result.status === "fulfilled" ? result.value : [],
+    result.status === "fulfilled" ? [result.value] : [],
   );
 };
 
@@ -557,8 +550,7 @@ ORDER BY
           query: `
 SELECT
   JSONExtractString(log_comment, 'projectId') AS projectId,
-  count() AS count,
-  hostName() AS clickhouseHost
+  count() AS count
 FROM ${systemTableRef("system.query_log")}
 WHERE
   event_time >= {fromTimestamp: DateTime64(3)}
@@ -570,7 +562,7 @@ WHERE
   AND JSONExtractString(log_comment, 'surface') = 'publicapi'
   AND JSONExtractString(log_comment, 'projectId') IN {projectIds: Array(String)}
   AND splitByChar('?', JSONExtractString(log_comment, 'route'))[1] = 'POST /api/public/dataset-run-items'
-GROUP BY projectId, clickhouseHost
+GROUP BY projectId
 SETTINGS skip_unavailable_shards = 1
       `,
           params: {
@@ -585,7 +577,10 @@ SETTINGS skip_unavailable_shards = 1
       failureMessage:
         "Failed to query dataset-run-items POST usage from ClickHouse service",
     })
-      .then((rows) => ({ status: "success" as const, rows }))
+      .then((serviceRows) => ({
+        status: "success" as const,
+        rows: serviceRows.flat(),
+      }))
       .catch((error: unknown) => {
         logger.warn(
           "Failed to query dataset-run-items POST usage for v4 migration",
@@ -689,7 +684,7 @@ const getLegacyApiUsageSummariesForService = async ({
   fromTimestamp: Date;
   toTimestamp: Date;
   preferredClickhouseService: PreferredClickhouseService;
-}): Promise<LegacyApiUsageSummaryByProjectServiceRow[]> => {
+}): Promise<LegacyApiUsageSummaryByProjectResultRow[]> => {
   if (projectIds.length === 0) return [];
 
   const rows = await queryClickhouse<LegacyApiUsageSummaryByProjectRow>({
@@ -698,7 +693,6 @@ WITH selected AS (
   SELECT
     JSONExtractString(log_comment, 'projectId') AS project_id,
     event_time_microseconds,
-    hostName() AS clickhouse_host,
     splitByChar('?', JSONExtractString(log_comment, 'route'))[1] AS route_path
   FROM ${systemTableRef("system.query_log")}
   WHERE
@@ -715,7 +709,6 @@ classified AS (
   SELECT
     project_id,
     event_time_microseconds,
-    clickhouse_host,
     multiIf(
       route_path IN (
         'GET /api/public/spans',
@@ -769,13 +762,12 @@ SELECT
   project_id AS projectId,
   concat('publicapi: ', legacy_route) AS entrypoint,
   sum(1.0 / clickhouse_queries_per_api_call) AS count,
-  formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen,
-  clickhouse_host AS clickhouseHost
+  formatDateTime(max(event_time_microseconds), '%Y-%m-%dT%H:%i:%S.%fZ', 'UTC') AS lastSeen
 FROM classified
 WHERE legacy_route IS NOT NULL
   AND clickhouse_queries_per_api_call IS NOT NULL
-GROUP BY project_id, legacy_route, clickhouse_host
-ORDER BY project_id ASC, legacy_route ASC, clickhouse_host ASC
+GROUP BY project_id, legacy_route
+ORDER BY project_id ASC, legacy_route ASC
 SETTINGS skip_unavailable_shards = 1
     `,
     params: {
@@ -793,7 +785,6 @@ SETTINGS skip_unavailable_shards = 1
     entrypoint: row.entrypoint,
     count: Number(row.count),
     lastSeen: row.lastSeen,
-    clickhouseHost: row.clickhouseHost,
   }));
 };
 
@@ -812,7 +803,7 @@ const getLegacyApiUsageSummaries = async ({
     readService: "ReadOnly",
     readUrl: env.CLICKHOUSE_READ_ONLY_URL,
   });
-  const serviceRows = await querySystemQueryLogAcrossServices({
+  const serviceResultSets = await querySystemQueryLogAcrossServices({
     preferredClickhouseServices,
     queryService: (preferredClickhouseService) =>
       getLegacyApiUsageSummariesForService({
@@ -824,34 +815,28 @@ const getLegacyApiUsageSummaries = async ({
     failureMessage: "Failed to query legacy API usage from ClickHouse service",
   });
 
-  const rowsByProjectEntrypointAndHost = new Map<
+  const uniqueServiceResultSets = new Map<
     string,
-    LegacyApiUsageSummaryByProjectServiceRow
+    LegacyApiUsageSummaryByProjectResultRow[]
   >();
-  for (const row of serviceRows) {
-    const key = `${row.projectId}\u0000${row.entrypoint}\u0000${row.clickhouseHost}`;
-    const existing = rowsByProjectEntrypointAndHost.get(key);
-    rowsByProjectEntrypointAndHost.set(
-      key,
-      existing
-        ? {
-            ...existing,
-            count: Math.max(existing.count, row.count),
-            lastSeen:
-              existing.lastSeen > row.lastSeen
-                ? existing.lastSeen
-                : row.lastSeen,
-          }
-        : row,
+  for (const rows of serviceResultSets) {
+    const sortedRows = [...rows].sort(
+      (left, right) =>
+        left.projectId.localeCompare(right.projectId) ||
+        left.entrypoint.localeCompare(right.entrypoint),
     );
+    uniqueServiceResultSets.set(JSON.stringify(sortedRows), sortedRows);
   }
+  const deduplicatedServiceRows = Array.from(
+    uniqueServiceResultSets.values(),
+  ).flat();
 
   const rowsByProjectAndEntrypoint = new Map<
     string,
     LegacyApiUsageSummaryByProjectResultRow
   >();
 
-  for (const row of rowsByProjectEntrypointAndHost.values()) {
+  for (const row of deduplicatedServiceRows) {
     const key = `${row.projectId}\u0000${row.entrypoint}`;
     const existing = rowsByProjectAndEntrypoint.get(key);
     rowsByProjectAndEntrypoint.set(
@@ -865,12 +850,7 @@ const getLegacyApiUsageSummaries = async ({
                 ? existing.lastSeen
                 : row.lastSeen,
           }
-        : {
-            projectId: row.projectId,
-            entrypoint: row.entrypoint,
-            count: row.count,
-            lastSeen: row.lastSeen,
-          },
+        : row,
     );
   }
 

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -739,7 +739,7 @@ const getLegacyApiUsageSummaries = async ({
       new URL(env.CLICKHOUSE_URL).toString()
       ? ["ReadOnly", "ReadWrite"]
       : ["ReadWrite"];
-  const serviceRows = await Promise.all(
+  const settledServiceRows = await Promise.allSettled(
     preferredClickhouseServices.map((preferredClickhouseService) =>
       getLegacyApiUsageSummariesForService({
         projectIds,
@@ -748,6 +748,30 @@ const getLegacyApiUsageSummaries = async ({
         preferredClickhouseService,
       }),
     ),
+  );
+  const firstSuccessfulResult = settledServiceRows.find(
+    (result) => result.status === "fulfilled",
+  );
+  if (!firstSuccessfulResult) {
+    const firstFailure = settledServiceRows.find(
+      (result) => result.status === "rejected",
+    );
+    throw firstFailure?.reason ?? new Error("ClickHouse services unavailable");
+  }
+
+  settledServiceRows.forEach((result, index) => {
+    if (result.status === "rejected") {
+      logger.warn("Failed to query legacy API usage from ClickHouse service", {
+        preferredClickhouseService: preferredClickhouseServices[index],
+        error:
+          result.reason instanceof Error
+            ? result.reason.message
+            : "Unknown error",
+      });
+    }
+  });
+  const serviceRows = settledServiceRows.flatMap((result) =>
+    result.status === "fulfilled" ? [result.value] : [],
   );
   const rowsByProjectAndEntrypoint = new Map<
     string,

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -10,6 +10,7 @@ import {
   type PrismaClient,
 } from "@langfuse/shared/src/db";
 import type { Session } from "next-auth";
+import { env } from "@langfuse/shared/src/env";
 import {
   convertDateToClickhouseDateTime,
   INTERNAL_INGESTION_SDK_NAMES,
@@ -18,6 +19,7 @@ import {
   queryClickhouse,
   systemTableRef,
   type IngestionSdkAttributionStatus,
+  type PreferredClickhouseService,
 } from "@langfuse/shared/src/server";
 import { getSdkVersionCapabilityStatus } from "@/src/features/sdk-version/lib/sdkVersionCapabilities";
 const MAX_DETECTION_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
@@ -604,14 +606,16 @@ SETTINGS skip_unavailable_shards = 1
   });
 };
 
-const getLegacyApiUsageSummaries = async ({
+const getLegacyApiUsageSummariesForService = async ({
   projectIds,
   fromTimestamp,
   toTimestamp,
+  preferredClickhouseService,
 }: {
   projectIds: string[];
   fromTimestamp: Date;
   toTimestamp: Date;
+  preferredClickhouseService: PreferredClickhouseService;
 }): Promise<LegacyApiUsageSummaryByProjectResultRow[]> => {
   if (projectIds.length === 0) return [];
 
@@ -655,7 +659,9 @@ classified AS (
       match(route_path, '^GET /api/public/observations/[^/?#]+$'), 'GET /api/public/observations/{id}',
       match(route_path, '^GET /api/public/scores/[^/?#]+$'), 'GET /api/public/scores/{id}',
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 'GET /api/public/v2/scores/{id}',
+      match(route_path, '^GET /api/public/datasets/[^/?#]+/runs$'), 'GET /api/public/datasets/{datasetName}/runs',
       match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 'GET /api/public/datasets/{datasetName}/runs/{runName}',
+      match(route_path, '^DELETE /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 'DELETE /api/public/datasets/{datasetName}/runs/{runName}',
       NULL
     ) AS legacy_route,
     multiIf(
@@ -678,7 +684,9 @@ classified AS (
       match(route_path, '^GET /api/public/observations/[^/?#]+$'), 1,
       match(route_path, '^GET /api/public/scores/[^/?#]+$'), 1,
       match(route_path, '^GET /api/public/v2/scores/[^/?#]+$'), 1,
+      match(route_path, '^GET /api/public/datasets/[^/?#]+/runs$'), 1,
       match(route_path, '^GET /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1,
+      match(route_path, '^DELETE /api/public/datasets/[^/?#]+/runs/[^/?#]+$'), 1,
       NULL
     ) AS clickhouse_queries_per_api_call
   FROM selected
@@ -702,7 +710,7 @@ SETTINGS skip_unavailable_shards = 1
       toTimestamp: convertDateToClickhouseDateTime(toTimestamp),
     },
     tags: { route: "v4-legacy-api-usage-summary" },
-    preferredClickhouseService: "ReadOnly",
+    preferredClickhouseService,
     clickhouseSettings: { skip_unavailable_shards: 1 },
   });
 
@@ -712,6 +720,63 @@ SETTINGS skip_unavailable_shards = 1
     count: Number(row.count),
     lastSeen: row.lastSeen,
   }));
+};
+
+const getLegacyApiUsageSummaries = async ({
+  projectIds,
+  fromTimestamp,
+  toTimestamp,
+}: {
+  projectIds: string[];
+  fromTimestamp: Date;
+  toTimestamp: Date;
+}): Promise<LegacyApiUsageSummaryByProjectResultRow[]> => {
+  if (projectIds.length === 0) return [];
+
+  const preferredClickhouseServices: PreferredClickhouseService[] =
+    env.CLICKHOUSE_READ_ONLY_URL &&
+    new URL(env.CLICKHOUSE_READ_ONLY_URL).toString() !==
+      new URL(env.CLICKHOUSE_URL).toString()
+      ? ["ReadOnly", "ReadWrite"]
+      : ["ReadWrite"];
+  const serviceRows = await Promise.all(
+    preferredClickhouseServices.map((preferredClickhouseService) =>
+      getLegacyApiUsageSummariesForService({
+        projectIds,
+        fromTimestamp,
+        toTimestamp,
+        preferredClickhouseService,
+      }),
+    ),
+  );
+  const rowsByProjectAndEntrypoint = new Map<
+    string,
+    LegacyApiUsageSummaryByProjectResultRow
+  >();
+
+  for (const row of serviceRows.flat()) {
+    const key = `${row.projectId}\u0000${row.entrypoint}`;
+    const existing = rowsByProjectAndEntrypoint.get(key);
+    rowsByProjectAndEntrypoint.set(
+      key,
+      existing
+        ? {
+            ...existing,
+            count: existing.count + row.count,
+            lastSeen:
+              existing.lastSeen > row.lastSeen
+                ? existing.lastSeen
+                : row.lastSeen,
+          }
+        : row,
+    );
+  }
+
+  return Array.from(rowsByProjectAndEntrypoint.values()).sort(
+    (left, right) =>
+      left.projectId.localeCompare(right.projectId) ||
+      left.entrypoint.localeCompare(right.entrypoint),
+  );
 };
 
 export const v4TransitionRouter = createTRPCRouter({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16106.preview.langfuse.com](https://pr-16106.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- classify legacy dataset-run list, detail, and delete API routes in the v4 migration check
- query both the read replica and primary ClickHouse query logs when they are distinct services
- merge counts and latest-seen timestamps in the tRPC layer before returning results to the frontend
- avoid duplicate reads when the read-only client points to the primary service

## Verification

- `pnpm --filter web run test src/__tests__/server/unit/v4TransitionRouter.servertest.ts`
- `pnpm run lint`
- `pnpm --filter web run typecheck`
- `pnpm prettier --check web/src/features/v4/server/v4TransitionRouter.ts web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands v4 legacy API classification for dataset-run routes and combines usage summaries from separate read-only and primary ClickHouse services.

- Adds list, detail, and delete dataset-run route classifications.
- Queries both ClickHouse services when their configured URLs differ.
- Sums matching usage counts and retains the latest timestamp.
- Avoids a duplicate query when both configured URLs are identical.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The partial-service failure should be handled before merging because one unhealthy ClickHouse endpoint currently disables the entire legacy-usage migration check.

The new Promise.all makes successful query-log data unusable whenever either independently configured ClickHouse service rejects.

**Files Needing Attention:** web/src/features/v4/server/v4TransitionRouter.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  RPC[Legacy usage tRPC procedure] --> Config{Distinct ClickHouse URLs?}
  Config -->|No| Primary[Query primary]
  Config -->|Yes| Replica[Query read-only]
  Config -->|Yes| Primary
  Replica --> All[Promise.all]
  Primary --> All
  All --> Merge[Merge by project and entrypoint]
  Merge --> UI[V4 migration status]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4/server/v4TransitionRouter.ts:742-751
**Partial service failure aborts summary**

If either independently configured ClickHouse endpoint is unavailable or cannot read `system.query_log`, `Promise.all` discards the successful result from the other endpoint and rejects the entire tRPC request, causing the v4 migration API-usage status to enter an error state despite usable data being available.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): merge legacy API usage across C..."](https://github.com/langfuse/langfuse/commit/f5f42819b1d94d095fff3ca85cf890f7b1123b21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53141509)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->