### PR TITLE
fix(web): include observation IO and metadata in legacy trace JSON download

### DIFF
--- a/web/src/__tests__/server/traces-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-trpc.servertest.ts
@@ -692,6 +692,77 @@ describe("traces trpc", () => {
     });
   });
 
+  describe("traces.observationsWithInputOutput", () => {
+    // Regression for https://github.com/langfuse/langfuse/issues/15337: the
+    // legacy trace JSON download serialized the page's observations, which are
+    // fetched with includeIO: false — so every downloaded observation lost its
+    // input, output, and metadata even though the detail panel shows them.
+    it("returns observation input, output, and metadata for the legacy trace download", async () => {
+      const trace = createTrace({
+        project_id: projectId,
+      });
+      const observation = createObservation({
+        project_id: projectId,
+        trace_id: trace.id,
+        start_time: new Date(trace.timestamp).getTime(),
+        input: JSON.stringify({ question: "What is Langfuse?" }),
+        output: JSON.stringify({
+          answer: "An open-source LLM engineering platform",
+        }),
+        metadata: { export_marker: "present" },
+      });
+
+      await createTracesCh([trace]);
+      await createObservationsCh([observation]);
+
+      // ClickHouse insert visibility can lag.
+      let observationsRes: Array<{
+        id: string;
+        input: unknown;
+        output: unknown;
+        metadata: unknown;
+      }> = [];
+      await waitForExpect(async () => {
+        observationsRes = await caller.traces.observationsWithInputOutput({
+          projectId,
+          traceId: trace.id,
+          timestamp: new Date(trace.timestamp),
+        });
+        expect(observationsRes.some((o) => o.id === observation.id)).toBe(true);
+      });
+
+      const downloaded = observationsRes.find((o) => o.id === observation.id);
+      expect(downloaded?.input).toEqual({ question: "What is Langfuse?" });
+      expect(downloaded?.output).toEqual({
+        answer: "An open-source LLM engineering platform",
+      });
+      expect(downloaded?.metadata).toEqual(
+        JSON.stringify({ export_marker: "present" }),
+      );
+    });
+
+    it("rejects access to a trace of another project", async () => {
+      const differentProjectId = randomUUID();
+      const trace = createTrace({
+        project_id: differentProjectId,
+      });
+      const observation = createObservation({
+        project_id: differentProjectId,
+        trace_id: trace.id,
+      });
+
+      await createTracesCh([trace]);
+      await createObservationsCh([observation]);
+
+      await expect(
+        caller.traces.observationsWithInputOutput({
+          projectId,
+          traceId: trace.id,
+        }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+  });
+
   describe("traces.filterOptions", () => {
     it("should include all possible categorical score values from score configs", async () => {
       // Create a trace

--- a/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
+++ b/web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx
@@ -36,6 +36,7 @@ import {
 import { StringParam, useQueryParam } from "use-query-params";
 import { cn } from "@/src/utils/tailwind";
 import { useCallback } from "react";
+import { api } from "@/src/utils/api";
 import {
   TraceSettingsDropdown,
   TraceViewOptionsMenuItems,
@@ -95,6 +96,7 @@ function TracePanelNavigationHeaderExpanded({
   const { roots, trace, observations } = useTraceData();
   const { isGraphViewAvailable } = useTraceGraphData();
   const { isBetaEnabled } = useV4Beta();
+  const utils = api.useUtils();
   const [viewMode, setViewMode] = useQueryParam("view", StringParam);
   const capture = usePostHogClientCapture();
   const analyticsDimensions = useTraceAnalyticsDimensions();
@@ -150,9 +152,31 @@ function TracePanelNavigationHeaderExpanded({
       capture("trace_detail:download_button_click", analyticsDimensions);
       try {
         if (!isBetaEnabled) {
+          // The page's observations are fetched with includeIO: false to keep
+          // page rendering light, so they carry no input/output/metadata. Fetch
+          // the full set so the download matches the observation detail panel;
+          // large traces keep the light set (with a warning), mirroring the
+          // omit-large-fields behavior of the V4 download route.
+          // The download helper serializes whatever set it receives; keep the
+          // variable loose so the light page set and the full fetched set both fit.
+          let downloadObservations: unknown[] = observations;
+          if (
+            observations.length < TRACE_DOWNLOAD_OMIT_LARGE_FIELDS_THRESHOLD
+          ) {
+            downloadObservations =
+              await utils.traces.observationsWithInputOutput.fetch({
+                traceId: trace.id,
+                projectId: trace.projectId,
+                timestamp: trace.timestamp,
+              });
+          } else {
+            toast.warning(
+              `Trace download excludes input, output, metadata, toolDefinitions, and toolCalls for traces with ${TRACE_DOWNLOAD_OMIT_LARGE_FIELDS_THRESHOLD}+ observations.`,
+            );
+          }
           downloadLegacyTraceAsJson({
             trace,
-            observations,
+            observations: downloadObservations,
           });
           return;
         }
@@ -174,7 +198,14 @@ function TracePanelNavigationHeaderExpanded({
             : "Failed to download trace JSON",
         );
       }
-    }, [isBetaEnabled, observations, trace, capture, analyticsDimensions]);
+    }, [
+      isBetaEnabled,
+      observations,
+      trace,
+      capture,
+      analyticsDimensions,
+      utils,
+    ]);
 
   const isTimelineView = viewMode === "timeline";
 

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -460,6 +460,29 @@ export const traceRouter = createTRPCRouter({
         })) as ObservationReturnTypeWithMetadata[],
       };
     }),
+  // Full observation set for the legacy trace JSON download: unlike
+  // byIdWithObservationsAndScores (which strips IO to keep the page query
+  // light), this includes input, output, metadata, and tool data so the
+  // download matches what the observation detail panel shows.
+  observationsWithInputOutput: protectedGetTraceProcedure
+    .input(
+      z.object({
+        traceId: z.string(), // used for security check
+        timestamp: z.date().nullish(), // timestamp of the trace. Used to query CH more efficiently
+        fromTimestamp: z.date().nullish(), // min timestamp of the trace. Used to query CH more efficiently
+        projectId: z.string(), // used for security check
+      }),
+    )
+    .query(async ({ input }) => {
+      const observations = await getObservationsForTrace({
+        traceId: input.traceId,
+        projectId: input.projectId,
+        timestamp: input.timestamp ?? input.fromTimestamp ?? undefined,
+        includeIO: true,
+      });
+
+      return observations.map((o) => toDomainWithStringifiedMetadata(o));
+    }),
   deleteMany: protectedProjectProcedure
     .input(
       z


### PR DESCRIPTION
## What

Fixes the legacy (non-V4-beta) trace JSON download omitting observation input, output, and metadata — closes langfuse/langfuse#15337.

## Why

The legacy "Download trace as JSON" path serialized the observations already loaded for the page. Those observations are fetched with `includeIO: false` to keep page rendering light, so every downloaded observation lost its `input`, `output`, and `metadata` — even though the observation detail panel displays them (it fetches them separately).

This affects self-hosted deployments still on the legacy trace UI, where the downloaded JSON is silently incomplete.

## How

* Added a `traces.observationsWithInputOutput` tRPC procedure that returns the full observation set for a trace via `getObservationsForTrace({ includeIO: true })`, reusing the repository's existing payload-size guard.
* The legacy download now fetches this full set at download time, keeping the existing `{ trace, observations }` export shape.
* Traces at or above the omit-large-fields threshold keep the light set and surface the same warning the V4 download route shows, so both paths agree on large-trace behavior.

## Verification

* `tsc --noEmit` — clean.
* New regression test `traces.observationsWithInputOutput` asserts input/output/metadata round-trip and that access is scoped to the caller's project.
* Reverse verification: flipping `includeIO` back to `false` makes the new test fail with `expected null to deeply equal { question: ... }`, reproducing the exact missing-IO behavior from the issue.

<details><summary>Greptile Summary</summary>

This PR adds an authenticated tRPC query that retrieves full observation IO for legacy trace downloads and updates the legacy UI to fetch it on demand while retaining large-trace omission behavior.

* Adds project-scoped regression coverage for observation input, output, and metadata retrieval.
* Fetches full observations when downloading legacy traces below the large-field threshold.
* Adds a dedicated full-observation procedure backed by the existing ClickHouse repository query.

</details>

<details><summary>Confidence Score: 4/5</summary>

The PR should not merge until legacy downloads preserve observation metadata as structured JSON rather than an encoded string.

The new full-observation path fixes omitted IO, but its domain conversion changes metadata into a string and the pass-through download serializer writes that incompatible representation into every affected legacy export.

**Files Needing Attention:** web/src/server/api/routers/traces.ts, web/src/features/traces/components/TracePanelNavigationHeader/TracePanelNavigationHeader.tsx, web/src/**tests**/server/traces-trpc.servertest.ts

</details>

<details><summary>Sequence Diagram</summary>

sequenceDiagram participant U as Legacy trace UI participant T as traces.observationsWithInputOutput participant CH as ClickHouse repository participant D as JSON download helper U->>U: Check observation count alt Fewer than 350 observations U->>T: Fetch trace observations T->>CH: getObservationsForTrace(includeIO: true) CH-->>T: Full observations T-->>U: Observations with stringified metadata else 350 or more observations U->>U: Retain light observations and warn end U->>D: Serialize trace and observations D-->>U: Download JSON file

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
### Issue 1
web/src/server/api/routers/traces.ts:484
**Metadata is double-encoded in exports**

When a legacy-UI user downloads a trace containing metadata and fewer than 350 observations, `toDomainWithStringifiedMetadata` converts each metadata object to a string before the pass-through download serializer writes it, causing parsed exports to contain escaped JSON strings instead of metadata objects.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
```

</details>

Reviews (1): Last reviewed commit: ["fix(web): include observation IO and met..."](<https://github.com/langfuse/langfuse/commit/e52e267f4f36b3eb6f57bd50d6c9fe1f7de11f3d>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=53761192>)

> Greptile also left **1 inline comment** on this PR.

**Context used:**

* Knowledge Base — [Web App (`web/`)](<https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md>)