### PR TITLE
fix(agent): show a clearer 8-hour write-lock notice in the assistant

### DIFF
--- a/packages/shared/src/in-app-agent/constants.ts
+++ b/packages/shared/src/in-app-agent/constants.ts
@@ -17,6 +17,12 @@ export const IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER =
 export const IN_APP_AGENT_LOCAL_SANDBOX_IMAGE =
   "langfuse-in-app-agent-sandbox:latest";
 
+export const IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE =
+  "Current conversation limit is 8 hours. To continue, please start a new conversation";
+
+export const IN_APP_AGENT_GENERIC_ERROR_MESSAGE =
+  "An error occurred. Please try again or start a new conversation";
+
 // Observation ids stay equal to the per-turn run id so persisted messages,
 // feedback, and traced generations all point at the same Langfuse observation.
 export const getInAppAgentInstrumentationObservationId = (runId: string) =>

--- a/packages/shared/src/in-app-agent/constants.ts
+++ b/packages/shared/src/in-app-agent/constants.ts
@@ -18,10 +18,10 @@ export const IN_APP_AGENT_LOCAL_SANDBOX_IMAGE =
   "langfuse-in-app-agent-sandbox:latest";
 
 export const IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE =
-  "Current conversation limit is 8 hours. To continue, please start a new conversation";
+  "This conversation has reached the 8-hour limit. Please start a new conversation.";
 
 export const IN_APP_AGENT_GENERIC_ERROR_MESSAGE =
-  "An error occurred. Please try again or start a new conversation";
+  "An error occurred. Please try again or start a new conversation.";
 
 // Observation ids stay equal to the per-turn run id so persisted messages,
 // feedback, and traced generations all point at the same Langfuse observation.

--- a/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
@@ -21,6 +21,7 @@ import {
   createInAppAgentConversationId,
   createInAppAgentRunId,
   IN_APP_AGENT_APPROVAL_DECISION_EVENT_NAME,
+  IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
 } from "@langfuse/shared/in-app-agent";
 import { ensureOwnedConversation } from "@langfuse/shared/in-app-agent/server/persistence";
 import { env as sharedEnv } from "@langfuse/shared/src/env";
@@ -808,8 +809,7 @@ describe("in-app agent background runs", () => {
       }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
-      message:
-        "Sandbox-enabled conversations become read-only after 8 hours. Start a new conversation to continue.",
+      message: IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
     });
 
     await expect(

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -107,9 +107,10 @@ export function ControlledInAppAgentWindow(
     shouldFlush: error !== null || isCancellingRun || shouldFlushCancelledRun,
   });
   const windowExecutionUi: InAppAgentWindowExecutionUi = {
-    notice: selectedConversationIsWriteLocked
-      ? null
-      : getBackgroundRunNotice(execution.run),
+    notice:
+      selectedConversationIsWriteLocked || error?.type === "write_lock"
+        ? null
+        : getBackgroundRunNotice(execution.run),
     stop:
       execution.run && isCancellableBackgroundRun(execution.run.status)
         ? {
@@ -123,9 +124,12 @@ export function ControlledInAppAgentWindow(
   };
   // Only a read-only conversation disables the composer outright. An assistant
   // turn -- including one paused on an approval -- blocks submission but leaves
-  // the draft editable.
+  // the draft editable. A server write-lock rejection is treated the same as
+  // the cached flag, so a stale conversation query cannot leave the composer open.
   const isConversationInteractionDisabled =
-    selectedConversationIsWriteLocked || isSelectedConversationHydrating;
+    selectedConversationIsWriteLocked ||
+    isSelectedConversationHydrating ||
+    error?.type === "write_lock";
   const isAssistantTurnInProgress =
     isRunning ||
     isAnimating ||
@@ -201,7 +205,9 @@ export function ControlledInAppAgentWindow(
       isExpanded={props.isExpanded}
       isConversationInteractionDisabled={isConversationInteractionDisabled}
       isSelectedConversationHydrating={isSelectedConversationHydrating}
-      disablePendingToolApprovalActions={selectedConversationIsWriteLocked}
+      disablePendingToolApprovalActions={
+        selectedConversationIsWriteLocked || error?.type === "write_lock"
+      }
       messages={drawerMessages}
       quickActionContext={quickActionContext}
       focusedQuickActions={focusedQuickActions}

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -23,9 +23,6 @@ import {
 import { InAppAgentRunStatus } from "@langfuse/shared";
 import { isUnsettledInAppAgentRunStatus } from "@langfuse/shared/in-app-agent";
 
-const SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE =
-  "Sandbox-enabled conversations become read-only after 8 hours. Start a new conversation to continue.";
-
 function getBackgroundRunNotice(
   run: BackgroundExecutionRunView | null,
 ): string | null {
@@ -110,7 +107,9 @@ export function ControlledInAppAgentWindow(
     shouldFlush: error !== null || isCancellingRun || shouldFlushCancelledRun,
   });
   const windowExecutionUi: InAppAgentWindowExecutionUi = {
-    notice: getBackgroundRunNotice(execution.run),
+    notice: selectedConversationIsWriteLocked
+      ? null
+      : getBackgroundRunNotice(execution.run),
     stop:
       execution.run && isCancellableBackgroundRun(execution.run.status)
         ? {
@@ -154,10 +153,7 @@ export function ControlledInAppAgentWindow(
     (pendingToolApprovals.length > 0 ||
       displayedPendingToolApprovals.length > 0);
   const displayError = selectedConversationIsWriteLocked
-    ? ({
-        type: "generic",
-        message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-      } as const)
+    ? ({ type: "write_lock" } as const)
     : error;
   const screenContextDescription = useMemo(
     () => getInAppAgentScreenContextDescription(router.asPath),

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { ScanSearch } from "lucide-react";
 import { InAppAgentRunStatus } from "@langfuse/shared";
+import { IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE } from "@langfuse/shared/in-app-agent";
 import { TooltipProvider } from "@/src/components/ui/tooltip";
 import {
   InAppAgentWindow,
@@ -46,6 +47,7 @@ const controlledAgent = vi.hoisted(() => ({
     selectedConversationId: undefined,
     selectedConversationTitle: null,
     selectedConversationIsWriteLocked: false,
+    selectConversation: vi.fn(),
     submit: vi.fn(),
     submitFeedback: vi.fn(),
   },
@@ -298,6 +300,12 @@ describe("ControlledInAppAgentWindow composer", () => {
     controlledAgent.value.isSubmitting = false;
     controlledAgent.value.pendingToolApprovals = [];
     controlledAgent.value.selectedConversationIsWriteLocked = false;
+    controlledAgent.value.selectConversation = vi.fn();
+    controlledAgent.value.execution = {
+      run: null,
+      isCancelling: false,
+      cancel: vi.fn(),
+    };
   });
 
   it("keeps a draft editable but prevents submitting it while an assistant turn is active", () => {
@@ -362,9 +370,19 @@ describe("ControlledInAppAgentWindow composer", () => {
     ).toBeEnabled();
   });
 
-  it("lets you leave a read-only conversation", () => {
+  it("hides a failed-run notice when the conversation is write-locked", () => {
     controlledAgent.value.isRunning = false;
     controlledAgent.value.selectedConversationIsWriteLocked = true;
+    controlledAgent.value.execution = {
+      run: {
+        id: "run-1",
+        status: InAppAgentRunStatus.FAILED,
+        errorCode: null,
+        cancelRequested: false,
+      },
+      isCancelling: false,
+      cancel: vi.fn(),
+    };
 
     render(
       <TooltipProvider>
@@ -378,14 +396,11 @@ describe("ControlledInAppAgentWindow composer", () => {
     );
 
     expect(
-      screen.getByRole("textbox", { name: "Message the assistant" }),
-    ).toBeDisabled();
+      screen.getByText(IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE),
+    ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Start new conversation" }),
-    ).toBeEnabled();
-    expect(
-      screen.getByRole("button", { name: /^Conversation history/ }),
-    ).toBeEnabled();
+      screen.queryByText("The run failed. Try again."),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -14,6 +14,7 @@ import {
   type InAppAgentWindowProps,
 } from "./InAppAgentWindow";
 import { ControlledInAppAgentWindow } from "./ControlledInAppAgentWindow";
+import type { InAppAgentError } from "./utils/utils";
 
 const capture = vi.fn();
 const controlledAgent = vi.hoisted(() => ({
@@ -21,7 +22,7 @@ const controlledAgent = vi.hoisted(() => ({
     conversations: [] as Array<{ id: string; title: string | null }>,
     activityByConversationId: new Map<string, { state: string }>(),
     attentionCount: 0,
-    error: null,
+    error: null as InAppAgentError | null,
     hasMoreConversations: false,
     isLoadingMoreConversations: false,
     isRunning: true,

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -402,6 +402,30 @@ describe("ControlledInAppAgentWindow composer", () => {
       screen.queryByText("The run failed. Try again."),
     ).not.toBeInTheDocument();
   });
+
+  it("locks the composer when a write-lock rejection arrives before the cached flag", () => {
+    controlledAgent.value.isRunning = false;
+    controlledAgent.value.selectedConversationIsWriteLocked = false;
+    controlledAgent.value.error = { type: "write_lock" };
+
+    render(
+      <TooltipProvider>
+        <ControlledInAppAgentWindow
+          isExpanded={false}
+          onClose={vi.fn()}
+          onDeleteConversation={vi.fn()}
+          onExpandedChange={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(
+      screen.getByText(IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeDisabled();
+  });
 });
 
 describe("ControlledInAppAgentWindow stop", () => {

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1419,7 +1419,7 @@ export const Error = meta.story({
       },
     ],
   },
-  play: async ({ args, canvasElement }) => {
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const alert = canvas.getByRole("alert");
 
@@ -1430,11 +1430,7 @@ export const Error = meta.story({
     await expect(
       canvas.getByRole("textbox", { name: "Message the assistant" }),
     ).toBeEnabled();
-
-    await userEvent.click(
-      within(alert).getByRole("button", { name: "Start new conversation" }),
-    );
-    await expect(args.onNewConversation).toHaveBeenCalledOnce();
+    await expect(within(alert).queryByRole("button")).not.toBeInTheDocument();
   },
 });
 
@@ -1454,7 +1450,7 @@ export const WriteLocked = meta.story({
       },
     ],
   },
-  play: async ({ args, canvasElement }) => {
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const alert = canvas.getByRole("alert");
 
@@ -1467,11 +1463,10 @@ export const WriteLocked = meta.story({
     await expect(
       canvas.getByRole("button", { name: /^Conversation history/ }),
     ).toBeEnabled();
-
-    await userEvent.click(
-      within(alert).getByRole("button", { name: "Start new conversation" }),
-    );
-    await expect(args.onNewConversation).toHaveBeenCalledOnce();
+    await expect(within(alert).queryByRole("button")).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", { name: "Start new conversation" }),
+    ).toBeEnabled();
   },
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1,7 +1,11 @@
 import preview from "../../../../.storybook/preview";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
-import type { AgUiMessage } from "@langfuse/shared/in-app-agent";
+import {
+  IN_APP_AGENT_GENERIC_ERROR_MESSAGE,
+  IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+  type AgUiMessage,
+} from "@langfuse/shared/in-app-agent";
 import {
   InAppAgentWindow,
   type InAppAgentWindowMessage,
@@ -1402,7 +1406,7 @@ export const Error = meta.story({
   args: {
     error: {
       type: "generic",
-      message: "Assistant is not enabled for this user",
+      message: "Internal sandbox bridge timeout",
     },
     messages: [
       {
@@ -1414,6 +1418,60 @@ export const Error = meta.story({
         },
       },
     ],
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole("alert");
+
+    await expect(alert).toHaveTextContent(IN_APP_AGENT_GENERIC_ERROR_MESSAGE);
+    await expect(alert).not.toHaveTextContent(
+      "Internal sandbox bridge timeout",
+    );
+    await expect(
+      canvas.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeEnabled();
+
+    await userEvent.click(
+      within(alert).getByRole("button", { name: "Start new conversation" }),
+    );
+    await expect(args.onNewConversation).toHaveBeenCalledOnce();
+  },
+});
+
+export const WriteLocked = meta.story({
+  args: {
+    error: { type: "write_lock" },
+    isConversationInteractionDisabled: true,
+    selectedConversationId: "conversation-1",
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: {
+          type: "text",
+          text: "Help me inspect this trace.",
+        },
+      },
+    ],
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole("alert");
+
+    await expect(alert).toHaveTextContent(
+      IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+    );
+    await expect(
+      canvas.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeDisabled();
+    await expect(
+      canvas.getByRole("button", { name: /^Conversation history/ }),
+    ).toBeEnabled();
+
+    await userEvent.click(
+      within(alert).getByRole("button", { name: "Start new conversation" }),
+    );
+    await expect(args.onNewConversation).toHaveBeenCalledOnce();
   },
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -22,6 +22,7 @@ import {
   Plus,
   SendHorizontal,
   Square,
+  TriangleAlert,
   Trash2,
   X,
 } from "lucide-react";
@@ -918,32 +919,38 @@ function InAppAgentRateLimitError({
 
 function InAppAgentIssueNotice({
   isExpanded,
-  message,
-  onStartNewConversation,
+  variant,
 }: {
   isExpanded: boolean;
-  message: string;
-  onStartNewConversation: () => void;
+  variant: "error" | "write_lock";
 }) {
+  const isWriteLock = variant === "write_lock";
+
   return (
-    <div
-      role="alert"
-      className={cn(
-        "border-dark-yellow bg-light-yellow text-dark-yellow flex w-full items-start gap-2 rounded-lg border px-2 py-1.5",
-        isExpanded ? "text-sm" : "text-xs",
-      )}
-    >
-      <Info aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
-      <p className="min-w-0 flex-1">{message}</p>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="border-dark-yellow text-dark-yellow hover:bg-dark-yellow/10 shrink-0"
-        onClick={onStartNewConversation}
-      >
-        Start new conversation
-      </Button>
+    <div className="shrink-0 px-2 pb-2">
+      <div className={cn(isExpanded && "mx-auto max-w-3xl")}>
+        <p
+          role="alert"
+          className={cn(
+            "flex w-full items-center gap-2 rounded-lg border px-2 py-1",
+            isWriteLock
+              ? "border-border bg-muted/60 text-foreground"
+              : "border-destructive/40 bg-destructive/10 text-destructive",
+            isExpanded ? "text-sm" : "text-xs",
+          )}
+        >
+          {isWriteLock ? (
+            <TriangleAlert aria-hidden="true" className="size-3 shrink-0" />
+          ) : (
+            <Info aria-hidden="true" className="size-3 shrink-0" />
+          )}
+          <span className="min-w-0 flex-1">
+            {isWriteLock
+              ? IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE
+              : IN_APP_AGENT_GENERIC_ERROR_MESSAGE}
+          </span>
+        </p>
+      </div>
     </div>
   );
 }
@@ -1465,18 +1472,6 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 );
               })}
             </ol>
-
-            {(error?.type === "generic" || error?.type === "write_lock") && (
-              <InAppAgentIssueNotice
-                isExpanded={isExpanded}
-                message={
-                  error.type === "write_lock"
-                    ? IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE
-                    : IN_APP_AGENT_GENERIC_ERROR_MESSAGE
-                }
-                onStartNewConversation={onNewConversation}
-              />
-            )}
           </div>
         </ConversationScroller>
         {pendingToolCalls.length > 0 ? (
@@ -1526,6 +1521,12 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             </div>
           </div>
         ) : null}
+        {(error?.type === "generic" || error?.type === "write_lock") && (
+          <InAppAgentIssueNotice
+            isExpanded={isExpanded}
+            variant={error.type === "write_lock" ? "write_lock" : "error"}
+          />
+        )}
         {backgroundHint.isVisible && props.onClose ? (
           <InAppAgentBackgroundHint
             isExpanded={isExpanded}

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -47,9 +47,11 @@ import {
   type InAppAgentMessageContent,
   type InAppAgentMessageRole,
 } from "./InAppAgentMessage";
-import type {
-  InAppAgentMessageFeedbackValue,
-  InAppAgentMessageSource,
+import {
+  IN_APP_AGENT_GENERIC_ERROR_MESSAGE,
+  IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+  type InAppAgentMessageFeedbackValue,
+  type InAppAgentMessageSource,
 } from "@langfuse/shared/in-app-agent";
 import { deduplicateBy } from "@/src/utils/arrays";
 import type { InAppAgentScreenContextDescription } from "@/src/features/in-app-agent/context";
@@ -914,22 +916,34 @@ function InAppAgentRateLimitError({
   );
 }
 
-function InAppAgentGenericError({
-  error,
+function InAppAgentIssueNotice({
   isExpanded,
+  message,
+  onStartNewConversation,
 }: {
-  error: Extract<InAppAgentError, { type: "generic" }>;
   isExpanded: boolean;
+  message: string;
+  onStartNewConversation: () => void;
 }) {
   return (
     <div
       role="alert"
       className={cn(
-        "border-destructive/40 dark:bg-destructive dark:border-destructive-foreground/20 bg-destructive/10 dark:text-destructive-foreground text-destructive rounded-lg border px-2 py-1",
+        "border-dark-yellow bg-light-yellow text-dark-yellow flex w-full items-start gap-2 rounded-lg border px-2 py-1.5",
         isExpanded ? "text-sm" : "text-xs",
       )}
     >
-      {error.message}
+      <Info aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+      <p className="min-w-0 flex-1">{message}</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="border-dark-yellow text-dark-yellow hover:bg-dark-yellow/10 shrink-0"
+        onClick={onStartNewConversation}
+      >
+        Start new conversation
+      </Button>
     </div>
   );
 }
@@ -1452,8 +1466,16 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               })}
             </ol>
 
-            {error?.type === "generic" && (
-              <InAppAgentGenericError error={error} isExpanded={isExpanded} />
+            {(error?.type === "generic" || error?.type === "write_lock") && (
+              <InAppAgentIssueNotice
+                isExpanded={isExpanded}
+                message={
+                  error.type === "write_lock"
+                    ? IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE
+                    : IN_APP_AGENT_GENERIC_ERROR_MESSAGE
+                }
+                onStartNewConversation={onNewConversation}
+              />
             )}
           </div>
         </ConversationScroller>

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -19,8 +19,8 @@ import useSessionStorage from "@/src/components/useSessionStorage";
 import {
   createInAppAgentConversationId,
   createInAppAgentMessageId,
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
 } from "@langfuse/shared/in-app-agent";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@langfuse/shared/in-app-agent";
 import {
   AgUiMessageSchema,
   dropEmptyAssistantMessages,
@@ -86,8 +86,6 @@ const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
 const OPEN_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-open";
 const FEEDBACK_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-feedback";
-const SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE =
-  "Sandbox-enabled conversations become read-only after 8 hours. Start a new conversation to continue.";
 const EMPTY_MESSAGES: AgUiMessage[] = [];
 const EMPTY_BACKGROUND_VIEW: BackgroundExecutionView = {
   messages: EMPTY_MESSAGES,
@@ -1078,10 +1076,7 @@ function InAppAiAgentProviderInner({
       }
 
       if (!startsNewConversation && selectedConversationIsWriteLocked) {
-        setError({
-          type: "generic",
-          message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-        });
+        setError({ type: "write_lock" });
         return false;
       }
 
@@ -1403,10 +1398,7 @@ function InAppAiAgentProviderInner({
       approvalScope: "once" | "conversation" = "once",
     ) => {
       if (selectedConversationIsWriteLocked) {
-        setError({
-          type: "generic",
-          message: SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
-        });
+        setError({ type: "write_lock" });
         return;
       }
 

--- a/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -1,5 +1,8 @@
 import type { AgUiMessage } from "@langfuse/shared/in-app-agent";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@langfuse/shared/in-app-agent";
+import {
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+} from "@langfuse/shared/in-app-agent";
 import {
   IN_APP_AGENT_LANGFUSE_MCP_TOOL_NAMES,
   IN_APP_AGENT_SANDBOX_TOOL_NAMES,
@@ -240,6 +243,15 @@ describe("getInAppAgentError", () => {
       type: "generic",
       message: "Assistant connection failed",
     });
+  });
+
+  it("maps a write-lock rejection to the write-lock notice", () => {
+    expect(
+      getInAppAgentError(
+        { message: IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE },
+        now,
+      ),
+    ).toEqual({ type: "write_lock" });
   });
 
   it("does not classify malformed embedded JSON as a rate limit", () => {

--- a/web/src/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.ts
@@ -19,6 +19,7 @@ import {
 
 export type InAppAgentError =
   | { type: "generic"; message: string }
+  | { type: "write_lock" }
   | { type: "rate_limit"; retryAt: number };
 
 const InAppAiAgentMessageSchema = AgUiMessageSchema.and(

--- a/web/src/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.ts
@@ -6,6 +6,7 @@ import { deduplicateBy } from "@/src/utils/arrays";
 import { safeJsonParse, stableJsonStringify } from "@langfuse/shared";
 import {
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
   IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE,
 } from "@langfuse/shared/in-app-agent";
 import {
@@ -347,6 +348,10 @@ export function getInAppAgentError(
       type: "rate_limit",
       retryAt: now + rateLimitError.details.retryAfterSeconds * 1_000,
     };
+  }
+
+  if (message.includes(IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE)) {
+    return { type: "write_lock" };
   }
 
   return { type: "generic", message };

--- a/web/src/features/in-app-agent/server/backgroundRunService.ts
+++ b/web/src/features/in-app-agent/server/backgroundRunService.ts
@@ -20,6 +20,7 @@ import { deleteApiKeyFromDb } from "@langfuse/shared/src/server/auth/apiKeys";
 import {
   createInAppAgentMessageId,
   createInAppAgentRunId,
+  IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
   parseInAppAgentApprovalDecisionEvent,
   type AgUiRunAgentInput,
 } from "@langfuse/shared/in-app-agent";
@@ -48,9 +49,6 @@ import { serializeInAppAgentDisplayState } from "@/src/features/in-app-agent/lib
 import { assertInAppAgentRunCapacity } from "@/src/features/in-app-agent/server/runCapacity";
 import { resolveInAppAgentRunContext } from "@/src/features/in-app-agent/server/runContext";
 import { getConversationSnapshotFromEvents } from "@/src/features/in-app-agent/server/conversationSnapshot";
-
-const SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE =
-  "Sandbox-enabled conversations become read-only after 8 hours. Start a new conversation to continue.";
 
 export async function getBackgroundConversationSnapshot(params: {
   prisma: PrismaClient;
@@ -240,7 +238,7 @@ export async function startBackgroundRun(params: {
     throw new BaseError(
       "PreconditionFailedError",
       412,
-      SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+      IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
       true,
     );
   }
@@ -405,7 +403,7 @@ export async function decideBackgroundApproval(params: {
     throw new BaseError(
       "PreconditionFailedError",
       412,
-      SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
+      IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
       true,
     );
   }

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -18,6 +18,7 @@ import {
 } from "@langfuse/shared/src/server/auth/apiKeys";
 import {
   getInAppAgentInstrumentationTraceId,
+  IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
   type AgUiEvent,
   type AgUiRunAgentInput,
   type InAppAgentToolApprovalRequest,
@@ -224,7 +225,7 @@ export async function executeInAppAgentRun(params: {
       })
     ) {
       throw new InAppAgentRunInitError(
-        "Conversation is write-locked (sandbox session expired)",
+        IN_APP_AGENT_SANDBOX_CONVERSATION_WRITE_LOCK_MESSAGE,
       );
     }
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16143.preview.langfuse.com](https://pr-16143.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- After 8 hours, sandbox-enabled conversations become write-locked. History stays visible; the composer cannot take another turn.
- Show that as a muted notice above the composer: *This conversation has reached the 8-hour limit. Please start a new conversation.* Start a new conversation from the header plus.
- Generic assistant failures use a red notice with safe copy. The composer stays enabled so retry still works. Raw error text is not shown.
- Hide competing failed-run notices while a conversation is write-locked. The rate-limit card is unchanged.

## Packages
- `@langfuse/shared`
- `web`
- `worker`

## Test plan
- [ ] Open an 8-hour-old sandbox conversation and confirm the grey limit notice above the composer; composer stays disabled; header plus still starts a new conversation.
- [ ] Trigger a generic assistant failure and confirm the red notice with no banner button; composer stays enabled and retry still works.
- [ ] Confirm a failed-run status line does not appear on top of the write-lock notice.
- [ ] Review Storybook **Error** and **Write Locked**.

## Verification
- `pnpm --filter web run test-client src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx` — Tests 17 passed (17)
- `pnpm --filter web run test-storybook` — Tests 335 passed (335); InAppAgentWindow.stories.tsx 33 passed
- `pnpm --filter web run test src/__tests__/server/in-app-agent-background-run.servertest.ts` — Tests 25 passed (25) (prior run; copy still uses the shared constant)
- Pre-commit: `Tasks: 7 successful, 7 total` (turbo lint)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR distinguishes expired sandbox conversations from retryable assistant failures and presents each with safe, purpose-specific notice copy.

- Adds shared constants for the write-lock and generic-error messages.
- Introduces a dedicated write-lock error variant and suppresses competing failed-run notices for locked conversations.
- Moves generic and write-lock notices above the composer while preserving retry behavior for generic failures.
- Aligns web admission and worker-side write-lock failures with the shared message.
- Adds client and Storybook coverage for generic-error and write-locked states.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The write-lock state remains enforced through structured state and server-side checks, while generic failures retain an enabled composer and no longer expose raw error text.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): restyle write-lock and error..."](https://github.com/langfuse/langfuse/commit/9eaa8b39670ca7c536acce61fa2c72dcde693f00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53340468)</sub>

**Context used:**

- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)

<!-- /greptile_comment -->