### PR TITLE
fix(shared): register recurring cron jobs via atomic BullMQ job schedulers

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -154,6 +154,11 @@ the same PR.
 
 - Keep backward compatibility in queue payloads when possible during rolling
   deployments.
+- Register recurring cron jobs through
+  `src/server/redis/scheduleRecurringJob.ts` (BullMQ job schedulers), never
+  via the deprecated `Queue.add(name, data, { repeat })` API. When changing a
+  cron pattern, append the old pattern to `previousPatterns` so the legacy
+  md5-keyed schedule is cleaned up on boot.
 - Do not hand-edit generated artifacts under `prisma/generated/*` or `dist/*`.
 - Avoid exposing server-only modules through `src/index.ts` if they must remain
   frontend-safe.

--- a/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export class BlobStorageIntegrationQueue {
@@ -35,31 +36,11 @@ export class BlobStorageIntegrationQueue {
 
     if (BlobStorageIntegrationQueue.instance) {
       logger.debug("Scheduling jobs for BlobStorageIntegrationQueue");
-      // Remove the old hourly cron pattern - BullMQ keys repeatable jobs by
-      // name + pattern, so changing the pattern creates a second schedule
-      // while the old one keeps firing.
-      BlobStorageIntegrationQueue.instance
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing repeatable-job cleanup; job scheduler migration should be handled separately.
-        .removeRepeatable(QueueJobs.BlobStorageIntegrationJob, {
-          pattern: "20 * * * *",
-        })
-        .catch((err) => {
-          logger.error(
-            "Error removing legacy BlobStorageIntegrationJob schedule",
-            err,
-          );
-        });
-      BlobStorageIntegrationQueue.instance
-        .add(
-          QueueJobs.BlobStorageIntegrationJob,
-          {},
-          {
-            repeat: { pattern: "*/20 * * * *" }, // every 20 minutes
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding BlobStorageIntegrationJob schedule", err);
-        });
+      scheduleRecurringJob(BlobStorageIntegrationQueue.instance, {
+        jobName: QueueJobs.BlobStorageIntegrationJob,
+        pattern: "*/20 * * * *", // every 20 minutes
+        previousPatterns: ["20 * * * *"], // old hourly schedule
+      });
     }
 
     return BlobStorageIntegrationQueue.instance;

--- a/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
+++ b/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
@@ -2,6 +2,7 @@ import { Queue } from "bullmq";
 import { env } from "../../env";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export class CloudFreeTierUsageThresholdQueue {
@@ -45,20 +46,16 @@ export class CloudFreeTierUsageThresholdQueue {
         "[CloudFreeTierUsageThresholdQueue] Scheduling recurring job",
         {
           pattern: "35 * * * *",
-          jobId: "free-tier-usage-threshold-hourly",
           description: "Every hour at minute 35",
           timestamp: new Date().toISOString(),
         },
       );
 
-      CloudFreeTierUsageThresholdQueue.instance.add(
-        QueueJobs.CloudFreeTierUsageThresholdJob,
-        { type: "recurring" },
-        {
-          repeat: { pattern: "35 * * * *" },
-          // jobId: "free-tier-usage-threshold-hourly", // CRITICAL: Unique ID prevents duplicates across containers
-        },
-      );
+      scheduleRecurringJob(CloudFreeTierUsageThresholdQueue.instance, {
+        jobName: QueueJobs.CloudFreeTierUsageThresholdJob,
+        pattern: "35 * * * *",
+        data: { type: "recurring" },
+      });
 
       // Optional: Bootstrap job for immediate execution on startup
       // This ensures usage thresholds are processed immediately when service starts

--- a/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
+++ b/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
@@ -51,10 +51,12 @@ export class CloudFreeTierUsageThresholdQueue {
         },
       );
 
+      // The legacy schedule carried data { type: "recurring" } to distinguish
+      // it from a bootstrap job that was never enabled; nothing reads it and
+      // job data has no semantics to BullMQ, so the payload is now empty.
       scheduleRecurringJob(CloudFreeTierUsageThresholdQueue.instance, {
         jobName: QueueJobs.CloudFreeTierUsageThresholdJob,
         pattern: "35 * * * *",
-        data: { type: "recurring" },
       });
 
       // Optional: Bootstrap job for immediate execution on startup

--- a/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
+++ b/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
@@ -2,6 +2,7 @@ import { Queue } from "bullmq";
 import { env } from "../../env";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export class CloudUsageMeteringQueue {
@@ -41,24 +42,13 @@ export class CloudUsageMeteringQueue {
     if (CloudUsageMeteringQueue.instance) {
       logger.info("[CloudUsageMeteringQueue] Scheduling recurring job", {
         pattern: "5 * * * *",
-        jobId: "cloud-usage-metering-recurring",
         timestamp: new Date().toISOString(),
       });
-      CloudUsageMeteringQueue.instance
-        .add(
-          QueueJobs.CloudUsageMeteringJob,
-          {},
-          {
-            // Run at minute 5 of every hour (e.g. 1:05, 2:05, 3:05, etc)
-            repeat: { pattern: "5 * * * *" },
-          },
-        )
-        .catch((err) => {
-          logger.error(
-            "[CloudUsageMeteringQueue] Failed to schedule recurring job",
-            err,
-          );
-        });
+      // Run at minute 5 of every hour (e.g. 1:05, 2:05, 3:05, etc)
+      scheduleRecurringJob(CloudUsageMeteringQueue.instance, {
+        jobName: QueueJobs.CloudUsageMeteringJob,
+        pattern: "5 * * * *",
+      });
 
       logger.info("[CloudUsageMeteringQueue] Scheduling bootstrap job", {
         jobId: "cloud-usage-metering-bootstrap",

--- a/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
+++ b/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 import { env } from "../../env";
 
@@ -40,17 +41,10 @@ export class CoreDataS3ExportQueue {
 
     if (CoreDataS3ExportQueue.instance) {
       logger.debug("Scheduling jobs for CoreDataS3ExportQueue");
-      CoreDataS3ExportQueue.instance
-        .add(
-          QueueJobs.CoreDataS3ExportJob,
-          {},
-          {
-            repeat: { pattern: "15 3 * * *" }, // every day at 3:15am
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding CoreDataS3ExportJob schedule", err);
-        });
+      scheduleRecurringJob(CoreDataS3ExportQueue.instance, {
+        jobName: QueueJobs.CoreDataS3ExportJob,
+        pattern: "15 3 * * *", // every day at 3:15am
+      });
     }
 
     return CoreDataS3ExportQueue.instance;

--- a/packages/shared/src/server/redis/dataRetentionQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export class DataRetentionQueue {
@@ -35,17 +36,10 @@ export class DataRetentionQueue {
 
     if (DataRetentionQueue.instance) {
       logger.debug("Scheduling jobs for DataRetentionQueue");
-      DataRetentionQueue.instance
-        .add(
-          QueueJobs.DataRetentionJob,
-          {},
-          {
-            repeat: { pattern: "15 3 * * *" }, // every day at 3:15am
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding DataRetentionQueue schedule", err);
-        });
+      scheduleRecurringJob(DataRetentionQueue.instance, {
+        jobName: QueueJobs.DataRetentionJob,
+        pattern: "15 3 * * *", // every day at 3:15am
+      });
     }
 
     return DataRetentionQueue.instance;

--- a/packages/shared/src/server/redis/dlqRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlqRetryQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export class DeadLetterRetryQueue {
@@ -35,17 +36,11 @@ export class DeadLetterRetryQueue {
 
     if (DeadLetterRetryQueue.instance) {
       logger.debug("Scheduling jobs for DeadLetterRetryQueue");
-      DeadLetterRetryQueue.instance
-        .add(
-          QueueJobs.DeadLetterRetryJob,
-          { timestamp: new Date() },
-          {
-            repeat: { pattern: "0 */10 * * * *" }, // every 10 minutes (with seconds precision)
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding DeadLetterRetryQueue schedule", err);
-        });
+      scheduleRecurringJob(DeadLetterRetryQueue.instance, {
+        jobName: QueueJobs.DeadLetterRetryJob,
+        pattern: "0 */10 * * * *", // every 10 minutes (with seconds precision)
+        data: { timestamp: new Date() },
+      });
     }
 
     return DeadLetterRetryQueue.instance;

--- a/packages/shared/src/server/redis/eventPropagationQueue.ts
+++ b/packages/shared/src/server/redis/eventPropagationQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export class EventPropagationQueue {
@@ -43,17 +44,11 @@ export class EventPropagationQueue {
       });
 
       logger.debug("Scheduling jobs for EventPropagationQueue");
-      EventPropagationQueue.instance
-        .add(
-          QueueJobs.EventPropagationJob,
-          { timestamp: new Date() },
-          {
-            repeat: { pattern: "* * * * *" }, // every minute
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding EventPropagationQueue schedule", err);
-        });
+      scheduleRecurringJob(EventPropagationQueue.instance, {
+        jobName: QueueJobs.EventPropagationJob,
+        pattern: "* * * * *", // every minute
+        data: { timestamp: new Date() },
+      });
     }
 
     return EventPropagationQueue.instance;

--- a/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
+++ b/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 import { env } from "../../env";
 
@@ -40,20 +41,10 @@ export class MeteringDataPostgresExportQueue {
 
     if (MeteringDataPostgresExportQueue.instance) {
       logger.debug("Scheduling jobs for MeteringDataPostgresExportQueue");
-      MeteringDataPostgresExportQueue.instance
-        .add(
-          QueueJobs.MeteringDataPostgresExportJob,
-          {},
-          {
-            repeat: { pattern: "30 2 * * *" }, // every day at 2:30am UTC
-          },
-        )
-        .catch((err) => {
-          logger.error(
-            "Error adding MeteringDataPostgresExportJob schedule",
-            err,
-          );
-        });
+      scheduleRecurringJob(MeteringDataPostgresExportQueue.instance, {
+        jobName: QueueJobs.MeteringDataPostgresExportJob,
+        pattern: "30 2 * * *", // every day at 2:30am UTC
+      });
     }
 
     return MeteringDataPostgresExportQueue.instance;

--- a/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export const MIXPANEL_SYNC_CRON_PATTERN = "30 * * * *"; // every hour at :30
@@ -37,17 +38,10 @@ export class MixpanelIntegrationQueue {
 
     if (MixpanelIntegrationQueue.instance) {
       logger.debug("Scheduling jobs for MixpanelIntegrationQueue");
-      MixpanelIntegrationQueue.instance
-        .add(
-          QueueJobs.MixpanelIntegrationJob,
-          {},
-          {
-            repeat: { pattern: MIXPANEL_SYNC_CRON_PATTERN },
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding MixpanelIntegrationJob schedule", err);
-        });
+      scheduleRecurringJob(MixpanelIntegrationQueue.instance, {
+        jobName: QueueJobs.MixpanelIntegrationJob,
+        pattern: MIXPANEL_SYNC_CRON_PATTERN,
+      });
     }
 
     return MixpanelIntegrationQueue.instance;

--- a/packages/shared/src/server/redis/postHogIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 export const POSTHOG_SYNC_CRON_PATTERN = "30 * * * *"; // every hour at :30
@@ -37,17 +38,10 @@ export class PostHogIntegrationQueue {
 
     if (PostHogIntegrationQueue.instance) {
       logger.debug("Scheduling jobs for PostHogIntegrationQueue");
-      PostHogIntegrationQueue.instance
-        .add(
-          QueueJobs.PostHogIntegrationJob,
-          {},
-          {
-            repeat: { pattern: POSTHOG_SYNC_CRON_PATTERN },
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding PostHogIntegrationJob schedule", err);
-        });
+      scheduleRecurringJob(PostHogIntegrationQueue.instance, {
+        jobName: QueueJobs.PostHogIntegrationJob,
+        pattern: POSTHOG_SYNC_CRON_PATTERN,
+      });
     }
 
     return PostHogIntegrationQueue.instance;

--- a/packages/shared/src/server/redis/scheduleRecurringJob.test.ts
+++ b/packages/shared/src/server/redis/scheduleRecurringJob.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Queue } from "bullmq";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const createQueueMock = () => {
+  const removeRepeatable = vi.fn().mockResolvedValue(true);
+  const upsertJobScheduler = vi.fn().mockResolvedValue({});
+  const queue = {
+    name: "test-queue",
+    removeRepeatable,
+    upsertJobScheduler,
+  } as unknown as Queue;
+  return { queue, removeRepeatable, upsertJobScheduler };
+};
+
+describe("scheduleRecurringJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes legacy schedules for the current and previous patterns before upserting", async () => {
+    const { queue, removeRepeatable, upsertJobScheduler } = createQueueMock();
+
+    await scheduleRecurringJob(queue, {
+      jobName: "my-job",
+      pattern: "*/15 * * * *",
+      previousPatterns: ["25 * * * *"],
+    });
+
+    expect(removeRepeatable).toHaveBeenCalledTimes(2);
+    expect(removeRepeatable).toHaveBeenCalledWith("my-job", {
+      pattern: "*/15 * * * *",
+    });
+    expect(removeRepeatable).toHaveBeenCalledWith("my-job", {
+      pattern: "25 * * * *",
+    });
+    expect(upsertJobScheduler).toHaveBeenCalledWith(
+      "my-job",
+      { pattern: "*/15 * * * *" },
+      { name: "my-job", data: {} },
+    );
+    // The legacy cleanup must complete before the scheduler is upserted, so
+    // a concurrently created legacy entry cannot outlive the migration.
+    for (const removeCall of removeRepeatable.mock.invocationCallOrder) {
+      expect(removeCall).toBeLessThan(
+        upsertJobScheduler.mock.invocationCallOrder[0]!,
+      );
+    }
+  });
+
+  it("passes template data through to the scheduler", async () => {
+    const { queue, upsertJobScheduler } = createQueueMock();
+
+    await scheduleRecurringJob(queue, {
+      jobName: "my-job",
+      pattern: "* * * * *",
+      data: { type: "recurring" },
+    });
+
+    expect(upsertJobScheduler).toHaveBeenCalledWith(
+      "my-job",
+      { pattern: "* * * * *" },
+      { name: "my-job", data: { type: "recurring" } },
+    );
+  });
+
+  it("still upserts the scheduler when legacy cleanup fails", async () => {
+    const { queue, removeRepeatable, upsertJobScheduler } = createQueueMock();
+    removeRepeatable.mockRejectedValue(new Error("redis down"));
+
+    await scheduleRecurringJob(queue, {
+      jobName: "my-job",
+      pattern: "* * * * *",
+    });
+
+    expect(upsertJobScheduler).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves instead of rejecting when the upsert fails", async () => {
+    const { queue, upsertJobScheduler } = createQueueMock();
+    upsertJobScheduler.mockRejectedValue(new Error("redis down"));
+
+    await expect(
+      scheduleRecurringJob(queue, {
+        jobName: "my-job",
+        pattern: "* * * * *",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/shared/src/server/redis/scheduleRecurringJob.ts
+++ b/packages/shared/src/server/redis/scheduleRecurringJob.ts
@@ -1,0 +1,70 @@
+import type { Queue } from "bullmq";
+import { logger } from "../logger";
+
+/**
+ * Registers a recurring cron job on a queue via a BullMQ job scheduler.
+ *
+ * Job schedulers replace the deprecated `Queue.add(name, data, { repeat })`
+ * API. The legacy path replaced the pending next iteration in two separate
+ * Redis round trips on every boot (delete the delayed job, then re-create
+ * it), so a producer failing between the two - e.g. a container killed
+ * mid-boot during a fleet-wide deploy - silently ended the schedule until
+ * the next boot re-registered it. `upsertJobScheduler` performs the same
+ * replacement in a single atomic Lua script, so concurrent boots and
+ * mid-boot crashes cannot lose the chain. BullMQ v6 removes the legacy API
+ * entirely.
+ *
+ * The scheduler id is the job name. Legacy schedules are keyed by
+ * md5(name + pattern) instead, so this helper also removes the legacy
+ * entries for the current pattern and any historical ones - without that
+ * cleanup the old chain keeps firing in parallel with the scheduler. The
+ * cleanup is idempotent and must stay in place for as long as a direct
+ * upgrade from a Langfuse version that scheduled via the legacy API is
+ * supported.
+ *
+ * Never rejects: scheduling runs fire-and-forget from queue singleton
+ * getters, so all failures are logged instead of thrown.
+ */
+export const scheduleRecurringJob = async (
+  queue: Queue,
+  opts: {
+    jobName: string;
+    pattern: string;
+    /**
+     * Cron patterns this job was registered with via the legacy repeat API
+     * in earlier releases. The current pattern is always cleaned up and does
+     * not need to be listed. When changing `pattern`, append the old value
+     * here, since each legacy pattern was a separate schedule.
+     */
+    previousPatterns?: string[];
+    /** Template data stored on the scheduler and passed to every iteration. */
+    data?: Record<string, unknown>;
+  },
+): Promise<void> => {
+  const { jobName, pattern, previousPatterns = [], data } = opts;
+
+  for (const legacyPattern of [pattern, ...previousPatterns]) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- Removes schedules created by the deprecated repeat API in earlier releases; keep while direct upgrades from those releases are supported.
+      await queue.removeRepeatable(jobName, { pattern: legacyPattern });
+    } catch (err) {
+      logger.error(
+        `Error removing legacy ${jobName} schedule (${legacyPattern}) on ${queue.name}`,
+        err,
+      );
+    }
+  }
+
+  try {
+    await queue.upsertJobScheduler(
+      jobName,
+      { pattern },
+      { name: jobName, data: data ?? {} },
+    );
+  } catch (err) {
+    logger.error(
+      `Error upserting ${jobName} scheduler on ${queue.name} - the recurring job may not run until the next boot`,
+      err,
+    );
+  }
+};

--- a/packages/shared/src/server/redis/scheduleRecurringJob.ts
+++ b/packages/shared/src/server/redis/scheduleRecurringJob.ts
@@ -1,6 +1,10 @@
 import type { Queue } from "bullmq";
 import { logger } from "../logger";
 
+// DO NOT REMOVE THIS FILE AND BEHAVIOUR WITHIN A MINOR LANGFUSE VERSION.
+// THIS REMOVES THE OLD REMOVER AND MAY LEAD TO DUPLICATE TRIGGERS FOR SELF-HOSTERS FOREVER.
+// HOLD BULLMQ v6 UPGRADE UNTIL LANGFUSE V5!
+
 /**
  * Registers a recurring cron job on a queue via a BullMQ job scheduler.
  *

--- a/packages/shared/src/server/redis/scheduleRecurringJob.ts
+++ b/packages/shared/src/server/redis/scheduleRecurringJob.ts
@@ -2,8 +2,12 @@ import type { Queue } from "bullmq";
 import { logger } from "../logger";
 
 // DO NOT REMOVE THIS FILE AND BEHAVIOUR WITHIN A MINOR LANGFUSE VERSION.
-// THIS REMOVES THE OLD REMOVER AND MAY LEAD TO DUPLICATE TRIGGERS FOR SELF-HOSTERS FOREVER.
-// HOLD BULLMQ v6 UPGRADE UNTIL LANGFUSE V5!
+// THE CLEANUP BELOW DELETES THE OLD md5-KEYED REPEAT SCHEDULES; WITHOUT IT,
+// SELF-HOSTERS UPGRADING FROM A LEGACY-SCHEDULING VERSION GET DUPLICATE CRON
+// TRIGGERS FOREVER (bullmq v6 workers keep iterating stranded md5-keyed
+// chains; only manual Redis cleanup stops them).
+// HOLD THE BULLMQ v6 UPGRADE UNTIL LANGFUSE V5: v6 deletes
+// Queue.removeRepeatable(), which this cleanup requires.
 
 /**
  * Registers a recurring cron job on a queue via a BullMQ job scheduler.

--- a/packages/shared/src/server/redis/v4LegacyApiUsageQueue.test.ts
+++ b/packages/shared/src/server/redis/v4LegacyApiUsageQueue.test.ts
@@ -12,15 +12,15 @@ describe("V4LegacyApiUsageQueue schedule", () => {
     vi.clearAllMocks();
   });
 
-  it("removes the legacy hourly repeatable job before scheduling */15", async () => {
-    const removeRepeatable = vi.fn().mockResolvedValue(undefined);
-    const add = vi.fn().mockResolvedValue(undefined);
+  it("removes the legacy repeatable schedules and upserts a job scheduler", async () => {
+    const removeRepeatable = vi.fn().mockResolvedValue(true);
+    const upsertJobScheduler = vi.fn().mockResolvedValue({});
     const on = vi.fn();
 
     vi.doMock("bullmq", () => ({
       Queue: class {
         removeRepeatable = removeRepeatable;
-        add = add;
+        upsertJobScheduler = upsertJobScheduler;
         on = on;
       },
     }));
@@ -45,18 +45,31 @@ describe("V4LegacyApiUsageQueue schedule", () => {
 
     V4LegacyApiUsageQueue.getInstance();
 
+    // Scheduling is fire-and-forget from getInstance, so wait for the chain.
+    await vi.waitFor(() => {
+      expect(upsertJobScheduler).toHaveBeenCalledTimes(1);
+    });
+
+    // Legacy repeatable entries are keyed by md5(name + pattern), so both the
+    // current pattern and the pre-migration hourly pattern must be cleaned up.
+    expect(removeRepeatable).toHaveBeenCalledWith(
+      QueueJobs.V4LegacyApiUsageJob,
+      { pattern: V4_LEGACY_API_USAGE_CRON_PATTERN },
+    );
     expect(removeRepeatable).toHaveBeenCalledWith(
       QueueJobs.V4LegacyApiUsageJob,
       { pattern: "25 * * * *" },
     );
-    expect(add).toHaveBeenCalledWith(
+    expect(upsertJobScheduler).toHaveBeenCalledWith(
       QueueJobs.V4LegacyApiUsageJob,
-      {},
-      { repeat: { pattern: V4_LEGACY_API_USAGE_CRON_PATTERN } },
+      { pattern: V4_LEGACY_API_USAGE_CRON_PATTERN },
+      { name: QueueJobs.V4LegacyApiUsageJob, data: {} },
     );
     expect(V4_LEGACY_API_USAGE_CRON_PATTERN).toBe("*/15 * * * *");
-    expect(removeRepeatable.mock.invocationCallOrder[0]).toBeLessThan(
-      add.mock.invocationCallOrder[0]!,
-    );
+    for (const removeCall of removeRepeatable.mock.invocationCallOrder) {
+      expect(removeCall).toBeLessThan(
+        upsertJobScheduler.mock.invocationCallOrder[0]!,
+      );
+    }
   });
 });

--- a/packages/shared/src/server/redis/v4LegacyApiUsageQueue.ts
+++ b/packages/shared/src/server/redis/v4LegacyApiUsageQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import { createBullMQQueueOptionsWithRedis } from "./redis";
+import { scheduleRecurringJob } from "./scheduleRecurringJob";
 import { logger } from "../logger";
 
 // Every 15 minutes. The worker re-scans a trailing margin each run, so the
@@ -39,31 +40,11 @@ export class V4LegacyApiUsageQueue {
 
     if (V4LegacyApiUsageQueue.instance) {
       logger.debug("Scheduling jobs for V4LegacyApiUsageQueue");
-      // Remove the old hourly cron pattern - BullMQ keys repeatable jobs by
-      // name + pattern, so changing the pattern creates a second schedule
-      // while the old one keeps firing.
-      V4LegacyApiUsageQueue.instance
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- Existing repeatable-job cleanup; job scheduler migration should be handled separately.
-        .removeRepeatable(QueueJobs.V4LegacyApiUsageJob, {
-          pattern: "25 * * * *",
-        })
-        .catch((err) => {
-          logger.error(
-            "Error removing legacy V4LegacyApiUsageJob schedule",
-            err,
-          );
-        });
-      V4LegacyApiUsageQueue.instance
-        .add(
-          QueueJobs.V4LegacyApiUsageJob,
-          {},
-          {
-            repeat: { pattern: V4_LEGACY_API_USAGE_CRON_PATTERN },
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding V4LegacyApiUsageJob schedule", err);
-        });
+      scheduleRecurringJob(V4LegacyApiUsageQueue.instance, {
+        jobName: QueueJobs.V4LegacyApiUsageJob,
+        pattern: V4_LEGACY_API_USAGE_CRON_PATTERN,
+        previousPatterns: ["25 * * * *"], // old hourly schedule
+      });
     }
 
     return V4LegacyApiUsageQueue.instance;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16223.preview.langfuse.com](https://pr-16223.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Problem

Every recurring cron job in Langfuse is registered via the deprecated `Queue.add(name, data, { repeat })` API. On that path, each booting container replaces the pending next iteration in **two separate Redis round trips**: a Lua script deletes the pending delayed job, then a separate `Job.create` call re-adds it. A producer that fails between the two — e.g. a container killed mid-boot during a fleet-wide deploy, or a Redis command lost in a cluster-wide connection storm — permanently ends the schedule: no error, no failed job, no stalled job. The queue just goes quiet until the next boot happens to re-register it.

This is not theoretical: it stalled event propagation in production for 85 minutes (delayed data visibility in the v4 UI), and the same registration pattern is shared by usage metering, data retention, blob-storage/PostHog/Mixpanel exports, DLQ retry, and the core-data S3 export. Upstream, the failure class is tracked in [taskforcesh/bullmq#3272](https://github.com/taskforcesh/bullmq/issues/3272); the atomic job-scheduler path was hardened there, but the legacy path never was, and bullmq v6 removes it entirely.

## Change

- New `scheduleRecurringJob` helper (`packages/shared/src/server/redis/scheduleRecurringJob.ts`):
  - registers the cron via `Queue.upsertJobScheduler` — delete + re-create runs as a **single atomic Lua script**, so concurrent boots and mid-boot crashes cannot lose the chain, and id collisions surface as thrown errors instead of silent no-ops;
  - removes the legacy md5-keyed schedules for the current pattern and any historical ones (`previousPatterns`), so the old chain cannot keep firing in parallel — this cleanup must stay while direct upgrades from legacy-scheduling versions are supported;
  - never rejects; all failures are logged (registration is fire-and-forget from queue singleton getters).
- Converted all 11 recurring-cron call sites to the helper. The scheduler id is the job name; job names, payloads, patterns, and default job options are unchanged.
- The two pre-existing `eslint-disable @typescript-eslint/no-deprecated` comments for `removeRepeatable` (blobStorage, v4LegacyApiUsage) are consolidated into one inside the helper (net 2 → 1); those two sites already carried the note "job scheduler migration should be handled separately" — this PR is that migration.
- Consumer side needs no changes: the worker already iterates scheduler-keyed jobs via the job-scheduler path in bullmq 5.76.3.

## Rollout / rollback notes

- **Rolling deploy**: safe. Old and new tasks run identical bullmq; only the boot-time registration differs. The legacy cleanup and the upsert cannot delete each other's entries (different key shapes), and any interleaving converges to exactly one scheduler.
- **Tick continuity**: the upsert schedules the next occurrence of the same pattern; no duplicate or missed tick expected at cutover.
- **Rollback**: a rolled-back container re-adds the legacy schedule while the named scheduler persists → duplicate ticks until cleanup. Handlers at highest duplicate sensitivity are already guarded (event propagation: Redis cursor + global concurrency 1; usage metering: DB lock + not-due check). To clean up after a rollback: `queue.removeJobScheduler("<job-name>")` per queue, or roll forward.

## Impacted packages

- `@langfuse/shared` (all changes; consumed by `worker` and `web` queue singletons)

## Verification

- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm tc` → `Tasks: 7 successful, 7 total`
- `pnpm --filter @langfuse/shared run test scheduleRecurringJob` → `Tests 4 passed (4)`
- `pnpm --filter @langfuse/shared run test v4LegacyApiUsageQueue` → `Tests 1 passed (1)`

A deterministic failing-first test for the original race isn't feasible without fault injection between bullmq's two internal Redis calls; the new tests instead pin the invariants that close it (single atomic upsert, legacy cleanup ordered before the upsert, never-reject semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates recurring BullMQ jobs from deprecated repeat options to a shared job-scheduler helper.
- Adds centralized legacy schedule cleanup and `upsertJobScheduler` registration.
- Converts eleven recurring queue registrations while preserving names, payloads, and cron patterns.
- Adds tests for cleanup ordering, payload forwarding, and error handling.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The non-atomic legacy cleanup and scheduler upsert can still stop or duplicate recurring work and should be fixed before merging.

Worker boot removes legacy schedules before creating their replacements, but failures on either side are only logged and never reconciled, allowing zero or two active recurring chains.

**Files Needing Attention:** packages/shared/src/server/redis/scheduleRecurringJob.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Worker boot
  participant H as scheduleRecurringJob
  participant R as Redis/BullMQ
  W->>H: Fire-and-forget registration
  H->>R: removeRepeatable(legacy pattern)
  R-->>H: Legacy chain removed
  Note over H,R: Process or connection failure here leaves no chain
  H->>R: upsertJobScheduler(job name)
  R-->>H: Scheduler registered
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/redis/scheduleRecurringJob.ts:49
**Non-atomic schedule migration**

If a worker terminates or loses Redis after `removeRepeatable` succeeds but before `upsertJobScheduler` completes, this once-per-boot helper leaves no recurring chain until another worker boots. Conversely, when cleanup fails transiently and the subsequent upsert succeeds, the legacy and scheduler chains both remain active and enqueue duplicate ticks.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): register recurring cron job..."](https://github.com/langfuse/langfuse/commit/7bda866fddabfa38c00b9204781f9e8c6763b253) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54280767)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->