### PR TITLE
fix(web): pin new Cloud PostHog and Mixpanel integrations to enriched events

### DIFF
--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -14,18 +14,16 @@ import { env } from "@/src/env.mjs";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
-// Integration row ages derive from the cutoff constants, never from literals, so
-// the NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides cannot turn a supported
-// override into a suite failure.
+// Row ages derive from the cutoff constants, never from literals, so the
+// NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides cannot fail the suite.
 const ROW_PRE_ANALYTICS_CUTOFF = new Date(
   LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
 );
 const ROW_POST_ANALYTICS_CUTOFF = new Date(
   LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
 );
-// The raced-CREATE pre-flight row must be grandfathered under BOTH exporter
-// cutoffs, so the pre-flight assert provably cannot be the thing that rejects
-// and only the in-transaction backstop can.
+// Grandfathered under BOTH exporter cutoffs, so the pre-flight assert provably
+// cannot be what rejects — only the in-transaction backstop can.
 const RACED_PREFLIGHT_CREATED_AT = new Date(
   Math.min(
     LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime(),
@@ -139,9 +137,8 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
   };
 
   // A pre-cutoff project no longer buys a *new* integration the right to a
-  // legacy source: brand-new Cloud integrations are pinned to enriched events.
-  // The project cutoff is still grandfathered for integrations that already
-  // exist — covered in "Cloud new-integration enriched pin" below.
+  // legacy source. Existing integrations stay grandfathered — see
+  // "Cloud new-integration enriched pin" below.
   it("Cloud + pre-cutoff project + legacy source on create → BAD_REQUEST", async () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
@@ -534,8 +531,8 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
     });
 
     // Both raced-CREATE cases below share one shape and differ only in whether
-    // the caller sent an explicit exportSource. That single difference is the
-    // point: the real settings form always sends one (it lives in the form's
+    // the caller sent an explicit exportSource. That difference is the point:
+    // the real settings form always sends one (it lives in the form's
     // defaultValues and onSubmit spreads every value), so a backstop that only
     // runs when the field is omitted never runs in production.
     const expectRacedCreateRejected = async (
@@ -543,19 +540,14 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
     ) => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
-      // Pre-cutoff project, so the project-level gate cannot fire. The only
-      // thing left that can reject is the backstop judging the CREATE on its
-      // own terms.
+      // Pre-cutoff project, so the project-level gate cannot fire either.
       await prisma.project.update({
         where: { id: project.id },
         data: { createdAt: PRE_CUTOFF },
       });
-      // The pre-flight read sees a row old enough to be grandfathered under
-      // either exporter cutoff, so the pre-flight assert allows the legacy
-      // source it carries and cannot be the thing that rejects. Meanwhile the
-      // DB genuinely holds no row, so the upsert lands as a CREATE — the race.
-      // If the backstop reused this stale createdAt, or skipped itself
-      // entirely, the legacy row would be persisted.
+      // The pre-flight read sees a grandfathered row and allows the legacy
+      // source; the DB holds no row, so the upsert lands as a CREATE. Reusing
+      // the stale createdAt, or skipping the backstop, persists a legacy row.
       const spy = vi
         .spyOn(prisma.mixpanelIntegration, "findUnique")
         .mockResolvedValueOnce({
@@ -609,10 +601,11 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
     });
   });
 
-  // New Cloud analytics integrations land on the enriched events source and
-  // cannot be moved off it. Integrations that already existed before the
-  // analytics exporter cutoff are grandfathered: they keep their legacy source
-  // and may opt into enriched, but are never rewritten behind the user's back.
+  // New Cloud integrations land on the enriched events source and cannot be
+  // moved off it. Rows created before the analytics exporter cutoff are
+  // grandfathered: they keep their legacy source and may opt into enriched, but
+  // are never rewritten behind the user's back. Self-hosted is exempt — the
+  // create defaults above still pass unchanged.
   describe("Cloud new-integration enriched pin", () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
@@ -676,22 +669,6 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
-    it("create with an explicit legacy source → BAD_REQUEST", async () => {
-      const { caller, project } = await prepareOldProject();
-      await expect(
-        caller.mixpanelIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-          exportSource: "TRACES_OBSERVATIONS" as const,
-        }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-      expect(
-        await prisma.mixpanelIntegration.findUnique({
-          where: { projectId: project.id },
-        }),
-      ).toBeNull();
-    });
-
     it("pre-cutoff row with a persisted legacy source: omitted source is preserved, not rewritten", async () => {
       const { caller, project } = await prepareOldProject();
       await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
@@ -709,10 +686,13 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.enabled).toBe(false);
     });
 
-    it("pre-cutoff row may re-assert its legacy source and may switch to enriched", async () => {
+    it("pre-cutoff row may re-assert legacy, opt into enriched, and switch back", async () => {
+      // The gate keys on the row's creation date, not its current source, so
+      // trying enriched must not be a one-way door: someone evaluating it needs
+      // to be able to back out while legacy still exists. The row also predates
+      // the analytics cutoff while postdating the blob one, so this catches an
+      // adapter that forwards the blob cutoff by mistake.
       const { caller, project } = await prepareOldProject();
-      // The row predates the analytics cutoff but postdates the blob one, so
-      // this also catches an adapter that forwards the blob cutoff by mistake.
       await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
       await expect(
         caller.mixpanelIntegration.update({
@@ -726,34 +706,19 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         ...baseConfig,
         exportSource: "EVENTS" as const,
       });
-      const result = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.config?.exportSource).toBe("EVENTS");
-    });
-
-    it("trying enriched is reversible: a grandfathered row may switch back to legacy", async () => {
-      // The gate keys on the row's creation date, not on its current source, so
-      // opting into enriched must not be a one-way door. Someone evaluating the
-      // enriched export needs to be able to back out while legacy still exists.
-      const { caller, project } = await prepareOldProject();
-      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      expect(
+        (await caller.mixpanelIntegration.get({ projectId: project.id })).config
+          ?.exportSource,
+      ).toBe("EVENTS");
       await caller.mixpanelIntegration.update({
         projectId: project.id,
         ...baseConfig,
-        exportSource: "EVENTS" as const,
+        exportSource: "TRACES_OBSERVATIONS" as const,
       });
-      await expect(
-        caller.mixpanelIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-          exportSource: "TRACES_OBSERVATIONS" as const,
-        }),
-      ).resolves.not.toThrow();
-      const back = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(back.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(
+        (await caller.mixpanelIntegration.get({ projectId: project.id })).config
+          ?.exportSource,
+      ).toBe("TRACES_OBSERVATIONS");
     });
 
     it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
@@ -775,53 +740,6 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
-    });
-
-    it("self-hosted on the legacy write mode is untouched by the pin", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-      const { caller, project } = await prepareOldProject();
-      await caller.mixpanelIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-      });
-      const created = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
-      // The legacy source stays an explicit, re-assertable choice — the pin
-      // neither rewrites it nor locks the field. (Enriched is unavailable on
-      // this write mode for a separate reason: the events table is not written.)
-      await expect(
-        caller.mixpanelIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-          exportSource: "TRACES_OBSERVATIONS" as const,
-        }),
-      ).resolves.not.toThrow();
-    });
-
-    it("self-hosted on a write mode that serves enriched may still switch to it", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
-      const { caller, project } = await prepareOldProject();
-      await caller.mixpanelIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-      });
-      const created = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
-      await caller.mixpanelIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-        exportSource: "EVENTS" as const,
-      });
-      const switched = await caller.mixpanelIntegration.get({
-        projectId: project.id,
-      });
-      expect(switched.config?.exportSource).toBe("EVENTS");
     });
   });
 

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -732,6 +732,30 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
+    it("trying enriched is reversible: a grandfathered row may switch back to legacy", async () => {
+      // The gate keys on the row's creation date, not on its current source, so
+      // opting into enriched must not be a one-way door. Someone evaluating the
+      // enriched export needs to be able to back out while legacy still exists.
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+      const back = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(back.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+    });
+
     it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
       const { caller, project } = await prepareOldProject();
       await seedLegacyRow(

--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -3,13 +3,36 @@ import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
-import { LEGACY_BLOB_EXPORT_CUTOFF } from "@langfuse/shared";
+import {
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
+} from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
+// Integration row ages derive from the cutoff constants, never from literals, so
+// the NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides cannot turn a supported
+// override into a suite failure.
+const ROW_PRE_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+);
+const ROW_POST_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+);
+// The raced-CREATE pre-flight row must be grandfathered under BOTH exporter
+// cutoffs, so the pre-flight assert provably cannot be the thing that rejects
+// and only the in-transaction backstop can.
+const RACED_PREFLIGHT_CREATED_AT = new Date(
+  Math.min(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime(),
+    LEGACY_BLOB_EXPORTER_CUTOFF.getTime(),
+  ) -
+    30 * MS_PER_DAY,
+);
 
 const buildSession = (orgId: string, projectId: string): Session => ({
   expires: "1",
@@ -115,7 +138,11 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
     return { project, caller };
   };
 
-  it("Cloud + pre-cutoff project + legacy source → allow", async () => {
+  // A pre-cutoff project no longer buys a *new* integration the right to a
+  // legacy source: brand-new Cloud integrations are pinned to enriched events.
+  // The project cutoff is still grandfathered for integrations that already
+  // exist — covered in "Cloud new-integration enriched pin" below.
+  it("Cloud + pre-cutoff project + legacy source on create → BAD_REQUEST", async () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
     try {
@@ -130,7 +157,7 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS" as const,
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
     }
@@ -455,19 +482,21 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
+    it("Cloud + post-cutoff project + create without exportSource → persists EVENTS", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
         data: { createdAt: POST_CUTOFF },
       });
-      await expect(
-        caller.mixpanelIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-        }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
     });
 
     it("raced delete between read and write: mis-created legacy row is rolled back (post-cutoff Cloud)", async () => {
@@ -504,6 +533,68 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
       ).toBeNull();
     });
 
+    // Both raced-CREATE cases below share one shape and differ only in whether
+    // the caller sent an explicit exportSource. That single difference is the
+    // point: the real settings form always sends one (it lives in the form's
+    // defaultValues and onSubmit spreads every value), so a backstop that only
+    // runs when the field is omitted never runs in production.
+    const expectRacedCreateRejected = async (
+      extraInput: { exportSource?: "TRACES_OBSERVATIONS" } = {},
+    ) => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      const { caller, project } = await prepare();
+      // Pre-cutoff project, so the project-level gate cannot fire. The only
+      // thing left that can reject is the backstop judging the CREATE on its
+      // own terms.
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      // The pre-flight read sees a row old enough to be grandfathered under
+      // either exporter cutoff, so the pre-flight assert allows the legacy
+      // source it carries and cannot be the thing that rejects. Meanwhile the
+      // DB genuinely holds no row, so the upsert lands as a CREATE — the race.
+      // If the backstop reused this stale createdAt, or skipped itself
+      // entirely, the legacy row would be persisted.
+      const spy = vi
+        .spyOn(prisma.mixpanelIntegration, "findUnique")
+        .mockResolvedValueOnce({
+          exportSource: "TRACES_OBSERVATIONS",
+          createdAt: RACED_PREFLIGHT_CREATED_AT,
+        } as never);
+      try {
+        await expect(
+          caller.mixpanelIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            ...extraInput,
+          }),
+        ).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+          // Pins the cutoff path: an unrelated BAD_REQUEST (credentials,
+          // validation) must not satisfy this test.
+          message: expect.stringContaining("created on or after"),
+        });
+      } finally {
+        spy.mockRestore();
+      }
+      expect(
+        await prisma.mixpanelIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    };
+
+    it("raced delete with the source omitted: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+      await expectRacedCreateRejected();
+    });
+
+    it("raced delete with the source explicitly present: the backstop still re-validates as a brand-new row", async () => {
+      await expectRacedCreateRejected({
+        exportSource: "TRACES_OBSERVATIONS",
+      });
+    });
+
     it("create without exportSource defaults to EVENTS on events_only", async () => {
       (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
       const { caller, project } = await prepare();
@@ -515,6 +606,198 @@ describe("Mixpanel Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
+    });
+  });
+
+  // New Cloud analytics integrations land on the enriched events source and
+  // cannot be moved off it. Integrations that already existed before the
+  // analytics exporter cutoff are grandfathered: they keep their legacy source
+  // and may opt into enriched, but are never rewritten behind the user's back.
+  describe("Cloud new-integration enriched pin", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      // dual keeps legacy writes active, so any rejection below comes from the
+      // Cloud cutoff rather than the write-mode capability gate.
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    });
+
+    // Pre-cutoff project so the only Cloud gate in play is the
+    // integration-level one.
+    const prepareOldProject = async () => {
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      return { caller, project };
+    };
+
+    // Seeds a legacy row of a chosen age: created while self-hosted (where
+    // legacy is still selectable), then backdated.
+    const seedLegacyRow = async (
+      caller: Awaited<ReturnType<typeof prepare>>["caller"],
+      projectId: string,
+      createdAt: Date,
+      exportSource: "TRACES_OBSERVATIONS" | "EVENTS" = "TRACES_OBSERVATIONS",
+    ) => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      try {
+        await caller.mixpanelIntegration.update({
+          projectId,
+          ...baseConfig,
+          exportSource,
+        });
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      }
+      await prisma.mixpanelIntegration.update({
+        where: { projectId },
+        data: { createdAt },
+      });
+    };
+
+    it("create with no existing row persists EVENTS", async () => {
+      const { caller, project } = await prepareOldProject();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("create with an explicit legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(
+        await prisma.mixpanelIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    });
+
+    it("pre-cutoff row with a persisted legacy source: omitted source is preserved, not rewritten", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          enabled: false,
+        }),
+      ).resolves.not.toThrow();
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(result.config?.enabled).toBe(false);
+    });
+
+    it("pre-cutoff row may re-assert its legacy source and may switch to enriched", async () => {
+      const { caller, project } = await prepareOldProject();
+      // The row predates the analytics cutoff but postdates the blob one, so
+      // this also catches an adapter that forwards the blob cutoff by mistake.
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(
+        caller,
+        project.id,
+        ROW_POST_ANALYTICS_CUTOFF,
+        "EVENTS",
+      );
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      const result = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("self-hosted on the legacy write mode is untouched by the pin", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      const { caller, project } = await prepareOldProject();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const created = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      // The legacy source stays an explicit, re-assertable choice — the pin
+      // neither rewrites it nor locks the field. (Enriched is unavailable on
+      // this write mode for a separate reason: the events table is not written.)
+      await expect(
+        caller.mixpanelIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("self-hosted on a write mode that serves enriched may still switch to it", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      const { caller, project } = await prepareOldProject();
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const created = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      await caller.mixpanelIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      const switched = await caller.mixpanelIntegration.get({
+        projectId: project.id,
+      });
+      expect(switched.config?.exportSource).toBe("EVENTS");
     });
   });
 

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -776,6 +776,30 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
+    it("trying enriched is reversible: a grandfathered row may switch back to legacy", async () => {
+      // The gate keys on the row's creation date, not on its current source, so
+      // opting into enriched must not be a one-way door. Someone evaluating the
+      // enriched export needs to be able to back out while legacy still exists.
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+      const back = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(back.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+    });
+
     it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
       const { caller, project } = await prepareOldProject();
       await seedLegacyRow(

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -3,13 +3,36 @@ import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
-import { LEGACY_BLOB_EXPORT_CUTOFF } from "@langfuse/shared";
+import {
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
+} from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
+// Integration row ages derive from the cutoff constants, never from literals, so
+// the NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides cannot turn a supported
+// override into a suite failure.
+const ROW_PRE_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+);
+const ROW_POST_ANALYTICS_CUTOFF = new Date(
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+);
+// The raced-CREATE pre-flight row must be grandfathered under BOTH exporter
+// cutoffs, so the pre-flight assert provably cannot be the thing that rejects
+// and only the in-transaction backstop can.
+const RACED_PREFLIGHT_CREATED_AT = new Date(
+  Math.min(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime(),
+    LEGACY_BLOB_EXPORTER_CUTOFF.getTime(),
+  ) -
+    30 * MS_PER_DAY,
+);
 
 const buildSession = (orgId: string, projectId: string): Session => ({
   expires: "1",
@@ -159,7 +182,11 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     return { project, caller };
   };
 
-  it("Cloud + pre-cutoff project + legacy source → allow", async () => {
+  // A pre-cutoff project no longer buys a *new* integration the right to a
+  // legacy source: brand-new Cloud integrations are pinned to enriched events.
+  // The project cutoff is still grandfathered for integrations that already
+  // exist — covered in "Cloud new-integration enriched pin" below.
+  it("Cloud + pre-cutoff project + legacy source on create → BAD_REQUEST", async () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
     try {
@@ -174,7 +201,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS" as const,
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     } finally {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
     }
@@ -499,19 +526,21 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
     });
 
-    it("Cloud + post-cutoff project + create without exportSource → BAD_REQUEST (validated default)", async () => {
+    it("Cloud + post-cutoff project + create without exportSource → persists EVENTS", async () => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
         data: { createdAt: POST_CUTOFF },
       });
-      await expect(
-        caller.posthogIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-        }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
     });
 
     it("raced delete between read and write: mis-created legacy row is rolled back (post-cutoff Cloud)", async () => {
@@ -548,6 +577,68 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       ).toBeNull();
     });
 
+    // Both raced-CREATE cases below share one shape and differ only in whether
+    // the caller sent an explicit exportSource. That single difference is the
+    // point: the real settings form always sends one (it lives in the form's
+    // defaultValues and onSubmit spreads every value), so a backstop that only
+    // runs when the field is omitted never runs in production.
+    const expectRacedCreateRejected = async (
+      extraInput: { exportSource?: "TRACES_OBSERVATIONS" } = {},
+    ) => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      const { caller, project } = await prepare();
+      // Pre-cutoff project, so the project-level gate cannot fire. The only
+      // thing left that can reject is the backstop judging the CREATE on its
+      // own terms.
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      // The pre-flight read sees a row old enough to be grandfathered under
+      // either exporter cutoff, so the pre-flight assert allows the legacy
+      // source it carries and cannot be the thing that rejects. Meanwhile the
+      // DB genuinely holds no row, so the upsert lands as a CREATE — the race.
+      // If the backstop reused this stale createdAt, or skipped itself
+      // entirely, the legacy row would be persisted.
+      const spy = vi
+        .spyOn(prisma.posthogIntegration, "findUnique")
+        .mockResolvedValueOnce({
+          exportSource: "TRACES_OBSERVATIONS",
+          createdAt: RACED_PREFLIGHT_CREATED_AT,
+        } as never);
+      try {
+        await expect(
+          caller.posthogIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            ...extraInput,
+          }),
+        ).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+          // Pins the cutoff path: an unrelated BAD_REQUEST (credentials,
+          // validation) must not satisfy this test.
+          message: expect.stringContaining("created on or after"),
+        });
+      } finally {
+        spy.mockRestore();
+      }
+      expect(
+        await prisma.posthogIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    };
+
+    it("raced delete with the source omitted: the backstop re-validates as a brand-new row, not the stale pre-flight row", async () => {
+      await expectRacedCreateRejected();
+    });
+
+    it("raced delete with the source explicitly present: the backstop still re-validates as a brand-new row", async () => {
+      await expectRacedCreateRejected({
+        exportSource: "TRACES_OBSERVATIONS",
+      });
+    });
+
     it("create without exportSource defaults to EVENTS on events_only", async () => {
       (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
       const { caller, project } = await prepare();
@@ -559,6 +650,198 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
+    });
+  });
+
+  // New Cloud analytics integrations land on the enriched events source and
+  // cannot be moved off it. Integrations that already existed before the
+  // analytics exporter cutoff are grandfathered: they keep their legacy source
+  // and may opt into enriched, but are never rewritten behind the user's back.
+  describe("Cloud new-integration enriched pin", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    beforeEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      // dual keeps legacy writes active, so any rejection below comes from the
+      // Cloud cutoff rather than the write-mode capability gate.
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+    });
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    });
+
+    // Pre-cutoff project so the only Cloud gate in play is the
+    // integration-level one.
+    const prepareOldProject = async () => {
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      return { caller, project };
+    };
+
+    // Seeds a row of a chosen age: created while self-hosted (where legacy is
+    // still selectable), then backdated.
+    const seedLegacyRow = async (
+      caller: Awaited<ReturnType<typeof prepare>>["caller"],
+      projectId: string,
+      createdAt: Date,
+      exportSource: "TRACES_OBSERVATIONS" | "EVENTS" = "TRACES_OBSERVATIONS",
+    ) => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      try {
+        await caller.posthogIntegration.update({
+          projectId,
+          ...baseConfig,
+          exportSource,
+        });
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      }
+      await prisma.posthogIntegration.update({
+        where: { projectId },
+        data: { createdAt },
+      });
+    };
+
+    it("create with no existing row persists EVENTS", async () => {
+      const { caller, project } = await prepareOldProject();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("create with an explicit legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(
+        await prisma.posthogIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+      ).toBeNull();
+    });
+
+    it("pre-cutoff row with a persisted legacy source: omitted source is preserved, not rewritten", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          enabled: false,
+        }),
+      ).resolves.not.toThrow();
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(result.config?.enabled).toBe(false);
+    });
+
+    it("pre-cutoff row may re-assert its legacy source and may switch to enriched", async () => {
+      const { caller, project } = await prepareOldProject();
+      // The row predates the analytics cutoff but postdates the blob one, so
+      // this also catches an adapter that forwards the blob cutoff by mistake.
+      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
+      const { caller, project } = await prepareOldProject();
+      await seedLegacyRow(
+        caller,
+        project.id,
+        ROW_POST_ANALYTICS_CUTOFF,
+        "EVENTS",
+      );
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      const result = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.exportSource).toBe("EVENTS");
+    });
+
+    it("self-hosted on the legacy write mode is untouched by the pin", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+      const { caller, project } = await prepareOldProject();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const created = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      // The legacy source stays an explicit, re-assertable choice — the pin
+      // neither rewrites it nor locks the field. (Enriched is unavailable on
+      // this write mode for a separate reason: the events table is not written.)
+      await expect(
+        caller.posthogIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("self-hosted on a write mode that serves enriched may still switch to it", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+      const { caller, project } = await prepareOldProject();
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+      const created = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      await caller.posthogIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "EVENTS" as const,
+      });
+      const switched = await caller.posthogIntegration.get({
+        projectId: project.id,
+      });
+      expect(switched.config?.exportSource).toBe("EVENTS");
     });
   });
 

--- a/web/src/__tests__/server/posthog-integration.servertest.ts
+++ b/web/src/__tests__/server/posthog-integration.servertest.ts
@@ -14,18 +14,16 @@ import { env } from "@/src/env.mjs";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
-// Integration row ages derive from the cutoff constants, never from literals, so
-// the NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides cannot turn a supported
-// override into a suite failure.
+// Row ages derive from the cutoff constants, never from literals, so the
+// NEXT_PUBLIC_LANGFUSE_*_CUTOFF dev overrides cannot fail the suite.
 const ROW_PRE_ANALYTICS_CUTOFF = new Date(
   LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
 );
 const ROW_POST_ANALYTICS_CUTOFF = new Date(
   LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
 );
-// The raced-CREATE pre-flight row must be grandfathered under BOTH exporter
-// cutoffs, so the pre-flight assert provably cannot be the thing that rejects
-// and only the in-transaction backstop can.
+// Grandfathered under BOTH exporter cutoffs, so the pre-flight assert provably
+// cannot be what rejects — only the in-transaction backstop can.
 const RACED_PREFLIGHT_CREATED_AT = new Date(
   Math.min(
     LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime(),
@@ -183,9 +181,8 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
   };
 
   // A pre-cutoff project no longer buys a *new* integration the right to a
-  // legacy source: brand-new Cloud integrations are pinned to enriched events.
-  // The project cutoff is still grandfathered for integrations that already
-  // exist — covered in "Cloud new-integration enriched pin" below.
+  // legacy source. Existing integrations stay grandfathered — see
+  // "Cloud new-integration enriched pin" below.
   it("Cloud + pre-cutoff project + legacy source on create → BAD_REQUEST", async () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
@@ -578,8 +575,8 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     });
 
     // Both raced-CREATE cases below share one shape and differ only in whether
-    // the caller sent an explicit exportSource. That single difference is the
-    // point: the real settings form always sends one (it lives in the form's
+    // the caller sent an explicit exportSource. That difference is the point:
+    // the real settings form always sends one (it lives in the form's
     // defaultValues and onSubmit spreads every value), so a backstop that only
     // runs when the field is omitted never runs in production.
     const expectRacedCreateRejected = async (
@@ -587,19 +584,14 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     ) => {
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       const { caller, project } = await prepare();
-      // Pre-cutoff project, so the project-level gate cannot fire. The only
-      // thing left that can reject is the backstop judging the CREATE on its
-      // own terms.
+      // Pre-cutoff project, so the project-level gate cannot fire either.
       await prisma.project.update({
         where: { id: project.id },
         data: { createdAt: PRE_CUTOFF },
       });
-      // The pre-flight read sees a row old enough to be grandfathered under
-      // either exporter cutoff, so the pre-flight assert allows the legacy
-      // source it carries and cannot be the thing that rejects. Meanwhile the
-      // DB genuinely holds no row, so the upsert lands as a CREATE — the race.
-      // If the backstop reused this stale createdAt, or skipped itself
-      // entirely, the legacy row would be persisted.
+      // The pre-flight read sees a grandfathered row and allows the legacy
+      // source; the DB holds no row, so the upsert lands as a CREATE. Reusing
+      // the stale createdAt, or skipping the backstop, persists a legacy row.
       const spy = vi
         .spyOn(prisma.posthogIntegration, "findUnique")
         .mockResolvedValueOnce({
@@ -653,10 +645,11 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     });
   });
 
-  // New Cloud analytics integrations land on the enriched events source and
-  // cannot be moved off it. Integrations that already existed before the
-  // analytics exporter cutoff are grandfathered: they keep their legacy source
-  // and may opt into enriched, but are never rewritten behind the user's back.
+  // New Cloud integrations land on the enriched events source and cannot be
+  // moved off it. Rows created before the analytics exporter cutoff are
+  // grandfathered: they keep their legacy source and may opt into enriched, but
+  // are never rewritten behind the user's back. Self-hosted is exempt — the
+  // create defaults above still pass unchanged.
   describe("Cloud new-integration enriched pin", () => {
     const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
     const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
@@ -720,22 +713,6 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.exportSource).toBe("EVENTS");
     });
 
-    it("create with an explicit legacy source → BAD_REQUEST", async () => {
-      const { caller, project } = await prepareOldProject();
-      await expect(
-        caller.posthogIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-          exportSource: "TRACES_OBSERVATIONS" as const,
-        }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-      expect(
-        await prisma.posthogIntegration.findUnique({
-          where: { projectId: project.id },
-        }),
-      ).toBeNull();
-    });
-
     it("pre-cutoff row with a persisted legacy source: omitted source is preserved, not rewritten", async () => {
       const { caller, project } = await prepareOldProject();
       await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
@@ -753,10 +730,13 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
       expect(result.config?.enabled).toBe(false);
     });
 
-    it("pre-cutoff row may re-assert its legacy source and may switch to enriched", async () => {
+    it("pre-cutoff row may re-assert legacy, opt into enriched, and switch back", async () => {
+      // The gate keys on the row's creation date, not its current source, so
+      // trying enriched must not be a one-way door: someone evaluating it needs
+      // to be able to back out while legacy still exists. The row also predates
+      // the analytics cutoff while postdating the blob one, so this catches an
+      // adapter that forwards the blob cutoff by mistake.
       const { caller, project } = await prepareOldProject();
-      // The row predates the analytics cutoff but postdates the blob one, so
-      // this also catches an adapter that forwards the blob cutoff by mistake.
       await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
       await expect(
         caller.posthogIntegration.update({
@@ -770,34 +750,19 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         ...baseConfig,
         exportSource: "EVENTS" as const,
       });
-      const result = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(result.config?.exportSource).toBe("EVENTS");
-    });
-
-    it("trying enriched is reversible: a grandfathered row may switch back to legacy", async () => {
-      // The gate keys on the row's creation date, not on its current source, so
-      // opting into enriched must not be a one-way door. Someone evaluating the
-      // enriched export needs to be able to back out while legacy still exists.
-      const { caller, project } = await prepareOldProject();
-      await seedLegacyRow(caller, project.id, ROW_PRE_ANALYTICS_CUTOFF);
+      expect(
+        (await caller.posthogIntegration.get({ projectId: project.id })).config
+          ?.exportSource,
+      ).toBe("EVENTS");
       await caller.posthogIntegration.update({
         projectId: project.id,
         ...baseConfig,
-        exportSource: "EVENTS" as const,
+        exportSource: "TRACES_OBSERVATIONS" as const,
       });
-      await expect(
-        caller.posthogIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-          exportSource: "TRACES_OBSERVATIONS" as const,
-        }),
-      ).resolves.not.toThrow();
-      const back = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(back.config?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(
+        (await caller.posthogIntegration.get({ projectId: project.id })).config
+          ?.exportSource,
+      ).toBe("TRACES_OBSERVATIONS");
     });
 
     it("post-cutoff row requesting a legacy source → BAD_REQUEST", async () => {
@@ -819,53 +784,6 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         projectId: project.id,
       });
       expect(result.config?.exportSource).toBe("EVENTS");
-    });
-
-    it("self-hosted on the legacy write mode is untouched by the pin", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-      const { caller, project } = await prepareOldProject();
-      await caller.posthogIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-      });
-      const created = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
-      // The legacy source stays an explicit, re-assertable choice — the pin
-      // neither rewrites it nor locks the field. (Enriched is unavailable on
-      // this write mode for a separate reason: the events table is not written.)
-      await expect(
-        caller.posthogIntegration.update({
-          projectId: project.id,
-          ...baseConfig,
-          exportSource: "TRACES_OBSERVATIONS" as const,
-        }),
-      ).resolves.not.toThrow();
-    });
-
-    it("self-hosted on a write mode that serves enriched may still switch to it", async () => {
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
-      const { caller, project } = await prepareOldProject();
-      await caller.posthogIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-      });
-      const created = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(created.config?.exportSource).toBe("TRACES_OBSERVATIONS");
-      await caller.posthogIntegration.update({
-        projectId: project.id,
-        ...baseConfig,
-        exportSource: "EVENTS" as const,
-      });
-      const switched = await caller.posthogIntegration.get({
-        projectId: project.id,
-      });
-      expect(switched.config?.exportSource).toBe("EVENTS");
     });
   });
 

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -669,4 +669,20 @@ describe("analytics settings pages: the new-integration enriched pin", () => {
       ).toBe(true);
     }
   });
+  it("a grandfathered row already on enriched still offers the way back to legacy", () => {
+    // The server allows the switch back; this is the UI half of that guarantee.
+    // If the selector were hidden once the row is on enriched, the escape hatch
+    // would exist only in the API.
+    const ctx = analyticsCloudCtx(ROW_PRE_ANALYTICS);
+    const { showField, options } = getExportSourceFieldState(
+      AnalyticsIntegrationExportSource.EVENTS,
+      ctx,
+    );
+    expect(showField).toBe(true);
+    expect(
+      options.find(
+        (o) => o.value === AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      ),
+    ).toMatchObject({ unavailable: false });
+  });
 });

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -544,10 +544,9 @@ describe("getExportSourceUnavailableMessage", () => {
   });
 });
 
-// The analytics settings pages supply an integration-level cutoff on top of what
-// buildExportSourceContext derives, so these contexts mirror what those pages
-// actually build. Row ages derive from the constant, never from literals: it is
-// overridable via NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF.
+// Mirrors the context the analytics settings pages build. Row ages derive from
+// the constant, never from literals: it is overridable via
+// NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF.
 describe("analytics settings pages: the new-integration enriched pin", () => {
   const ROW_PRE_ANALYTICS = new Date(
     LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
@@ -558,17 +557,16 @@ describe("analytics settings pages: the new-integration enriched pin", () => {
 
   const analyticsCloudCtx = (
     integrationCreatedAt: Date | null,
-  ): ExportSourceContext => ({
-    ...buildExportSourceContext({
+  ): ExportSourceContext =>
+    buildExportSourceContext({
       writeMode: "dual",
       isCloud: true,
       // Pre-cutoff project, so the only Cloud gate in play is the
       // integration-level one.
       projectCreatedAt: PROJECT_PRE,
       integrationCreatedAt,
-    }),
-    exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-  });
+      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+    });
 
   it("brand-new Cloud integration: selector hidden, pinned to the enriched source", () => {
     const { showField, defaultValue, options } = getExportSourceFieldState(
@@ -577,8 +575,8 @@ describe("analytics settings pages: the new-integration enriched pin", () => {
     );
     expect(showField).toBe(false);
     expect(defaultValue).toBe(AnalyticsIntegrationExportSource.EVENTS);
-    // Hidden because there is genuinely nothing to choose, not because the
-    // choice was suppressed.
+    // Hidden because there is nothing left to choose, not because the choice
+    // was suppressed.
     expect(options.map((o) => o.value)).toEqual([
       AnalyticsIntegrationExportSource.EVENTS,
     ]);
@@ -594,8 +592,7 @@ describe("analytics settings pages: the new-integration enriched pin", () => {
     expect(defaultValue).toBe(
       AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
     );
-    // A real choice, not a dead end: the user may opt into enriched, and is
-    // neither forced to nor rewritten.
+    // A real choice: opting into enriched is offered, never forced.
     expect(
       isExportSourceSelectable(
         AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
@@ -610,8 +607,8 @@ describe("analytics settings pages: the new-integration enriched pin", () => {
   it("post-cutoff Cloud integration on a legacy source: selector forced visible, source kept, never rewritten", () => {
     // Reachable: a Cloud row created after the cutoff date but before this gate
     // shipped still carries the legacy source. Pinning the form value to the
-    // enriched source here would change which streams that integration exports
-    // on the next save of any unrelated field (LFE-10296).
+    // enriched source here would change what it exports on the next save of any
+    // unrelated field.
     const ctx = analyticsCloudCtx(ROW_POST_ANALYTICS);
     const { showField, defaultValue, options } = getExportSourceFieldState(
       AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
@@ -621,8 +618,7 @@ describe("analytics settings pages: the new-integration enriched pin", () => {
     expect(defaultValue).toBe(
       AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
     );
-    // Kept, but genuinely blocked — the form must not be saveable as-is, and the
-    // blocked-save alert points at this option.
+    // Kept, but blocked — the save must fail rather than substitute a source.
     expect(
       isExportSourceSelectable(
         AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
@@ -636,47 +632,12 @@ describe("analytics settings pages: the new-integration enriched pin", () => {
     ).toBe(true);
   });
 
-  it("the pin keys on the analytics cutoff, not the blob one", () => {
-    // A row between the two cutoffs: pinned if the blob date leaked in,
-    // grandfathered under the analytics date the pages actually pass.
-    const between = new Date(
-      LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
-    );
-    expect(between < LEGACY_ANALYTICS_EXPORTER_CUTOFF).toBe(true);
-    expect(
-      isExportSourceSelectable(
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-        analyticsCloudCtx(between),
-      ),
-    ).toBe(true);
-  });
-
-  it("self-hosted is untouched by the pin whatever the row age", () => {
-    for (const integrationCreatedAt of [null, ROW_POST_ANALYTICS]) {
-      const ctx: ExportSourceContext = {
-        ...buildExportSourceContext({
-          writeMode: "dual",
-          isCloud: false,
-          integrationCreatedAt,
-        }),
-        exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-      };
-      expect(
-        isExportSourceSelectable(
-          AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-          ctx,
-        ),
-      ).toBe(true);
-    }
-  });
   it("a grandfathered row already on enriched still offers the way back to legacy", () => {
-    // The server allows the switch back; this is the UI half of that guarantee.
-    // If the selector were hidden once the row is on enriched, the escape hatch
-    // would exist only in the API.
-    const ctx = analyticsCloudCtx(ROW_PRE_ANALYTICS);
+    // The UI half of the reversibility guarantee: hiding the selector once the
+    // row sits on enriched would leave the escape hatch API-only.
     const { showField, options } = getExportSourceFieldState(
       AnalyticsIntegrationExportSource.EVENTS,
-      ctx,
+      analyticsCloudCtx(ROW_PRE_ANALYTICS),
     );
     expect(showField).toBe(true);
     expect(

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -1,5 +1,6 @@
 import {
   AnalyticsIntegrationExportSource,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   LEGACY_BLOB_EXPORT_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
   type BlobExportWriteMode,
@@ -540,5 +541,132 @@ describe("getExportSourceUnavailableMessage", () => {
     const message = getExportSourceUnavailableMessage("legacy-writes-disabled");
     expect(message).toContain("LANGFUSE_MIGRATION_V4_WRITE_MODE=events_only");
     expect(message).not.toContain("no longer available for this project");
+  });
+});
+
+// The analytics settings pages supply an integration-level cutoff on top of what
+// buildExportSourceContext derives, so these contexts mirror what those pages
+// actually build. Row ages derive from the constant, never from literals: it is
+// overridable via NEXT_PUBLIC_LANGFUSE_ANALYTICS_EXPORTER_CUTOFF.
+describe("analytics settings pages: the new-integration enriched pin", () => {
+  const ROW_PRE_ANALYTICS = new Date(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+  );
+  const ROW_POST_ANALYTICS = new Date(
+    LEGACY_ANALYTICS_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+  );
+
+  const analyticsCloudCtx = (
+    integrationCreatedAt: Date | null,
+  ): ExportSourceContext => ({
+    ...buildExportSourceContext({
+      writeMode: "dual",
+      isCloud: true,
+      // Pre-cutoff project, so the only Cloud gate in play is the
+      // integration-level one.
+      projectCreatedAt: PROJECT_PRE,
+      integrationCreatedAt,
+    }),
+    exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  });
+
+  it("brand-new Cloud integration: selector hidden, pinned to the enriched source", () => {
+    const { showField, defaultValue, options } = getExportSourceFieldState(
+      undefined,
+      analyticsCloudCtx(null),
+    );
+    expect(showField).toBe(false);
+    expect(defaultValue).toBe(AnalyticsIntegrationExportSource.EVENTS);
+    // Hidden because there is genuinely nothing to choose, not because the
+    // choice was suppressed.
+    expect(options.map((o) => o.value)).toEqual([
+      AnalyticsIntegrationExportSource.EVENTS,
+    ]);
+  });
+
+  it("grandfathered pre-cutoff Cloud integration: selector shown, legacy source kept and still selectable", () => {
+    const ctx = analyticsCloudCtx(ROW_PRE_ANALYTICS);
+    const { showField, defaultValue } = getExportSourceFieldState(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      ctx,
+    );
+    expect(showField).toBe(true);
+    expect(defaultValue).toBe(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    );
+    // A real choice, not a dead end: the user may opt into enriched, and is
+    // neither forced to nor rewritten.
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        ctx,
+      ),
+    ).toBe(true);
+    expect(
+      isExportSourceSelectable(AnalyticsIntegrationExportSource.EVENTS, ctx),
+    ).toBe(true);
+  });
+
+  it("post-cutoff Cloud integration on a legacy source: selector forced visible, source kept, never rewritten", () => {
+    // Reachable: a Cloud row created after the cutoff date but before this gate
+    // shipped still carries the legacy source. Pinning the form value to the
+    // enriched source here would change which streams that integration exports
+    // on the next save of any unrelated field (LFE-10296).
+    const ctx = analyticsCloudCtx(ROW_POST_ANALYTICS);
+    const { showField, defaultValue, options } = getExportSourceFieldState(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      ctx,
+    );
+    expect(showField).toBe(true);
+    expect(defaultValue).toBe(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    );
+    // Kept, but genuinely blocked — the form must not be saveable as-is, and the
+    // blocked-save alert points at this option.
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        ctx,
+      ),
+    ).toBe(false);
+    expect(
+      options.find(
+        (o) => o.value === AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      )?.unavailable,
+    ).toBe(true);
+  });
+
+  it("the pin keys on the analytics cutoff, not the blob one", () => {
+    // A row between the two cutoffs: pinned if the blob date leaked in,
+    // grandfathered under the analytics date the pages actually pass.
+    const between = new Date(
+      LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+    );
+    expect(between < LEGACY_ANALYTICS_EXPORTER_CUTOFF).toBe(true);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        analyticsCloudCtx(between),
+      ),
+    ).toBe(true);
+  });
+
+  it("self-hosted is untouched by the pin whatever the row age", () => {
+    for (const integrationCreatedAt of [null, ROW_POST_ANALYTICS]) {
+      const ctx: ExportSourceContext = {
+        ...buildExportSourceContext({
+          writeMode: "dual",
+          isCloud: false,
+          integrationCreatedAt,
+        }),
+        exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+      };
+      expect(
+        isExportSourceSelectable(
+          AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+          ctx,
+        ),
+      ).toBe(true);
+    }
   });
 });

--- a/web/src/features/analytics-integrations/exportSource.ts
+++ b/web/src/features/analytics-integrations/exportSource.ts
@@ -22,11 +22,13 @@ export function buildExportSourceContext({
   isCloud,
   projectCreatedAt,
   integrationCreatedAt,
+  exporterCutoff,
 }: {
   writeMode: BlobExportWriteMode;
   isCloud: boolean;
   projectCreatedAt?: Date;
   integrationCreatedAt?: Date | null;
+  exporterCutoff?: Date;
 }): ExportSourceContext {
   return {
     isCloud,
@@ -34,6 +36,7 @@ export function buildExportSourceContext({
     legacyWritesActive: areLegacyWritesActive(writeMode),
     projectCreatedAt,
     integrationCreatedAt,
+    exporterCutoff,
   };
 }
 

--- a/web/src/features/analytics-integrations/server/analyticsExportSource.ts
+++ b/web/src/features/analytics-integrations/server/analyticsExportSource.ts
@@ -3,6 +3,7 @@ import {
   areEnrichedWritesActive,
   areLegacyWritesActive,
   InvalidRequestError,
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
   type ExportSourceContext,
 } from "@langfuse/shared";
@@ -40,13 +41,23 @@ function readDeployment(): Deployment {
 function buildContext(
   deployment: Deployment,
   projectCreatedAt: Date | undefined,
+  integrationCreatedAt: Date | null,
 ): ExportSourceContext {
-  return { ...deployment, projectCreatedAt };
+  return {
+    ...deployment,
+    projectCreatedAt,
+    integrationCreatedAt,
+    exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+  };
 }
 
 /**
  * Validates the requested source (throwing InvalidRequestError when blocked)
  * and returns the value the upsert's CREATE branch should carry.
+ *
+ * That value prefers the persisted source over the new-row default, because a
+ * concurrent delete can turn the upsert into a CREATE that was meant as an
+ * UPDATE; assertRacedCreateAllowed then judges whatever landed.
  */
 export async function resolveAnalyticsExportSource({
   db,
@@ -60,9 +71,13 @@ export async function resolveAnalyticsExportSource({
   existingIntegration: ExistingAnalyticsIntegration | null | undefined;
 }): Promise<AnalyticsIntegrationExportSource> {
   const deployment = readDeployment();
-  const createDefaultExportSource = deployment.legacyWritesActive
-    ? AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-    : AnalyticsIntegrationExportSource.EVENTS;
+  // On Cloud a new row is pinned to enriched events regardless of write mode:
+  // the legacy source is not available to it, so defaulting to it would only
+  // produce a rejection.
+  const createDefaultExportSource =
+    deployment.isCloud || !deployment.legacyWritesActive
+      ? AnalyticsIntegrationExportSource.EVENTS
+      : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
 
   const nextExportSource =
     requestedExportSource ??
@@ -81,33 +96,43 @@ export async function resolveAnalyticsExportSource({
   assertExportSourceAllowed({
     nextExportSource,
     persistedExportSource: existingIntegration?.exportSource,
-    ctx: buildContext(deployment, projectCreatedAt),
+    ctx: buildContext(
+      deployment,
+      projectCreatedAt,
+      existingIntegration?.createdAt ?? null,
+    ),
   });
 
-  return createDefaultExportSource;
+  return (
+    requestedExportSource ??
+    existingIntegration?.exportSource ??
+    createDefaultExportSource
+  );
 }
 
 /**
  * In-transaction backstop (mirrors blob storage's service.ts). The pre-flight
- * read is racy: a concurrent delete can flip the expected UPDATE into a CREATE
- * carrying the unvalidated legacy default. A changed createdAt detects that,
- * and the row is then re-validated as an explicit choice.
+ * read is racy: a concurrent delete can flip the expected UPDATE into a CREATE.
+ * A changed createdAt detects that, and the row is then re-validated as the
+ * brand-new row it is — not as the grandfathered one the pre-flight read saw.
+ *
+ * This runs whether or not the request named a source. An explicit source is
+ * validated up front against the *existing* row's age, so a raced create leaves
+ * it judged by the wrong row: the pre-flight read grandfathered an old row that
+ * no longer exists.
  */
 export async function assertRacedCreateAllowed({
   tx,
   projectId,
-  requestedExportSource,
   existingIntegration,
   result,
 }: {
   tx: Prisma.TransactionClient;
   projectId: string;
-  requestedExportSource: AnalyticsIntegrationExportSource | undefined;
   existingIntegration: ExistingAnalyticsIntegration | null | undefined;
   result: ExistingAnalyticsIntegration;
 }): Promise<void> {
   if (
-    requestedExportSource !== undefined ||
     !existingIntegration ||
     result.createdAt.getTime() === existingIntegration.createdAt.getTime()
   ) {
@@ -119,7 +144,7 @@ export async function assertRacedCreateAllowed({
   });
   const validation = validateExportSource(
     result.exportSource,
-    buildContext(readDeployment(), project.createdAt),
+    buildContext(readDeployment(), project.createdAt, null),
   );
   if (!validation.ok) throw new InvalidRequestError(validation.message);
 }

--- a/web/src/features/analytics-integrations/server/analyticsExportSource.ts
+++ b/web/src/features/analytics-integrations/server/analyticsExportSource.ts
@@ -53,11 +53,9 @@ function buildContext(
 
 /**
  * Validates the requested source (throwing InvalidRequestError when blocked)
- * and returns the value the upsert's CREATE branch should carry.
- *
- * That value prefers the persisted source over the new-row default, because a
- * concurrent delete can turn the upsert into a CREATE that was meant as an
- * UPDATE; assertRacedCreateAllowed then judges whatever landed.
+ * and returns the value the upsert's CREATE branch should carry. That value
+ * prefers the persisted source, because a concurrent delete can turn an upsert
+ * meant as an UPDATE into a CREATE; assertRacedCreateAllowed judges what lands.
  */
 export async function resolveAnalyticsExportSource({
   db,
@@ -71,9 +69,8 @@ export async function resolveAnalyticsExportSource({
   existingIntegration: ExistingAnalyticsIntegration | null | undefined;
 }): Promise<AnalyticsIntegrationExportSource> {
   const deployment = readDeployment();
-  // On Cloud a new row is pinned to enriched events regardless of write mode:
-  // the legacy source is not available to it, so defaulting to it would only
-  // produce a rejection.
+  // On Cloud the legacy source is unavailable to a new row, so defaulting to it
+  // would only produce a rejection.
   const createDefaultExportSource =
     deployment.isCloud || !deployment.legacyWritesActive
       ? AnalyticsIntegrationExportSource.EVENTS
@@ -113,13 +110,12 @@ export async function resolveAnalyticsExportSource({
 /**
  * In-transaction backstop (mirrors blob storage's service.ts). The pre-flight
  * read is racy: a concurrent delete can flip the expected UPDATE into a CREATE.
- * A changed createdAt detects that, and the row is then re-validated as the
- * brand-new row it is — not as the grandfathered one the pre-flight read saw.
+ * A changed createdAt detects that, and the row is re-validated as the brand-new
+ * row it is — not as the grandfathered one the pre-flight read saw.
  *
- * This runs whether or not the request named a source. An explicit source is
- * validated up front against the *existing* row's age, so a raced create leaves
- * it judged by the wrong row: the pre-flight read grandfathered an old row that
- * no longer exists.
+ * This runs whether or not the request named a source: an explicit source is
+ * also validated against the existing row's age, so a raced create leaves it
+ * judged by a row that no longer exists.
  */
 export async function assertRacedCreateAllowed({
   tx,

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -115,7 +115,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           message: "Mixpanel Project Token is required",
         });
       }
-      const createDefaultExportSource = await resolveAnalyticsExportSource({
+      const createExportSource = await resolveAnalyticsExportSource({
         db: ctx.prisma,
         projectId: input.projectId,
         requestedExportSource: input.exportSource,
@@ -140,7 +140,7 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
             mixpanelRegion: config.mixpanelRegion,
             encryptedMixpanelProjectToken,
             enabled: config.enabled,
-            exportSource: config.exportSource ?? createDefaultExportSource,
+            exportSource: createExportSource,
           },
           update: {
             encryptedMixpanelProjectToken,
@@ -155,7 +155,6 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
         await assertRacedCreateAllowed({
           tx,
           projectId: input.projectId,
-          requestedExportSource: input.exportSource,
           existingIntegration,
           result,
         });

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -128,7 +128,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
           message: "PostHog Project API Key is required",
         });
       }
-      const createDefaultExportSource = await resolveAnalyticsExportSource({
+      const createExportSource = await resolveAnalyticsExportSource({
         db: ctx.prisma,
         projectId: input.projectId,
         requestedExportSource: input.exportSource,
@@ -153,7 +153,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
             posthogHostName: config.posthogHostname,
             encryptedPosthogApiKey,
             enabled: config.enabled,
-            exportSource: config.exportSource ?? createDefaultExportSource,
+            exportSource: createExportSource,
           },
           update: {
             encryptedPosthogApiKey,
@@ -170,7 +170,6 @@ export const posthogIntegrationRouter = createTRPCRouter({
         await assertRacedCreateAllowed({
           tx,
           projectId: input.projectId,
-          requestedExportSource: input.exportSource,
           existingIntegration,
           result,
         });

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -33,6 +33,7 @@ import {
   type MixpanelRegion,
 } from "@/src/features/mixpanel-integration/types";
 import {
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
   type BlobExportWriteMode,
   type ExportSourceContext,
@@ -169,14 +170,20 @@ const MixpanelIntegrationSettingsForm = ({
 }) => {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const integrationCreatedAt = state?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () =>
-      buildExportSourceContext({
+    () => ({
+      ...buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
         projectCreatedAt: new Date(projectCreatedAt),
+        integrationCreatedAt: integrationCreatedAt
+          ? new Date(integrationCreatedAt)
+          : null,
       }),
-    [writeMode, isLangfuseCloud, projectCreatedAt],
+      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+    }),
+    [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
   const {
     options: exportSourceOptions,

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -172,17 +172,16 @@ const MixpanelIntegrationSettingsForm = ({
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const integrationCreatedAt = state?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () => ({
-      ...buildExportSourceContext({
+    () =>
+      buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
         projectCreatedAt: new Date(projectCreatedAt),
         integrationCreatedAt: integrationCreatedAt
           ? new Date(integrationCreatedAt)
           : null,
+        exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
       }),
-      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-    }),
     [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
   const {

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -166,17 +166,16 @@ const PostHogIntegrationSettings = ({
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const integrationCreatedAt = state?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () => ({
-      ...buildExportSourceContext({
+    () =>
+      buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
         projectCreatedAt: new Date(projectCreatedAt),
         integrationCreatedAt: integrationCreatedAt
           ? new Date(integrationCreatedAt)
           : null,
+        exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
       }),
-      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
-    }),
     [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
   const {

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -31,6 +31,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration/types";
 import { PostHogStatusSection } from "@/src/features/posthog-integration/components/PostHogStatusSection";
 import {
+  LEGACY_ANALYTICS_EXPORTER_CUTOFF,
   validateExportSource,
   type BlobExportWriteMode,
   type ExportSourceContext,
@@ -163,14 +164,20 @@ const PostHogIntegrationSettings = ({
 }) => {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const integrationCreatedAt = state?.createdAt;
   const exportSourceCtx: ExportSourceContext = useMemo(
-    () =>
-      buildExportSourceContext({
+    () => ({
+      ...buildExportSourceContext({
         writeMode,
         isCloud: isLangfuseCloud,
         projectCreatedAt: new Date(projectCreatedAt),
+        integrationCreatedAt: integrationCreatedAt
+          ? new Date(integrationCreatedAt)
+          : null,
       }),
-    [writeMode, isLangfuseCloud, projectCreatedAt],
+      exporterCutoff: LEGACY_ANALYTICS_EXPORTER_CUTOFF,
+    }),
+    [writeMode, isLangfuseCloud, projectCreatedAt, integrationCreatedAt],
   );
   const {
     options: exportSourceOptions,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16242.preview.langfuse.com](https://pr-16242.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

A brand-new PostHog or Mixpanel integration on Langfuse Cloud could still be
created on the legacy traces/observations export source. Unlike blob storage, the
analytics adapters never fed the integration row's `createdAt` into the policy
context, so the integration-level cutoff never ran — and on any project old enough
to predate the project-level cutoff, the create default fell back to legacy. New
integrations now start on enriched events.

**Grandfathered integrations are unaffected.** A row created before the analytics
cutoff keeps its persisted legacy source, may opt into enriched, and is never
rewritten behind the user's back. That includes rows created *after* the cutoff
date but *before* this ships: the settings form keeps their blocked source visible
and blocks the save rather than silently substituting one, so no integration's
export streams change without the user choosing it.

**Self-hosted is untouched.** The cutoffs stay Cloud-only — their dates are
arbitrary from an operator's perspective.

### Also: the raced-create backstop now runs on the explicit-source path

The in-transaction backstop guards a TOCTOU: a concurrent delete between the
pre-flight read and the upsert flips an expected UPDATE into a CREATE, which then
carries a source that was validated against a row that no longer exists. It only
ran when the request omitted `exportSource` — but the real settings form always
sends the field (it sits in the form's `defaultValues` and `onSubmit` spreads every
value), so in production the backstop effectively never ran.

This is only *observable* once the integration-level cutoff exists, since without
it the pre-flight verdict and the brand-new-row verdict can never disagree. That is
why it lands here rather than as its own PR — there would be no test that
distinguishes fixed from broken.

### Opting into enriched is deliberately reversible

The gate keys on the integration row's **creation date**, not on its current
source. So a row created before the cutoff may move to enriched and back as often
as it likes, for as long as legacy exists — someone evaluating the enriched export
can back out. Both halves of that are tested: the routers accept the round trip,
and the settings form keeps offering the legacy option once the row sits on
enriched, so the escape hatch is reachable rather than API-only.

With the cutoff dated ahead of this merge, every integration that exists today
keeps that reversible path. Only integrations created from the cutoff onward are
pinned, and those never carried legacy data to return to.

The corollary, stated so it is a choice rather than a surprise: a row *born* after
the cutoff has no route to legacy, and its selector is hidden because there is
genuinely nothing to choose. That is the deprecation doing its job.

### Verification

| Check | Result |
|---|---|
| `turbo run lint typecheck --filter=web --filter=@langfuse/shared` | `Tasks: 7 successful, 7 total` |
| PostHog + Mixpanel routers | `Tests 67 passed (67)` |
| shared export-source policy | `Tests 28 passed (28)` |
| client export-source adapters | `Tests 49 passed (49)` |
| `assertExportSourceAllowed` unit | `Tests 16 passed (16)` |
| blob storage tRPC control | `Tests 45 passed (45)` |
| blob storage form field groups | `Tests 12 passed (12)` |

New coverage, both integrations: create pins to enriched; a pre-cutoff row's
omitted source is preserved; a pre-cutoff row may re-assert legacy, opt into
enriched and switch back; a post-cutoff row requesting legacy is rejected; and both
raced-create paths roll back. Client-side: a post-cutoff row on a legacy source
keeps the selector visible with the source intact, and a grandfathered row already
on enriched is still offered the way back.

Four pre-existing assertions are inverted by design and updated: a pre-cutoff Cloud
project no longer buys a *new* integration the right to a legacy source, and the
Cloud create default is now valid on a post-cutoff project rather than rejected.

Known gap: the client tests call `buildExportSourceContext` directly, so they cover
the derivation but not that the settings pages call it with the right arguments —
that plumbing is a code-review item. The server tests do exercise the real router
path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
