### PR TITLE
chore(worker): count completed queue jobs in the rate metric

### DIFF
--- a/worker/src/__tests__/workerManagerMetrics.test.ts
+++ b/worker/src/__tests__/workerManagerMetrics.test.ts
@@ -129,4 +129,16 @@ describe("WorkerManager queue metrics", () => {
       ["langfuse.queue.trace_delete.rate", 1, { type: "stalled" }],
     ]);
   });
+
+  it("emits a rate counter for completed jobs but not for active ones", () => {
+    // Own queue name: register() no-ops on the statically registered one above.
+    WorkerManager.register("trace-upsert" as never, async () => "processed");
+
+    mocks.handlers.get("active")?.({ id: "job-id", name: "job" });
+    mocks.handlers.get("completed")?.({ id: "job-id", name: "job" });
+
+    expect(mocks.recordIncrement.mock.calls).toEqual([
+      ["langfuse.queue.trace_upsert.rate", 1, { type: "completed" }],
+    ]);
+  });
 });

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -154,14 +154,21 @@ export class WorkerManager {
     markQueueWorkerRegistered();
     logger.info(`${queueName} executor started: ${worker.isRunning()}`);
 
+    const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
+
     // Liveness signal for the ?failIfQueueConsumptionStuck=true health check.
     // "active" and "completed" prove this container's consumption loop is
     // alive; "failed" is excluded because the stalled-checker emits it for
     // jobs this container never picked up.
     worker.on("active", markQueueJobActivity);
-    worker.on("completed", markQueueJobActivity);
-
-    const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
+    // No "active" counter: metricWrapper already records "request" on pickup.
+    worker.on("completed", () => {
+      markQueueJobActivity();
+      recordIncrement(baseMetric + ".rate", 1, {
+        type: "completed",
+        ...shardTag,
+      });
+    });
 
     // Add error handling
     worker.on("failed", (job: Job | undefined, err: Error) => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16203.preview.langfuse.com](https://pr-16203.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

`WorkerManager` recorded `<queue>.rate` increments for `request`, `failed`, `error` and `stalled`, but the `completed` worker event only fed the liveness helper `markQueueJobActivity` — no counter was emitted. That left no metric distinguishing "a job ran and finished" from "a job ran and disappeared".

This was the missing signal in a recent production queue stall: the queue's rate metric showed a `request` series and an `error` series, no `failed` or `stalled` series at all, and no way to confirm from telemetry whether the last job actually completed. Establishing that required reading individual log lines one at a time.

The `completed` handler now also calls `recordIncrement`. `markQueueJobActivity` stays wired to both `active` and `completed` — it serves the `?failIfQueueConsumptionStuck=true` health check and is a separate concern from the counter. `active` deliberately gets no counter of its own: BullMQ emits it immediately before invoking the processor that records `request`, so the series would be a duplicate. Shard tag resolution is unchanged, so sharded queues keep aggregating under their base metric name.

Result: `sum:langfuse.queue.<queue>.rate{...} by {type}` now returns a `completed` series alongside `request`, `error`, `failed` and `stalled`.

No changes to the health check, no new dashboards.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have added a test that proves the counter is emitted, confirmed red against the unpatched handler first, and that asserts `active` stays counter-free
- I have verified the existing liveness wiring and metric suites still pass
- Verified locally: `pnpm turbo run lint typecheck --filter=worker` (5 successful, 5 total), `workerManagerMetrics` (2 passed), `queueConsumptionHealth` (4 passed), `workerManager` (11 passed)