### PR TITLE
fix: render reasoning for empty completions

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/generic.ts
+++ b/packages/shared/src/utils/chatml/adapters/generic.ts
@@ -64,6 +64,26 @@ function normalizeGoogleMessage(msg: unknown): Record<string, unknown> {
   return normalized;
 }
 
+function normalizeLegacyReasoningOutput(data: unknown): unknown {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return data;
+
+  const output = data as Record<string, unknown>;
+  const keys = Object.keys(output);
+  if (
+    keys.length !== 2 ||
+    typeof output.completion !== "string" ||
+    typeof output.reasoning !== "string"
+  ) {
+    return data;
+  }
+
+  return {
+    role: "assistant",
+    content: output.completion,
+    thinking: [{ type: "thinking", content: output.reasoning }],
+  };
+}
+
 function preprocessData(data: unknown): unknown {
   if (!data) return data;
 
@@ -154,9 +174,11 @@ export const genericAdapter: ProviderAdapter = {
 
   preprocess(
     data: unknown,
-    _kind: "input" | "output",
+    kind: "input" | "output",
     _ctx: NormalizerContext,
   ): unknown {
-    return preprocessData(data);
+    return preprocessData(
+      kind === "output" ? normalizeLegacyReasoningOutput(data) : data,
+    );
   },
 };

--- a/web/src/features/traces/hooks/useChatMLParser.clienttest.ts
+++ b/web/src/features/traces/hooks/useChatMLParser.clienttest.ts
@@ -2,6 +2,39 @@ import { renderHook } from "@testing-library/react";
 import { type ChatMLParserResult, useChatMLParser } from "./useChatMLParser";
 
 describe("useChatMLParser", () => {
+  it("preserves reasoning when a legacy completion is empty", () => {
+    const input = [{ role: "user", content: "Solve this problem." }];
+    const output = {
+      completion: "",
+      reasoning: "Work through the constraints first.",
+    };
+
+    const { result } = renderHook(() =>
+      useChatMLParser(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        input,
+        output,
+      ),
+    );
+
+    expect(result.current.canDisplayAsChat).toBe(true);
+    expect(result.current.allMessages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: "",
+        thinking: [
+          {
+            type: "thinking",
+            content: "Work through the constraints first.",
+          },
+        ],
+      }),
+    );
+  });
+
   it("groups output-side tool call arguments by tool name", () => {
     const input = {
       messages: [


### PR DESCRIPTION
## What changed

- Normalize the exact legacy `{ completion, reasoning }` output shape into an assistant ChatML message.
- Preserve reasoning as a thinking block even when `completion` is an empty string.
- Add client regression coverage for the observation panel parser.

## Why

Legacy reasoning-model output with an empty completion was treated as passthrough JSON. The pretty observation view therefore dropped the reasoning block and fell back to the flat JSON representation.

## Root cause

The generic ChatML adapter did not recognize the legacy completion/reasoning pair, so normalization stored both fields under `json` instead of mapping `reasoning` to `thinking`.

## Impact

The observation panel now renders reasoning output consistently for empty completions. The adapter only matches objects containing exactly the two legacy string fields, so unrelated structured outputs are unchanged.

## Validation

- `pnpm --filter web run test-client src/features/traces/hooks/useChatMLParser.clienttest.ts` (4 tests passed)
- `pnpm --filter @langfuse/shared run build`
- Web TypeScript typecheck
- ESLint on both changed files
- Prettier check
- `git diff --check`

Fixes #15343

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates generic ChatML output normalization so legacy `{ completion, reasoning }` objects render as assistant messages, preserving reasoning when completion is empty.
- Restricts conversion to output objects containing exactly the two expected string fields.
- Adds client regression coverage for empty-completion reasoning output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The normalized assistant message matches the canonical ChatML schema, survives generic preprocessing, and reaches the existing thinking-block rendering path; the regression test covers the reported empty-completion case.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: render reasoning for empty completi..."](https://github.com/langfuse/langfuse/commit/f70d1d70b984b1d9524942fbf391db82dde8a960) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53719006)</sub>

<!-- /greptile_comment -->