### PR TITLE
fix(redis): avoid CROSSSLOT on v4 legacy API usage multi-key ops

### DIFF
--- a/packages/shared/src/server/redis/redis.test.ts
+++ b/packages/shared/src/server/redis/redis.test.ts
@@ -9,7 +9,8 @@ vi.mock("../../env", () => ({
   },
 }));
 
-import { scanKeys } from "./redis";
+import { env } from "../../env";
+import { safeMultiGet, scanKeys } from "./redis";
 
 type ScanCall = [string, "MATCH", string, "COUNT", number];
 
@@ -78,5 +79,41 @@ describe("scanKeys", () => {
       "COUNT",
       1000,
     );
+  });
+});
+
+describe("safeMultiGet", () => {
+  it("uses mget when cluster mode is disabled", async () => {
+    env.REDIS_CLUSTER_ENABLED = "false";
+    const mget = vi.fn(async () => ["a", null, "c"]);
+    const get = vi.fn();
+    const client = { mget, get } as unknown as Redis;
+
+    await expect(safeMultiGet(client, ["k1", "k2", "k3"])).resolves.toEqual([
+      "a",
+      null,
+      "c",
+    ]);
+    expect(mget).toHaveBeenCalledWith(["k1", "k2", "k3"]);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("uses per-key get when cluster mode is enabled", async () => {
+    env.REDIS_CLUSTER_ENABLED = "true";
+    const mget = vi.fn();
+    const get = vi.fn(async (key: string) => `value:${key}`);
+    const client = { mget, get } as unknown as Redis;
+
+    await expect(safeMultiGet(client, ["k1", "k2"])).resolves.toEqual([
+      "value:k1",
+      "value:k2",
+    ]);
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(mget).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty array for empty input", async () => {
+    const client = { mget: vi.fn(), get: vi.fn() } as unknown as Redis;
+    await expect(safeMultiGet(client, [])).resolves.toEqual([]);
   });
 });

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -335,6 +335,23 @@ export const safeMultiDel = async (
   }
 };
 
+/**
+ * Execute multiple Redis GET operations safely in cluster mode.
+ * MGET requires all keys to hash to the same slot; fall back to per-key GET.
+ */
+export const safeMultiGet = async (
+  redis: Redis | Cluster | null,
+  keys: string[],
+): Promise<(string | null)[]> => {
+  if (!redis || keys.length === 0) return [];
+
+  if (env.REDIS_CLUSTER_ENABLED === "true") {
+    return Promise.all(keys.map(async (key: string) => redis.get(key)));
+  }
+
+  return redis.mget(keys);
+};
+
 const scanKeysForNode = async (
   client: Redis,
   pattern: string,

--- a/web/src/features/v4/server/v4TransitionCache.ts
+++ b/web/src/features/v4/server/v4TransitionCache.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 import {
   logger,
   redis,
+  safeMultiGet,
   v4ExperimentPostUsageBlobSchema,
   v4ExperimentPostUsageProjectKey,
   v4LegacyApiUsageBlobSchema,
@@ -100,7 +101,8 @@ const readBlobs = async <T>(
     return keys.map(() => null);
   }
   try {
-    const rawValues = await redis!.mget(keys);
+    // Cluster-safe: project keys hash to different slots.
+    const rawValues = await safeMultiGet(redis, keys);
     return rawValues.map((rawValue) => {
       if (!rawValue) return null;
       try {

--- a/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
+++ b/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
@@ -49,7 +49,9 @@ const redisMock = vi.hoisted(() => ({
     }
     return 0;
   }),
-  del: vi.fn(async (...keys: string[]) => {
+  del: vi.fn(async (...args: Array<string | string[]>) => {
+    // Mirror ioredis: del(...keys) and del(keys[]) are both valid.
+    const keys = args.flat();
     let deleted = 0;
     for (const key of keys) {
       if (redisState.store.delete(key)) deleted += 1;

--- a/worker/src/features/v4/handleV4LegacyApiUsageJob.ts
+++ b/worker/src/features/v4/handleV4LegacyApiUsageJob.ts
@@ -5,6 +5,8 @@ import {
   logger,
   queryClickhouse,
   redis,
+  safeMultiDel,
+  safeMultiGet,
   systemTableRef,
   v4ExperimentPostUsageProjectKey,
   v4LegacyApiHourBucketKey,
@@ -318,14 +320,17 @@ const setexInChunks = async (
 const mgetInChunks = async (keys: string[]): Promise<(string | null)[]> => {
   const values: (string | null)[] = [];
   for (let index = 0; index < keys.length; index += CHUNK_SIZE) {
-    values.push(...(await redis!.mget(keys.slice(index, index + CHUNK_SIZE))));
+    // Cluster-safe: MGET/multi-key DEL fail with CROSSSLOT across hour/project keys.
+    values.push(
+      ...(await safeMultiGet(redis, keys.slice(index, index + CHUNK_SIZE))),
+    );
   }
   return values;
 };
 
 const delInChunks = async (keys: string[]): Promise<void> => {
   for (let index = 0; index < keys.length; index += CHUNK_SIZE) {
-    await redis!.del(...keys.slice(index, index + CHUNK_SIZE));
+    await safeMultiDel(redis, keys.slice(index, index + CHUNK_SIZE));
   }
 };
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16180.preview.langfuse.com](https://pr-16180.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Production Redis Cluster was failing the v4 legacy API usage worker with `ReplyError: CROSSSLOT Keys in request don't hash to the same slot` (e.g. [trace](https://app.datadoghq.eu/apm/trace/7520440289183314566)).
- Hour-bucket / project keys hash to different slots, so batch `MGET` / multi-key `DEL` are invalid on cluster.
- Add `safeMultiGet` (mirror of `safeMultiDel`), use it in the worker chunk helpers and web `readBlobs`.

## Test plan
- [x] `vitest` `packages/shared/src/server/redis/redis.test.ts` (incl. new `safeMultiGet` cases)
- [x] `vitest` worker `handleV4LegacyApiUsageJob` + metrics tests
- [ ] Confirm next hourly `v4-legacy-api-usage-queue` run succeeds in prod after deploy (no CROSSSLOT)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes v4 transition cache reads and cleanup operations compatible with Redis Cluster by replacing cross-slot multi-key commands with cluster-safe per-key operations.
- Adds and tests a shared `safeMultiGet` helper.
- Uses cluster-safe reads in the web cache and legacy API usage worker.
- Routes worker cleanup through the existing `safeMultiDel` helper.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness or security regressions identified.

The cluster-aware branches avoid invalid cross-slot commands while preserving input ordering, cache fallback behavior, and worker cleanup semantics.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Caller[Web cache or v4 usage worker] --> Helper[safeMultiGet]
  Helper --> Mode{Redis Cluster enabled?}
  Mode -->|No| MGET[Single MGET]
  Mode -->|Yes| GETS[Per-key GET operations]
  MGET --> Values[Ordered values]
  GETS --> Values
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(redis): avoid CROSSSLOT on v4 legacy..."](https://github.com/langfuse/langfuse/commit/8c3c2e6e673e4623c2c0ba03168b624cabc29cf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53766320)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)

<!-- /greptile_comment -->