### PR TITLE
fix(v4): clarify OTel ingestion guidance

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -811,7 +811,11 @@ describe("V4MigrationDetailsContent", () => {
         screen.getByText("Update OTel Instrumentation").closest("button")!,
       ).getByText("1"),
     ).toBeInTheDocument();
-    expect(screen.getByText(/delayed ingestion path/)).toBeInTheDocument();
+    expect(
+      screen.getByText("x-langfuse-ingestion-version: 4").closest("p"),
+    ).toHaveTextContent(
+      "Your OpenTelemetry data is using delayed ingestion. For real-time ingestion, upgrade your integration or, if you use OpenTelemetry directly, set x-langfuse-ingestion-version: 4 on your OTLP exporter. Migration guide.",
+    );
     expect(screen.getByText("openlit 1.35.4")).toBeInTheDocument();
     expect(screen.getByText("· delayed")).toBeInTheDocument();
     expect(screen.queryByText("Update SDK")).not.toBeInTheDocument();

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -547,15 +547,15 @@ export function V4MigrationOtelSection({
       defaultOpen={defaultOpen}
     >
       <p className="text-muted-foreground text-sm leading-relaxed">
-        OTel data is arriving through the delayed ingestion path. Set the{" "}
-        <MonoValue>x-langfuse-ingestion-version</MonoValue> header to{" "}
-        <MonoValue>4</MonoValue> on the OTLP exporter to use real-time
-        ingestion.{" "}
+        Your OpenTelemetry data is using delayed ingestion. For real-time
+        ingestion, upgrade your integration or, if you use OpenTelemetry
+        directly, set <MonoValue>x-langfuse-ingestion-version: 4</MonoValue> on
+        your OTLP exporter.{" "}
         <ExternalLink
           href={OTEL_V4_MIGRATION_URL}
           analytics={{ section: "otel", link: "otel_migration_docs" }}
         >
-          OpenTelemetry migration guide
+          Migration guide
         </ExternalLink>
         .
       </p>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16107.preview.langfuse.com](https://pr-16107.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- clarify that users of OTel-based integrations should upgrade the integration
- retain direct OTLP exporter guidance for custom OpenTelemetry setups
- update the existing client test to cover the complete notice

## Impacted packages

- `web`

## Verification

- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm exec dotenv -e .env.test.example -e .env.dev.example -- pnpm --filter web run test-client V4MigrationContent.clienttest.tsx` — Tests 39 passed (39)
- `pnpm prettier --check web/src/features/v4-migration/V4MigrationContent.clienttest.tsx web/src/features/v4-migration/V4MigrationContent.tsx` — All matched files use Prettier code style!

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR clarifies the v4 migration notice so integration users are directed to upgrade their integration while custom OpenTelemetry users retain explicit OTLP header guidance.

- Rewords the delayed-ingestion notice and shortens the migration link label.
- Strengthens the client test to assert the complete rendered notice.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The change is limited to clearer migration copy and a matching test assertion, and no reachable behavioral, security, or build failure was established.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): clarify OTel ingestion guidance"](https://github.com/langfuse/langfuse/commit/863ae31dd7844686bee0767911a1e96db030262d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53150587)</sub>

<!-- /greptile_comment -->