### PR TITLE
feat(web): Health settings pages for migration status and SDK verification

### DIFF
--- a/web/src/__tests__/organization-settings-pages.clienttest.tsx
+++ b/web/src/__tests__/organization-settings-pages.clienttest.tsx
@@ -78,6 +78,10 @@ vi.mock("@/src/ee/features/audit-log-viewer/OrgAuditLogsSettingsPage", () => ({
   OrgAuditLogsSettingsPage: () => null,
 }));
 
+vi.mock("@/src/features/v4-migration/OrgHealthSettingsPage", () => ({
+  OrgHealthSettingsPage: () => null,
+}));
+
 vi.mock("@/src/features/rbac/utils/checkOrganizationAccess", () => ({
   useHasOrganizationAccess: vi.fn(),
 }));

--- a/web/src/__tests__/server/unit/latestSdkVersions.servertest.ts
+++ b/web/src/__tests__/server/unit/latestSdkVersions.servertest.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: { debug: vi.fn(), warn: vi.fn() },
+  redis: null,
+  ClickHouseClientManager: {
+    getInstance: () => ({ closeAllConnections: vi.fn() }),
+  },
+}));
+
+import { FALLBACK_LATEST_SDK_VERSIONS } from "@/src/features/v4-migration/latestSdkVersions";
+import {
+  createLatestSdkVersionsResolver,
+  type LatestSdkVersionsResolverDependencies,
+} from "@/src/features/v4/server/latestSdkVersions";
+
+const PYPI_URL = "https://pypi.org/pypi/langfuse/json";
+const NPM_URL = "https://registry.npmjs.org/@langfuse/tracing/latest";
+
+const jsonResponse = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as Response;
+
+const errorResponse = (status: number) =>
+  ({
+    ok: false,
+    status,
+    json: async () => ({}),
+  }) as Response;
+
+const registryFetch = (
+  responses: Partial<Record<string, () => Response | Promise<Response>>>,
+) =>
+  vi.fn(async (input: RequestInfo | URL) => {
+    const respond = responses[String(input)];
+    if (!respond) throw new Error(`Unexpected fetch: ${String(input)}`);
+    return respond();
+  }) as unknown as typeof fetch & ReturnType<typeof vi.fn>;
+
+const healthyRegistries = () =>
+  registryFetch({
+    [PYPI_URL]: () => jsonResponse({ info: { version: "4.20.0" } }),
+    [NPM_URL]: () => jsonResponse({ version: "5.12.3" }),
+  });
+
+const createResolver = (
+  overrides: Partial<LatestSdkVersionsResolverDependencies> = {},
+) => {
+  const fetchImpl = overrides.fetchImpl ?? healthyRegistries();
+  const getCache = overrides.getCache ?? vi.fn().mockResolvedValue(null);
+  const setCache = overrides.setCache ?? vi.fn().mockResolvedValue(undefined);
+  const resolver = createLatestSdkVersionsResolver({
+    fetchImpl,
+    getCache,
+    setCache,
+  });
+  return { fetchImpl, getCache, setCache, resolver };
+};
+
+describe("latest SDK versions registry lookup", () => {
+  it("returns cached versions without hitting the registries", async () => {
+    const cached = { python: "4.15.0", javascript: "5.11.0" };
+    const { fetchImpl, setCache, resolver } = createResolver({
+      getCache: vi.fn().mockResolvedValue(JSON.stringify(cached)),
+    });
+
+    await expect(resolver()).resolves.toEqual(cached);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it("fetches both registries on cache miss and caches the result for 24h", async () => {
+    const { fetchImpl, setCache, resolver } = createResolver();
+
+    await expect(resolver()).resolves.toEqual({
+      python: "4.20.0",
+      javascript: "5.12.3",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(setCache).toHaveBeenCalledOnce();
+    expect(setCache).toHaveBeenCalledWith(
+      JSON.stringify({ python: "4.20.0", javascript: "5.12.3" }),
+      24 * 60 * 60,
+    );
+  });
+
+  it("falls back per registry and skips caching when one registry fails", async () => {
+    const { setCache, resolver } = createResolver({
+      fetchImpl: registryFetch({
+        [PYPI_URL]: () => errorResponse(503),
+        [NPM_URL]: () => jsonResponse({ version: "5.12.3" }),
+      }),
+    });
+
+    await expect(resolver()).resolves.toEqual({
+      python: FALLBACK_LATEST_SDK_VERSIONS.python,
+      javascript: "5.12.3",
+    });
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it("returns the pinned fallback when both registries are down", async () => {
+    const { setCache, resolver } = createResolver({
+      fetchImpl: registryFetch({
+        [PYPI_URL]: () => {
+          throw new Error("network down");
+        },
+        [NPM_URL]: () => {
+          throw new Error("network down");
+        },
+      }),
+    });
+
+    await expect(resolver()).resolves.toEqual(FALLBACK_LATEST_SDK_VERSIONS);
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it("rejects registry payloads that are not version strings", async () => {
+    const { setCache, resolver } = createResolver({
+      fetchImpl: registryFetch({
+        [PYPI_URL]: () => jsonResponse({ info: { version: "<html>oops" } }),
+        [NPM_URL]: () => jsonResponse({ version: 42 }),
+      }),
+    });
+
+    await expect(resolver()).resolves.toEqual(FALLBACK_LATEST_SDK_VERSIONS);
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it("ignores corrupt cache entries and refetches", async () => {
+    const { fetchImpl, resolver } = createResolver({
+      getCache: vi.fn().mockResolvedValue("not-json{"),
+    });
+
+    await expect(resolver()).resolves.toEqual({
+      python: "4.20.0",
+      javascript: "5.12.3",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores cache entries with invalid version shapes", async () => {
+    const { fetchImpl, resolver } = createResolver({
+      getCache: vi.fn().mockResolvedValue(JSON.stringify({ python: "4.15.0" })),
+    });
+
+    await expect(resolver()).resolves.toEqual({
+      python: "4.20.0",
+      javascript: "5.12.3",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("survives cache read and write failures", async () => {
+    const { resolver } = createResolver({
+      getCache: vi.fn().mockRejectedValue(new Error("Redis unavailable")),
+      setCache: vi.fn().mockRejectedValue(new Error("Redis unavailable")),
+    });
+
+    await expect(resolver()).resolves.toEqual({
+      python: "4.20.0",
+      javascript: "5.12.3",
+    });
+  });
+
+  it("deduplicates concurrent lookups into one registry round-trip", async () => {
+    const { fetchImpl, resolver } = createResolver();
+
+    const [first, second] = await Promise.all([resolver(), resolver()]);
+
+    expect(first).toEqual(second);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries after a completed lookup instead of memoizing forever", async () => {
+    const { fetchImpl, resolver } = createResolver();
+
+    await resolver();
+    await resolver();
+
+    // Redis is the cross-request cache; the in-process memo only spans
+    // concurrent calls, so a second sequential call consults deps again.
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+});

--- a/web/src/features/v4-migration/HealthStatusBanner.tsx
+++ b/web/src/features/v4-migration/HealthStatusBanner.tsx
@@ -1,0 +1,41 @@
+import { CheckCircle2, TriangleAlert } from "lucide-react";
+
+import { Card } from "@/src/components/ui/card";
+import { cn } from "@/src/utils/tailwind";
+
+/**
+ * The Health page's one-glance verdict: a bordered card with a dim,
+ * low-saturation tint (fills read quieter than text) and a full-size
+ * sentence, so "am I OK?" is the first thing the eye lands on instead of a
+ * muted footnote.
+ */
+export function HealthStatusBanner({
+  tone,
+  children,
+}: {
+  tone: "green" | "yellow";
+  children: React.ReactNode;
+}) {
+  return (
+    <Card
+      className={cn(
+        "flex flex-row items-center gap-2.5 p-3",
+        tone === "green" && "bg-light-green/40",
+        tone === "yellow" && "bg-light-yellow/40",
+      )}
+    >
+      {tone === "green" ? (
+        <CheckCircle2
+          aria-hidden
+          className="text-dark-green h-4 w-4 shrink-0"
+        />
+      ) : (
+        <TriangleAlert
+          aria-hidden
+          className="text-dark-yellow h-4 w-4 shrink-0"
+        />
+      )}
+      <p className="text-foreground text-sm">{children}</p>
+    </Card>
+  );
+}

--- a/web/src/features/v4-migration/OrgHealthSettingsPage.tsx
+++ b/web/src/features/v4-migration/OrgHealthSettingsPage.tsx
@@ -1,0 +1,115 @@
+import { useSession } from "next-auth/react";
+
+import Header from "@/src/components/layouts/header";
+import { V4MigrationStatusDot } from "@/src/features/v4-migration/V4MigrationBadgeContent";
+import { OrgStatusSection } from "@/src/features/v4-migration/V4MigrationStatusPage";
+import {
+  useAccountV4MigrationData,
+  type V4MigrationOrganization,
+} from "@/src/features/v4-migration/hooks/useV4MigrationData";
+import { getProjectMigrationReadiness } from "@/src/features/v4-migration/migrationData";
+import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
+import { api } from "@/src/utils/api";
+
+/**
+ * Org Health settings page: the fleet view — every project's migration and
+ * SDK state in one table, rows linking to each project's Health settings
+ * page. Unlike the migration status page (a work list), migrated projects
+ * stay visible here: this is where an admin verifies the whole org is green.
+ */
+export function OrgHealthSettingsPage({ orgId }: { orgId: string }) {
+  const v4UpgradeUiEnabled = useV4UpgradeUiEnabled();
+  const session = useSession();
+
+  const sessionOrg = session.data?.user?.organizations?.find(
+    (candidate) => candidate.id === orgId,
+  );
+  const org: V4MigrationOrganization | null = sessionOrg
+    ? {
+        id: sessionOrg.id,
+        name: sessionOrg.name,
+        projects: sessionOrg.projects
+          .filter((project) => !project.deletedAt)
+          .map((project) => ({ id: project.id, name: project.name })),
+      }
+    : null;
+
+  const statusByProjectId = useAccountV4MigrationData({
+    organizations: org ? [org] : [],
+    enabled: v4UpgradeUiEnabled && Boolean(org),
+  });
+  const lastTrace = api.organizations.lastTraceByProject.useQuery(
+    { orgId },
+    {
+      enabled: Boolean(org && org.projects.length > 0),
+      refetchOnWindowFocus: false,
+      staleTime: 5 * 60 * 1000,
+    },
+  );
+
+  const readinessCounts = org
+    ? org.projects.reduce(
+        (counts, project) => {
+          const status = statusByProjectId.get(project.id);
+          if (!status) return counts;
+          const readiness = getProjectMigrationReadiness(status);
+          if (readiness === "ready") counts.ready += 1;
+          if (readiness === "action-needed") counts.actionNeeded += 1;
+          return counts;
+        },
+        { ready: 0, actionNeeded: 0 },
+      )
+    : { ready: 0, actionNeeded: 0 };
+  const allGreen =
+    org !== null &&
+    org.projects.length > 0 &&
+    readinessCounts.ready === org.projects.length;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <Header title="Health" />
+        <p className="text-muted-foreground text-sm">
+          Instrumentation health across every project in this organization. Open
+          a project row for its detailed checks and SDK versions.
+        </p>
+      </div>
+
+      {!v4UpgradeUiEnabled ? (
+        <p className="text-muted-foreground text-sm">
+          Health checks are not available yet.
+        </p>
+      ) : !org || org.projects.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No projects in this organization yet.
+        </p>
+      ) : (
+        <>
+          {allGreen ? (
+            <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
+              <V4MigrationStatusDot variant="done" />
+              {org.projects.length === 1
+                ? "The project in this organization is fully v4 compatible."
+                : `All ${org.projects.length} projects are fully v4 compatible.`}
+            </p>
+          ) : readinessCounts.actionNeeded > 0 ? (
+            <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
+              <V4MigrationStatusDot variant="action" />
+              {readinessCounts.actionNeeded} of {org.projects.length}{" "}
+              {org.projects.length === 1 ? "project" : "projects"}{" "}
+              {readinessCounts.actionNeeded === 1 ? "needs" : "need"} attention.
+            </p>
+          ) : null}
+          <OrgStatusSection
+            org={org}
+            statusByProjectId={statusByProjectId}
+            lastTraceTimes={lastTrace.data ?? []}
+            hideReadyProjects={false}
+            showOrgHeading={false}
+            rowHref={(projectId) => `/project/${projectId}/settings/health`}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/v4-migration/OrgHealthSettingsPage.tsx
+++ b/web/src/features/v4-migration/OrgHealthSettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useSession } from "next-auth/react";
 
 import Header from "@/src/components/layouts/header";
-import { V4MigrationStatusDot } from "@/src/features/v4-migration/V4MigrationBadgeContent";
+import { HealthStatusBanner } from "@/src/features/v4-migration/HealthStatusBanner";
 import { OrgStatusSection } from "@/src/features/v4-migration/V4MigrationStatusPage";
 import {
   useAccountV4MigrationData,
@@ -86,19 +86,21 @@ export function OrgHealthSettingsPage({ orgId }: { orgId: string }) {
       ) : (
         <>
           {allGreen ? (
-            <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
-              <V4MigrationStatusDot variant="done" />
+            <HealthStatusBanner tone="green">
               {org.projects.length === 1
                 ? "The project in this organization is fully v4 compatible."
                 : `All ${org.projects.length} projects are fully v4 compatible.`}
-            </p>
+            </HealthStatusBanner>
           ) : readinessCounts.actionNeeded > 0 ? (
-            <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
-              <V4MigrationStatusDot variant="action" />
+            <HealthStatusBanner tone="yellow">
               {readinessCounts.actionNeeded} of {org.projects.length}{" "}
               {org.projects.length === 1 ? "project" : "projects"}{" "}
-              {readinessCounts.actionNeeded === 1 ? "needs" : "need"} attention.
-            </p>
+              {readinessCounts.actionNeeded === 1 ? "needs" : "need"} attention
+              {readinessCounts.ready > 0
+                ? ` · ${readinessCounts.ready} migrated`
+                : ""}
+              .
+            </HealthStatusBanner>
           ) : null}
           <OrgStatusSection
             org={org}

--- a/web/src/features/v4-migration/ProjectHealthSettingsPage.tsx
+++ b/web/src/features/v4-migration/ProjectHealthSettingsPage.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+
+import Header from "@/src/components/layouts/header";
+import { V4MigrationStatusDot } from "@/src/features/v4-migration/V4MigrationBadgeContent";
+import { V4MigrationDetailsContent } from "@/src/features/v4-migration/V4MigrationContent";
+import { SdkVersionsTable } from "@/src/features/v4-migration/SdkVersionsTable";
+import { useProjectV4MigrationData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
+import {
+  createV4MigrationDetectionRange,
+  getProjectMigrationReadiness,
+} from "@/src/features/v4-migration/migrationData";
+import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
+import { api } from "@/src/utils/api";
+
+/**
+ * Project Health settings page: the permanent home for "is my instrumentation
+ * healthy". Two sections today — the per-SDK-version traffic table (the
+ * verify view, always on) and the v4 migration checklist (embedded from the
+ * migration panel, retires with the migration era). The status row gives the
+ * calm all-green confirmation this page exists for.
+ */
+export function ProjectHealthSettingsPage({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const v4UpgradeUiEnabled = useV4UpgradeUiEnabled(projectId);
+  // Hour-bucketed 14-day window, held in state so the query key is stable.
+  const [detectionRange] = useState(() => createV4MigrationDetectionRange());
+  const sdkSummary = api.v4Transition.sdkUsageSummary.useQuery(
+    {
+      projectId,
+      fromTimestamp: detectionRange.fromTimestamp,
+      toTimestamp: detectionRange.toTimestamp,
+    },
+    { refetchOnWindowFocus: false, staleTime: 5 * 60 * 1000 },
+  );
+  const migrationData = useProjectV4MigrationData({
+    projectId,
+    enabled: v4UpgradeUiEnabled,
+  });
+  const readiness = v4UpgradeUiEnabled
+    ? getProjectMigrationReadiness(migrationData)
+    : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <Header title="Health" />
+        <p className="text-muted-foreground text-sm">
+          Verify this project&apos;s instrumentation: which SDK versions send
+          data, whether they are current, and what still needs attention.
+        </p>
+      </div>
+
+      {readiness === "ready" && (
+        <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
+          <V4MigrationStatusDot variant="done" />
+          All checks passed. This project is fully v4 compatible.
+        </p>
+      )}
+      {readiness === "action-needed" && (
+        <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
+          <V4MigrationStatusDot variant="action" />
+          This project needs attention — see the action items below.
+        </p>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <h3 className="text-base font-bold">SDK versions</h3>
+        <p className="text-muted-foreground text-sm">
+          Every SDK and version that sent data in the last 14 days.
+        </p>
+        {sdkSummary.isLoading ? (
+          <p className="text-muted-foreground text-sm">Checking ingestion…</p>
+        ) : sdkSummary.isError ? (
+          <p className="text-muted-foreground text-sm">
+            SDK usage is unavailable right now.
+          </p>
+        ) : (
+          <SdkVersionsTable series={sdkSummary.data?.sdkUsageSeries ?? []} />
+        )}
+      </div>
+
+      {v4UpgradeUiEnabled && (
+        <div className="flex flex-col gap-6">
+          <V4MigrationDetailsContent projectId={projectId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/v4-migration/ProjectHealthSettingsPage.tsx
+++ b/web/src/features/v4-migration/ProjectHealthSettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
-import Header from "@/src/components/layouts/header";
-import { V4MigrationStatusDot } from "@/src/features/v4-migration/V4MigrationBadgeContent";
+import Header, { SubHeader } from "@/src/components/layouts/header";
+import { HealthStatusBanner } from "@/src/features/v4-migration/HealthStatusBanner";
 import { V4MigrationDetailsContent } from "@/src/features/v4-migration/V4MigrationContent";
 import { SdkVersionsTable } from "@/src/features/v4-migration/SdkVersionsTable";
 import { useProjectV4MigrationData } from "@/src/features/v4-migration/hooks/useV4MigrationData";
@@ -14,10 +14,10 @@ import { api } from "@/src/utils/api";
 
 /**
  * Project Health settings page: the permanent home for "is my instrumentation
- * healthy". Two sections today — the per-SDK-version traffic table (the
- * verify view, always on) and the v4 migration checklist (embedded from the
- * migration panel, retires with the migration era). The status row gives the
- * calm all-green confirmation this page exists for.
+ * healthy". The status banner answers "am I OK?" at a glance; the SDK table
+ * is the always-on verify view; the migration checklist (embedded from the
+ * migration panel, width-constrained to the drawer proportions it was
+ * designed for) retires with the migration era.
  */
 export function ProjectHealthSettingsPage({
   projectId,
@@ -54,20 +54,18 @@ export function ProjectHealthSettingsPage({
       </div>
 
       {readiness === "ready" && (
-        <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
-          <V4MigrationStatusDot variant="done" />
+        <HealthStatusBanner tone="green">
           All checks passed. This project is fully v4 compatible.
-        </p>
+        </HealthStatusBanner>
       )}
       {readiness === "action-needed" && (
-        <p className="text-muted-foreground flex items-center gap-2.5 text-sm">
-          <V4MigrationStatusDot variant="action" />
-          This project needs attention — see the action items below.
-        </p>
+        <HealthStatusBanner tone="yellow">
+          This project needs attention — work through the action items below.
+        </HealthStatusBanner>
       )}
 
       <div className="flex flex-col gap-2">
-        <h3 className="text-base font-bold">SDK versions</h3>
+        <SubHeader title="SDK versions" />
         <p className="text-muted-foreground text-sm">
           Every SDK and version that sent data in the last 14 days.
         </p>
@@ -83,8 +81,10 @@ export function ProjectHealthSettingsPage({
       </div>
 
       {v4UpgradeUiEnabled && (
-        <div className="flex flex-col gap-6">
-          <V4MigrationDetailsContent projectId={projectId} />
+        // The checklist was designed for a ~420px drawer; 672px is the widest
+        // it stays legible (trigger rows, message boxes, the agent prompt).
+        <div className="flex max-w-2xl flex-col gap-6">
+          <V4MigrationDetailsContent projectId={projectId} host="page" />
         </div>
       )}
     </div>

--- a/web/src/features/v4-migration/SdkVersionsTable.tsx
+++ b/web/src/features/v4-migration/SdkVersionsTable.tsx
@@ -8,10 +8,12 @@ import {
   TableRow,
 } from "@/src/components/ui/table";
 import {
+  FALLBACK_LATEST_SDK_VERSIONS,
   getSdkFreshness,
   type SdkFreshness,
 } from "@/src/features/v4-migration/latestSdkVersions";
 import { type V4MigrationSdkUsageSeries } from "@/src/features/v4-migration/sdkVersionStatus";
+import { api } from "@/src/utils/api";
 import { formatCompactRelativeTime } from "@/src/utils/dates";
 import { cn } from "@/src/utils/tailwind";
 
@@ -75,6 +77,17 @@ export function SdkVersionsTable({
 }: {
   series: V4MigrationSdkUsageSeries[];
 }) {
+  // Registry-backed latest versions; the pinned fallback keeps freshness
+  // rendering while the query loads (or if it fails — the server also
+  // degrades to the same constants).
+  const { data: latestSdkVersions } =
+    api.v4Transition.latestSdkVersions.useQuery(undefined, {
+      staleTime: 60 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    });
+  const latestByCanonicalName =
+    latestSdkVersions ?? FALLBACK_LATEST_SDK_VERSIONS;
+
   if (series.length === 0) {
     return (
       <p className="text-muted-foreground text-sm">
@@ -132,7 +145,9 @@ export function SdkVersionsTable({
                   <CompatibilityPill series={row} />
                 </TableCell>
                 <TableCell>
-                  <FreshnessPill freshness={getSdkFreshness(row)} />
+                  <FreshnessPill
+                    freshness={getSdkFreshness(row, latestByCanonicalName)}
+                  />
                 </TableCell>
               </TableRow>
             ))}

--- a/web/src/features/v4-migration/SdkVersionsTable.tsx
+++ b/web/src/features/v4-migration/SdkVersionsTable.tsx
@@ -7,52 +7,49 @@ import {
   TableHeader,
   TableRow,
 } from "@/src/components/ui/table";
-import {
-  getSdkFreshness,
-  type SdkFreshness,
-} from "@/src/features/v4-migration/latestSdkVersions";
+import { getSdkFreshness } from "@/src/features/v4-migration/latestSdkVersions";
 import { type V4MigrationSdkUsageSeries } from "@/src/features/v4-migration/sdkVersionStatus";
 import { formatCompactRelativeTime } from "@/src/utils/dates";
-import { cn } from "@/src/utils/tailwind";
 
 const compactNumber = new Intl.NumberFormat("en-US", {
   notation: "compact",
   maximumFractionDigits: 1,
 });
 
-function Pill({
-  tone,
-  children,
-}: {
-  tone: "green" | "yellow" | "muted";
-  children: React.ReactNode;
-}) {
+/**
+ * One Status column, worst verdict wins, and only problems get a filled
+ * pill: yellow is reserved for "act now" (migration blocker), advisory
+ * freshness renders as a quiet outline, healthy rows as plain muted text —
+ * so an all-green table reads calm instead of shouting.
+ */
+function StatusCell({ series }: { series: V4MigrationSdkUsageSeries }) {
+  if (series.v4MigrationStatus === "upgrade_required") {
+    return (
+      <span className="bg-light-yellow text-dark-yellow inline-flex w-fit shrink-0 items-center rounded-full px-2 py-0.5 text-xs whitespace-nowrap">
+        Upgrade required
+      </span>
+    );
+  }
+  if (series.v4MigrationStatus === "unknown") {
+    return (
+      <span className="text-muted-foreground text-xs whitespace-nowrap">
+        Unknown
+      </span>
+    );
+  }
+  const freshness = getSdkFreshness(series);
+  if (freshness === "behind") {
+    return (
+      <span className="border-border text-muted-foreground inline-flex w-fit shrink-0 items-center rounded-full border px-2 py-0.5 text-xs whitespace-nowrap">
+        Compatible · behind latest
+      </span>
+    );
+  }
   return (
-    <span
-      className={cn(
-        "inline-flex w-fit shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-bold whitespace-nowrap",
-        tone === "green" && "bg-light-green text-dark-green",
-        tone === "yellow" && "bg-light-yellow text-dark-yellow",
-        tone === "muted" && "bg-muted text-muted-foreground",
-      )}
-    >
-      {children}
+    <span className="text-muted-foreground text-xs whitespace-nowrap">
+      {freshness === "current" ? "Compatible · current" : "Compatible"}
     </span>
   );
-}
-
-function CompatibilityPill({ series }: { series: V4MigrationSdkUsageSeries }) {
-  if (series.v4MigrationStatus === "compatible")
-    return <Pill tone="green">Compatible</Pill>;
-  if (series.v4MigrationStatus === "upgrade_required")
-    return <Pill tone="yellow">Upgrade required</Pill>;
-  return <Pill tone="muted">Unknown</Pill>;
-}
-
-function FreshnessPill({ freshness }: { freshness: SdkFreshness }) {
-  if (freshness === "current") return <Pill tone="green">Current</Pill>;
-  if (freshness === "behind") return <Pill tone="yellow">Behind</Pill>;
-  return null;
 }
 
 const seriesKey = (series: V4MigrationSdkUsageSeries) =>
@@ -60,15 +57,19 @@ const seriesKey = (series: V4MigrationSdkUsageSeries) =>
     "|",
   );
 
-const displaySdkName = (series: V4MigrationSdkUsageSeries) =>
-  series.sdkName === "unknown" ? "Unattributed" : series.sdkName;
+// Match the checklist's naming ("Python", "JavaScript") instead of raw
+// ingestion names, so the two sections on the page agree with each other.
+const displaySdkName = (series: V4MigrationSdkUsageSeries) => {
+  if (series.canonicalSdkName === "python") return "Python";
+  if (series.canonicalSdkName === "javascript") return "JavaScript";
+  return series.sdkName === "unknown" ? "Unattributed" : series.sdkName;
+};
 
 /**
  * Per-SDK-version traffic table for the Health page: every (SDK, version,
- * key) series seen in the detection window, with the migration compatibility
- * verdict and, for current-major series, freshness against the latest
- * released version. The verify view: post-migration, this is how a user
- * confirms everything stayed green.
+ * key) series seen in the detection window with one worst-of status verdict.
+ * The verify view: post-migration, this is how a user confirms everything
+ * stayed green.
  */
 export function SdkVersionsTable({
   series,
@@ -97,42 +98,38 @@ export function SdkVersionsTable({
             <TableRow>
               <TableHead>SDK</TableHead>
               <TableHead>Version</TableHead>
-              <TableHead>API key</TableHead>
               <TableHead className="text-right">Events (14d)</TableHead>
               <TableHead>Last seen</TableHead>
-              <TableHead>Compatibility</TableHead>
-              <TableHead>Freshness</TableHead>
+              <TableHead>Status</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {rows.map((row) => (
-              <TableRow key={seriesKey(row)}>
-                <TableCell className="font-mono text-xs">
+              // The API key lives in the row tooltip: it disambiguates
+              // duplicate-looking rows without spending a column of
+              // identical truncated prefixes.
+              <TableRow key={seriesKey(row)} title={row.publicKey}>
+                <TableCell density="comfortable" className="text-xs">
                   {displaySdkName(row)}
                 </TableCell>
-                <TableCell className="font-mono text-xs">
+                <TableCell density="comfortable" className="font-mono text-xs">
                   {row.sdkVersion === "unknown" ? "—" : row.sdkVersion}
                 </TableCell>
                 <TableCell
-                  className="text-muted-foreground max-w-[10rem] truncate font-mono text-xs"
-                  title={row.publicKey}
+                  density="comfortable"
+                  className="text-right text-xs tabular-nums"
                 >
-                  {row.publicKey || "—"}
-                </TableCell>
-                <TableCell className="text-right text-xs tabular-nums">
                   {compactNumber.format(row.eventCount)}
                 </TableCell>
                 <TableCell
+                  density="comfortable"
                   className="text-muted-foreground text-xs whitespace-nowrap"
                   title={row.lastSeen}
                 >
                   {formatCompactRelativeTime(new Date(row.lastSeen))}
                 </TableCell>
-                <TableCell>
-                  <CompatibilityPill series={row} />
-                </TableCell>
-                <TableCell>
-                  <FreshnessPill freshness={getSdkFreshness(row)} />
+                <TableCell density="comfortable">
+                  <StatusCell series={row} />
                 </TableCell>
               </TableRow>
             ))}

--- a/web/src/features/v4-migration/SdkVersionsTable.tsx
+++ b/web/src/features/v4-migration/SdkVersionsTable.tsx
@@ -1,0 +1,144 @@
+import { Card } from "@/src/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/src/components/ui/table";
+import {
+  getSdkFreshness,
+  type SdkFreshness,
+} from "@/src/features/v4-migration/latestSdkVersions";
+import { type V4MigrationSdkUsageSeries } from "@/src/features/v4-migration/sdkVersionStatus";
+import { formatCompactRelativeTime } from "@/src/utils/dates";
+import { cn } from "@/src/utils/tailwind";
+
+const compactNumber = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function Pill({
+  tone,
+  children,
+}: {
+  tone: "green" | "yellow" | "muted";
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex w-fit shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-bold whitespace-nowrap",
+        tone === "green" && "bg-light-green text-dark-green",
+        tone === "yellow" && "bg-light-yellow text-dark-yellow",
+        tone === "muted" && "bg-muted text-muted-foreground",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function CompatibilityPill({ series }: { series: V4MigrationSdkUsageSeries }) {
+  if (series.v4MigrationStatus === "compatible")
+    return <Pill tone="green">Compatible</Pill>;
+  if (series.v4MigrationStatus === "upgrade_required")
+    return <Pill tone="yellow">Upgrade required</Pill>;
+  return <Pill tone="muted">Unknown</Pill>;
+}
+
+function FreshnessPill({ freshness }: { freshness: SdkFreshness }) {
+  if (freshness === "current") return <Pill tone="green">Current</Pill>;
+  if (freshness === "behind") return <Pill tone="yellow">Behind</Pill>;
+  return null;
+}
+
+const seriesKey = (series: V4MigrationSdkUsageSeries) =>
+  [series.source, series.sdkName, series.sdkVersion, series.publicKey].join(
+    "|",
+  );
+
+const displaySdkName = (series: V4MigrationSdkUsageSeries) =>
+  series.sdkName === "unknown" ? "Unattributed" : series.sdkName;
+
+/**
+ * Per-SDK-version traffic table for the Health page: every (SDK, version,
+ * key) series seen in the detection window, with the migration compatibility
+ * verdict and, for current-major series, freshness against the latest
+ * released version. The verify view: post-migration, this is how a user
+ * confirms everything stayed green.
+ */
+export function SdkVersionsTable({
+  series,
+}: {
+  series: V4MigrationSdkUsageSeries[];
+}) {
+  if (series.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No ingestion detected in the last 14 days.
+      </p>
+    );
+  }
+
+  const rows = [...series].sort(
+    (left, right) =>
+      right.lastSeen.localeCompare(left.lastSeen) ||
+      left.sdkName.localeCompare(right.sdkName),
+  );
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="overflow-x-auto">
+        <Table className="table-auto">
+          <TableHeader>
+            <TableRow>
+              <TableHead>SDK</TableHead>
+              <TableHead>Version</TableHead>
+              <TableHead>API key</TableHead>
+              <TableHead className="text-right">Events (14d)</TableHead>
+              <TableHead>Last seen</TableHead>
+              <TableHead>Compatibility</TableHead>
+              <TableHead>Freshness</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={seriesKey(row)}>
+                <TableCell className="font-mono text-xs">
+                  {displaySdkName(row)}
+                </TableCell>
+                <TableCell className="font-mono text-xs">
+                  {row.sdkVersion === "unknown" ? "—" : row.sdkVersion}
+                </TableCell>
+                <TableCell
+                  className="text-muted-foreground max-w-[10rem] truncate font-mono text-xs"
+                  title={row.publicKey}
+                >
+                  {row.publicKey || "—"}
+                </TableCell>
+                <TableCell className="text-right text-xs tabular-nums">
+                  {compactNumber.format(row.eventCount)}
+                </TableCell>
+                <TableCell
+                  className="text-muted-foreground text-xs whitespace-nowrap"
+                  title={row.lastSeen}
+                >
+                  {formatCompactRelativeTime(new Date(row.lastSeen))}
+                </TableCell>
+                <TableCell>
+                  <CompatibilityPill series={row} />
+                </TableCell>
+                <TableCell>
+                  <FreshnessPill freshness={getSdkFreshness(row)} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </Card>
+  );
+}

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   Copy,
   Info,
+  TriangleAlert,
 } from "lucide-react";
 import { env } from "@/src/env.mjs";
 import { useCanUseInAppAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
@@ -389,11 +390,21 @@ function SdkUsageSeriesRows({
           >
             {/* Action line: what it is and what to do about it. */}
             <div className="text-muted-foreground flex items-center gap-1.5">
-              <span aria-hidden="true">{needsAction(usage) ? "⚠️" : "✅"}</span>
+              {needsAction(usage) ? (
+                <TriangleAlert
+                  aria-hidden="true"
+                  className="text-dark-yellow h-3.5 w-3.5 shrink-0"
+                />
+              ) : (
+                <Check
+                  aria-hidden="true"
+                  className="text-dark-green h-3.5 w-3.5 shrink-0"
+                />
+              )}
               <MonoValue>{sdkLabel}</MonoValue>
               {suffix(usage)}
             </div>
-            {/* Metadata line, indented under the label (emoji + gap). */}
+            {/* Metadata line, indented under the label (icon + gap). */}
             <div className="text-muted-foreground flex flex-wrap items-baseline gap-x-1.5 pl-5">
               {publicKey ? (
                 <span title={usage.publicKey || undefined}>{publicKey}</span>
@@ -1295,10 +1306,15 @@ export function V4MigrationAgentUpgradeSection({
 export function V4MigrationDetailsContent({
   onNavigate,
   projectId: projectIdProp,
+  host = "drawer",
 }: {
   onNavigate?: () => void;
   /** Project the content links point at; falls back to the route project. */
   projectId?: string;
+  /** "page" (Health settings) drops the drawer-only leading separator and
+   *  collapses the agent-upgrade pitch once the project is fully migrated —
+   *  an upgrade CTA is not content for a healthy verify page. */
+  host?: "drawer" | "page";
 }) {
   const router = useRouter();
   const capture = usePostHogClientCapture();
@@ -1429,11 +1445,13 @@ export function V4MigrationDetailsContent({
 
   return (
     <>
-      <Separator />
+      {host === "drawer" && <Separator />}
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-2 text-base font-bold">
-          Action items
+          {/* A heading named "Action items" over a green "everything is up
+              to date" line would be a small hierarchy lie. */}
+          {readiness === "ready" ? "Checks" : "Action items"}
         </div>
         <p className="text-muted-foreground text-sm">
           SDK, instrumentation, experiment, and API checks cover activity from
@@ -1547,9 +1565,12 @@ export function V4MigrationDetailsContent({
         </div>
       </div>
 
-      <Separator />
-
-      <V4MigrationAgentUpgradeSection projectId={projectId} />
+      {!(host === "page" && readiness === "ready") && (
+        <>
+          <Separator />
+          <V4MigrationAgentUpgradeSection projectId={projectId} />
+        </>
+      )}
 
       <Separator />
 

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -152,7 +152,9 @@ describe("V4MigrationStatusPage", () => {
     render(<V4MigrationStatusPage />);
 
     const table = screen.getByRole("table");
-    expect(table).toHaveClass("min-w-[60rem]", "table-auto");
+    // Six columns fit without a forced min width; the scroll container
+    // still guards small viewports.
+    expect(table).toHaveClass("table-auto");
     expect(table.parentElement).toHaveClass("overflow-x-auto");
   });
 

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -107,6 +107,16 @@ function StatusPill({ readiness }: { readiness: ProjectMigrationReadiness }) {
     );
   }
 
+  // Only rendered where ready rows are shown (the org Health settings page);
+  // the migration status page filters them out before this.
+  if (readiness === "ready") {
+    return (
+      <span className="bg-light-green text-dark-green inline-flex w-fit shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-bold whitespace-nowrap">
+        Migrated
+      </span>
+    );
+  }
+
   if (readiness !== "action-needed") return null;
 
   return (
@@ -159,14 +169,24 @@ function SortableHead({
   );
 }
 
-function OrgStatusSection({
+export function OrgStatusSection({
   org,
   statusByProjectId,
   lastTraceTimes,
+  hideReadyProjects = true,
+  showOrgHeading = true,
+  rowHref,
 }: {
   org: V4MigrationOrganization;
   statusByProjectId: Map<string, ProjectMigrationStatus>;
   lastTraceTimes: { projectId: string; lastTraceAt: Date }[];
+  /** The migration page is a work list (ready rows drop out); the org Health
+   *  settings page shows the whole fleet. */
+  hideReadyProjects?: boolean;
+  showOrgHeading?: boolean;
+  /** When set, rows navigate here (e.g. the project Health settings page)
+   *  instead of opening the migration panel over the traces view. */
+  rowHref?: (projectId: string) => string;
 }) {
   const router = useRouter();
   const capture = usePostHogClientCapture();
@@ -187,6 +207,11 @@ function OrgStatusSection({
     row: { id: string; name: string; status: ProjectMigrationStatus },
     readiness: ProjectMigrationReadiness,
   ) => {
+    if (rowHref) {
+      capture("v4_migration:status_row_clicked");
+      router.push(rowHref(row.id));
+      return;
+    }
     // Forced-v3 projects have no migration panel — just navigate to the project.
     if (!row.status.forceV3Experience) {
       openProjectMigration(row, readiness);
@@ -216,7 +241,7 @@ function OrgStatusSection({
     const status = statusByProjectId.get(project.id);
     if (!status) return [];
     const readiness = getProjectMigrationReadiness(status);
-    if (readiness === "ready") return [];
+    if (hideReadyProjects && readiness === "ready") return [];
     const lastTraceAt = lastTraceTimes?.find(
       (trace) => trace.projectId === project.id,
     )?.lastTraceAt;
@@ -298,9 +323,11 @@ function OrgStatusSection({
 
   return (
     <div className="flex flex-col gap-2">
-      <h3 className="text-muted-foreground truncate text-sm" title={org.name}>
-        {org.name}
-      </h3>
+      {showOrgHeading && (
+        <h3 className="text-muted-foreground truncate text-sm" title={org.name}>
+          {org.name}
+        </h3>
+      )}
       <Card className="overflow-hidden">
         <div className="overflow-x-auto">
           <Table className="min-w-[60rem] table-auto">
@@ -368,13 +395,13 @@ function OrgStatusSection({
                   >
                     <TableCell density="comfortable" className="max-w-48">
                       <Link
-                        href={`/project/${row.id}/traces`}
+                        href={rowHref?.(row.id) ?? `/project/${row.id}/traces`}
                         className="block truncate font-bold hover:underline"
                         title={row.name}
                         onClick={(event) => {
                           event.stopPropagation();
                           // Forced-v3 projects have no migration panel.
-                          if (!row.status.forceV3Experience) {
+                          if (!rowHref && !row.status.forceV3Experience) {
                             openProjectMigration(row, readiness);
                           }
                         }}

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -31,8 +31,6 @@ import {
 } from "@/src/features/v4-migration/hooks/useV4MigrationData";
 import {
   getProjectMigrationReadiness,
-  type MigrationActionState,
-  type MigrationCountState,
   type ProjectMigrationReadiness,
   type ProjectMigrationStatus,
 } from "@/src/features/v4-migration/migrationData";
@@ -57,35 +55,6 @@ function FaqLink({ href, children }: { href: string; children: ReactNode }) {
     >
       {children}
     </a>
-  );
-}
-
-function AffectedCell({ count }: { count: MigrationCountState }) {
-  if (count.status === "loading") {
-    return <span className="text-foreground-tertiary">Checking…</span>;
-  }
-  if (count.status === "error") {
-    return <span className="text-foreground-tertiary">Unavailable</span>;
-  }
-  if (count.count === 0) {
-    return <span className="text-foreground-tertiary">0</span>;
-  }
-  return <span>{count.count}</span>;
-}
-
-function MigrationActionCell({ state }: { state: MigrationActionState }) {
-  if (state.status === "loading") {
-    return <span className="text-foreground-tertiary">Checking…</span>;
-  }
-  if (state.status === "error") {
-    return <span className="text-foreground-tertiary">Unavailable</span>;
-  }
-  return state.result === "required" ? (
-    <span>Update required</span>
-  ) : state.result === "sdk_usage_inconclusive" ? (
-    <span>Needs review</span>
-  ) : (
-    <span className="text-foreground-tertiary">Up to date</span>
   );
 }
 
@@ -126,15 +95,38 @@ function StatusPill({ readiness }: { readiness: ProjectMigrationReadiness }) {
   );
 }
 
-type SortKey =
-  | "name"
-  | "status"
-  | "sdk"
-  | "evals"
-  | "experiments"
-  | "apis"
-  | "exports"
-  | "lastTrace";
+type SortKey = "name" | "status" | "sdk" | "openItems" | "lastTrace";
+
+// One rollup column instead of four mostly-zero "Affected X" columns: a
+// short list of what is actually open, or an em dash.
+const openItemsCount = (status: ProjectMigrationStatus): number =>
+  (status.evals.status === "loaded" ? status.evals.count : 0) +
+  (status.experiments.status === "loaded" &&
+  status.experiments.result === "required"
+    ? 1
+    : 0) +
+  (status.apis.status === "loaded" ? status.apis.count : 0) +
+  (status.exports.status === "loaded" ? status.exports.count : 0);
+
+const openItemsLabel = (status: ProjectMigrationStatus): string => {
+  const parts: string[] = [];
+  if (status.evals.status === "loaded" && status.evals.count > 0)
+    parts.push(
+      `${status.evals.count} eval${status.evals.count === 1 ? "" : "s"}`,
+    );
+  if (
+    status.experiments.status === "loaded" &&
+    status.experiments.result === "required"
+  )
+    parts.push("experiments");
+  if (status.apis.status === "loaded" && status.apis.count > 0)
+    parts.push(`${status.apis.count} API${status.apis.count === 1 ? "" : "s"}`);
+  if (status.exports.status === "loaded" && status.exports.count > 0)
+    parts.push(
+      `${status.exports.count} export${status.exports.count === 1 ? "" : "s"}`,
+    );
+  return parts.length > 0 ? parts.join(", ") : "—";
+};
 type OrderBy = { column: SortKey; order: "ASC" | "DESC" } | null;
 
 // Header styling and none → DESC → ASC → none sort cycle copied from the
@@ -290,18 +282,8 @@ export function OrgStatusSection({
                     : row.status.sdk.status === "checking"
                       ? 1
                       : 0;
-      case "evals":
-        return row.status.evals.count;
-      case "experiments":
-        return row.status.experiments.result === "required"
-          ? 2
-          : row.status.experiments.result === "sdk_usage_inconclusive"
-            ? 1
-            : 0;
-      case "apis":
-        return row.status.apis.count;
-      case "exports":
-        return row.status.exports.count;
+      case "openItems":
+        return openItemsCount(row.status);
       case "lastTrace":
         return row.lastTraceSort;
     }
@@ -330,7 +312,7 @@ export function OrgStatusSection({
       )}
       <Card className="overflow-hidden">
         <div className="overflow-x-auto">
-          <Table className="min-w-[60rem] table-auto">
+          <Table className="table-auto">
             <TableHeader>
               <TableRow>
                 <SortableHead
@@ -352,26 +334,8 @@ export function OrgStatusSection({
                   onSort={handleSort}
                 />
                 <SortableHead
-                  label="Affected Evals"
-                  column="evals"
-                  orderBy={orderBy}
-                  onSort={handleSort}
-                />
-                <SortableHead
-                  label="Affected Experiments"
-                  column="experiments"
-                  orderBy={orderBy}
-                  onSort={handleSort}
-                />
-                <SortableHead
-                  label="Affected APIs"
-                  column="apis"
-                  orderBy={orderBy}
-                  onSort={handleSort}
-                />
-                <SortableHead
-                  label="Affected Exports"
-                  column="exports"
+                  label="Open items"
+                  column="openItems"
                   orderBy={orderBy}
                   onSort={handleSort}
                 />
@@ -381,7 +345,7 @@ export function OrgStatusSection({
                   orderBy={orderBy}
                   onSort={handleSort}
                 />
-                <TableHead className="w-24" />
+                <TableHead />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -451,17 +415,11 @@ export function OrgStatusSection({
                         </span>
                       )}
                     </TableCell>
-                    <TableCell density="comfortable">
-                      <AffectedCell count={row.status.evals} />
-                    </TableCell>
-                    <TableCell density="comfortable">
-                      <MigrationActionCell state={row.status.experiments} />
-                    </TableCell>
-                    <TableCell density="comfortable">
-                      <AffectedCell count={row.status.apis} />
-                    </TableCell>
-                    <TableCell density="comfortable">
-                      <AffectedCell count={row.status.exports} />
+                    <TableCell
+                      density="comfortable"
+                      className="text-muted-foreground whitespace-nowrap"
+                    >
+                      {openItemsLabel(row.status)}
                     </TableCell>
                     <TableCell
                       density="comfortable"

--- a/web/src/features/v4-migration/latestSdkVersions.ts
+++ b/web/src/features/v4-migration/latestSdkVersions.ts
@@ -1,14 +1,16 @@
 // Latest released Langfuse SDK versions, for the Health page's freshness
 // ("Behind") badges.
 //
-// TODO(health-pages): OPEN QUESTION — these are hardcoded as of 2026-08-14 and
-// rot as SDKs release. Before this ships, replace with a server-side registry
-// lookup (npm for @langfuse/tracing, PyPI for langfuse) cached ~24h in Redis
-// with these values as fallback. Tracked in the PR description.
-const LATEST_SDK_VERSION_BY_CANONICAL_NAME: Record<
-  "python" | "javascript",
-  string
-> = {
+// The live values come from the `v4Transition.latestSdkVersions` tRPC query
+// (registry lookup cached in Redis, see
+// web/src/features/v4/server/latestSdkVersions.ts). These constants are the
+// fallback used while that query loads and when the registries are
+// unreachable.
+
+export type LatestSdkVersions = Record<"python" | "javascript", string>;
+
+/** Latest released SDK versions as of 2026-08-14. Fallback only. */
+export const FALLBACK_LATEST_SDK_VERSIONS: LatestSdkVersions = {
   python: "4.14.4",
   javascript: "5.10.0",
 };
@@ -35,12 +37,15 @@ const compareVersions = (a: number[], b: number[]): number => {
  * the compatibility badge's job, and comparing a v3 JS SDK against
  * @langfuse/tracing 5.x would be misleading.
  */
-export const getSdkFreshness = (series: {
-  canonicalSdkName: "python" | "javascript" | null;
-  sdkVersion: string;
-  sdkVersionMajor: number | null;
-  latestSdkMajor: number | null;
-}): SdkFreshness => {
+export const getSdkFreshness = (
+  series: {
+    canonicalSdkName: "python" | "javascript" | null;
+    sdkVersion: string;
+    sdkVersionMajor: number | null;
+    latestSdkMajor: number | null;
+  },
+  latestByCanonicalName: LatestSdkVersions,
+): SdkFreshness => {
   if (
     !series.canonicalSdkName ||
     series.sdkVersionMajor === null ||
@@ -49,9 +54,7 @@ export const getSdkFreshness = (series: {
   ) {
     return "unknown";
   }
-  const latest = parseVersion(
-    LATEST_SDK_VERSION_BY_CANONICAL_NAME[series.canonicalSdkName],
-  );
+  const latest = parseVersion(latestByCanonicalName[series.canonicalSdkName]);
   const current = parseVersion(series.sdkVersion);
   if (!latest || !current) return "unknown";
   return compareVersions(current, latest) >= 0 ? "current" : "behind";

--- a/web/src/features/v4-migration/latestSdkVersions.ts
+++ b/web/src/features/v4-migration/latestSdkVersions.ts
@@ -1,0 +1,58 @@
+// Latest released Langfuse SDK versions, for the Health page's freshness
+// ("Behind") badges.
+//
+// TODO(health-pages): OPEN QUESTION — these are hardcoded as of 2026-08-14 and
+// rot as SDKs release. Before this ships, replace with a server-side registry
+// lookup (npm for @langfuse/tracing, PyPI for langfuse) cached ~24h in Redis
+// with these values as fallback. Tracked in the PR description.
+const LATEST_SDK_VERSION_BY_CANONICAL_NAME: Record<
+  "python" | "javascript",
+  string
+> = {
+  python: "4.14.4",
+  javascript: "5.10.0",
+};
+
+export type SdkFreshness = "current" | "behind" | "unknown";
+
+const parseVersion = (version: string): number[] | null => {
+  const parts = version.split(".").map((part) => Number.parseInt(part, 10));
+  if (parts.length < 2 || parts.some((part) => Number.isNaN(part))) return null;
+  return parts;
+};
+
+const compareVersions = (a: number[], b: number[]): number => {
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+};
+
+/**
+ * Freshness relative to the latest released version of the SAME current-major
+ * SDK line. Legacy-major series report "unknown": their staleness is already
+ * the compatibility badge's job, and comparing a v3 JS SDK against
+ * @langfuse/tracing 5.x would be misleading.
+ */
+export const getSdkFreshness = (series: {
+  canonicalSdkName: "python" | "javascript" | null;
+  sdkVersion: string;
+  sdkVersionMajor: number | null;
+  latestSdkMajor: number | null;
+}): SdkFreshness => {
+  if (
+    !series.canonicalSdkName ||
+    series.sdkVersionMajor === null ||
+    series.latestSdkMajor === null ||
+    series.sdkVersionMajor < series.latestSdkMajor
+  ) {
+    return "unknown";
+  }
+  const latest = parseVersion(
+    LATEST_SDK_VERSION_BY_CANONICAL_NAME[series.canonicalSdkName],
+  );
+  const current = parseVersion(series.sdkVersion);
+  if (!latest || !current) return "unknown";
+  return compareVersions(current, latest) >= 0 ? "current" : "behind";
+};

--- a/web/src/features/v4/server/latestSdkVersions.ts
+++ b/web/src/features/v4/server/latestSdkVersions.ts
@@ -1,0 +1,160 @@
+import { logger, redis } from "@langfuse/shared/src/server";
+
+import {
+  FALLBACK_LATEST_SDK_VERSIONS,
+  type LatestSdkVersions,
+} from "@/src/features/v4-migration/latestSdkVersions";
+
+/**
+ * Registry lookup for the latest released Langfuse SDK versions, backing the
+ * Health page's freshness ("Behind") badges.
+ *
+ * Fixed registry URLs only — no user input reaches the fetches, so this is
+ * SSRF-safe by construction. Results are cached in Redis for ~24h; on cache
+ * miss + fetch failure the hardcoded FALLBACK_LATEST_SDK_VERSIONS are used.
+ * This never throws to the caller.
+ */
+
+const CACHE_KEY = "langfuse:v4-migration:latest-sdk-versions:v1";
+const CACHE_TTL_SECONDS = 24 * 60 * 60;
+const FETCH_TIMEOUT_MS = 5_000;
+
+// Loose SemVer-ish check so a registry hiccup (HTML error page, empty body)
+// can never poison the cache with a non-version string.
+const VERSION_PATTERN = /^\d+\.\d+(\.\d+)?([-+.].*)?$/;
+
+const REGISTRY_SOURCES: Record<
+  keyof LatestSdkVersions,
+  { url: string; extractVersion: (body: unknown) => unknown }
+> = {
+  python: {
+    url: "https://pypi.org/pypi/langfuse/json",
+    extractVersion: (body) =>
+      (body as { info?: { version?: unknown } })?.info?.version,
+  },
+  javascript: {
+    url: "https://registry.npmjs.org/@langfuse/tracing/latest",
+    extractVersion: (body) => (body as { version?: unknown })?.version,
+  },
+};
+
+const parseValidVersions = (value: string): LatestSdkVersions | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  const candidate = parsed as Partial<Record<keyof LatestSdkVersions, unknown>>;
+  const python = candidate?.python;
+  const javascript = candidate?.javascript;
+  if (
+    typeof python !== "string" ||
+    typeof javascript !== "string" ||
+    !VERSION_PATTERN.test(python) ||
+    !VERSION_PATTERN.test(javascript)
+  ) {
+    return null;
+  }
+  return { python, javascript };
+};
+
+export type LatestSdkVersionsResolverDependencies = {
+  fetchImpl: typeof fetch;
+  getCache: () => Promise<string | null>;
+  setCache: (value: string, ttlSeconds: number) => Promise<void>;
+};
+
+export const createLatestSdkVersionsResolver = ({
+  fetchImpl,
+  getCache,
+  setCache,
+}: LatestSdkVersionsResolverDependencies) => {
+  let inFlight: Promise<LatestSdkVersions> | null = null;
+
+  const fetchRegistryVersion = async (
+    sdk: keyof LatestSdkVersions,
+  ): Promise<string | null> => {
+    const { url, extractVersion } = REGISTRY_SOURCES[sdk];
+    try {
+      const response = await fetchImpl(url, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(`Registry responded with status ${response.status}`);
+      }
+      const version = extractVersion(await response.json());
+      if (typeof version !== "string" || !VERSION_PATTERN.test(version)) {
+        throw new Error(`Registry returned an invalid version: ${version}`);
+      }
+      return version;
+    } catch (error) {
+      logger.warn("Failed to fetch latest SDK version from registry", {
+        sdk,
+        url,
+        error,
+      });
+      return null;
+    }
+  };
+
+  const resolve = async (): Promise<LatestSdkVersions> => {
+    try {
+      const cached = await getCache();
+      if (cached) {
+        const cachedVersions = parseValidVersions(cached);
+        if (cachedVersions) return cachedVersions;
+      }
+    } catch (error) {
+      logger.warn("Failed to read latest SDK versions from cache", { error });
+    }
+
+    const [python, javascript] = await Promise.all([
+      fetchRegistryVersion("python"),
+      fetchRegistryVersion("javascript"),
+    ]);
+
+    const versions: LatestSdkVersions = {
+      python: python ?? FALLBACK_LATEST_SDK_VERSIONS.python,
+      javascript: javascript ?? FALLBACK_LATEST_SDK_VERSIONS.javascript,
+    };
+
+    // Only cache fully successful lookups: a registry that was down should be
+    // retried on the next request instead of pinning its fallback for 24h.
+    if (python !== null && javascript !== null) {
+      try {
+        await setCache(JSON.stringify(versions), CACHE_TTL_SECONDS);
+      } catch (error) {
+        logger.warn("Failed to write latest SDK versions to cache", { error });
+      }
+    }
+
+    return versions;
+  };
+
+  return (): Promise<LatestSdkVersions> => {
+    // Deduplicate concurrent lookups within this web process so a cold cache
+    // cannot fan out one registry request per concurrent Health page view.
+    inFlight ??= resolve()
+      .catch((error): LatestSdkVersions => {
+        // Defense in depth: resolve() already degrades per step, but the
+        // Health page must render even if something above still throws.
+        logger.warn("Failed to resolve latest SDK versions", { error });
+        return FALLBACK_LATEST_SDK_VERSIONS;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+    return inFlight;
+  };
+};
+
+export const getLatestSdkVersions = createLatestSdkVersionsResolver({
+  fetchImpl: fetch,
+  getCache: async () => (redis ? redis.get(CACHE_KEY) : null),
+  setCache: async (value, ttlSeconds) => {
+    if (!redis) return;
+    await redis.set(CACHE_KEY, value, "EX", ttlSeconds);
+  },
+});

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -1,9 +1,11 @@
 import { z } from "zod/v4";
 import {
+  authenticatedProcedure,
   createTRPCRouter,
   protectedOrganizationProcedure,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
+import { getLatestSdkVersions } from "@/src/features/v4/server/latestSdkVersions";
 import {
   AnalyticsIntegrationExportSource,
   type Prisma,
@@ -862,6 +864,13 @@ const getLegacyApiUsageSummaries = async ({
 };
 
 export const v4TransitionRouter = createTRPCRouter({
+  /**
+   * Latest released SDK versions for the Health page's freshness badges.
+   * Registry-backed and Redis-cached; global data, so no project/org scoping.
+   * Never throws — falls back to pinned constants when registries are down.
+   */
+  latestSdkVersions: authenticatedProcedure.query(() => getLatestSdkVersions()),
+
   forceV3Experience: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
     .query(({ input }) => isForceV3ExperienceProject(input.projectId)),

--- a/web/src/pages/organization/[organizationId]/settings/index.tsx
+++ b/web/src/pages/organization/[organizationId]/settings/index.tsx
@@ -12,6 +12,7 @@ import { BillingSettings } from "@/src/ee/features/billing/components/BillingSet
 import { useHasEntitlement, usePlan } from "@/src/features/entitlements/hooks";
 import ContainerPage from "@/src/components/layouts/container-page";
 import { SSOSettings } from "@/src/ee/features/sso-settings/components/SSOSettings";
+import { OrgHealthSettingsPage } from "@/src/features/v4-migration/OrgHealthSettingsPage";
 import { isCloudPlan } from "@langfuse/shared";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { ApiKeyList } from "@/src/features/public-api/components/ApiKeyList";
@@ -158,6 +159,12 @@ export const getOrganizationSettingsPages = ({
     ],
     content: <SSOSettings orgId={organization.id} />,
     show: isLangfuseCloud,
+  },
+  {
+    title: "Health",
+    slug: "health",
+    cmdKKeywords: ["sdk", "version", "migration", "v4", "instrumentation"],
+    content: <OrgHealthSettingsPage orgId={organization.id} />,
   },
   {
     title: "Projects",

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -24,6 +24,7 @@ import { BatchExportsSettingsPage } from "@/src/features/batch-exports/component
 import { BatchActionsSettingsPage } from "@/src/features/batch-actions/components/BatchActionsSettingsPage";
 import { AuditLogsSettingsPage } from "@/src/ee/features/audit-log-viewer/AuditLogsSettingsPage";
 import { ModelsSettings } from "@/src/features/models/components/ModelSettings";
+import { ProjectHealthSettingsPage } from "@/src/features/v4-migration/ProjectHealthSettingsPage";
 import ConfigureRetention from "@/src/features/projects/components/ConfigureRetention";
 import ContainerPage from "@/src/components/layouts/container-page";
 import ProtectedLabelsSettings from "@/src/features/prompts/components/ProtectedLabelsSettings";
@@ -179,6 +180,12 @@ export const getProjectSettingsPages = ({
     slug: "models",
     cmdKKeywords: ["cost", "token"],
     content: <ModelsSettings projectId={project.id} />,
+  },
+  {
+    title: "Health",
+    slug: "health",
+    cmdKKeywords: ["sdk", "version", "migration", "v4", "instrumentation"],
+    content: <ProjectHealthSettingsPage projectId={project.id} />,
   },
   {
     title: "Protected Prompt Labels",

--- a/web/src/pages/v4-migration.tsx
+++ b/web/src/pages/v4-migration.tsx
@@ -1,1 +1,31 @@
-export { default } from "@/src/features/v4-migration/V4MigrationStatusPage";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useSession } from "next-auth/react";
+
+/**
+ * The standalone migration status page moved into organization settings as
+ * the Health tab. The org id lives in the session rather than the URL, so
+ * this is a client-side redirect; users with several organizations land on
+ * their first one (the old page showed all orgs stacked — open question in
+ * the PR whether multi-org users need a picker here).
+ */
+export default function V4MigrationRedirect() {
+  const router = useRouter();
+  const session = useSession();
+
+  const firstOrgId = session.data?.user?.organizations?.[0]?.id;
+
+  // The router is the external system: replace the route once the session
+  // resolved. Unauthenticated visitors fall through to the sign-in redirect
+  // the target page performs itself.
+  useEffect(() => {
+    if (session.status === "loading") return;
+    router.replace(
+      firstOrgId ? `/organization/${firstOrgId}/settings/health` : "/",
+    );
+  }, [session.status, firstOrgId, router]);
+
+  return (
+    <p className="text-muted-foreground p-4 text-sm">Redirecting to Health…</p>
+  );
+}


### PR DESCRIPTION
## Motivation

The migration surfaces are campaign UI that hide themselves when a project turns green, so there is no durable place to verify instrumentation health. This adds a permanent Health home under Settings: the migration home today, the "is everything green, is my SDK current" destination after the migration era.

## What changed

| Change | Where |
|---|---|
| **Project Health settings tab**: status verdict banner, per-SDK-version traffic table (events 14d, last seen, one worst-of Status column), embedded migration checklist (same components as the panel; the compare toggle is now permanently reachable) | `ProjectHealthSettingsPage.tsx`, `HealthStatusBanner.tsx`, `SdkVersionsTable.tsx`, project settings index |
| **Org Health settings tab**: fleet table reusing the migration status table (collapsed to 6 columns with an Open items summary), migrated projects stay visible with a green Migrated pill, rows link to each project's Health page | `OrgHealthSettingsPage.tsx`, `V4MigrationStatusPage.tsx` (OrgStatusSection exported + parameterized), org settings index |
| **Live latest-SDK-version lookup** for the Status column: server-side PyPI/npm fetch, 24h Redis cache, pinned constants as fallback (also used client-side while the query loads), fixed hosts + 5s timeout | `web/src/features/v4/server/latestSdkVersions.ts`, `v4TransitionRouter.ts`, `latestSdkVersions.ts` |
| **/v4-migration redirects** into org settings Health (client-side; org id lives in the session) | `pages/v4-migration.tsx` |

No new analytics events; existing status_row_clicked keeps firing.

## Open questions

1. **Multi-org users on /v4-migration** land on their first org's Health page; the old page stacked all orgs. Acceptable, or does the redirect need an org picker?
2. The standalone status page component (summary card, FAQ) is now unreferenced except for the exported table; delete or keep until after the migration era?

## Verification

- v4-migration client tests 104/104 · registry unit tests 10/10 · web typecheck exit 0 · lint via pre-commit 7 successful
- Both pages + redirect reviewed on local dev (migration-era and all-green states, project + org); screenshots to be attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)
