### PR TITLE
fix(api): accept epoch fromTimestamp on public metrics v2

### DIFF
--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -327,12 +327,17 @@ describe("queryBuilder DateTime64 parameter encoding", () => {
       orderBy: null,
     } as QueryType;
 
-    const { query: compiledQuery, parameters } = await new QueryBuilder(
-      undefined,
-      "v2",
-    ).build(query, "test-project", true);
+    const queryBuilder = new QueryBuilder(undefined, "v2");
+    queryBuilder.setRootEventConditionMaxWindowHours(0);
 
-    expect(compiledQuery).toContain("DateTime64(3)");
+    const { query: compiledQuery, parameters } = await queryBuilder.build(
+      query,
+      "test-project",
+      true,
+    );
+
+    expect(compiledQuery).toContain("DateTime64(3, 'UTC')");
+    expect(compiledQuery).not.toContain(": DateTime64(3)}");
 
     const dateTimeParams = Object.entries(parameters).filter(
       ([key]) =>
@@ -342,6 +347,10 @@ describe("queryBuilder DateTime64 parameter encoding", () => {
     );
 
     expect(dateTimeParams.length).toBeGreaterThan(0);
+    expect(dateTimeParams.some(([key]) => key.startsWith("subFrom"))).toBe(
+      true,
+    );
+    expect(dateTimeParams.some(([key]) => key.startsWith("subTo"))).toBe(true);
     for (const [, value] of dateTimeParams) {
       // ClickHouse rejects numeric 0 for DateTime64(3) query parameters.
       expect(value).not.toBe(0);

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -313,3 +313,41 @@ describe("legacy traces compatibility when routed through v2", () => {
     },
   );
 });
+
+describe("queryBuilder DateTime64 parameter encoding", () => {
+  it("encodes epoch fromTimestamp without ClickHouse-rejected numeric 0", async () => {
+    const query = {
+      view: "traces",
+      dimensions: [],
+      metrics: [{ measure: "count", aggregation: "count" }],
+      filters: [],
+      timeDimension: null,
+      fromTimestamp: "1970-01-01T00:00:00.000Z",
+      toTimestamp: "2026-08-14T21:30:00.000Z",
+      orderBy: null,
+    } as QueryType;
+
+    const { query: compiledQuery, parameters } = await new QueryBuilder(
+      undefined,
+      "v2",
+    ).build(query, "test-project", true);
+
+    expect(compiledQuery).toContain("DateTime64(3)");
+
+    const dateTimeParams = Object.entries(parameters).filter(
+      ([key]) =>
+        key.startsWith("dateTimeFilter") ||
+        key.startsWith("subFrom") ||
+        key.startsWith("subTo"),
+    );
+
+    expect(dateTimeParams.length).toBeGreaterThan(0);
+    for (const [, value] of dateTimeParams) {
+      // ClickHouse rejects numeric 0 for DateTime64(3) query parameters.
+      expect(value).not.toBe(0);
+      expect(typeof value).toBe("string");
+    }
+    expect(Object.values(parameters)).toContain("1970-01-01 00:00:00.000");
+    expect(Object.values(parameters)).toContain("2026-08-14 21:30:00.000");
+  });
+});

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -359,4 +359,31 @@ describe("queryBuilder DateTime64 parameter encoding", () => {
     expect(Object.values(parameters)).toContain("1970-01-01 00:00:00.000");
     expect(Object.values(parameters)).toContain("2026-08-14 21:30:00.000");
   });
+
+  it("binds WITH FILL bounds as UTC DateTime64 parameters", async () => {
+    const query = {
+      view: "traces",
+      dimensions: [],
+      metrics: [{ measure: "count", aggregation: "count" }],
+      filters: [],
+      timeDimension: { granularity: "day" },
+      fromTimestamp: "2025-01-01T00:00:00.000Z",
+      toTimestamp: "2025-01-02T00:00:00.000Z",
+      orderBy: null,
+    } as QueryType;
+
+    const { query: compiledQuery, parameters } = await new QueryBuilder(
+      undefined,
+      "v2",
+    ).build(query, "test-project", true);
+
+    expect(compiledQuery).toContain(
+      "toDate({fillFromDate: DateTime64(3, 'UTC')})",
+    );
+    expect(compiledQuery).toContain(
+      "toDate({fillToDate: DateTime64(3, 'UTC')})",
+    );
+    expect(parameters.fillFromDate).toBe("2025-01-01 00:00:00.000");
+    expect(parameters.fillToDate).toBe("2025-01-02 00:00:00.000");
+  });
 });

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "crypto";
 import { type z } from "zod";
-import { convertDateToClickhouseDateTime } from "../../../server/clickhouse/client";
 import { shouldSkipObservationsFinal } from "../../../server/queries/clickhouse-sql/query-options";
 import {
+  bindUtcDateTimeParam,
   FilterList,
   filtersRequireEventsFull,
   type Filter,
@@ -1248,14 +1248,18 @@ export class QueryBuilder {
         step = "INTERVAL 1 DAY"; // Default to day if granularity is unknown
     }
 
-    parameters["fillFromDate"] = convertDateToClickhouseDateTime(
+    const fillFromDateParam = bindUtcDateTimeParam(
+      "fillFromDate",
       new Date(fromTimestamp),
     );
-    parameters["fillToDate"] = convertDateToClickhouseDateTime(
+    const fillToDateParam = bindUtcDateTimeParam(
+      "fillToDate",
       new Date(toTimestamp),
     );
+    parameters["fillFromDate"] = fillFromDateParam.value;
+    parameters["fillToDate"] = fillToDateParam.value;
 
-    return ` WITH FILL FROM ${this.getTimeDimensionSql("{fillFromDate: DateTime64(3)}", appliedBucketingDimension.granularity)} TO ${this.getTimeDimensionSql("{fillToDate: DateTime64(3)}", appliedBucketingDimension.granularity)} STEP ${step}`;
+    return ` WITH FILL FROM ${this.getTimeDimensionSql(fillFromDateParam.placeholder, appliedBucketingDimension.granularity)} TO ${this.getTimeDimensionSql(fillToDateParam.placeholder, appliedBucketingDimension.granularity)} STEP ${step}`;
   }
 
   /**
@@ -1672,21 +1676,22 @@ export class QueryBuilder {
         const baseTable = this.actualTableName(view);
         const tableAlias = this.tableAlias(view);
         const { column, condition } = view.rootEventCondition;
+        const fromParam = bindUtcDateTimeParam(
+          fromP,
+          new Date(query.fromTimestamp),
+        );
+        const toParam = bindUtcDateTimeParam(toP, new Date(query.toTimestamp));
         const subquery =
           `SELECT ${tableAlias}.${column} FROM ${baseTable} ${tableAlias} ` +
           `WHERE ${tableAlias}.project_id = {${projP}: String} ` +
           `AND ${condition} ` +
-          `AND ${tableAlias}.${view.timeDimension} >= {${fromP}: DateTime64(3, 'UTC')} ` +
-          `AND ${tableAlias}.${view.timeDimension} <= {${toP}: DateTime64(3, 'UTC')}`;
+          `AND ${tableAlias}.${view.timeDimension} >= ${fromParam.placeholder} ` +
+          `AND ${tableAlias}.${view.timeDimension} <= ${toParam.placeholder}`;
         fromClause +=
           ` AND (${baseTable}.${column} IN (${subquery})` +
           ` OR NOT EXISTS (${subquery} LIMIT 1))`;
-        parameters[fromP] = convertDateToClickhouseDateTime(
-          new Date(query.fromTimestamp),
-        );
-        parameters[toP] = convertDateToClickhouseDateTime(
-          new Date(query.toTimestamp),
-        );
+        parameters[fromP] = fromParam.value;
+        parameters[toP] = toParam.value;
         parameters[projP] = projectId;
       }
     }

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -1676,8 +1676,8 @@ export class QueryBuilder {
           `SELECT ${tableAlias}.${column} FROM ${baseTable} ${tableAlias} ` +
           `WHERE ${tableAlias}.project_id = {${projP}: String} ` +
           `AND ${condition} ` +
-          `AND ${tableAlias}.${view.timeDimension} >= {${fromP}: DateTime64(3)} ` +
-          `AND ${tableAlias}.${view.timeDimension} <= {${toP}: DateTime64(3)}`;
+          `AND ${tableAlias}.${view.timeDimension} >= {${fromP}: DateTime64(3, 'UTC')} ` +
+          `AND ${tableAlias}.${view.timeDimension} <= {${toP}: DateTime64(3, 'UTC')}`;
         fromClause +=
           ` AND (${baseTable}.${column} IN (${subquery})` +
           ` OR NOT EXISTS (${subquery} LIMIT 1))`;

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -1681,8 +1681,12 @@ export class QueryBuilder {
         fromClause +=
           ` AND (${baseTable}.${column} IN (${subquery})` +
           ` OR NOT EXISTS (${subquery} LIMIT 1))`;
-        parameters[fromP] = new Date(query.fromTimestamp).getTime();
-        parameters[toP] = new Date(query.toTimestamp).getTime();
+        parameters[fromP] = convertDateToClickhouseDateTime(
+          new Date(query.fromTimestamp),
+        );
+        parameters[toP] = convertDateToClickhouseDateTime(
+          new Date(query.toTimestamp),
+        );
         parameters[projP] = projectId;
       }
     }

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -257,9 +257,10 @@ export const clickhouseClient = (
 };
 
 /**
- * Accepts a JavaScript date and returns the DateTime in format YYYY-MM-DD HH:MM:SS
+ * Accepts a JavaScript date and returns its UTC calendar time in ClickHouse's
+ * YYYY-MM-DD HH:MM:SS.sss format.
  */
 export const convertDateToClickhouseDateTime = (date: Date): string => {
-  // 2024-11-06T20:37:00.123Z -> 2024-11-06 21:37:00.123
+  // 2024-11-06T20:37:00.123Z -> 2024-11-06 20:37:00.123
   return date.toISOString().replace("T", " ").replace("Z", "");
 };

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.datetime.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.datetime.test.ts
@@ -16,7 +16,7 @@ describe("DateTimeFilter ClickHouse parameter encoding", () => {
 
     const applied = filter.apply();
 
-    expect(applied.query).toContain("DateTime64(3)");
+    expect(applied.query).toContain("DateTime64(3, 'UTC')");
     const paramValue = Object.values(applied.params)[0];
     // ClickHouse rejects query parameter value 0 for DateTime64(3):
     // "Cannot parse DateTime: value 0 cannot be parsed as DateTime64(3)"
@@ -25,7 +25,7 @@ describe("DateTimeFilter ClickHouse parameter encoding", () => {
   });
 
   it("encodes ordinary timestamps as ClickHouse DateTime64 strings", () => {
-    const value = new Date("2026-08-14T21:30:00.123Z");
+    const value = new Date("2026-08-14T23:30:00.123+02:00");
     const filter = new DateTimeFilter({
       clickhouseTable: "traces",
       field: "timestamp",
@@ -36,6 +36,8 @@ describe("DateTimeFilter ClickHouse parameter encoding", () => {
     const applied = filter.apply();
     const paramValue = Object.values(applied.params)[0];
 
+    expect(applied.query).toContain("DateTime64(3, 'UTC')");
     expect(paramValue).toBe(convertDateToClickhouseDateTime(value));
+    expect(paramValue).toBe("2026-08-14 21:30:00.123");
   });
 });

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.datetime.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.datetime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { convertDateToClickhouseDateTime } from "../../clickhouse/client";
+import { DateTimeFilter } from "./clickhouse-filter";
+
+describe("DateTimeFilter ClickHouse parameter encoding", () => {
+  it("encodes Unix epoch as a ClickHouse DateTime64 string, not numeric 0", () => {
+    const epoch = new Date("1970-01-01T00:00:00.000Z");
+    const filter = new DateTimeFilter({
+      clickhouseTable: "traces",
+      field: "timestamp",
+      operator: ">=",
+      value: epoch,
+      tablePrefix: "t",
+    });
+
+    const applied = filter.apply();
+
+    expect(applied.query).toContain("DateTime64(3)");
+    const paramValue = Object.values(applied.params)[0];
+    // ClickHouse rejects query parameter value 0 for DateTime64(3):
+    // "Cannot parse DateTime: value 0 cannot be parsed as DateTime64(3)"
+    expect(paramValue).not.toBe(0);
+    expect(paramValue).toBe(convertDateToClickhouseDateTime(epoch));
+  });
+
+  it("encodes ordinary timestamps as ClickHouse DateTime64 strings", () => {
+    const value = new Date("2026-08-14T21:30:00.123Z");
+    const filter = new DateTimeFilter({
+      clickhouseTable: "traces",
+      field: "timestamp",
+      operator: "<=",
+      value,
+    });
+
+    const applied = filter.apply();
+    const paramValue = Object.values(applied.params)[0];
+
+    expect(paramValue).toBe(convertDateToClickhouseDateTime(value));
+  });
+});

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -173,6 +173,11 @@ export class NumberFilter implements Filter {
   }
 }
 
+export const bindUtcDateTimeParam = (name: string, value: Date) => ({
+  placeholder: `{${name}: DateTime64(3, 'UTC')}`,
+  value: convertDateToClickhouseDateTime(value),
+});
+
 export class DateTimeFilter implements Filter {
   public clickhouseTable: string;
   public field: string;
@@ -197,15 +202,16 @@ export class DateTimeFilter implements Filter {
   apply(): ClickhouseFilter {
     const uid = clickhouseCompliantRandomCharacters();
     const varName = `dateTimeFilter${uid}`;
+    const dateTimeParam = bindUtcDateTimeParam(varName, new Date(this.value));
     // Use ClickHouse DateTime string encoding rather than epoch millis.
     // ClickHouse rejects query parameter value 0 for DateTime64(3), which is
     // exactly what Date#getTime() returns for 1970-01-01T00:00:00.000Z. The
     // converter emits UTC calendar time, so declare UTC explicitly rather than
     // relying on the ClickHouse server or session timezone.
     return {
-      query: `${this.tablePrefix ? this.tablePrefix + "." : ""}${this.field} ${this.operator} {${varName}: DateTime64(3, 'UTC')}`,
+      query: `${this.tablePrefix ? this.tablePrefix + "." : ""}${this.field} ${this.operator} ${dateTimeParam.placeholder}`,
       params: {
-        [varName]: convertDateToClickhouseDateTime(new Date(this.value)),
+        [varName]: dateTimeParam.value,
       },
     };
   }

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -199,9 +199,11 @@ export class DateTimeFilter implements Filter {
     const varName = `dateTimeFilter${uid}`;
     // Use ClickHouse DateTime string encoding rather than epoch millis.
     // ClickHouse rejects query parameter value 0 for DateTime64(3), which is
-    // exactly what Date#getTime() returns for 1970-01-01T00:00:00.000Z.
+    // exactly what Date#getTime() returns for 1970-01-01T00:00:00.000Z. The
+    // converter emits UTC calendar time, so declare UTC explicitly rather than
+    // relying on the ClickHouse server or session timezone.
     return {
-      query: `${this.tablePrefix ? this.tablePrefix + "." : ""}${this.field} ${this.operator} {${varName}: DateTime64(3)}`,
+      query: `${this.tablePrefix ? this.tablePrefix + "." : ""}${this.field} ${this.operator} {${varName}: DateTime64(3, 'UTC')}`,
       params: {
         [varName]: convertDateToClickhouseDateTime(new Date(this.value)),
       },

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -3,6 +3,7 @@ import {
   type FtsMatchOperator,
   filterOperators,
 } from "../../../interfaces/filters";
+import { convertDateToClickhouseDateTime } from "../../clickhouse/client";
 import { clickhouseCompliantRandomCharacters } from "../../repositories";
 import { escapeSqlLikePattern } from "../../utils/sqlLike";
 import {
@@ -196,9 +197,14 @@ export class DateTimeFilter implements Filter {
   apply(): ClickhouseFilter {
     const uid = clickhouseCompliantRandomCharacters();
     const varName = `dateTimeFilter${uid}`;
+    // Use ClickHouse DateTime string encoding rather than epoch millis.
+    // ClickHouse rejects query parameter value 0 for DateTime64(3), which is
+    // exactly what Date#getTime() returns for 1970-01-01T00:00:00.000Z.
     return {
       query: `${this.tablePrefix ? this.tablePrefix + "." : ""}${this.field} ${this.operator} {${varName}: DateTime64(3)}`,
-      params: { [varName]: new Date(this.value).getTime() },
+      params: {
+        [varName]: convertDateToClickhouseDateTime(new Date(this.value)),
+      },
     };
   }
 }

--- a/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/events-stream-query.test.ts
@@ -2,6 +2,7 @@ import type { FilterCondition } from "../../../types";
 import type { OrderByState } from "../../../interfaces/orderBy";
 import { InvalidRequestError } from "../../../errors";
 import { describe, expect, it } from "vitest";
+import { convertDateToClickhouseDateTime } from "../../clickhouse/client";
 import {
   buildEventsObservationRowSelection,
   groupEventsObservationFilters,
@@ -81,7 +82,9 @@ describe("buildEventsStreamQuery", () => {
       limit: 17,
     });
     expect(Object.values(params)).toContainEqual(["GENERATION"]);
-    expect(Object.values(params)).toContain(cutoffCreatedAt.getTime());
+    expect(Object.values(params)).toContain(
+      convertDateToClickhouseDateTime(cutoffCreatedAt),
+    );
   });
 
   it("omits the optional cutoff when it is absent", () => {

--- a/web/src/__tests__/server/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-v2-api.servertest.ts
@@ -9,6 +9,7 @@ import {
   createEventsCh,
   createScoresCh,
   createTraceScore,
+  DateTimeFilter,
   queryClickhouse,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
@@ -119,6 +120,29 @@ describe("/api/public/v2/metrics API Endpoint", () => {
   });
 
   maybe("Basic Functionality", () => {
+    it("preserves DateTime64 filter instants outside the ClickHouse session timezone", async () => {
+      const instant = new Date("2026-08-14T23:30:00.123+02:00");
+      const applied = new DateTimeFilter({
+        clickhouseTable: "events",
+        field: "start_time",
+        operator: ">=",
+        value: instant,
+      }).apply();
+      const placeholder = applied.query.match(/\{[^}]+\}/)?.[0];
+
+      if (!placeholder) {
+        throw new Error("DateTimeFilter did not produce a query parameter");
+      }
+
+      const result = await queryClickhouse<{ timestampMs: string }>({
+        query: `SELECT toUnixTimestamp64Milli(${placeholder}) AS timestampMs`,
+        params: applied.params,
+        clickhouseSettings: { session_timezone: "Europe/Berlin" },
+      });
+
+      expect(Number(result[0]?.timestampMs)).toBe(instant.getTime());
+    });
+
     it("should apply default row_limit of 100 when not specified", async () => {
       // Create enough observations to exceed default limit
       const rowLimitTraceId = randomUUID();
@@ -247,7 +271,7 @@ describe("/api/public/v2/metrics API Endpoint", () => {
           },
         ],
         fromTimestamp: "1970-01-01T00:00:00.000Z",
-        toTimestamp: new Date().toISOString(),
+        toTimestamp: new Date(timestamp.getTime() + 10_000).toISOString(),
       };
 
       const response = await makeZodVerifiedAPICall(
@@ -257,8 +281,10 @@ describe("/api/public/v2/metrics API Endpoint", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data).toHaveLength(1);
+      expect(Number(response.body.data[0]?.count_count)).toBe(
+        observationIds.length,
+      );
     });
 
     it("should support latency metrics with microsecond to millisecond conversion", async () => {

--- a/web/src/__tests__/server/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-v2-api.servertest.ts
@@ -231,6 +231,36 @@ describe("/api/public/v2/metrics API Endpoint", () => {
       expect(Array.isArray(response.body.data)).toBe(true);
     });
 
+    it("should accept Unix epoch fromTimestamp without ClickHouse DateTime64 parse errors", async () => {
+      // Regression: ClickHouse rejects DateTime64(3) query parameter value 0,
+      // which is Date#getTime() for 1970-01-01T00:00:00.000Z. Clients often use
+      // epoch as an open-ended lower bound; the API must return 200, not 500.
+      const query = {
+        view: "observations",
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "traceId",
+            operator: "=",
+            value: traceId,
+            type: "string",
+          },
+        ],
+        fromTimestamp: "1970-01-01T00:00:00.000Z",
+        toTimestamp: new Date().toISOString(),
+      };
+
+      const response = await makeZodVerifiedAPICall(
+        GetMetricsV1Response,
+        "GET",
+        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toBeDefined();
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
     it("should support latency metrics with microsecond to millisecond conversion", async () => {
       const query = {
         view: "observations",

--- a/web/src/__tests__/server/orderByToPrisma.servertest.ts
+++ b/web/src/__tests__/server/orderByToPrisma.servertest.ts
@@ -98,7 +98,7 @@ describe("orderByToPrisma (Convert orderBy to Prisma.sql)", () => {
     );
 
     expect(filterList.apply().query).toMatch(
-      /^s\.timestamp >= \{dateTimeFilter[A-Za-z]{5}: DateTime64\(3\)\}$/,
+      /^s\.timestamp >= \{dateTimeFilter[A-Za-z]{5}: DateTime64\(3, 'UTC'\)\}$/,
     );
   });
 });

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -129,9 +129,8 @@ const LEGACY_CAMEL_CASE_MAP: Record<string, string> = {
  */
 function prepareScoresNumericV2Params(filter: FilterState) {
   const [from, to] = extractFromAndToTimestampsFromFilter(filter);
-  // Fallback to 2000-01-01 instead of epoch 0 — ClickHouse DateTimeFilter
-  // passes new Date(value).getTime() as the parameter, and the value 0
-  // (epoch) is rejected by ClickHouse's DateTime64(3) parameter parser.
+  // Preserve the existing default range. DateTimeFilter now accepts epoch as a
+  // lower bound, but widening dashboard queries is a separate behavior change.
   const fromIso = from?.value
     ? new Date(from.value as Date).toISOString()
     : new Date("2000-01-01T00:00:00.000Z").toISOString();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16169.preview.langfuse.com](https://pr-16169.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Public `GET /api/public/v2/metrics` returned HTTP 500 when clients sent `fromTimestamp: "1970-01-01T00:00:00.000Z"`. ClickHouse rejects numeric query parameter `0` for `DateTime64(3)`, and `Date#getTime()` for Unix epoch is exactly `0`.

This change encodes datetime filter parameters (and metrics query root-event window params) with `convertDateToClickhouseDateTime` string values instead of epoch millis, matching the encoding used elsewhere in the ClickHouse query layer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Impacted packages: `@langfuse/shared`, `web` (regression test only)
- Verification:
  - Shared unit tests (`clickhouse-filter.datetime`, `queryBuilder.filterValidation`, `events-stream-query`, `queryBuilder.intervalBucketing`): `Tests 50 passed (50)`
  - Pre-commit lint: `Tasks: 7 successful, 7 total`
  - ClickHouse 24.8: numeric `0` fails with `Cannot parse DateTime: value 0 cannot be parsed as DateTime64(3)`; string `1970-01-01 00:00:00.000` succeeds
  - Web metrics v2 epoch regression: `Tests 1 passed | 45 skipped (46)`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15172](https://linear.app/clickhouse/issue/LFE-15172/bug-public-v2-metrics-returns-500-for-epoch-fromtimestamp-in-prod-us)

<div><a href="https://cursor.com/agents/bc-f093cd31-807a-44cc-9020-c57946bf0bd4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f093cd31-807a-44cc-9020-c57946bf0bd4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes epoch timestamp handling in public metrics queries by serializing DateTime64 filter and root-event window parameters as ClickHouse datetime strings instead of numeric epoch milliseconds.
- Updates shared DateTimeFilter and QueryBuilder parameter encoding.
- Adds focused unit and server regression coverage for Unix epoch inputs.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The timezone-dependent filtering should be fixed before merging because non-UTC ClickHouse deployments can receive silently shifted metrics windows.

The epoch fix works under UTC, but it strips the timezone marker before binding timestamps to timezone-less DateTime64 parameters, so server timezone configuration can change the represented instant.

**Files Needing Attention:** packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts; packages/shared/src/features/query/server/queryBuilder.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts:204-207
**Timezone-dependent DateTime filters**

If ClickHouse uses a non-UTC session timezone, `convertDateToClickhouseDateTime` removes the UTC designator before this timezone-less `DateTime64(3)` binding, causing filter boundaries to shift and queries to return events from the wrong time window. The same encoding affects the root-event window parameters in `queryBuilder.ts`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): encode DateTime64 params as st..."](https://github.com/langfuse/langfuse/commit/c84864671a98f493c90742fcaf8fab54863def6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53736967)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->