### PR TITLE
feat(notifications): add a posthog-export-failed project notification event

### DIFF
--- a/packages/shared/prisma/migrations/20260813120000_add_posthog_integration_error_fields/migration.sql
+++ b/packages/shared/prisma/migrations/20260813120000_add_posthog_integration_error_fields/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "posthog_integrations" ADD COLUMN IF NOT EXISTS "last_error" TEXT;
+ALTER TABLE "posthog_integrations" ADD COLUMN IF NOT EXISTS "last_error_at" TIMESTAMP(3);

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1070,6 +1070,12 @@ model PosthogIntegration {
   createdAt              DateTime                         @default(now()) @map("created_at")
   exportSource           AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
 
+  // Last deterministic customer-config fault (bad hostname) that disabled the
+  // integration. Written by the worker, surfaced in the integration settings
+  // status section, and cleared on a successful run.
+  lastError   String?   @map("last_error")
+  lastErrorAt DateTime? @map("last_error_at")
+
   @@map("posthog_integrations")
 }
 

--- a/packages/shared/src/domain/automations.ts
+++ b/packages/shared/src/domain/automations.ts
@@ -29,6 +29,7 @@ export const TriggerEventSourceSchema = z.enum([
  */
 export const ProjectNotificationEventTypeSchema = z.enum([
   "blob-export-failed",
+  "posthog-export-failed",
   "evaluator-blocked",
 ]);
 export type ProjectNotificationEventType = z.infer<

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -20,6 +20,7 @@ export * from "./services/email/usageThresholdWarning/sendUsageThresholdWarningE
 export * from "./services/email/usageThresholdSuspension/sendUsageThresholdSuspensionEmail";
 export * from "./services/email/commentMention/sendCommentMentionEmail";
 export * from "./services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail";
+export * from "./services/email/posthogExportFailed/sendPostHogExportFailedEmail";
 export * from "./services/PromptService";
 export * from "./services/PromptService/types";
 export * from "./services/traces-ui-table-service";

--- a/packages/shared/src/server/notifications/buildProjectNotificationSlackMessage.ts
+++ b/packages/shared/src/server/notifications/buildProjectNotificationSlackMessage.ts
@@ -9,6 +9,7 @@ import {
 /** projectNotificationTitle maps an event type to a human-readable Slack title. */
 const projectNotificationTitle: Record<ProjectNotificationEventType, string> = {
   "blob-export-failed": "Blob storage export failed",
+  "posthog-export-failed": "PostHog export failed",
   "evaluator-blocked": "Evaluator blocked",
 };
 

--- a/packages/shared/src/server/notifications/dispatchProjectNotification.ts
+++ b/packages/shared/src/server/notifications/dispatchProjectNotification.ts
@@ -9,6 +9,7 @@ import { QueueJobs, QueueName } from "../queues";
 import { WebhookQueue } from "../redis/webhookQueue";
 import { getAutomations } from "../repositories/automation-repository";
 import { sendBlobStorageExportFailedEmail } from "../services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail";
+import { sendPostHogExportFailedEmail } from "../services/email/posthogExportFailed/sendPostHogExportFailedEmail";
 import { sendEvaluatorBlockedEmail } from "../services/email/evaluatorBlocked/sendEvaluatorBlockedEmail";
 import { getProjectAdminEmails } from "../services/getProjectAdminEmails";
 import { type ProjectNotificationEvent } from "./types";
@@ -171,6 +172,16 @@ async function sendEventAdminEmails({
         env: emailEnv,
         projectName: event.projectName,
         settingsUrl: `${emailEnv.NEXTAUTH_URL}/project/${event.projectId}/settings/integrations/blobstorage`,
+        receiverEmails,
+        disabled: event.disabled ?? false,
+      });
+      return;
+    }
+    case "posthog-export-failed": {
+      await sendPostHogExportFailedEmail({
+        env: emailEnv,
+        projectName: event.projectName,
+        settingsUrl: `${emailEnv.NEXTAUTH_URL}/project/${event.projectId}/settings/integrations/posthog`,
         receiverEmails,
         disabled: event.disabled ?? false,
       });

--- a/packages/shared/src/server/notifications/types.ts
+++ b/packages/shared/src/server/notifications/types.ts
@@ -52,6 +52,14 @@ export const ProjectNotificationEventSchema = z.discriminatedUnion(
     }),
     projectNotificationEventBaseSchema.extend({
       eventType: z.literal(
+        ProjectNotificationEventTypeSchema.enum["posthog-export-failed"],
+      ),
+      // true when the integration was auto-disabled after a deterministic
+      // customer-config fault (terminal event; selects the "disabled" variant).
+      disabled: z.boolean().optional(),
+    }),
+    projectNotificationEventBaseSchema.extend({
+      eventType: z.literal(
         ProjectNotificationEventTypeSchema.enum["evaluator-blocked"],
       ),
       blockReason: z.enum(EvaluatorBlockReason),

--- a/packages/shared/src/server/services/email/posthogExportFailed/sendPostHogExportFailedEmail.tsx
+++ b/packages/shared/src/server/services/email/posthogExportFailed/sendPostHogExportFailedEmail.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import {
+  sendIntegrationExportFailedEmail,
+  type SendIntegrationExportFailedEmailParams,
+} from "../integrationExportFailed/sendIntegrationExportFailedEmail";
+import { type IntegrationExportFailedEmailCopy } from "../integrationExportFailed/IntegrationExportFailedEmailTemplate";
+
+export type SendPostHogExportFailedEmailParams =
+  SendIntegrationExportFailedEmailParams;
+
+export const postHogExportFailedEmailCopy: IntegrationExportFailedEmailCopy = {
+  subjectLabel: "PostHog",
+  headingLabel: "PostHog",
+  inlineLabel: "PostHog",
+  disabledBody: (projectName) => (
+    <>
+      The PostHog export for project &quot;{projectName}
+      &quot; has been disabled after a configuration fault. This usually means
+      the PostHog host is no longer reachable or valid. Once you have updated
+      it, simply re-enable the export in the integration settings and it will
+      pick up right where it left off.
+    </>
+  ),
+};
+
+export const sendPostHogExportFailedEmail = (
+  params: SendPostHogExportFailedEmailParams,
+) => sendIntegrationExportFailedEmail(postHogExportFailedEmailCopy, params);

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -192,6 +192,8 @@ export const posthogIntegrationRouter = createTRPCRouter({
             // undefined → Prisma omits the column → preserves the persisted
             // value on partial updates (LFE-10296).
             exportSource: config.exportSource,
+            // lastError is deliberately left intact so the last fault stays
+            // visible until a successful run clears it.
           },
         });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16135.preview.langfuse.com](https://pr-16135.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Bottom of a three-PR stack. Groundwork only — nothing emits this event yet, so
this PR is inert in production. Split out so the worker change that consumes it
(the PR above) reviews as a self-contained behaviour change instead of a
600-line mixed diff.

Two additive pieces, each mirroring what blob storage already has:

- **Persist the fault on the integration row.** `last_error` / `last_error_at`
  record the deterministic customer-config fault that stopped the export, so
  the settings page can tell the customer *what* to fix rather than only that
  the export is off. Cleared by the next successful run. Additive nullable
  columns, no backfill.
- **Register `posthog-export-failed` with the project-notification fan-out**:
  the discriminated-union member, the Slack title, and the admin-email case.
  The email is a thin caller of the shared integration-export-failed sender
  extracted in the already-merged refactor, supplying PostHog's labels and its
  disabled-variant copy.

**Deliberately *not* copied from blob storage: the
`last_failure_notification_sent_at` cooldown column.** PostHog guarantees
at-most-once notification through an atomic `enabled` true→false claim in the
worker rather than a cooldown timestamp, so the column would be written by
nothing and read by nothing. Parity for its own sake isn't worth a permanent
schema column; if PostHog ever gains a retry-based notification path, the change
that needs the column can add it.

`last_error` is deliberately *not* reset when the customer saves the
integration, so the last fault stays visible until a successful run clears it.

The user-facing notification-channel toggle lives in the PR above, so this one
adds no user-visible surface.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have added tests that prove my fix is effective
- New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
