### PR TITLE
fix(otel): preserve structured gen_ai.system_instructions

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.systemInstructions.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.systemInstructions.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Mapping of gen_ai.system_instructions onto gen_ai.input.messages.
+ *
+ * Structured LiteLLM messages (`{role, parts}`) must be prepended as-is.
+ * Canonical text parts stay concatenated. Empty or unmappable values are
+ * skipped instead of being string-coerced to "[object Object]".
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../redis/redis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../redis/redis")>()),
+  redis: { set: vi.fn().mockResolvedValue("OK") },
+}));
+
+import {
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "./OtelIngestionProcessor";
+
+const createProcessor = () =>
+  new OtelIngestionProcessor({
+    projectId: "test-project-system-instructions",
+    publicKey: "pk-test",
+    sdkName: "python",
+    sdkVersion: "3.8.1",
+  });
+
+type OtelAttribute = { key: string; value: Record<string, unknown> };
+
+const buildBatch = (attributes: OtelAttribute[]): ResourceSpan[] => [
+  {
+    resource: {
+      attributes: [{ key: "service.name", value: { stringValue: "test-svc" } }],
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: "langfuse-sdk",
+          version: "3.8.1",
+          attributes: [
+            { key: "public_key", value: { stringValue: "pk-test" } },
+          ],
+        },
+        spans: [
+          {
+            traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+            spanId: Buffer.from("0123456789abcdef", "hex"),
+            name: "litellm_request",
+            kind: 1,
+            startTimeUnixNano: "1752384000000000000",
+            endTimeUnixNano: "1752384001000000000",
+            attributes,
+            status: {},
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const parseObservationInput = (events: { type: string; body: unknown }[]) => {
+  const observation = events.find(
+    (event) => event.type.endsWith("-create") && event.type !== "trace-create",
+  );
+  const input = (observation?.body as { input?: unknown } | undefined)?.input;
+  return typeof input === "string" ? JSON.parse(input) : input;
+};
+
+const mapSystemInstructions = async (
+  inputMessages: unknown,
+  systemInstructions: unknown,
+) => {
+  const processor = createProcessor();
+  const events = await processor.processToIngestionEvents(
+    buildBatch([
+      {
+        key: "gen_ai.input.messages",
+        value: { stringValue: JSON.stringify(inputMessages) },
+      },
+      {
+        key: "gen_ai.system_instructions",
+        value: {
+          stringValue:
+            typeof systemInstructions === "string"
+              ? systemInstructions
+              : JSON.stringify(systemInstructions),
+        },
+      },
+    ]),
+  );
+  return parseObservationInput(events);
+};
+
+describe("OTel gen_ai.system_instructions mapping", () => {
+  const userMessages = [
+    { role: "user", parts: [{ type: "text", content: "Hello" }] },
+  ];
+
+  it("preserves structured system messages instead of string-coercing them", async () => {
+    const systemInstructions = [
+      {
+        role: "system",
+        parts: [{ type: "text", content: "Be concise." }],
+      },
+      {
+        role: "system",
+        parts: [{ type: "text", content: "Use plain language." }],
+      },
+    ];
+
+    const input = await mapSystemInstructions(userMessages, systemInstructions);
+
+    expect(input).toEqual([...systemInstructions, ...userMessages]);
+    expect(JSON.stringify(input)).not.toContain("[object Object]");
+  });
+
+  it("concatenates canonical text instruction parts into one system message", async () => {
+    const systemInstructions = [
+      { type: "text", content: "You are a helpful assistant." },
+      { type: "text", content: "Answer concisely." },
+    ];
+
+    const input = await mapSystemInstructions(userMessages, systemInstructions);
+
+    expect(input).toEqual([
+      {
+        role: "system",
+        content: "You are a helpful assistant.\nAnswer concisely.",
+      },
+      ...userMessages,
+    ]);
+  });
+
+  it("preserves non-text instruction parts without string coercion", async () => {
+    const systemInstructions = [
+      { type: "text", content: "Describe the image." },
+      { type: "binary", content_type: "image/png", id: "file-1" },
+    ];
+
+    const input = await mapSystemInstructions(userMessages, systemInstructions);
+
+    expect(input).toEqual([
+      {
+        role: "system",
+        parts: [
+          { type: "text", content: "Describe the image." },
+          { type: "binary", content_type: "image/png", id: "file-1" },
+        ],
+      },
+      ...userMessages,
+    ]);
+    expect(JSON.stringify(input)).not.toContain("[object Object]");
+  });
+
+  it("leaves input unchanged when instructions are empty or unmappable", async () => {
+    expect(await mapSystemInstructions(userMessages, [])).toEqual(userMessages);
+    expect(
+      await mapSystemInstructions(userMessages, [
+        { unexpected: true },
+        null,
+        42,
+      ]),
+    ).toEqual(userMessages);
+  });
+
+  it("does not prepend instructions when input already has a system message", async () => {
+    const inputMessages = [
+      {
+        role: "system",
+        parts: [{ type: "text", content: "Existing system prompt." }],
+      },
+      ...userMessages,
+    ];
+    const systemInstructions = [
+      { role: "system", parts: [{ type: "text", content: "Be concise." }] },
+    ];
+
+    const input = await mapSystemInstructions(
+      inputMessages,
+      systemInstructions,
+    );
+
+    expect(input).toEqual(inputMessages);
+  });
+});

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2185,8 +2185,10 @@ export class OtelIngestionProcessor {
   }
 
   /**
-   * Prepends gen_ai.system_instructions as a {role: "system", content} message,
-   * consistent with how gen_ai.system.message events are mapped.
+   * Prepends gen_ai.system_instructions onto a chat-message array.
+   * Preserves complete structured system messages (e.g. LiteLLM `{role, parts}`),
+   * concatenates canonical text instruction parts, and skips empty/unmappable
+   * values instead of string-coercing them to "[object Object]".
    * No-ops if messages already contain a system message.
    */
   private prependSystemInstructions(
@@ -2198,37 +2200,116 @@ export class OtelIngestionProcessor {
       if (!Array.isArray(messages)) return input;
 
       const hasSystemMessage = messages.some(
-        (msg: Record<string, unknown>) => msg?.role === "system",
+        (msg: unknown) =>
+          OtelIngestionProcessor.isPlainObject(msg) && msg.role === "system",
       );
       if (hasSystemMessage) return input;
 
-      let content: string;
-      try {
-        const parsed =
-          typeof systemInstructions === "string"
-            ? JSON.parse(systemInstructions)
-            : systemInstructions;
-        if (Array.isArray(parsed)) {
-          content = parsed
-            .map((p: Record<string, unknown>) =>
-              typeof p === "object" && p?.content
-                ? String(p.content)
-                : String(p),
-            )
-            .join("\n");
-        } else {
-          content = String(parsed);
-        }
-      } catch {
-        content = String(systemInstructions);
-      }
+      const systemMessages =
+        this.mapSystemInstructionsToMessages(systemInstructions);
+      if (systemMessages.length === 0) return input;
 
-      const systemMessage = { role: "system", content };
-      const merged = [systemMessage, ...messages];
+      const merged = [...systemMessages, ...messages];
       return typeof input === "string" ? JSON.stringify(merged) : merged;
     } catch {
       return input;
     }
+  }
+
+  private mapSystemInstructionsToMessages(
+    systemInstructions: unknown,
+  ): Record<string, unknown>[] {
+    const items = this.normalizeSystemInstructionItems(systemInstructions);
+    if (items.length === 0) return [];
+
+    const messages: Record<string, unknown>[] = [];
+    const pendingParts: unknown[] = [];
+
+    const flushPendingParts = () => {
+      if (pendingParts.length === 0) return;
+
+      const textParts = pendingParts.filter(
+        (part): part is string => typeof part === "string",
+      );
+      if (textParts.length === pendingParts.length) {
+        messages.push({
+          role: "system",
+          content: textParts.join("\n"),
+        });
+      } else {
+        messages.push({
+          role: "system",
+          parts: pendingParts.map((part) =>
+            typeof part === "string" ? { type: "text", content: part } : part,
+          ),
+        });
+      }
+      pendingParts.length = 0;
+    };
+
+    for (const item of items) {
+      if (typeof item === "string") {
+        if (item.length > 0) pendingParts.push(item);
+        continue;
+      }
+
+      if (!OtelIngestionProcessor.isPlainObject(item)) {
+        continue;
+      }
+
+      if (typeof item.role === "string") {
+        const hasParts = Array.isArray(item.parts);
+        const hasContent = "content" in item;
+        if (!hasParts && !hasContent) continue;
+        flushPendingParts();
+        messages.push(item);
+        continue;
+      }
+
+      if (typeof item.content === "string") {
+        if (item.content.length === 0) {
+          if (item.type && item.type !== "text") {
+            pendingParts.push(item);
+          }
+          continue;
+        }
+        if (!item.type || item.type === "text") {
+          pendingParts.push(item.content);
+          continue;
+        }
+        pendingParts.push(item);
+        continue;
+      }
+
+      if (item.content != null && typeof item.content !== "string") {
+        pendingParts.push(item);
+        continue;
+      }
+
+      if (item.type) {
+        pendingParts.push(item);
+      }
+    }
+
+    flushPendingParts();
+    return messages;
+  }
+
+  private normalizeSystemInstructionItems(value: unknown): unknown[] {
+    if (value == null) return [];
+
+    if (typeof value === "string") {
+      if (value.length === 0) return [];
+      try {
+        return this.normalizeSystemInstructionItems(JSON.parse(value));
+      } catch {
+        return value.trim().length === 0 ? [] : [value];
+      }
+    }
+
+    if (Array.isArray(value)) return value;
+    if (OtelIngestionProcessor.isPlainObject(value)) return [value];
+    return [];
   }
 
   private extractEnvironment(

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -2778,6 +2778,134 @@ describe("OTel Resource Span Mapping", () => {
       expect(observationEvent?.body.input).toBe(JSON.stringify(allMessages));
     });
 
+    const createGenAiInputSpan = ({
+      inputMessages,
+      systemInstructions,
+    }: {
+      inputMessages: unknown;
+      systemInstructions: unknown;
+    }) => ({
+      resource: {},
+      scopeSpans: [
+        {
+          spans: [
+            {
+              ...defaultSpanProps,
+              attributes: [
+                {
+                  key: "gen_ai.input.messages",
+                  value: { stringValue: JSON.stringify(inputMessages) },
+                },
+                {
+                  key: "gen_ai.system_instructions",
+                  value: {
+                    stringValue:
+                      typeof systemInstructions === "string"
+                        ? systemInstructions
+                        : JSON.stringify(systemInstructions),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const parseObservationInput = (events: TestIngestionEvent[]) => {
+      const observation = events.find(
+        (e) => e.type.endsWith("-create") && e.type !== "trace-create",
+      );
+      const input = observation?.body.input;
+      return typeof input === "string" ? JSON.parse(input) : input;
+    };
+
+    it("should preserve structured gen_ai.system_instructions messages instead of string-coercing them", async () => {
+      const inputMessages = [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "Hello" }],
+        },
+      ];
+      const systemInstructions = [
+        {
+          role: "system",
+          parts: [{ type: "text", content: "Be concise." }],
+        },
+        {
+          role: "system",
+          parts: [{ type: "text", content: "Use plain language." }],
+        },
+      ];
+
+      const events = await convertOtelSpanToIngestionEvent(
+        createGenAiInputSpan({ inputMessages, systemInstructions }),
+        new Set(),
+      );
+      const input = parseObservationInput(events);
+
+      expect(input).toEqual([...systemInstructions, ...inputMessages]);
+      expect(JSON.stringify(input)).not.toContain("[object Object]");
+    });
+
+    it("should preserve non-text gen_ai.system_instructions parts without string coercion", async () => {
+      const inputMessages = [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "Hello" }],
+        },
+      ];
+      const systemInstructions = [
+        { type: "text", content: "Describe the image." },
+        { type: "binary", content_type: "image/png", id: "file-1" },
+      ];
+
+      const events = await convertOtelSpanToIngestionEvent(
+        createGenAiInputSpan({ inputMessages, systemInstructions }),
+        new Set(),
+      );
+      const input = parseObservationInput(events);
+
+      expect(input).toEqual([
+        {
+          role: "system",
+          parts: [
+            { type: "text", content: "Describe the image." },
+            { type: "binary", content_type: "image/png", id: "file-1" },
+          ],
+        },
+        ...inputMessages,
+      ]);
+      expect(JSON.stringify(input)).not.toContain("[object Object]");
+    });
+
+    it("should leave input unchanged when gen_ai.system_instructions cannot be mapped safely", async () => {
+      const inputMessages = [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "Hello" }],
+        },
+      ];
+
+      const emptyEvents = await convertOtelSpanToIngestionEvent(
+        createGenAiInputSpan({ inputMessages, systemInstructions: [] }),
+        new Set(),
+      );
+      expect(parseObservationInput(emptyEvents)).toEqual(inputMessages);
+
+      const unsafeEvents = await convertOtelSpanToIngestionEvent(
+        createGenAiInputSpan({
+          inputMessages,
+          systemInstructions: [{ unexpected: true }, null, 42],
+        }),
+        new Set(),
+      );
+      expect(parseObservationInput(unsafeEvents)).toEqual(inputMessages);
+      expect(JSON.stringify(parseObservationInput(unsafeEvents))).not.toContain(
+        "[object Object]",
+      );
+    });
+
     it("should prioritize OpenInference over OTel GenAI and model detection", async () => {
       const resourceSpan = {
         scopeSpans: [


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16194.preview.langfuse.com](https://pr-16194.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

OTEL ingestion was string-coercing structured `gen_ai.system_instructions` values. LiteLLM emits complete `{ role, parts }` messages, which have no top-level `content`, so `String(message)` became `"[object Object]"` and the original instructions were lost.

The mapper now:

- Prepends complete structured system messages as-is
- Still concatenates canonical text instruction parts and plain strings
- Preserves non-text instruction parts without string coercion
- Leaves input unchanged when instructions are empty or unmappable
- Still skips prepending when the input already contains a system message

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `@langfuse/shared` — OTEL ingestion mapping
- `web` — mapping regression tests

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- My code follows the style guidelines of this project (`pnpm run format`)
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my PR needs changes to the documentation
- I have checked if my changes generate no new warnings (`pnpm run lint`)
- I have added tests that prove my fix is effective or that my feature works
- I have checked if new and existing unit tests pass locally with my changes

## Verification

- `pnpm --filter @langfuse/shared run test src/server/otel/OtelIngestionProcessor.systemInstructions.test.ts src/server/otel/OtelIngestionProcessor.metadataDropped.test.ts` — `Tests 29 passed (29)`
- `pnpm --filter @langfuse/shared run typecheck` — exit 0
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`

Skipped running `web` `otelMapping.servertest.ts` here because Postgres/Docker were unavailable; the same cases were added to that suite for CI. Worker OTEL tests were skipped because they do not exercise this mapping.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14431](https://linear.app/clickhouse/issue/LFE-14431/bugotel-structured-gen-aisystem-instructions-render-as-object-object)

<div><a href="https://cursor.com/agents/bc-b7ed966f-02da-4170-9221-c9778d0f9dde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7ed966f-02da-4170-9221-c9778d0f9dde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

