### PR TITLE
fix(api): carry endpoint deprecation notices into the API reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -541,7 +541,7 @@ To export the respective `openapi.yml` files which power the online API referenc
 pnpm run openapi:export
 ```
 
-This command also syncs standard OpenAPI `deprecated` flags from the endpoint `availability` metadata in the Fern definitions.
+This command also syncs standard OpenAPI `deprecated` flags and `**Deprecated:** …` description notices from the endpoint `availability` metadata in the Fern definitions.
 
 To generate the server SDKs, run:
 

--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -18,7 +18,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset run items are replaced by experiment items; use GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, dataset run items are replaced by experiment items; use `GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>` instead."
       method: GET
       docs: List dataset run items
       path: /dataset-run-items

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -9,7 +9,7 @@ service:
     batch:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Send data via the OpenTelemetry endpoint at POST /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Send data via the OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration docs](https://langfuse.com/integrations/native/opentelemetry)."
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -9,7 +9,7 @@ service:
     metrics:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/metrics?query=<urlencoded json query> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use `GET /api/public/v2/metrics?query=<urlencoded json query>` instead."
       docs: |
         Get metrics from the Langfuse project using a query object.
 

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -21,7 +21,7 @@ service:
     getMany:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to> instead."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
       docs: |
         Get a list of observations.
 

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -15,12 +15,8 @@ service:
     get-many:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores instead."
-      docs: |
-        **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
-        is no longer available on Langfuse v4 and later.
-
-        Get a list of scores (supports both trace and session scores)
+        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed in a future release. Use `GET /api/public/v3/scores` instead."
+      docs: Get a list of scores (supports both trace and session scores)
       method: GET
       path: /v2/scores
       request:
@@ -100,12 +96,8 @@ service:
     get-by-id:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. Use GET /api/public/v3/scores with the id filter instead."
-      docs: |
-        **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
-        instead. This endpoint is no longer available on Langfuse v4 and later.
-
-        Get a score (supports both trace and session scores)
+        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed in a future release. Use `GET /api/public/v3/scores` with the `id` filter instead."
+      docs: Get a score (supports both trace and session scores)
       method: GET
       path: /v2/scores/{scoreId}
       path-parameters:

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -36,7 +36,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>."
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
       docs: Get list of traces
       method: GET
       path: /traces

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1135,7 +1135,15 @@ paths:
       security: *ref_0
   /api/public/dataset-run-items:
     post:
-      description: Create a dataset run item
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, create experiment data via the SDK
+        experiment runner or the OpenTelemetry endpoint at POST
+        /api/public/otel/v1/traces. See the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Create a dataset run item
       operationId: datasetRunItems_create
       tags:
         - DatasetRunItems
@@ -1181,7 +1189,16 @@ paths:
               $ref: '#/components/schemas/CreateDatasetRunItemRequest'
       deprecated: true
     get:
-      description: List dataset run items
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, dataset run items are replaced by
+        experiment items; use `GET
+        /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>`
+        instead. See the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        List dataset run items
       operationId: datasetRunItems_list
       tags:
         - DatasetRunItems
@@ -1390,7 +1407,15 @@ paths:
       security: *ref_0
   /api/public/datasets/{datasetName}/runs/{runName}:
     get:
-      description: Get a dataset run and its items
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, dataset runs are replaced by
+        experiments; use GET /api/public/experiments instead. See the [Langfuse
+        v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Get a dataset run and its items
       operationId: datasets_getRun
       tags:
         - Datasets
@@ -1440,7 +1465,14 @@ paths:
       security: *ref_0
       deprecated: true
     delete:
-      description: Delete a dataset run and all its run items. This action is irreversible.
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, dataset runs are replaced by
+        experiments. See the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Delete a dataset run and all its run items. This action is irreversible.
       operationId: datasets_deleteRun
       tags:
         - Datasets
@@ -1491,7 +1523,15 @@ paths:
       deprecated: true
   /api/public/datasets/{datasetName}/runs:
     get:
-      description: Get dataset runs
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, dataset runs are replaced by
+        experiments; use GET /api/public/experiments instead. See the [Langfuse
+        v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Get dataset runs
       operationId: datasets_getRuns
       tags:
         - Datasets
@@ -1896,6 +1936,14 @@ paths:
   /api/public/ingestion:
     post:
       description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. Send data via the OpenTelemetry endpoint at `POST
+        /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration
+        docs](https://langfuse.com/integrations/native/opentelemetry). See the
+        [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 
 
@@ -1994,6 +2042,12 @@ paths:
   /api/public/metrics:
     get:
       description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. Use `GET /api/public/v2/metrics?query=<urlencoded
+        json query>` instead. See the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
         Get metrics from the Langfuse project using a query object.
 
 
@@ -2095,7 +2149,15 @@ paths:
       deprecated: true
   /api/public/observations/{observationId}:
     get:
-      description: Get a observation
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. Use `GET
+        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`
+        instead. See the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Get a observation
       operationId: legacy_observationsV1_get
       tags:
         - LegacyObservationsV1
@@ -2145,6 +2207,13 @@ paths:
   /api/public/observations:
     get:
       description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. Use `GET
+        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`
+        instead. See the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
         Get a list of observations.
 
 
@@ -5169,7 +5238,13 @@ paths:
                 password:
                   type: string
                   nullable: true
-                  description: Initial password for the user
+                  description: >-
+                    Ignored. Accepted only for compatibility with identity
+                    providers that always send a password on user creation (Okta
+                    sends a placeholder value even when password sync is
+                    disabled). No credential is created for the user;
+                    provisioned users authenticate via SSO or set a password
+                    themselves through the password reset flow.
               required:
                 - userName
                 - name
@@ -5759,9 +5834,13 @@ paths:
               $ref: '#/components/schemas/CreateScoreRequest'
   /api/public/v2/scores:
     get:
-      description: |-
-        **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
-        is no longer available on Langfuse v4 and later.
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint is not
+        available on Langfuse v4 and later and will be removed in a future
+        release. Use `GET /api/public/v3/scores` instead. See the [Langfuse v3
+        to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
 
         Get a list of scores (supports both trace and session scores)
       operationId: scores_get-many
@@ -5985,9 +6064,13 @@ paths:
       deprecated: true
   /api/public/v2/scores/{scoreId}:
     get:
-      description: |-
-        **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
-        instead. This endpoint is no longer available on Langfuse v4 and later.
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint is not
+        available on Langfuse v4 and later and will be removed in a future
+        release. Use `GET /api/public/v3/scores` with the `id` filter instead.
+        See the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
 
         Get a score (supports both trace and session scores)
       operationId: scores_get-by-id
@@ -6037,6 +6120,14 @@ paths:
   /api/public/sessions:
     get:
       description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, read session data via `GET
+        /api/public/v2/observations?filter=<urlencoded sessionId
+        filter>&fromStartTime=<from>&toStartTime=<to>`. See the [Langfuse v3 to
+        v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
         Get sessions.
 
 
@@ -6137,6 +6228,14 @@ paths:
   /api/public/sessions/{sessionId}:
     get:
       description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, read session data via `GET
+        /api/public/v2/observations?filter=<urlencoded sessionId
+        filter>&fromStartTime=<from>&toStartTime=<to>`. See the [Langfuse v3 to
+        v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
         Get a session.
 
 
@@ -6195,7 +6294,15 @@ paths:
       deprecated: true
   /api/public/traces/{traceId}:
     get:
-      description: Get a specific trace
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, read span and trace data via `GET
+        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. See
+        the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Get a specific trace
       operationId: trace_get
       tags:
         - Trace
@@ -6300,7 +6407,15 @@ paths:
       security: *ref_0
   /api/public/traces:
     get:
-      description: Get list of traces
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, read span and trace data via `GET
+        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. See
+        the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Get list of traces
       operationId: trace_list
       tags:
         - Trace

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -804,8 +804,7 @@ paths:
         - name: objectType
           in: query
           description: >-
-            Filter comments by object type (trace, observation, session,
-            prompt).
+            Filter comments by object type (trace, observation, session, prompt).
           required: false
           schema:
             type: string
@@ -1089,8 +1088,7 @@ paths:
       security: *ref_0
     delete:
       description: >-
-        Delete a dataset item and all its run items. This action is
-        irreversible.
+        Delete a dataset item and all its run items. This action is irreversible.
       operationId: datasetItems_delete
       tags:
         - DatasetItems
@@ -4523,8 +4521,7 @@ paths:
       security: *ref_0
     post:
       description: >-
-        Create a new API key for a project (requires organization-scoped API
-        key)
+        Create a new API key for a project (requires organization-scoped API key)
       operationId: projects_createApiKey
       tags:
         - Projects
@@ -7909,8 +7906,7 @@ paths:
         - name: evaluationRuleId
           in: path
           description: >-
-            Evaluation rule identifier returned by the evaluation rule
-            endpoints.
+            Evaluation rule identifier returned by the evaluation rule endpoints.
           required: true
           schema:
             type: string
@@ -9945,8 +9941,7 @@ components:
           type: number
           format: double
           description: >-
-            The numeric value of the score. Equals 1 for "True" and 0 for
-            "False"
+            The numeric value of the score. Equals 1 for "True" and 0 for "False"
         stringValue:
           type: string
           description: >-
@@ -10132,8 +10127,7 @@ components:
           type: number
           format: double
           description: >-
-            The numeric value of the score. Equals 1 for "True" and 0 for
-            "False"
+            The numeric value of the score. Equals 1 for "True" and 0 for "False"
         stringValue:
           type: string
           description: >-
@@ -14521,8 +14515,7 @@ components:
         model:
           type: string
           description: >-
-            Model identifier exposed by the provider, for example
-            `gpt-4.1-mini`.
+            Model identifier exposed by the provider, for example `gpt-4.1-mini`.
       required:
         - provider
         - model
@@ -16598,8 +16591,7 @@ components:
         id:
           type: string
           description: >-
-            Identifier of the exact evaluator version currently used by the
-            rule.
+            Identifier of the exact evaluator version currently used by the rule.
         name:
           type: string
           description: Evaluator family name.

--- a/web/scripts/openapi/fern-deprecations.ts
+++ b/web/scripts/openapi/fern-deprecations.ts
@@ -6,6 +6,7 @@ type FernAvailability =
   | string
   | {
       status?: string;
+      message?: string;
     };
 
 type FernDefinition = {
@@ -27,6 +28,12 @@ type FernDefinition = {
 export type DeprecatedOperation = {
   method: string;
   endpointPath: string;
+  /**
+   * Customer-facing explanation of what to use instead. Rendered as Markdown,
+   * so example calls need backticks or a `<placeholder>` is read as an HTML tag
+   * and disappears from the API reference.
+   */
+  message: string;
 };
 
 function listYamlFiles(directory: string): string[] {
@@ -54,6 +61,13 @@ function isDeprecated(availability: FernAvailability | undefined): boolean {
   );
 }
 
+function readMessage(availability: FernAvailability | undefined): string {
+  const message =
+    typeof availability === "object" ? (availability.message ?? "") : "";
+  // The message is folded into one line of the OpenAPI description.
+  return message.replace(/\s+/g, " ").trim();
+}
+
 export function getFernDeprecatedOperations(
   definitionDirectory: string,
 ): DeprecatedOperation[] {
@@ -69,11 +83,18 @@ export function getFernDeprecatedOperations(
 
     if (!service?.endpoints) return [];
 
-    return Object.values(service.endpoints).flatMap((endpoint) => {
+    return Object.entries(service.endpoints).flatMap(([name, endpoint]) => {
       if (!isDeprecated(endpoint.availability)) return [];
       if (!endpoint.method || endpoint.path === undefined) {
         throw new Error(
           `Deprecated endpoint in ${definitionPath} must define method and path`,
+        );
+      }
+
+      const message = readMessage(endpoint.availability);
+      if (!message) {
+        throw new Error(
+          `Deprecated endpoint "${name}" in ${definitionPath} must define availability.message, which is what API consumers read in the reference`,
         );
       }
 
@@ -86,6 +107,7 @@ export function getFernDeprecatedOperations(
             endpoint["base-path"],
             endpoint.path,
           ),
+          message,
         },
       ];
     });

--- a/web/scripts/openapi/stamp-deprecations.ts
+++ b/web/scripts/openapi/stamp-deprecations.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import {
+  isMap,
+  isScalar,
+  parse,
+  parseDocument,
+  Scalar,
+  stringify,
+  type YAMLMap,
+} from "yaml";
+
+import { type DeprecatedOperation } from "./fern-deprecations";
+
+/** Fold width and indent step used by `fern export`. */
+const LINE_WIDTH = 80;
+const INDENT_STEP = 2;
+
+/**
+ * The exported spec repeats one `security` alias per operation, which trips the
+ * default alias-expansion guard. This file is our own build output, so the
+ * guard has nothing to protect here.
+ */
+const PARSE_OPTIONS = { maxAliasCount: -1 };
+
+const NOTICE_LABEL = "**Deprecated:**";
+/** Matches a notice this script wrote, so re-runs replace instead of stacking. */
+const NOTICE_PATTERN = /^\*\*Deprecated:\*\*[^\n]*(?:\n\n|$)/;
+
+/**
+ * Every deprecation in the definitions retires a Langfuse v3 endpoint, so the
+ * notice can point at the upgrade guide without each message repeating the link.
+ */
+const UPGRADE_GUIDE_URL =
+  "https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4";
+
+/** The notice put in front of a deprecated operation's description. */
+export function deprecationNotice(message: string): string {
+  return `${NOTICE_LABEL} ${message} See the [Langfuse v3 to v4 upgrade guide](${UPGRADE_GUIDE_URL}).`;
+}
+
+/** Block scalar styles whose exact line breaks we keep when rewriting a field. */
+const BLOCK_STYLES: ReadonlySet<unknown> = new Set([
+  Scalar.BLOCK_FOLDED,
+  Scalar.BLOCK_LITERAL,
+]);
+
+type OpenApiOperation = { deprecated?: boolean; description?: string };
+type OpenApiDocument = {
+  paths: Record<string, Record<string, OpenApiOperation>>;
+};
+
+type Edit = { start: number; end: number; text: string };
+type ScalarPair = { key: Scalar; value: Scalar };
+
+function rangeOf(node: Scalar | YAMLMap): [number, number, number] {
+  if (!node.range)
+    throw new Error("Cannot locate a node in the OpenAPI source");
+  return node.range;
+}
+
+/**
+ * Serializes `key: value` at the indentation the exported spec uses for
+ * operation fields, so the emitted block scalar folds exactly like the export.
+ *
+ * Passing the field's original block style keeps the text that was already
+ * there byte-identical: only the lines this script adds show up in the diff.
+ */
+function emitPair(
+  key: string,
+  value: string,
+  column: number,
+  style?: Scalar.Type,
+): string {
+  let node: Scalar<string> | string = value;
+  if (style) {
+    const scalar = new Scalar(value);
+    scalar.type = style;
+    node = scalar;
+  }
+
+  // Serialized at column 0 against the width that is left, then indented back
+  // in: the splice starts at the key, which the source already indents, and
+  // blank lines stay blank the way the export writes them.
+  const lines = stringify(
+    { [key]: node },
+    { lineWidth: LINE_WIDTH - column, indent: INDENT_STEP },
+  )
+    .trimEnd()
+    .split("\n");
+  const indent = " ".repeat(column);
+
+  return `${lines
+    .map((line, index) => (index === 0 || !line ? line : `${indent}${line}`))
+    .join("\n")}\n`;
+}
+
+function columnOf(source: string, offset: number): number {
+  return offset - (source.lastIndexOf("\n", offset - 1) + 1);
+}
+
+/** End offset of the line holding a pair's value, newline included. */
+function pairEnd(source: string, value: Scalar): number {
+  let end = rangeOf(value)[1];
+  if (source[end - 1] === "\n") return end;
+  while (end < source.length && source[end] !== "\n") end += 1;
+  return end < source.length ? end + 1 : end;
+}
+
+function findScalarPair(
+  operation: YAMLMap,
+  name: string,
+): ScalarPair | undefined {
+  for (const item of operation.items) {
+    if (!isScalar(item.key) || item.key.value !== name) continue;
+    if (!isScalar(item.value)) {
+      throw new Error(`Expected "${name}" to hold a scalar value`);
+    }
+    return { key: item.key, value: item.value };
+  }
+  return undefined;
+}
+
+function firstKeyOf(operation: YAMLMap): Scalar {
+  const key = operation.items[0]?.key;
+  if (!isScalar(key)) throw new Error("Cannot patch an operation without keys");
+  return key;
+}
+
+/**
+ * A value that now spans lines has to become a block scalar: keep the style the
+ * export chose for the field, and otherwise fold the way it folds its own prose.
+ */
+function blockStyleFor(
+  description: string,
+  previous?: Scalar.Type,
+): Scalar.Type | undefined {
+  if (!description.includes("\n")) return undefined;
+  return previous && BLOCK_STYLES.has(previous)
+    ? previous
+    : Scalar.BLOCK_FOLDED;
+}
+
+function stripNotice(description: unknown): string {
+  return typeof description === "string"
+    ? description.replace(NOTICE_PATTERN, "")
+    : "";
+}
+
+/** Appends `deprecated: true` unless the operation already carries it. */
+function planDeprecatedFlag(
+  source: string,
+  operation: YAMLMap,
+  label: string,
+): Edit | undefined {
+  const deprecated = operation.get("deprecated");
+  if (deprecated === true) return undefined;
+  if (deprecated !== undefined) {
+    throw new Error(`${label} has an invalid deprecated value`);
+  }
+
+  const range = rangeOf(operation);
+  const column = columnOf(source, range[0]);
+  // Insert on its own line directly after the operation's last line.
+  const offset = source.lastIndexOf("\n", range[1] - 1) + 1;
+
+  return {
+    start: offset,
+    end: offset,
+    text: `${" ".repeat(column)}deprecated: true\n`,
+  };
+}
+
+/**
+ * Prepends the deprecation notice to the operation description, replacing a
+ * notice from an earlier run rather than stacking a second one.
+ */
+function planNotice(
+  source: string,
+  operation: YAMLMap,
+  message: string,
+  label: string,
+): { description: string; edit?: Edit } {
+  const column = columnOf(source, rangeOf(firstKeyOf(operation))[0]);
+  const pair = findScalarPair(operation, "description");
+  const base = stripNotice(pair?.value.value);
+  if (base.startsWith("**Deprecated")) {
+    throw new Error(
+      `${label} opens its Fern docs with a hand-written deprecation notice, which would render twice; keep that text in availability.message instead`,
+    );
+  }
+
+  const notice = deprecationNotice(message);
+  const description = base ? `${notice}\n\n${base}` : notice;
+
+  if (!pair) {
+    const offset = rangeOf(firstKeyOf(operation))[0] - column;
+    return {
+      description,
+      edit: {
+        start: offset,
+        end: offset,
+        text: `${" ".repeat(column)}${emitPair("description", description, column)}`,
+      },
+    };
+  }
+
+  if (pair.value.value === description) return { description };
+
+  const style = blockStyleFor(description, pair.value.type);
+  return {
+    description,
+    edit: {
+      start: rangeOf(pair.key)[0] - column,
+      end: pairEnd(source, pair.value),
+      text: `${" ".repeat(column)}${emitPair("description", description, column, style)}`,
+    },
+  };
+}
+
+function applyEdits(source: string, edits: Edit[]): string {
+  return [...edits]
+    .sort((left, right) => right.start - left.start || right.end - left.end)
+    .reduce(
+      (text, edit) =>
+        `${text.slice(0, edit.start)}${edit.text}${text.slice(edit.end)}`,
+      source,
+    );
+}
+
+/**
+ * Writes the standard OpenAPI `deprecated` flag and a `**Deprecated:** …`
+ * notice onto every operation Fern marks deprecated.
+ *
+ * Edits are spliced at node offsets so everything outside those two fields
+ * stays byte-identical to the export, and the result is verified by re-parsing
+ * and comparing against the expected document.
+ */
+export function stampDeprecations(
+  source: string,
+  operations: DeprecatedOperation[],
+): string {
+  const document = parseDocument(source);
+  if (document.errors.length > 0) {
+    throw new Error(document.errors.map((error) => error.message).join("\n"));
+  }
+
+  const expected = parse(source, PARSE_OPTIONS) as OpenApiDocument;
+  const edits: Edit[] = [];
+
+  for (const { method, endpointPath, message } of operations) {
+    const label = `${method.toUpperCase()} ${endpointPath}`;
+    const operation = document.getIn(["paths", endpointPath, method], true);
+
+    if (!isMap(operation)) {
+      throw new Error(`OpenAPI schema does not contain ${label}`);
+    }
+
+    const flag = planDeprecatedFlag(source, operation, label);
+    const notice = planNotice(source, operation, message, label);
+
+    if (flag) edits.push(flag);
+    if (notice.edit) edits.push(notice.edit);
+
+    const target = expected.paths[endpointPath][method];
+    target.deprecated = true;
+    target.description = notice.description;
+  }
+
+  const text = applyEdits(source, edits);
+  // The splices must not change anything beyond the two fields they target.
+  assert.deepStrictEqual(parse(text, PARSE_OPTIONS), expected);
+
+  return text;
+}

--- a/web/scripts/openapi/stamp-deprecations.ts
+++ b/web/scripts/openapi/stamp-deprecations.ts
@@ -1,26 +1,18 @@
 import assert from "node:assert/strict";
-import {
-  isMap,
-  isScalar,
-  parse,
-  parseDocument,
-  Scalar,
-  stringify,
-  type YAMLMap,
-} from "yaml";
+import { isMap, isScalar, parse, parseDocument, Scalar } from "yaml";
 
 import { type DeprecatedOperation } from "./fern-deprecations";
 
-/** Fold width and indent step used by `fern export`. */
+/** Fold width used by `fern export`. */
 const LINE_WIDTH = 80;
-const INDENT_STEP = 2;
 
 /**
- * The exported spec repeats one `security` alias per operation, which trips the
- * default alias-expansion guard. This file is our own build output, so the
- * guard has nothing to protect here.
+ * Resolving the spec to plain JS repeats one `security` alias per operation,
+ * which trips the default alias-expansion guard. This file is our own build
+ * output, so the guard has nothing to protect here. `parseDocument` keeps
+ * aliases as nodes and needs no such option.
  */
-const PARSE_OPTIONS = { maxAliasCount: -1 };
+const RESOLVE_OPTIONS = { maxAliasCount: -1 };
 
 const NOTICE_LABEL = "**Deprecated:**";
 /** Matches a notice this script wrote, so re-runs replace instead of stacking. */
@@ -38,202 +30,36 @@ export function deprecationNotice(message: string): string {
   return `${NOTICE_LABEL} ${message} See the [Langfuse v3 to v4 upgrade guide](${UPGRADE_GUIDE_URL}).`;
 }
 
-/** Block scalar styles whose exact line breaks we keep when rewriting a field. */
-const BLOCK_STYLES: ReadonlySet<unknown> = new Set([
-  Scalar.BLOCK_FOLDED,
-  Scalar.BLOCK_LITERAL,
-]);
-
 type OpenApiOperation = { deprecated?: boolean; description?: string };
 type OpenApiDocument = {
   paths: Record<string, Record<string, OpenApiOperation>>;
 };
 
-type Edit = { start: number; end: number; text: string };
-type ScalarPair = { key: Scalar; value: Scalar };
-
-function rangeOf(node: Scalar | YAMLMap): [number, number, number] {
-  if (!node.range)
-    throw new Error("Cannot locate a node in the OpenAPI source");
-  return node.range;
-}
-
 /**
- * Serializes `key: value` at the indentation the exported spec uses for
- * operation fields, so the emitted block scalar folds exactly like the export.
- *
- * Passing the field's original block style keeps the text that was already
- * there byte-identical: only the lines this script adds show up in the diff.
+ * Writes prose the way the export writes its own: a block scalar once it spans
+ * lines, folded unless the field was already literal.
  */
-function emitPair(
-  key: string,
-  value: string,
-  column: number,
-  style?: Scalar.Type,
-): string {
-  let node: Scalar<string> | string = value;
-  if (style) {
-    const scalar = new Scalar(value);
-    scalar.type = style;
-    node = scalar;
-  }
-
-  // Serialized at column 0 against the width that is left, then indented back
-  // in: the splice starts at the key, which the source already indents, and
-  // blank lines stay blank the way the export writes them.
-  const lines = stringify(
-    { [key]: node },
-    { lineWidth: LINE_WIDTH - column, indent: INDENT_STEP },
-  )
-    .trimEnd()
-    .split("\n");
-  const indent = " ".repeat(column);
-
-  return `${lines
-    .map((line, index) => (index === 0 || !line ? line : `${indent}${line}`))
-    .join("\n")}\n`;
-}
-
-function columnOf(source: string, offset: number): number {
-  return offset - (source.lastIndexOf("\n", offset - 1) + 1);
-}
-
-/** End offset of the line holding a pair's value, newline included. */
-function pairEnd(source: string, value: Scalar): number {
-  let end = rangeOf(value)[1];
-  if (source[end - 1] === "\n") return end;
-  while (end < source.length && source[end] !== "\n") end += 1;
-  return end < source.length ? end + 1 : end;
-}
-
-function findScalarPair(
-  operation: YAMLMap,
-  name: string,
-): ScalarPair | undefined {
-  for (const item of operation.items) {
-    if (!isScalar(item.key) || item.key.value !== name) continue;
-    if (!isScalar(item.value)) {
-      throw new Error(`Expected "${name}" to hold a scalar value`);
-    }
-    return { key: item.key, value: item.value };
-  }
-  return undefined;
-}
-
-function firstKeyOf(operation: YAMLMap): Scalar {
-  const key = operation.items[0]?.key;
-  if (!isScalar(key)) throw new Error("Cannot patch an operation without keys");
-  return key;
-}
-
-/**
- * A value that now spans lines has to become a block scalar: keep the style the
- * export chose for the field, and otherwise fold the way it folds its own prose.
- */
-function blockStyleFor(
+function descriptionScalar(
   description: string,
   previous?: Scalar.Type,
-): Scalar.Type | undefined {
-  if (!description.includes("\n")) return undefined;
-  return previous && BLOCK_STYLES.has(previous)
-    ? previous
-    : Scalar.BLOCK_FOLDED;
-}
+): Scalar<string> | string {
+  if (!description.includes("\n")) return description;
 
-function stripNotice(description: unknown): string {
-  return typeof description === "string"
-    ? description.replace(NOTICE_PATTERN, "")
-    : "";
-}
-
-/** Appends `deprecated: true` unless the operation already carries it. */
-function planDeprecatedFlag(
-  source: string,
-  operation: YAMLMap,
-  label: string,
-): Edit | undefined {
-  const deprecated = operation.get("deprecated");
-  if (deprecated === true) return undefined;
-  if (deprecated !== undefined) {
-    throw new Error(`${label} has an invalid deprecated value`);
-  }
-
-  const range = rangeOf(operation);
-  const column = columnOf(source, range[0]);
-  // Insert on its own line directly after the operation's last line.
-  const offset = source.lastIndexOf("\n", range[1] - 1) + 1;
-
-  return {
-    start: offset,
-    end: offset,
-    text: `${" ".repeat(column)}deprecated: true\n`,
-  };
-}
-
-/**
- * Prepends the deprecation notice to the operation description, replacing a
- * notice from an earlier run rather than stacking a second one.
- */
-function planNotice(
-  source: string,
-  operation: YAMLMap,
-  message: string,
-  label: string,
-): { description: string; edit?: Edit } {
-  const column = columnOf(source, rangeOf(firstKeyOf(operation))[0]);
-  const pair = findScalarPair(operation, "description");
-  const base = stripNotice(pair?.value.value);
-  if (base.startsWith("**Deprecated")) {
-    throw new Error(
-      `${label} opens its Fern docs with a hand-written deprecation notice, which would render twice; keep that text in availability.message instead`,
-    );
-  }
-
-  const notice = deprecationNotice(message);
-  const description = base ? `${notice}\n\n${base}` : notice;
-
-  if (!pair) {
-    const offset = rangeOf(firstKeyOf(operation))[0] - column;
-    return {
-      description,
-      edit: {
-        start: offset,
-        end: offset,
-        text: `${" ".repeat(column)}${emitPair("description", description, column)}`,
-      },
-    };
-  }
-
-  if (pair.value.value === description) return { description };
-
-  const style = blockStyleFor(description, pair.value.type);
-  return {
-    description,
-    edit: {
-      start: rangeOf(pair.key)[0] - column,
-      end: pairEnd(source, pair.value),
-      text: `${" ".repeat(column)}${emitPair("description", description, column, style)}`,
-    },
-  };
-}
-
-function applyEdits(source: string, edits: Edit[]): string {
-  return [...edits]
-    .sort((left, right) => right.start - left.start || right.end - left.end)
-    .reduce(
-      (text, edit) =>
-        `${text.slice(0, edit.start)}${edit.text}${text.slice(edit.end)}`,
-      source,
-    );
+  const scalar = new Scalar(description);
+  scalar.type =
+    previous === Scalar.BLOCK_LITERAL
+      ? Scalar.BLOCK_LITERAL
+      : Scalar.BLOCK_FOLDED;
+  return scalar;
 }
 
 /**
  * Writes the standard OpenAPI `deprecated` flag and a `**Deprecated:** …`
  * notice onto every operation Fern marks deprecated.
  *
- * Edits are spliced at node offsets so everything outside those two fields
- * stays byte-identical to the export, and the result is verified by re-parsing
- * and comparing against the expected document.
+ * Printing the parsed document reflows a handful of long descriptions the
+ * exporter had folded differently, which is why the result is checked against
+ * the expected document: formatting may move, meaning may not.
  */
 export function stampDeprecations(
   source: string,
@@ -244,8 +70,7 @@ export function stampDeprecations(
     throw new Error(document.errors.map((error) => error.message).join("\n"));
   }
 
-  const expected = parse(source, PARSE_OPTIONS) as OpenApiDocument;
-  const edits: Edit[] = [];
+  const expected = parse(source, RESOLVE_OPTIONS) as OpenApiDocument;
 
   for (const { method, endpointPath, message } of operations) {
     const label = `${method.toUpperCase()} ${endpointPath}`;
@@ -255,20 +80,41 @@ export function stampDeprecations(
       throw new Error(`OpenAPI schema does not contain ${label}`);
     }
 
-    const flag = planDeprecatedFlag(source, operation, label);
-    const notice = planNotice(source, operation, message, label);
+    const deprecated = operation.get("deprecated");
+    if (deprecated !== undefined && deprecated !== true) {
+      throw new Error(`${label} has an invalid deprecated value`);
+    }
 
-    if (flag) edits.push(flag);
-    if (notice.edit) edits.push(notice.edit);
+    const previous = operation.get("description", true);
+    const base = isScalar(previous)
+      ? String(previous.value ?? "").replace(NOTICE_PATTERN, "")
+      : "";
+    if (base.startsWith("**Deprecated")) {
+      throw new Error(
+        `${label} opens its Fern docs with a hand-written deprecation notice, which would render twice; keep that text in availability.message instead`,
+      );
+    }
+
+    const notice = deprecationNotice(message);
+    const description = base ? `${notice}\n\n${base}` : notice;
+
+    operation.set("deprecated", true);
+    operation.set(
+      "description",
+      descriptionScalar(
+        description,
+        isScalar(previous) ? previous.type : undefined,
+      ),
+    );
 
     const target = expected.paths[endpointPath][method];
     target.deprecated = true;
-    target.description = notice.description;
+    target.description = description;
   }
 
-  const text = applyEdits(source, edits);
-  // The splices must not change anything beyond the two fields they target.
-  assert.deepStrictEqual(parse(text, PARSE_OPTIONS), expected);
+  const text = document.toString({ lineWidth: LINE_WIDTH });
+  // Nothing may change beyond the two fields on the operations we touched.
+  assert.deepStrictEqual(parse(text, RESOLVE_OPTIONS), expected);
 
   return text;
 }

--- a/web/scripts/openapi/sync-deprecations.ts
+++ b/web/scripts/openapi/sync-deprecations.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { isMap, parseDocument } from "yaml";
 
 import { getFernDeprecatedOperations } from "./fern-deprecations";
+import { stampDeprecations } from "./stamp-deprecations";
 
 const webDirectory = process.cwd();
 const definitionDirectory = path.resolve(
@@ -14,60 +14,12 @@ const openApiPath = path.resolve(
   "public/generated/api/openapi.yml",
 );
 
-let openApiSource = fs.readFileSync(openApiPath, "utf8");
-const openApi = parseDocument(openApiSource);
-
-if (openApi.errors.length > 0) {
-  throw new Error(openApi.errors.map((error) => error.message).join("\n"));
-}
-
 const deprecatedOperations = getFernDeprecatedOperations(definitionDirectory);
-const insertions: Array<{ offset: number; value: string }> = [];
+const openApiSource = fs.readFileSync(openApiPath, "utf8");
+const syncedSource = stampDeprecations(openApiSource, deprecatedOperations);
 
-for (const { method, endpointPath } of deprecatedOperations) {
-  const operation = openApi.getIn(["paths", endpointPath, method], true);
+if (syncedSource !== openApiSource) fs.writeFileSync(openApiPath, syncedSource);
 
-  if (!isMap(operation)) {
-    throw new Error(
-      `OpenAPI schema does not contain ${method.toUpperCase()} ${endpointPath}`,
-    );
-  }
-
-  const deprecated = operation.get("deprecated");
-  if (deprecated === true) continue;
-  if (deprecated !== undefined) {
-    throw new Error(
-      `${method.toUpperCase()} ${endpointPath} has an invalid deprecated value`,
-    );
-  }
-  if (!operation.range) {
-    throw new Error(
-      `Cannot locate ${method.toUpperCase()} ${endpointPath} in the OpenAPI source`,
-    );
-  }
-
-  const operationLineStart =
-    openApiSource.lastIndexOf("\n", operation.range[0]) + 1;
-  const insertionOffset =
-    openApiSource.lastIndexOf("\n", operation.range[1] - 1) + 1;
-  const indentation = openApiSource.slice(
-    operationLineStart,
-    operation.range[0],
-  );
-
-  insertions.push({
-    offset: insertionOffset,
-    value: `${indentation}deprecated: true\n`,
-  });
-}
-
-for (const { offset, value } of insertions.sort(
-  (left, right) => right.offset - left.offset,
-)) {
-  openApiSource = `${openApiSource.slice(0, offset)}${value}${openApiSource.slice(offset)}`;
-}
-
-fs.writeFileSync(openApiPath, openApiSource);
 console.log(
   `Synced ${deprecatedOperations.length} deprecated OpenAPI operations from Fern definitions.`,
 );

--- a/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
+++ b/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
@@ -213,6 +213,19 @@ describe("OpenAPI deprecations", () => {
     );
   });
 
+  it("keeps a literal description literal instead of folding it", () => {
+    const literal = SPEC.replace("description: >-", "description: |-");
+    const stamped = stampDeprecations(
+      literal,
+      operations([["get", "/api/public/sessions", MESSAGE]]),
+    );
+
+    expect(stamped).toContain("      description: |-\n");
+    expect(
+      parseSpec(stamped).paths["/api/public/sessions"].get.description,
+    ).toContain(deprecationNotice(MESSAGE));
+  });
+
   it("is idempotent across repeated runs", () => {
     const deprecated = operations([
       ["get", "/api/public/traces", MESSAGE],

--- a/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
+++ b/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
@@ -3,10 +3,22 @@ import os from "node:os";
 import path from "node:path";
 import { parse } from "yaml";
 
-import { getFernDeprecatedOperations } from "../../../../scripts/openapi/fern-deprecations";
+import {
+  getFernDeprecatedOperations,
+  type DeprecatedOperation,
+} from "../../../../scripts/openapi/fern-deprecations";
+import {
+  deprecationNotice,
+  stampDeprecations,
+} from "../../../../scripts/openapi/stamp-deprecations";
 
+type OpenApiOperation = {
+  deprecated?: boolean;
+  description?: string;
+  security?: unknown;
+};
 type OpenApiDocument = {
-  paths: Record<string, Record<string, { deprecated?: boolean }>>;
+  paths: Record<string, Record<string, OpenApiOperation>>;
 };
 
 const definitionDirectory = path.resolve(
@@ -18,11 +30,67 @@ const openApiPath = path.resolve(
   "public/generated/api/openapi.yml",
 );
 
+const MESSAGE = "Use `GET /api/public/v2/observations?from=<from>` instead.";
+
+/** Spec fixture in the shape `fern export` produces, aliased `security` included. */
+const SPEC = `openapi: 3.0.1
+paths:
+  /api/public/traces:
+    get:
+      description: Get list of traces
+      operationId: trace_list
+      security: &ref_0
+        - BasicAuth: []
+    post:
+      description: Create a trace
+      operationId: trace_create
+      security: *ref_0
+  /api/public/sessions:
+    get:
+      description: >-
+        Get sessions.
+
+
+        Sessions group traces that belong to one conversation.
+      operationId: sessions_list
+      security: *ref_0
+`;
+
+function operations(
+  entries: Array<[string, string, string]>,
+): DeprecatedOperation[] {
+  return entries.map(([method, endpointPath, message]) => ({
+    method,
+    endpointPath,
+    message,
+  }));
+}
+
+function parseSpec(source: string): OpenApiDocument {
+  return parse(source, { maxAliasCount: -1 }) as OpenApiDocument;
+}
+
+function withDefinition(
+  files: Record<string, string>,
+  assertions: (directory: string) => void,
+) {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "fern-deprecations-"),
+  );
+
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      fs.writeFileSync(path.join(directory, name), contents);
+    }
+    assertions(directory);
+  } finally {
+    fs.rmSync(directory, { recursive: true });
+  }
+}
+
 describe("OpenAPI deprecations", () => {
   it("matches the deprecated endpoints in the Fern definitions", () => {
-    const openApi = parse(fs.readFileSync(openApiPath, "utf8"), {
-      maxAliasCount: -1,
-    }) as OpenApiDocument;
+    const openApi = parseSpec(fs.readFileSync(openApiPath, "utf8"));
     const openApiDeprecatedOperations = Object.entries(openApi.paths).flatMap(
       ([endpointPath, pathItem]) =>
         Object.entries(pathItem).flatMap(([method, operation]) =>
@@ -37,35 +105,159 @@ describe("OpenAPI deprecations", () => {
     );
   });
 
-  it("supports deprecated endpoints at a service base path", () => {
-    const fixtureDirectory = fs.mkdtempSync(
-      path.join(os.tmpdir(), "fern-deprecations-"),
-    );
+  it("carries every Fern deprecation message into the operation description", () => {
+    const openApi = parseSpec(fs.readFileSync(openApiPath, "utf8"));
 
-    try {
-      fs.writeFileSync(
-        path.join(fixtureDirectory, "api.yml"),
-        "base-path: /api\n",
-      );
-      fs.writeFileSync(
-        path.join(fixtureDirectory, "service.yml"),
-        [
+    for (const { method, endpointPath, message } of getFernDeprecatedOperations(
+      definitionDirectory,
+    )) {
+      expect(
+        openApi.paths[endpointPath][method].description,
+        `${method.toUpperCase()} ${endpointPath}`,
+      ).toContain(deprecationNotice(message));
+    }
+  });
+
+  it("supports deprecated endpoints at a service base path", () => {
+    withDefinition(
+      {
+        "api.yml": "base-path: /api\n",
+        "service.yml": [
           "service:",
           "  base-path: /public",
           "  endpoints:",
           "    get:",
-          "      availability: deprecated",
+          "      availability:",
+          "        status: deprecated",
+          `        message: "${MESSAGE}"`,
           "      method: GET",
           '      path: ""',
           "",
         ].join("\n"),
-      );
+      },
+      (directory) => {
+        expect(getFernDeprecatedOperations(directory)).toEqual([
+          { method: "get", endpointPath: "/api/public", message: MESSAGE },
+        ]);
+      },
+    );
+  });
 
-      expect(getFernDeprecatedOperations(fixtureDirectory)).toEqual([
-        { method: "get", endpointPath: "/api/public" },
-      ]);
-    } finally {
-      fs.rmSync(fixtureDirectory, { recursive: true });
-    }
+  it("refuses a deprecation without a message", () => {
+    withDefinition(
+      {
+        "api.yml": "base-path: /api\n",
+        "service.yml": [
+          "service:",
+          "  endpoints:",
+          "    get:",
+          "      availability: deprecated",
+          "      method: GET",
+          "      path: /traces",
+          "",
+        ].join("\n"),
+      },
+      (directory) => {
+        expect(() => getFernDeprecatedOperations(directory)).toThrow(
+          /must define availability.message/,
+        );
+      },
+    );
+  });
+
+  it("stamps the flag and the notice, leaving other operations untouched", () => {
+    const stamped = stampDeprecations(
+      SPEC,
+      operations([["get", "/api/public/traces", MESSAGE]]),
+    );
+    const openApi = parseSpec(stamped);
+    const operation = openApi.paths["/api/public/traces"].get;
+
+    expect(operation.deprecated).toBe(true);
+    expect(operation.description).toBe(
+      `${deprecationNotice(MESSAGE)}\n\nGet list of traces`,
+    );
+
+    const untouched = openApi.paths["/api/public/traces"].post;
+    expect(untouched.description).toBe("Create a trace");
+    expect(untouched.deprecated).toBeUndefined();
+    expect(stamped).toContain("      description: Create a trace\n");
+  });
+
+  it("keeps the aliased security block intact", () => {
+    const stamped = stampDeprecations(
+      SPEC,
+      operations([["get", "/api/public/traces", MESSAGE]]),
+    );
+
+    expect(stamped.match(/security: \*ref_0/g)).toHaveLength(2);
+    expect(
+      parseSpec(stamped).paths["/api/public/traces"].post.security,
+    ).toEqual([{ BasicAuth: [] }]);
+  });
+
+  it("preserves the block style and text of a multi-line description", () => {
+    const stamped = stampDeprecations(
+      SPEC,
+      operations([["get", "/api/public/sessions", MESSAGE]]),
+    );
+
+    expect(stamped).toContain("      description: >-\n");
+    expect(stamped).toContain(
+      "        Sessions group traces that belong to one conversation.\n",
+    );
+    expect(
+      parseSpec(stamped).paths["/api/public/sessions"].get.description,
+    ).toBe(
+      `${deprecationNotice(MESSAGE)}\n\nGet sessions.\n\nSessions group traces that belong to one conversation.`,
+    );
+  });
+
+  it("is idempotent across repeated runs", () => {
+    const deprecated = operations([
+      ["get", "/api/public/traces", MESSAGE],
+      ["get", "/api/public/sessions", MESSAGE],
+    ]);
+    const once = stampDeprecations(SPEC, deprecated);
+
+    expect(stampDeprecations(once, deprecated)).toBe(once);
+  });
+
+  it("replaces an outdated notice instead of stacking a second one", () => {
+    const once = stampDeprecations(
+      SPEC,
+      operations([["get", "/api/public/traces", "Old guidance."]]),
+    );
+    const twice = stampDeprecations(
+      once,
+      operations([["get", "/api/public/traces", "New guidance."]]),
+    );
+
+    expect(parseSpec(twice).paths["/api/public/traces"].get.description).toBe(
+      `${deprecationNotice("New guidance.")}\n\nGet list of traces`,
+    );
+  });
+
+  it("refuses a description that already opens with a hand-written notice", () => {
+    const handWritten = SPEC.replace(
+      "description: Get list of traces",
+      "description: '**Deprecated.** Use something else.'",
+    );
+
+    expect(() =>
+      stampDeprecations(
+        handWritten,
+        operations([["get", "/api/public/traces", MESSAGE]]),
+      ),
+    ).toThrow(/hand-written deprecation notice/);
+  });
+
+  it("fails when a deprecated endpoint has no operation in the spec", () => {
+    expect(() =>
+      stampDeprecations(
+        SPEC,
+        operations([["get", "/api/public/does-not-exist", MESSAGE]]),
+      ),
+    ).toThrow(/does not contain GET \/api\/public\/does-not-exist/);
   });
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16121.preview.langfuse.com](https://pr-16121.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

#16099 stamps `deprecated: true` onto the 15 deprecated operations. That tells a reader *that* an endpoint is going away, but not what to reach for instead — which is the part they actually need. Every deprecated Fern endpoint already carries an `availability.message` saying exactly that, and none of it reaches the reference, because `fern export` drops `availability` wholesale. OpenAPI has no field for a deprecation *message*, so the text has to live in `description`.

This PR copies that message to the top of the operation description as a `**Deprecated:** …` notice and appends a link to the v3 → v4 upgrade guide, so the rendered page shows the badge, the strikethrough, the replacement call, *and* somewhere to go next.

Before / after for `GET /api/public/traces/{traceId}`:

```diff
   /api/public/traces/{traceId}:
     get:
-      description: Get a specific trace
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release. In Langfuse v4, read span and trace data via `GET
+        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. See
+        the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Get a specific trace
```

The upgrade-guide link lives in one constant in the script rather than in fifteen Fern messages, so there is one place to change when the guide moves.

### How it edits the generated spec

`stampDeprecations()` sets the two fields on the parsed document and prints it back. That is deliberately the boring option, and it has one visible cost: printing reflows **13 long descriptions elsewhere in the spec** that the exporter had folded slightly differently (the `-` lines in the diff that are not deprecation-related). Those are a one-time, stable reformat — the sync always runs directly after the export, so the same input produces the same output, and re-running it is a byte-level no-op.

An earlier revision of this PR avoided that by splicing at YAML node offsets, keeping every untouched line byte-identical. It cost ~250 lines reimplementing block-scalar emission (fold width, indentation, block style, node end offsets) and bought no correctness — both versions produce the same parsed document. Measured: 26 lines of collateral reflow versus 173 lines of machinery. The second commit removes it.

What survived from that revision is the safety net, which now earns its keep against the printer rather than against manual splices: the script builds a plain-JS mirror of the spec, applies the intended mutations to it, and `assert.deepStrictEqual`s the printed result against it. Formatting may move; meaning may not. A dropped alias, a fold that lost a line break, or a value broken mid-word fails the export instead of reaching the artifact.

Prose keeps the block style the export chose for the field, so the 28 literal (`|-`) descriptions in the spec are not silently folded.

### Three behaviour changes worth calling out

1. **A deprecated endpoint must now carry a message.** Without one the reference has nothing useful to say, so the export fails instead of shipping a bare flag. This is why the base-path fixture test moved from the `availability: deprecated` shorthand to the object form.
2. **`availability.message` is now the only place deprecation prose lives.** `GET /api/public/v2/scores` and `/v2/scores/{scoreId}` opened their Fern `docs` with a hand-written `**Deprecated.**` paragraph, which would have rendered a second banner directly under the generated one. That prose — including the fact only it carried, that the endpoints are gone on v4 — moved into `availability.message`, and the script now fails the export when a description still opens with a hand-written deprecation paragraph, rather than silently stripping an author's text or stacking two notices.
3. **The messages are Markdown-rendered, so the existing ones needed escaping.** The reference was parsing `<from>`/`<to>` as HTML tags and dropping them, which would have told readers to call `?fromStartTime=&toStartTime=`. The example calls in the affected messages are now wrapped in backticks.

One unrelated hunk comes along for free: re-exporting picks up the SCIM `password` description, which had drifted from its Fern definition before this PR.

### Verified

- `pnpm --filter web run test src/__tests__/server/unit/openapi-deprecations.servertest.ts` — `Tests  12 passed (12)`, covering the committed-artifact drift check, the message-into-description check, folded and literal block styles, alias preservation, idempotency, notice replacement, and the three failure modes.
- `pnpm turbo run lint --filter=web` — `Tasks: 4 successful, 4 total`; `pnpm run typecheck` — `Tasks: 7 successful, 7 total`.
- Re-ran `npx fern-api export --api server web/public/generated/api/openapi.yml && pnpm --filter web exec tsx scripts/openapi/sync-deprecations.ts` on the rebased branch: the committed artifact came back byte-identical, so what is in the diff is exactly what the pipeline produces.
- Rendered the patched spec in a local Scalar instance and confirmed the badge, the strikethrough path, and the notice with the placeholders intact.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't checked if my PR needs changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->
