### PR TITLE
fix(worker): pin analytics export egress to connect-time SSRF validation (v3 backport of #16091)

### DIFF
--- a/packages/shared/src/server/outbound-url/validation.ts
+++ b/packages/shared/src/server/outbound-url/validation.ts
@@ -27,6 +27,11 @@ export class OutboundUrlValidationError extends Error {
   }
 }
 
+// Prefix of the message thrown on DNS-resolution failure. Exported so consumers
+// can detect this failure by message when the typed `code` is lost — e.g. after
+// RedirectValidationError re-wraps the inner error by message text only.
+export const DNS_LOOKUP_FAILED_MESSAGE_PREFIX = "DNS lookup failed for";
+
 export interface OutboundUrlValidationWhitelist {
   hosts: string[];
   ips: string[];
@@ -77,7 +82,7 @@ export async function resolveHost(hostname: string): Promise<string[]> {
   if (!ips.size) {
     throw new OutboundUrlValidationError(
       "dns-lookup-failed",
-      `DNS lookup failed for ${hostname}`,
+      `${DNS_LOOKUP_FAILED_MESSAGE_PREFIX} ${hostname}`,
     );
   }
   return [...ips];

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Connect-time SSRF pinning for the PostHog and Mixpanel analytics exporters.
+ *
+ * Both sender tests neutralise the string pre-check (that models "the host
+ * validated as public") and point the send at a `localhost` NAME, whose
+ * connect-time lookup re-resolves to 127.0.0.1 (that models "it rebinds at
+ * connect"). Pointing them at a statically-blocked host instead would pass even
+ * without connect-time pinning, which is why they are shaped this way.
+ *
+ * The PostHog leg is exercised through `countingFetch`, the transport the
+ * handler injects into the SDK, rather than through the handler itself: on this
+ * branch's posthog-node, `flush()` does not drain the queue — the send happens
+ * on the SDK's own background timer, after the handler has already returned — so
+ * the handler cannot observe the send outcome and a handler-level assertion
+ * would pass whether or not the egress is pinned. `countingFetch` is the seam
+ * every PostHog export byte goes through, so it is where the guarantee lives.
+ */
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isUnrecoverableError } from "../errors/UnrecoverableError";
+import { findOutboundUrlValidationError } from "../errors/findOutboundUrlValidationError";
+
+// The senders read their allowlist from the environment, and vitest loads
+// ../.env. A developer who allowlists localhost for local webhook testing would
+// otherwise turn the block assertions below into mystery failures.
+vi.hoisted(() => {
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_HOST;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IPS;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IP_SEGMENTS;
+});
+
+const openServers: Server[] = [];
+
+async function startLoopbackServer(
+  onRequest: () => void,
+): Promise<{ nameUrl: string; port: number }> {
+  const server = createServer((_req, res) => {
+    onRequest();
+    res.end("{}");
+  });
+  openServers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return { nameUrl: `http://localhost:${port}`, port };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    openServers
+      .splice(0)
+      .map((s) => new Promise<void>((r) => s.close(() => r()))),
+  );
+  vi.restoreAllMocks();
+});
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: { posthogIntegration: { findFirst: vi.fn(), update: vi.fn() } },
+}));
+
+// Keep the REAL secure-outbound egress helpers; silence only the logger.
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getCurrentSpan: vi.fn(() => undefined),
+  };
+});
+
+vi.mock("@langfuse/shared/encryption", () => ({
+  decrypt: vi.fn(() => "phc_decrypted"),
+}));
+
+vi.mock("../env", () => ({
+  env: {
+    LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
+  },
+  v4WritesToLegacyTables: (e: { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }) =>
+    e.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only",
+  v4WritesToEventsTable: (e: { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }) =>
+    e.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "legacy",
+}));
+
+// Imported after mocks are registered.
+import { countingFetch } from "../features/posthog/handlePostHogIntegrationProjectJob";
+import {
+  OutboundUrlValidationError,
+  RedirectValidationError,
+} from "@langfuse/shared/src/server";
+import { rethrowIfOutboundValidationFailure } from "../features/analyticsIntegrationEgress";
+import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
+import type { MixpanelEvent } from "../features/mixpanel/transformers";
+
+function causeChainIncludes(error: unknown, needle: string): boolean {
+  let current: any = error;
+  for (let depth = 0; depth < 6 && current; depth++) {
+    if (typeof current.message === "string" && current.message.includes(needle))
+      return true;
+    current = current.cause;
+  }
+  return false;
+}
+
+describe("PostHog export transport — SSRF connect-time pinning", () => {
+  it("blocks a validated host that resolves to a blocked IP before egress", async () => {
+    let requestCount = 0;
+    const { nameUrl, port } = await startLoopbackServer(() => {
+      requestCount++;
+    });
+
+    // Negative control: the pre-fix path (bare global fetch) reaches the server,
+    // so a later count of 0 proves the pinning blocked the send rather than the
+    // harness being unreachable.
+    await fetch(`http://localhost:${port}/batch/`, {
+      method: "POST",
+      body: "{}",
+    });
+    expect(requestCount).toBe(1);
+
+    const volume = { bytes: 0 };
+    const send = countingFetch(volume);
+
+    let thrown: unknown;
+    try {
+      await send!(`${nameUrl}/batch/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      } as unknown as Parameters<NonNullable<typeof send>>[1]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    // Still 1: the export send never reached the wire.
+    expect(requestCount).toBe(1);
+    expect(thrown).toBeDefined();
+    // Non-vacuous: only an OutboundUrlValidationError carrying `blocked-ip` (or
+    // `blocked-hostname`) produces this message, and the host passes the string
+    // pre-check, so it can only have come from the connect-time lookup.
+    expect(causeChainIncludes(thrown, "Blocked IP address detected")).toBe(
+      true,
+    );
+    // The block is classified terminal, so the caller stops re-attempting it.
+    expect(findOutboundUrlValidationError(thrown)).toBeDefined();
+  }, 40_000);
+});
+
+describe("Mixpanel sender — SSRF connect-time pinning", () => {
+  it("rejects a validated host that connects to a blocked IP, before egress and terminally", async () => {
+    let requestCount = 0;
+    const { nameUrl, port } = await startLoopbackServer(() => {
+      requestCount++;
+    });
+
+    // Negative control, as above.
+    await fetch(`http://localhost:${port}/import?strict=1`, {
+      method: "POST",
+      body: "[]",
+    });
+    expect(requestCount).toBe(1);
+
+    const client = new MixpanelClient({
+      projectToken: "t",
+      region: "api",
+      baseUrl: nameUrl,
+    });
+    client.addEvent({
+      event: "trace",
+      properties: { token: "t", distinct_id: "1", $insert_id: 1 },
+    } as unknown as MixpanelEvent);
+
+    let thrown: unknown;
+    try {
+      await client.flush();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(requestCount).toBe(1);
+    expect(thrown).toBeDefined();
+    expect(isUnrecoverableError(thrown)).toBe(true);
+    expect(causeChainIncludes(thrown, "Blocked IP address detected")).toBe(
+      true,
+    );
+  }, 40_000);
+});
+
+describe("outbound validation classification", () => {
+  it("treats a DNS lookup failure as retryable and a blocked IP as terminal", () => {
+    const wrap = (cause: Error) =>
+      Object.assign(new TypeError("fetch failed"), { cause });
+
+    expect(
+      findOutboundUrlValidationError(
+        wrap(
+          new OutboundUrlValidationError(
+            "dns-lookup-failed",
+            "DNS lookup failed for exporter.example.com",
+          ),
+        ),
+      ),
+    ).toBeUndefined();
+
+    expect(
+      findOutboundUrlValidationError(
+        wrap(
+          new OutboundUrlValidationError(
+            "blocked-ip",
+            "Blocked IP address detected: 127.0.0.1",
+          ),
+        ),
+      ),
+    ).toBeDefined();
+  });
+});
+
+/**
+ * Everything a structured logger or tracer can pull off a thrown error: its
+ * enumerable own fields (winston copies those into the JSON log line), its
+ * message, its stack, and the same again for each `cause` a chain-walking
+ * reporter follows. A credential must appear in none of them.
+ */
+function serializableSurface(error: unknown): string {
+  const parts: string[] = [];
+  let current: any = error;
+  for (let depth = 0; depth < 6 && current; depth++) {
+    parts.push(JSON.stringify({ ...current }));
+    if (typeof current.message === "string") parts.push(current.message);
+    if (typeof current.stack === "string") parts.push(current.stack);
+    current = current.cause;
+  }
+  return parts.join("\n");
+}
+
+function captureRethrow(error: unknown): unknown {
+  try {
+    rethrowIfOutboundValidationFailure(error, {
+      logSubject: "Mixpanel outbound send",
+      jobSubject: "Mixpanel export",
+    });
+  } catch (caught) {
+    return caught;
+  }
+  return undefined;
+}
+
+describe("terminal outbound failure reporting", () => {
+  // The rejected redirect target is embedded verbatim in the validation error —
+  // in its message, its stack, and its enumerable `redirectUrl` field — so a
+  // credentialed Location header would otherwise reach the log line and
+  // BullMQ's persisted failedReason.
+  const credentialedRedirect = () =>
+    Object.assign(new TypeError("fetch failed"), {
+      cause: new RedirectValidationError(
+        "Blocked IP address detected: 169.254.169.254",
+        "http://exporter:hunter2@169.254.169.254/",
+        0,
+      ),
+    });
+
+  it("redacts credentials from a rejected redirect target", () => {
+    const thrown = captureRethrow(credentialedRedirect());
+
+    expect(isUnrecoverableError(thrown)).toBe(true);
+    const message = (thrown as Error).message;
+    expect(message).not.toContain("hunter2");
+    expect(message).toContain("http://***@169.254.169.254/");
+    // The diagnostic reason must survive redaction, otherwise the operator
+    // cannot tell a blocked IP from a rejected scheme.
+    expect(message).toContain("Blocked IP address detected: 169.254.169.254");
+  });
+
+  it("keeps credentials out of every field a logger or tracer can serialize", () => {
+    const thrown = captureRethrow(credentialedRedirect());
+
+    // Redacting only the message is not enough: the queue's generic `failed`
+    // handler passes the whole error to the logger and to traceException, so a
+    // raw error retained as an enumerable `cause` leaks the URL anyway.
+    expect(serializableSurface(thrown)).not.toContain("hunter2");
+    expect(serializableSurface(thrown)).not.toContain(
+      "exporter:hunter2@169.254.169.254",
+    );
+    // Non-vacuous: the redacted reason really is reachable on that surface.
+    expect(serializableSurface(thrown)).toContain(
+      "Blocked IP address detected: 169.254.169.254",
+    );
+  });
+
+  it("does not expose the retained cause as an enumerable field", () => {
+    const thrown = captureRethrow(credentialedRedirect());
+
+    expect((thrown as Error).cause).toBeDefined();
+    expect(Object.keys(thrown as object)).not.toContain("cause");
+  });
+
+  it("leaves a credential-free message untouched and stays a no-op for other errors", () => {
+    expect(() =>
+      rethrowIfOutboundValidationFailure(new Error("connection reset"), {
+        logSubject: "Mixpanel outbound send",
+        jobSubject: "Mixpanel export",
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      rethrowIfOutboundValidationFailure(
+        new OutboundUrlValidationError(
+          "blocked-ip",
+          "Blocked IP address detected: 127.0.0.1",
+        ),
+        { logSubject: "Mixpanel outbound send", jobSubject: "Mixpanel export" },
+      ),
+    ).toThrow("Blocked IP address detected: 127.0.0.1");
+  });
+});

--- a/worker/src/errors/findOutboundUrlValidationError.ts
+++ b/worker/src/errors/findOutboundUrlValidationError.ts
@@ -1,0 +1,57 @@
+/**
+ * Walk an error's `cause` chain looking for a connect-time secure-outbound
+ * validation failure: a blocked resolved IP or a rejected redirect target.
+ * undici surfaces the connect-time block as a generic "fetch failed" TypeError
+ * whose `cause` holds the real validation error, and SDKs (e.g. posthog-node)
+ * may wrap it again, so the signal only shows up by walking the chain.
+ *
+ * Matched by error NAME rather than `instanceof`: importing the shared error
+ * classes as values breaks in tests that replace the
+ * `@langfuse/shared/src/server` barrel without `importOriginal`, and a
+ * classifier that throws would destroy the very error it is meant to describe.
+ */
+import { DNS_LOOKUP_FAILED_MESSAGE_PREFIX } from "@langfuse/shared/src/server";
+
+const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
+  "OutboundUrlValidationError",
+  "RedirectValidationError",
+]);
+
+// A resolver hiccup is not a policy block: the host may be legitimate and the
+// next attempt may succeed, so it must stay retryable. RedirectValidationError
+// re-wraps the inner failure by message only — no code, no cause — so a DNS
+// failure on a redirect hop is recognisable only by its message text. The
+// substring is imported from the throw site so the two stay in sync.
+const isTransientDnsFailure = (error: Error): boolean =>
+  (error as { code?: unknown }).code === "dns-lookup-failed" ||
+  error.message.includes(DNS_LOOKUP_FAILED_MESSAGE_PREFIX);
+
+/**
+ * The validation error, but only when the block is permanent. Returns undefined
+ * when nothing in the chain is a validation error, or when the failure is a
+ * transient DNS-resolution error that deserves a retry.
+ */
+export function findOutboundUrlValidationError(
+  error: unknown,
+): Error | undefined {
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== null && current !== undefined && !visited.has(current)) {
+    visited.add(current);
+
+    if (
+      current instanceof Error &&
+      OUTBOUND_VALIDATION_ERROR_NAMES.has(current.name)
+    ) {
+      return isTransientDnsFailure(current) ? undefined : current;
+    }
+
+    current =
+      typeof current === "object" && current !== null && "cause" in current
+        ? (current as { cause: unknown }).cause
+        : undefined;
+  }
+
+  return undefined;
+}

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -1,0 +1,91 @@
+import {
+  logger,
+  validateWebhookURL,
+  whitelistFromEnv,
+  type RedirectOptions,
+} from "@langfuse/shared/src/server";
+import { UnrecoverableError } from "../errors/UnrecoverableError";
+import { findOutboundUrlValidationError } from "../errors/findOutboundUrlValidationError";
+
+/**
+ * Redirect budget for the analytics integration exporters. Both senders
+ * previously used a plain fetch, which auto-follows up to 20 redirects, so the
+ * budget stays generous enough not to break a self-hosted endpoint behind a
+ * redirecting edge. Mirrors MAX_LLM_REDIRECTS on the LLM egress path.
+ */
+const ANALYTICS_INTEGRATION_MAX_REDIRECTS = 10;
+
+/**
+ * Connect-time-pinned egress settings shared by both analytics senders, so the
+ * redirect budget, the validator and the whitelist source cannot drift apart
+ * between them. `logContext` is the only per-sender part.
+ */
+export const buildAnalyticsRedirectOptions = (
+  logContext: string,
+): RedirectOptions => ({
+  maxRedirects: ANALYTICS_INTEGRATION_MAX_REDIRECTS,
+  redirectValidation: {
+    validateUrl: validateWebhookURL,
+    whitelist: whitelistFromEnv(),
+    logContext,
+  },
+});
+
+// A rejected redirect target is reported with its URL embedded verbatim, and a
+// Location header may carry userinfo, so the message can hold a password.
+const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^/?#\s@]*@/gi;
+
+const redactUrlCredentials = (text: string): string =>
+  text.replace(URL_CREDENTIALS, "$1***@");
+
+/**
+ * A serialization-safe stand-in for the validation error. The original holds the
+ * offending URL three times over — in its message, in its stack, and, for a
+ * rejected redirect, in an enumerable `redirectUrl` field — and the generic
+ * queue failure handler both logs the thrown error and reports it to tracing,
+ * so everything reachable from `cause` is written out verbatim.
+ */
+const sanitizedCause = (validationError: Error): Error => {
+  const sanitized = new Error(redactUrlCredentials(validationError.message));
+  sanitized.name = validationError.name;
+  if (validationError.stack) {
+    sanitized.stack = redactUrlCredentials(validationError.stack);
+  }
+  return sanitized;
+};
+
+/**
+ * Rethrow a connect-time SSRF block as terminal, so BullMQ stops re-attempting
+ * a send that cannot succeed; no-op for anything else, which the caller keeps
+ * handling as retryable.
+ *
+ * Nothing the thrown error carries may hold a credential: the message, the
+ * retained cause and that cause's own stack all outlive the job, via the log
+ * line and via the `failedReason` BullMQ persists.
+ */
+export function rethrowIfOutboundValidationFailure(
+  error: unknown,
+  labels: { logSubject: string; jobSubject: string },
+): void {
+  const validationError = findOutboundUrlValidationError(error);
+  if (!validationError) return;
+
+  const reason = redactUrlCredentials(validationError.message);
+  logger.error(`${labels.logSubject} blocked by SSRF protection: ${reason}`, {
+    errorName: validationError.name,
+  });
+
+  const unrecoverable = new UnrecoverableError(
+    `${labels.jobSubject} blocked by SSRF protection: ${reason}`,
+  );
+  // Non-enumerable, because a structured logger handed this error copies every
+  // enumerable field into the log line — which is how the raw URL escaped a
+  // redacted message before.
+  Object.defineProperty(unrecoverable, "cause", {
+    value: sanitizedCause(validationError),
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  throw unrecoverable;
+}

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -1,5 +1,9 @@
-import { logger } from "@langfuse/shared/src/server";
+import { logger, fetchWithSecureRedirects } from "@langfuse/shared/src/server";
 import { gzipSync } from "zlib";
+import {
+  buildAnalyticsRedirectOptions,
+  rethrowIfOutboundValidationFailure,
+} from "../analyticsIntegrationEgress";
 import type { MixpanelEvent } from "./transformers";
 
 type MixpanelClientConfig = {
@@ -9,6 +13,12 @@ type MixpanelClientConfig = {
    * Validated at API layer via MIXPANEL_REGIONS in web/src/features/mixpanel-integration/types.ts
    */
   region: string;
+  /**
+   * Overrides the Mixpanel API origin. Test-only seam, so the send can be
+   * pointed at a local server; production leaves it unset and derives the
+   * origin from `region`.
+   */
+  baseUrl?: string;
 };
 
 export class MixpanelClient {
@@ -62,7 +72,9 @@ export class MixpanelClient {
    * Send a batch of events to Mixpanel Import API
    */
   private async sendBatch(events: MixpanelEvent[]): Promise<void> {
-    const url = `https://${this.config.region}.mixpanel.com/import?strict=1`;
+    const origin =
+      this.config.baseUrl ?? `https://${this.config.region}.mixpanel.com`;
+    const url = `${origin}/import?strict=1`;
     const body = JSON.stringify(events);
 
     // Compress the body with gzip
@@ -74,15 +86,23 @@ export class MixpanelClient {
     const authHeader = `Basic ${Buffer.from(`${this.config.projectToken}:`).toString("base64")}`;
 
     try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Content-Encoding": "gzip",
-          Authorization: authHeader,
+      // Re-resolve and re-validate the destination IP at socket connect time: a
+      // host that validated as public can rebind to a private/loopback address
+      // before the socket opens (TOCTOU). Redirect targets are re-validated
+      // with the same URL validator.
+      const { response } = await fetchWithSecureRedirects(
+        url,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+            Authorization: authHeader,
+          },
+          body: compressedBody as unknown as BodyInit,
         },
-        body: compressedBody as unknown as BodyInit,
-      });
+        buildAnalyticsRedirectOptions("Mixpanel integration"),
+      );
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -129,6 +149,13 @@ export class MixpanelClient {
         result,
       });
     } catch (error) {
+      // A connect-time SSRF block is a permanent misconfiguration, not a
+      // transient failure, so skip the remaining BullMQ attempts for this job
+      // rather than re-running the same hopeless send.
+      rethrowIfOutboundValidationFailure(error, {
+        logSubject: "Mixpanel outbound send",
+        jobSubject: "Mixpanel export",
+      });
       logger.error("Error sending batch to Mixpanel", error);
       throw error;
     }

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -10,7 +10,12 @@ import {
   getEventsForAnalyticsIntegrations,
   getCurrentSpan,
   validateWebhookURL,
+  fetchWithSecureRedirects,
 } from "@langfuse/shared/src/server";
+import {
+  buildAnalyticsRedirectOptions,
+  rethrowIfOutboundValidationFailure,
+} from "../analyticsIntegrationEgress";
 import {
   transformTraceForPostHog,
   transformGenerationForPostHog,
@@ -52,7 +57,7 @@ type PostHogClientOptions = NonNullable<
 // calls /flags/, so only /batch/ request bodies are measured (LFE-10508).
 export const countingFetch =
   (volume: { bytes: number }): PostHogClientOptions["fetch"] =>
-  (url, options) => {
+  async (url, options) => {
     if (url.endsWith("/batch/")) {
       const body = options.body;
       if (typeof body === "string") {
@@ -68,7 +73,16 @@ export const countingFetch =
         );
       }
     }
-    return globalThis.fetch(url, options as RequestInit);
+    // Re-resolve and re-validate the destination IP at socket connect time: a
+    // host that validated as public in the pre-check can rebind to a
+    // private/loopback address before the socket opens (TOCTOU). Redirect
+    // targets are re-validated with the same URL validator.
+    const { response } = await fetchWithSecureRedirects(
+      url,
+      options as RequestInit,
+      buildAnalyticsRedirectOptions("PostHog integration"),
+    );
+    return response;
   };
 
 const processPostHogTraces = async (config: PostHogExecutionConfig) => {
@@ -422,6 +436,16 @@ export const handlePostHogIntegrationProjectJob = async (
       `[POSTHOG] PostHog integration processing complete for project ${projectId}`,
     );
   } catch (error) {
+    // A connect-time SSRF block is a permanent misconfiguration of the
+    // integration host, not a transient failure, so skip the remaining BullMQ
+    // attempts for this job rather than re-running the same hopeless send. The
+    // integration stays enabled, so the schedule re-enqueues the project next
+    // cycle, which is what lets a fixed endpoint recover on its own.
+    rethrowIfOutboundValidationFailure(error, {
+      logSubject: `[POSTHOG] Outbound send for project ${projectId}`,
+      jobSubject: `PostHog integration for project ${projectId}`,
+    });
+
     logger.error(
       `[POSTHOG] Error processing PostHog integration for project ${projectId}`,
       error,


### PR DESCRIPTION
v3 backport of #16091.

## Problem

The PostHog and Mixpanel analytics exporters validate the configured host once, up front, and then send over an unpinned `fetch`. A host that answers with a public IP during that pre-check can rebind to a private or loopback address before the socket actually connects (TOCTOU / DNS rebinding), so the export payload is delivered to an internal target.

On `v3` this is reachable on any deployment: the PostHog integration host is a normal project setting with no Cloud-only gating, `handlePostHogIntegrationProjectJob.ts` validates `posthogHostName` once via `validateWebhookURL`, and the SDK transport it injects then calls `globalThis.fetch` directly.

The same upstream commit also stops the rejected-redirect URL — which may carry userinfo in a `Location` header — from reaching the worker log line and the error message BullMQ persists as the job's `failedReason`.

## What this changes

- Both senders now go through `fetchWithSecureRedirects`, which re-resolves and re-validates every destination IP at connect time and re-validates redirect targets. That helper already existed on this branch (`packages/shared/src/server/outbound-url/fetch.ts`), used by `secureLlmFetch`, SSO config validation and the dataset router — no new shared infrastructure.
- A connect-time block is a permanent misconfiguration, so it surfaces as an `UnrecoverableError` and BullMQ skips the job's remaining attempts. A transient DNS-resolution failure stays retryable.
- Credentials are stripped from the thrown error's message, from the retained `cause`, and from that cause's stack; the cause is attached non-enumerably so a structured logger does not walk it.
- `DNS_LOOKUP_FAILED_MESSAGE_PREFIX` is exported from the shared validator so the retryable/terminal classifier can recognise a DNS failure by message text after `RedirectValidationError` re-wraps it. The thrown string is unchanged.

## Why this is an adapted backport, not a cherry-pick

Upstream, this fix sits on top of #16095, a fail-fast/auto-disable refactor of the PostHog job's error handling that was **not** backported. The upstream diff edits a `reason`-classification / `dispatchProjectNotification` block that does not exist on this branch, so a raw `git cherry-pick` conflicts or drops the security-relevant lines.

Ported here:

- `worker/src/errors/findOutboundUrlValidationError.ts` and `worker/src/features/analyticsIntegrationEgress.ts` are **byte-identical to upstream** — both turned out to be self-contained, and every symbol they need (`whitelistFromEnv`, `RedirectOptions`, `validateWebhookURL`, `UnrecoverableError`) already exists here with the same shape.
- The two call sites are adapted. The PostHog handler gets the terminal-classification call in its plain `catch`, without upstream's `reason === undefined` guard (there is no classifier here). The Mixpanel client has no timeout/abort plumbing on this branch, so only the fetch swap and the `catch` hook are ported.
- `LANGFUSE_MIXPANEL_TIMEOUT_MS` does not exist here, so the test's env mock omits it.

## Test adaptation, and a behaviour difference worth knowing

Upstream's suite drives the PostHog leg through the job handler. That does not work here: on this branch's `posthog-node` (`^5.32.0`, resolving to 5.38.4), `flush()` does **not** drain the queue — the send happens on the SDK's own background timer, roughly 10s later, after the handler has already returned. Measured directly with an injected fetch spy:

```
after capture(): 0 calls
after flush():   0 calls
after ~10s:      0 calls
after ~15s:      1 call   → http://localhost:PORT/batch/
after shutdown(): 1 call
```

So a handler-level assertion would pass whether or not the egress is pinned, and the handler's `on("error")`/`sendError` path cannot observe the send outcome. The PostHog test therefore targets `countingFetch`, the transport the handler injects — the seam every PostHog export byte passes through, and where the guarantee actually lives. The Mixpanel leg is a direct `fetch`, so it is still driven end-to-end through `client.flush()` and does assert the terminal `UnrecoverableError`.

Two consequences of that SDK behaviour, both **pre-existing on this branch and deliberately not addressed here**: PostHog export failures surface asynchronously after the job has already succeeded and advanced `lastSyncAt`, and the terminal-classification call in that handler's `catch` is therefore best-effort for the pinning case. It is kept for parity with upstream and still fires on synchronous failures.

## Verification

Run against this branch:

- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter worker run test analyticsIntegrationSsrfPinning` — `Tests 7 passed (7)`
- Neighbouring suites green: `posthogIntegrationProjectJob` `6 passed (6)`, `mixpanelIntegrationProjectJob` `8 passed (8)`, `posthogExportVolume` `1 passed (1)`, `mixpanelExportVolume` `1 passed (1)`, `outbound-connection-validation` `5 passed (5)`, `secureLlmFetch` `11 passed (11)`, `webhook-validation` `22 passed (22)`.
- `webhook-redirect` reports `7 failed | 4 passed (11)`, which is **identical on clean `v3`** (checked out detached at `f6c77b7084` and re-run) — pre-existing, environment-dependent, unrelated to this change.

### Revert-check

Production files restored to their pre-fix `v3` state with the new tests left in place, to confirm the tests catch a live vulnerability rather than a hypothetical one. Both sender legs fail, each on the request counter:

```
× blocks a validated host that resolves to a blocked IP before egress
× rejects a validated host that connects to a blocked IP, before egress and terminally
AssertionError: expected 2 to be 1
```

The count going from 1 to 2 is the export payload being delivered to the loopback address that the string pre-check had just accepted — the SSRF completing on unpatched `v3`. Each test also carries an in-test negative control (a bare `fetch` to the same URL, asserted to reach the server) so a count of 1 in the patched run cannot be an unreachable harness.

Working tree confirmed clean (`git status --porcelain` empty) after restoring.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport routes PostHog and Mixpanel analytics exports through connect-time destination validation, revalidates redirects, and safely classifies permanent SSRF blocks without persisting credential-bearing errors.

- Exports the shared DNS-failure message prefix for retry classification.
- Adds secure analytics redirect options and sanitized terminal-error handling.
- Replaces both analytics senders' plain fetch paths with secure, redirect-aware egress.
- Adds regression coverage for DNS rebinding, terminal classification, and credential redaction.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge; the only identified issue is non-blocking import organization in the new test module.

The analytics senders now use the existing connect-time validation and redirect-validation path, and the terminal-error sanitizer preserves retry semantics without exposing redirect credentials; only the test file's import placement needs cleanup.

**Files Needing Attention:** worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Exporter as Analytics exporter
  participant SecureFetch as fetchWithSecureRedirects
  participant DNS as DNS resolver
  participant Validator as Outbound URL validator
  participant Vendor as PostHog / Mixpanel
  Exporter->>SecureFetch: Send analytics batch
  SecureFetch->>DNS: Resolve destination at connect time
  DNS-->>SecureFetch: Candidate addresses
  SecureFetch->>Validator: Validate every resolved address
  alt Address is allowed
    SecureFetch->>Vendor: Connect and send request
    Vendor-->>SecureFetch: Response or redirect
    opt Redirect
      SecureFetch->>Validator: Validate redirect target
      SecureFetch->>DNS: Resolve redirect at connect time
    end
    SecureFetch-->>Exporter: Final response
  else Address or redirect is blocked
    Validator-->>SecureFetch: Validation error
    SecureFetch-->>Exporter: Rejected request
    Exporter->>Exporter: Redact credentials and throw UnrecoverableError
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts:77-84
**Keep static imports together**

These static imports appear after executable mock setup rather than at the top of the module, departing from the repository's required import organization and making the test's dependency setup harder to follow consistently.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): pin analytics export egress..."](https://github.com/langfuse/langfuse/commit/e48f917fa217ceb20f855c864c186d52e4ba32b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53968173)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)
- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)
</details>

<!-- /greptile_comment -->