### PR TITLE
feat(web): enable PostHog heatmap capture

### DIFF
--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -110,7 +110,7 @@ if (
       },
     },
     autocapture: false,
-    enable_heatmaps: false,
+    enable_heatmaps: true,
     persistence: "cookie",
   });
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16230.preview.langfuse.com](https://pr-16230.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Enables PostHog heatmap capture in the cloud app's posthog-js init (`enable_heatmaps: true`). It was explicitly disabled, so no in-app page has any heatmap data in PostHog today — this blocks UX analysis (e.g. the v4 migration status page `/v4-migration` and the sidebar).

## What this captures

Heatmap capture records click / mouse-move / scroll coordinates with element metadata (`$$heatmap` events). No text content is captured, and autocapture stays off. The PostHog project-level heatmaps toggle is already on; this flag was the only blocker.

## Verification

One-line boolean flip in the init config object; no lint/tests run (no behavioral code paths touched). After deploy, `$$heatmap` events should appear in PostHog project 7132 and page heatmaps become viewable under PostHog → Heatmaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Enables PostHog heatmap capture for the cloud web application.
- Changes the global PostHog initialization setting from `enable_heatmaps: false` to `enable_heatmaps: true`.
- Leaves general autocapture disabled and retains cookie-based persistence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the focused configuration change matches its stated telemetry purpose without an established contract violation.

The change only enables PostHog heatmaps within the existing client-side, environment-gated initialization while preserving disabled autocapture, and no concrete reachable failure was established.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): enable PostHog heatmap captur..."](https://github.com/langfuse/langfuse/commit/a45a0301fac65f41775852891c9561738184d105) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54307394)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->