### PR TITLE
test(redis): restore REDIS_CLUSTER_ENABLED after safeMultiGet tests

### DIFF
--- a/packages/shared/src/server/redis/redis.test.ts
+++ b/packages/shared/src/server/redis/redis.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Redis } from "ioredis";
 
 vi.mock("../../env", () => ({
@@ -83,6 +83,10 @@ describe("scanKeys", () => {
 });
 
 describe("safeMultiGet", () => {
+  afterEach(() => {
+    env.REDIS_CLUSTER_ENABLED = "false";
+  });
+
   it("uses mget when cluster mode is disabled", async () => {
     env.REDIS_CLUSTER_ENABLED = "false";
     const mget = vi.fn(async () => ["a", null, "c"]);


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16181.preview.langfuse.com](https://pr-16181.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Follow-up to #16180 Claude review: restore `env.REDIS_CLUSTER_ENABLED` in `afterEach` so `safeMultiGet` tests do not leak cluster mode into later suites in `redis.test.ts`.
- The CROSSSLOT production fix already merged in #16180; this is test hygiene only.

## Test plan
- [x] `vitest` `packages/shared/src/server/redis/redis.test.ts`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents `safeMultiGet` tests from leaking Redis cluster mode through their shared mocked environment.
- Imports Vitest’s `afterEach` hook.
- Resets `env.REDIS_CLUSTER_ENABLED` to its mocked default after every `safeMultiGet` test.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified.

The cleanup restores the only mutated Redis cluster flag to the test file’s hard-coded initial value, preventing state leakage without changing production behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["test(redis): restore REDIS\_CLUSTER\_ENABL..."](https://github.com/langfuse/langfuse/commit/6a2ec35b3780963b3ec7b14a4d27a5879eb1bcba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53768664)</sub>

<!-- /greptile_comment -->