### PR TITLE
fix(v4): shorten sidebar lookback to three days

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -396,7 +396,7 @@ describe("V4MigrationDetailsContent", () => {
 
     expect(
       screen.getByText(
-        "SDK, instrumentation, experiment, and API checks cover activity from the last 14 days.",
+        "SDK, instrumentation, experiment, and API checks cover activity from the last 3 days.",
       ),
     ).toBeInTheDocument();
     expect(
@@ -567,7 +567,7 @@ describe("V4MigrationDetailsContent", () => {
           "ingestionSource;stringOptions;;any of;ingestion-api-dual-write," +
           "ingestionSdkName;stringOptions;;any of;python," +
           "ingestionSdkVersion;stringOptions;;any of;2.60.3",
-      )}&dateRange=14d`,
+      )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`,
     );
     expect(evidenceLink).toHaveAttribute("target", "_blank");
     expect(evidenceLink).toHaveAttribute("rel", "noopener noreferrer");
@@ -691,7 +691,7 @@ describe("V4MigrationDetailsContent", () => {
       `/project/project-1/observations?filter=${encodeURIComponent(
         "ingestionApiKey;stringOptions;;any of;," +
           "ingestionSource;stringOptions;;any of;otel-dual-write",
-      )}&dateRange=14d`,
+      )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`,
     );
     expect(evidenceLink).toHaveAttribute("target", "_blank");
     expect(evidenceLink).toHaveAttribute("rel", "noopener noreferrer");
@@ -961,7 +961,7 @@ describe("V4MigrationDetailsContent", () => {
       `/project/project-1/observations?filter=${encodeURIComponent(
         "ingestionApiKey;stringOptions;;any of;pk-lf-1234567890abcdef," +
           "ingestionSource;stringOptions;;any of;ingestion-api-dual-write",
-      )}&dateRange=14d`,
+      )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`,
     );
     expect(evidenceLink).toHaveAttribute("target", "_blank");
     expect(evidenceLink).toHaveAttribute("rel", "noopener noreferrer");

--- a/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
+++ b/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
@@ -165,6 +165,14 @@ describe("account v4 migration data", () => {
       expect.objectContaining({ orgId: "org-1" }),
       expect.objectContaining({ enabled: true }),
     );
+    const sdkRange = mocks.sdkUsageSummaryByProject.mock.calls[0]?.[0];
+    const apiRange = mocks.legacyApiUsageSummaryByProject.mock.calls[0]?.[0];
+    expect(
+      sdkRange.toTimestamp.getTime() - sdkRange.fromTimestamp.getTime(),
+    ).toBe(3 * 24 * 60 * 60 * 1000);
+    expect(
+      apiRange.toTimestamp.getTime() - apiRange.fromTimestamp.getTime(),
+    ).toBe(3 * 24 * 60 * 60 * 1000);
   });
 
   it("marks projects forced onto the v3 experience as partner-managed", () => {

--- a/web/src/features/v4-migration/migrationData.clienttest.ts
+++ b/web/src/features/v4-migration/migrationData.clienttest.ts
@@ -29,13 +29,13 @@ const migrationStatus = (
 });
 
 describe("v4 migration data", () => {
-  it("uses a stable fourteen-day range aligned to the hour", () => {
+  it("uses a stable three-day range aligned to the hour", () => {
     const range = createV4MigrationDetectionRange(
       new Date("2026-07-23T10:42:31.000Z").getTime(),
     );
 
     expect(range).toEqual({
-      fromTimestamp: new Date("2026-07-09T11:00:00.000Z"),
+      fromTimestamp: new Date("2026-07-20T11:00:00.000Z"),
       toTimestamp: new Date("2026-07-23T11:00:00.000Z"),
     });
   });

--- a/web/src/features/v4-migration/migrationData.ts
+++ b/web/src/features/v4-migration/migrationData.ts
@@ -1,7 +1,7 @@
 import { type RouterOutputs } from "@/src/utils/api";
 import { type V4MigrationSdkState } from "@/src/features/v4-migration/sdkVersionStatus";
 
-export const V4_MIGRATION_LOOKBACK_DAYS = 14;
+export const V4_MIGRATION_LOOKBACK_DAYS = 3;
 
 const V4_MIGRATION_LOOKBACK_MS =
   V4_MIGRATION_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16153.preview.langfuse.com](https://pr-16153.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- shorten the v4 sidebar detection lookback from 14 days to 3 days
- apply the window consistently to SDK, instrumentation, experiment, and legacy API checks
- update sidebar copy, evidence-link expectations, and regression coverage

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client src/features/v4-migration/migrationData.clienttest.ts src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts src/features/v4-migration/V4MigrationContent.clienttest.tsx` — `Tests 46 passed (46)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`

## Browser review

Browser signoff was attempted but blocked because the local Postgres and Redis services were unavailable.