### PR TITLE
Revert "docs: fix grammar in README (set up, drop-in, Alpine Linux)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ See [self-hosting documentation](https://langfuse.com/self-hosting) to learn mor
 | [Langchain](https://langfuse.com/docs/integrations/langchain)                | Python, JS/TS              | Automated instrumentation by passing callback handler to Langchain application.                                                                  |
 | [LlamaIndex](https://langfuse.com/docs/integrations/llama-index/get-started) | Python                     | Automated instrumentation via LlamaIndex callback system.                                                                                        |
 | [Haystack](https://langfuse.com/docs/integrations/haystack)                  | Python                     | Automated instrumentation via Haystack content tracing system.                                                                                   |
-| [LiteLLM](https://langfuse.com/docs/integrations/litellm)                    | Python, JS/TS (proxy only) | Use any LLM as a drop-in replacement for GPT. Use Azure, OpenAI, Cohere, Anthropic, Ollama, VLLM, Sagemaker, HuggingFace, Replicate (100+ LLMs). |
+| [LiteLLM](https://langfuse.com/docs/integrations/litellm)                    | Python, JS/TS (proxy only) | Use any LLM as a drop in replacement for GPT. Use Azure, OpenAI, Cohere, Anthropic, Ollama, VLLM, Sagemaker, HuggingFace, Replicate (100+ LLMs). |
 | [Vercel AI SDK](https://langfuse.com/docs/integrations/vercel-ai-sdk)        | JS/TS                      | TypeScript toolkit designed to help developers build AI-powered applications with React, Next.js, Vue, Svelte, Node.js.                          |
 | [Mastra](https://langfuse.com/docs/integrations/mastra)                      | JS/TS                      | Open source framework for building AI agents and multi-agent systems.                                                                            |
 | [API](https://langfuse.com/docs/api)                                         |                            | Directly call the public API. OpenAPI spec available.                                                                                            |
@@ -241,7 +241,7 @@ Your contributions are welcome!
 
 - Vote on [Ideas](https://github.com/orgs/langfuse/discussions/categories/ideas) in GitHub Discussions.
 - Raise and comment on [Issues](https://github.com/langfuse/langfuse/issues).
-- Open a PR - see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to set up a development environment.
+- Open a PR - see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to setup a development environment.
 
 ## 🥇 License
 
@@ -249,7 +249,7 @@ This repository is MIT licensed, except for the `ee` folders. See [LICENSE](LICE
 
 ## Dependencies
 
-We deploy this code base in Docker containers based on the Alpine Linux image ([source](https://github.com/nodejs/docker-node)). You may find the Dockerfiles in [web/Dockerfile](web/Dockerfile) and [worker/Dockerfile](worker/Dockerfile).
+We deploy this code base in Docker containers based on the Linux Alpine Image ([source](https://github.com/nodejs/docker-node)). You may find the Dockerfiles in [web/Dockerfile](web/Dockerfile) and [worker/Dockerfile](worker/Dockerfile).
 
 ## ⭐️ Star History
 


### PR DESCRIPTION
Reverts langfuse/langfuse#16119

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts the README grammar corrections made in #16119.
- Restores “drop in replacement” in the LiteLLM description.
- Restores “setup a development environment” in the contribution guidance.
- Restores “Linux Alpine Image” in the dependency description.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only performs the explicitly described README wording revert.

The changes are limited to documentation text and introduce no runtime, build, security, or public API failures.
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;docs: fix grammar in README (set..."](https://github.com/langfuse/langfuse/commit/fd3be184f8c1133464a1d97de2240bec8e5fe8cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53287135)</sub>

<!-- /greptile_comment -->