### PR TITLE
fix(v4): wait for migration status before rendering

### DIFF
--- a/web/src/features/v4-migration/V4MigrationLoadingState.stories.tsx
+++ b/web/src/features/v4-migration/V4MigrationLoadingState.stories.tsx
@@ -1,0 +1,8 @@
+import preview from "../../../.storybook/preview";
+import { V4MigrationLoadingState } from "./V4MigrationLoadingState";
+
+const meta = preview.meta({
+  component: V4MigrationLoadingState,
+});
+
+export const Loading = meta.story({});

--- a/web/src/features/v4-migration/V4MigrationLoadingState.tsx
+++ b/web/src/features/v4-migration/V4MigrationLoadingState.tsx
@@ -1,0 +1,9 @@
+export function V4MigrationLoadingState() {
+  return (
+    <div className="flex min-h-full flex-1 items-center justify-center px-6 py-12">
+      <p className="text-primary text-center text-base leading-6" role="status">
+        Checking project status ...
+      </p>
+    </div>
+  );
+}

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -191,6 +191,9 @@ describe("V4MigrationStatusPage", () => {
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     expect(screen.queryByText("What's new in v4")).not.toBeInTheDocument();
     expect(screen.getByText(/Checking project status/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: "Langfuse Icon" }),
+    ).not.toBeInTheDocument();
   });
 
   it("hides project content until last-trace data has finished loading", () => {

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   // Evals are the simplest way to keep the single test project on the table:
   // ready projects are hidden, so most cases need one open action item.
   evalCount: 1,
+  lastTracePending: false,
 }));
 
 vi.mock("next/router", () => ({
@@ -113,10 +114,21 @@ vi.mock("@/src/features/v4-migration/hooks/useV4MigrationData", () => ({
 
 vi.mock("@/src/utils/api", () => ({
   api: {
-    organizations: {
-      lastTraceByProject: {
-        useQuery: () => ({ data: [] }),
-      },
+    useQueries: (
+      buildQueries: (router: {
+        organizations: { lastTraceByProject: () => unknown };
+      }) => unknown,
+    ) => {
+      buildQueries({
+        organizations: {
+          lastTraceByProject: vi.fn(),
+        },
+      });
+      return [
+        mocks.lastTracePending
+          ? { data: undefined, isError: false }
+          : { data: [], isError: false },
+      ];
     },
   },
 }));
@@ -133,6 +145,7 @@ describe("V4MigrationStatusPage", () => {
       delayedOtelIngestionCount: 0,
     };
     mocks.evalCount = 1;
+    mocks.lastTracePending = false;
   });
 
   it("keeps the project table readable through horizontal scrolling", () => {
@@ -163,7 +176,7 @@ describe("V4MigrationStatusPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps projects whose checks are still running or failed", () => {
+  it("hides project content until every migration check has finished", () => {
     mocks.evalCount = 0;
     mocks.sdk = {
       status: "checking",
@@ -174,10 +187,21 @@ describe("V4MigrationStatusPage", () => {
 
     render(<V4MigrationStatusPage />);
 
-    expect(screen.getByText("Test project")).toBeInTheDocument();
-    expect(
-      screen.queryByText("All projects are up to date. Nothing to do here."),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Test project")).not.toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.queryByText("What's new in v4")).not.toBeInTheDocument();
+    expect(screen.getByText(/Checking project status/)).toBeInTheDocument();
+  });
+
+  it("hides project content until last-trace data has finished loading", () => {
+    mocks.lastTracePending = true;
+
+    render(<V4MigrationStatusPage />);
+
+    expect(screen.queryByText("Test project")).not.toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.queryByText("What's new in v4")).not.toBeInTheDocument();
+    expect(screen.getByText(/Checking project status/)).toBeInTheDocument();
   });
 
   it("opens the summary card with a link to the v4 docs", () => {

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -191,6 +191,8 @@ describe("V4MigrationStatusPage", () => {
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     expect(screen.queryByText("What's new in v4")).not.toBeInTheDocument();
     expect(screen.getByText(/Checking project status/)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveClass("text-base", "leading-6");
+    expect(screen.getByRole("status")).not.toHaveClass("text-2xl", "font-bold");
     expect(
       screen.queryByRole("img", { name: "Langfuse Icon" }),
     ).not.toBeInTheDocument();

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { ArrowRight } from "lucide-react";
 import ContainerPage from "@/src/components/layouts/container-page";
+import { Spinner } from "@/src/components/layouts/spinner";
 import { Card } from "@/src/components/ui/card";
 import {
   Table,
@@ -161,18 +162,15 @@ function SortableHead({
 function OrgStatusSection({
   org,
   statusByProjectId,
+  lastTraceTimes,
 }: {
   org: V4MigrationOrganization;
   statusByProjectId: Map<string, ProjectMigrationStatus>;
+  lastTraceTimes: { projectId: string; lastTraceAt: Date }[];
 }) {
   const router = useRouter();
   const capture = usePostHogClientCapture();
   const openMigrationPanel = useOpenV4MigrationPanel();
-  const { data: lastTraceTimes } =
-    api.organizations.lastTraceByProject.useQuery(
-      { orgId: org.id },
-      { enabled: org.projects.length > 0 },
-    );
 
   const openProjectMigration = (
     row: { id: string; name: string },
@@ -487,6 +485,18 @@ function V4MigrationStatusPageContent() {
     organizations: orgs,
     enabled: true,
   });
+  // Start the table's remaining data alongside the migration checks. Keeping
+  // these queries in the page lets one loading boundary wait for the complete
+  // snapshot instead of mounting each organization table with placeholder
+  // values that update after its rows become visible.
+  const lastTraceQueries = api.useQueries((t) =>
+    orgs.map((org) =>
+      t.organizations.lastTraceByProject(
+        { orgId: org.id },
+        { enabled: org.projects.length > 0 },
+      ),
+    ),
+  );
 
   const faqItems: { q: string; a: ReactNode }[] = [
     {
@@ -578,9 +588,23 @@ function V4MigrationStatusPageContent() {
   // Ready projects are hidden from the org tables, so the page needs its own
   // "nothing left to do" state once every project drops out.
   const listedProjects = readiness.filter((state) => state !== "ready").length;
-  const isChecking =
+  const isLoading =
     session.status === "loading" ||
-    readiness.some((state) => state === "checking");
+    readiness.some((state) => state === "checking") ||
+    orgs.some(
+      (org, index) =>
+        org.projects.length > 0 &&
+        lastTraceQueries[index]?.data === undefined &&
+        !lastTraceQueries[index]?.isError,
+    );
+
+  if (isLoading) {
+    return (
+      <ContainerPage headerProps={{ title: "Migration status" }}>
+        <Spinner message="Checking project status" />
+      </ContainerPage>
+    );
+  }
 
   return (
     <ContainerPage
@@ -601,11 +625,7 @@ function V4MigrationStatusPageContent() {
             {actionNeededProjects > 0 && <V4MigrationDeadlineNote />}
           </div>
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-            {isChecking ? (
-              <span className="text-muted-foreground text-sm">
-                Checking project status…
-              </span>
-            ) : totalProjects === 0 ? (
+            {totalProjects === 0 ? (
               <span className="text-muted-foreground text-sm">
                 No active projects
               </span>
@@ -625,15 +645,16 @@ function V4MigrationStatusPageContent() {
           </div>
         </Card>
 
-        {orgs.map((org) => (
+        {orgs.map((org, index) => (
           <OrgStatusSection
             key={org.id}
             org={org}
             statusByProjectId={statusByProjectId}
+            lastTraceTimes={lastTraceQueries[index]?.data ?? []}
           />
         ))}
 
-        {!isChecking && totalProjects > 0 && listedProjects === 0 && (
+        {totalProjects > 0 && listedProjects === 0 && (
           <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
             <V4MigrationStatusDot variant="done" />
             All projects are up to date. Nothing to do here.

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { ArrowRight } from "lucide-react";
 import ContainerPage from "@/src/components/layouts/container-page";
-import { Spinner } from "@/src/components/layouts/spinner";
 import { Card } from "@/src/components/ui/card";
 import {
   Table,
@@ -601,7 +600,14 @@ function V4MigrationStatusPageContent() {
   if (isLoading) {
     return (
       <ContainerPage headerProps={{ title: "Migration status" }}>
-        <Spinner message="Checking project status" />
+        <div className="flex min-h-full flex-1 items-center justify-center px-6 py-12">
+          <p
+            className="text-primary text-center text-2xl leading-9 font-bold tracking-tight"
+            role="status"
+          >
+            Checking project status ...
+          </p>
+        </div>
       </ContainerPage>
     );
   }

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -37,6 +37,7 @@ import {
   type ProjectMigrationStatus,
 } from "@/src/features/v4-migration/migrationData";
 import { PARTNER_INTEGRATION_FAQ_URL } from "@/src/features/v4-migration/partnerIntegrationDocs";
+import { V4MigrationLoadingState } from "@/src/features/v4-migration/V4MigrationLoadingState";
 
 const V4_DOCS_URL = "https://langfuse.com/docs/v4";
 const SDK_UPGRADE_URL =
@@ -600,14 +601,7 @@ function V4MigrationStatusPageContent() {
   if (isLoading) {
     return (
       <ContainerPage headerProps={{ title: "Migration status" }}>
-        <div className="flex min-h-full flex-1 items-center justify-center px-6 py-12">
-          <p
-            className="text-primary text-center text-2xl leading-9 font-bold tracking-tight"
-            role="status"
-          >
-            Checking project status ...
-          </p>
-        </div>
+        <V4MigrationLoadingState />
       </ContainerPage>
     );
   }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16134.preview.langfuse.com](https://pr-16134.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- start the migration readiness and last-trace queries in parallel
- keep the v4 migration page behind one loading boundary until the complete project snapshot is available
- prevent projects that are already up to date from flashing in the work list
- cover pending migration checks and pending last-trace data with client regressions

## Root cause

The account migration hook returns every project immediately with per-check loading states. The status page treated those checking projects as visible rows, then removed ready projects as the requests resolved. Last-trace queries were also owned by each organization table, causing another visible update after the tables mounted.

## Impacted package

- `web`

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-client v4-migration` — `Test Files 13 passed (13)`, `Tests 103 passed (103)`
- `pnpm exec prettier --check web/src/features/v4-migration/V4MigrationStatusPage.tsx web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx` — all matched files use Prettier code style
- focused regressions were confirmed failing against the previous page implementation

## Verification limitations

- Full local web typechecking is currently blocked by unrelated generated Prisma/shared-package errors in this fresh worktree; neither changed file is reported.
- Browser signoff is blocked because the local Postgres and Redis services are unavailable, so the app redirects to sign-in before the migration page can be exercised.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves organization last-trace queries to the migration status page and waits for both migration readiness and trace data before rendering the project snapshot.

- Starts migration and last-trace requests together.
- Replaces incremental table rendering with a single loading boundary.
- Adds client regressions for pending migration checks and last-trace queries.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable changed-code failures identified.

The consolidated queries preserve organization-to-result alignment, successful and terminal error states both leave the loading boundary, and the added tests cover the intended pending states.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): wait for migration status befor..."](https://github.com/langfuse/langfuse/commit/1e30220f2821832a3008443d3d78a46c34f7bc0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53308837)</sub>

<!-- /greptile_comment -->