### PR TITLE
chore(api): remove internal ticket references from comments

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -1,6 +1,6 @@
 types:
   # Migration signal attached as the top-level `_deprecation` key on responses
-  # from deprecated (legacy, pre-v4-data-model) endpoints. See LFE-10895.
+  # from deprecated (legacy, pre-v4-data-model) endpoints.
   Deprecation:
     docs: Migration signal returned by deprecated endpoints. Optional fields are omitted when they have no value.
     properties:

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -160,7 +160,7 @@ export const paginationMetaResponseZod = z.object({
 
 /**
  * Top-level `_deprecation` metadata returned by legacy public API endpoints.
- * Optional fields are omitted when empty (never null). See LFE-10895.
+ * Optional fields are omitted when empty (never null).
  */
 export const deprecationResponseZod = z.object({
   message: z.string(),

--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -34,7 +34,7 @@ const maybeDescribe =
     ? describe
     : describe.skip;
 
-// LFE-10895: legacy (v3-data-model) endpoints attach a top-level `_deprecation`
+// Legacy (v3-data-model) endpoints attach a top-level `_deprecation`
 // object so coding agents get a self-correcting migration signal.
 maybeDescribe("public API deprecation signal", () => {
   let auth: string;

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -86,7 +86,7 @@ export type AuthedProjectAPIRouteConfig<
    * events_only mode and would silently return stale or empty data.
    */
   rejectInEventsOnlyMode?: boolean;
-  /** Stamps a top-level `_deprecation` object onto responses (LFE-10895). */
+  /** Stamps a top-level `_deprecation` object onto responses. */
   deprecation?: ApiDeprecationInfo;
   fn: (params: {
     query: z.infer<TQuery>;

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -1,7 +1,7 @@
 import { type ApiDeprecationInfo } from "@langfuse/shared";
 import { OBSERVATIONS_API_V2_DOCS_URL } from "./rateLimitUpgradePaths";
 
-// LFE-10895. Family-level deprecation signals for legacy (v3) public API
+// Family-level deprecation signals for legacy (v3) public API
 // endpoints. Attach one via the `deprecation` route-config field; the response
 // gets a top-level `_deprecation` key.
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16206.preview.langfuse.com](https://pr-16206.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Removes internal ticket identifiers from code comments around the public-API deprecation-signal feature (Fern commons definition, deprecation constants, route config, shared zod schema, and the server test). Repo guidelines forbid internal ticket ids in published files; the comments now describe the behavior on its own terms. Comment-only change — no behavior or contract change, so no Fern regeneration needed.

## Type of change

- [x] Chore (refactoring, documentation, or other non-functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My changes do not require an update to the documentation

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes internal ticket references from comments without changing runtime behavior.

- Cleans references from the public API schema and shared deprecation metadata documentation.
- Updates related route configuration, deprecation definitions, and server-test comments.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only removes internal ticket references from comments.

All changed lines are documentation-only comment edits and preserve schemas, types, tests, imports, and runtime logic.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(api): remove internal ticket refer..."](https://github.com/langfuse/langfuse/commit/17cf385d96fb4dda6bc72467b71102f945213992) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53982140)</sub>

<!-- /greptile_comment -->