### PR TITLE
fix(web): auto-expand v4 migration todo action items

### DIFF
--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -754,6 +754,49 @@ describe("V4MigrationDetailsContent", () => {
     );
   });
 
+  it("auto-expands action item sections so the guidance is visible without a click", () => {
+    // Default mock has apis count 1, so "Migrate APIs" renders as an action
+    // item. It should open on mount so users see how to proceed.
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    const apisTrigger = screen.getByText("Migrate APIs").closest("button")!;
+    // Opened by default: the first click collapses it, which is not an
+    // expansion and must not fire the engagement event.
+    fireEvent.click(apisTrigger);
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      "v4_migration:section_expanded",
+      { section: "apis" },
+    );
+    // Re-opening a section the user collapsed is a genuine expansion.
+    fireEvent.click(apisTrigger);
+    expect(
+      mocks.capture.mock.calls.filter(
+        ([name]) => name === "v4_migration:section_expanded",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("keeps the detected instrumentation summary collapsed by default", () => {
+    // Compatible-only traffic: the "Detected V4-compatible instrumentation"
+    // section is a settled summary, not a todo, so it stays collapsed.
+    mocks.migrationData.sdk = {
+      ...cleanSdkState(),
+      sdkUsageSeries: [makeSdkUsageSeries({})],
+    };
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    const detectedTrigger = screen
+      .getByText("Detected V4-compatible instrumentation")
+      .closest("button")!;
+    // Collapsed by default: the first click expands it and fires the event.
+    fireEvent.click(detectedTrigger);
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "v4_migration:section_expanded",
+      { section: "detected_instrumentation" },
+    );
+  });
+
   it("captures section_expanded and evidence_link_clicked in the SDK section", () => {
     const onNavigate = vi.fn();
     mocks.migrationData.sdk = {
@@ -775,14 +818,20 @@ describe("V4MigrationDetailsContent", () => {
       />,
     );
 
+    // The SDK todo auto-expands, so the first click collapses it and must not
+    // count as engagement.
+    fireEvent.click(screen.getByText("Update SDK").closest("button")!);
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      "v4_migration:section_expanded",
+      { section: "sdk" },
+    );
+
+    // Re-opening the collapsed section is a genuine expansion.
     fireEvent.click(screen.getByText("Update SDK").closest("button")!);
     expect(mocks.capture).toHaveBeenCalledWith(
       "v4_migration:section_expanded",
       { section: "sdk" },
     );
-
-    // Collapsing must not count as engagement.
-    fireEvent.click(screen.getByText("Update SDK").closest("button")!);
     expect(
       mocks.capture.mock.calls.filter(
         ([name]) => name === "v4_migration:section_expanded",

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -776,6 +776,34 @@ describe("V4MigrationDetailsContent", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps unresolved checks collapsed until they contain confirmed todos", () => {
+    mocks.migrationData.sdk = {
+      ...cleanSdkState(),
+      status: "checking",
+    };
+    mocks.migrationData.evals = { status: "loading", count: 0 };
+    mocks.migrationData.experiments = { status: "error" };
+    mocks.migrationData.apis = { status: "error", count: 0 };
+    mocks.migrationData.exports = { status: "loading", count: 0 };
+
+    render(<V4MigrationDetailsContent projectId="project-1" />);
+
+    for (const [title, section] of [
+      ["Update SDK", "sdk"],
+      ["Update Evals", "evals"],
+      ["Update Experiments", "experiments"],
+      ["Migrate APIs", "apis"],
+      ["Migrate Integrations", "integrations"],
+    ] as const) {
+      // Collapsed by default: the first click is a user expansion.
+      fireEvent.click(screen.getByText(title).closest("button")!);
+      expect(mocks.capture).toHaveBeenCalledWith(
+        "v4_migration:section_expanded",
+        { section },
+      );
+    }
+  });
+
   it("keeps the detected instrumentation summary collapsed by default", () => {
     // Compatible-only traffic: the "Detected V4-compatible instrumentation"
     // section is a settled summary, not a todo, so it stays collapsed.

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1382,6 +1382,21 @@ export function V4MigrationDetailsContent({
   const exportsClean =
     migrationData.exports.status === "loaded" &&
     migrationData.exports.count === 0;
+  const sdkTodoCount = getSdkSectionState(migrationData.sdk).actionableCount;
+  const otelTodoCount = getOtelSectionState(migrationData.sdk).delayedCount;
+  const customInstrumentationTodoCount = getCustomInstrumentationSectionState(
+    migrationData.sdk,
+  ).series.length;
+  const evalsHaveTodos =
+    migrationData.evals.status === "loaded" && migrationData.evals.count > 0;
+  const experimentsHaveTodos =
+    migrationData.experiments.status === "loaded" &&
+    migrationData.experiments.result !== "not_required";
+  const apisHaveTodos =
+    migrationData.apis.status === "loaded" && migrationData.apis.count > 0;
+  const exportsHaveTodos =
+    migrationData.exports.status === "loaded" &&
+    migrationData.exports.count > 0;
   const cleanSectionLabels = [
     evalsClean ? "evals" : null,
     experimentsClean ? "experiments" : null,
@@ -1443,26 +1458,25 @@ export function V4MigrationDetailsContent({
           counts refresh about every 15 minutes, so recent calls may not appear
           yet.
         </p>
-        {/* Todo sections open on mount so the remediation guidance is visible
-            without an extra click — showing only a collapsed "Update SDK" row
-            left users unsure how to proceed. The settled summary line and the
-            "Detected V4-compatible instrumentation" section below stay
-            collapsed: they are confirmations, not action items. */}
+        {/* Sections with confirmed todos open on mount so the remediation
+            guidance is visible without an extra click. Loading, error,
+            settled-summary, and detected-compatible sections stay collapsed:
+            they do not contain confirmed action items. */}
         <div>
           <V4MigrationSdkSection
             sdk={migrationData.sdk}
             projectId={evidenceProjectId}
-            defaultOpen
+            defaultOpen={sdkTodoCount > 0}
           />
           <V4MigrationOtelSection
             sdk={migrationData.sdk}
             projectId={evidenceProjectId}
-            defaultOpen
+            defaultOpen={otelTodoCount > 0}
           />
           <V4MigrationCustomInstrumentationSection
             sdk={migrationData.sdk}
             projectId={evidenceProjectId}
-            defaultOpen
+            defaultOpen={customInstrumentationTodoCount > 0}
           />
 
           {!evalsClean && (
@@ -1478,7 +1492,7 @@ export function V4MigrationDetailsContent({
               }
               evalsUrl={evalsUrl}
               onNavigate={onNavigate}
-              defaultOpen
+              defaultOpen={evalsHaveTodos}
             />
           )}
 
@@ -1486,7 +1500,7 @@ export function V4MigrationDetailsContent({
             <V4MigrationExperimentsSection
               state={migrationData.experiments}
               upgradePath={migrationData.experimentInstrumentationUpgradePath}
-              defaultOpen
+              defaultOpen={experimentsHaveTodos}
             />
           )}
 
@@ -1494,7 +1508,7 @@ export function V4MigrationDetailsContent({
             <V4MigrationApisSection
               state={migrationData.apis}
               usage={migrationData.apiUsage}
-              defaultOpen
+              defaultOpen={apisHaveTodos}
             />
           )}
 
@@ -1504,7 +1518,7 @@ export function V4MigrationDetailsContent({
               integrations={migrationData.legacyIntegrations}
               integrationsUrl={integrationsUrl}
               onNavigate={onNavigate}
-              defaultOpen
+              defaultOpen={exportsHaveTodos}
             />
           )}
 

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1443,18 +1443,26 @@ export function V4MigrationDetailsContent({
           counts refresh about every 15 minutes, so recent calls may not appear
           yet.
         </p>
+        {/* Todo sections open on mount so the remediation guidance is visible
+            without an extra click — showing only a collapsed "Update SDK" row
+            left users unsure how to proceed. The settled summary line and the
+            "Detected V4-compatible instrumentation" section below stay
+            collapsed: they are confirmations, not action items. */}
         <div>
           <V4MigrationSdkSection
             sdk={migrationData.sdk}
             projectId={evidenceProjectId}
+            defaultOpen
           />
           <V4MigrationOtelSection
             sdk={migrationData.sdk}
             projectId={evidenceProjectId}
+            defaultOpen
           />
           <V4MigrationCustomInstrumentationSection
             sdk={migrationData.sdk}
             projectId={evidenceProjectId}
+            defaultOpen
           />
 
           {!evalsClean && (
@@ -1470,6 +1478,7 @@ export function V4MigrationDetailsContent({
               }
               evalsUrl={evalsUrl}
               onNavigate={onNavigate}
+              defaultOpen
             />
           )}
 
@@ -1477,6 +1486,7 @@ export function V4MigrationDetailsContent({
             <V4MigrationExperimentsSection
               state={migrationData.experiments}
               upgradePath={migrationData.experimentInstrumentationUpgradePath}
+              defaultOpen
             />
           )}
 
@@ -1484,6 +1494,7 @@ export function V4MigrationDetailsContent({
             <V4MigrationApisSection
               state={migrationData.apis}
               usage={migrationData.apiUsage}
+              defaultOpen
             />
           )}
 
@@ -1493,6 +1504,7 @@ export function V4MigrationDetailsContent({
               integrations={migrationData.legacyIntegrations}
               integrationsUrl={integrationsUrl}
               onNavigate={onNavigate}
+              defaultOpen
             />
           )}
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16212.preview.langfuse.com](https://pr-16212.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The v4 migration panel rendered every action item collapsed. A project whose only remaining todo was **Update SDK** showed a single collapsed row, which left users unsure how to proceed.

This passes `defaultOpen` to the actionable todo sections so their remediation guidance is visible as soon as the panel opens:

- Update SDK
- Update OTel Instrumentation
- Upgrade Instrumentation
- Update Evals
- Update Experiments
- Migrate APIs
- Migrate Integrations

The settled "…are up to date." summary line and the **Detected V4-compatible instrumentation** confirmation stay collapsed — they are confirmations, not todos.

Analytics are unchanged: `v4_migration:section_expanded` still fires only on genuine user expansions (Radix `defaultOpen` does not fire `onOpenChange`), and `v4_migration:panel_checks_loaded` already reports per-section counts, so what was shown is still measurable.

Fixes LFE-15238

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Added a client test proving the todo sections open on mount and that the settled "Detected" summary stays collapsed; updated the existing SDK analytics test to the collapse-then-expand sequence.
- `pnpm --filter web run test-client src/features/v4-migration/V4MigrationContent.clienttest.tsx` → `Tests 42 passed (42)`.
- `pnpm --filter web run lint` → passed with no warnings/errors.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15238](https://linear.app/clickhouse/issue/LFE-15238/auto-expand-todo-action-items-in-v4-sidebar)

<div><a href="https://cursor.com/agents/bc-670e2573-f8ba-4e8e-91d2-65130c5978c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-670e2573-f8ba-4e8e-91d2-65130c5978c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR opens actionable v4 migration sections by default while leaving settled confirmation sections collapsed.

- Passes `defaultOpen` to SDK, OTel, custom instrumentation, eval, experiment, API, and integration remediation sections.
- Updates client tests to verify initial expansion behavior and user-expansion analytics.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The default-open behavior is limited to sections that represent actionable or transient migration states, and the updated tests preserve user-triggered expansion analytics.
</details>

<sub>Reviews (1): Last reviewed commit: ["Auto-expand v4 migration todo action ite..."](https://github.com/langfuse/langfuse/commit/e52a851109df1c72c75f38b48c5ad002f7f71c07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54018411)</sub>

<!-- /greptile_comment -->