### PR TITLE
fix(api): scope the v3 sunset notices to Langfuse Cloud

### DIFF
--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -9,7 +9,7 @@ service:
     create:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, create experiment data via the SDK experiment runner or the OpenTelemetry endpoint at POST /api/public/otel/v1/traces. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       method: POST
       docs: Create a dataset run item
       path: /dataset-run-items
@@ -18,7 +18,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use `GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset run items are replaced by experiment items; use `GET /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>` instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       method: GET
       docs: List dataset run items
       path: /dataset-run-items

--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -36,7 +36,7 @@ service:
     getRun:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       method: GET
       docs: Get a dataset run and its items
       path: /datasets/{datasetName}/runs/{runName}
@@ -47,7 +47,7 @@ service:
     deleteRun:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       method: DELETE
       docs: Delete a dataset run and all its run items. This action is irreversible.
       path: /datasets/{datasetName}/runs/{runName}
@@ -58,7 +58,7 @@ service:
     getRuns:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, dataset runs are replaced by experiments; use GET /api/public/experiments instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       method: GET
       docs: Get dataset runs
       path: /datasets/{datasetName}/runs

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -9,7 +9,7 @@ service:
     batch:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Send data via the OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration docs](https://langfuse.com/integrations/native/opentelemetry)."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Send data via the OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration docs](https://langfuse.com/integrations/native/opentelemetry). Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 

--- a/fern/apis/server/definition/legacy/metrics-v1.yml
+++ b/fern/apis/server/definition/legacy/metrics-v1.yml
@@ -9,7 +9,7 @@ service:
     metrics:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/metrics?query=<urlencoded json query>` instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/metrics?query=<urlencoded json query>` instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Get metrics from the Langfuse project using a query object.
 

--- a/fern/apis/server/definition/legacy/observations-v1.yml
+++ b/fern/apis/server/definition/legacy/observations-v1.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: Get a observation
       method: GET
       path: /observations/{observationId}
@@ -21,7 +21,7 @@ service:
     getMany:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Use `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>` instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Get a list of observations.
 

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -15,7 +15,7 @@ service:
     get-many:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on November 16, 2026. Use `GET /api/public/v3/scores` instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Use `GET /api/public/v3/scores` instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: Get a list of scores (supports both trace and session scores)
       method: GET
       path: /v2/scores
@@ -96,7 +96,7 @@ service:
     get-by-id:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint is not available on Langfuse v4 and later and will be removed on November 16, 2026. Use `GET /api/public/v3/scores` with the `id` filter instead."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Use `GET /api/public/v3/scores` with the `id` filter instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: Get a score (supports both trace and session scores)
       method: GET
       path: /v2/scores/{scoreId}

--- a/fern/apis/server/definition/sessions.yml
+++ b/fern/apis/server/definition/sessions.yml
@@ -9,7 +9,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Get sessions.
 
@@ -42,7 +42,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, read session data via `GET /api/public/v2/observations?filter=<urlencoded sessionId filter>&fromStartTime=<from>&toStartTime=<to>`. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Get a session.
 

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -9,7 +9,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: Get a specific trace
       method: GET
       path: /traces/{traceId}
@@ -36,7 +36,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`."
+        message: "On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. In Langfuse v4, read span and trace data via `GET /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: Get list of traces
       method: GET
       path: /traces

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1134,10 +1134,12 @@ paths:
   /api/public/dataset-run-items:
     post:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, create experiment data via the SDK
-        experiment runner or the OpenTelemetry endpoint at POST
-        /api/public/otel/v1/traces. See the [Langfuse v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, create
+        experiment data via the SDK experiment runner or the OpenTelemetry
+        endpoint at POST /api/public/otel/v1/traces. Self-hosted deployments are
+        unaffected by this date; the endpoint becomes unavailable when they
+        upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -1188,11 +1190,13 @@ paths:
       deprecated: true
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, dataset run items are replaced by
-        experiment items; use `GET
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, dataset
+        run items are replaced by experiment items; use `GET
         /api/public/experiment-items?fromStartTime=<from>&toStartTime=<to>`
-        instead. See the [Langfuse v3 to v4 upgrade
+        instead. Self-hosted deployments are unaffected by this date; the
+        endpoint becomes unavailable when they upgrade to Langfuse v4. See the
+        [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -1406,10 +1410,12 @@ paths:
   /api/public/datasets/{datasetName}/runs/{runName}:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, dataset runs are replaced by
-        experiments; use GET /api/public/experiments instead. See the [Langfuse
-        v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, dataset
+        runs are replaced by experiments; use GET /api/public/experiments
+        instead. Self-hosted deployments are unaffected by this date; the
+        endpoint becomes unavailable when they upgrade to Langfuse v4. See the
+        [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -1464,9 +1470,11 @@ paths:
       deprecated: true
     delete:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, dataset runs are replaced by
-        experiments. See the [Langfuse v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, dataset
+        runs are replaced by experiments. Self-hosted deployments are unaffected
+        by this date; the endpoint becomes unavailable when they upgrade to
+        Langfuse v4. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -1522,10 +1530,12 @@ paths:
   /api/public/datasets/{datasetName}/runs:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, dataset runs are replaced by
-        experiments; use GET /api/public/experiments instead. See the [Langfuse
-        v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, dataset
+        runs are replaced by experiments; use GET /api/public/experiments
+        instead. Self-hosted deployments are unaffected by this date; the
+        endpoint becomes unavailable when they upgrade to Langfuse v4. See the
+        [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -1934,11 +1944,14 @@ paths:
   /api/public/ingestion:
     post:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. Send data via the OpenTelemetry endpoint at `POST
-        /api/public/otel/v1/traces` instead, see the [OpenTelemetry integration
-        docs](https://langfuse.com/integrations/native/opentelemetry). See the
-        [Langfuse v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. Send data via the
+        OpenTelemetry endpoint at `POST /api/public/otel/v1/traces` instead, see
+        the [OpenTelemetry integration
+        docs](https://langfuse.com/integrations/native/opentelemetry).
+        Self-hosted deployments are unaffected by this date; the endpoint
+        becomes unavailable when they upgrade to Langfuse v4. See the [Langfuse
+        v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -2040,9 +2053,12 @@ paths:
   /api/public/metrics:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. Use `GET /api/public/v2/metrics?query=<urlencoded
-        json query>` instead. See the [Langfuse v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. Use `GET
+        /api/public/v2/metrics?query=<urlencoded json query>` instead.
+        Self-hosted deployments are unaffected by this date; the endpoint
+        becomes unavailable when they upgrade to Langfuse v4. See the [Langfuse
+        v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -2148,10 +2164,12 @@ paths:
   /api/public/observations/{observationId}:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. Use `GET
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. Use `GET
         /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`
-        instead. See the [Langfuse v3 to v4 upgrade
+        instead. Self-hosted deployments are unaffected by this date; the
+        endpoint becomes unavailable when they upgrade to Langfuse v4. See the
+        [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -2205,10 +2223,12 @@ paths:
   /api/public/observations:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. Use `GET
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. Use `GET
         /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`
-        instead. See the [Langfuse v3 to v4 upgrade
+        instead. Self-hosted deployments are unaffected by this date; the
+        endpoint becomes unavailable when they upgrade to Langfuse v4. See the
+        [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -5832,10 +5852,11 @@ paths:
   /api/public/v2/scores:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint is not
-        available on Langfuse v4 and later and will be removed on November 16,
-        2026. Use `GET /api/public/v3/scores` instead. See the [Langfuse v3 to
-        v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. Use `GET
+        /api/public/v3/scores` instead. Self-hosted deployments are unaffected
+        by this date; the endpoint becomes unavailable when they upgrade to
+        Langfuse v4. See the [Langfuse v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -6062,10 +6083,12 @@ paths:
   /api/public/v2/scores/{scoreId}:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint is not
-        available on Langfuse v4 and later and will be removed on November 16,
-        2026. Use `GET /api/public/v3/scores` with the `id` filter instead. See
-        the [Langfuse v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. Use `GET
+        /api/public/v3/scores` with the `id` filter instead. Self-hosted
+        deployments are unaffected by this date; the endpoint becomes
+        unavailable when they upgrade to Langfuse v4. See the [Langfuse v3 to v4
+        upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -6117,11 +6140,13 @@ paths:
   /api/public/sessions:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, read session data via `GET
-        /api/public/v2/observations?filter=<urlencoded sessionId
-        filter>&fromStartTime=<from>&toStartTime=<to>`. See the [Langfuse v3 to
-        v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, read
+        session data via `GET /api/public/v2/observations?filter=<urlencoded
+        sessionId filter>&fromStartTime=<from>&toStartTime=<to>`. Self-hosted
+        deployments are unaffected by this date; the endpoint becomes
+        unavailable when they upgrade to Langfuse v4. See the [Langfuse v3 to v4
+        upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -6225,11 +6250,13 @@ paths:
   /api/public/sessions/{sessionId}:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, read session data via `GET
-        /api/public/v2/observations?filter=<urlencoded sessionId
-        filter>&fromStartTime=<from>&toStartTime=<to>`. See the [Langfuse v3 to
-        v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, read
+        session data via `GET /api/public/v2/observations?filter=<urlencoded
+        sessionId filter>&fromStartTime=<from>&toStartTime=<to>`. Self-hosted
+        deployments are unaffected by this date; the endpoint becomes
+        unavailable when they upgrade to Langfuse v4. See the [Langfuse v3 to v4
+        upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -6292,10 +6319,13 @@ paths:
   /api/public/traces/{traceId}:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, read span and trace data via `GET
-        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. See
-        the [Langfuse v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, read span
+        and trace data via `GET
+        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`.
+        Self-hosted deployments are unaffected by this date; the endpoint
+        becomes unavailable when they upgrade to Langfuse v4. See the [Langfuse
+        v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 
@@ -6405,10 +6435,13 @@ paths:
   /api/public/traces:
     get:
       description: >-
-        **Deprecated:** Langfuse v3 is deprecated; this endpoint will be removed
-        on November 16, 2026. In Langfuse v4, read span and trace data via `GET
-        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`. See
-        the [Langfuse v3 to v4 upgrade
+        **Deprecated:** On Langfuse Cloud, Langfuse v3 is deprecated and this
+        endpoint will be removed on November 16, 2026. In Langfuse v4, read span
+        and trace data via `GET
+        /api/public/v2/observations?fromStartTime=<from>&toStartTime=<to>`.
+        Self-hosted deployments are unaffected by this date; the endpoint
+        becomes unavailable when they upgrade to Langfuse v4. See the [Langfuse
+        v3 to v4 upgrade
         guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
 

--- a/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
+++ b/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
@@ -132,9 +132,7 @@ describe("OpenAPI deprecations", () => {
     }
   });
 
-  // The sunset date is a Langfuse Cloud commitment. Self-hosted deployments
-  // choose when to move to v4, so a message that states the date without
-  // scoping it promises a removal that will never apply to them.
+  // The date is a Cloud commitment; self-hosted is not bound by it.
   it("scopes every sunset message to Langfuse Cloud", () => {
     for (const { method, endpointPath, message } of getFernDeprecatedOperations(
       definitionDirectory,

--- a/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
+++ b/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
@@ -132,6 +132,21 @@ describe("OpenAPI deprecations", () => {
     }
   });
 
+  // The sunset date is a Langfuse Cloud commitment. Self-hosted deployments
+  // choose when to move to v4, so a message that states the date without
+  // scoping it promises a removal that will never apply to them.
+  it("scopes every sunset message to Langfuse Cloud", () => {
+    for (const { method, endpointPath, message } of getFernDeprecatedOperations(
+      definitionDirectory,
+    )) {
+      const operation = `${method.toUpperCase()} ${endpointPath}`;
+      expect(message, operation).toContain("On Langfuse Cloud,");
+      expect(message, operation).toContain(
+        "Self-hosted deployments are unaffected",
+      );
+    }
+  });
+
   it("keeps the human-readable sunset date in sync with the machine-readable one", () => {
     expect(
       new Date(`${V3_SUNSET_DATE}T00:00:00Z`).toLocaleDateString("en-US", {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16209.preview.langfuse.com](https://pr-16209.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The `November 16, 2026` sunset date on the legacy v3 endpoints is a Langfuse Cloud lifecycle commitment, but every deprecation message in the Fern definitions stated it unconditionally. A self-hosted operator reading the API reference was told their endpoints disappear on a fixed date, which is not true — self-hosted deployments choose when they move to v4.

This rewrites all 15 endpoint sunset messages to name Cloud as the scope and to say what actually happens self-hosted:

> **Before:** `Langfuse v3 is deprecated; this endpoint will be removed on November 16, 2026. Use GET /api/public/v3/scores instead.`
>
> **After:** `On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on November 16, 2026. Use GET /api/public/v3/scores instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4.`

The wording follows the pattern already established for the blob storage `exportSource` gates, which were the only correctly-scoped deprecation notices in the API surface.

Affected definitions: `sessions.yml` (2), `datasets.yml` (3), `trace.yml` (2), `scores.yml` (2), `dataset-run-items.yml` (2), `legacy/observations-v1.yml` (2), `ingestion.yml` (1), `legacy/metrics-v1.yml` (1). The generated `openapi.yml` mirror is restamped via `scripts/openapi/sync-deprecations.ts`, so only operation descriptions change there — no structural edits to the spec.

Deliberately **not** changed: field-level deprecations (`Model.inputPrice`/`prices`, `Observation.usage`, `calculated*Cost`, `parseIoAsJson`, SCIM `password`). Those are deployment-agnostic API-shape deprecations ("use `pricingTiers` instead"), not lifecycle sunsets, and are correct as unqualified statements.

A new case in `openapi-deprecations.servertest.ts` asserts every deprecated operation carries the Cloud scope, so an unqualified sunset message cannot land again. Verified it fails when the scope is removed from a message.

Known follow-up, not in this PR: the runtime `_deprecation` response body is still gated on `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` rather than on the Cloud region, and that flag defaults to `true` — so self-hosted deployments currently receive `sunsetAt` in REST responses. That gate and the matching runtime notice text are handled separately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] `pnpm turbo run lint --filter=web` — `Tasks: 4 successful, 4 total`
- [x] `pnpm turbo run typecheck --filter=web` — `Tasks: 4 successful, 4 total`
- [x] `pnpm --filter web run test src/__tests__/server/unit/openapi-deprecations.servertest.ts` — `Tests 15 passed (15)`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies that the November 16, 2026 legacy-v3 endpoint sunset applies to Langfuse Cloud, while self-hosted availability depends on upgrading to v4.

- Updates 15 Fern operation-level deprecation notices with Cloud and self-hosted scope.
- Regenerates the matching OpenAPI operation descriptions.
- Adds regression coverage requiring the scoped wording on deprecated Fern operations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the Fern source definitions, generated OpenAPI descriptions, and regression test aligned.

The changes are limited to deprecation documentation and corresponding test coverage, and no changed-code-triggered behavioral, security, build, or contract failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api): trim the deprecation guar..."](https://github.com/langfuse/langfuse/commit/2761669990ef372bd3ff72a4bb0962774e336837) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53992155)</sub>

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->