### PR TITLE
chore(shared): log the node-level cause behind Redis connection errors

### DIFF
--- a/packages/shared/src/server/redis/redis.test.ts
+++ b/packages/shared/src/server/redis/redis.test.ts
@@ -11,6 +11,10 @@ vi.mock("../../env", () => ({
 
 import { env } from "../../env";
 import { safeMultiGet, scanKeys } from "./redis";
+import {
+  buildRedisErrorContext,
+  formatRedisErrorMessage,
+} from "./redisErrorContext";
 
 type ScanCall = [string, "MATCH", string, "COUNT", number];
 
@@ -119,5 +123,134 @@ describe("safeMultiGet", () => {
   it("returns an empty array for empty input", async () => {
     const client = { mget: vi.fn(), get: vi.fn() } as unknown as Redis;
     await expect(safeMultiGet(client, [])).resolves.toEqual([]);
+  });
+});
+
+/** Mirrors ioredis' ClusterAllFailedError: fixed message, cause on lastNodeError. */
+const clusterAllFailedError = (lastNodeError: unknown) =>
+  Object.assign(new Error("Failed to refresh slots cache."), {
+    name: "ClusterAllFailedError",
+    lastNodeError,
+  });
+
+describe("buildRedisErrorContext", () => {
+  it("lifts lastNodeError out of a ClusterAllFailedError", () => {
+    // ioredis times out `CLUSTER SLOTS` with a bare Error("timeout").
+    const context = buildRedisErrorContext(
+      clusterAllFailedError(new Error("timeout")),
+      "10.0.1.5:6379",
+    );
+
+    expect(context.failureMode).toBe("timeout");
+    expect(context.error.message).toBe("Failed to refresh slots cache.");
+    expect(context.lastNodeError).toMatchObject({
+      message: "timeout",
+      node: "10.0.1.5:6379",
+    });
+  });
+
+  it("keeps the socket-level fields of the node error", () => {
+    const nodeError = Object.assign(
+      new Error("connect ECONNREFUSED 10.0.1.5:6379"),
+      {
+        code: "ECONNREFUSED",
+        errno: -61,
+        syscall: "connect",
+        address: "10.0.1.5",
+        port: 6379,
+      },
+    );
+
+    const context = buildRedisErrorContext(clusterAllFailedError(nodeError));
+
+    expect(context.failureMode).toBe("connection-refused");
+    expect(context.lastNodeError).toMatchObject({
+      code: "ECONNREFUSED",
+      errno: -61,
+      syscall: "connect",
+      address: "10.0.1.5",
+      port: 6379,
+    });
+    expect(context.lastNodeError).not.toHaveProperty("node");
+  });
+
+  it.each([
+    ["timeout", new Error("timeout"), "timeout"],
+    [
+      "cluster-down",
+      new Error("CLUSTERDOWN Hash slot not served"),
+      "cluster-down",
+    ],
+    ["auth", new Error("WRONGPASS invalid username-password pair"), "auth"],
+    [
+      "readonly",
+      new Error("READONLY You can't write against a replica."),
+      "readonly",
+    ],
+    [
+      "dns",
+      Object.assign(new Error("getaddrinfo ENOTFOUND redis"), {
+        code: "ENOTFOUND",
+      }),
+      "dns",
+    ],
+    [
+      "tls",
+      Object.assign(new Error("certificate has expired"), {
+        code: "CERT_HAS_EXPIRED",
+      }),
+      "tls",
+    ],
+    ["unknown", new Error("something else entirely"), "unknown"],
+  ])(
+    "distinguishes %s behind the identical wrapper message",
+    (_label, nodeError, expected) => {
+      expect(
+        buildRedisErrorContext(clusterAllFailedError(nodeError)).failureMode,
+      ).toBe(expected);
+    },
+  );
+
+  it("classifies plain non-cluster errors and omits lastNodeError", () => {
+    const context = buildRedisErrorContext(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+
+    expect(context.failureMode).toBe("connection-reset");
+    expect(context.lastNodeError).toBeUndefined();
+    expect(context.error.stack).toBeDefined();
+  });
+
+  it("does not throw on non-Error values", () => {
+    expect(buildRedisErrorContext("boom")).toMatchObject({
+      failureMode: "unknown",
+      error: { message: "boom" },
+    });
+  });
+});
+
+describe("formatRedisErrorMessage", () => {
+  it("puts the failure mode and node cause into the log line", () => {
+    const context = buildRedisErrorContext(
+      clusterAllFailedError(
+        Object.assign(new Error("connect ECONNREFUSED 10.0.1.5:6379"), {
+          code: "ECONNREFUSED",
+        }),
+      ),
+      "10.0.1.5:6379",
+    );
+
+    expect(formatRedisErrorMessage("Redis cluster error", context)).toBe(
+      "Redis cluster error [connection-refused]: Failed to refresh slots cache. " +
+        "(last node error: connect ECONNREFUSED 10.0.1.5:6379 [ECONNREFUSED] from 10.0.1.5:6379)",
+    );
+  });
+
+  it("omits the cause suffix when there is no node error", () => {
+    const context = buildRedisErrorContext(new Error("Connection is closed."));
+
+    expect(formatRedisErrorMessage("Redis error", context)).toBe(
+      "Redis error [connection-closed]: Connection is closed.",
+    );
   });
 });

--- a/packages/shared/src/server/redis/redis.test.ts
+++ b/packages/shared/src/server/redis/redis.test.ts
@@ -126,7 +126,6 @@ describe("safeMultiGet", () => {
   });
 });
 
-/** Mirrors ioredis' ClusterAllFailedError: fixed message, cause on lastNodeError. */
 const clusterAllFailedError = (lastNodeError: unknown) =>
   Object.assign(new Error("Failed to refresh slots cache."), {
     name: "ClusterAllFailedError",
@@ -135,7 +134,6 @@ const clusterAllFailedError = (lastNodeError: unknown) =>
 
 describe("buildRedisErrorContext", () => {
   it("lifts lastNodeError out of a ClusterAllFailedError", () => {
-    // ioredis times out `CLUSTER SLOTS` with a bare Error("timeout").
     const context = buildRedisErrorContext(
       clusterAllFailedError(new Error("timeout")),
       "10.0.1.5:6379",
@@ -220,9 +218,7 @@ describe("buildRedisErrorContext", () => {
     expect(context.lastNodeError).toBeUndefined();
   });
 
-  // The text log format in ../logger.ts renders `info.stack` and nothing else,
-  // and the JSON format exposed a top-level `stack` before this context existed.
-  // Nesting it under `error` would silently drop stacks from text logs.
+  // The text format in ../logger.ts renders `info.stack` and nothing else.
   it("keeps the stack at the top level, not nested under error", () => {
     const context = buildRedisErrorContext(
       clusterAllFailedError(new Error("timeout")),

--- a/packages/shared/src/server/redis/redis.test.ts
+++ b/packages/shared/src/server/redis/redis.test.ts
@@ -218,7 +218,18 @@ describe("buildRedisErrorContext", () => {
 
     expect(context.failureMode).toBe("connection-reset");
     expect(context.lastNodeError).toBeUndefined();
-    expect(context.error.stack).toBeDefined();
+  });
+
+  // The text log format in ../logger.ts renders `info.stack` and nothing else,
+  // and the JSON format exposed a top-level `stack` before this context existed.
+  // Nesting it under `error` would silently drop stacks from text logs.
+  it("keeps the stack at the top level, not nested under error", () => {
+    const context = buildRedisErrorContext(
+      clusterAllFailedError(new Error("timeout")),
+    );
+
+    expect(context.stack).toContain("Failed to refresh slots cache.");
+    expect(context.error).not.toHaveProperty("stack");
   });
 
   it("does not throw on non-Error values", () => {

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -3,6 +3,20 @@ import type { QueueBaseOptions } from "bullmq";
 import fs from "fs";
 import { env } from "../../env";
 import { logger } from "../logger";
+import {
+  buildRedisErrorContext,
+  formatRedisErrorMessage,
+  getLastNodeError,
+} from "./redisErrorContext";
+
+const logRedisError = (
+  prefix: string,
+  error: unknown,
+  nodeAddress?: string,
+) => {
+  const context = buildRedisErrorContext(error, nodeAddress);
+  logger.error(formatRedisErrorMessage(prefix, context), context);
+};
 
 const defaultRedisOptions: Partial<RedisOptions> = {
   enableReadyCheck: true,
@@ -146,8 +160,21 @@ const createRedisClusterInstance = (
 
   const cluster = new Cluster(nodes, clusterOptions);
 
+  // `ClusterAllFailedError.lastNodeError` carries no address, so remember the
+  // one ioredis reported for it and only reuse it for that exact error.
+  let lastNodeFailure: { error: unknown; address: string } | undefined;
+  cluster.on("node error", (error: unknown, address: string) => {
+    lastNodeFailure = { error, address };
+  });
+
   cluster.on("error", (error) => {
-    logger.error("Redis cluster error", error);
+    const lastNodeError = getLastNodeError(error);
+    const nodeAddress =
+      lastNodeError !== undefined && lastNodeFailure?.error === lastNodeError
+        ? lastNodeFailure.address
+        : undefined;
+
+    logRedisError("Redis cluster error", error, nodeAddress);
   });
 
   return cluster;
@@ -200,7 +227,7 @@ const createRedisSentinelInstance = (
   });
 
   instance.on("error", (error) => {
-    logger.error("Redis sentinel error", error);
+    logRedisError("Redis sentinel error", error);
   });
 
   return instance;
@@ -248,7 +275,7 @@ export const createNewRedisInstance = (
       : null;
 
   instance?.on("error", (error) => {
-    logger.error("Redis error", error);
+    logRedisError("Redis error", error);
   });
 
   return instance;

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -160,8 +160,7 @@ const createRedisClusterInstance = (
 
   const cluster = new Cluster(nodes, clusterOptions);
 
-  // `ClusterAllFailedError.lastNodeError` carries no address, so remember the
-  // one ioredis reported for it and only reuse it for that exact error.
+  // The `node error` event is the only place ioredis reports which node failed.
   let lastNodeFailure: { error: unknown; address: string } | undefined;
   cluster.on("node error", (error: unknown, address: string) => {
     lastNodeFailure = { error, address };

--- a/packages/shared/src/server/redis/redisErrorContext.ts
+++ b/packages/shared/src/server/redis/redisErrorContext.ts
@@ -36,7 +36,13 @@ type RedisErrorDetails = {
 
 export type RedisErrorContext = {
   failureMode: RedisFailureMode;
-  error: RedisErrorDetails & { stack?: string };
+  /**
+   * Deliberately top-level, not nested under `error`: the text log format in
+   * `../logger.ts` only renders `info.stack`, and the JSON format already
+   * exposed a top-level `stack` before this context existed.
+   */
+  stack?: string;
+  error: RedisErrorDetails;
   /** Present only on `ClusterAllFailedError`; `node` comes from the `node error` event. */
   lastNodeError?: RedisErrorDetails & { node?: string };
 };
@@ -160,10 +166,8 @@ export const buildRedisErrorContext = (
     // Classify the node-level cause when we have one: the wrapper message is
     // the same string for every failure.
     failureMode: classifyRedisFailure(lastNodeError ?? error),
-    error: {
-      ...describeError(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    },
+    stack: error instanceof Error ? error.stack : undefined,
+    error: describeError(error),
     ...(lastNodeError !== undefined
       ? {
           // No stack: it always points into ioredis internals, and these lines

--- a/packages/shared/src/server/redis/redisErrorContext.ts
+++ b/packages/shared/src/server/redis/redisErrorContext.ts
@@ -1,0 +1,193 @@
+/**
+ * Diagnostics for Redis connection errors.
+ *
+ * ioredis reports a failed cluster slot-map refresh as
+ * `ClusterAllFailedError: Failed to refresh slots cache.` — one identical
+ * message for every underlying cause. The cause lives on `lastNodeError`, the
+ * error returned by the final node ioredis tried, and is dropped by the
+ * default error serialisation. These helpers lift it out and label the failure
+ * mode so a timeout, a refused connection and a CLUSTERDOWN reply read as three
+ * different incidents.
+ */
+
+/** Cause of a Redis connection failure, as far as the error object reveals it. */
+export type RedisFailureMode =
+  | "timeout"
+  | "connection-refused"
+  | "connection-reset"
+  | "connection-closed"
+  | "host-unreachable"
+  | "dns"
+  | "tls"
+  | "auth"
+  | "cluster-down"
+  | "readonly"
+  | "unknown";
+
+type RedisErrorDetails = {
+  name?: string;
+  message?: string;
+  code?: string;
+  errno?: number;
+  syscall?: string;
+  address?: string;
+  port?: number;
+};
+
+export type RedisErrorContext = {
+  failureMode: RedisFailureMode;
+  error: RedisErrorDetails & { stack?: string };
+  /** Present only on `ClusterAllFailedError`; `node` comes from the `node error` event. */
+  lastNodeError?: RedisErrorDetails & { node?: string };
+};
+
+const readString = (source: object, key: string): string | undefined => {
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+const readNumber = (source: object, key: string): number | undefined => {
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : undefined;
+};
+
+const describeError = (error: unknown): RedisErrorDetails => {
+  if (typeof error !== "object" || error === null) {
+    return { message: String(error) };
+  }
+
+  return {
+    name: error instanceof Error ? error.name : readString(error, "name"),
+    message:
+      error instanceof Error ? error.message : readString(error, "message"),
+    // Node attaches these to socket-level failures (ECONNREFUSED, ETIMEDOUT, …).
+    code: readString(error, "code"),
+    errno: readNumber(error, "errno"),
+    syscall: readString(error, "syscall"),
+    address: readString(error, "address"),
+    port: readNumber(error, "port"),
+  };
+};
+
+/** The node-level error ioredis wrapped, if this is a `ClusterAllFailedError`. */
+export const getLastNodeError = (error: unknown): unknown => {
+  if (typeof error !== "object" || error === null) return undefined;
+  return (error as { lastNodeError?: unknown }).lastNodeError ?? undefined;
+};
+
+const CODE_FAILURE_MODES: Record<string, RedisFailureMode> = {
+  ECONNREFUSED: "connection-refused",
+  ECONNRESET: "connection-reset",
+  EPIPE: "connection-reset",
+  ETIMEDOUT: "timeout",
+  ESOCKETTIMEDOUT: "timeout",
+  EHOSTUNREACH: "host-unreachable",
+  ENETUNREACH: "host-unreachable",
+  ENOTFOUND: "dns",
+  EAI_AGAIN: "dns",
+  CERT_HAS_EXPIRED: "tls",
+  DEPTH_ZERO_SELF_SIGNED_CERT: "tls",
+  SELF_SIGNED_CERT_IN_CHAIN: "tls",
+  UNABLE_TO_VERIFY_LEAF_SIGNATURE: "tls",
+  ERR_TLS_CERT_ALTNAME_INVALID: "tls",
+};
+
+export const classifyRedisFailure = (error: unknown): RedisFailureMode => {
+  const { code, message } = describeError(error);
+
+  if (code) {
+    const byCode =
+      CODE_FAILURE_MODES[code] ?? (code.startsWith("ERR_TLS_") ? "tls" : null);
+    if (byCode) return byCode;
+  }
+
+  if (!message) return "unknown";
+
+  // Redis replies carry their condition as an uppercase prefix on the message.
+  if (message.includes("CLUSTERDOWN")) return "cluster-down";
+  if (message.includes("READONLY")) return "readonly";
+  if (
+    message.includes("NOAUTH") ||
+    message.includes("WRONGPASS") ||
+    message.includes("NOPERM") ||
+    message.includes("invalid password") ||
+    message.includes("without any password configured")
+  ) {
+    return "auth";
+  }
+
+  const lowerCaseMessage = message.toLowerCase();
+  // ioredis times out `CLUSTER SLOTS` with a bare `new Error("timeout")`.
+  if (
+    lowerCaseMessage.includes("timeout") ||
+    lowerCaseMessage.includes("timed out")
+  ) {
+    return "timeout";
+  }
+  if (
+    lowerCaseMessage.includes("certificate") ||
+    lowerCaseMessage.includes("ssl") ||
+    lowerCaseMessage.includes("tls")
+  ) {
+    return "tls";
+  }
+  if (
+    lowerCaseMessage.includes("connection is closed") ||
+    lowerCaseMessage.includes("connection is already closed") ||
+    lowerCaseMessage.includes("stream isn't writeable") ||
+    lowerCaseMessage.includes("is disconnected") ||
+    lowerCaseMessage.includes("is disconnecting")
+  ) {
+    return "connection-closed";
+  }
+
+  return "unknown";
+};
+
+/**
+ * Builds the structured log payload for a Redis error.
+ *
+ * `nodeAddress` is the `host:port` ioredis reported alongside the matching
+ * `node error` event; pass it only when it belongs to this `lastNodeError`.
+ */
+export const buildRedisErrorContext = (
+  error: unknown,
+  nodeAddress?: string,
+): RedisErrorContext => {
+  const lastNodeError = getLastNodeError(error);
+
+  return {
+    // Classify the node-level cause when we have one: the wrapper message is
+    // the same string for every failure.
+    failureMode: classifyRedisFailure(lastNodeError ?? error),
+    error: {
+      ...describeError(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    },
+    ...(lastNodeError !== undefined
+      ? {
+          // No stack: it always points into ioredis internals, and these lines
+          // arrive in the thousands during a slot-refresh burst.
+          lastNodeError: {
+            ...describeError(lastNodeError),
+            ...(nodeAddress ? { node: nodeAddress } : {}),
+          },
+        }
+      : {}),
+  };
+};
+
+/** Single-line summary so text-format logs stay diagnosable too. */
+export const formatRedisErrorMessage = (
+  prefix: string,
+  context: RedisErrorContext,
+): string => {
+  const cause = context.lastNodeError;
+  const causeSuffix = cause
+    ? ` (last node error: ${cause.message ?? cause.name ?? "unknown"}${
+        cause.code ? ` [${cause.code}]` : ""
+      }${cause.node ? ` from ${cause.node}` : ""})`
+    : "";
+
+  return `${prefix} [${context.failureMode}]: ${context.error.message ?? "unknown error"}${causeSuffix}`;
+};

--- a/packages/shared/src/server/redis/redisErrorContext.ts
+++ b/packages/shared/src/server/redis/redisErrorContext.ts
@@ -1,16 +1,10 @@
 /**
- * Diagnostics for Redis connection errors.
- *
- * ioredis reports a failed cluster slot-map refresh as
+ * ioredis reports every failed cluster slot-map refresh as
  * `ClusterAllFailedError: Failed to refresh slots cache.` — one identical
- * message for every underlying cause. The cause lives on `lastNodeError`, the
- * error returned by the final node ioredis tried, and is dropped by the
- * default error serialisation. These helpers lift it out and label the failure
- * mode so a timeout, a refused connection and a CLUSTERDOWN reply read as three
- * different incidents.
+ * message whatever went wrong. The cause is the error from the last node it
+ * tried, on `lastNodeError`.
  */
 
-/** Cause of a Redis connection failure, as far as the error object reveals it. */
 export type RedisFailureMode =
   | "timeout"
   | "connection-refused"
@@ -36,14 +30,10 @@ type RedisErrorDetails = {
 
 export type RedisErrorContext = {
   failureMode: RedisFailureMode;
-  /**
-   * Deliberately top-level, not nested under `error`: the text log format in
-   * `../logger.ts` only renders `info.stack`, and the JSON format already
-   * exposed a top-level `stack` before this context existed.
-   */
+  /** Must stay top-level: the text format in `../logger.ts` renders `info.stack`. */
   stack?: string;
   error: RedisErrorDetails;
-  /** Present only on `ClusterAllFailedError`; `node` comes from the `node error` event. */
+  /** `node` comes from the `node error` event; the error itself carries no address. */
   lastNodeError?: RedisErrorDetails & { node?: string };
 };
 
@@ -66,7 +56,6 @@ const describeError = (error: unknown): RedisErrorDetails => {
     name: error instanceof Error ? error.name : readString(error, "name"),
     message:
       error instanceof Error ? error.message : readString(error, "message"),
-    // Node attaches these to socket-level failures (ECONNREFUSED, ETIMEDOUT, …).
     code: readString(error, "code"),
     errno: readNumber(error, "errno"),
     syscall: readString(error, "syscall"),
@@ -75,7 +64,6 @@ const describeError = (error: unknown): RedisErrorDetails => {
   };
 };
 
-/** The node-level error ioredis wrapped, if this is a `ClusterAllFailedError`. */
 export const getLastNodeError = (error: unknown): unknown => {
   if (typeof error !== "object" || error === null) return undefined;
   return (error as { lastNodeError?: unknown }).lastNodeError ?? undefined;
@@ -150,12 +138,7 @@ export const classifyRedisFailure = (error: unknown): RedisFailureMode => {
   return "unknown";
 };
 
-/**
- * Builds the structured log payload for a Redis error.
- *
- * `nodeAddress` is the `host:port` ioredis reported alongside the matching
- * `node error` event; pass it only when it belongs to this `lastNodeError`.
- */
+/** Pass `nodeAddress` only when it belongs to this error's `lastNodeError`. */
 export const buildRedisErrorContext = (
   error: unknown,
   nodeAddress?: string,
@@ -163,15 +146,11 @@ export const buildRedisErrorContext = (
   const lastNodeError = getLastNodeError(error);
 
   return {
-    // Classify the node-level cause when we have one: the wrapper message is
-    // the same string for every failure.
     failureMode: classifyRedisFailure(lastNodeError ?? error),
     stack: error instanceof Error ? error.stack : undefined,
     error: describeError(error),
     ...(lastNodeError !== undefined
       ? {
-          // No stack: it always points into ioredis internals, and these lines
-          // arrive in the thousands during a slot-refresh burst.
           lastNodeError: {
             ...describeError(lastNodeError),
             ...(nodeAddress ? { node: nodeAddress } : {}),
@@ -181,7 +160,6 @@ export const buildRedisErrorContext = (
   };
 };
 
-/** Single-line summary so text-format logs stay diagnosable too. */
 export const formatRedisErrorMessage = (
   prefix: string,
   context: RedisErrorContext,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16200.preview.langfuse.com](https://pr-16200.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

When ioredis cannot rebuild its cluster slot map it throws
`ClusterAllFailedError: Failed to refresh slots cache.` — the same message for
every underlying cause. The actionable detail lives on the error's
`lastNodeError` (the failure from the final node ioredis attempted), and the
default error serialisation drops it. A recent production burst produced ~9,200
log lines on a single service in ~3h, every one of them carrying an identical
message plus an ioredis-internal stack and nothing about the node failure.
Root-causing it meant inferring the failure mode from a stack frame and
correlating against ElastiCache metrics by hand.

This PR makes the log line answer the question directly:

- Extracts `lastNodeError` and logs its `message`, `name`, `code`, `errno`,
  `syscall`, `address` and `port`.
- Classifies the failure into an explicit `failureMode` — `timeout`,
  `connection-refused`, `connection-reset`, `connection-closed`,
  `host-unreachable`, `dns`, `tls`, `auth`, `cluster-down`, `readonly`,
  `unknown` — derived from the node-level cause rather than the wrapper. A
  slot-refresh timeout, a refused connection and a `CLUSTERDOWN` reply are three
  different incidents and now read as three different lines.
- Recovers the failing node's `host:port` from the matching `node error` event,
  which is the only place ioredis reports it. The address is only attached when
  the event's error is reference-identical to `lastNodeError`, so it can never
  be mismatched to a different node.
- Puts `failureMode` and the node cause into the message string too, so
  text-format logs (`LANGFUSE_LOG_FORMAT=text`) stay diagnosable, not just JSON.
- Applies the same treatment to the sentinel and single-node handlers.

Example of the emitted JSON, verified against the real winston config:

```json
{
  "level": "error",
  "message": "Redis cluster error [timeout]: Failed to refresh slots cache. (last node error: timeout from 10.0.1.5:6379)",
  "stack": "ClusterAllFailedError: Failed to refresh slots cache.\n    at …",
  "failureMode": "timeout",
  "error": { "name": "ClusterAllFailedError", "message": "Failed to refresh slots cache." },
  "lastNodeError": { "name": "Error", "message": "timeout", "node": "10.0.1.5:6379" }
}
```

`stack` stays at the **top level** rather than nested under `error`. Two
reasons: the text log format renders `info.stack` and nothing else, so nesting
it would silently drop Redis stacks from `LANGFUSE_LOG_FORMAT=text`
deployments; and the JSON payload already exposed a top-level `stack`. The new
payload is therefore a strict superset of the old one — `message`, `stack` and
`lastNodeError` keep their positions, and `lastNodeError` is now populated
instead of serialising as `{}` (its content is what the old logs dropped).

No stack is emitted for `lastNodeError`: it always points into ioredis
internals, and these lines arrive in the thousands during a burst. Absent
fields are omitted rather than logged as `null`, so line size is unchanged for
errors that carry no extra detail.

Behaviour is otherwise unchanged — this only affects what the existing
`error`-event handlers log.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Tests cover the classification of each failure mode behind the identical
      wrapper message, the recovered node address, non-`Error` values, and the
      formatted message string (`packages/shared/src/server/redis/redis.test.ts`).
- [x] `pnpm turbo run lint --filter=@langfuse/shared --filter=web --filter=worker` — 6 successful, 6 total
- [x] `pnpm turbo run typecheck --filter=@langfuse/shared --filter=web --filter=worker` — 6 successful, 6 total
- [x] `pnpm --filter @langfuse/shared run test redis.test.ts` — 19 passed (19)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR enriches Redis connection-error logs with structured failure classifications and the node-level cause wrapped by ioredis.
- Adds helpers to extract, classify, structure, and format Redis errors.
- Applies the enriched logging to Cluster, Sentinel, and standalone Redis clients.
- Adds unit coverage for common Redis failure modes and formatted messages.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking regression that removes Redis stack traces from text-format logs.

The new diagnostics preserve useful error messages and structured JSON context, but nesting the stack under `error.stack` prevents the existing text formatter from rendering it.

**Files Needing Attention:** packages/shared/src/server/redis/redis.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/redis/redis.ts:18
**Preserve stacks in text logs**

When `LANGFUSE_LOG_FORMAT=text`, the new plain context object stores the stack under `error.stack`, but the text formatter only renders top-level `info.stack`. Redis error stacks therefore disappear from text logs, reducing the diagnostic value of these messages.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(shared): log the node-level cause ..."](https://github.com/langfuse/langfuse/commit/02383c60149b6ebc548421ed2c6c2cd876917952) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53958397)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->
