### PR TITLE
fix(annotation-queues): navigate completed queue items

### DIFF
--- a/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
@@ -127,8 +127,8 @@ describe("annotationQueueItems trpc", () => {
     });
   });
 
-  describe("completed queue navigation", () => {
-    it("returns unseen completed items in queue order", async () => {
+  describe("navigationById", () => {
+    it("returns adjacent completed queue items in queue order", async () => {
       const setup = await createOrgProjectAndApiKey();
       orgIds.push(setup.org.id);
 
@@ -166,31 +166,30 @@ describe("annotationQueueItems trpc", () => {
       ]);
 
       await expect(
-        caller.annotationQueueItems.unseenPendingItemCountByQueueId({
+        caller.annotationQueueItems.navigationById({
           projectId: setup.project.id,
           queueId: queue.id,
-          seenItemIds: [],
-          status: AnnotationQueueStatus.COMPLETED,
+          itemId: firstItem.id,
         }),
-      ).resolves.toBe(2);
+      ).resolves.toEqual({
+        previousItemId: null,
+        nextItemId: secondItem.id,
+        position: 1,
+        totalItems: 2,
+      });
 
       await expect(
-        caller.annotationQueues.fetchAndLockNext({
+        caller.annotationQueueItems.navigationById({
           projectId: setup.project.id,
           queueId: queue.id,
-          seenItemIds: [],
-          status: AnnotationQueueStatus.COMPLETED,
+          itemId: secondItem.id,
         }),
-      ).resolves.toMatchObject({ id: firstItem.id });
-
-      await expect(
-        caller.annotationQueues.fetchAndLockNext({
-          projectId: setup.project.id,
-          queueId: queue.id,
-          seenItemIds: [firstItem.id],
-          status: AnnotationQueueStatus.COMPLETED,
-        }),
-      ).resolves.toMatchObject({ id: secondItem.id });
+      ).resolves.toEqual({
+        previousItemId: firstItem.id,
+        nextItemId: null,
+        position: 2,
+        totalItems: 2,
+      });
     });
   });
 });

--- a/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
@@ -1,6 +1,9 @@
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import { AnnotationQueueObjectType } from "@langfuse/shared";
+import {
+  AnnotationQueueObjectType,
+  AnnotationQueueStatus,
+} from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
@@ -121,6 +124,73 @@ describe("annotationQueueItems trpc", () => {
           itemId: item.id,
         }),
       ).rejects.toThrow("User does not have access to this resource or action");
+    });
+  });
+
+  describe("completed queue navigation", () => {
+    it("returns unseen completed items in queue order", async () => {
+      const setup = await createOrgProjectAndApiKey();
+      orgIds.push(setup.org.id);
+
+      const { caller } = createCallerForProjectRole(setup);
+      const queue = await prisma.annotationQueue.create({
+        data: {
+          name: "Completed Queue",
+          scoreConfigIds: [],
+          projectId: setup.project.id,
+        },
+      });
+      const [firstItem, secondItem] = await Promise.all([
+        prisma.annotationQueueItem.create({
+          data: {
+            queueId: queue.id,
+            objectId: uuidv4(),
+            objectType: AnnotationQueueObjectType.TRACE,
+            projectId: setup.project.id,
+            status: AnnotationQueueStatus.COMPLETED,
+            completedAt: new Date(),
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          },
+        }),
+        prisma.annotationQueueItem.create({
+          data: {
+            queueId: queue.id,
+            objectId: uuidv4(),
+            objectType: AnnotationQueueObjectType.TRACE,
+            projectId: setup.project.id,
+            status: AnnotationQueueStatus.COMPLETED,
+            completedAt: new Date(),
+            createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          },
+        }),
+      ]);
+
+      await expect(
+        caller.annotationQueueItems.unseenPendingItemCountByQueueId({
+          projectId: setup.project.id,
+          queueId: queue.id,
+          seenItemIds: [],
+          status: AnnotationQueueStatus.COMPLETED,
+        }),
+      ).resolves.toBe(2);
+
+      await expect(
+        caller.annotationQueues.fetchAndLockNext({
+          projectId: setup.project.id,
+          queueId: queue.id,
+          seenItemIds: [],
+          status: AnnotationQueueStatus.COMPLETED,
+        }),
+      ).resolves.toMatchObject({ id: firstItem.id });
+
+      await expect(
+        caller.annotationQueues.fetchAndLockNext({
+          projectId: setup.project.id,
+          queueId: queue.id,
+          seenItemIds: [firstItem.id],
+          status: AnnotationQueueStatus.COMPLETED,
+        }),
+      ).resolves.toMatchObject({ id: secondItem.id });
     });
   });
 });

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -66,8 +66,6 @@ export const AnnotationQueueItemPage: React.FC<{
   >(null);
   const [seenItemIds, setSeenItemIds] = useState<string[]>([]);
   const [progressIndex, setProgressIndex] = useState(0);
-  const [navigationStatus, setNavigationStatus] =
-    useState<AnnotationQueueStatus>(AnnotationQueueStatus.PENDING);
 
   const hasAccess = useHasProjectAccess({
     projectId,
@@ -80,6 +78,17 @@ export const AnnotationQueueItemPage: React.FC<{
     { projectId, itemId: itemId as string },
     { enabled: !!itemId && sessionLoaded, refetchOnMount: false },
   );
+  const itemNavigation = api.annotationQueueItems.navigationById.useQuery(
+    {
+      queueId: annotationQueueId,
+      projectId,
+      itemId: queryItemId as string,
+    },
+    {
+      enabled: isSingleItem && !!queryItemId && sessionLoaded,
+      refetchOnWindowFocus: false,
+    },
+  );
 
   const fetchAndLockNextMutation =
     api.annotationQueues.fetchAndLockNext.useMutation();
@@ -88,20 +97,11 @@ export const AnnotationQueueItemPage: React.FC<{
   useEffect(() => {
     async function fetchNextItem() {
       if (!itemId && !isSingleItem && sessionLoaded) {
-        let nextItem = await fetchAndLockNextMutation.mutateAsync({
+        const nextItem = await fetchAndLockNextMutation.mutateAsync({
           queueId: annotationQueueId,
           projectId,
           seenItemIds,
         });
-        if (!nextItem) {
-          nextItem = await fetchAndLockNextMutation.mutateAsync({
-            queueId: annotationQueueId,
-            projectId,
-            seenItemIds,
-            status: AnnotationQueueStatus.COMPLETED,
-          });
-          setNavigationStatus(AnnotationQueueStatus.COMPLETED);
-        }
         setNextItemData(nextItem);
       }
     }
@@ -110,15 +110,14 @@ export const AnnotationQueueItemPage: React.FC<{
   }, [sessionLoaded]);
   const { configs } = useAnnotationQueueData({ annotationQueueId, projectId });
 
-  const unseenItemCount =
+  const unseenPendingItemCount =
     api.annotationQueueItems.unseenPendingItemCountByQueueId.useQuery(
       {
         queueId: annotationQueueId,
         projectId,
         seenItemIds,
-        status: navigationStatus,
       },
-      { refetchOnWindowFocus: false },
+      { enabled: !isSingleItem, refetchOnWindowFocus: false },
     );
 
   const utils = api.useUtils();
@@ -134,19 +133,19 @@ export const AnnotationQueueItemPage: React.FC<{
           queueId: annotationQueueId,
           projectId,
           seenItemIds,
-          status: navigationStatus,
         });
         setNextItemData(nextItem);
-        if (!nextItem) return;
       }
 
-      setProgressIndex(Math.max(progressIndex + 1, 0));
+      if (progressIndex + 1 < totalItems) {
+        setProgressIndex(Math.max(progressIndex + 1, 0));
+      }
     },
   });
 
   const totalItems = useMemo(() => {
-    return seenItemIds.length + (unseenItemCount.data ?? 0);
-  }, [unseenItemCount.data, seenItemIds.length]);
+    return seenItemIds.length + (unseenPendingItemCount.data ?? 0);
+  }, [unseenPendingItemCount.data, seenItemIds.length]);
 
   const relevantItem = useMemo(() => {
     if (isSingleItem) return seenItemData.data;
@@ -190,24 +189,57 @@ export const AnnotationQueueItemPage: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [relevantItem]);
 
-  const isNextItemAvailable = totalItems > progressIndex + 1;
+  const isNextItemAvailable = isSingleItem
+    ? Boolean(itemNavigation.data?.nextItemId)
+    : totalItems > progressIndex + 1;
+  const isPreviousItemAvailable = isSingleItem
+    ? Boolean(itemNavigation.data?.previousItemId)
+    : progressIndex > 0;
+  const displayedPosition = isSingleItem
+    ? (itemNavigation.data?.position ?? 1)
+    : progressIndex + 1;
+  const displayedTotalItems = isSingleItem
+    ? (itemNavigation.data?.totalItems ?? 1)
+    : totalItems;
   const isPending = relevantItem?.status === AnnotationQueueStatus.PENDING;
 
   // LFE-7628 — keyboard-first navigation/completion.
   const handleNavigateBack = useCallback(() => {
+    if (isSingleItem) {
+      const previousItemId = itemNavigation.data?.previousItemId;
+      if (!previousItemId) return;
+      router.push({
+        pathname: `/project/${projectId}/annotation-queues/${annotationQueueId}/items/${previousItemId}`,
+        query: { singleItem: "true" },
+      });
+      return;
+    }
     setProgressIndex((prev) => prev - 1);
-  }, []);
+  }, [
+    annotationQueueId,
+    isSingleItem,
+    itemNavigation.data?.previousItemId,
+    projectId,
+    router,
+  ]);
 
   const handleNavigateNext = useCallback(async () => {
+    if (isSingleItem) {
+      const nextItemId = itemNavigation.data?.nextItemId;
+      if (!nextItemId) return;
+      await router.push({
+        pathname: `/project/${projectId}/annotation-queues/${annotationQueueId}/items/${nextItemId}`,
+        query: { singleItem: "true" },
+      });
+      return;
+    }
     if (progressIndex >= seenItemIds.length - 1) {
       const nextItem = await fetchAndLockNextMutation.mutateAsync({
         queueId: annotationQueueId,
         projectId,
         seenItemIds,
-        status: navigationStatus,
       });
       setNextItemData(nextItem);
-      if (!nextItem) return;
     }
     setProgressIndex(Math.max(progressIndex + 1, 0));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -216,7 +248,9 @@ export const AnnotationQueueItemPage: React.FC<{
     seenItemIds,
     annotationQueueId,
     projectId,
-    navigationStatus,
+    isSingleItem,
+    itemNavigation.data?.nextItemId,
+    router,
   ]);
 
   const handleComplete = useCallback(async () => {
@@ -379,7 +413,8 @@ export const AnnotationQueueItemPage: React.FC<{
   if (
     (seenItemData.isPending && itemId) ||
     (fetchAndLockNextMutation.isPending && !itemId) ||
-    unseenItemCount.isPending ||
+    (!isSingleItem && unseenPendingItemCount.isPending) ||
+    (isSingleItem && itemNavigation.isPending) ||
     objectData.isLoading ||
     (!sessionLoaded && !isSingleItem)
   ) {
@@ -445,17 +480,19 @@ export const AnnotationQueueItemPage: React.FC<{
         {renderContent()}
       </div>
       <div className="grid w-full shrink-0 grid-cols-1 justify-end gap-2 py-2 sm:grid-cols-[auto_min-content]">
-        {!isSingleItem && (
+        {(!isSingleItem || itemNavigation.data) && (
           <div className="flex max-h-10 flex-row items-center gap-2">
             <span className="bg-muted grid h-9 min-w-16 items-center rounded-md p-1 text-center text-sm">
-              {progressIndex + 1} / {totalItems}
+              {displayedPosition} / {displayedTotalItems}
             </span>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   onClick={handleNavigateBack}
                   variant="outline"
-                  disabled={progressIndex === 0 || !hasAccess}
+                  disabled={
+                    !isPreviousItemAvailable || (!isSingleItem && !hasAccess)
+                  }
                   size="lg"
                   className={cn(
                     "gap-1.5 px-4 transition-colors duration-150",
@@ -465,46 +502,54 @@ export const AnnotationQueueItemPage: React.FC<{
                   aria-label="Previous item"
                 >
                   <ArrowLeft className="h-4 w-4" />
-                  <KeyboardShortcut>←</KeyboardShortcut>
+                  {!isSingleItem && <KeyboardShortcut>←</KeyboardShortcut>}
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
                 <span>Previous item</span>
-                <KeyboardShortcut className="ml-2">←</KeyboardShortcut>
+                {!isSingleItem && (
+                  <KeyboardShortcut className="ml-2">←</KeyboardShortcut>
+                )}
               </TooltipContent>
             </Tooltip>
-            {/* Shortcut legend so annotators can discover keyboard-first flow */}
-            <span className="text-muted-foreground hidden items-center gap-1.5 pl-1 text-[11px] lg:flex">
-              <KeyboardShortcut
-                className="h-4 px-1 text-[9px]"
-                keys={[modLabel, "↵"]}
-              />
-              complete + next ·
-              <KeyboardShortcut className="h-4 min-w-4 px-1 text-[9px]">
-                →
-              </KeyboardShortcut>
-              skip
-            </span>
-            <button
-              type="button"
-              onClick={() => setShowShortcuts(true)}
-              className="text-muted-foreground hover:text-foreground hidden items-center gap-1 text-[11px] transition-colors lg:flex"
-              aria-label="Show keyboard shortcuts"
-            >
-              <KeyboardShortcut className="h-4 min-w-4 px-1 text-[9px]">
-                ?
-              </KeyboardShortcut>
-              shortcuts
-            </button>
+            {!isSingleItem && (
+              <>
+                {/* Shortcut legend so annotators can discover keyboard-first flow */}
+                <span className="text-muted-foreground hidden items-center gap-1.5 pl-1 text-[11px] lg:flex">
+                  <KeyboardShortcut
+                    className="h-4 px-1 text-[9px]"
+                    keys={[modLabel, "↵"]}
+                  />
+                  complete + next ·
+                  <KeyboardShortcut className="h-4 min-w-4 px-1 text-[9px]">
+                    →
+                  </KeyboardShortcut>
+                  skip
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setShowShortcuts(true)}
+                  className="text-muted-foreground hover:text-foreground hidden items-center gap-1 text-[11px] transition-colors lg:flex"
+                  aria-label="Show keyboard shortcuts"
+                >
+                  <KeyboardShortcut className="h-4 min-w-4 px-1 text-[9px]">
+                    ?
+                  </KeyboardShortcut>
+                  shortcuts
+                </button>
+              </>
+            )}
           </div>
         )}
         <div className="flex w-full min-w-[265px] items-center justify-end gap-2">
-          {!isSingleItem && (
+          {(!isSingleItem || itemNavigation.data) && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   onClick={handleNavigateNext}
-                  disabled={!isNextItemAvailable || !hasAccess}
+                  disabled={
+                    !isNextItemAvailable || (!isSingleItem && !hasAccess)
+                  }
                   size="lg"
                   className={cn(
                     "gap-1.5 px-4 transition-colors duration-150",
@@ -513,15 +558,17 @@ export const AnnotationQueueItemPage: React.FC<{
                       "border-primary/60 bg-accent/60 ring-primary/20 ring-2",
                   )}
                   variant="outline"
-                  aria-label="Skip to next item"
+                  aria-label={isSingleItem ? "Next item" : "Skip to next item"}
                 >
                   <ArrowRight className="h-4 w-4" />
-                  <KeyboardShortcut>→</KeyboardShortcut>
+                  {!isSingleItem && <KeyboardShortcut>→</KeyboardShortcut>}
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <span>Skip to next item</span>
-                <KeyboardShortcut className="ml-2">→</KeyboardShortcut>
+                <span>{isSingleItem ? "Next item" : "Skip to next item"}</span>
+                {!isSingleItem && (
+                  <KeyboardShortcut className="ml-2">→</KeyboardShortcut>
+                )}
               </TooltipContent>
             </Tooltip>
           )}

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -66,6 +66,8 @@ export const AnnotationQueueItemPage: React.FC<{
   >(null);
   const [seenItemIds, setSeenItemIds] = useState<string[]>([]);
   const [progressIndex, setProgressIndex] = useState(0);
+  const [navigationStatus, setNavigationStatus] =
+    useState<AnnotationQueueStatus>(AnnotationQueueStatus.PENDING);
 
   const hasAccess = useHasProjectAccess({
     projectId,
@@ -86,11 +88,20 @@ export const AnnotationQueueItemPage: React.FC<{
   useEffect(() => {
     async function fetchNextItem() {
       if (!itemId && !isSingleItem && sessionLoaded) {
-        const nextItem = await fetchAndLockNextMutation.mutateAsync({
+        let nextItem = await fetchAndLockNextMutation.mutateAsync({
           queueId: annotationQueueId,
           projectId,
           seenItemIds,
         });
+        if (!nextItem) {
+          nextItem = await fetchAndLockNextMutation.mutateAsync({
+            queueId: annotationQueueId,
+            projectId,
+            seenItemIds,
+            status: AnnotationQueueStatus.COMPLETED,
+          });
+          setNavigationStatus(AnnotationQueueStatus.COMPLETED);
+        }
         setNextItemData(nextItem);
       }
     }
@@ -99,12 +110,13 @@ export const AnnotationQueueItemPage: React.FC<{
   }, [sessionLoaded]);
   const { configs } = useAnnotationQueueData({ annotationQueueId, projectId });
 
-  const unseenPendingItemCount =
+  const unseenItemCount =
     api.annotationQueueItems.unseenPendingItemCountByQueueId.useQuery(
       {
         queueId: annotationQueueId,
         projectId,
         seenItemIds,
+        status: navigationStatus,
       },
       { refetchOnWindowFocus: false },
     );
@@ -122,19 +134,19 @@ export const AnnotationQueueItemPage: React.FC<{
           queueId: annotationQueueId,
           projectId,
           seenItemIds,
+          status: navigationStatus,
         });
         setNextItemData(nextItem);
+        if (!nextItem) return;
       }
 
-      if (progressIndex + 1 < totalItems) {
-        setProgressIndex(Math.max(progressIndex + 1, 0));
-      }
+      setProgressIndex(Math.max(progressIndex + 1, 0));
     },
   });
 
   const totalItems = useMemo(() => {
-    return seenItemIds.length + (unseenPendingItemCount.data ?? 0);
-  }, [unseenPendingItemCount.data, seenItemIds.length]);
+    return seenItemIds.length + (unseenItemCount.data ?? 0);
+  }, [unseenItemCount.data, seenItemIds.length]);
 
   const relevantItem = useMemo(() => {
     if (isSingleItem) return seenItemData.data;
@@ -192,12 +204,20 @@ export const AnnotationQueueItemPage: React.FC<{
         queueId: annotationQueueId,
         projectId,
         seenItemIds,
+        status: navigationStatus,
       });
       setNextItemData(nextItem);
+      if (!nextItem) return;
     }
     setProgressIndex(Math.max(progressIndex + 1, 0));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [progressIndex, seenItemIds, annotationQueueId, projectId]);
+  }, [
+    progressIndex,
+    seenItemIds,
+    annotationQueueId,
+    projectId,
+    navigationStatus,
+  ]);
 
   const handleComplete = useCallback(async () => {
     if (!relevantItem) return;
@@ -359,7 +379,7 @@ export const AnnotationQueueItemPage: React.FC<{
   if (
     (seenItemData.isPending && itemId) ||
     (fetchAndLockNextMutation.isPending && !itemId) ||
-    unseenPendingItemCount.isPending ||
+    unseenItemCount.isPending ||
     objectData.isLoading ||
     (!sessionLoaded && !isSingleItem)
   ) {

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -250,15 +250,66 @@ export const queueItemRouter = createTRPCRouter({
         totalItems,
       };
     }),
+  navigationById: protectedProjectProcedure
+    .input(
+      z.object({
+        queueId: z.string(),
+        projectId: z.string(),
+        itemId: z.string(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "annotationQueues:read",
+      });
+
+      const [navigation] = await ctx.prisma.$queryRaw<
+        Array<{
+          previousItemId: string | null;
+          nextItemId: string | null;
+          position: bigint;
+          totalItems: bigint;
+        }>
+      >(Prisma.sql`
+        SELECT
+          ordered."previousItemId",
+          ordered."nextItemId",
+          ordered.position,
+          ordered."totalItems"
+        FROM (
+          SELECT
+            aqi.id,
+            LAG(aqi.id) OVER queue_order AS "previousItemId",
+            LEAD(aqi.id) OVER queue_order AS "nextItemId",
+            ROW_NUMBER() OVER queue_order AS position,
+            COUNT(*) OVER () AS "totalItems"
+          FROM annotation_queue_items aqi
+          WHERE
+            aqi.project_id = ${input.projectId}
+            AND aqi.queue_id = ${input.queueId}
+          WINDOW queue_order AS (
+            ORDER BY aqi.created_at ASC, aqi.object_id ASC, aqi.object_type ASC
+          )
+        ) ordered
+        WHERE ordered.id = ${input.itemId}
+      `);
+
+      return navigation
+        ? {
+            ...navigation,
+            position: Number(navigation.position),
+            totalItems: Number(navigation.totalItems),
+          }
+        : null;
+    }),
   unseenPendingItemCountByQueueId: protectedProjectProcedure
     .input(
       z.object({
         queueId: z.string(),
         projectId: z.string(),
         seenItemIds: z.array(z.string()),
-        status: z
-          .enum(AnnotationQueueStatus)
-          .default(AnnotationQueueStatus.PENDING),
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -272,7 +323,7 @@ export const queueItemRouter = createTRPCRouter({
         where: {
           queueId: input.queueId,
           projectId: input.projectId,
-          status: input.status,
+          status: AnnotationQueueStatus.PENDING,
           id: {
             notIn: input.seenItemIds,
           },

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -256,6 +256,9 @@ export const queueItemRouter = createTRPCRouter({
         queueId: z.string(),
         projectId: z.string(),
         seenItemIds: z.array(z.string()),
+        status: z
+          .enum(AnnotationQueueStatus)
+          .default(AnnotationQueueStatus.PENDING),
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -269,7 +272,7 @@ export const queueItemRouter = createTRPCRouter({
         where: {
           queueId: input.queueId,
           projectId: input.projectId,
-          status: AnnotationQueueStatus.PENDING,
+          status: input.status,
           id: {
             notIn: input.seenItemIds,
           },

--- a/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
@@ -470,6 +470,9 @@ export const queueRouter = createTRPCRouter({
         projectId: z.string(),
         seenItemIds: z.array(z.string()),
         isBetaEnabled: z.boolean().optional().default(false),
+        status: z
+          .enum(AnnotationQueueStatus)
+          .default(AnnotationQueueStatus.PENDING),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -486,12 +489,16 @@ export const queueRouter = createTRPCRouter({
         where: {
           queueId: input.queueId,
           projectId: input.projectId,
-          status: AnnotationQueueStatus.PENDING,
-          OR: [
-            { lockedAt: null },
-            { lockedAt: { lt: fiveMinutesAgo } },
-            { lockedByUserId: ctx.session.user.id },
-          ],
+          status: input.status,
+          ...(input.status === AnnotationQueueStatus.PENDING
+            ? {
+                OR: [
+                  { lockedAt: null },
+                  { lockedAt: { lt: fiveMinutesAgo } },
+                  { lockedByUserId: ctx.session.user.id },
+                ],
+              }
+            : {}),
           NOT: {
             id: { in: input.seenItemIds },
           },
@@ -501,23 +508,29 @@ export const queueRouter = createTRPCRouter({
         },
       });
 
-      // Expected behavior, non-error case: all items have been seen AND/OR completed, no more unseen pending items
+      // Expected behavior: no unseen item remains for the requested status.
       if (!item) return null;
 
-      const updatedItem = await ctx.prisma.annotationQueueItem.update({
-        where: {
-          id: item.id,
-          projectId: input.projectId,
-        },
-        data: {
-          lockedAt: now,
-          lockedByUserId: ctx.session.user.id,
-        },
-      });
+      const updatedItem =
+        input.status === AnnotationQueueStatus.PENDING
+          ? await ctx.prisma.annotationQueueItem.update({
+              where: {
+                id: item.id,
+                projectId: input.projectId,
+              },
+              data: {
+                lockedAt: now,
+                lockedByUserId: ctx.session.user.id,
+              },
+            })
+          : item;
 
       const inflatedUpdatedItem = {
         ...updatedItem,
-        lockedByUser: { name: ctx.session.user.name },
+        lockedByUser:
+          input.status === AnnotationQueueStatus.PENDING
+            ? { name: ctx.session.user.name }
+            : null,
       };
 
       if (item.objectType === AnnotationQueueObjectType.OBSERVATION) {

--- a/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
@@ -470,9 +470,6 @@ export const queueRouter = createTRPCRouter({
         projectId: z.string(),
         seenItemIds: z.array(z.string()),
         isBetaEnabled: z.boolean().optional().default(false),
-        status: z
-          .enum(AnnotationQueueStatus)
-          .default(AnnotationQueueStatus.PENDING),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -489,16 +486,12 @@ export const queueRouter = createTRPCRouter({
         where: {
           queueId: input.queueId,
           projectId: input.projectId,
-          status: input.status,
-          ...(input.status === AnnotationQueueStatus.PENDING
-            ? {
-                OR: [
-                  { lockedAt: null },
-                  { lockedAt: { lt: fiveMinutesAgo } },
-                  { lockedByUserId: ctx.session.user.id },
-                ],
-              }
-            : {}),
+          status: AnnotationQueueStatus.PENDING,
+          OR: [
+            { lockedAt: null },
+            { lockedAt: { lt: fiveMinutesAgo } },
+            { lockedByUserId: ctx.session.user.id },
+          ],
           NOT: {
             id: { in: input.seenItemIds },
           },
@@ -508,29 +501,23 @@ export const queueRouter = createTRPCRouter({
         },
       });
 
-      // Expected behavior: no unseen item remains for the requested status.
+      // Expected behavior, non-error case: all items have been seen AND/OR completed, no more unseen pending items
       if (!item) return null;
 
-      const updatedItem =
-        input.status === AnnotationQueueStatus.PENDING
-          ? await ctx.prisma.annotationQueueItem.update({
-              where: {
-                id: item.id,
-                projectId: input.projectId,
-              },
-              data: {
-                lockedAt: now,
-                lockedByUserId: ctx.session.user.id,
-              },
-            })
-          : item;
+      const updatedItem = await ctx.prisma.annotationQueueItem.update({
+        where: {
+          id: item.id,
+          projectId: input.projectId,
+        },
+        data: {
+          lockedAt: now,
+          lockedByUserId: ctx.session.user.id,
+        },
+      });
 
       const inflatedUpdatedItem = {
         ...updatedItem,
-        lockedByUser:
-          input.status === AnnotationQueueStatus.PENDING
-            ? { name: ctx.session.user.name }
-            : null,
+        lockedByUser: { name: ctx.session.user.name },
       };
 
       if (item.objectType === AnnotationQueueObjectType.OBSERVATION) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16165.preview.langfuse.com](https://pr-16165.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds previous/next navigation to annotation queue items opened directly from the queue items table. Navigation follows the table's queue order and works for completed items.

The `Process queue` flow is unchanged: it only processes pending items and still shows “No more items left to annotate!” when the queue is fully completed.

[Completed queue Process queue empty state](https://cursor.com/agents/bc-dd639f0e-43b6-4e2c-8341-1327e7584fcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompleted_queue_process_no_items.webp)

[completed_queue_item_link_navigation.mp4](https://cursor.com/agents/bc-dd639f0e-43b6-4e2c-8341-1327e7584fcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompleted_queue_item_link_navigation.mp4)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code

## Verification

- `pnpm --filter web run typecheck`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- CI web server suite — `Test Files 238 passed (238)`, `Tests 4381 passed | 10 skipped (4391)`
- Preview browser review on a synthetic fully completed two-item queue:
  - `Process queue` retained the no-items message.
  - Opening the first item ID displayed navigation at `1 / 2`.
  - Next loaded the distinct completed item at `2 / 2`.

## Impacted packages

- `web`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd639f0e-43b6-4e2c-8341-1327e7584fcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd639f0e-43b6-4e2c-8341-1327e7584fcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

