### PR TITLE
chore(api): mark trace delete endpoints as deprecated

### DIFF
--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -25,6 +25,9 @@ service:
           docs: The unique langfuse identifier of a trace
       response: commons.TraceWithFullDetails
     delete:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release without a replacement. To remove old data automatically, configure [data retention](https://langfuse.com/docs/administration/data-retention)."
       docs: Delete a specific trace
       method: DELETE
       path: /traces/{traceId}
@@ -190,6 +193,9 @@ service:
               - Score filters require a join with the scores table and may impact query performance
       response: Traces
     deleteMultiple:
+      availability:
+        status: deprecated
+        message: "Langfuse v3 is deprecated; this endpoint will be removed in a future release without a replacement. To remove old data automatically, configure [data retention](https://langfuse.com/docs/administration/data-retention)."
       docs: Delete multiple traces
       method: DELETE
       path: /traces

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -6358,7 +6358,16 @@ paths:
       security: *ref_0
       deprecated: true
     delete:
-      description: Delete a specific trace
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release without a replacement. To remove old data
+        automatically, configure [data
+        retention](https://langfuse.com/docs/administration/data-retention). See
+        the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Delete a specific trace
       operationId: trace_delete
       tags:
         - Trace
@@ -6402,6 +6411,7 @@ paths:
             application/json:
               schema: {}
       security: *ref_0
+      deprecated: true
   /api/public/traces:
     get:
       description: >-
@@ -6739,7 +6749,16 @@ paths:
       security: *ref_0
       deprecated: true
     delete:
-      description: Delete multiple traces
+      description: >-
+        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
+        in a future release without a replacement. To remove old data
+        automatically, configure [data
+        retention](https://langfuse.com/docs/administration/data-retention). See
+        the [Langfuse v3 to v4 upgrade
+        guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+
+
+        Delete multiple traces
       operationId: trace_deleteMultiple
       tags:
         - Trace
@@ -6791,6 +6810,7 @@ paths:
                   description: List of trace IDs to delete
               required:
                 - traceIds
+      deprecated: true
   /api/public/unstable/dashboard-widgets:
     get:
       description: |-


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16144.preview.langfuse.com](https://pr-16144.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Marks the two trace delete endpoints as deprecated in the API reference, following up on #16121 which added deprecation notices to the trace read paths:

- `DELETE /api/public/traces/{traceId}`
- `DELETE /api/public/traces`

Both are retired without a replacement. The stamped notice points readers at [data retention](https://langfuse.com/docs/administration/data-retention) for recurring cleanup and at the v3 to v4 upgrade guide.

Changes:

- `fern/apis/server/definition/trace.yml`: `availability: deprecated` with a customer-facing message on both endpoints.
- `web/public/generated/api/openapi.yml`: regenerated via `pnpm run openapi:export`, which stamps `deprecated: true` and the `**Deprecated:** …` notice.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Marks the single-trace and bulk-trace DELETE endpoints as deprecated in the Fern source specification and generated OpenAPI contract.
- Adds deprecation messages directing users toward automatic data retention.
- Regenerates OpenAPI descriptions and `deprecated: true` markers for both operations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it changes only API deprecation metadata and keeps the Fern and generated OpenAPI specifications aligned.

Both trace deletion operations are consistently marked deprecated with appropriate deletion-specific migration guidance, without altering their request, response, authentication, or runtime behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(api): mark trace delete endpoints ..."](https://github.com/langfuse/langfuse/commit/39a340d6ed7ba061bb3e167c662e08be1cdfe957) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53341564)</sub>

<!-- /greptile_comment -->