### PR TITLE
refactor(in-app-agent): remove legacy approval table ORM usage

### DIFF
--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -182,7 +182,6 @@ model Project {
   InAppAgentConversation    InAppAgentConversation[]
   InAppAgentEvent           InAppAgentEvent[]
   InAppAgentRun             InAppAgentRun[]
-  InAppAgentPendingToolApproval InAppAgentPendingToolApproval[]
 
   @@index([orgId])
   @@map("projects")
@@ -247,7 +246,6 @@ model InAppAgentConversation {
 
   events InAppAgentEvent[]
   runs   InAppAgentRun[]
-  pendingToolApprovals InAppAgentPendingToolApproval[]
 
   @@id([id, projectId])
   @@index([projectId, createdByUserId, deletedAt, updatedAt, id], map: "in_app_agent_conversations_project_user_list_idx")
@@ -304,24 +302,6 @@ model InAppAgentRun {
   @@id([id, projectId])
   @@index([projectId, conversationId, createdAt], map: "in_app_agent_runs_project_conversation_created_idx")
   @@map("in_app_agent_runs")
-}
-
-model InAppAgentPendingToolApproval {
-  // Background execution never reads or writes this table. Retain it
-  // temporarily so existing rows and relations remain valid.
-  projectId           String                 @map("project_id")
-  project             Project                @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  conversationId      String                 @map("conversation_id")
-  conversation        InAppAgentConversation @relation(fields: [conversationId, projectId], references: [id, projectId], onDelete: Cascade)
-  toolCallId          String                 @map("tool_call_id")
-  approvalFingerprint String                 @map("approval_fingerprint")
-  expiresAt           DateTime               @map("expires_at")
-  createdAt           DateTime               @default(now()) @map("created_at")
-  updatedAt           DateTime               @default(now()) @updatedAt @map("updated_at")
-
-  @@id([projectId, conversationId, toolCallId])
-  @@index([expiresAt], map: "in_app_agent_pending_tool_approvals_expires_at_idx")
-  @@map("in_app_agent_pending_tool_approvals")
 }
 
 model BackgroundMigration {

--- a/web/src/features/in-app-agent/README.md
+++ b/web/src/features/in-app-agent/README.md
@@ -218,8 +218,9 @@ Human approval is separate from the MCP tool override. Shared `server/tools.ts` 
 
 Conversation-scoped grants live in `InAppAgentConversation.alwaysAllowedTools`, holding server-prefixed names such as `langfuse_createDashboardWidget`. The prefix is part of the identity, so a stored grant cannot be mistaken for a same-named tool on another MCP surface; unprefixed entries are rejected when the policy is rebuilt. Grants are written inside the same locked transaction as the approval decision in `server/runLifecycle.ts`. A one-off `Approve` writes nothing there; only `Always approve` does. The worker rebuilds the policy from the column on every run rather than trusting enqueue-time authorization. Mastra emits an interrupt, the browser asks the user, and the router records the decision for a durable worker continuation. `server/human-in-the-loop.ts` adapts Mastra's runtime interrupt payload into the Langfuse-owned `tool_approval_request` contract from `schema.ts`; the browser stores and forwards only that runtime-neutral shape.
 
-The `InAppAgentPendingToolApproval` table is not used by background execution.
-It remains temporarily so existing rows and Prisma relations stay valid.
+The legacy `in_app_agent_pending_tool_approvals` table is not used or modeled
+by background execution. It remains in the database temporarily for
+compatibility and will be cleaned up separately.
 
 Sandbox tools are separate from MCP authorization. When a sandbox provider is enabled, `server/tools.ts` adds local `read`, `write`, `edit`, and `bash` tools backed by the sandbox provider contract rather than the MCP registry.
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16229.preview.langfuse.com](https://pr-16229.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Remove the legacy pending-approval Prisma model and relations.
- Keep the existing physical table and historical migration unchanged.
- Document that background execution no longer uses or models the table.

## Verification

- `CI=true pnpm --filter @langfuse/shared run db:generate`
- `CI=true pnpm --filter @langfuse/shared run typecheck`
- `CI=true pnpm run lint`
- `git diff --check`
- The DB-backed worker/web integration test could not run because PostgreSQL was unavailable at `localhost:5432`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes the legacy pending-tool-approval model and relations from Prisma while intentionally retaining the physical table, and updates the in-app-agent documentation accordingly.
- Removes `InAppAgentPendingToolApproval` from the generated Prisma client surface.
- Removes its relations from projects and conversations.
- Documents that the legacy table remains for later cleanup.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the retained legacy table is protected from being folded into the next generated migration as an unintended drop.

The application has no remaining ORM callers, but Prisma's desired schema now omits a physical table that the PR explicitly intends to preserve, so a subsequent unrelated migration can delete it prematurely.

**Files Needing Attention:** packages/shared/prisma/schema.prisma
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/prisma/schema.prisma:304
**Retained table becomes migration drop**

When the next unrelated migration is generated with `prisma migrate dev`, the table created by migration history is absent from the updated desired schema, so Prisma includes its deletion and prematurely removes the compatibility table and its rows instead of leaving cleanup as a separate deliberate change.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(in-app-agent): remove legacy ap..."](https://github.com/langfuse/langfuse/commit/5070b1d2dcc134917eb8ca92620fc823b90d10cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54306389)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)

<!-- /greptile_comment -->