### PR TITLE
chore(web): hoist the shared export-source test context helper

### DIFF
--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -25,6 +25,16 @@ const PROJECT_PRE = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const PROJECT_POST = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
 const ROW_PRE = new Date(LEGACY_BLOB_EXPORTER_CUTOFF.getTime() - MS_PER_DAY);
 
+// Self-hosted unless a case overrides it, so the two capability flags always
+// come from the real builder rather than being hand-set per case.
+const ctxFor = (
+  writeMode: BlobExportWriteMode,
+  over: Partial<
+    Omit<ExportSourceContext, "enrichedAvailable" | "legacyWritesActive">
+  > = {},
+): ExportSourceContext =>
+  buildExportSourceContext({ writeMode, isCloud: false, ...over });
+
 const cloudPreCutoff: ExportSourceContext = {
   isCloud: true,
   enrichedAvailable: true,
@@ -263,14 +273,6 @@ describe("shouldHideExportSourceSelector", () => {
 describe("write mode drives the settings-page selector", () => {
   const WRITE_MODES: BlobExportWriteMode[] = ["legacy", "dual", "events_only"];
 
-  const ctxFor = (
-    writeMode: BlobExportWriteMode,
-    over: Partial<
-      Omit<ExportSourceContext, "enrichedAvailable" | "legacyWritesActive">
-    > = {},
-  ): ExportSourceContext =>
-    buildExportSourceContext({ writeMode, isCloud: false, ...over });
-
   const selectableValues = (ctx: ExportSourceContext) =>
     getExportSourceOptions(undefined, ctx)
       .filter((o) => !o.unavailable)
@@ -406,14 +408,6 @@ describe("write mode drives the settings-page selector", () => {
 // The pages consume only this composite, so the pieces being correct
 // individually is not enough — visibility and the default must agree.
 describe("getExportSourceFieldState", () => {
-  const ctxFor = (
-    writeMode: BlobExportWriteMode,
-    over: Partial<
-      Omit<ExportSourceContext, "enrichedAvailable" | "legacyWritesActive">
-    > = {},
-  ): ExportSourceContext =>
-    buildExportSourceContext({ writeMode, isCloud: false, ...over });
-
   it.each<BlobExportWriteMode>(["legacy", "dual", "events_only"])(
     "%s: a hidden selector always leaves a selectable default",
     (mode) => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16238.preview.langfuse.com](https://pr-16238.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

`exportSource.clienttest.ts` had two byte-for-byte identical `ctxFor` helpers, one
scoped inside each of the `write mode drives the settings-page selector` and
`getExportSourceFieldState` describe blocks. Nothing catches the duplication —
each copy is `describe`-scoped, so there is no name collision and both behave
identically today — but a change to `buildExportSourceContext`'s shape would have
to be made twice, and updating only one would silently leave a describe block
asserting against a stale context.

Hoists a single `ctxFor` to file scope next to the existing shared constants
(`PROJECT_PRE`, `PROJECT_POST`, `ROW_PRE`) and deletes both local copies.
Test-only change, no production code touched and no assertions altered.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- `pnpm --filter web run test-client exportSource.clienttest.ts` → 45 passed (45), unchanged from before
- `pnpm turbo run lint --filter=web` → 4 successful, 4 total
- `pnpm turbo run typecheck --filter=web` → 4 successful, 4 total

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hoists two identical test-context helpers into one module-level helper without changing their behavior.
- Removes duplicate `ctxFor` declarations from two test suites.
- Reuses one shared helper that continues to build self-hosted contexts through the production context builder.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the helper hoist preserves the same inputs, defaults, and context-building behavior.

The removed helpers were identical to the new module-level helper, depend on no suite-local state, and all existing call sites continue to resolve to equivalent deterministic behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(web): hoist the shared export-sour..."](https://github.com/langfuse/langfuse/commit/33c0f5b5232bd97674b3523c6049f8977aac6f1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54326990)</sub>

<!-- /greptile_comment -->