### PR TITLE
fix(otel): preserve structured gen_ai.system_instructions instead of coercing to '[object Object]'

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -63,6 +63,56 @@ function parseObservationLevel(
   return OBSERVATION_LEVEL_ALIASES[value.trim().toUpperCase()];
 }
 
+/**
+ * Extracts plain text from a parts array as emitted by Google/Gemini,
+ * Microsoft Agent, and LiteLLM (each part carrying its text in `text` or
+ * `content`). Non-text parts are dropped rather than coerced.
+ */
+function textFromParts(parts: unknown): string {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .map((part: unknown) => {
+      if (typeof part === "string" || typeof part === "number") {
+        return String(part);
+      }
+      if (part && typeof part === "object") {
+        const p = part as Record<string, unknown>;
+        if (typeof p.text === "string") return p.text;
+        if (typeof p.content === "string") return p.content;
+      }
+      return "";
+    })
+    .filter((text: string) => text !== "")
+    .join("\n");
+}
+
+/**
+ * Converts a single gen_ai.system_instructions element to text. Providers
+ * emit several shapes: plain strings, {type: "text", content}, and complete
+ * messages shaped {role, parts: [...]} (LiteLLM). Objects that match none of
+ * these are JSON-serialized so structured instructions are preserved instead
+ * of being destroyed by string coercion ("[object Object]").
+ */
+function systemInstructionToText(instruction: unknown): string {
+  if (typeof instruction === "string" || typeof instruction === "number") {
+    return String(instruction);
+  }
+  if (instruction && typeof instruction === "object") {
+    const rec = instruction as Record<string, unknown>;
+    if (typeof rec.content === "string" && rec.content) return rec.content;
+    if (Array.isArray(rec.content)) {
+      const fromContent = textFromParts(rec.content);
+      if (fromContent) return fromContent;
+    }
+    if (Array.isArray(rec.parts)) {
+      const fromParts = textFromParts(rec.parts);
+      if (fromParts) return fromParts;
+    }
+    return JSON.stringify(instruction);
+  }
+  return "";
+}
+
 // Type definitions for internal processor state
 interface TraceState {
   hasFullTrace: boolean;
@@ -2208,20 +2258,19 @@ export class OtelIngestionProcessor {
           typeof systemInstructions === "string"
             ? JSON.parse(systemInstructions)
             : systemInstructions;
-        if (Array.isArray(parsed)) {
-          content = parsed
-            .map((p: Record<string, unknown>) =>
-              typeof p === "object" && p?.content
-                ? String(p.content)
-                : String(p),
-            )
-            .join("\n");
-        } else {
-          content = String(parsed);
-        }
+        content = Array.isArray(parsed)
+          ? parsed
+              .map((p: unknown) => systemInstructionToText(p))
+              .filter((text: string) => text !== "")
+              .join("\n")
+          : systemInstructionToText(parsed);
       } catch {
         content = String(systemInstructions);
       }
+
+      // Nothing extractable (e.g. an empty instruction list): skip instead of
+      // prepending an empty system message.
+      if (!content) return input;
 
       const systemMessage = { role: "system", content };
       const merged = [systemMessage, ...messages];

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -2778,6 +2778,295 @@ describe("OTel Resource Span Mapping", () => {
       expect(observationEvent?.body.input).toBe(JSON.stringify(allMessages));
     });
 
+    it("should extract text from structured {role, parts} system instructions (LiteLLM)", async () => {
+      const traceId = "abcdef1234567890abcdef1234567892";
+
+      const allMessages = [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "Hello" }],
+        },
+      ];
+
+      // LiteLLM emits gen_ai.system_instructions as complete messages shaped
+      // {role, parts: [...]} without a top-level content field. Previously
+      // these were coerced with String() and rendered as "[object Object]",
+      // silently destroying the instructions.
+      const systemInstructions = [
+        {
+          role: "system",
+          parts: [
+            {
+              type: "text",
+              text: "You are a helpful assistant routed through LiteLLM.",
+            },
+          ],
+        },
+      ];
+
+      const pydanticAiSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "pydantic-ai",
+              version: "1.66.0",
+              attributes: [],
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("80854cd6bd218bf7", "hex"),
+                name: "agent run",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "logfire.msg",
+                    value: { stringValue: "agent run" },
+                  },
+                  {
+                    key: "final_result",
+                    value: { stringValue: "result" },
+                  },
+                  {
+                    key: "pydantic_ai.all_messages",
+                    value: {
+                      stringValue: JSON.stringify(allMessages),
+                    },
+                  },
+                  {
+                    key: "gen_ai.system_instructions",
+                    value: {
+                      stringValue: JSON.stringify(systemInstructions),
+                    },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        pydanticAiSpan,
+        new Set(),
+      );
+
+      const observationEvent = events.find((e) => e.type === "span-create");
+      expect(observationEvent).toBeDefined();
+
+      const expectedMessages = [
+        {
+          role: "system",
+          content: "You are a helpful assistant routed through LiteLLM.",
+        },
+        ...allMessages,
+      ];
+
+      expect(observationEvent?.body.input).toBe(
+        JSON.stringify(expectedMessages),
+      );
+      // The extracted text must not fall back to object string coercion
+      expect(observationEvent?.body.input).not.toContain("[object Object]");
+    });
+
+    it("should prepend plain string system instructions", async () => {
+      const traceId = "abcdef1234567890abcdef1234567893";
+
+      const allMessages = [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "Hello" }],
+        },
+      ];
+
+      const systemInstructions = ["You are a concise assistant."];
+
+      const pydanticAiSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "pydantic-ai",
+              version: "1.66.0",
+              attributes: [],
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("80854cd6bd218bf8", "hex"),
+                name: "agent run",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "logfire.msg",
+                    value: { stringValue: "agent run" },
+                  },
+                  {
+                    key: "final_result",
+                    value: { stringValue: "result" },
+                  },
+                  {
+                    key: "pydantic_ai.all_messages",
+                    value: {
+                      stringValue: JSON.stringify(allMessages),
+                    },
+                  },
+                  {
+                    key: "gen_ai.system_instructions",
+                    value: {
+                      stringValue: JSON.stringify(systemInstructions),
+                    },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        pydanticAiSpan,
+        new Set(),
+      );
+
+      const observationEvent = events.find((e) => e.type === "span-create");
+      expect(observationEvent).toBeDefined();
+
+      const expectedMessages = [
+        { role: "system", content: "You are a concise assistant." },
+        ...allMessages,
+      ];
+
+      expect(observationEvent?.body.input).toBe(
+        JSON.stringify(expectedMessages),
+      );
+    });
+
+    it("should not prepend a system message when the instruction list is empty", async () => {
+      const traceId = "abcdef1234567890abcdef1234567894";
+
+      const allMessages = [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "Hello" }],
+        },
+      ];
+
+      const systemInstructions: unknown[] = [];
+
+      const pydanticAiSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "pydantic-ai",
+              version: "1.66.0",
+              attributes: [],
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("80854cd6bd218bf9", "hex"),
+                name: "agent run",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "logfire.msg",
+                    value: { stringValue: "agent run" },
+                  },
+                  {
+                    key: "final_result",
+                    value: { stringValue: "result" },
+                  },
+                  {
+                    key: "pydantic_ai.all_messages",
+                    value: {
+                      stringValue: JSON.stringify(allMessages),
+                    },
+                  },
+                  {
+                    key: "gen_ai.system_instructions",
+                    value: {
+                      stringValue: JSON.stringify(systemInstructions),
+                    },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        pydanticAiSpan,
+        new Set(),
+      );
+
+      const observationEvent = events.find((e) => e.type === "span-create");
+      expect(observationEvent).toBeDefined();
+
+      // Empty instruction list must not yield an empty system message
+      expect(observationEvent?.body.input).toBe(JSON.stringify(allMessages));
+    });
+
     it("should prioritize OpenInference over OTel GenAI and model detection", async () => {
       const resourceSpan = {
         scopeSpans: [


### PR DESCRIPTION
## Problem

`gen_ai.system_instructions` is emitted by several providers as a JSON array. The current mapping in `prependSystemInstructions` keeps a truthy top-level `content` field but falls back to `String(element)` for everything else.

Complete messages shaped `{role: "system", parts: [...]}` — as emitted by [LiteLLM](https://docs.litellm.ai/docs/observability/opentelemetry_integration#attributes-reference) — have no top-level `content`, so the fallback coerces them to `"[object Object]"` and the system instructions are silently destroyed during ingestion. That permanently loses captured observability data and produces misleading trace input.

## Changes

Replace the coercion in `prependSystemInstructions` (`packages/shared/src/server/otel/OtelIngestionProcessor.ts`) with shape-aware extraction:

- keep plain string/number instructions as-is
- read a top-level string `content` when present (existing behaviour)
- extract text from `content` or `parts` arrays, supporting both the `text` (Google) and `content` (Microsoft Agent) part fields, matching the conventions used by the chatml adapters
- serialize any remaining object with `JSON.stringify` so structured instructions are preserved instead of lost
- skip prepending when nothing extractable remains (e.g. an empty instruction list) rather than emitting an empty system message

## Tests

Add otel mapping regression tests covering:

- the `{role, parts}` shape (asserts the extracted text is prepended and `[object Object]` never appears)
- plain string instructions
- the empty instruction list (no empty system message is prepended)

Verified: reverting the fix makes the new tests fail with the `[object Object]` content; with the fix all 248 tests in `otelMapping.servertest.ts` pass.

Closes #15336

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds shape-aware extraction for structured OTel system instructions and regression coverage for LiteLLM-style parts, strings, and empty lists. The new fallback needs to satisfy its declared non-nullable return contract.
- Extracts text from content and parts arrays.
- JSON-serializes otherwise-unrecognized objects.
- Avoids prepending empty system messages.
- Adds focused OTel ingestion regression tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The shared-package type failure should be corrected before merging.

The new helper returns a potentially undefined JSON.stringify result from a function declared to return string, while the shared package is compiled with strict TypeScript checks.

**Files Needing Attention:** packages/shared/src/server/otel/OtelIngestionProcessor.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:111
**JSON fallback breaks return contract**

Under the shared package's strict TypeScript configuration, `JSON.stringify` returns `string | undefined`, but `systemInstructionToText` declares a `string` return, causing the shared package typecheck and build to fail.

```suggestion
    return JSON.stringify(instruction) ?? "";
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): preserve structured gen\_ai.sy..."](https://github.com/langfuse/langfuse/commit/5981d6b69b4d07c61d3c5f348b114840474ecdde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53385705)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->