### PR TITLE
fix(web): clarify v4 migration API usage refresh accuracy

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -396,7 +396,7 @@ describe("V4MigrationDetailsContent", () => {
 
     expect(
       screen.getByText(
-        "SDK, instrumentation, experiment, and API checks cover activity from the last 14 days.",
+        "SDK, instrumentation, experiment, and API checks cover activity from the last 14 days. API and experiment usage counts refresh about once an hour, so recent calls may not appear yet.",
       ),
     ).toBeInTheDocument();
     expect(

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -896,7 +896,8 @@ export function V4MigrationApisSection({
         <>
           <p className="text-muted-foreground mb-2 text-sm">
             You&apos;ve called these deprecated endpoints in the last{" "}
-            {V4_MIGRATION_LOOKBACK_DAYS} days. They stop working soon; the{" "}
+            {V4_MIGRATION_LOOKBACK_DAYS} days. Counts refresh about once an hour
+            and can lag live traffic. They stop working soon; the{" "}
             <ExternalLink
               href={DEPRECATED_API_MIGRATION_URL}
               analytics={{ section: "apis", link: "deprecated_api_docs" }}
@@ -940,7 +941,8 @@ export function V4MigrationApisSection({
       ) : (
         <p className="text-muted-foreground text-sm">
           No deprecated public API usage detected in the last{" "}
-          {V4_MIGRATION_LOOKBACK_DAYS} days.
+          {V4_MIGRATION_LOOKBACK_DAYS} days. This check refreshes about once an
+          hour.
         </p>
       )}
     </Section>
@@ -1437,7 +1439,8 @@ export function V4MigrationDetailsContent({
         </div>
         <p className="text-muted-foreground text-sm">
           SDK, instrumentation, experiment, and API checks cover activity from
-          the last {V4_MIGRATION_LOOKBACK_DAYS} days.
+          the last {V4_MIGRATION_LOOKBACK_DAYS} days. API and experiment usage
+          counts refresh about once an hour, so recent calls may not appear yet.
         </p>
         <div>
           <V4MigrationSdkSection


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16182.preview.langfuse.com](https://pr-16182.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Migrate APIs / Action items copy now states that API and experiment usage counts refresh about once an hour and can lag live traffic.
- Matches observed behavior: UI reads Redis snapshots (`computedAt` / heartbeat), not live `query_log`.

## Test plan
- [x] `V4MigrationContent.clienttest.tsx`
- [ ] Spot-check Migrate APIs section in the v4 migration panel

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Clarifies that v4 migration API and experiment usage counts refresh approximately hourly and may lag live traffic.

- Updates migration-panel copy for both detected and undetected deprecated API usage.
- Updates the corresponding component test expectation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The changes are limited to accurate explanatory UI copy and its corresponding test expectation, with no runtime logic, data flow, or security behavior modified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): clarify v4 migration API usage..."](https://github.com/langfuse/langfuse/commit/cd097a34f29f3e4fc8bf4d16a1f27f4b0bfac9c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53772008)</sub>

<!-- /greptile_comment -->