### PR TITLE
ci: switch pipelines back to Blacksmith

### DIFF
--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -21,7 +21,7 @@ on:
         required: false
 jobs:
   ecs-deploy:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: ${{ inputs.environment }}
     permissions:
       contents: read

--- a/.github/workflows/build-sandbox-microvm-image.yml
+++ b/.github/workflows/build-sandbox-microvm-image.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     name: Build & Publish (${{ matrix.environment }})
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: ${{ matrix.environment }}
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ concurrency:
 name: Deploy to ECS
 jobs:
   affected-services:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       services: ${{ steps.affected-services.outputs.result }}
     steps:
@@ -67,7 +67,7 @@ jobs:
             console.log('Services', `${process.env.services}` ?? 'n/a');
 
   affected-environments:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       environments: ${{ steps.affected-environments.outputs.result }}
     steps:
@@ -120,7 +120,7 @@ jobs:
   notify-slack-on-failure:
     needs: [affected-services, affected-environments, ecs-deploy]
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -51,7 +51,7 @@ env:
 jobs:
   audit:
     if: github.repository == 'langfuse/langfuse'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     outputs:
       has_changes: ${{ steps.prepare.outputs.has_changes }}
@@ -711,7 +711,7 @@ jobs:
   publish:
     needs: audit
     if: needs.audit.outputs.has_changes == 'true' && needs.audit.outputs.dry_run_mode == 'disabled'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - name: Download pull request artifact

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,7 +47,7 @@ jobs:
   # it instantly and their jobs start without waiting for it (~45-100s of
   # wall clock per run).
   pre-job:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'push'
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -76,7 +76,7 @@ jobs:
           fi
 
   llm-connections-filter:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       changed: ${{ steps.filter.outputs.llm_connections }}
     timeout-minutes: 15
@@ -101,7 +101,7 @@ jobs:
               - 'worker/src/__tests__/llmConnections.test.ts'
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -167,7 +167,7 @@ jobs:
         run: pnpm run typecheck
 
   knip:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -201,7 +201,7 @@ jobs:
         run: pnpm exec knip
 
   prettier-check:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -262,7 +262,7 @@ jobs:
           fi
 
   tests-eslint-plugin:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -298,7 +298,7 @@ jobs:
         run: pnpm --filter @repo/eslint-plugin run test
 
   tests-storybook:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -353,7 +353,7 @@ jobs:
 
   tests-shared:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -411,11 +411,11 @@ jobs:
         include:
           - component: web
             service: langfuse-web
-            runner: ubuntu-latest
+            runner: blacksmith-8vcpu-ubuntu-2404
             health_url: http://localhost:3000/api/public/health
           - component: worker
             service: langfuse-worker
-            runner: ubuntu-latest
+            runner: blacksmith-4vcpu-ubuntu-2404
             health_url: http://localhost:3030/api/health
     steps:
       - name: Checkout
@@ -487,7 +487,7 @@ jobs:
           if-no-files-found: ignore
   tests-web:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -656,7 +656,7 @@ jobs:
 
   tests-web-client:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
@@ -695,7 +695,7 @@ jobs:
 
   tests-worker:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -794,7 +794,7 @@ jobs:
           LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT: ${{ matrix.deploy-mode == '' && 'http://localhost:4566' || '' }}
   test-worker-llm-connections:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
       - llm-connections-filter
@@ -875,7 +875,7 @@ jobs:
           LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY: ${{ secrets.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY }}
 
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -998,7 +998,7 @@ jobs:
         run: pnpm --filter=web run test:e2e
 
   e2e-server-tests:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -1101,7 +1101,7 @@ jobs:
 
   all-ci-passed:
     # This allows us to have a branch protection rule for tests and deploys with matrix
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       [
         lint,
@@ -1302,7 +1302,7 @@ jobs:
             image_name: langfuse
           - component: worker
             image_name: langfuse-worker
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       packages: write
       contents: read
@@ -1451,7 +1451,7 @@ jobs:
       - build-docker-image-release
       - publish-docker-image-release
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -155,7 +155,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.state == 'open' &&
       (github.event.action != 'labeled' || github.event.label.name == 'preview')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: "protected branches"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +42,7 @@ jobs:
   notify-slack-on-failure:
     needs: release
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   generate-sdk-api-specs:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       python_has_changes: ${{ steps.prepare-python-sdk.outputs.has_changes }}
       python_branch_name: ${{ steps.prepare-python-sdk.outputs.branch_name }}
@@ -170,7 +170,7 @@ jobs:
   push-python-sdk:
     needs: generate-sdk-api-specs
     if: needs.generate-sdk-api-specs.outputs.python_has_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Download Python SDK update
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -227,7 +227,7 @@ jobs:
   push-typescript-sdk:
     needs: generate-sdk-api-specs
     if: needs.generate-sdk-api-specs.outputs.typescript_has_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Download TypeScript SDK update
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -287,7 +287,7 @@ jobs:
       - push-python-sdk
       - push-typescript-sdk
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Storybook preview
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: >-
       (github.event_name == 'push' && github.ref_name == 'main') ||
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
Reverts langfuse/langfuse#16085

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts the temporary migration to GitHub-hosted runners and restores established Blacksmith runner labels across CI, deployment, release, audit, SDK-generation, sandbox-image, preview, and Storybook workflows.

- Assigns most jobs to `blacksmith-4vcpu-ubuntu-2404`.
- Assigns resource-intensive lint, web test, and web Docker-build jobs to `blacksmith-8vcpu-ubuntu-2404`.
- Leaves workflow logic, permissions, triggers, and job steps unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it restores previously established Blacksmith runner assignments without changing workflow behavior.

Repository history and existing workflow usage support the selected runner labels, and no concrete scheduling, capability, security, or workflow-contract failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;ci: switch pipelines back to Git..."](https://github.com/langfuse/langfuse/commit/cba061cfd90ba8d6b2eeed764fb5a56a98f6922f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53299134)</sub>

<!-- /greptile_comment -->