### PR TITLE
feat(web): prompt AI opt-in on tracing onboarding

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -266,6 +266,8 @@ export const events = {
     "tracing_api_key_create_clicked",
     "tracing_agent_prompt_copy_clicked",
     "tracing_manual_docs_link_clicked",
+    "tracing_ai_opt_in_not_now_clicked",
+    "tracing_ai_opt_in_enabled",
   ],
   user_settings: ["theme_changed", "feature_preview_toggled"],
   project_settings: [

--- a/web/src/features/setup/components/TracingAIFeatureOptInDialog.clienttest.tsx
+++ b/web/src/features/setup/components/TracingAIFeatureOptInDialog.clienttest.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TracingAIFeatureOptInDialog } from "./TracingAIFeatureOptInDialog";
+
+describe("TracingAIFeatureOptInDialog", () => {
+  it("allows admins to enable AI features or dismiss", () => {
+    const onClose = vi.fn();
+    const onEnableAiFeatures = vi.fn();
+
+    render(
+      <TracingAIFeatureOptInDialog
+        open
+        isLoading={false}
+        hasOrganizationUpdateAccess
+        organizationId="org-1"
+        onClose={onClose}
+        onEnableAiFeatures={onEnableAiFeatures}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Enable AI features" }));
+    expect(onEnableAiFeatures).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows admin handoff copy for non-admin users", () => {
+    render(
+      <TracingAIFeatureOptInDialog
+        open
+        isLoading={false}
+        hasOrganizationUpdateAccess={false}
+        organizationId="org-1"
+        onClose={vi.fn()}
+        onEnableAiFeatures={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Only organization admins can enable AI features."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Organization Settings" }),
+    ).toHaveAttribute("href", "/organization/org-1/settings");
+    expect(
+      screen.queryByRole("button", { name: "Enable AI features" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/setup/components/TracingAIFeatureOptInDialog.clienttest.tsx
+++ b/web/src/features/setup/components/TracingAIFeatureOptInDialog.clienttest.tsx
@@ -37,7 +37,7 @@ describe("TracingAIFeatureOptInDialog", () => {
     );
 
     expect(
-      screen.getByText("Only organization admins can enable AI features."),
+      screen.getByText(/Only organization admins can enable AI features\./),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Organization Settings" }),

--- a/web/src/features/setup/components/TracingAIFeatureOptInDialog.tsx
+++ b/web/src/features/setup/components/TracingAIFeatureOptInDialog.tsx
@@ -1,0 +1,110 @@
+import { ExternalLink } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+
+const AI_FEATURES_DOCS_URL = "https://langfuse.com/security/ai-features";
+
+export function TracingAIFeatureOptInDialog({
+  open,
+  isLoading,
+  hasOrganizationUpdateAccess,
+  organizationId,
+  onClose,
+  onEnableAiFeatures,
+}: {
+  open: boolean;
+  isLoading: boolean;
+  hasOrganizationUpdateAccess: boolean;
+  organizationId?: string;
+  onClose: () => void;
+  onEnableAiFeatures: () => void;
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen && !isLoading) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Enable AI features for your organization?</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <div className="space-y-3 text-sm">
+            <p className="text-muted-foreground">
+              Enable AI features to use the in-app assistant and other
+              AI-powered capabilities while onboarding tracing.
+            </p>
+            <p className="text-muted-foreground">
+              When enabled, any data <i>can</i> be sent to AWS Bedrock within
+              your Langfuse data region. Your data will not be used for model
+              training, and applicable HIPAA, SOC2, GDPR, and ISO 27001
+              compliance remains intact.
+            </p>
+            <a
+              href={AI_FEATURES_DOCS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary inline-flex items-center gap-1 hover:underline"
+            >
+              Learn more in the docs.
+              <ExternalLink className="h-3 w-3" />
+            </a>
+
+            {!hasOrganizationUpdateAccess ? (
+              <p className="text-muted-foreground">
+                Only organization admins can enable AI features.
+                {organizationId ? (
+                  <>
+                    {" "}
+                    Ask an admin to enable this in{" "}
+                    <a
+                      href={`/organization/${organizationId}/settings`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:underline"
+                    >
+                      Organization Settings
+                    </a>
+                    .
+                  </>
+                ) : null}
+              </p>
+            ) : null}
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isLoading}
+              onClick={onClose}
+            >
+              Not now
+            </Button>
+            {hasOrganizationUpdateAccess ? (
+              <Button
+                type="button"
+                onClick={onEnableAiFeatures}
+                loading={isLoading}
+              >
+                Enable AI features
+              </Button>
+            ) : null}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/project/[projectId]/traces/index.tsx
+++ b/web/src/pages/project/[projectId]/traces/index.tsx
@@ -1,4 +1,6 @@
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { useSession } from "next-auth/react";
 import TracesTable from "@/src/components/table/use-cases/traces";
 import Page from "@/src/components/layouts/page";
 import { api } from "@/src/utils/api";
@@ -11,12 +13,53 @@ import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import ObservationsEventsTable from "@/src/features/events/components/EventsTable";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import { V4MigrationDelayBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+import { TracingAIFeatureOptInDialog } from "@/src/features/setup/components/TracingAIFeatureOptInDialog";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+
+const AI_OPT_IN_DISMISS_KEY_PREFIX = "langfuse:tracing-ai-opt-in-dismissed";
+
+const getAiOptInDismissKey = (organizationId: string) =>
+  `${AI_OPT_IN_DISMISS_KEY_PREFIX}:${organizationId}`;
+
+const hasDismissedAiOptIn = (organizationId: string) => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return (
+      localStorage.getItem(getAiOptInDismissKey(organizationId)) === "true"
+    );
+  } catch {
+    return false;
+  }
+};
+
+const markAiOptInDismissed = (organizationId: string) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    localStorage.setItem(getAiOptInDismissKey(organizationId), "true");
+  } catch {
+    // Ignore localStorage write failures and keep onboarding usable.
+  }
+};
 
 export default function Traces() {
   const router = useRouter();
+  const { update: updateSession } = useSession();
+  const capture = usePostHogClientCapture();
+  const utils = api.useUtils();
   const projectId = router.query.projectId as string;
   const { isBetaEnabled, isInitializing } = useV4Beta();
-  const { project } = useQueryProject();
+  const { project, organization } = useQueryProject();
+  const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const [showAiOptInDialog, setShowAiOptInDialog] = useState(false);
 
   // Check if the user has tracing configured
   // Skip polling entirely if the project flag is already set in the session
@@ -37,6 +80,82 @@ export default function Traces() {
     );
 
   const showOnboarding = !isLoading && !hasTracingConfigured;
+  const hasOrganizationUpdateAccess = useHasOrganizationAccess({
+    organizationId: organization?.id,
+    scope: "organization:update",
+  });
+  const shouldPromptForAiOptIn =
+    showOnboarding &&
+    isLangfuseCloud &&
+    Boolean(organization?.id) &&
+    !organization?.aiFeaturesEnabled;
+
+  const updateAiFeaturesMutation = api.organizations.update.useMutation();
+
+  useEffect(() => {
+    if (!shouldPromptForAiOptIn || !organization?.id) {
+      setShowAiOptInDialog(false);
+      return;
+    }
+
+    setShowAiOptInDialog(!hasDismissedAiOptIn(organization.id));
+  }, [organization?.id, shouldPromptForAiOptIn]);
+
+  const dismissAiOptInDialog = useCallback(() => {
+    if (organization?.id) {
+      markAiOptInDismissed(organization.id);
+    }
+
+    capture("onboarding:tracing_ai_opt_in_not_now_clicked", {
+      hasOrganizationUpdateAccess,
+    });
+    setShowAiOptInDialog(false);
+  }, [capture, hasOrganizationUpdateAccess, organization?.id]);
+
+  const enableAiFeatures = useCallback(async () => {
+    if (
+      !organization?.id ||
+      !hasOrganizationUpdateAccess ||
+      updateAiFeaturesMutation.isPending
+    ) {
+      return;
+    }
+
+    try {
+      await updateAiFeaturesMutation.mutateAsync({
+        orgId: organization.id,
+        aiFeaturesEnabled: true,
+      });
+      await updateSession();
+      await utils.organizations.byId.invalidate();
+      markAiOptInDismissed(organization.id);
+      setShowAiOptInDialog(false);
+      capture("onboarding:tracing_ai_opt_in_enabled");
+    } catch (error) {
+      showErrorToast(
+        "Failed to enable AI features",
+        error instanceof Error ? error.message : "Please try again.",
+      );
+    }
+  }, [
+    capture,
+    hasOrganizationUpdateAccess,
+    organization?.id,
+    updateAiFeaturesMutation,
+    updateSession,
+    utils.organizations.byId,
+  ]);
+
+  const aiOptInDialog = (
+    <TracingAIFeatureOptInDialog
+      open={showAiOptInDialog}
+      isLoading={updateAiFeaturesMutation.isPending}
+      hasOrganizationUpdateAccess={hasOrganizationUpdateAccess}
+      organizationId={organization?.id}
+      onClose={dismissAiOptInDialog}
+      onEnableAiFeatures={enableAiFeatures}
+    />
+  );
 
   if (showOnboarding) {
     return (
@@ -52,6 +171,7 @@ export default function Traces() {
         scrollable
       >
         <TracesOnboarding projectId={projectId} />
+        {aiOptInDialog}
       </Page>
     );
   }
@@ -105,6 +225,7 @@ export default function Traces() {
       ) : (
         <TracesTable projectId={projectId} showControlsInPageHeader />
       )}
+      {aiOptInDialog}
     </Page>
   );
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16208.preview.langfuse.com](https://pr-16208.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds an AI opt-in dialog on the tracing onboarding surface for Langfuse Cloud organizations where AI features are disabled.

Behavior:
- Shows a modal on the traces onboarding page (`/project/[projectId]/traces`) for eligible orgs.
- Provides compliance/data-handling copy and docs link.
- Allows org admins to enable AI features directly.
- Allows users to dismiss with **Not now**, persisted per organization in `localStorage`.
- Hides the enable action for users without `organization:update` access and shows admin handoff copy.

### Tracking plan
Question: Do users accept or defer AI enablement at tracing onboarding?
- Event: `onboarding:tracing_ai_opt_in_enabled`
- Event: `onboarding:tracing_ai_opt_in_not_now_clicked`
- Props: `hasOrganizationUpdateAccess` (metadata only)
- Key dimension: onboarding AI opt-in decision outcome

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Validation

- `pnpm --filter web run test-client src/features/setup/components/TracingAIFeatureOptInDialog.clienttest.tsx`
  - `Test Files  1 passed (1)`
  - `Tests  2 passed (2)`
- `pnpm --filter web run lint`
  - completed with no lint warnings/errors.

## Walkthrough

[tracing_ai_opt_in_not_now_persistence.mp4](https://cursor.com/agents/bc-0bdd4aa9-47c2-4276-b7c8-f278994ea855/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftracing_ai_opt_in_not_now_persistence.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bdd4aa9-47c2-4276-b7c8-f278994ea855?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bdd4aa9-47c2-4276-b7c8-f278994ea855&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

