### PR TITLE
feat(v4-migration): enable the v4 migration UI by default for self-hosters

### DIFF
--- a/web/src/__tests__/server/userAccount.servertest.ts
+++ b/web/src/__tests__/server/userAccount.servertest.ts
@@ -116,6 +116,7 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
         parseFlags(user.featureFlags, {
           email: user.email,
           v4BetaEnabled: true,
+          isLangfuseCloud: true,
         }).modernSession,
       ).toBe(false);
     },
@@ -132,6 +133,41 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
       }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
   });
+
+  it("persists an opt-out when a self-hoster disables the default-on v4 migration UI", async () => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    const { caller, userId } = await createCaller({
+      featureFlags: ["templateFlag"],
+      v4BetaEnabled: true,
+    });
+
+    const result = await caller.userAccount.setFeaturePreviewEnabled({
+      flag: "v4UpgradeUi",
+      enabled: false,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      flag: "v4UpgradeUi",
+      enabled: false,
+    });
+
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { featureFlags: true, email: true },
+    });
+    expect(user.featureFlags).toEqual([
+      "templateFlag",
+      getFeaturePreviewOptOutFlag("v4UpgradeUi"),
+    ]);
+    expect(
+      parseFlags(user.featureFlags, {
+        email: user.email,
+        v4BetaEnabled: true,
+        isLangfuseCloud: false,
+      }).v4UpgradeUi,
+    ).toBe(false);
+  });
 });
 
 async function createCaller({
@@ -140,12 +176,14 @@ async function createCaller({
   featureFlags = ["templateFlag"],
   includeProjectInSession = true,
   email,
+  v4BetaEnabled = false,
 }: {
   plan?: Plan;
   aiFeaturesEnabled?: boolean;
   featureFlags?: string[];
   includeProjectInSession?: boolean;
   email?: string;
+  v4BetaEnabled?: boolean;
 } = {}) {
   const id = randomUUID();
   const orgId = `org-${id}`;
@@ -219,6 +257,7 @@ async function createCaller({
         experimentsV4Enabled: false,
       },
       admin: false,
+      v4BetaEnabled,
     },
     environment: {
       enableExperimentalFeatures: false,

--- a/web/src/features/feature-flags/utils.clienttest.ts
+++ b/web/src/features/feature-flags/utils.clienttest.ts
@@ -7,6 +7,7 @@ describe("parseFlags", () => {
     const flags = parseFlags([], {
       email: "team.member@langfuse.com",
       v4BetaEnabled: true,
+      isLangfuseCloud: true,
     });
 
     expect(flags.modernSession).toBe(true);
@@ -17,6 +18,7 @@ describe("parseFlags", () => {
     const flags = parseFlags([], {
       email: "team.member@clickhouse.com",
       v4BetaEnabled: true,
+      isLangfuseCloud: true,
     });
 
     expect(flags.modernSession).toBe(true);
@@ -27,6 +29,7 @@ describe("parseFlags", () => {
     const flags = parseFlags([], {
       email: "user@example.com",
       v4BetaEnabled: true,
+      isLangfuseCloud: true,
     });
 
     expect(flags.modernSession).toBe(false);
@@ -37,9 +40,53 @@ describe("parseFlags", () => {
     const flags = parseFlags([getFeaturePreviewOptOutFlag("modernSession")], {
       email: "team.member@langfuse.com",
       v4BetaEnabled: true,
+      isLangfuseCloud: true,
     });
 
     expect(flags.modernSession).toBe(false);
     expect(flags.searchBar).toBe(true);
+  });
+
+  it("enables the v4 migration UI by default on self-hosted v4 deployments", () => {
+    const flags = parseFlags([], {
+      email: "user@example.com",
+      v4BetaEnabled: true,
+      isLangfuseCloud: false,
+    });
+
+    expect(flags.v4UpgradeUi).toBe(true);
+    // Other previews stay opt-in for non team members.
+    expect(flags.modernSession).toBe(false);
+    expect(flags.searchBar).toBe(false);
+  });
+
+  it("honors a self-hoster's explicit opt-out of the v4 migration UI", () => {
+    const flags = parseFlags([getFeaturePreviewOptOutFlag("v4UpgradeUi")], {
+      email: "user@example.com",
+      v4BetaEnabled: true,
+      isLangfuseCloud: false,
+    });
+
+    expect(flags.v4UpgradeUi).toBe(false);
+  });
+
+  it("keeps the v4 migration UI off for self-hosters without the v4 read path", () => {
+    const flags = parseFlags([], {
+      email: "user@example.com",
+      v4BetaEnabled: false,
+      isLangfuseCloud: false,
+    });
+
+    expect(flags.v4UpgradeUi).toBe(false);
+  });
+
+  it("does not enable the v4 migration UI by default on cloud", () => {
+    const flags = parseFlags([], {
+      email: "user@example.com",
+      v4BetaEnabled: true,
+      isLangfuseCloud: true,
+    });
+
+    expect(flags.v4UpgradeUi).toBe(false);
   });
 });

--- a/web/src/features/feature-flags/utils.ts
+++ b/web/src/features/feature-flags/utils.ts
@@ -27,22 +27,54 @@ export const receivesFeaturePreviewsByDefault = (
   );
 };
 
+export type FeaturePreviewDefaultContext = FeaturePreviewAvailabilityContext & {
+  email: string | null | undefined;
+  isLangfuseCloud: boolean;
+};
+
+/**
+ * Whether a Feature Preview flag is switched on by default for this user and
+ * deployment (before the user's explicit opt-out is applied). Both the session
+ * flag parser and the toggle mutation consult this so a default-on flag can be
+ * turned back off by persisting an opt-out marker rather than silently
+ * reappearing.
+ */
+export const featurePreviewDefaultsToEnabled = (
+  flag: FeaturePreviewFlag,
+  context: FeaturePreviewDefaultContext,
+): boolean => {
+  // Langfuse/ClickHouse team members receive every available preview by default.
+  if (
+    receivesFeaturePreviewsByDefault(context.email) &&
+    isFeaturePreviewAvailable(flag, context)
+  ) {
+    return true;
+  }
+
+  // Self-hosted deployments that read the v4 events tables get the v4 migration
+  // UI by default, so operators see the upgrade guidance without first flipping
+  // a Feature Preview toggle. Cloud keeps its existing per-user rollout.
+  if (
+    flag === "v4UpgradeUi" &&
+    !context.isLangfuseCloud &&
+    context.v4BetaEnabled
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
 export const parseFlags = (
   dbFlags: string[],
-  context: FeaturePreviewAvailabilityContext & {
-    email: string | null | undefined;
-  },
+  context: FeaturePreviewDefaultContext,
 ): Flags => {
   const parsedFlags = {} as Flags;
-  const enableFeaturePreviewsByDefault = receivesFeaturePreviewsByDefault(
-    context.email,
-  );
 
   availableFlags.forEach((flag) => {
     if (
-      enableFeaturePreviewsByDefault &&
       isFeaturePreviewFlag(flag) &&
-      isFeaturePreviewAvailable(flag, context)
+      featurePreviewDefaultsToEnabled(flag, context)
     ) {
       parsedFlags[flag] = !dbFlags.includes(getFeaturePreviewOptOutFlag(flag));
       return;

--- a/web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts
+++ b/web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts
@@ -35,7 +35,11 @@ describe("useV4UpgradeUiEnabled", () => {
   });
 
   it("maps the database flag into the session flag shape", () => {
-    const context = { email: undefined, v4BetaEnabled: false };
+    const context = {
+      email: undefined,
+      v4BetaEnabled: false,
+      isLangfuseCloud: true,
+    };
     expect(parseFlags(["v4UpgradeUi"], context).v4UpgradeUi).toBe(true);
     expect(parseFlags([], context).v4UpgradeUi).toBe(false);
   });

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -14,6 +14,7 @@ import { getSfdcService } from "@/src/ee/features/sfdc-sync/server";
 import {
   getFeaturePreviewOptOutFlag,
   receivesFeaturePreviewsByDefault,
+  featurePreviewDefaultsToEnabled,
 } from "@/src/features/feature-flags/utils";
 import { featurePreviewFlags } from "@/src/features/feature-flags/available-flags";
 
@@ -145,9 +146,21 @@ export const userAccountRouter = createTRPCRouter({
           const featureFlagsWithoutOverride = currentUser.featureFlags.filter(
             (flag) => flag !== input.flag && flag !== optOutFlag,
           );
+          // When a flag would otherwise default back on for this
+          // user/deployment, disabling it must persist an opt-out marker;
+          // otherwise merely dropping it from the array would let the default
+          // flip it on again. Team members receive every preview by default,
+          // and self-hosted v4 deployments receive the migration UI by default.
+          const persistOptOut =
+            receivesFeaturePreviewsByDefault(currentUser.email) ||
+            featurePreviewDefaultsToEnabled(input.flag, {
+              email: currentUser.email,
+              v4BetaEnabled: ctx.session.user.v4BetaEnabled === true,
+              isLangfuseCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+            });
           const nextFeatureFlags = input.enabled
             ? [...featureFlagsWithoutOverride, input.flag]
-            : receivesFeaturePreviewsByDefault(currentUser.email)
+            : persistOptOut
               ? [...featureFlagsWithoutOverride, optOutFlag]
               : featureFlagsWithoutOverride;
           await tx.user.update({

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -140,6 +140,7 @@ const staticProviders: Provider[] = [
           // The full session callback resolves deployment and rollout
           // availability before applying employee defaults.
           v4BetaEnabled: false,
+          isLangfuseCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
         }),
         canCreateOrganizations: canCreateOrganizations(dbUser.email),
         organizations: [],
@@ -984,6 +985,7 @@ export async function getAuthOptions(signupAttribution?: {
                     featureFlags: parseFlags(dbUser.featureFlags, {
                       email: dbUser.email,
                       v4BetaEnabled,
+                      isLangfuseCloud,
                     }),
                     hasPassword: Boolean(dbUser.password),
                   }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16114.preview.langfuse.com](https://pr-16114.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Enables the v4 migration/upgrade UI by default on self-hosted deployments, so operators are guided through the v4 migration without first flipping a Feature Preview toggle.

Previously, the v4 migration UI (nav "Update" pill, upgrade badges, migration panel/banner, and status page) was gated behind the per-user `v4UpgradeUi` Feature Preview flag, which was only default-on for Langfuse/ClickHouse team members. Self-hosters had to manually opt in through the Feature Preview modal.

### Behavior

- **Self-hosted + v4 read path active** (`v4BetaEnabled`, i.e. `events_only` write mode, or `dual` with opt-in): the v4 migration UI is now on by default.
- **Cloud**: unchanged — the existing per-user rollout and team-member defaults still apply.
- **Self-hosted without the v4 read path** (`legacy`, or `dual` not opted in): the migration UI stays off, since the migration surfaces read the v4 events tables.
- **Opt-out**: users can still disable it from the Feature Preview modal. The toggle mutation now persists an opt-out marker for any flag that would otherwise default back on (team-member previews and the self-hosted migration UI), so a disable sticks instead of silently reappearing.

### How

- Added `featurePreviewDefaultsToEnabled(flag, context)` in `web/src/features/feature-flags/utils.ts` as the single source of truth for per-flag deployment/user defaults. `parseFlags` consults it, and it adds the self-hosted `v4UpgradeUi` default.
- Threaded `isLangfuseCloud` into both `parseFlags` call sites in `web/src/server/auth.ts`.
- Updated `userAccount.setFeaturePreviewEnabled` to persist an opt-out marker when disabling a default-on flag (preserving the prior team-member behavior and adding the self-hosted case).

Fixes the request to enable the v4 migration UI by default for self-hosters.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Tests added/updated:
  - `web/src/features/feature-flags/utils.clienttest.ts` — self-hosted default-on, opt-out, and cloud/no-read-path cases.
  - `web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts` — updated context shape.
  - `web/src/__tests__/server/userAccount.servertest.ts` — self-hoster opt-out persists a marker.
- Verification run locally:
  - `pnpm --filter web run typecheck` — passed.
  - `pnpm --filter web run lint` / pre-commit `turbo run lint` — `7 successful, 7 total`.
  - Client tests (`v4-migration` + `feature-flags`) — `Tests 111 passed (111)`.
  - Server test (`userAccount.servertest.ts`) — `Tests 7 passed (7)`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14647](https://linear.app/clickhouse/issue/LFE-14647/enable-the-v4-migration-ui-by-default-for-self-hoster)

<div><a href="https://cursor.com/agents/bc-7b4258af-c40c-435a-a54a-b75b8157aba6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b4258af-c40c-435a-a54a-b75b8157aba6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

