### PR TITLE
feat(v4-migration): enable the v4 migration UI by default for self-hosters

### DIFF
--- a/web/src/__tests__/server/userAccount.servertest.ts
+++ b/web/src/__tests__/server/userAccount.servertest.ts
@@ -116,6 +116,8 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
         parseFlags(user.featureFlags, {
           email: user.email,
           v4BetaEnabled: true,
+          isLangfuseCloud: true,
+          v4WriteMode: "events_only",
         }).modernSession,
       ).toBe(false);
     },
@@ -131,6 +133,62 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
         enabled: true,
       }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+
+  it.each(["events_only", "dual"] as const)(
+    "persists an opt-out when a self-hoster disables the v4 migration UI on %s",
+    async (writeMode) => {
+      const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = writeMode;
+
+      try {
+        const { caller, userId } = await createCaller({
+          featureFlags: ["templateFlag"],
+        });
+
+        await caller.userAccount.setFeaturePreviewEnabled({
+          flag: "v4UpgradeUi",
+          enabled: false,
+        });
+
+        const user = await prisma.user.findUniqueOrThrow({
+          where: { id: userId },
+          select: { featureFlags: true },
+        });
+        expect(user.featureFlags).toEqual([
+          "templateFlag",
+          getFeaturePreviewOptOutFlag("v4UpgradeUi"),
+        ]);
+      } finally {
+        (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+      }
+    },
+  );
+
+  it("does not persist an opt-out when a self-hoster on legacy disables the v4 migration UI", async () => {
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+
+    try {
+      const { caller, userId } = await createCaller({
+        featureFlags: ["templateFlag", "v4UpgradeUi"],
+      });
+
+      await caller.userAccount.setFeaturePreviewEnabled({
+        flag: "v4UpgradeUi",
+        enabled: false,
+      });
+
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { id: userId },
+        select: { featureFlags: true },
+      });
+      expect(user.featureFlags).toEqual(["templateFlag"]);
+    } finally {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    }
   });
 });
 

--- a/web/src/features/feature-flags/utils.clienttest.ts
+++ b/web/src/features/feature-flags/utils.clienttest.ts
@@ -1,10 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import { getFeaturePreviewOptOutFlag, parseFlags } from "./utils";
+import {
+  featurePreviewDefaultsToEnabled,
+  getFeaturePreviewOptOutFlag,
+  parseFlags,
+  type FeaturePreviewDefaultContext,
+} from "./utils";
+
+const baseContext: FeaturePreviewDefaultContext = {
+  email: "user@example.com",
+  v4BetaEnabled: false,
+  isLangfuseCloud: false,
+  v4WriteMode: "legacy",
+};
 
 describe("parseFlags", () => {
   it("enables feature previews by default for Langfuse team members", () => {
     const flags = parseFlags([], {
+      ...baseContext,
       email: "team.member@langfuse.com",
       v4BetaEnabled: true,
     });
@@ -15,6 +28,7 @@ describe("parseFlags", () => {
 
   it("enables feature previews by default for ClickHouse team members", () => {
     const flags = parseFlags([], {
+      ...baseContext,
       email: "team.member@clickhouse.com",
       v4BetaEnabled: true,
     });
@@ -25,6 +39,7 @@ describe("parseFlags", () => {
 
   it("does not enable feature previews by default for other users", () => {
     const flags = parseFlags([], {
+      ...baseContext,
       email: "user@example.com",
       v4BetaEnabled: true,
     });
@@ -35,11 +50,93 @@ describe("parseFlags", () => {
 
   it("honors a Langfuse team member's explicit opt-out", () => {
     const flags = parseFlags([getFeaturePreviewOptOutFlag("modernSession")], {
+      ...baseContext,
       email: "team.member@langfuse.com",
       v4BetaEnabled: true,
     });
 
     expect(flags.modernSession).toBe(false);
     expect(flags.searchBar).toBe(true);
+  });
+});
+
+describe("v4UpgradeUi default", () => {
+  it("is on by default on Langfuse Cloud regardless of write mode", () => {
+    for (const v4WriteMode of ["legacy", "dual", "events_only"] as const) {
+      const flags = parseFlags([], {
+        ...baseContext,
+        isLangfuseCloud: true,
+        v4WriteMode,
+      });
+      expect(flags.v4UpgradeUi).toBe(true);
+    }
+  });
+
+  it("is on by default for self-hosted events_only and dual deployments", () => {
+    for (const v4WriteMode of ["events_only", "dual"] as const) {
+      const flags = parseFlags([], {
+        ...baseContext,
+        isLangfuseCloud: false,
+        v4WriteMode,
+      });
+      expect(flags.v4UpgradeUi).toBe(true);
+    }
+  });
+
+  it("stays off by default for self-hosted legacy deployments", () => {
+    const flags = parseFlags([], {
+      ...baseContext,
+      isLangfuseCloud: false,
+      v4WriteMode: "legacy",
+    });
+    expect(flags.v4UpgradeUi).toBe(false);
+  });
+
+  it("can be explicitly opted into on a self-hosted legacy deployment", () => {
+    const flags = parseFlags(["v4UpgradeUi"], {
+      ...baseContext,
+      isLangfuseCloud: false,
+      v4WriteMode: "legacy",
+    });
+    expect(flags.v4UpgradeUi).toBe(true);
+  });
+
+  it("honors an opt-out on a default-on deployment", () => {
+    const flags = parseFlags([getFeaturePreviewOptOutFlag("v4UpgradeUi")], {
+      ...baseContext,
+      isLangfuseCloud: false,
+      v4WriteMode: "events_only",
+    });
+    expect(flags.v4UpgradeUi).toBe(false);
+  });
+});
+
+describe("featurePreviewDefaultsToEnabled", () => {
+  it("returns true for v4UpgradeUi on non-legacy self-hosted deployments", () => {
+    expect(
+      featurePreviewDefaultsToEnabled("v4UpgradeUi", {
+        ...baseContext,
+        v4WriteMode: "dual",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for v4UpgradeUi on legacy self-hosted deployments", () => {
+    expect(
+      featurePreviewDefaultsToEnabled("v4UpgradeUi", {
+        ...baseContext,
+        v4WriteMode: "legacy",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not default modernSession on for non-team members", () => {
+    expect(
+      featurePreviewDefaultsToEnabled("modernSession", {
+        ...baseContext,
+        v4BetaEnabled: true,
+        v4WriteMode: "events_only",
+      }),
+    ).toBe(false);
   });
 });

--- a/web/src/features/feature-flags/utils.ts
+++ b/web/src/features/feature-flags/utils.ts
@@ -27,22 +27,58 @@ export const receivesFeaturePreviewsByDefault = (
   );
 };
 
+// Mirrors LANGFUSE_MIGRATION_V4_WRITE_MODE (packages/shared/src/env.ts). Kept as
+// a local string union so this frontend-safe module does not import the
+// server-only env schema.
+export type V4WriteMode = "legacy" | "dual" | "events_only";
+
+export type FeaturePreviewDefaultContext = FeaturePreviewAvailabilityContext & {
+  email: string | null | undefined;
+  isLangfuseCloud: boolean;
+  v4WriteMode: V4WriteMode;
+};
+
+/**
+ * Whether a Feature Preview flag is switched on by default for this user and
+ * deployment, before the user's explicit opt-out is applied. Both the session
+ * flag parser and the toggle mutation consult this so a default-on flag can be
+ * turned back off by persisting an opt-out marker instead of silently
+ * reappearing on the next session.
+ */
+export const featurePreviewDefaultsToEnabled = (
+  flag: FeaturePreviewFlag,
+  context: FeaturePreviewDefaultContext,
+): boolean => {
+  // Langfuse/ClickHouse team members receive every available preview by default.
+  if (
+    receivesFeaturePreviewsByDefault(context.email) &&
+    isFeaturePreviewAvailable(flag, context)
+  ) {
+    return true;
+  }
+
+  // The v4 migration/upgrade UI is on by default wherever the v4 events tables
+  // are the read path: on Langfuse Cloud, and on self-hosted deployments whose
+  // write mode is `events_only` or `dual`. Self-hosted `legacy` deployments do
+  // not write the events tables, so the migration surfaces would have nothing
+  // to read — keep it off there. Operators can still opt out.
+  if (flag === "v4UpgradeUi") {
+    return context.isLangfuseCloud || context.v4WriteMode !== "legacy";
+  }
+
+  return false;
+};
+
 export const parseFlags = (
   dbFlags: string[],
-  context: FeaturePreviewAvailabilityContext & {
-    email: string | null | undefined;
-  },
+  context: FeaturePreviewDefaultContext,
 ): Flags => {
   const parsedFlags = {} as Flags;
-  const enableFeaturePreviewsByDefault = receivesFeaturePreviewsByDefault(
-    context.email,
-  );
 
   availableFlags.forEach((flag) => {
     if (
-      enableFeaturePreviewsByDefault &&
       isFeaturePreviewFlag(flag) &&
-      isFeaturePreviewAvailable(flag, context)
+      featurePreviewDefaultsToEnabled(flag, context)
     ) {
       parsedFlags[flag] = !dbFlags.includes(getFeaturePreviewOptOutFlag(flag));
       return;

--- a/web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts
+++ b/web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts
@@ -35,7 +35,12 @@ describe("useV4UpgradeUiEnabled", () => {
   });
 
   it("maps the database flag into the session flag shape", () => {
-    const context = { email: undefined, v4BetaEnabled: false };
+    const context = {
+      email: undefined,
+      v4BetaEnabled: false,
+      isLangfuseCloud: false,
+      v4WriteMode: "legacy" as const,
+    };
     expect(parseFlags(["v4UpgradeUi"], context).v4UpgradeUi).toBe(true);
     expect(parseFlags([], context).v4UpgradeUi).toBe(false);
   });

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -12,6 +12,7 @@ import { V4_PREVIEW_LABEL } from "@/src/features/events/lib/v4PreviewLabel";
 import { env } from "@/src/env.mjs";
 import { getSfdcService } from "@/src/ee/features/sfdc-sync/server";
 import {
+  featurePreviewDefaultsToEnabled,
   getFeaturePreviewOptOutFlag,
   receivesFeaturePreviewsByDefault,
 } from "@/src/features/feature-flags/utils";
@@ -145,9 +146,24 @@ export const userAccountRouter = createTRPCRouter({
           const featureFlagsWithoutOverride = currentUser.featureFlags.filter(
             (flag) => flag !== input.flag && flag !== optOutFlag,
           );
+          // When a flag would otherwise default back on for this
+          // user/deployment, disabling it must persist an opt-out marker;
+          // dropping it from the array alone would let the default flip it on
+          // again on the next session. Team members receive every preview by
+          // default (persist regardless of the current availability so the
+          // opt-out survives a later availability change), and cloud/self-hosted
+          // v4 deployments receive the migration UI by default.
+          const persistOptOut =
+            receivesFeaturePreviewsByDefault(currentUser.email) ||
+            featurePreviewDefaultsToEnabled(input.flag, {
+              email: currentUser.email,
+              v4BetaEnabled: ctx.session.user.v4BetaEnabled === true,
+              isLangfuseCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+              v4WriteMode: env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
+            });
           const nextFeatureFlags = input.enabled
             ? [...featureFlagsWithoutOverride, input.flag]
-            : receivesFeaturePreviewsByDefault(currentUser.email)
+            : persistOptOut
               ? [...featureFlagsWithoutOverride, optOutFlag]
               : featureFlagsWithoutOverride;
           await tx.user.update({

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -140,6 +140,8 @@ const staticProviders: Provider[] = [
           // The full session callback resolves deployment and rollout
           // availability before applying employee defaults.
           v4BetaEnabled: false,
+          isLangfuseCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+          v4WriteMode: env.LANGFUSE_MIGRATION_V4_WRITE_MODE,
         }),
         canCreateOrganizations: canCreateOrganizations(dbUser.email),
         organizations: [],
@@ -984,6 +986,8 @@ export async function getAuthOptions(signupAttribution?: {
                     featureFlags: parseFlags(dbUser.featureFlags, {
                       email: dbUser.email,
                       v4BetaEnabled,
+                      isLangfuseCloud,
+                      v4WriteMode,
                     }),
                     hasPassword: Boolean(dbUser.password),
                   }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16118.preview.langfuse.com](https://pr-16118.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Enables the v4 migration/upgrade UI by default based on deployment mode, so operators are guided through the v4 migration without first flipping a Feature Preview toggle.

Previously the v4 migration UI (nav "Update" pill, upgrade badges, migration panel/banner, and status page) was gated behind the per-user `v4UpgradeUi` Feature Preview flag, which was only default-on for Langfuse/ClickHouse team members. Everyone else had to opt in manually.

The default now follows the deployment matrix requested in the issue (driven by the `LANGFUSE_MIGRATION_V4_WRITE_MODE` env variable and the Cloud region setting):

| Deployment | v4 migration UI default |
| --- | --- |
| Langfuse Cloud | **on** |
| Self-hosted `events_only` | **on** |
| Self-hosted `dual` | **on** |
| Self-hosted `legacy` | off |

Self-hosted `legacy` deployments do not write the v4 events tables that the migration surfaces read, so it stays off there. Unlike the v4 beta preview read-path (`v4BetaEnabled`), the migration UI on `dual` no longer requires the per-user opt-in — it is on by default, matching the issue.

### How

- Added `featurePreviewDefaultsToEnabled(flag, context)` in `web/src/features/feature-flags/utils.ts` as the single source of truth for per-flag deployment/user defaults. `parseFlags` consults it. It keeps the team-member default and adds the `v4UpgradeUi` default `isLangfuseCloud || v4WriteMode !== "legacy"`.
- Threaded `isLangfuseCloud` and `v4WriteMode` into both `parseFlags` call sites in `web/src/server/auth.ts`.
- `userAccount.setFeaturePreviewEnabled` persists an opt-out marker when disabling a flag that would otherwise default back on (team-member previews, and the new Cloud/self-hosted migration UI), so a disable sticks instead of silently reappearing.

Fixes the request to enable the v4 migration UI by default for self-hosters.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Tests added/updated:
  - `web/src/features/feature-flags/utils.clienttest.ts` — full default matrix (Cloud, `events_only`, `dual`, `legacy`), opt-in on legacy, and opt-out on a default-on deployment.
  - `web/src/features/v4-migration/useV4UpgradeUiEnabled.clienttest.ts` — updated context shape.
  - `web/src/__tests__/server/userAccount.servertest.ts` — self-hoster opt-out persists a marker on `events_only`/`dual`, and does not on `legacy`.
- Verification run locally:
  - `pnpm --filter web run typecheck` — clean run reports 0 errors.
  - Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`.
  - Client tests (`feature-flags` + `v4-migration`) — `Tests 17 passed (17)`.
  - Server test (`userAccount.servertest.ts`) — `Tests 9 passed (9)`.

Linear Issue: [LFE-14647](https://linear.app/clickhouse/issue/LFE-14647/enable-the-v4-migration-ui-by-default-for-self-hoster)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14647](https://linear.app/clickhouse/issue/LFE-14647/enable-the-v4-migration-ui-by-default-for-self-hoster)

<div><a href="https://cursor.com/agents/bc-426b7fe6-2fc7-4ba6-b07e-90895a156b1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-426b7fe6-2fc7-4ba6-b07e-90895a156b1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

