### PR TITLE
fix(assistant): keep the mobile drawer on the visible viewport

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
@@ -22,7 +22,9 @@ vi.mock(
   "@/src/features/in-app-agent/components/ControlledInAppAgentWindow",
   () => ({
     ControlledInAppAgentWindow: () => (
-      <div data-in-app-agent-window-drag-handle="true" data-testid="window" />
+      <div data-in-app-agent-window-drag-handle="true" data-testid="window">
+        <textarea data-testid="composer" />
+      </div>
     ),
   }),
 );
@@ -41,6 +43,43 @@ function firePointerEvent(
 
   Object.defineProperty(event, "pointerId", { value: init.pointerId });
   fireEvent(element, event);
+}
+
+// The visual viewport is how a phone reports the on-screen keyboard: it shrinks
+// while the layout viewport (`innerHeight`) does not. jsdom implements neither
+// side, so the test owns both.
+function stubVisualViewport(layoutHeight: number) {
+  const viewport = Object.assign(new EventTarget(), {
+    height: layoutHeight,
+    offsetTop: 0,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: layoutHeight,
+  });
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    writable: true,
+    value: viewport,
+  });
+
+  return function resizeTo(height: number, offsetTop = 0) {
+    viewport.height = height;
+    viewport.offsetTop = offsetTop;
+    viewport.dispatchEvent(new Event("resize"));
+  };
+}
+
+function stubHandheld() {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches: query.includes("pointer: coarse"),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
 }
 
 describe("InAppAgentWindowHost", () => {
@@ -136,14 +175,7 @@ describe("InAppAgentWindowHost", () => {
     // coarse-pointer clause can match. Pins that the shell asks the handheld
     // predicate, not the width-only one that sent a rotated phone back to the
     // floating window.
-    vi.stubGlobal(
-      "matchMedia",
-      vi.fn((query: string) => ({
-        matches: query.includes("pointer: coarse"),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      })),
-    );
+    stubHandheld();
     mocks.open = true;
 
     const { rerender } = render(<InAppAgentWindowHost />);
@@ -161,5 +193,42 @@ describe("InAppAgentWindowHost", () => {
       "data-state",
       "closed",
     );
+  });
+
+  it("re-anchors the handheld drawer to the visible viewport on every keyboard cycle", () => {
+    stubHandheld();
+    // A phone with a 669px viewport and a 290px keyboard, as reported.
+    const resizeViewportTo = stubVisualViewport(669);
+    mocks.open = true;
+
+    render(<InAppAgentWindowHost />);
+    const drawer = document.querySelector<HTMLElement>("#in-app-agent-drawer");
+    const composer = screen.getByTestId("composer");
+
+    // Repeated cycles are the point: the reported symptom needed "a couple of
+    // times", which is a flag falling out of phase rather than one bad
+    // measurement. iOS also reports the closing keyboard in more than one step
+    // and blurs the field on the way out.
+    for (const closingSteps of [[669], [520, 669], [669]]) {
+      composer.focus();
+      resizeViewportTo(669 - 290);
+      // Above the keyboard, and the anchors — never an inline height — own it.
+      expect(drawer?.style.bottom).toBe("290px");
+      expect(drawer?.style.height).toBe("");
+
+      composer.blur();
+      for (const height of closingSteps) {
+        resizeViewportTo(height);
+      }
+      expect(drawer?.style.bottom).toBe("0px");
+      expect(drawer?.style.height).toBe("");
+    }
+
+    // Safari can also scroll the visual viewport instead of shrinking it; the
+    // drawer follows the visible band rather than the layout viewport.
+    composer.focus();
+    resizeViewportTo(669 - 290, 290);
+    expect(drawer?.style.bottom).toBe("0px");
+    expect(drawer?.style.top).toBe("max(var(--banner-offset), 290px)");
   });
 });

--- a/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx
@@ -114,6 +114,9 @@ describe("InAppAgentWindowHost", () => {
   afterEach(() => {
     document.querySelector("[data-overlay-root]")?.remove();
     vi.unstubAllGlobals();
+    // jsdom has no visual viewport, so leaving a stubbed one behind would hand
+    // the next test a phone it never asked for.
+    Reflect.deleteProperty(window, "visualViewport");
   });
 
   it("keeps geometry while open and resets it on close/reopen", () => {

--- a/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, type ReactNode, type RefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
 
 import {
   MovableResizablePanel,
@@ -60,6 +66,58 @@ export function useInAppAgentWindowShellPanelControl({
   });
 }
 
+/**
+ * Holds a top/bottom-anchored fixed element on the *visible* viewport while the
+ * on-screen keyboard is up.
+ *
+ * A phone's keyboard shrinks the visual viewport but not the layout viewport
+ * that `position: fixed` measures from, so `bottom: 0` lands behind the
+ * keyboard. Recomputed from what the viewport reports on every event and never
+ * accumulated: no number of open/close cycles can leave it out of phase, and
+ * anything unexpected clamps back to the plain CSS anchoring. Written straight
+ * onto the element because a keyboard transition streams events and the
+ * assistant is an expensive tree to re-render.
+ */
+function useVisibleViewportAnchoring(
+  element: HTMLElement | null,
+  isEnabled: boolean,
+) {
+  useEffect(() => {
+    // External system: the visual viewport. `resize` fires when the keyboard
+    // opens or closes, `scroll` when Safari slides the visible band instead to
+    // reveal a focused field. Absent on older browsers — CSS then owns it.
+    const viewport = window.visualViewport;
+    if (!isEnabled || !element || !viewport) {
+      return;
+    }
+
+    const anchor = () => {
+      const bandTop = Math.max(0, Math.round(viewport.offsetTop));
+      const hiddenBelowBand = Math.max(
+        0,
+        Math.round(window.innerHeight - viewport.height - bandTop),
+      );
+
+      element.style.bottom = `${hiddenBelowBand}px`;
+      // `max()` so the banner keeps the top edge whenever it is the lower of
+      // the two; written at all only while the band is scrolled.
+      element.style.top =
+        bandTop > 0 ? `max(var(--banner-offset), ${bandTop}px)` : "";
+    };
+
+    anchor();
+    viewport.addEventListener("resize", anchor);
+    viewport.addEventListener("scroll", anchor);
+
+    return () => {
+      viewport.removeEventListener("resize", anchor);
+      viewport.removeEventListener("scroll", anchor);
+      element.style.bottom = "";
+      element.style.top = "";
+    };
+  }, [element, isEnabled]);
+}
+
 type InAppAgentWindowShellProps = {
   children: (props: { isHeaderDragHandleEnabled: boolean }) => ReactNode;
   floatingPanelHandle: MovableResizablePanelHandle;
@@ -80,6 +138,14 @@ export function InAppAgentWindowShell({
   panelRef,
 }: InAppAgentWindowShellProps) {
   const isHandheld = useIsHandheld();
+  // State, not a ref: the drawer portals into its layer container, which itself
+  // resolves in an effect, so the node arrives a commit late and has to be the
+  // dependency that arms the anchoring.
+  const [drawerElement, setDrawerElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+
+  useVisibleViewportAnchoring(drawerElement, isHandheld && open);
 
   // A phone has one presentation: the whole screen below the banner. A real
   // (Vaul) modal drawer — the same treatment as the support / migration
@@ -103,8 +169,17 @@ export function InAppAgentWindowShell({
         }}
         dismissible={false}
         forceDirection="bottom"
+        // Vaul's own keyboard dodge is off because it is stateful: it toggles a
+        // "keyboard is open" flag on every large visual-viewport step instead of
+        // reading the direction, so an extra step — iOS reports the closing
+        // keyboard in two — leaves the flag inverted, and the next dismissal is
+        // skipped entirely, stranding the drawer at keyboard height. It also
+        // writes an inline `height`, which over-constrains this box.
+        // `useVisibleViewportAnchoring` above does the same job statelessly.
+        repositionInputs={false}
       >
         <DrawerContent
+          ref={setDrawerElement}
           id="in-app-agent-drawer"
           size="full"
           // `h-auto` at every breakpoint so top/bottom anchoring owns the
@@ -112,8 +187,7 @@ export function InAppAgentWindowShell({
           // and the `md:` half survives tailwind-merge — a landscape phone is
           // both handheld and wider than `md`, and `top` + `bottom` + `height`
           // over-constrains the box, dropping `bottom` and pushing the composer
-          // off-screen by the banner offset. Vaul still overrides the height to
-          // dodge the on-screen keyboard.
+          // off-screen by the banner offset.
           className="top-banner-offset inset-x-0 bottom-0 h-auto rounded-none border-0 md:h-auto"
           onEscapeKeyDown={(event) => {
             event.preventDefault();

--- a/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -169,13 +169,11 @@ export function InAppAgentWindowShell({
         }}
         dismissible={false}
         forceDirection="bottom"
-        // Vaul's own keyboard dodge is off because it is stateful: it toggles a
-        // "keyboard is open" flag on every large visual-viewport step instead of
-        // reading the direction, so an extra step — iOS reports the closing
-        // keyboard in two — leaves the flag inverted, and the next dismissal is
-        // skipped entirely, stranding the drawer at keyboard height. It also
-        // writes an inline `height`, which over-constrains this box.
-        // `useVisibleViewportAnchoring` above does the same job statelessly.
+        // Vaul's own keyboard dodge is off: it TOGGLES a "keyboard is open" flag
+        // on every large visual-viewport step instead of reading the direction,
+        // so one extra step — iOS reports a closing keyboard in two — inverts it
+        // and the next dismissal is skipped, stranding the drawer at keyboard
+        // height. It also writes an inline `height`, over-constraining this box.
         repositionInputs={false}
       >
         <DrawerContent


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16155.preview.langfuse.com](https://pr-16155.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

On a phone, opening the Assistant, tapping into the composer and dismissing the keyboard **a couple of times** left the drawer occupying only the upper half of the screen, with a keyboard-sized band of dead space below the composer. Everything inside was laid out correctly — only the drawer's height was wrong.

The cause is not our geometry: it is Vaul's keyboard dodge, which decides *"is the keyboard up?"* by **toggling** a flag on every large visual-viewport step instead of reading the direction of the change. iOS reports a closing keyboard in more than one step, so the flag falls out of phase — and once it does, Vaul's own guard skips the next dismissal entirely and the keyboard-open height survives.

This turns that dodge off for this one drawer and **derives** the geometry from the visual viewport instead. Nothing accumulates, so no number of cycles can desynchronise it.

## Why

The handheld Assistant is a Vaul drawer anchored `top` + `bottom` with `h-auto`, deliberately: it is a page, not a sheet. Vaul dodges the on-screen keyboard by writing an **inline `height`** onto that box — which over-constrains a top+bottom box, so a wrong height becomes visible dead space rather than a shifted panel.

Worse, the height it writes depends on state it accumulates across events:

```js
// vaul@1.1.2
if (Math.abs(previousDiffFromInitial.current - diffFromInitial) > 60) {
  keyboardIsOpen.current = !keyboardIsOpen.current;   // a toggle, not an observation
}
```

and every write is behind `if (isInput(document.activeElement) || keyboardIsOpen.current)`. The keyboard blurs the field on its way out, so once the flag is inverted, **both** halves of that guard are false and the dismissal is a no-op.

"Takes a couple of times" was the whole tell: state that desynchronises, not a miscalculation.

## What

- `repositionInputs={false}` on the handheld drawer — the sanctioned upstream opt-out of the `visualViewport` logic.
- A small hook in the shell that, on every visual-viewport `resize`/`scroll`, moves the drawer's **bottom anchor** up by the layout-viewport band hidden below the visible one, and follows the band's **top** when Safari scrolls the viewport instead of shrinking it. No inline height at all — the anchors keep owning the box.

Every value is recomputed from what the viewport reports right now, and anything unexpected clamps to `0`, which is exactly today's plain CSS anchoring. Android needs no special case: where the keyboard resizes the layout viewport, the hidden band is zero and `bottom: 0` is already correct.

## Result

Full height below the banner after any number of keyboard cycles; composer and send button stay above the keyboard while it is up; the banner inset is respected in both states. Sibling change: #16001, which put `viewport-fit=cover` and the safe-area insets into this same geometry — its wins are untouched here (no viewport meta, `touch-action`, or safe-area change).

Scoped on purpose: `components/ui/drawer.tsx` is **not** touched, so the support drawer and the v4 migration panel are unaffected.

<details>
<summary>Mechanism, the instrumentation trace, verification, and the alternatives considered</summary>

### The trace

Driven through Vaul's real handler with an iOS-shaped event sequence — a 669px viewport, a 290px keyboard, no banner:

**Before**

```
1 keyboard opens          vv=379  focus=TEXTAREA  height=379px  bottom=290px  box=379px
1 keyboard closes         vv=669  focus=TEXTAREA  height=669px  bottom=  0px  box=669px
2 keyboard opens          vv=379  focus=TEXTAREA  height=379px  bottom=290px  box=379px
2 keyboard closes (1/2)   vv=539  focus=TEXTAREA  height=669px  bottom=130px  box=669px   <- flips the flag a 2nd time
2 keyboard closes (2/2)   vv=669  focus=TEXTAREA  height=669px  bottom=  0px  box=669px
3 keyboard opens          vv=379  focus=TEXTAREA  height=379px  bottom=290px  box=379px
3 keyboard closes         vv=669  focus=BODY      height=379px  bottom=290px  box=379px   <- stranded
```

Row 4 is the extra step (Safari restoring its bottom toolbar once the keyboard is gone). From row 5 the flag is inverted; on row 7 the field is blurred, the guard is false, and the inline `height: 379px` — the visual viewport while the keyboard was up — plus `bottom: 290px` survive.

379px of drawer over 290px of dead space in a 669px viewport is the reported screenshot to the pixel.

**After**

```
1 keyboard opens          vv=379  focus=TEXTAREA  height=  -   bottom=290px  box=379px
1 keyboard closes         vv=669  focus=TEXTAREA  height=  -   bottom=  0px  box=669px
2 keyboard opens          vv=379  focus=TEXTAREA  height=  -   bottom=290px  box=379px
2 keyboard closes (1/2)   vv=539  focus=TEXTAREA  height=  -   bottom=130px  box=539px
2 keyboard closes (2/2)   vv=669  focus=TEXTAREA  height=  -   bottom=  0px  box=669px
3 keyboard opens          vv=379  focus=TEXTAREA  height=  -   bottom=290px  box=379px
3 keyboard closes         vv=669  focus=BODY      height=  -   bottom=  0px  box=669px
```

The half-retracted step now tracks the keyboard (539px) instead of snapping to full height and back, which removes the flicker reported alongside the stuck state.

### Verification

Real Chrome at 390x669 with the visual viewport scripted (the layout and CSS are real; only the keyboard is simulated), and the same sequence as a client test:

| state | box |
| --- | --- |
| keyboard closed | `top=0 h=669` |
| keyboard open | `top=0 h=379`, composer bottom 336, send button bottom 366 — both above the band |
| viewport scrolled instead of shrunk | `top=290 h=379 bottom=669` — the visible band exactly |
| with a 40px banner, keyboard open | `top=40 h=339 bottom=379` |
| close and reopen | inline styles cleared, `top=0 h=669` |
| page behind, keyboard open | `body{overflow:hidden}`, `scrollY` unchanged |
| landscape shape (700x360), 200px keyboard | `h=160` — cramped, but the composer and send button stay inside the band and typing works; the tab row is what gets covered |

`--banner-offset` is 0 on a dev machine, which is how banner-anchored geometry passes while broken, so the banner row above was measured with the variable forced.

**Still needs a device**: real iOS Safari and Android Chrome, portrait and landscape. Chrome's touch emulation does not reproduce iOS keyboard or `visualViewport` behaviour, so this is not certified from emulation.

### Alternatives considered

- **Upgrade Vaul** — 1.1.2 is the latest release and the upstream reports (emilkowalski/vaul#294, #538) are open, so there is nothing to upgrade to.
- **Patch Vaul** (`keyboardIsOpen.current = <direction of the change>`) — the true root-cause fix and it would cover every drawer, but it re-points a dependency for all twelve drawer surfaces to fix one, and it would leave the geometry dependent on a heuristic we cannot test. Kept as the upstream report instead.
- **Neutralise the inline writes with `!important`** — the common community workaround. It removes the dodge along with the bug: the composer then sits behind the keyboard.
- **Solve it in CSS** (`100dvh`, or `interactive-widget=resizes-content` in the viewport meta) — neither reaches the case: the dynamic viewport units do not account for the virtual keyboard on iOS, and `interactive-widget` is not implemented in iOS Safari, which is where this was reported. `visualViewport` is the only signal that carries it.

### Trade-off

`repositionInputs={false}` also switches off Vaul's react-aria iOS scroll prevention. Vaul's *other* lock is independent and stays: `usePositionFixed` still pins `body { position: fixed }` on iOS, and `react-remove-scroll` still locks the page behind the overlay (verified above). What is lost is the focus transform that suppressed Safari's own scroll-into-view — which is why the hook follows `visualViewport.offsetTop` as well as its height.

### Follow-up (not in this PR)

The mobile support drawer and the v4 migration panel are the same shape — top+bottom anchored full-screen drawers, and the support drawer has text inputs — so they are exposed to the same upstream hazard with no report against them yet. Worth lifting this anchoring into the drawer primitive as an opt-in for full-screen mobile drawers, in its own change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
