### PR TITLE
fix(web): hold the mobile zoom lock inside portalled overlays

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -7,7 +7,7 @@ import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { cn } from "@/src/utils/tailwind";
 import { memo, useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { useIsMobile } from "@/src/hooks/use-mobile";
+import { useIsHandheld } from "@/src/hooks/use-mobile";
 import { getPathnameWithoutBasePath } from "@/src/utils/api";
 import { urlSearchParamsToQuery } from "@/src/utils/navigation";
 import { PeekTableStateProvider } from "@/src/components/table/peek/contexts/PeekTableStateContext";
@@ -154,7 +154,9 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   const { isBetaEnabled: isV4 } = useV4Beta();
   const itemId = router.query.peek as string | undefined;
   const isExpanded = router.query[PEEK_VIEW_PARAM] === PEEK_VIEW_EXPANDED;
-  const isMobile = useIsMobile();
+  // Handheld, not width-only: a phone in landscape is wider than `md` but is
+  // still a phone, and must get the full-screen drawer rather than the sheet.
+  const isHandheld = useIsHandheld();
 
   // Expanded is view state, owned by the peek and reflected in the URL so it is
   // shareable + survives reload. Managed here (not threaded through every table
@@ -209,7 +211,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   const ignoredSelectors = props.peekEventOptions?.ignoredSelectors ?? [];
 
   // Gate the first render on mount so we never paint the desktop sheet before
-  // `useIsMobile` resolves (which would flash the wrong shell on a mobile
+  // `useIsHandheld` resolves (which would flash the wrong shell on a mobile
   // deep-link). Click-to-open is already post-mount, so it has no delay.
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
@@ -245,7 +247,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
       actions={props.actions}
       actionsMenu={props.actionsMenu}
       expand={
-        isMobile
+        isHandheld
           ? undefined
           : {
               isExpanded: panel.isExpanded,
@@ -279,7 +281,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   // `return null` above), which is what resets the state (see README).
   return (
     <PeekTableStateProvider>
-      {isMobile ? (
+      {isHandheld ? (
         // Mobile: a vaul bottom drawer with native swipe-down dismissal.
         <Drawer
           open={!!itemId}

--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -15,8 +15,10 @@ Peek views allow users to quickly preview table items in a side panel. When navi
   table behind stays interactive. A left-edge handle resizes it; dragging to the
   far edge (or the header Expand button) **expands** it to the max width
   (viewport − sidebar; the sidebar stays visible).
-- **Mobile** (`useIsMobile`, <768px) — a `vaul` bottom drawer with native
-  swipe-down dismissal (Expand is hidden).
+- **Handheld** (`useIsHandheld` — narrower than `md`, _or_ a coarse pointer on a
+  short screen, i.e. a phone in landscape) — a `vaul` bottom drawer with native
+  swipe-down dismissal (Expand is hidden). Not width-only: a landscape phone is
+  wider than `md` and would otherwise get the desktop sheet.
 
 Dismissal:
 

--- a/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
+++ b/web/src/features/trace-graph-view/components/ElkGraphRenderer.tsx
@@ -359,7 +359,9 @@ export const ElkGraphRenderer: React.FC<ElkGraphRendererProps> = ({
       ref={containerRef}
       role="group"
       aria-label="Trace agent graph"
-      className="bg-background/50 relative h-full w-full cursor-grab overflow-hidden active:cursor-grabbing"
+      // `touch-none`: d3-zoom owns pan and pinch here. Without it WebKit zooms
+      // the page instead, since `preventDefault` cannot cancel its pinch.
+      className="bg-background/50 relative h-full w-full cursor-grab touch-none overflow-hidden active:cursor-grabbing"
       onPointerDown={(e) =>
         (pointerDownPos.current = { x: e.clientX, y: e.clientY })
       }

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -151,8 +151,9 @@ const MyApp: AppType<{ session: Session | null }> = ({
       {/* Replaces Next's default `width=device-width` (next/head dedupes by
           name). `maximum-scale=1` stops iOS Safari auto-zooming a focused
           sub-16px field; iOS ignores `user-scalable=no` for user gestures, so
-          the engine-level zoom block is `touch-action` on html/body
-          (styles/globals.css). `viewport-fit=cover` is what makes
+          the engine-level zoom block is `touch-action` on `#__next` and the
+          overlay layers — NOT on html/body, which WebKit ignores for page
+          pinch (styles/globals.css). `viewport-fit=cover` is what makes
           `env(safe-area-inset-*)` non-zero. */}
       <Head>
         <meta

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -607,10 +607,21 @@
   body {
     /* Prevent pull-to-refresh and rubber-banding on the page level only */
     overscroll-behavior-y: none;
-    /* Omitting `pinch-zoom` blocks pinch and double-tap zoom at the engine
-       level, which modern iOS honors where it ignores `user-scalable=no`
-       (viewport meta lives in pages/_app.tsx). Elements that own their own
-       gestures set their own `touch-action`. */
+  }
+
+  /* The page never zooms, so a pinch belongs to the surface under it (omitting
+     `pinch-zoom` is the block; the viewport meta lives in pages/_app.tsx).
+     Naming `html, body` alone is NOT enough: WebKit ignores root-level
+     `touch-action` for page pinch, just as it ignores `user-scalable=no`, and
+     overlays portal OUT of `#__next` into the layer containers, so each needs
+     the declaration. Deliberately layered — vaul injects
+     `[data-vaul-drawer]{touch-action:none}` unlayered, which beats any layer;
+     that is stricter, so the drawer keeps owning its drag. Surfaces that own a
+     gesture set their own `touch-action` (a `touch-*` utility wins over this). */
+  html,
+  body,
+  div#__next,
+  [data-overlay-root] > [data-layer] > * {
     touch-action: pan-x pan-y;
   }
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16150.preview.langfuse.com](https://pr-16150.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The mobile zoom lock from #16001 never actually held on iOS — not in the app, and not in the peek. It was declared only on `html, body`, and **WebKit ignores root-level `touch-action` for page pinch**, exactly as it ignores `user-scalable=no`. So on iOS the page stayed zoomable everywhere, and a pinch meant to drive a trace graph zoomed the page instead. This states the policy once — over the app root *and* every portalled overlay — and gives the graph's d3-zoom container the `touch-action` it needs to own its own gesture.

Seed: #16001 (`5dc661a42`).

## Why

Two-finger pinch on mobile was clashing with the surfaces that want that gesture — the trace graph, the timeline, the tree. Measured on a real iPhone, the reason was not the peek "leaking" a lock that worked elsewhere; the lock was not working anywhere on iOS:

| where you pinch | iOS Safari/WebKit, before |
| --- | --- |
| app content | **page zooms** (2.5×) |
| peek — mobile drawer | blocked, but only by accident (see below) |
| peek — desktop-shaped sheet | **page zooms** |

The mobile drawer looked locked only because **vaul** injects `[data-vaul-drawer]{touch-action:none}` at runtime, which happens to sit on a non-root element. Nothing in our own CSS was doing the work.

## What

One rule, one place, in `globals.css`:

```css
html, body,
div#__next,
[data-overlay-root] > [data-layer] > * { touch-action: pan-x pan-y; }
```

- `div#__next` — a **non-root** element, which is what WebKit actually honours.
- `[data-overlay-root] > [data-layer] > *` — overlays portal *out* of `#__next` into the layer containers, so ancestor inheritance never reaches them. Same selector the layer system already uses for `pointer-events`.
- It stays inside `@layer base` deliberately: vaul's rule is **unlayered**, so it beats any layered rule regardless of specificity. That rule is *stricter* than ours, so the drawer keeps owning its drag — our rule is a floor, not an override.

Plus `touch-none` on the trace graph's d3-zoom container, so a pinch there zooms the graph. WebKit's pinch is a UIProcess gesture that `preventDefault()` cannot cancel, so the element-level `touch-action` is the only thing that keeps the gesture.

## Result

The page never zooms — in the app shell, in the drawer peek, in the sheet peek — and gesture-owning surfaces keep their gesture. Vertical scrolling, drawer swipe-to-dismiss, and #16001's focus-zoom fix are all unchanged.

**Accessibility:** suppressing pinch-zoom cuts against WCAG 1.4.4, and iOS ignores `user-scalable=no` deliberately for that reason. This is a deliberate product call already taken in #16001; the mitigation is that content is legible without zoom. This PR only makes the existing decision hold consistently — it does not extend it.

<details>
<summary>Mechanism, measurements, and verification</summary>

### The two traps

1. **Root-level `touch-action` is not honoured for page pinch in WebKit.** Measured on a real iPhone: with `touch-action: pan-x pan-y` on `html, body` as the only lever, app content still zoomed to 4.9×. With no lever at all it zoomed to 2.4×. The viewport meta is ignored for user-initiated pinch too. So on iOS, *neither* of #16001's levers blocked page zoom.
2. **Portals escape ancestor inheritance in practice.** Overlays render into `body > [data-overlay-root] > [data-layer]`, outside `#__next`. Measured chain inside the live mobile peek, before this change:

   ```
   p:auto < … < [data-vaul-drawer]:none < [data-layer=panel]:auto
         < [data-overlay-root]:auto < body:pan-x pan-y < html:pan-x pan-y
   ```

   Every element between the touched node and `body` is `auto`; the only non-root declaration is vaul's.

### Cascade-layer gotcha (verified)

vaul calls `__insertCSS` at runtime, so its rules are **unlayered** and beat every `@layer`:

| rule on the drawer | computed |
| --- | --- |
| `@layer utilities { touch-action: pan-y }` | `none` (vaul wins) |
| unlayered `touch-action: pan-y` | `pan-y` (overrides vaul) |

This is why a Tailwind `touch-*` class on a vaul drawer silently does nothing, and why our rule is intentionally layered.

### Blink

Blink blocks page pinch via the **viewport meta**, everywhere including portals; `touch-action` on `html, body` does nothing for page zoom there either. Verified with real compositor pinch gestures (`Input.synthesizePinchGesture`, iPhone touch emulation), so Blink was already correct before and after.

### After the change

| check | result |
| --- | --- |
| `div#__next` computed `touch-action` | `pan-x pan-y` |
| peek sheet content (`[data-peek-content]`) | `pan-x pan-y` |
| vaul drawer (`[data-vaul-drawer]`) | still `none` — vaul keeps precedence |
| graph container | `none` |
| pinch on graph, full page | graph zooms, page does not |
| pinch on graph, inside the peek | graph zooms, page does not |
| touch scroll — traces table | scrolls |
| touch scroll — peek body | scrolls (through vaul's `none` ancestor) |
| vaul swipe-to-dismiss | dismisses |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the existing mobile page-zoom policy effective inside the app root and portalled overlays, while assigning trace-graph touch gestures to d3-zoom.
- Extends the global `touch-action` rule to `#__next` and direct children of overlay layers.
- Adds `touch-none` to the trace graph’s d3-zoom container.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable regressions identified.

The global selector covers the repository’s layered overlay mounting structure, and the graph gesture rule is applied to the same non-scrollable container already controlled by d3-zoom.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): hold the mobile zoom lock insi..."](https://github.com/langfuse/langfuse/commit/37b67450f74097dfe2e2bb375b1dd9a47872760a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53363714)</sub>

<!-- /greptile_comment -->