### PR TITLE
fix(web): move the compare-traces toggle into the migration action items

### DIFF
--- a/web/src/features/v4-migration/V4MigrationBadgeContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationBadgeContent.tsx
@@ -8,16 +8,18 @@ import { cn } from "@/src/utils/tailwind";
 export function V4MigrationStatusDot({
   variant,
 }: {
-  variant: "action" | "done";
+  // "neutral" marks optional helpers in the checklist — neither pending
+  // work (amber) nor a completed check (green).
+  variant: "action" | "done" | "neutral";
 }) {
   return (
     <span
       aria-hidden
       className={cn(
         "size-1.75 shrink-0 rounded-full",
-        variant === "action"
-          ? "bg-orange-400 dark:bg-orange-400"
-          : "bg-green-400 dark:bg-green-400",
+        variant === "action" && "bg-orange-400 dark:bg-orange-400",
+        variant === "done" && "bg-green-400 dark:bg-green-400",
+        variant === "neutral" && "bg-gray-400 dark:bg-gray-400",
       )}
     />
   );

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1488,6 +1488,47 @@ export function V4MigrationDetailsContent({
             />
           )}
 
+          {/* The toggle row hides itself when the session cannot toggle v4
+              (legacy/events_only write mode, post-rollout auto-enrollment), so
+              this checklist row must hide on the same condition. Neutral dot:
+              an optional helper, not pending work or a completed check. */}
+          {canToggleV4 && (
+            <div className="flex w-full items-center gap-2.5 py-2.5">
+              <V4MigrationStatusDot variant="neutral" />
+              <span className="text-foreground flex min-w-0 items-center gap-1.5 text-sm font-bold">
+                Compare traces while you upgrade
+                <HoverCard openDelay={200}>
+                  <HoverCardTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="Why compare traces?"
+                      className="shrink-0"
+                    >
+                      <Info className="h-3.5 w-3.5" />
+                    </button>
+                  </HoverCardTrigger>
+                  <HoverCardPortal>
+                    <HoverCardContent className="w-80 text-sm">
+                      The latest SDK no longer sets trace input and output;{" "}
+                      <ExternalLink
+                        href={OBSERVATIONS_DATA_MODEL_URL}
+                        analytics={{
+                          section: "compare_row",
+                          link: "observations_data_model_docs",
+                        }}
+                      >
+                        v4 infers them from observations
+                      </ExternalLink>
+                      .
+                    </HoverCardContent>
+                  </HoverCardPortal>
+                </HoverCard>
+              </span>
+              <span className="flex-1" />
+              <V4PreviewToggleRow projectId={projectId} />
+            </div>
+          )}
+
           {cleanSummary && (
             <p className="text-muted-foreground flex items-center gap-2.5 py-2.5 text-sm">
               <V4MigrationStatusDot variant="done" />
@@ -1505,46 +1546,6 @@ export function V4MigrationDetailsContent({
       <Separator />
 
       <V4MigrationAgentUpgradeSection projectId={projectId} />
-
-      {/* The toggle row hides itself when the session cannot toggle v4
-          (legacy/events_only write mode, post-rollout auto-enrollment), so the
-          copy describing it must hide on the same condition. */}
-      {canToggleV4 && (
-        <>
-          <div className="flex items-center justify-between gap-2">
-            <p className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-sm">
-              Compare traces while you upgrade
-              <HoverCard openDelay={200}>
-                <HoverCardTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Why compare traces?"
-                    className="shrink-0"
-                  >
-                    <Info className="h-3.5 w-3.5" />
-                  </button>
-                </HoverCardTrigger>
-                <HoverCardPortal>
-                  <HoverCardContent className="w-80 text-sm">
-                    The latest SDK no longer sets trace input and output;{" "}
-                    <ExternalLink
-                      href={OBSERVATIONS_DATA_MODEL_URL}
-                      analytics={{
-                        section: "compare_row",
-                        link: "observations_data_model_docs",
-                      }}
-                    >
-                      v4 infers them from observations
-                    </ExternalLink>
-                    .
-                  </HoverCardContent>
-                </HoverCardPortal>
-              </HoverCard>
-            </p>
-            <V4PreviewToggleRow projectId={projectId} />
-          </div>
-        </>
-      )}
 
       <Separator />
 

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1488,14 +1488,26 @@ export function V4MigrationDetailsContent({
             />
           )}
 
-          {/* The toggle row hides itself when the session cannot toggle v4
-              (legacy/events_only write mode, post-rollout auto-enrollment), so
-              this checklist row must hide on the same condition. Neutral dot:
-              an optional helper, not pending work or a completed check. */}
+          {cleanSummary && (
+            <p className="text-muted-foreground flex items-center gap-2.5 py-2.5 text-sm">
+              <V4MigrationStatusDot variant="done" />
+              {cleanSummary}
+            </p>
+          )}
+
+          <V4MigrationDetectedInstrumentationSection
+            sdk={migrationData.sdk}
+            projectId={evidenceProjectId}
+          />
+
+          {/* Always the last checklist row. Hides itself when the session
+              cannot toggle v4 (legacy/events_only write mode, post-rollout
+              auto-enrollment). Neutral dot + muted text: an optional helper
+              in the settled-summary style, not pending work. */}
           {canToggleV4 && (
             <div className="flex w-full items-center gap-2.5 py-2.5">
               <V4MigrationStatusDot variant="neutral" />
-              <span className="text-foreground flex min-w-0 items-center gap-1.5 text-sm font-bold">
+              <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-sm">
                 Compare traces while you upgrade
                 <HoverCard openDelay={200}>
                   <HoverCardTrigger asChild>
@@ -1528,18 +1540,6 @@ export function V4MigrationDetailsContent({
               <V4PreviewToggleRow projectId={projectId} />
             </div>
           )}
-
-          {cleanSummary && (
-            <p className="text-muted-foreground flex items-center gap-2.5 py-2.5 text-sm">
-              <V4MigrationStatusDot variant="done" />
-              {cleanSummary}
-            </p>
-          )}
-
-          <V4MigrationDetectedInstrumentationSection
-            sdk={migrationData.sdk}
-            projectId={evidenceProjectId}
-          />
         </div>
       </div>
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16129.preview.langfuse.com](https://pr-16129.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

| Change | Where |
|---|---|
| **Compare-traces toggle moved into the action items** — always the last checklist row, neutral (grey) status dot, muted settled-summary text style; was a floating row below the agent section. Same `canToggleV4` visibility + hover explainer. | `V4MigrationContent.tsx`, `V4MigrationBadgeContent.tsx` |

No new analytics events. Split out of #16122 to merge independently.

## Verification

- `pnpm --filter web run test-client src/features/v4-migration` — content suite 40/40, all 13 files pass
- lint + prettier via pre-commit hook: `Tasks: 7 successful`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Moves the compare-traces toggle into the migration action-item checklist while preserving its visibility and behavior.
- Adds a neutral status-dot variant for optional checklist helpers.
- Places the compare-traces control last in the action-item list with muted styling.
- Removes the previous standalone row below the agent-upgrade section.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable functional, security, or quality issues identified.

The toggle retains the same visibility condition and underlying component, and the new checklist layout supports the widths of its existing panel and modal render sites.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep the compare-traces row la..."](https://github.com/langfuse/langfuse/commit/fb05bbc4c661571a0ddfbd85d2a4315887a38021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53294540)</sub>

<!-- /greptile_comment -->

