### PR TITLE
chore(in-app-agent): assert feedback on an ordinary turn scores its own run

### DIFF
--- a/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
@@ -652,6 +652,14 @@ describe("in-app agent persistence", () => {
       messageId: "feedback-user",
       content: "Answer me",
     });
+    await appendAssistantText({
+      projectId,
+      conversationId: conversation.id,
+      runId: rootRun.id,
+      events,
+      messageId: "plain-assistant",
+      chunks: ["Answering directly"],
+    });
     // The final answer comes from an approval continuation, but the trace it is
     // recorded on belongs to the root run. The parent settles when it parks for
     // approval, so only the continuation is active.
@@ -706,17 +714,39 @@ describe("in-app agent persistence", () => {
         }),
       ).resolves.toEqual({ feedback: { value: "thumbs_up", comment: null } });
 
-      await waitForExpect(async () => {
-        const score = await getScoreById({
+      await expect(
+        caller.submitFeedback({
           projectId,
-          scoreId: `afbs_feedback-assistant_${userId}`,
-        });
-        expect(score?.traceId).toBe(
-          getInAppAgentInstrumentationTraceId(rootRun.id),
-        );
-        expect(score?.observationId).toBe(
-          getInAppAgentInstrumentationObservationId(rootRun.id),
-        );
+          conversationId: conversation.id,
+          messageId: "plain-assistant",
+          runId: rootRun.id,
+          value: "thumbs_down",
+          comment: null,
+        }),
+      ).resolves.toEqual({ feedback: { value: "thumbs_down", comment: null } });
+
+      // Both the continuation's answer and the root run's own answer score onto
+      // the single trace the agent turn was recorded on.
+      await waitForExpect(async () => {
+        const [continuationScore, plainScore] = await Promise.all([
+          getScoreById({
+            projectId,
+            scoreId: `afbs_feedback-assistant_${userId}`,
+          }),
+          getScoreById({
+            projectId,
+            scoreId: `afbs_plain-assistant_${userId}`,
+          }),
+        ]);
+
+        for (const score of [continuationScore, plainScore]) {
+          expect(score?.traceId).toBe(
+            getInAppAgentInstrumentationTraceId(rootRun.id),
+          );
+          expect(score?.observationId).toBe(
+            getInAppAgentInstrumentationObservationId(rootRun.id),
+          );
+        }
       });
     } finally {
       (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID =


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16240.preview.langfuse.com](https://pr-16240.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Follow-up to #16236, which fixed feedback scores dangling off the agent turn's trace after a tool approval.

That PR extended the existing feedback case to run on an approval continuation, which left the dominant path unasserted: nothing checked that a turn **without** an approval scores the trace of the run that produced it. The case's accepting branch previously passed `value: null`, which returns before the score is written, so this was never covered before either.

## Change

Test only. In the same case, the root run also answers directly, that answer is rated, and both scores are asserted to land on the one trace the agent turn was recorded on.

Verified the assertion has teeth: making `resolveInAppAgentRootRunId` mishandle an unparseable request (return `""` instead of falling back to the run id) fails only the new assertion — `expected '-trace' to be 'arun_s4q3…-trace'`.

## Impacted packages

- `web` — `src/__tests__/server/in-app-agent-persistence.servertest.ts`

## Verification

- `pnpm --filter web run test in-app-agent-persistence` → `Tests  25 passed (25)`
- `pnpm run lint` → `Tasks:    7 successful, 7 total` (pre-commit hook, plus `All matched files use Prettier code style!`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This test-only change extends in-app-agent persistence coverage to verify that feedback on both an ordinary root-run answer and an approval-continuation answer is attached to the root run’s instrumentation trace.

- Adds a directly answered assistant message to the root run.
- Submits distinct feedback for the root and continuation messages.
- Polls and verifies both scores’ trace and observation associations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only expands test coverage and introduces no production behavior change or actionable test defect.

The added messages use distinct feedback score IDs, both feedback paths resolve to the intended root-run instrumentation identifiers, and eventual score persistence remains covered by polling.
</details>

<sub>Reviews (1): Last reviewed commit: ["test(in-app-agent): assert feedback on a..."](https://github.com/langfuse/langfuse/commit/8b03edea3674999749a1f0706ac0328682155003) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54332857)</sub>

**Context used:**

- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)

<!-- /greptile_comment -->