### PR TITLE
fix(monitors): stop pausing monitors on transient ClickHouse resource errors

### DIFF
--- a/packages/shared/src/features/monitors/processor/processor.ts
+++ b/packages/shared/src/features/monitors/processor/processor.ts
@@ -9,6 +9,7 @@ import {
   instrumentSync,
 } from "../../../server/instrumentation";
 import { logger } from "../../../server/logger";
+import { ClickHouseResourceError } from "../../../server/repositories/clickhouse";
 import {
   getTriggerConfigurations as defaultGetTriggerConfigurations,
   type TriggerDomainWithActions,
@@ -162,6 +163,16 @@ export class MonitorProcessor {
       }
       metricMap["count_count"] = parseNumericValue(row["count_count"]);
     } catch (error) {
+      // Resource pressure is transient, not a bad query; rethrow so the monitor stays ACTIVE and the scheduler retries.
+      if (error instanceof ClickHouseResourceError) {
+        logger.warn("queryMetrics hit a ClickHouse resource limit; retrying", {
+          errorType: error.errorType,
+          projectId: event.projectId,
+          schedulerBatchId: event.schedulerBatchId.toString(),
+          monitorIds: event.monitors.map((m) => m.monitorId),
+        });
+        throw error;
+      }
       logger.error(
         "queryMetrics failed; flipping affected monitors to ERROR_BAD_QUERY",
         {

--- a/worker/package.json
+++ b/worker/package.json
@@ -26,7 +26,8 @@
     "lint:fix": "eslint . --cache --cache-location dist/.eslintcache --fix --concurrency 2",
     "refill-ingestion-events": "dotenv -e ../.env -- tsx src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts",
     "refill-billing-event": "dotenv -e ../.env -- tsx src/scripts/refill-billing-event.ts",
-    "refill-queue-event": "dotenv -e ../.env -- tsx src/scripts/refillQueueEvent/index.ts"
+    "refill-queue-event": "dotenv -e ../.env -- tsx src/scripts/refillQueueEvent/index.ts",
+    "retry-monitor-bad-query-errors": "dotenv -e ../.env -- tsx src/scripts/retryMonitorBadQueryErrors.ts"
   },
   "author": "engineering@langfuse.com",
   "dependencies": {

--- a/worker/src/__tests__/monitorProcessor.test.ts
+++ b/worker/src/__tests__/monitorProcessor.test.ts
@@ -1,7 +1,11 @@
 import { v4 } from "uuid";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { createOrgProjectAndApiKey, logger } from "@langfuse/shared/src/server";
+import {
+  ClickHouseResourceError,
+  createOrgProjectAndApiKey,
+  logger,
+} from "@langfuse/shared/src/server";
 import { InvalidRequestError } from "@langfuse/shared";
 import {
   MonitorProcessor,
@@ -96,7 +100,7 @@ type ProcessCase = {
   injectError?: {
     stage: InjectErrorStage;
     message: string;
-    errorClass?: "invalid-request";
+    errorClass?: "invalid-request" | "resource";
   };
   preempt?: { newClaimedAt: Date };
   preemptPause?: { at: Date };
@@ -696,6 +700,37 @@ const cases: ProcessCase[] = [
           alertedAt: null,
           lastClaimedAt: justAfterRunAt,
           lastCompletedAt: justAfterRunAt,
+        },
+      ],
+    },
+  },
+  {
+    name: "ClickHouseResourceError on executeQuery: rethrows, stays ACTIVE, not ERROR_BAD_QUERY",
+    monitors: [
+      {
+        id: monitorAId,
+        severity: MonitorSeveritySchema.enum.OK,
+        severityChangedAt: tenMinutesAgo,
+        lastPublishedAt: runAt,
+      },
+    ],
+    injectError: {
+      stage: "executeQuery",
+      errorClass: "resource",
+      message: "Timeout exceeded",
+    },
+    expect: {
+      throws: "Timeout exceeded",
+      publishCallCount: 0,
+      rows: [
+        {
+          id: monitorAId,
+          status: MonitorStatusSchema.enum.ACTIVE,
+          severity: MonitorSeveritySchema.enum.OK,
+          severityChangedAt: tenMinutesAgo,
+          alertedAt: null,
+          lastClaimedAt: justAfterRunAt,
+          lastCompletedAt: null,
         },
       ],
     },
@@ -1310,6 +1345,12 @@ describe("MonitorProcessor.process (integration)", () => {
       if (c.injectError?.stage === "executeQuery") {
         if (c.injectError.errorClass === "invalid-request") {
           throw new InvalidRequestError(c.injectError.message);
+        }
+        if (c.injectError.errorClass === "resource") {
+          throw new ClickHouseResourceError(
+            "TIMEOUT",
+            new Error(c.injectError.message),
+          );
         }
         throw new Error(c.injectError.message);
       }

--- a/worker/src/__tests__/retryMonitorBadQueryErrors.test.ts
+++ b/worker/src/__tests__/retryMonitorBadQueryErrors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { __test } from "../scripts/retryMonitorBadQueryErrors";
+
+const { parseArgs } = __test;
+
+describe("retryMonitorBadQueryErrors parseArgs", () => {
+  it("defaults to a dry run so an accidental invocation never mutates", () => {
+    expect(parseArgs([])).toEqual({ apply: false, jitterMinutes: 15 });
+  });
+
+  it("enables the update only when --apply is present", () => {
+    expect(parseArgs(["--apply"]).apply).toBe(true);
+  });
+
+  it("reads a custom --jitter-minutes", () => {
+    expect(parseArgs(["--jitter-minutes=15"]).jitterMinutes).toBe(15);
+  });
+
+  it("allows a zero jitter for a big-bang reactivation", () => {
+    expect(parseArgs(["--jitter-minutes=0"]).jitterMinutes).toBe(0);
+  });
+
+  it("falls back to the default on a negative or non-numeric jitter", () => {
+    expect(parseArgs(["--jitter-minutes=-5"]).jitterMinutes).toBe(15);
+    expect(parseArgs(["--jitter-minutes=abc"]).jitterMinutes).toBe(15);
+  });
+});

--- a/worker/src/scripts/retryMonitorBadQueryErrors.ts
+++ b/worker/src/scripts/retryMonitorBadQueryErrors.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S tsx
+/**
+ * One-off remediation that reactivates monitors paused at ERROR_BAD_QUERY,
+ * for use after a fix stops a transient failure from flipping them there.
+ *
+ * Reactivating sets severity to UNKNOWN (rendered as "pending" in the UI) and
+ * jitters each monitor's first run across --jitter-minutes so their queries
+ * don't all re-fire in one scheduler tick; the default keeps the pending
+ * window short. Deploy the flip fix first, or the next failure re-pauses them.
+ *
+ * Point DATABASE_URL at the target env (via tunnel), dry-run, then --apply:
+ *
+ * USAGE:
+ *   pnpm --filter=worker retry-monitor-bad-query-errors
+ *   pnpm --filter=worker retry-monitor-bad-query-errors --apply
+ *   pnpm --filter=worker retry-monitor-bad-query-errors --apply --jitter-minutes=30
+ */
+
+import { prisma } from "@langfuse/shared/src/db";
+import { logger } from "@langfuse/shared/src/server";
+
+/** defaultJitterMinutes spreads the reactivated monitors' first run over this window, kept short so the UNKNOWN "pending" state clears within ~15 minutes. */
+const defaultJitterMinutes = 15;
+
+/** retryMonitorBadQueryErrors reactivates every monitor stuck in ERROR_BAD_QUERY, mirroring the service resume transition and jittering the first run. */
+async function retryMonitorBadQueryErrors(args: {
+  apply: boolean;
+  jitterMinutes: number;
+}): Promise<void> {
+  const preview = await countStuckMonitors();
+  logger.info(
+    `retryMonitorBadQueryErrors: ${preview.monitors} monitors in ERROR_BAD_QUERY across ${preview.queryShapes} query shapes (apply=${args.apply}, jitterMinutes=${args.jitterMinutes})`,
+  );
+
+  if (!args.apply) {
+    logger.info("retryMonitorBadQueryErrors: dry run, pass --apply to execute");
+    return;
+  }
+
+  const reactivated = await prisma.$executeRaw`
+    UPDATE monitors
+    SET status = 'ACTIVE',
+        severity = 'UNKNOWN',
+        severity_changed_at = now(),
+        next_run_at = now() + random() * make_interval(mins => ${args.jitterMinutes}::int),
+        last_published_at = NULL,
+        last_completed_at = NULL,
+        last_claimed_at = NULL,
+        alerted_at = NULL
+    WHERE status = 'ERROR_BAD_QUERY'
+  `;
+  logger.info(
+    `retryMonitorBadQueryErrors: reactivated ${reactivated} monitors`,
+  );
+}
+
+/** countStuckMonitors returns how many ERROR_BAD_QUERY monitors exist and how many distinct query shapes they collapse into. */
+async function countStuckMonitors(): Promise<{
+  monitors: number;
+  queryShapes: number;
+}> {
+  const [row] = await prisma.$queryRaw<
+    { monitors: bigint; query_shapes: bigint }[]
+  >`
+    SELECT count(*) AS monitors,
+           count(DISTINCT (project_id, scheduler_batch_id)) AS query_shapes
+    FROM monitors
+    WHERE status = 'ERROR_BAD_QUERY'
+  `;
+  return {
+    monitors: Number(row?.monitors ?? 0),
+    queryShapes: Number(row?.query_shapes ?? 0),
+  };
+}
+
+/** parseArgs reads --apply and --jitter-minutes from argv. */
+function parseArgs(argv: string[]): { apply: boolean; jitterMinutes: number } {
+  const apply = argv.includes("--apply");
+  const jitterArg = argv
+    .find((a) => a.startsWith("--jitter-minutes="))
+    ?.split("=")[1];
+  const parsed = jitterArg === undefined ? NaN : Number(jitterArg);
+  const jitterMinutes =
+    Number.isFinite(parsed) && parsed >= 0 ? parsed : defaultJitterMinutes;
+  return { apply, jitterMinutes };
+}
+
+if (require.main === module) {
+  retryMonitorBadQueryErrors(parseArgs(process.argv.slice(2)))
+    .catch((err) => {
+      logger.error("retryMonitorBadQueryErrors failed", { err });
+      process.exit(1);
+    })
+    .finally(() => process.exit(0));
+}
+
+export const __test = { parseArgs };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16217.preview.langfuse.com](https://pr-16217.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Valid monitors were being permanently paused as `ERROR_BAD_QUERY` whenever their ClickHouse query hit a transient resource limit (timeout, memory limit, overcommit) — a deschedule that only a human could undo, despite the query being fine.

To achieve this we:
- Rethrow ClickHouse resource errors from the monitor processor instead of catching them and flipping the monitor to `ERROR_BAD_QUERY`, so the scheduler retries and the monitor self-heals once ClickHouse recovers.
- Kept genuine bad-query failures (malformed SQL, unresolvable shape) flipping to `ERROR_BAD_QUERY` as before — the discrimination keys off the `ClickHouseResourceError` class.
- Added a `retry-monitor-bad-query-errors` worker script to reactivate the monitors already stuck in `ERROR_BAD_QUERY`, jittering each one's first run so their queries don't all re-fire in a single scheduler tick.

**Note**: The remediation script is a one-off run per env, and must run *after* this deploys — running it earlier just lets the next resource error re-pause everything. Genuine bad queries correctly re-pause on their next evaluation.

## Verification

- [x] `pnpm --filter @langfuse/shared --filter worker run lint` (also full `turbo run lint` via pre-commit, 7/7)
- [x] worker: `pnpm --filter worker run test monitorProcessor.test` — `34 passed`
- [x] worker: `pnpm --filter worker run test retryMonitorBadQueryErrors` — `5 passed`
- [x] web: `pnpm --filter web run test monitors.servertest` — `22 passed`
- [x] Local end-to-end of the remediation script: seed 3 stuck monitors → dry-run → `--apply` → verified reset + jitter spread → cleanup

## Test plan

- [ ] With the fix deployed, drive a ClickHouse timeout / memory-limit on a monitor query and confirm the monitor stays `ACTIVE` (not `ERROR_BAD_QUERY`) and re-evaluates within ~5 min.
- [ ] Confirm a genuinely malformed monitor query still flips to `ERROR_BAD_QUERY`.
- [ ] Run `pnpm --filter=worker retry-monitor-bad-query-errors` (dry-run) against an env, confirm the reported counts, then `--apply` and confirm the monitors return to `ACTIVE`/`UNKNOWN` and clear the "pending" state within ~15 min.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents recognized transient ClickHouse resource errors from permanently pausing otherwise valid monitors and adds a one-off remediation script for monitors already paused.
- Rethrows `ClickHouseResourceError` so ACTIVE monitors are retried through scheduler TTL recovery.
- Preserves existing `ERROR_BAD_QUERY` handling for other query failures.
- Adds a dry-run-by-default bulk reactivation script with randomized scheduling.
- Adds processor and argument-parsing tests for the new behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

Recognized resource errors retain ACTIVE state and have an established scheduler recovery path, while the remediation script mirrors the normal resume transition apart from its intentional scheduling jitter.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Monitor scheduler publishes evaluation] --> B[Processor claims ACTIVE monitors]
  B --> C[Query ClickHouse]
  C -->|Success| D[Complete evaluation and update monitor state]
  C -->|Recognized resource error| E[Rethrow and leave monitor ACTIVE]
  E --> F[Scheduler detects incomplete run after TTL]
  F --> A
  C -->|Other query error| G[Set ERROR_BAD_QUERY]
  H[One-off remediation script] -->|Reset existing ERROR_BAD_QUERY monitors| I[ACTIVE and UNKNOWN with jittered next run]
  I --> A
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(monitors): add retry-monitor-bad-q..."](https://github.com/langfuse/langfuse/commit/e24b2e955c3f4ab615a5c2b314da9121dafceb9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54131206)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)

<!-- /greptile_comment -->