### PR TITLE
ci: harden playwright install retry and cache test-docker-build layers

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -346,7 +346,23 @@ jobs:
         # same reason. `prisma generate` only reads the schema; it needs no DB.
         run: pnpm --filter=shared run db:generate
       - name: Install playwright
-        run: pnpm --filter=web exec playwright install --with-deps --only-shell chromium
+        # apt-get (pulled in by --with-deps) occasionally stalls against a
+        # slow/unresponsive mirror and can ride the job's timeout-minutes
+        # instead of failing fast (observed: a 10-minute hang cancelled by
+        # the job timeout). A normal install takes well under a minute, so
+        # bound each attempt and retry instead of trusting the job-level
+        # timeout as the only guard.
+        run: |
+          attempt=1
+          until timeout 120 pnpm --filter=web exec playwright install --with-deps --only-shell chromium; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "Playwright install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "Attempt $attempt failed (possibly a stalled apt mirror), retrying in $((attempt * 15))s..." >&2
+            sleep $((attempt * 15))
+            attempt=$((attempt + 1))
+          done
       - name: run Storybook tests
         run: pnpm --filter web run test-storybook
       - name: build Storybook
@@ -429,6 +445,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
           password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
+      # test-docker-build previously built on a fresh local builder every run,
+      # unlike build-docker-image-release which already persists layers via a
+      # Blacksmith-backed builder. Same fix, applied here: cache-key is
+      # namespaced separately from the release cache-keys
+      # (langfuse/${{ image_name }}-${{ platform_tag }}) since this build uses
+      # different args (NEXT_IGNORE_BUILD_ERRORS=true) and only ever targets
+      # amd64. No nofallback here (unlike the release job): a Blacksmith
+      # hiccup should degrade this PR-check build to a slower local builder,
+      # not fail the check.
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@1e75355f81cbb3f93cba1eb5dd5e5b05110ca8f9 # v2.0.1
+        with:
+          cache-key: langfuse/test-${{ matrix.component }}
       - name: Set NEXT_PUBLIC_BUILD_ID
         run: echo "NEXT_PUBLIC_BUILD_ID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Start dependency containers in background

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -445,15 +445,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
           password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
-      # test-docker-build previously built on a fresh local builder every run,
-      # unlike build-docker-image-release which already persists layers via a
-      # Blacksmith-backed builder. Same fix, applied here: cache-key is
-      # namespaced separately from the release cache-keys
-      # (langfuse/${{ image_name }}-${{ platform_tag }}) since this build uses
-      # different args (NEXT_IGNORE_BUILD_ERRORS=true) and only ever targets
-      # amd64. No nofallback here (unlike the release job): a Blacksmith
-      # hiccup should degrade this PR-check build to a slower local builder,
-      # not fail the check.
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@1e75355f81cbb3f93cba1eb5dd5e5b05110ca8f9 # v2.0.1
         with:


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16152.preview.langfuse.com](https://pr-16152.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

Two independent, CI-only reliability/cost fixes surfaced by a Blacksmith CI right-sizing report. No release pipeline changes here.

### 1. `tests-storybook`: bound and retry the playwright install

`playwright install --with-deps` occasionally stalls on a slow/unresponsive apt mirror during the `--with-deps` step. The job only had a `timeout-minutes: 10` guard (added in #16023), so a stall rides the full 10 minutes before the whole job gets cancelled with no useful diagnostic.

Verified this is still actively happening, not just a historical/latent issue: pulling job history via the GitHub API found a real occurrence on 2026-08-14 (run [31806190450](https://github.com/langfuse/langfuse/actions/runs/31806190450)) where the "Install playwright" step ran 9m21s before being cancelled by the job timeout. Successful installs normally take 14-36s.

Fix: wrap the install in a bounded retry (2 min per attempt, up to 3 attempts, short backoff) instead of relying on the job-level timeout as the only guard, so a stalled mirror fails fast with a clear message and gets a couple of retries rather than silently burning most of the job's time budget.

### 2. `test-docker-build`: persist Docker layer cache

This job (runs on every PR) built images with a fresh local Docker builder every time, with no persistent layer cache. `build-docker-image-release` already solves this with `useblacksmith/setup-docker-builder` plus a `cache-key`; this applies the same pattern here, under its own cache-key namespace (`langfuse/test-<component>`) so it does not collide with the release build's cache (different build args, `NEXT_IGNORE_BUILD_ERRORS=true`, and amd64-only here).

Unlike the release job, this omits `nofallback`: a Blacksmith caching hiccup should degrade this PR check to a slower local builder, not fail the check outright.

## Out of scope

Deduplicating the release job's double build (once for GHCR, once for Docker Hub) is a separate, higher-risk change to the tag-triggered release path and is intentionally not included here.

## Verification

- `pnpm run lint`: `Tasks: 7 successful, 7 total`
- `zizmor .github/workflows/pipeline.yml`: `No findings to report.`
- YAML validity checked with `python3 -c "import yaml; yaml.safe_load(...)"`.
- No unit/integration tests apply (workflow YAML only); correctness will be observed on this PR's own CI runs (`tests-storybook` and `test-docker-build` jobs).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves CI reliability and cost efficiency without changing release behavior.
- Bounds Playwright dependency installation to three two-minute attempts with short backoffs.
- Adds persistent, component-scoped Docker layer caching to PR image builds.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the workflow changes bounded and appropriately isolated from release-build caches.

The Playwright retry remains within a finite limit, and the Docker cache is separated by component and from release cache namespaces while retaining local-builder fallback behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: drop explanatory comment on test-doc..."](https://github.com/langfuse/langfuse/commit/11b48ef3fdb6164a029e76dc29ab158d05a8f9d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53374125)</sub>

<!-- /greptile_comment -->