### PR TITLE
fix(api): serve the v3 deprecation signal on Cloud only

### DIFF
--- a/web/src/__tests__/server/deprecation-signal.servertest.ts
+++ b/web/src/__tests__/server/deprecation-signal.servertest.ts
@@ -22,21 +22,12 @@ import {
   V3_SUNSET_DATE,
 } from "@/src/features/public-api/server/deprecations";
 import { OBSERVATIONS_API_V2_DOCS_URL } from "@/src/features/public-api/server/rateLimitUpgradePaths";
-import { env } from "@/src/env.mjs";
 import { randomUUID } from "crypto";
 
-// `_deprecation` injection is gated on LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN,
-// which also enables the events read path (requires ClickHouse >= 25.12). The
-// -azure / -redis-cluster CI modes intentionally run older ClickHouse with the
-// flag off, so skip there — same pattern as the other events-read-path suites.
-const maybeDescribe =
-  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
-    ? describe
-    : describe.skip;
-
 // Legacy (v3-data-model) endpoints attach a top-level `_deprecation`
-// object so coding agents get a self-correcting migration signal.
-maybeDescribe("public API deprecation signal", () => {
+// object so coding agents get a self-correcting migration signal. Cloud-only:
+// assumes the server under test sets NEXT_PUBLIC_LANGFUSE_CLOUD_REGION.
+describe("public API deprecation signal", () => {
   let auth: string;
   let projectId: string;
 

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -312,13 +312,10 @@ export const createAuthedProjectAPIRoute = <
   routeConfig: AuthedProjectAPIRouteConfig<TQuery, TBody, TResponse>,
 ): ((req: NextApiRequest, res: NextApiResponse) => Promise<void>) => {
   return async (req: NextApiRequest, res: NextApiResponse) => {
-    // Only surface deprecation notices on deployments on (or opting into) v4.
-    // Self-hosted deployments still on v3 (opt-in unset/false) should not see
-    // them yet, so gate the injected `_deprecation` on the preview flag.
-    const deprecation =
-      env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
-        ? routeConfig.deprecation
-        : undefined;
+    // Cloud-only: the sunset date binds Cloud, not self-hosted deployments.
+    const deprecation = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+      ? routeConfig.deprecation
+      : undefined;
 
     // Short-circuit routes that read from legacy traces/observations tables
     // when the deployment is in events_only mode — those tables are no longer

--- a/web/src/features/public-api/server/deprecations.ts
+++ b/web/src/features/public-api/server/deprecations.ts
@@ -13,7 +13,7 @@ export const V3_SUNSET_HUMAN = "November 16, 2026";
 
 // Shared deprecation reason — references the deprecated Langfuse v3 system
 // version (not an API version). Customer-facing wording lives here — edit once.
-const V3_NOTICE = `Langfuse v3 is deprecated; this endpoint will be removed on ${V3_SUNSET_HUMAN}.`;
+const V3_NOTICE = `On Langfuse Cloud, Langfuse v3 is deprecated and this endpoint will be removed on ${V3_SUNSET_HUMAN}.`;
 
 // v4 replacement endpoints, referenced by both the message and `replacement`.
 // Placeholder style matches rateLimitUpgradePaths (<from>, <to>, filters).


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16210.preview.langfuse.com](https://pr-16210.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The `_deprecation` object on legacy v3 endpoint responses carries `sunsetAt: "2026-11-16"`, a Langfuse Cloud commitment. It was gated on `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`:

```ts
const deprecation =
  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
    ? routeConfig.deprecation
    : undefined;
```

That flag has defaulted to `"true"` since the v4 env defaults were flipped, so every self-hosted deployment received the removal date unless the operator explicitly set the flag to `"false"`. The gate's own comment stated the intent — "self-hosted deployments still on v3 (opt-in unset/false) should not see them yet" — but `unset` resolves to `"true"` through the zod default, so the gate admitted exactly the deployments it meant to exclude. This is a correctness fix, not a tightening.

It now gates on `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION`, matching `handleBlobStorageIntegrationProjectJob.ts`, which resolves the same policy the same way ("Legacy-source deprecation is a Cloud policy … so the deprecation notice below is Cloud-only too"). The flag's default is deliberate and untouched here — this change routes around it rather than fighting it.

The integration suite keeps asserting the Cloud path (`.env.dev.example` sets the region to `DEV`). Its `maybeDescribe` guard is gone: half of it was dead — no endpoint under test reads `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` (those routes gate on `LANGFUSE_MIGRATION_V4_WRITE_MODE` via `rejectInEventsOnlyMode`), and nothing in `.env*.example` or CI ever sets that flag to `false`. The guard only existed because `_deprecation` injection used to be gated on that flag, which is precisely what this PR changes. A plain `describe` now fails loudly instead of skipping silently.

Note the self-hosted case has no automated coverage: the suite drives real HTTP against a server on port 3000, so the gate runs in the server process and cannot be steered from the test process.

This also aligns the runtime notice text with the Cloud-scoped Fern/OpenAPI wording from #16209, now merged, so the response body and the published API reference state the same scope.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] `pnpm turbo run lint typecheck --filter=web` — `Tasks: 5 successful, 5 total`
- [x] `openapi-deprecations.servertest.ts`, `deprecation-signal.servertest.ts` — `Tests 24 passed (24)`, integration suite run against a local server with Postgres/ClickHouse
