### PR TITLE
chore(deps): bump nanoid to 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ overrides:
   esbuild: 0.28.1
   undici@7: 7.29.0
   zod: 4.3.6
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   katex: ^0.16.21
   tar-fs: ^2.1.2
   rollup@^4.0.0: ^4.22.4
@@ -787,8 +787,8 @@ importers:
         specifier: ^0.552.0
         version: 0.552.0(react@19.2.4)
       nanoid:
-        specifier: 3.3.17
-        version: 3.3.17
+        specifier: 3.3.18
+        version: 3.3.18
       next:
         specifier: 16.3.0
         version: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(@types/node@24.3.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -9547,8 +9547,8 @@ packages:
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12233,7 +12233,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       secure-json-parse: 2.7.0
       zod: 4.3.6
 
@@ -21758,7 +21758,7 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -22391,7 +22391,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ overrides:
   esbuild: "0.28.1"
   "undici@7": 7.29.0
   zod: 4.3.6
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   katex: ^0.16.21
   tar-fs: ^2.1.2
   rollup@^4.0.0: ^4.22.4

--- a/web/package.json
+++ b/web/package.json
@@ -135,7 +135,7 @@
     "langfuse": "3.38.4",
     "lodash": "^4.18.1",
     "lucide-react": "^0.552.0",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "next": "16.3.0",
     "next-auth": "^4.24.14",
     "next-query-params": "^5.1.0",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16141.preview.langfuse.com](https://pr-16141.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR upgrades nanoid from 3.3.17 to 3.3.18 across the web package and workspace override.

- Updates the direct web dependency and workspace-wide override.
- Regenerates the lockfile with the matching version and integrity metadata.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable compatibility, resolution, or security issues identified.

The direct dependency, workspace override, and lockfile remain coordinated, and existing nanoid import patterns and supported Node targets are compatible with the patch update.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump nanoid to 3.3.18"](https://github.com/langfuse/langfuse/commit/9668c1947c549905d4af0e404d16702f0278ad7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53331322)</sub>

<!-- /greptile_comment -->