### PR TITLE
feat(web): offer export sources by deployment capability, not per-user beta

### DIFF
--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -403,10 +403,8 @@ describe("write mode drives the settings-page selector", () => {
   );
 });
 
-// The three settings pages consume only this composite, so the pieces agreeing
-// individually is not enough: visibility and the create default have to agree
-// with each other. A form mounted on a hidden selector whose default fails
-// validation blocks every save with no field to correct.
+// The pages consume only this composite, so the pieces being correct
+// individually is not enough — visibility and the default must agree.
 describe("getExportSourceFieldState", () => {
   const ctxFor = (
     writeMode: BlobExportWriteMode,
@@ -416,8 +414,6 @@ describe("getExportSourceFieldState", () => {
   ): ExportSourceContext =>
     buildExportSourceContext({ writeMode, isCloud: false, ...over });
 
-  // Whenever the selector is hidden the default must be saveable on its own,
-  // because there is no field left for the user to fix it with.
   it.each<BlobExportWriteMode>(["legacy", "dual", "events_only"])(
     "%s: a hidden selector always leaves a selectable default",
     (mode) => {
@@ -454,8 +450,8 @@ describe("getExportSourceFieldState", () => {
     expect(defaultValue).toBe(expected);
   });
 
-  // A stale persisted source keeps the selector on screen so the blocked-save
-  // alert has something to point at, and keeps the value so the alert names it.
+  // Kept as the default even though unselectable: the blocked-save alert
+  // names it.
   it("keeps the selector for a persisted source the deployment can no longer write", () => {
     const ctx = ctxFor("events_only");
     const { showField, defaultValue } = getExportSourceFieldState(
@@ -482,8 +478,8 @@ describe("getExportSourceFieldState", () => {
     expect(defaultValue).toBe(AnalyticsIntegrationExportSource.EVENTS);
   });
 
-  // Availability is a deployment property, so two members of one project must
-  // never be offered different options for the same shared config row.
+  // Pre-cutoff projects are exempt from the cutoff, leaving only the write
+  // mode.
   it.each<BlobExportWriteMode>(["legacy", "dual", "events_only"])(
     "%s: pre-cutoff Cloud matches self-hosted",
     (mode) => {

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -8,6 +8,7 @@ import {
 
 import {
   buildExportSourceContext,
+  getExportSourceFieldState,
   getExportSourceFormValue,
   getExportSourceOptions,
   getExportSourceUnavailableMessage,
@@ -398,6 +399,104 @@ describe("write mode drives the settings-page selector", () => {
           }),
         ),
       ).toEqual(getExportSourceOptions(undefined, ctxFor(mode)));
+    },
+  );
+});
+
+// The three settings pages consume only this composite, so the pieces agreeing
+// individually is not enough: visibility and the create default have to agree
+// with each other. A form mounted on a hidden selector whose default fails
+// validation blocks every save with no field to correct.
+describe("getExportSourceFieldState", () => {
+  const ctxFor = (
+    writeMode: BlobExportWriteMode,
+    over: Partial<
+      Omit<ExportSourceContext, "enrichedAvailable" | "legacyWritesActive">
+    > = {},
+  ): ExportSourceContext =>
+    buildExportSourceContext({ writeMode, isCloud: false, ...over });
+
+  // Whenever the selector is hidden the default must be saveable on its own,
+  // because there is no field left for the user to fix it with.
+  it.each<BlobExportWriteMode>(["legacy", "dual", "events_only"])(
+    "%s: a hidden selector always leaves a selectable default",
+    (mode) => {
+      const ctx = ctxFor(mode);
+      const { showField, defaultValue } = getExportSourceFieldState(
+        undefined,
+        ctx,
+      );
+      if (!showField) {
+        expect(isExportSourceSelectable(defaultValue, ctx)).toBe(true);
+      }
+    },
+  );
+
+  it("dual offers the choice, with the events source defaulted", () => {
+    const { showField, defaultValue, options } = getExportSourceFieldState(
+      undefined,
+      ctxFor("dual"),
+    );
+    expect(showField).toBe(true);
+    expect(options).toHaveLength(3);
+    expect(defaultValue).toBe(AnalyticsIntegrationExportSource.EVENTS);
+  });
+
+  it.each<[BlobExportWriteMode, AnalyticsIntegrationExportSource]>([
+    ["legacy", AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS],
+    ["events_only", AnalyticsIntegrationExportSource.EVENTS],
+  ])("%s hides the selector and defaults to %s", (mode, expected) => {
+    const { showField, defaultValue } = getExportSourceFieldState(
+      undefined,
+      ctxFor(mode),
+    );
+    expect(showField).toBe(false);
+    expect(defaultValue).toBe(expected);
+  });
+
+  // A stale persisted source keeps the selector on screen so the blocked-save
+  // alert has something to point at, and keeps the value so the alert names it.
+  it("keeps the selector for a persisted source the deployment can no longer write", () => {
+    const ctx = ctxFor("events_only");
+    const { showField, defaultValue } = getExportSourceFieldState(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      ctx,
+    );
+    expect(showField).toBe(true);
+    expect(defaultValue).toBe(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    );
+    expect(isExportSourceSelectable(defaultValue, ctx)).toBe(false);
+  });
+
+  it("post-cutoff Cloud hides the field and pins the events source", () => {
+    const { showField, defaultValue } = getExportSourceFieldState(
+      undefined,
+      ctxFor("dual", {
+        isCloud: true,
+        projectCreatedAt: PROJECT_POST,
+        integrationCreatedAt: ROW_PRE,
+      }),
+    );
+    expect(showField).toBe(false);
+    expect(defaultValue).toBe(AnalyticsIntegrationExportSource.EVENTS);
+  });
+
+  // Availability is a deployment property, so two members of one project must
+  // never be offered different options for the same shared config row.
+  it.each<BlobExportWriteMode>(["legacy", "dual", "events_only"])(
+    "%s: pre-cutoff Cloud matches self-hosted",
+    (mode) => {
+      expect(
+        getExportSourceFieldState(
+          undefined,
+          ctxFor(mode, {
+            isCloud: true,
+            projectCreatedAt: PROJECT_PRE,
+            integrationCreatedAt: ROW_PRE,
+          }),
+        ),
+      ).toEqual(getExportSourceFieldState(undefined, ctxFor(mode)));
     },
   );
 });

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -465,7 +465,7 @@ describe("getExportSourceFieldState", () => {
     expect(isExportSourceSelectable(defaultValue, ctx)).toBe(false);
   });
 
-  it("post-cutoff Cloud hides the field and pins the events source", () => {
+  it("post-cutoff Cloud leaves only the events source to offer", () => {
     const { showField, defaultValue } = getExportSourceFieldState(
       undefined,
       ctxFor("dual", {
@@ -476,6 +476,29 @@ describe("getExportSourceFieldState", () => {
     );
     expect(showField).toBe(false);
     expect(defaultValue).toBe(AnalyticsIntegrationExportSource.EVENTS);
+  });
+
+  // The cutoff gates newly chosen sources only. Hiding the field and pinning
+  // the events source instead would rewrite a persisted legacy source on the
+  // next save of any other field on the page.
+  it("post-cutoff Cloud keeps a persisted legacy source visible and blocked", () => {
+    const ctx = ctxFor("dual", {
+      isCloud: true,
+      projectCreatedAt: PROJECT_POST,
+      integrationCreatedAt: ROW_PRE,
+    });
+    const { showField, defaultValue, options } = getExportSourceFieldState(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      ctx,
+    );
+    expect(showField).toBe(true);
+    expect(defaultValue).toBe(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    );
+    expect(isExportSourceSelectable(defaultValue, ctx)).toBe(false);
+    expect(options.find((o) => o.value === defaultValue)?.unavailable).toBe(
+      true,
+    );
   });
 
   // Pre-cutoff projects are exempt from the cutoff, leaving only the write

--- a/web/src/features/analytics-integrations/exportSource.ts
+++ b/web/src/features/analytics-integrations/exportSource.ts
@@ -96,28 +96,19 @@ export type ExportSourceFieldState = {
 };
 
 // Visibility and the default have to agree: a hidden selector whose default is
-// not selectable blocks every save with no field left to fix it with.
-//
-// Post-cutoff Cloud is the exception to shouldHideExportSourceSelector's
-// stale-source rule: the field is hidden and EVENTS pinned even when a legacy
-// source is persisted, so that value is silently replaced on save.
+// not selectable blocks every save with no field left to fix it with. Both
+// therefore derive from the same option list, with no per-context override —
+// the persisted value survives even where it can no longer be chosen, so the
+// blocked-save alert names it instead of a save quietly replacing it.
 export function getExportSourceFieldState(
   persisted: AnalyticsIntegrationExportSource | null | undefined,
   ctx: ExportSourceContext,
 ): ExportSourceFieldState {
-  const legacyValidation = validateExportSource(
-    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-    ctx,
-  );
-  const isPostCutoffCloud =
-    !legacyValidation.ok && legacyValidation.reason === "cloud-cutoff";
   const options = getExportSourceOptions(persisted ?? null, ctx);
   return {
     options,
-    showField: !isPostCutoffCloud && !shouldHideExportSourceSelector(options),
-    defaultValue: isPostCutoffCloud
-      ? AnalyticsIntegrationExportSource.EVENTS
-      : getExportSourceFormValue(persisted, ctx),
+    showField: !shouldHideExportSourceSelector(options),
+    defaultValue: getExportSourceFormValue(persisted, ctx),
   };
 }
 

--- a/web/src/features/analytics-integrations/exportSource.ts
+++ b/web/src/features/analytics-integrations/exportSource.ts
@@ -89,6 +89,45 @@ export function getExportSourceOptions(
   });
 }
 
+export type ExportSourceFieldState = {
+  options: SelectableExportSourceOption[];
+  showField: boolean;
+  defaultValue: AnalyticsIntegrationExportSource;
+};
+
+// Everything the three export-source fields need, derived only from deployment
+// capability and the project's Cloud cutoff.
+//
+// A stale persisted source normally keeps the selector on screen, because
+// getExportSourceOptions returns it marked unavailable and a lone unavailable
+// option does not count as "no decision to make" — that is what gives the
+// blocked-save alert something to point at.
+//
+// Post-cutoff Cloud is the one case where that does not hold: the field is
+// hidden and EVENTS is pinned unconditionally, so a project whose persisted
+// source is a legacy one has it silently replaced on save with no alert. That
+// contradicts the rule above and is tracked separately rather than changed
+// here, since it is a Cloud behaviour change in its own right.
+export function getExportSourceFieldState(
+  persisted: AnalyticsIntegrationExportSource | null | undefined,
+  ctx: ExportSourceContext,
+): ExportSourceFieldState {
+  const legacyValidation = validateExportSource(
+    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    ctx,
+  );
+  const isPostCutoffCloud =
+    !legacyValidation.ok && legacyValidation.reason === "cloud-cutoff";
+  const options = getExportSourceOptions(persisted ?? null, ctx);
+  return {
+    options,
+    showField: !isPostCutoffCloud && !shouldHideExportSourceSelector(options),
+    defaultValue: isPostCutoffCloud
+      ? AnalyticsIntegrationExportSource.EVENTS
+      : getExportSourceFormValue(persisted, ctx),
+  };
+}
+
 // Blocked-save alert body per policy reason.
 const EXPORT_SOURCE_UNAVAILABLE_MESSAGES: Record<
   ExportSourceBlockedReason,

--- a/web/src/features/analytics-integrations/exportSource.ts
+++ b/web/src/features/analytics-integrations/exportSource.ts
@@ -95,19 +95,12 @@ export type ExportSourceFieldState = {
   defaultValue: AnalyticsIntegrationExportSource;
 };
 
-// Everything the three export-source fields need, derived only from deployment
-// capability and the project's Cloud cutoff.
+// Visibility and the default have to agree: a hidden selector whose default is
+// not selectable blocks every save with no field left to fix it with.
 //
-// A stale persisted source normally keeps the selector on screen, because
-// getExportSourceOptions returns it marked unavailable and a lone unavailable
-// option does not count as "no decision to make" — that is what gives the
-// blocked-save alert something to point at.
-//
-// Post-cutoff Cloud is the one case where that does not hold: the field is
-// hidden and EVENTS is pinned unconditionally, so a project whose persisted
-// source is a legacy one has it silently replaced on save with no alert. That
-// contradicts the rule above and is tracked separately rather than changed
-// here, since it is a Cloud behaviour change in its own right.
+// Post-cutoff Cloud is the exception to shouldHideExportSourceSelector's
+// stale-source rule: the field is hidden and EVENTS pinned even when a legacy
+// source is persisted, so that value is silently replaced on save.
 export function getExportSourceFieldState(
   persisted: AnalyticsIntegrationExportSource | null | undefined,
   ctx: ExportSourceContext,

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -33,7 +33,6 @@ import {
   type MixpanelRegion,
 } from "@/src/features/mixpanel-integration/types";
 import {
-  AnalyticsIntegrationExportSource,
   validateExportSource,
   type BlobExportWriteMode,
   type ExportSourceContext,
@@ -42,12 +41,10 @@ import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 // Shared export-source UI adapters; policy in export-source-policy.ts.
 import {
   buildExportSourceContext,
-  getExportSourceOptions,
+  getExportSourceFieldState,
   getExportSourceUnavailableMessage,
   isExportSourceSelectable,
-  shouldHideExportSourceSelector,
 } from "@/src/features/analytics-integrations/exportSource";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -171,7 +168,6 @@ const MixpanelIntegrationSettingsForm = ({
   projectCreatedAt: string;
 }) => {
   const capture = usePostHogClientCapture();
-  const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const exportSourceCtx: ExportSourceContext = useMemo(
     () =>
@@ -182,27 +178,11 @@ const MixpanelIntegrationSettingsForm = ({
       }),
     [writeMode, isLangfuseCloud, projectCreatedAt],
   );
-  const legacyValidation = validateExportSource(
-    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-    exportSourceCtx,
-  );
-  // Post-cutoff Cloud projects: field hidden, form value pinned to EVENTS via
-  // the default below (LFE-9688 / 9830 behavior, unchanged).
-  const isPostCutoffCloud =
-    !legacyValidation.ok && legacyValidation.reason === "cloud-cutoff";
-  const exportSourceOptions = getExportSourceOptions(
-    state?.exportSource ?? null,
-    exportSourceCtx,
-  );
-  // Selector is beta-gated, except a persisted source blocked by capability
-  // forces it visible so the blocked-save alert has something to point at.
-  const persistedBlockedByCapability =
-    state?.exportSource != null &&
-    !isPostCutoffCloud &&
-    !isExportSourceSelectable(state.exportSource, exportSourceCtx);
-  const showExportSourceField =
-    ((isBetaEnabled && !isPostCutoffCloud) || persistedBlockedByCapability) &&
-    !shouldHideExportSourceSelector(exportSourceOptions);
+  const {
+    options: exportSourceOptions,
+    showField: showExportSourceField,
+    defaultValue: defaultExportSource,
+  } = getExportSourceFieldState(state?.exportSource, exportSourceCtx);
 
   // Blocked-save validation instead of silent rewrite (LFE-10296).
   const formSchema = useMemo(
@@ -228,13 +208,6 @@ const MixpanelIntegrationSettingsForm = ({
       }),
     [exportSourceCtx, state],
   );
-
-  const defaultExportSource = isPostCutoffCloud
-    ? AnalyticsIntegrationExportSource.EVENTS
-    : (state?.exportSource ??
-      (isBetaEnabled || !exportSourceCtx.legacyWritesActive
-        ? AnalyticsIntegrationExportSource.EVENTS
-        : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
 
   const mixpanelForm = useForm({
     resolver: zodResolver(formSchema),

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -31,7 +31,6 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration/types";
 import { PostHogStatusSection } from "@/src/features/posthog-integration/components/PostHogStatusSection";
 import {
-  AnalyticsIntegrationExportSource,
   validateExportSource,
   type BlobExportWriteMode,
   type ExportSourceContext,
@@ -40,12 +39,10 @@ import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 // Shared export-source UI adapters; policy in export-source-policy.ts.
 import {
   buildExportSourceContext,
-  getExportSourceOptions,
+  getExportSourceFieldState,
   getExportSourceUnavailableMessage,
   isExportSourceSelectable,
-  shouldHideExportSourceSelector,
 } from "@/src/features/analytics-integrations/exportSource";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -165,7 +162,6 @@ const PostHogIntegrationSettings = ({
   projectCreatedAt: string;
 }) => {
   const capture = usePostHogClientCapture();
-  const { isBetaEnabled } = useV4Beta();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const exportSourceCtx: ExportSourceContext = useMemo(
     () =>
@@ -176,27 +172,11 @@ const PostHogIntegrationSettings = ({
       }),
     [writeMode, isLangfuseCloud, projectCreatedAt],
   );
-  const legacyValidation = validateExportSource(
-    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-    exportSourceCtx,
-  );
-  // Post-cutoff Cloud projects: field hidden, form value pinned to EVENTS via
-  // the default below (LFE-9688 / 9830 behavior, unchanged).
-  const isPostCutoffCloud =
-    !legacyValidation.ok && legacyValidation.reason === "cloud-cutoff";
-  const exportSourceOptions = getExportSourceOptions(
-    state?.exportSource ?? null,
-    exportSourceCtx,
-  );
-  // Selector is beta-gated, except a persisted source blocked by capability
-  // forces it visible so the blocked-save alert has something to point at.
-  const persistedBlockedByCapability =
-    state?.exportSource != null &&
-    !isPostCutoffCloud &&
-    !isExportSourceSelectable(state.exportSource, exportSourceCtx);
-  const showExportSourceField =
-    ((isBetaEnabled && !isPostCutoffCloud) || persistedBlockedByCapability) &&
-    !shouldHideExportSourceSelector(exportSourceOptions);
+  const {
+    options: exportSourceOptions,
+    showField: showExportSourceField,
+    defaultValue: defaultExportSource,
+  } = getExportSourceFieldState(state?.exportSource, exportSourceCtx);
 
   // Blocked-save validation instead of silent rewrite (LFE-10296).
   const formSchema = useMemo(
@@ -222,13 +202,6 @@ const PostHogIntegrationSettings = ({
       }),
     [exportSourceCtx, state],
   );
-
-  const defaultExportSource = isPostCutoffCloud
-    ? AnalyticsIntegrationExportSource.EVENTS
-    : (state?.exportSource ??
-      (isBetaEnabled || !exportSourceCtx.legacyWritesActive
-        ? AnalyticsIntegrationExportSource.EVENTS
-        : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS));
 
   const posthogForm = useForm({
     resolver: zodResolver(formSchema),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16149.preview.langfuse.com](https://pr-16149.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Stacked on the write-mode derivation PR below it. That one made availability a single deployment-level rule; this one removes the last input that contradicts it.

Selector visibility and the create default on PostHog and Mixpanel were gated on the per-user V4 beta flag. Consequences:

- Two members of the same project saw different options for one shared config row.
- Both pages diverged from blob storage, which was never gated this way.
- The flag is not an independent switch — `v4BetaEnabled` is itself derived from the write mode, so it was a second, less accurate copy of the rule this stack exists to unify.

All three pages now go through one `getExportSourceFieldState`, which decides purely from the deployment's write mode and the project's Cloud cutoff.

## ⚠️ This is Cloud-visible — please push back if you disagree

The gate is dropped **everywhere, including Cloud**. There is deliberately no `isCloud` escape hatch.

For a pre-cutoff Cloud project on `dual`, with a user who does not have the V4 beta enabled, on the PostHog or Mixpanel settings page:

| | Before | After |
|---|---|---|
| Export-source selector | not rendered | rendered, three selectable options |
| Create default | legacy traces + observations | events source |

The argument for accepting it: a pre-cutoff Cloud project on `dual` genuinely can export either source, so offering the choice is truthful rather than merely permissive. Blob storage already behaved this way, so this makes the three integrations consistent.

Post-cutoff Cloud projects are unaffected — the field stays hidden and the events source stays pinned.

The alternative is keeping the gate on the Cloud branch only. That preserves a second definition of availability in exactly the code path this stack unifies, and keeps the two-users-one-row inconsistency. Worth stating explicitly so it can be chosen deliberately.

## Tests

Adds the composition tests the extracted helpers never had. Visibility and the create default were only ever asserted apart, and it is their *agreement* that matters: a hidden selector whose default fails validation blocks every save with no field left to correct it. That combination is now asserted directly, including the invariant that a hidden selector always leaves a selectable default.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Non-breaking, but user-visible on Cloud as described above.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm turbo run typecheck lint` — 9 successful, 9 total
- `pnpm --filter web run test-client` — 3280 passed, 51 skipped
- `pnpm --filter @langfuse/shared run test` — 913 passed, 2 skipped

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the per-user beta gate for PostHog and Mixpanel export-source selection with deployment-capability-based behavior.

- Centralizes selector visibility, available options, and form defaults in `getExportSourceFieldState`.
- Applies the shared field state to both integration settings pages.
- Adds tests covering write modes, Cloud cutoffs, hidden-field defaults, and persisted unavailable sources.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code failure identified.

The centralized field state remains consistent with the client and server export-source validation contracts across supported write modes and Cloud cutoff behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): offer export sources by deplo..."](https://github.com/langfuse/langfuse/commit/cc62d719c4bf21f228a41039a94e63797c40cf54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53361242)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->