### PR TITLE
fix(in-app-agent): score message feedback on the approval-chain root run

### DIFF
--- a/packages/shared/src/features/inAppAgent/types.ts
+++ b/packages/shared/src/features/inAppAgent/types.ts
@@ -97,3 +97,15 @@ export const InAppAgentRunRequestSchema = z.discriminatedUnion("kind", [
 ]);
 
 export type InAppAgentRunRequest = z.infer<typeof InAppAgentRunRequestSchema>;
+
+// Approval continuations inherit the root run's trace ids, so telemetry keyed
+// off a run must resolve the root first.
+export const resolveInAppAgentRootRunId = (
+  request: unknown,
+  runId: string,
+): string => {
+  const parsed = InAppAgentRunRequestSchema.safeParse(request);
+  return parsed.success && parsed.data.kind === "approvalDecision"
+    ? (parsed.data.rootRunId ?? parsed.data.parentRunId)
+    : runId;
+};

--- a/packages/shared/src/in-app-agent/server/runLifecycle.ts
+++ b/packages/shared/src/in-app-agent/server/runLifecycle.ts
@@ -15,6 +15,7 @@ import type { AgUiEvent } from "../schema";
 import type { InAppAgentPrefixedLangfuseMcpToolName } from "./tools";
 import {
   InAppAgentRunRequestSchema,
+  resolveInAppAgentRootRunId,
   type InAppAgentRunRequest,
 } from "../../features/inAppAgent/types";
 import {
@@ -282,10 +283,10 @@ export async function decideToolApproval(params: {
       parentRequest.success && parentRequest.data.kind === "approvalDecision"
         ? (parentRequest.data.continuationNumber ?? 1) + 1
         : 1;
-    const rootRunId =
-      parentRequest.success && parentRequest.data.kind === "approvalDecision"
-        ? (parentRequest.data.rootRunId ?? params.parentRunId)
-        : params.parentRunId;
+    const rootRunId = resolveInAppAgentRootRunId(
+      parentRun.request,
+      params.parentRunId,
+    );
     const traceStartedAt =
       parentRequest.success &&
       parentRequest.data.kind === "approvalDecision" &&

--- a/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
@@ -11,21 +11,26 @@ import type { Flags } from "@/src/features/feature-flags/types";
 import { EventType } from "@ag-ui/core";
 import { randomUUID } from "crypto";
 import { vi } from "vitest";
+import waitForExpect from "wait-for-expect";
 
 import {
   InAppAgentRunErrorCode,
   InAppAgentRunStatus,
+  type InAppAgentRunRequest,
   type Plan,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   createOrgProjectAndApiKey,
   generateLLMText,
+  getScoreById,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 import {
   createInAppAgentConversationId,
   createInAppAgentRunId,
+  getInAppAgentInstrumentationObservationId,
+  getInAppAgentInstrumentationTraceId,
 } from "@langfuse/shared/in-app-agent";
 import {
   dropEmptyAssistantMessages,
@@ -154,6 +159,7 @@ describe("in-app agent persistence", () => {
     conversationId: string;
     userId: string;
     runId?: string;
+    request?: InAppAgentRunRequest;
   }) => {
     const now = new Date();
 
@@ -168,6 +174,7 @@ describe("in-app agent persistence", () => {
         status: InAppAgentRunStatus.RUNNING,
         claimedAt: now,
         heartbeatAt: now,
+        ...(params.request ? { request: params.request } : {}),
       },
     });
   };
@@ -630,10 +637,10 @@ describe("in-app agent persistence", () => {
     }
   });
 
-  it("requires feedback run ids to match persisted assistant messages", async () => {
+  it("scores feedback on the approval-chain root run and rejects run id mismatches", async () => {
     const { caller, projectId, userId } = await createCaller();
     const conversation = await createConversation({ projectId, userId });
-    const run = await createClaimedRunFixture({
+    const rootRun = await createClaimedRunFixture({
       projectId,
       conversationId: conversation.id,
       userId,
@@ -641,14 +648,31 @@ describe("in-app agent persistence", () => {
     const events = await startCompactRun({
       projectId,
       conversationId: conversation.id,
-      runId: run.id,
+      runId: rootRun.id,
       messageId: "feedback-user",
       content: "Answer me",
+    });
+    // The final answer comes from an approval continuation, but the trace it is
+    // recorded on belongs to the root run. The parent settles when it parks for
+    // approval, so only the continuation is active.
+    await finishConversationRun({ projectId, runId: rootRun.id });
+    const continuationRun = await createClaimedRunFixture({
+      projectId,
+      conversationId: conversation.id,
+      userId,
+      request: {
+        kind: "approvalDecision",
+        parentRunId: rootRun.id,
+        rootRunId: rootRun.id,
+        toolCallId: "tool-call-1",
+        approved: true,
+        context: [],
+      },
     });
     await appendAssistantText({
       projectId,
       conversationId: conversation.id,
-      runId: run.id,
+      runId: continuationRun.id,
       events,
       messageId: "feedback-assistant",
       chunks: ["Here is an answer"],
@@ -667,16 +691,37 @@ describe("in-app agent persistence", () => {
       "Feedback can only be submitted for persisted assistant messages",
     );
 
-    await expect(
-      caller.submitFeedback({
-        projectId,
-        conversationId: conversation.id,
-        messageId: "feedback-assistant",
-        runId: run.id,
-        value: null,
-        comment: null,
-      }),
-    ).resolves.toEqual({ feedback: null });
+    const originalAiFeaturesProjectId = env.LANGFUSE_AI_FEATURES_PROJECT_ID;
+    try {
+      (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID = projectId;
+
+      await expect(
+        caller.submitFeedback({
+          projectId,
+          conversationId: conversation.id,
+          messageId: "feedback-assistant",
+          runId: continuationRun.id,
+          value: "thumbs_up",
+          comment: null,
+        }),
+      ).resolves.toEqual({ feedback: { value: "thumbs_up", comment: null } });
+
+      await waitForExpect(async () => {
+        const score = await getScoreById({
+          projectId,
+          scoreId: `afbs_feedback-assistant_${userId}`,
+        });
+        expect(score?.traceId).toBe(
+          getInAppAgentInstrumentationTraceId(rootRun.id),
+        );
+        expect(score?.observationId).toBe(
+          getInAppAgentInstrumentationObservationId(rootRun.id),
+        );
+      });
+    } finally {
+      (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID =
+        originalAiFeaturesProjectId;
+    }
   });
 
   it("does not reduce partial assistant content before the end event", async () => {

--- a/web/src/features/in-app-agent/server/router.ts
+++ b/web/src/features/in-app-agent/server/router.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import {
   InvalidRequestError,
+  resolveInAppAgentRootRunId,
   ScoreDataTypeEnum,
   ScoreSourceEnum,
   TEXT_SCORE_MAX_LENGTH,
@@ -400,15 +401,26 @@ export const inAppAgentRouter = createTRPCRouter({
       const scoreProjectId = env.LANGFUSE_AI_FEATURES_PROJECT_ID;
 
       if (projectAvailability.aiTelemetryEnabled && scoreProjectId) {
+        // Approval continuations trace onto the root run, so score the root too.
+        const run = await ctx.prisma.inAppAgentRun.findUnique({
+          where: {
+            id_projectId: { id: input.runId, projectId: input.projectId },
+          },
+          select: { request: true },
+        });
+        const telemetryRunId = resolveInAppAgentRootRunId(
+          run?.request,
+          input.runId,
+        );
+
         await upsertScore({
           id: scoreId,
           timestamp: convertDateToClickhouseDateTime(now),
           project_id: scoreProjectId,
           environment: IN_APP_AGENT_FEEDBACK_ENVIRONMENT,
-          trace_id: getInAppAgentInstrumentationTraceId(input.runId),
-          observation_id: getInAppAgentInstrumentationObservationId(
-            input.runId,
-          ),
+          trace_id: getInAppAgentInstrumentationTraceId(telemetryRunId),
+          observation_id:
+            getInAppAgentInstrumentationObservationId(telemetryRunId),
           session_id: input.conversationId,
           name: IN_APP_AGENT_FEEDBACK_SCORE_NAME,
           value: input.value === "thumbs_up" ? 1 : 0,


### PR DESCRIPTION
## Problem

Agent turns that pass through a tool approval resume in a new continuation run. The instrumentation records the complete chain on the **root** run's trace and root observation:

```ts
// packages/shared/src/in-app-agent/server/instrumentation.ts
const rootRunId = this.approvalContinuation?.rootRunId ?? params.runId;
this.traceId = getInAppAgentInstrumentationTraceId(rootRunId);
this.rootObservationId = getInAppAgentInstrumentationObservationId(rootRunId);
```

The feedback mutation still derived its ids from `input.runId`, which is the run that produced the final answer message — for an approval turn, the continuation run. So the thumbs up/down score was written against `${continuationRunId}-trace` / `continuationRunId`, ids that are never created. Nothing errored: the score row landed in ClickHouse but dangled off the real `agent-turn` trace, and feedback stopped aggregating for exactly the turns that involved an approval.

## Change

- Add `resolveInAppAgentRootRunId(request, runId)` beside `InAppAgentRunRequestSchema`. It reads a run's stored request and returns the root run of its approval chain (continuations already carry `rootRunId` forward, so no recursion is needed).
- `submitFeedback` resolves the root run before deriving the score's `trace_id` / `observation_id`. The lookup sits inside the existing telemetry guard so it costs nothing when telemetry is off. `scoreId` and `metadata.message_id` still key off the message, so re-rating a message keeps upserting the same score.
- The continuation writer in `decideToolApproval` now calls the same helper instead of repeating the rule inline — that duplication drifting is what caused the bug.

Continuation rows written before the root-run tracing change have no `rootRunId`, so the helper falls back to `parentRunId`. That matches the instrumentation's own fallback (`rootRunId = approvalRequest.runId`, the run that raised the approval), so old rows stay self-consistent.

## Impacted packages

- `@langfuse/shared` — `features/inAppAgent/types.ts`, `in-app-agent/server/runLifecycle.ts`
- `web` — `features/in-app-agent/server/router.ts`

## Verification

- `pnpm run lint` → `Tasks:    7 successful, 7 total`
- `pnpm run typecheck` → `Tasks:    7 successful, 7 total`
- `pnpm --filter web run test in-app-agent-persistence` → `Tests  25 passed (25)`
- `pnpm --filter worker run test in-app-agent` → `Tests  19 passed (19)`

Confirmed red before green: with only the router hunk reverted, the extended test fails with `expected 'arun_wz9p…-trace' to be 'arun_jzcw…-trace'` — the score landing on the continuation's trace instead of the root's.

## Tests

No new test cases. `web/src/__tests__/server/in-app-agent-persistence.servertest.ts` already owned which run id feedback keys off, so that case was extended in place: its accepting branch now submits a real `thumbs_up` on a continuation run (previously `value: null`, which returns before the score is written and so could not observe the bug) and asserts the score's `traceId` / `observationId` against the root run. The run-id mismatch assertion is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
