### PR TITLE
feat(api): allow admin auth for model routes

### DIFF
--- a/web/src/pages/api/public/models/[modelId]/index.ts
+++ b/web/src/pages/api/public/models/[modelId]/index.ts
@@ -14,6 +14,7 @@ import {
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get model definitions",
+    isAdminApiKeyAuthAllowed: true,
     querySchema: GetModelV1Query,
     responseSchema: GetModelV1Response,
     fn: async ({ query, auth }) => {
@@ -26,6 +27,7 @@ export default withMiddlewares({
 
   DELETE: createAuthedProjectAPIRoute({
     name: "Delete model",
+    isAdminApiKeyAuthAllowed: true,
     querySchema: DeleteModelV1Query,
     responseSchema: DeleteModelV1Response,
     fn: async ({ query, auth }) => {

--- a/web/src/pages/api/public/models/index.ts
+++ b/web/src/pages/api/public/models/index.ts
@@ -14,6 +14,7 @@ import {
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get model definitions",
+    isAdminApiKeyAuthAllowed: true,
     querySchema: GetModelsV1Query,
     responseSchema: GetModelsV1Response,
     fn: async ({ query, auth }) => {
@@ -27,6 +28,7 @@ export default withMiddlewares({
 
   POST: createAuthedProjectAPIRoute({
     name: "Create custom model definition",
+    isAdminApiKeyAuthAllowed: true,
     bodySchema: PostModelsV1Body,
     responseSchema: PostModelsV1Response,
     fn: async ({ body, auth }) => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16224.preview.langfuse.com](https://pr-16224.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- Enable the existing self-hosted `ADMIN_API_KEY` authentication path for the public model collection and item routes.
- Allow administrators to list, create, read, and delete project-scoped model definitions by selecting the target with `x-langfuse-project-id`.
- Preserve regular project API-key authentication and the existing Langfuse Cloud restriction.

## Why

Self-hosted operators managing many projects need to provision custom model definitions and pricing programmatically without creating and coordinating a separate project API key for every project.

## Impact

This is an opt-in route configuration change only. It reuses the existing admin-key validation, target-project lookup, audit scope, and self-hosted-only guard; model persistence and pricing behavior are unchanged.

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm exec dotenv -e .env.test.example -e .env.dev.example -- pnpm --filter web run test src/__tests__/server/admin-api-key-auth.servertest.ts` — `Tests 14 passed (14)`
- `pnpm exec prettier --check web/src/pages/api/public/models/index.ts web/src/pages/api/public/models/[modelId]/index.ts` — `All matched files use Prettier code style!`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables the existing self-hosted administrator authentication flow for the model collection and item routes.

- Allows administrators to list, create, read, and delete models for the project selected by `x-langfuse-project-id`.
- Preserves the existing project API-key path and self-hosted-only restriction.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with administrator access remaining constrained by the existing self-hosted authentication and validated project-selection flow.

The changed routes reuse the established administrator authentication wrapper, and every model read and mutation continues to derive its project and audit scope from the validated authentication result.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): allow admin auth for model ro..."](https://github.com/langfuse/langfuse/commit/454db904aee7797822d411bb5977ebcd5a4ab6af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54282296)</sub>

**Context used:**

- Knowledge Base — [Public API](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/public-api.md)

<!-- /greptile_comment -->