### PR TITLE
fix(v4): clarify migration activity window

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -370,6 +370,11 @@ describe("V4MigrationDetailsContent", () => {
 
     expect(
       screen.getByText(
+        "SDK, instrumentation, experiment, and API checks cover activity from the last 14 days.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
         "Evals, experiments, APIs and integrations are up to date.",
       ),
     ).toBeInTheDocument();

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1427,6 +1427,10 @@ export function V4MigrationDetailsContent({
         <div className="flex items-center gap-2 text-base font-bold">
           Action items
         </div>
+        <p className="text-muted-foreground text-sm">
+          SDK, instrumentation, experiment, and API checks cover activity from
+          the last {V4_MIGRATION_LOOKBACK_DAYS} days.
+        </p>
         <div>
           <V4MigrationSdkSection
             sdk={migrationData.sdk}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16127.preview.langfuse.com](https://pr-16127.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- add a muted activity-window note below the v4 sidebar Action items heading
- reuse the existing migration lookback constant so the displayed 14-day window stays aligned with detection
- cover the explanatory copy in the existing sidebar client suite

## Impacted packages

- web

## Verification

- `pnpm run db:generate` — Tasks: 1 successful, 1 total
- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx` with test environment values — Tests: 39 passed (39)
- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm exec prettier --check web/src/features/v4-migration/V4MigrationContent.tsx web/src/features/v4-migration/V4MigrationContent.clienttest.tsx` — all matched files use Prettier code style

## Browser review

Not run locally because this session did not expose Playwright or browser automation. The change is a single text-only line and is covered by the existing rendered component test.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds explanatory text clarifying that selected v4 migration checks inspect the last 14 days of activity.

- Renders the existing migration lookback constant beneath the Action items heading.
- Extends the client test to verify the resulting 14-day explanatory copy.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new text accurately limits its claim to the four checks that use the shared 14-day migration detection range, and the accompanying test verifies the rendered copy.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): clarify migration activity wind..."](https://github.com/langfuse/langfuse/commit/335db4f6f0b10154a1fbb0cf533b69f5092f319d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53294436)</sub>

<!-- /greptile_comment -->