### PR TITLE
fix(filters): hide non-matching facets during a sidebar search, active ones included

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -868,6 +868,8 @@ describe("DataTableControls facet-name search", () => {
     searchFor("token");
     expect(screen.getByText("Total Tokens")).toBeVisible();
     expect(screen.getByText("Environment")).not.toBeVisible();
+    // The query hides a facet whose name misses it even while it is filtering.
+    expect(screen.getByText("User ID")).not.toBeVisible();
     // The column key matches too: the label's space would defeat "userid".
     searchFor("userid");
     expect(screen.getByText("User ID")).toBeVisible();
@@ -881,20 +883,42 @@ describe("DataTableControls facet-name search", () => {
     expect(screen.getByText("x")).toBeInTheDocument();
   });
 
-  it("keeps a selected facet visible when it does not match, and says so", () => {
-    const { rerender } = render(controls(catalog(["userId"])));
+  it("reaches the no-match state with a filter active, without touching it", () => {
+    // A query hides every facet it misses, so the dead end is reachable while a
+    // filter is in force. Hiding is presentation ONLY: nothing here may reset,
+    // clear or re-apply anything, or a keystroke in the search box would change
+    // the rows on screen.
+    const mutations: string[] = [];
+    const filters = catalog(["userId"]).map((filter) => ({
+      ...filter,
+      onChange: () => mutations.push(`change:${filter.column}`),
+      onReset: () => mutations.push(`reset:${filter.column}`),
+    }));
+    const qf: QueryFilter = {
+      ...queryFilter(filters),
+      clearAll: () => mutations.push("clearAll"),
+      setFilterState: () => mutations.push("setFilterState"),
+      onExpandedChange: () => mutations.push("expand"),
+    };
+    render(
+      <TooltipProvider>
+        <DataTableControls queryFilter={qf} />
+      </TooltipProvider>,
+    );
 
     searchFor("zzz");
-    // Pinned by its selection, not by the query.
-    expect(screen.getByText("User ID")).toBeVisible();
+    expect(screen.getByText("User ID")).not.toBeVisible();
     expect(screen.getByText("Environment")).not.toBeVisible();
-    expect(
-      screen.getByText('No other filters match "zzz"'),
-    ).toBeInTheDocument();
-
-    // With nothing pinned above it, the same dead end drops the "other".
-    rerender(controls(catalog()));
     expect(screen.getByText('No filters match "zzz"')).toBeInTheDocument();
+    expect(mutations).toEqual([]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear filter search" }),
+    );
+    // Back in full, selection intact — its header summary still reads it.
+    expect(screen.getByText("User ID")).toBeVisible();
+    expect(screen.getByText("x")).toBeInTheDocument();
+    expect(mutations).toEqual([]);
   });
 
   it("hides a non-matching facet rather than unmounting it, so an open draft survives", () => {

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -284,28 +284,21 @@ export function DataTableControls({
   // must never narrow the list behind the user's back.
   const facetSearchQuery = showFacetSearch ? facetSearch.trim() : "";
 
-  // Matching facet columns, or null when not searching. Selected/added facets
-  // stay visible whether or not they match — a query must never hide what is
-  // currently filtering — so the match set is also what tells "nothing matched"
-  // apart from "only the pinned ones are left".
-  const facetSearchMatches = facetSearchQuery
-    ? new Set(
-        displayedFilters
-          .filter((filter) => facetNameRank(filter, facetSearchQuery) !== null)
-          .map((filter) => filter.column),
-      )
-    : null;
-  // Search FILTERS, it does not reorder: the settled promoted block and config
-  // order still own every position.
+  // The name search FILTERS, it does not reorder: the settled promoted block
+  // and config order still own every position. A facet whose name misses the
+  // query goes whether or not it is filtering — what is in force stays on show
+  // above the list (the header's active count, plus the search bar's tokens
+  // where there is one), so the sidebar need not repeat it mid-search.
   //
   // Non-matching facets are HIDDEN, never unmounted. Every facet holds
   // uncommitted local state — a typed-but-not-added text filter, a metadata
   // condition mid-build, a "show more" expansion, a debounced numeric draft —
-  // and unmounting throws all of it away with nothing said. Typing in a box
-  // above the list must not be able to do that.
-  const visibleFilters = facetSearchMatches
+  // and unmounting throws all of it away with nothing said. Now that an ACTIVE
+  // facet can be hidden too, that matters more, not less: hiding is
+  // presentation only and must never touch the filter state.
+  const visibleFilters = facetSearchQuery
     ? displayedFilters.filter(
-        (filter) => facetSearchMatches.has(filter.column) || isPromoted(filter),
+        (filter) => facetNameRank(filter, facetSearchQuery) !== null,
       )
     : displayedFilters;
   const visibleColumns = new Set(visibleFilters.map((filter) => filter.column));
@@ -411,6 +404,8 @@ export function DataTableControls({
 
     const changed = [...became, ...ceased];
     if (changed.length !== 1) return;
+    // A name search may be hiding the target; display:none has no box, so this
+    // simply does nothing rather than scrolling to an invisible row.
     const facetElement = scrollRootRef.current?.querySelector(
       `[data-facet-column="${CSS.escape(changed[0])}"]`,
     );
@@ -756,14 +751,11 @@ export function DataTableControls({
         })}
       </Accordion>
 
-      {/* Nothing in the catalog matched. Says "other" when pinned
-          selections are still listed above, so the message never
-          contradicts the facets on screen. */}
-      {facetSearchMatches?.size === 0 && (
+      {/* Nothing matched — including any facet currently filtering, which the
+          query hides like the rest. */}
+      {facetSearchQuery !== "" && visibleFilters.length === 0 && (
         <p className="text-muted-foreground px-3 pt-6 text-center text-xs break-words">
-          {visibleFilters.length > 0
-            ? `No other filters match "${facetSearchQuery}"`
-            : `No filters match "${facetSearchQuery}"`}
+          {`No filters match "${facetSearchQuery}"`}
         </p>
       )}
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16154.preview.langfuse.com](https://pr-16154.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The filter sidebar's facet-name search now hides **every** facet whose name misses the query — including facets that carry an applied filter. This **reverses an acceptance criterion from #16045** ("selected filters must stay visible even when they don't match the search"), on the product call that the sidebar shouldn't repeat, mid-search, what is already on display above it. Hiding stays presentation only: no filter, no draft and no result is touched.

Seed: #16045 (`e37d75334`).

## Why

#16045 pinned any facet carrying an applied filter, so a query could never empty the list. Search `token` on the events sidebar and you were still looking at Environment and Status — the two facets you had *not* asked about — because they happened to be filtering. The filters in force are already shown above the list, so the sidebar was duplicating them at exactly the moment someone asked it to show something else.

## What

- **One rule:** a facet is visible when its name matches the query. Nothing else pins it.
- **Simpler, not more conditional:** `visibleFilters` *is* the match set now, so the separate `facetSearchMatches` set disappears, and with it the two-branch empty state it existed to feed. One message remains — `No filters match "…"` — reachable now while a filter is applied.
- Value-less facets added through "Add filter" follow the same rule.

Net −6 lines in the component.

## Result

Searching the sidebar does what searching a list should: you see what you asked for and nothing else. What is filtering stays legible above it — the `Filters N` count in the sidebar header, plus the search bar's tokens on the events tables — and clearing the query restores the full list with every selection intact.

<details>
<summary>Mechanism, the invariant, the surface audit, and verification</summary>

### The invariant: hidden ≠ cleared

#16045 deliberately *hides* non-matching facets rather than unmounting them, because every facet holds uncommitted local state — a typed-but-not-added text filter, a metadata condition mid-build, a "show more" expansion, a debounced numeric draft. That reasoning matters more now, not less, since the facets being hidden can be ones with a filter applied. Hiding is a `hidden` attribute on a stable wrapper inside a single keyed child array; the filter state is never read or written by the search.

Pinned by tests: a query with a filter active fires none of the mutation callbacks the component owns (`onChange`, `onReset`, `clearAll`, `setFilterState`, `onExpandedChange`), and clearing it brings the facet back with its summary intact.

### Follow-scroll

A filter applied from the search bar scrolls the sidebar to that facet. With a query active, that facet may now be hidden — `display: none` has no box, so `scrollIntoView` simply does nothing rather than chasing an invisible row. Verified in the browser: applying `level:DEFAULT` from the search bar while the sidebar query was `token` left the sidebar at `scrollTop: 0`, showing only the four token facets, with the header count going 1 → 2.

### Expand/collapse-all

Already read the facets on screen, and gets more correct: it now offers to expand exactly the matches, and facets hidden by a query keep whatever expansion they had.

### Surface audit — where the facet search appears, and what still shows the active filters

The search appears on any sidebar with more than 12 filters, so the change is worth checking per surface:

| Surface | facets | search | always-visible active-filter display while searching |
| --- | --- | --- | --- |
| Events table (full page, desktop + mobile) | ~41 | yes | search-bar **tokens** + header `Filters N` |
| Traces | 22 | yes | header `Filters N` (count only) |
| Observations | 28 | yes | header `Filters N` (count only) |
| Sessions | 17 | yes | header `Filters N` (count only) |
| Scores | 13 | yes | header `Filters N` (count only) |
| Experiments (10), experiment items (8), prompts (4), eval logs (3), evaluators (3), monitors (2) | ≤10 | no | n/a |

Two things worth knowing rather than blocking on:

1. The grammar search bar renders only on the events tables. On traces / observations / sessions / scores the always-visible signal is the **count**, not which filters are applied; the tooltip that names them exists only on the collapsed rail. Clearing the query restores the list, so the information is one keystroke away.
2. In the **mobile events Filters sheet on embedded, page-scoped tables** (user- and session-detail tabs), the grammar bar is deliberately off and the inline layout suppresses the sidebar's own count badge, so while a query hides everything the sheet shows no count at all — the footer's "Show N results" is the only hint. A one-line change (render the badge in the inline header too) would close it; kept out of this PR to keep it surgical.

### Verification

- `pnpm --filter web run test-client src/components/table/data-table-controls.clienttest.tsx` — `Tests 28 passed (28)`. The two changed cases were confirmed to fail against the old `|| isPromoted(filter)` behaviour before the fix landed.
- `pnpm run lint` — `Tasks: 7 successful, 7 total`; `pnpm --filter web run typecheck` clean.
- Browser, events sidebar (41 facets) with `environment` filtered: query `token` hides the active Environment facet while the header stays `Filters 1`, the URL filter is byte-identical and the row count holds at 24. Query `zzz` reaches `No filters match "zzz"` with 0 facets on screen, the filter still applied and the search bar still showing its token. Clearing restores all 41 with both selections intact.
- Browser, sessions sidebar (18 facets): confirmed the facet search is present with no grammar bar, which is the surface-audit caveat above.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes facet-name search so every nonmatching facet is hidden, including facets with active filters, while preserving mounted component and filter state.

- Simplifies visibility calculation to the name-search match set.
- Consolidates the empty state into a single “No filters match” message.
- Extends tests to verify active filters remain unchanged while hidden and reappear after clearing the query.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The changed search path only controls wrapper visibility; active filter state and local facet state remain intact, and the updated empty state accurately reflects the visible match set.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filters): hide non-matching facets d..."](https://github.com/langfuse/langfuse/commit/4181666ba4b46f4cac7e13d3721d421cad6e5d2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53381276)</sub>

<!-- /greptile_comment -->