### PR TITLE
feat(v4-migration): add migration link to personal settings menus

### DIFF
--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -36,7 +36,10 @@ import type { RouteGroup } from "@/src/components/layouts/routes";
 import dynamic from "next/dynamic";
 import { ControlledFeaturePreviewModal } from "@/src/features/feature-previews/components/ControlledFeaturePreviewModal";
 import { InAppAgentWindowHost } from "@/src/features/in-app-agent/components/InAppAgentWindowHost";
-import { useV4UpgradeUiEnabled } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
+import {
+  useV4UpgradeUiEnabled,
+  useV4UpgradeUiFlag,
+} from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { findCurrentInstance } from "@/src/ee/features/ui-customization/instanceLinks";
 import { api } from "@/src/utils/api";
@@ -124,6 +127,9 @@ export function AuthenticatedLayout({
   const router = useRouter();
   useProjectCookie(router);
   const uiCustomization = useUiCustomization();
+  // Account-level entry: use the raw flag (same as account settings tabs), not
+  // project-scoped force-v3 suppression.
+  const showV4Migration = useV4UpgradeUiFlag();
 
   // Safe assertion: AuthenticatedLayout is only rendered after auth checks pass
   // in AppLayout, which guarantees session.user exists at this point
@@ -180,6 +186,15 @@ export function AuthenticatedLayout({
       name: "Account Settings",
       href: "/account/settings",
     },
+    ...(showV4Migration
+      ? [
+          {
+            type: "link" as const,
+            name: "v4 Migration",
+            href: "/v4-migration",
+          },
+        ]
+      : []),
     {
       type: "action" as const,
       name: "Theme",

--- a/web/src/components/nav/topbar-account.tsx
+++ b/web/src/components/nav/topbar-account.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { ThemeToggle } from "@/src/features/theming/ThemeToggle";
+import { useV4UpgradeUiFlag } from "@/src/features/v4-migration/useV4UpgradeUiEnabled";
 import { cn } from "@/src/utils/tailwind";
 
 /**
@@ -27,6 +28,7 @@ import { cn } from "@/src/utils/tailwind";
  */
 export const TopbarAccount = ({ className }: { className?: string }) => {
   const session = useSession();
+  const showV4Migration = useV4UpgradeUiFlag();
   const user = session.data?.user;
 
   if (!user) return null;
@@ -75,6 +77,11 @@ export const TopbarAccount = ({ className }: { className?: string }) => {
         <DropdownMenuItem asChild>
           <Link href="/account/settings">Account settings</Link>
         </DropdownMenuItem>
+        {showV4Migration ? (
+          <DropdownMenuItem asChild>
+            <Link href="/v4-migration">v4 Migration</Link>
+          </DropdownMenuItem>
+        ) : null}
         {/* ThemeToggle stops propagation itself; keep the row from closing the
             menu so the user can flip themes and keep the menu open. */}
         <DropdownMenuItem onSelect={(e) => e.preventDefault()}>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16191.preview.langfuse.com](https://pr-16191.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Add a gated **v4 Migration** link to the sidebar personal settings dropdown and the mobile topbar account menu
- Links to `/v4-migration`, shown when `v4UpgradeUi` is enabled (same flag as account/org/project settings tabs)

## Test plan
- [ ] With `v4UpgradeUi` on, open the sidebar user menu and confirm **v4 Migration** appears after Account Settings and opens `/v4-migration`
- [ ] With `v4UpgradeUi` on (mobile), open the topbar account menu and confirm the same link
- [ ] With `v4UpgradeUi` off, confirm the link is hidden in both menus

## Packages
- `web`

## Verification
- Pre-commit: `Tasks: 7 successful, 7 total` (turbo lint)
- Browser review skipped (local web stack/env not running)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds feature-flagged entry points to the existing v4 migration page.
- Adds a “v4 Migration” link to the authenticated sidebar account menu.
- Adds the equivalent link to the mobile topbar account menu.
- Uses the same raw `v4UpgradeUi` flag as existing account, organization, and project settings tabs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with both navigation entries consistently gated and targeting the existing migration page.

The new links use the established account-level feature flag, render within the existing authenticated session context, and match the route and gating semantics already used by settings navigation.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(v4-migration): add migration link t..."](https://github.com/langfuse/langfuse/commit/1b2a41a0f96d14bc736471c4f09358da1b1b713e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53900031)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->