### PR TITLE
refactor(web,shared): let each integration family carry its own exporter cutoff

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -70,6 +70,8 @@ NEXT_PUBLIC_LANGFUSE_CLOUD_REGION="DEV"
 # Same, for the integration-level cutoff applied to the blob storage
 # integration row's creation date instead of the project's.
 # NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF=
+# Integration-level cutoff for PostHog/Mixpanel export sources.
+# NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF=
 
 # Langfuse experimental features
 LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES="false"

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -37,6 +37,7 @@ const EnvSchema = z.object({
   NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
   // Same, for the integration-level cutoff (BlobStorageIntegration.createdAt).
   NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF: z.iso.datetime().optional(),
+  NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF: z.iso.datetime().optional(),
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.test.ts
@@ -6,8 +6,10 @@ import {
   areLegacyWritesActive,
   getAvailableExportSources,
   isEnrichedBlobExportSource,
+  isLegacyBlobExporter,
   isLegacyBlobExportSource,
   LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
   validateExportSource,
   type BlobExportWriteMode,
@@ -329,5 +331,103 @@ describe("isLegacyBlobExportSource", () => {
     const source = "EVENTS";
     expect(isLegacyBlobExportSource(source)).toBe(false);
     expect(isEnrichedBlobExportSource(source)).toBe(true);
+  });
+});
+
+// Each integration family carries its own integration-level cutoff. Dates are
+// derived from the constants, never written as literals: both are overridable
+// via NEXT_PUBLIC_* for local testing, and a literal would silently stop
+// testing the shipped value.
+describe("per-family exporter cutoff", () => {
+  const cloud = (over: Partial<ExportSourceContext>): ExportSourceContext =>
+    ctx({ isCloud: true, projectCreatedAt: PROJECT_PRE, ...over });
+
+  it("defaults to the blob cutoff when the context omits one", () => {
+    // Grandfathered under the blob default...
+    expect(
+      reasonOf("TRACES_OBSERVATIONS", cloud({ integrationCreatedAt: ROW_PRE })),
+    ).toBeUndefined();
+    // ...and blocked once the row reaches it.
+    expect(
+      reasonOf("TRACES_OBSERVATIONS", cloud({ integrationCreatedAt: ROW_AT })),
+    ).toBe("cloud-cutoff");
+  });
+
+  it("a later context cutoff grandfathers a row the blob default would block", () => {
+    // Between the two cutoffs: blocked under the blob default, allowed under the
+    // analytics one. This is the whole point of the parameter.
+    const between = new Date(
+      LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+    );
+    expect(between < LEGACY_ANALYTICS_EXPORTER_CUTOFF).toBe(true);
+    expect(
+      reasonOf("TRACES_OBSERVATIONS", cloud({ integrationCreatedAt: between })),
+    ).toBe("cloud-cutoff");
+    expect(
+      reasonOf(
+        "TRACES_OBSERVATIONS",
+        cloud({
+          integrationCreatedAt: between,
+          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("a brand-new Cloud row is blocked under any cutoff, today's date notwithstanding", () => {
+    for (const exporterCutoff of [
+      undefined,
+      LEGACY_BLOB_EXPORTER_CUTOFF,
+      LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+    ]) {
+      expect(
+        reasonOf(
+          "TRACES_OBSERVATIONS",
+          cloud({ integrationCreatedAt: null, exporterCutoff }),
+        ),
+      ).toBe("cloud-cutoff");
+    }
+  });
+
+  it("self-hosted is exempt from every exporter cutoff", () => {
+    expect(
+      isLegacyBlobExporter(null, false, LEGACY_ANALYTICS_EXPORTER_CUTOFF),
+    ).toBe(true);
+    expect(
+      reasonOf(
+        "TRACES_OBSERVATIONS",
+        ctx({
+          isCloud: false,
+          integrationCreatedAt: null,
+          exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("names the context cutoff in the rejection message, not the blob default", () => {
+    const res = validateExportSource(
+      "TRACES_OBSERVATIONS",
+      cloud({
+        integrationCreatedAt: null,
+        exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+      }),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.message).toContain(
+      LEGACY_ANALYTICS_EXPORTER_CUTOFF.toISOString(),
+    );
+    expect(res.message).not.toContain(
+      LEGACY_BLOB_EXPORTER_CUTOFF.toISOString(),
+    );
+  });
+
+  it("the analytics cutoff postdates the blob one", () => {
+    // Guards against someone 'tidying' the analytics constant onto the blob
+    // date, which would retroactively invalidate grandfathered analytics rows.
+    expect(LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime()).toBeGreaterThan(
+      LEGACY_BLOB_EXPORTER_CUTOFF.getTime(),
+    );
   });
 });

--- a/packages/shared/src/features/analytics-integrations/export-source-policy.ts
+++ b/packages/shared/src/features/analytics-integrations/export-source-policy.ts
@@ -9,8 +9,8 @@
 // The reasoning, in one place:
 //
 // - CLOUD DATE CUTOFFS ("cloud-cutoff"): Cloud projects created on or after
-//   LEGACY_BLOB_EXPORT_CUTOFF, and Cloud blob storage integration rows created
-//   on or after LEGACY_BLOB_EXPORTER_CUTOFF (including brand-new rows), cannot
+//   LEGACY_BLOB_EXPORT_CUTOFF, and Cloud integration rows created on or after
+//   their family's exporter cutoff (including brand-new rows), cannot
 //   use legacy export sources. These cutoffs are Cloud-only by design,
 //   permanently: their dates are arbitrary from a self-hosted operator's
 //   perspective (LFE-10065, LFE-10148). They apply to newly chosen values
@@ -46,23 +46,35 @@
 
 import { AnalyticsIntegrationExportSource } from "@prisma/client";
 
-// NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF / _EXPORTER_CUTOFF override the
-// defaults for local dev testing.
-const _override = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
-  ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
-  : null;
-export const LEGACY_BLOB_EXPORT_CUTOFF =
-  _override && !isNaN(_override.getTime())
-    ? _override
-    : new Date("2026-05-20T00:00:00.000Z");
+// An unset or unparsable override falls back to the shipped default, so a typo
+// in a local .env degrades to production behaviour rather than NaN dates.
+function cutoffFromEnv(
+  override: string | undefined,
+  fallbackIso: string,
+): Date {
+  if (!override) return new Date(fallbackIso);
+  const parsed = new Date(override);
+  return isNaN(parsed.getTime()) ? new Date(fallbackIso) : parsed;
+}
 
-const _exporterOverride = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF
-  ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF)
-  : null;
-export const LEGACY_BLOB_EXPORTER_CUTOFF =
-  _exporterOverride && !isNaN(_exporterOverride.getTime())
-    ? _exporterOverride
-    : new Date("2026-06-22T00:00:00.000Z");
+// The NEXT_PUBLIC_* overrides exist for local dev testing of the cutoffs.
+export const LEGACY_BLOB_EXPORT_CUTOFF = cutoffFromEnv(
+  process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF,
+  "2026-05-20T00:00:00.000Z",
+);
+
+export const LEGACY_BLOB_EXPORTER_CUTOFF = cutoffFromEnv(
+  process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF,
+  "2026-06-22T00:00:00.000Z",
+);
+
+// PostHog/Mixpanel run their own, later exporter cutoff: their integration-level
+// gate ships after blob storage's, so reusing the blob date would retroactively
+// invalidate rows that were legitimately created on a legacy source.
+export const LEGACY_ANALYTICS_EXPORTER_CUTOFF = cutoffFromEnv(
+  process.env.NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF,
+  "2026-08-19T00:00:00.000Z",
+);
 
 // satisfies ensures each element remains a valid enum member — catches renames
 // at compile time. A new enum variant does NOT automatically error here; the
@@ -107,13 +119,16 @@ export function isLegacyBlobExportSource(
 }
 
 /**
- * Whether a blob storage integration row counts as legacy — i.e. may still use
- * legacy export sources. Applied to `BlobStorageIntegration.createdAt`.
+ * Whether an integration row counts as legacy — i.e. may still use legacy
+ * export sources. Applied to the integration row's `createdAt`.
  *
  * - `!isCloud` → `true`: self-hosted is exempt (cutoff does not apply).
  * - `null` createdAt → `false`: no existing row means a brand-new integration,
  *   which follows new-customer rules.
  * - otherwise legacy iff the row was created strictly before the cutoff.
+ *
+ * `exporterCutoff` defaults to the blob date so existing blob callers are
+ * unaffected; each integration family passes its own.
  *
  * validateExportSource expresses the integration-level cutoff through this
  * predicate; it is also exported for row-age heuristics outside the policy
@@ -122,10 +137,11 @@ export function isLegacyBlobExportSource(
 export function isLegacyBlobExporter(
   integrationCreatedAt: Date | null,
   isCloud: boolean,
+  exporterCutoff: Date = LEGACY_BLOB_EXPORTER_CUTOFF,
 ): boolean {
   if (!isCloud) return true;
   if (integrationCreatedAt == null) return false;
-  return integrationCreatedAt < LEGACY_BLOB_EXPORTER_CUTOFF;
+  return integrationCreatedAt < exporterCutoff;
 }
 
 /**
@@ -152,9 +168,10 @@ export function areEnrichedWritesActive(
  * skip their check when absent:
  * - projectCreatedAt: omit to skip the project-level Cloud cutoff (e.g. when
  *   the caller has no project in scope).
- * - integrationCreatedAt: omit to skip the integration-level Cloud cutoff
- *   (PostHog/Mixpanel have no such cutoff); pass null for "no existing row",
- *   which follows new-customer rules on Cloud.
+ * - integrationCreatedAt: omit to skip the integration-level Cloud cutoff; pass
+ *   null for "no existing row", which follows new-customer rules on Cloud.
+ * - exporterCutoff: the integration-level cutoff date. Each integration family
+ *   has its own; defaults to LEGACY_BLOB_EXPORTER_CUTOFF.
  */
 export type ExportSourceContext = {
   isCloud: boolean;
@@ -162,6 +179,7 @@ export type ExportSourceContext = {
   legacyWritesActive: boolean;
   projectCreatedAt?: Date;
   integrationCreatedAt?: Date | null;
+  exporterCutoff?: Date;
 };
 
 export type ExportSourceBlockedReason =
@@ -180,8 +198,14 @@ const ENRICHED_UNAVAILABLE_MESSAGE =
 // counted separately in logs. Customer-facing via the public REST PUT.
 const PROJECT_CUTOFF_MESSAGE =
   "Legacy export sources are not available for Cloud projects created on or after 2026-05-20. Use 'OBSERVATIONS_V2' instead.";
-const exporterCutoffMessage = () =>
-  `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`;
+// Covers both integration-level rejections: a brand-new integration (which
+// follows new-customer rules whatever today's date is) and an existing one that
+// postdates the cutoff. Worded integration-neutrally — blob storage, PostHog and
+// Mixpanel all reach it, each with its own cutoff.
+const exporterCutoffMessage = (
+  exporterCutoff: Date = LEGACY_BLOB_EXPORTER_CUTOFF,
+) =>
+  `Legacy export sources are not available on Cloud for new integrations, or for integrations created on or after ${exporterCutoff.toISOString()}. Use 'OBSERVATIONS_V2' instead.`;
 
 // Self-hosted-operator-facing: naming the env var is intentional. Worded
 // integration-neutrally since blob storage, PostHog, and Mixpanel all surface
@@ -215,12 +239,16 @@ export function validateExportSource(
     }
     if (
       ctx.integrationCreatedAt !== undefined &&
-      !isLegacyBlobExporter(ctx.integrationCreatedAt, ctx.isCloud)
+      !isLegacyBlobExporter(
+        ctx.integrationCreatedAt,
+        ctx.isCloud,
+        ctx.exporterCutoff,
+      )
     ) {
       return {
         ok: false,
         reason: "cloud-cutoff",
-        message: exporterCutoffMessage(),
+        message: exporterCutoffMessage(ctx.exporterCutoff),
       };
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
   "globalDependencies": [".env"],
   "globalEnv": [
     "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF",
-    "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF"
+    "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF",
+    "NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF"
   ],
   "envMode": "loose",
   "tasks": {

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -202,6 +202,13 @@ Sentry instrumentation skill first and decide whether it should capture at all
   unique test data over global reset helpers.
 - Put pure server unit tests that do not need Postgres bootstrap under
   `src/__tests__/server/unit/**` so they skip the shared DB setup hook.
+- Server tests that drive the public REST API over HTTP need a web server on
+  port 3000 **serving the test database**. `web/vitest.config.mts` loads
+  `../.env.test`, which points `DATABASE_URL` at its own database, while
+  `pnpm run dev:web` loads only `.env` — so that server talks to a different
+  database, finds none of the API keys the tests just created, and every
+  authenticated call comes back 401 `Invalid credentials`. Start it with
+  `pnpm exec dotenv -e .env.test -e .env -- pnpm --filter web run dev`.
 - Preserve the server-test project split in `vitest.config.mts`. Most tests
   consume the built `@langfuse/shared` package; only tests importing
   `@langfuse/shared/in-app-agent` or `@langfuse/shared/src/env` use the

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1774,9 +1774,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(result.status).toBe(400);
-      expect(result.body.message).toContain(
-        "blob storage integrations created on or after",
-      );
+      expect(result.body.message).toContain("integrations created on or after");
       expect(result.body.message).toContain(
         LEGACY_BLOB_EXPORTER_CUTOFF.toISOString(),
       );
@@ -1814,9 +1812,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(result.status).toBe(400);
-      expect(result.body.message).toContain(
-        "blob storage integrations created on or after",
-      );
+      expect(result.body.message).toContain("integrations created on or after");
     });
 
     it("post-cutoff existing row + legacy source → 400", async () => {
@@ -1832,9 +1828,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(result.status).toBe(400);
-      expect(result.body.message).toContain(
-        "blob storage integrations created on or after",
-      );
+      expect(result.body.message).toContain("integrations created on or after");
     });
 
     it("no existing row + OBSERVATIONS_V2 → 200", async () => {

--- a/web/src/__tests__/server/unit/assertExportSourceAllowed.servertest.ts
+++ b/web/src/__tests__/server/unit/assertExportSourceAllowed.servertest.ts
@@ -4,7 +4,9 @@ import {
   areEnrichedWritesActive,
   areLegacyWritesActive,
   InvalidRequestError,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
   type BlobExportWriteMode,
   type ExportSourceContext,
 } from "@langfuse/shared";
@@ -143,6 +145,33 @@ describe("assertExportSourceAllowed", () => {
         nextExportSource: undefined,
         persistedExportSource: null,
         ctx: cloudPostCutoff,
+      }),
+    ).not.toThrow();
+  });
+  // Forwarding guard: adapters override the integration-level cutoff through the
+  // context. A destructuring assert that dropped the field would silently fall
+  // back to the blob cutoff and reject a row its own family grandfathers.
+  it("forwards a context-supplied exporterCutoff instead of the blob default", () => {
+    // Between the blob cutoff and the analytics one: blocked under the default,
+    // grandfathered under the override.
+    const between = new Date(
+      LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + 24 * 60 * 60 * 1000,
+    );
+    const base = {
+      nextExportSource: "TRACES_OBSERVATIONS" as const,
+      ctx: {
+        isCloud: true,
+        enrichedAvailable: true,
+        legacyWritesActive: true,
+        projectCreatedAt: new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - 1),
+        integrationCreatedAt: between,
+      },
+    };
+    expect(() => assertExportSourceAllowed(base)).toThrow(InvalidRequestError);
+    expect(() =>
+      assertExportSourceAllowed({
+        ...base,
+        ctx: { ...base.ctx, exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF },
       }),
     ).not.toThrow();
   });

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -575,6 +575,7 @@ export const env = createEnv({
       .optional(),
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF: z.iso.datetime().optional(),
+    NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF: z.iso.datetime().optional(),
     NEXT_PUBLIC_DEMO_PROJECT_ID: z.string().optional(),
     NEXT_PUBLIC_DEMO_ORG_ID: z.string().optional(),
     NEXT_PUBLIC_SIGN_UP_DISABLED: z.enum(["true", "false"]).default("false"),
@@ -630,6 +631,8 @@ export const env = createEnv({
       process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF,
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF:
       process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF,
+    NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF:
+      process.env.NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF,
     NEXT_PUBLIC_SIGN_UP_DISABLED: process.env.NEXT_PUBLIC_SIGN_UP_DISABLED,
     NEXT_PUBLIC_PREVIEW_PR_URL: process.env.NEXT_PUBLIC_PREVIEW_PR_URL,
     NEXT_PUBLIC_PREVIEW_PR_AUTHOR: process.env.NEXT_PUBLIC_PREVIEW_PR_AUTHOR,

--- a/web/src/features/analytics-integrations/server/analyticsExportSource.ts
+++ b/web/src/features/analytics-integrations/server/analyticsExportSource.ts
@@ -1,0 +1,125 @@
+import {
+  AnalyticsIntegrationExportSource,
+  areEnrichedWritesActive,
+  areLegacyWritesActive,
+  InvalidRequestError,
+  validateExportSource,
+  type ExportSourceContext,
+} from "@langfuse/shared";
+import { type Prisma } from "@langfuse/shared/src/db";
+
+import { env } from "@/src/env.mjs";
+import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+
+/**
+ * Write-time export-source handling for the PostHog and Mixpanel routers, whose
+ * upserts are otherwise identical here. Assembles the ExportSourceContext both
+ * routers need — see export-source-policy.ts for the policy itself.
+ */
+
+type ExistingAnalyticsIntegration = {
+  exportSource: AnalyticsIntegrationExportSource;
+  createdAt: Date;
+};
+
+type Deployment = {
+  isCloud: boolean;
+  enrichedAvailable: boolean;
+  legacyWritesActive: boolean;
+};
+
+function readDeployment(): Deployment {
+  const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+  return {
+    isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+    enrichedAvailable: areEnrichedWritesActive(writeMode),
+    legacyWritesActive: areLegacyWritesActive(writeMode),
+  };
+}
+
+function buildContext(
+  deployment: Deployment,
+  projectCreatedAt: Date | undefined,
+): ExportSourceContext {
+  return { ...deployment, projectCreatedAt };
+}
+
+/**
+ * Validates the requested source (throwing InvalidRequestError when blocked)
+ * and returns the value the upsert's CREATE branch should carry.
+ */
+export async function resolveAnalyticsExportSource({
+  db,
+  projectId,
+  requestedExportSource,
+  existingIntegration,
+}: {
+  db: Prisma.TransactionClient;
+  projectId: string;
+  requestedExportSource: AnalyticsIntegrationExportSource | undefined;
+  existingIntegration: ExistingAnalyticsIntegration | null | undefined;
+}): Promise<AnalyticsIntegrationExportSource> {
+  const deployment = readDeployment();
+  const createDefaultExportSource = deployment.legacyWritesActive
+    ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
+    : AnalyticsIntegrationExportSource.EVENTS;
+
+  const nextExportSource =
+    requestedExportSource ??
+    (existingIntegration ? undefined : createDefaultExportSource);
+  // The Cloud cutoffs need the project only for explicitly chosen (or
+  // create-defaulted) sources.
+  const projectCreatedAt = nextExportSource
+    ? (
+        await db.project.findUniqueOrThrow({
+          where: { id: projectId },
+          select: { createdAt: true },
+        })
+      ).createdAt
+    : undefined;
+
+  assertExportSourceAllowed({
+    nextExportSource,
+    persistedExportSource: existingIntegration?.exportSource,
+    ctx: buildContext(deployment, projectCreatedAt),
+  });
+
+  return createDefaultExportSource;
+}
+
+/**
+ * In-transaction backstop (mirrors blob storage's service.ts). The pre-flight
+ * read is racy: a concurrent delete can flip the expected UPDATE into a CREATE
+ * carrying the unvalidated legacy default. A changed createdAt detects that,
+ * and the row is then re-validated as an explicit choice.
+ */
+export async function assertRacedCreateAllowed({
+  tx,
+  projectId,
+  requestedExportSource,
+  existingIntegration,
+  result,
+}: {
+  tx: Prisma.TransactionClient;
+  projectId: string;
+  requestedExportSource: AnalyticsIntegrationExportSource | undefined;
+  existingIntegration: ExistingAnalyticsIntegration | null | undefined;
+  result: ExistingAnalyticsIntegration;
+}): Promise<void> {
+  if (
+    requestedExportSource !== undefined ||
+    !existingIntegration ||
+    result.createdAt.getTime() === existingIntegration.createdAt.getTime()
+  ) {
+    return;
+  }
+  const project = await tx.project.findUniqueOrThrow({
+    where: { id: projectId },
+    select: { createdAt: true },
+  });
+  const validation = validateExportSource(
+    result.exportSource,
+    buildContext(readDeployment(), project.createdAt),
+  );
+  if (!validation.ok) throw new InvalidRequestError(validation.message);
+}

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+import {
+  assertRacedCreateAllowed,
+  resolveAnalyticsExportSource,
+} from "@/src/features/analytics-integrations/server/analyticsExportSource";
 import { isPrismaRecordNotFoundError } from "@/src/features/analytics-integrations/server/isPrismaRecordNotFoundError";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -15,11 +18,7 @@ import { env } from "@/src/env.mjs";
 import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
-  areEnrichedWritesActive,
-  areLegacyWritesActive,
-  InvalidRequestError,
   LangfuseNotFoundError,
-  validateExportSource,
 } from "@langfuse/shared";
 
 export const mixpanelIntegrationRouter = createTRPCRouter({
@@ -95,9 +94,6 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         }
       }
 
-      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-      const legacyWritesActive = areLegacyWritesActive(writeMode);
-      const enrichedAvailable = areEnrichedWritesActive(writeMode);
       const existingIntegration =
         await ctx.prisma.mixpanelIntegration.findUnique({
           where: { projectId: input.projectId },
@@ -119,31 +115,11 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           message: "Mixpanel Project Token is required",
         });
       }
-      const createDefaultExportSource = legacyWritesActive
-        ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-        : AnalyticsIntegrationExportSource.EVENTS;
-      const nextExportSource =
-        input.exportSource ??
-        (existingIntegration ? undefined : createDefaultExportSource);
-      // The Cloud cutoffs need the project only for explicitly chosen (or
-      // create-defaulted) sources.
-      const projectCreatedAt = nextExportSource
-        ? (
-            await ctx.prisma.project.findUniqueOrThrow({
-              where: { id: input.projectId },
-              select: { createdAt: true },
-            })
-          ).createdAt
-        : undefined;
-      assertExportSourceAllowed({
-        nextExportSource,
-        persistedExportSource: existingIntegration?.exportSource,
-        ctx: {
-          isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-          enrichedAvailable,
-          legacyWritesActive,
-          projectCreatedAt,
-        },
+      const createDefaultExportSource = await resolveAnalyticsExportSource({
+        db: ctx.prisma,
+        projectId: input.projectId,
+        requestedExportSource: input.exportSource,
+        existingIntegration,
       });
 
       await auditLog({
@@ -176,28 +152,13 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           },
         });
 
-        // Race backstop (mirrors blob storage's service.ts): a concurrent
-        // delete between the pre-flight read and this upsert can flip the
-        // expected UPDATE into a CREATE carrying the unvalidated legacy
-        // default. Detectable as a createdAt change; re-validate the persisted
-        // row as an explicit choice and roll back on failure.
-        if (
-          input.exportSource === undefined &&
-          existingIntegration &&
-          result.createdAt.getTime() !== existingIntegration.createdAt.getTime()
-        ) {
-          const project = await tx.project.findUniqueOrThrow({
-            where: { id: input.projectId },
-            select: { createdAt: true },
-          });
-          const validation = validateExportSource(result.exportSource, {
-            isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-            enrichedAvailable,
-            legacyWritesActive,
-            projectCreatedAt: project.createdAt,
-          });
-          if (!validation.ok) throw new InvalidRequestError(validation.message);
-        }
+        await assertRacedCreateAllowed({
+          tx,
+          projectId: input.projectId,
+          requestedExportSource: input.exportSource,
+          existingIntegration,
+          result,
+        });
       });
     }),
   delete: protectedProjectProcedure

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { assertExportSourceAllowed } from "@/src/features/analytics-integrations/server/assertExportSourceAllowed";
+import {
+  assertRacedCreateAllowed,
+  resolveAnalyticsExportSource,
+} from "@/src/features/analytics-integrations/server/analyticsExportSource";
 import { isPrismaRecordNotFoundError } from "@/src/features/analytics-integrations/server/isPrismaRecordNotFoundError";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -16,11 +19,7 @@ import { validateWebhookURL } from "@langfuse/shared/src/server";
 import { getDisplayCredential } from "@/src/features/analytics-integrations/server/displayCredential";
 import {
   AnalyticsIntegrationExportSource,
-  areEnrichedWritesActive,
-  areLegacyWritesActive,
-  InvalidRequestError,
   LangfuseNotFoundError,
-  validateExportSource,
 } from "@langfuse/shared";
 
 export const posthogIntegrationRouter = createTRPCRouter({
@@ -108,9 +107,6 @@ export const posthogIntegrationRouter = createTRPCRouter({
         });
       }
 
-      const writeMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
-      const legacyWritesActive = areLegacyWritesActive(writeMode);
-      const enrichedAvailable = areEnrichedWritesActive(writeMode);
       const existingIntegration =
         await ctx.prisma.posthogIntegration.findUnique({
           where: { projectId: input.projectId },
@@ -132,31 +128,11 @@ export const posthogIntegrationRouter = createTRPCRouter({
           message: "PostHog Project API Key is required",
         });
       }
-      const createDefaultExportSource = legacyWritesActive
-        ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-        : AnalyticsIntegrationExportSource.EVENTS;
-      const nextExportSource =
-        input.exportSource ??
-        (existingIntegration ? undefined : createDefaultExportSource);
-      // The Cloud cutoffs need the project only for explicitly chosen (or
-      // create-defaulted) sources.
-      const projectCreatedAt = nextExportSource
-        ? (
-            await ctx.prisma.project.findUniqueOrThrow({
-              where: { id: input.projectId },
-              select: { createdAt: true },
-            })
-          ).createdAt
-        : undefined;
-      assertExportSourceAllowed({
-        nextExportSource,
-        persistedExportSource: existingIntegration?.exportSource,
-        ctx: {
-          isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-          enrichedAvailable,
-          legacyWritesActive,
-          projectCreatedAt,
-        },
+      const createDefaultExportSource = await resolveAnalyticsExportSource({
+        db: ctx.prisma,
+        projectId: input.projectId,
+        requestedExportSource: input.exportSource,
+        existingIntegration,
       });
 
       await auditLog({
@@ -191,28 +167,13 @@ export const posthogIntegrationRouter = createTRPCRouter({
           },
         });
 
-        // Race backstop (mirrors blob storage's service.ts): a concurrent
-        // delete between the pre-flight read and this upsert can flip the
-        // expected UPDATE into a CREATE carrying the unvalidated legacy
-        // default. Detectable as a createdAt change; re-validate the persisted
-        // row as an explicit choice and roll back on failure.
-        if (
-          input.exportSource === undefined &&
-          existingIntegration &&
-          result.createdAt.getTime() !== existingIntegration.createdAt.getTime()
-        ) {
-          const project = await tx.project.findUniqueOrThrow({
-            where: { id: input.projectId },
-            select: { createdAt: true },
-          });
-          const validation = validateExportSource(result.exportSource, {
-            isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
-            enrichedAvailable,
-            legacyWritesActive,
-            projectCreatedAt: project.createdAt,
-          });
-          if (!validation.ok) throw new InvalidRequestError(validation.message);
-        }
+        await assertRacedCreateAllowed({
+          tx,
+          projectId: input.projectId,
+          requestedExportSource: input.exportSource,
+          existingIntegration,
+          result,
+        });
       });
     }),
   delete: protectedProjectProcedure


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16241.preview.langfuse.com](https://pr-16241.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Preparation for pinning new Cloud PostHog/Mixpanel integrations to the enriched
events export source. **No behaviour changes** — split out so the follow-up is
purely the behaviour change.

Three things:

**1. The integration-level ("exporter") cutoff becomes per-family.** It was
hard-coded to the blob storage date inside both `isLegacyBlobExporter` and the
rejection message, so a second integration family could not have its own.
`ExportSourceContext` gains an optional `exporterCutoff`, threaded through both,
defaulting to the existing blob constant — every blob call site keeps its current
behaviour. A new `LEGACY_ANALYTICS_EXPORTER_CUTOFF` is added for PostHog and
Mixpanel to pass once their gate lands; **nothing supplies the field yet.**

The analytics cutoff has to postdate blob's. Its gate ships later, so reusing the
blob date would retroactively invalidate analytics rows that were legitimately
created on a legacy source. A test pins that ordering.

**2. The PostHog and Mixpanel routers stop duplicating their write path.** Both
derived the write mode, computed the create default, assembled the policy context,
ran the pre-flight assert and ran the raced-create backstop in byte-identical
blocks. That moves into one module both call, which is what lets the follow-up
wire the new cutoff in a single place instead of twice, correctly, in lockstep.

**3. Smaller cleanups.** The three copies of the env-override date parsing
collapse into one helper. The integration-level rejection message is reworded to
be true for both paths that reach it — a brand-new integration (which follows
new-customer rules whatever today's date is) and an existing one that postdates
the cutoff — and integration-neutral, since three families now surface it. Three
assertions on the old wording are updated. Adds a note on running the REST server
tests against the test database, which is not obvious and costs an hour to
rediscover.

### How the no-behaviour-change claim is checked

The existing PostHog and Mixpanel router suites pass **unmodified** — that is the
contract for the extraction. The blob storage suites are the control for the
shared-policy change.

| Check | Result |
|---|---|
| `turbo run lint typecheck --filter=web --filter=@langfuse/shared` | `Tasks: 7 successful, 7 total` |
| integration servertests (web server up on :3000) | `Tests 194 passed (194)` |
| ↳ of which PostHog + Mixpanel routers, unmodified | `28 passed` + `27 passed` |
| ↳ of which blob storage REST + tRPC control | `58 passed` + `45 passed` + `19 passed` |
| shared export-source policy | `Tests 28 passed (28)` |
| client export-source adapters | `Tests 45 passed (45)` |
| `assertExportSourceAllowed` unit | `Tests 16 passed (16)` |

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces separate integration-level cutoff configuration for analytics exporters and extracts shared PostHog/Mixpanel export-source validation. However, the extracted context builder omits the fields needed to enforce the new analytics cutoff.

- Adds `NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF` across shared and web environment configuration.
- Parameterizes shared export-source policy by integration-family cutoff.
- Consolidates PostHog and Mixpanel validation and raced-create handling.
- Extends unit and policy coverage for per-family cutoff behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The analytics cutoff enforcement must be wired into the shared PostHog/Mixpanel context before this PR is merged.

The policy implementation supports the new family cutoff, but both ordinary writes and the raced-create backstop omit the context fields that activate it, allowing prohibited legacy sources to be persisted.

**Files Needing Attention:** web/src/features/analytics-integrations/server/analyticsExportSource.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[PostHog or Mixpanel upsert] --> B[resolveAnalyticsExportSource]
  B --> C[buildContext]
  C --> D[projectCreatedAt only]
  D --> E[validateExportSource]
  E --> F{integrationCreatedAt supplied?}
  F -->|No| G[Analytics exporter cutoff skipped]
  G --> H[Legacy source may be persisted]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/analytics-integrations/server/analyticsExportSource.ts:44
**Analytics cutoff context is omitted**

When a Cloud PostHog or Mixpanel integration on a pre-cutoff project creates or explicitly selects a legacy source after the analytics exporter cutoff, `buildContext` omits both `integrationCreatedAt` and `exporterCutoff`, so normal validation and the raced-create backstop skip the integration-level check and persist a prohibited legacy source.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web,shared): let each integrati..."](https://github.com/langfuse/langfuse/commit/67e80a17b30cbd4984b9782edc8ec80d27ddc0ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54333259)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->