### PR TITLE
fix(clickhouse): query all clustered query logs

### DIFF
--- a/packages/shared/src/server/clickhouse/queryTracking.test.ts
+++ b/packages/shared/src/server/clickhouse/queryTracking.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  env: {
+    CLICKHOUSE_CLUSTER_ENABLED: "true",
+    CLICKHOUSE_CLUSTER_NAME: "default",
+  },
+}));
+
+vi.mock("../../env", () => ({ env: mocks.env }));
+vi.mock("../repositories", () => ({ queryClickhouse: vi.fn() }));
+
+import { systemTableRef } from "./queryTracking";
+
+describe("systemTableRef", () => {
+  it("queries all query log tables on every replica in clustered mode", () => {
+    expect(systemTableRef("system.query_log")).toBe(
+      "clusterAllReplicas('default', merge(system, '^query_log*'))",
+    );
+  });
+});

--- a/packages/shared/src/server/clickhouse/queryTracking.ts
+++ b/packages/shared/src/server/clickhouse/queryTracking.ts
@@ -24,6 +24,9 @@ export function systemTableRef(
   table: "system.processes" | "system.query_log",
 ): string {
   if (env.CLICKHOUSE_CLUSTER_ENABLED === "true") {
+    if (table === "system.query_log") {
+      return `clusterAllReplicas('${env.CLICKHOUSE_CLUSTER_NAME}', merge(system, '^query_log*'))`;
+    }
     return `clusterAllReplicas('${env.CLICKHOUSE_CLUSTER_NAME}', '${table}')`;
   }
   return table;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16198.preview.langfuse.com](https://pr-16198.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Clustered ClickHouse deployments can rotate query logs into suffixed tables. Query all matching `query_log*` tables across every replica so query-status polling and error lookup do not miss completed queries.

Impacted package: `@langfuse/shared`. No dependencies or documentation changes are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory tasks

- [x] Self-reviewed the focused diff

## Verification

- `pnpm --filter @langfuse/shared run test queryTracking.test.ts` — 1 test passed
- `pnpm --filter web run test v4TransitionRouter.servertest.ts` — 36 tests passed
- `pnpm --filter worker run test handleV4LegacyApiUsageJob.test.ts` — 8 tests passed
- `pnpm run lint` — 7 tasks successful
- `pnpm --filter @langfuse/shared run build` — passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes clustered query-log lookups to combine matching system tables across replicas and adds a focused unit test for the generated SQL. However, the new regular expression does not match ClickHouse’s suffixed rotated tables.

- Uses `merge(system, ...)` inside `clusterAllReplicas` for clustered `system.query_log` reads.
- Leaves `system.processes` and non-clustered table references unchanged.
- Adds a unit test for the clustered query-log table expression.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the Merge table regex is corrected to include suffixed rotated query-log tables.

The changed expression still omits `query_log_<N>` tables because `*` repeats only the final `g`, leaving query-status, error, and usage lookups incomplete under the exact clustered rotation scenario this PR addresses.

**Files Needing Attention:** packages/shared/src/server/clickhouse/queryTracking.ts, packages/shared/src/server/clickhouse/queryTracking.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/clickhouse/queryTracking.ts:28
**Regex excludes rotated query logs**

When ClickHouse rotates the log into tables such as `query_log_1`, the `^query_log*` regex repeats only the final `g` and excludes those suffixed tables, causing query-status, error, and usage lookups to keep missing their records.

```suggestion
      return `clusterAllReplicas('${env.CLICKHOUSE_CLUSTER_NAME}', merge(system, '^query_log.*'))`;
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(clickhouse): query all clustered que..."](https://github.com/langfuse/langfuse/commit/e1f98462d1fe54e433dbee80f2583807906b3ebb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53935201)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->