### PR TITLE
fix(widgets): align custom dashboard time-series granularity

### DIFF
--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -69,6 +69,10 @@ import { useScheduledDashboardExecuteQuery } from "@/src/hooks/useDashboardQuery
 import { CopyWidgetDialog } from "@/src/features/widgets/components/CopyWidgetDialog";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Badge } from "@/src/components/ui/badge";
+import {
+  dashboardDateRangeAggregationSettings,
+  findClosestDashboardInterval,
+} from "@/src/utils/date-range-utils";
 
 export interface WidgetPlacement {
   id: string;
@@ -116,8 +120,7 @@ export function DashboardWidget({
    */
   onPasteWidget?: (anchor: WidgetPlacement) => void;
   /**
-   * Duplicates this widget (new widget row seeded from `widget`) next to this
-   * tile. Passed only on editable (non-locked) dashboards.
+   * Duplicates this widget (new widget row seeded from `widget`) next to it.
    */
   onDuplicateWidget?: (
     anchor: WidgetPlacement,
@@ -204,6 +207,14 @@ export function DashboardWidget({
       ? dateRange.from
       : new Date(new Date().getTime() - 1000);
     const toTimestamp = dateRange ? dateRange.to : new Date();
+    const dashboardAggregation = findClosestDashboardInterval({
+      from: fromTimestamp,
+      to: toTimestamp,
+    });
+    const dashboardGranularity = dashboardAggregation
+      ? (dashboardDateRangeAggregationSettings[dashboardAggregation].dateTrunc ??
+        "day")
+      : "auto";
 
     const isTimeSeries = isTimeSeriesChart(
       widget.data?.chartType ?? "LINE_TIME_SERIES",
@@ -255,7 +266,9 @@ export function DashboardWidget({
           aggregation: metric.agg as z.infer<typeof metricAggregations>,
         })) ?? [],
       filters: mergedFilters,
-      timeDimension: isTimeSeries ? { granularity: "auto" as const } : null,
+      timeDimension: isTimeSeries
+        ? { granularity: dashboardGranularity }
+        : null,
       fromTimestamp: fromTimestamp.toISOString(),
       toTimestamp: toTimestamp.toISOString(),
       orderBy,

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -120,7 +120,8 @@ export function DashboardWidget({
    */
   onPasteWidget?: (anchor: WidgetPlacement) => void;
   /**
-   * Duplicates this widget (new widget row seeded from `widget`) next to it.
+   * Duplicates this widget (new widget row seeded from `widget`) next to this
+   * tile. Passed only on editable (non-locked) dashboards.
    */
   onDuplicateWidget?: (
     anchor: WidgetPlacement,


### PR DESCRIPTION
## Summary

Align custom dashboard time-series widget bucketing with the granularity used by built-in dashboard cards.

Custom query-backed widgets currently always send `timeDimension.granularity: "auto"`. For ranges such as **Past 3 hours**, backend auto bucketing resolves this to hourly buckets, while built-in dashboard charts use the dashboard preset's `dateTrunc` (`minute` for `last3Hours`). This makes custom charts appear much sparser next to built-in charts and can look like data points are missing.

This change reuses the same dashboard range mapping already used by `PresetDashboardWidget`:

- find the closest dashboard aggregation for the current date range
- use `dashboardDateRangeAggregationSettings[agg].dateTrunc`
- pass that granularity to custom time-series widget queries

For example, Past 3 hours now resolves to `minute` instead of `auto` → `hour`.

## Root cause

`DashboardWidget` hardcoded `timeDimension: { granularity: "auto" }`, while dashboard-native charts derive their granularity from the dashboard range preset.

## Impact

Custom dashboard time-series widgets now have bucket density consistent with built-in dashboard charts for the same dashboard time range. Query semantics/data are unchanged aside from the time bucket granularity.

This is similar in spirit to #13111 / #13242, which aligned custom-widget presentation semantics with built-in dashboard behavior.

## Validation

- Compared this branch against the current upstream `main`; only `web/src/features/widgets/components/DashboardWidget.tsx` is modified (15 additions, 1 deletion).
- Verified the mapping reuses the existing `findClosestDashboardInterval` / `dashboardDateRangeAggregationSettings` path used by preset dashboard widgets.
- Full lint/typecheck is left to CI because the execution environment used for this change cannot clone/install repository dependencies.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns custom dashboard time-series bucketing with the date-range granularity used by built-in dashboard widgets.
- Derives the closest dashboard aggregation from the active date range.
- Uses that aggregation’s configured `dateTrunc` value for time-series widget queries.
- Preserves existing behavior for non-time-series widgets.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no identified blocking or non-blocking issues.

The selected dashboard granularities are valid query values, non-time-series queries remain unchanged, and no reachable failure was established for the new mapping.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: restore untouched widget comments"](https://github.com/langfuse/langfuse/commit/458f04e2ab32aefe5e090e06cdf0e284af10e923) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54604786)</sub>

<!-- /greptile_comment -->