### PR TITLE
chore(worker): remove unused event propagation concurrency env var

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -511,11 +511,6 @@ const EnvSchema = z.object({
     .positive()
     .default(3_600_000), // 60 minutes
 
-  LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY: z.coerce
-    .number()
-    .positive()
-    .default(10),
-
   LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS: z.coerce
     .number()
     .int()

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -330,10 +330,6 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("true"),
 
-  LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY: z.coerce
-    .number()
-    .positive()
-    .default(10),
   LANGFUSE_DATASET_RUN_BACKFILL_CHUNK_SIZE: z.coerce
     .number()
     .positive()


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16228.preview.langfuse.com](https://pr-16228.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Removes the unused environment variable `LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY`.

It was declared in two env schemas (`worker/src/env.ts` and `packages/shared/src/env.ts`, zod coerce number, default 10) but never read anywhere: the actual event-propagation concurrency is hardcoded via `setGlobalConcurrency(1)` in `packages/shared/src/server/redis/eventPropagationQueue.ts` and `concurrency: 1` on the worker registration in `worker/src/app.ts`. A repo-wide grep (including all `.env*.example` files) confirms these two declarations were the only references, so removing them is a no-op at runtime.

Impacted packages: `@langfuse/shared`, `worker`.

Verification:
- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm tc` — Tasks: 7 successful, 7 total
- Repo-wide grep after removal: zero remaining references

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes an unused event-propagation concurrency environment variable without changing runtime behavior.
- Deletes the obsolete variable from the shared environment schema.
- Deletes the same variable from the worker environment schema.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the removed environment variable has no remaining consumers and its removal does not alter event-propagation concurrency.

Both schemas tolerate the formerly configured key as an unknown environment value, while the queue and worker continue to configure concurrency independently.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): remove unused event propa..."](https://github.com/langfuse/langfuse/commit/169f027145d280e125f447b471cc5da50b9d4746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54294177)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->