### PR TITLE
feat(web): mask customer IO content in PostHog session recordings

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -79,6 +79,8 @@ export default [
             "io-message-header",
             // Used by parent arbitrary selectors to tune IO preview body spacing and borders.
             "io-message-content",
+            // posthog-js block class: elements carrying it are excluded from session recordings.
+            "ph-no-capture",
             // Component-level selector hook for code block wrappers, not a Tailwind utility.
             "codeblock",
             // Sonner root hook used by group-[.toaster] descendant variants.

--- a/web/src/components/DiffViewer.tsx
+++ b/web/src/components/DiffViewer.tsx
@@ -197,7 +197,7 @@ const DiffViewer: React.FC<DiffViewerProps> = ({
   }
 
   return (
-    <div className={cn("w-full", className)}>
+    <div className={cn("ph-no-capture w-full", className)}>
       <Card>
         <CardContent className="p-0">
           <div className="grid grid-cols-2">

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -101,7 +101,7 @@ export function JSONView(props: {
     <>
       <div
         className={cn(
-          "io-message-content flex max-w-full min-w-0 gap-2 text-xs wrap-break-word whitespace-pre-wrap",
+          "io-message-content ph-no-capture flex max-w-full min-w-0 gap-2 text-xs wrap-break-word whitespace-pre-wrap",
           props.borderless ? "" : "p-2",
           props.title === "assistant" || props.title === "Output"
             ? "bg-accent-light-green dark:border-accent-dark-green/30"
@@ -329,7 +329,7 @@ export function CodeView(props: {
         )}
         <code
           className={cn(
-            "relative max-w-full min-w-0 flex-1 px-4 py-3 font-mono text-xs",
+            "ph-no-capture relative max-w-full min-w-0 flex-1 px-4 py-3 font-mono text-xs",
             !props.title && !lineWrap ? "w-[calc(100%-2.5rem)] pr-12" : "",
             lineWrap
               ? "wrap-break-word whitespace-pre-wrap"

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -168,7 +168,7 @@ export function JSONView(props: {
           <div className="text-muted-foreground my-1 px-0 py-1 text-xs">
             Media
           </div>
-          <div className="flex flex-wrap gap-2 pt-1 pb-4">
+          <div className="ph-no-capture flex flex-wrap gap-2 pt-1 pb-4">
             {props.media.map((m) => (
               <LangfuseMediaView
                 mediaAPIReturnValue={m}

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -102,7 +102,7 @@ const IOTableCellContent = ({
   return singleLine ? (
     <div
       className={cn(
-        "h-full w-full self-stretch truncate overflow-hidden overflow-y-auto rounded-sm",
+        "ph-no-capture h-full w-full self-stretch truncate overflow-hidden overflow-y-auto rounded-sm",
         paddingClassName,
         className,
       )}
@@ -238,7 +238,7 @@ export const IOTableCell = ({
         </div>
       </HoverCardTrigger>
       <HoverCardContent
-        className="max-h-[40vh] w-[400px] overflow-y-auto"
+        className="ph-no-capture max-h-[40vh] w-[400px] overflow-y-auto"
         side="top"
         align="start"
       >

--- a/web/src/components/ui/LargeStringFallback.tsx
+++ b/web/src/components/ui/LargeStringFallback.tsx
@@ -56,7 +56,7 @@ export function LargeStringFallback({
   };
 
   return (
-    <div className="io-message-content">
+    <div className="io-message-content ph-no-capture">
       <div className="my-2 flex flex-col gap-2 rounded-sm border border-dashed p-3">
         <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
           {title ? (

--- a/web/src/components/ui/MarkdownJsonView.tsx
+++ b/web/src/components/ui/MarkdownJsonView.tsx
@@ -33,7 +33,9 @@ export function MarkdownJsonViewHeader({
 
   return (
     <div className="io-message-header group-hover:bg-muted/80 flex flex-row items-center justify-between px-1 py-1 text-sm font-bold capitalize transition-colors">
-      <div className="flex items-center gap-2">
+      {/* Masked from session recordings: the title can be a customer-provided
+          message `name` (or tool name) rather than a fixed role string. */}
+      <div className="ph-no-capture flex items-center gap-2">
         {titleIcon}
         {title}
       </div>

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -649,7 +649,7 @@ export function MarkdownView({
           <div className="text-muted-foreground mx-3 border-t px-2 py-1 text-xs">
             Media
           </div>
-          <div className="mx-3 flex flex-wrap gap-2 px-2 pt-1 pb-4">
+          <div className="ph-no-capture mx-3 flex flex-wrap gap-2 px-2 pt-1 pb-4">
             {remainingMedia.map((m) => (
               <LangfuseMediaView
                 mediaAPIReturnValue={m}

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -585,7 +585,7 @@ export function MarkdownView({
       {afterHeader}
       <div
         className={cn(
-          "io-message-content grid grid-flow-row gap-2 px-1 py-2",
+          "io-message-content ph-no-capture grid grid-flow-row gap-2 px-1 py-2",
           title === "assistant" || title === "Output" || title === "Model"
             ? "bg-accent-light-green"
             : "",

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -1274,7 +1274,7 @@ export function PrettyJsonView(props: {
       {largeStringValue !== null ? (
         <LargeStringFallback title={props.title} value={largeStringValue} />
       ) : props.isLoading || props.isParsing ? (
-        <div className="io-message-content">
+        <div className="io-message-content ph-no-capture">
           <div
             className={cn(
               getContainerClasses(
@@ -1297,7 +1297,7 @@ export function PrettyJsonView(props: {
           </div>
         </div>
       ) : emptyValueDisplay && isPrettyView ? (
-        <div className="io-message-content">
+        <div className="io-message-content ph-no-capture">
           <div
             className={cn(
               "flex items-center",
@@ -1314,7 +1314,7 @@ export function PrettyJsonView(props: {
           </div>
         </div>
       ) : isMarkdownMode ? (
-        <div className="io-message-content">
+        <div className="io-message-content ph-no-capture">
           {shouldRenderStandaloneMedia ? (
             standaloneMediaReferenceStrings.map((referenceString, index) => (
               <LangfuseMediaView
@@ -1334,7 +1334,7 @@ export function PrettyJsonView(props: {
         <>
           {/* Always render JsonPrettyTable to preserve internal React Table state */}
           <div
-            className="io-message-content"
+            className="io-message-content ph-no-capture"
             style={{ display: shouldUseTableView ? "flex" : "none" }}
           >
             <div
@@ -1372,7 +1372,7 @@ export function PrettyJsonView(props: {
 
           {/* Always render JSONView to preserve its state too */}
           <div
-            className="io-message-content"
+            className="io-message-content ph-no-capture"
             style={{ display: shouldUseTableView ? "none" : "block" }}
           >
             <JSONView

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -1400,7 +1400,7 @@ export function PrettyJsonView(props: {
           <div className="text-muted-foreground my-1 px-2 py-1 text-xs">
             Media
           </div>
-          <div className="flex flex-wrap gap-2 px-2 pt-1 pb-4">
+          <div className="ph-no-capture flex flex-wrap gap-2 px-2 pt-1 pb-4">
             {remainingMarkdownMedia.map((m) => (
               <LangfuseMediaView
                 mediaAPIReturnValue={m}
@@ -1419,7 +1419,7 @@ export function PrettyJsonView(props: {
             <div className="text-muted-foreground my-1 px-2 py-1 text-xs">
               Media
             </div>
-            <div className="flex flex-wrap gap-2 px-2 pt-1 pb-4">
+            <div className="ph-no-capture flex flex-wrap gap-2 px-2 pt-1 pb-4">
               {props.media.map((m) => (
                 <LangfuseMediaView
                   mediaAPIReturnValue={m}

--- a/web/src/features/datasets/components/DatasetItemMediaAttachments.tsx
+++ b/web/src/features/datasets/components/DatasetItemMediaAttachments.tsx
@@ -301,7 +301,7 @@ function DatasetItemAttachments({
   return (
     <div className="flex flex-col gap-2">
       <span className="text-sm font-bold">Attachments</span>
-      <div className="flex flex-wrap gap-2">
+      <div className="ph-no-capture flex flex-wrap gap-2">
         {referenceStrings.map((referenceString) => (
           <LangfuseMediaView
             key={referenceString}

--- a/web/src/features/traces/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewJSON.tsx
@@ -617,7 +617,7 @@ function IOPreviewJSONInner({
   );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col border-t border-b">
+    <div className="ph-no-capture flex min-h-0 flex-1 flex-col border-t border-b">
       {/* Inline comment bubble - shows when text is selected */}
       {enableInlineComments && (
         <InlineCommentBubble onAddComment={handleAddComment} />

--- a/web/src/features/traces/components/IOPreview/components/CorrectedOutputDiffDialog.tsx
+++ b/web/src/features/traces/components/IOPreview/components/CorrectedOutputDiffDialog.tsx
@@ -110,7 +110,7 @@ export const CorrectedOutputDiffDialog: React.FC<
               </div>
               <div>
                 <p className="mb-1 text-sm font-bold">Corrected Output</p>
-                <pre className="bg-muted/30 max-h-[50vh] overflow-auto rounded-md border p-3 text-xs break-words whitespace-pre-wrap">
+                <pre className="ph-no-capture bg-muted/30 max-h-[50vh] overflow-auto rounded-md border p-3 text-xs break-words whitespace-pre-wrap">
                   {formattedCorrectedOutput}
                 </pre>
               </div>
@@ -125,7 +125,7 @@ export const CorrectedOutputDiffDialog: React.FC<
               </div>
             </div>
           ) : (
-            <div className="space-y-4">
+            <div className="ph-no-capture space-y-4">
               <DiffViewer
                 oldString={formattedActualOutput}
                 newString={formattedCorrectedOutput}

--- a/web/src/features/traces/components/IOPreview/components/LargeJsonFieldFallback.tsx
+++ b/web/src/features/traces/components/IOPreview/components/LargeJsonFieldFallback.tsx
@@ -100,7 +100,7 @@ export function LargeJsonFieldFallback({
   }
 
   return (
-    <div className="io-message-content">
+    <div className="io-message-content ph-no-capture">
       <div className="my-2 flex flex-col gap-2 rounded-sm border border-dashed p-3">
         <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
           {!hideTitle && (

--- a/web/src/features/traces/components/IOPreview/components/SectionMedia.tsx
+++ b/web/src/features/traces/components/IOPreview/components/SectionMedia.tsx
@@ -17,7 +17,7 @@ export function SectionMedia({ media }: SectionMediaProps) {
   return (
     <>
       <div className="text-muted-foreground my-1 px-2 py-1 text-xs">Media</div>
-      <div className="flex flex-wrap gap-2 px-2 pt-1 pb-4">
+      <div className="ph-no-capture flex flex-wrap gap-2 px-2 pt-1 pb-4">
         {media.map((m) => (
           <LangfuseMediaView
             mediaAPIReturnValue={m}

--- a/web/src/features/traces/components/IOPreview/components/ToolCallDefinitionCard.tsx
+++ b/web/src/features/traces/components/IOPreview/components/ToolCallDefinitionCard.tsx
@@ -146,7 +146,7 @@ function ToolGroupHoverContent({
               <div className="flex min-w-0 items-center gap-2">
                 <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
                 <span
-                  className="text-foreground block truncate font-mono text-xs font-bold"
+                  className="ph-no-capture text-foreground block truncate font-mono text-xs font-bold"
                   title={tool.name}
                 >
                   {toolDefinitionNumber !== undefined && (
@@ -341,7 +341,7 @@ function ToolDefinitionRow({
         <div className="flex min-w-0 items-center gap-2">
           <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
           <span
-            className="text-foreground block truncate font-mono text-xs font-bold"
+            className="ph-no-capture text-foreground block truncate font-mono text-xs font-bold"
             title={tool.name}
           >
             {toolDefinitionNumber !== undefined && (
@@ -394,7 +394,7 @@ function ToolDefinitionRow({
                   <div className="text-muted-foreground mb-1.5 text-xs font-bold">
                     Description
                   </div>
-                  <div className="text-foreground text-sm">
+                  <div className="ph-no-capture text-foreground text-sm">
                     {tool.description}
                   </div>
                 </div>

--- a/web/src/features/traces/components/ThinkingBlock.tsx
+++ b/web/src/features/traces/components/ThinkingBlock.tsx
@@ -32,12 +32,14 @@ export function ThinkingBlock({
         />
         <span className="text-xs font-bold">Thinking</span>
         {!expanded && (
-          <span className="line-clamp-1 text-xs italic">{displayContent}</span>
+          <span className="ph-no-capture line-clamp-1 text-xs italic">
+            {displayContent}
+          </span>
         )}
       </button>
 
       {expanded && (
-        <div className="text-muted-foreground mt-1 ml-4 text-sm whitespace-pre-wrap italic">
+        <div className="ph-no-capture text-muted-foreground mt-1 ml-4 text-sm whitespace-pre-wrap italic">
           {content}
         </div>
       )}
@@ -78,7 +80,7 @@ export function RedactedThinkingBlock({
       </button>
 
       {expanded && (
-        <div className="bg-muted/50 text-muted-foreground mt-1 ml-4 rounded p-2 font-mono text-xs break-all">
+        <div className="ph-no-capture bg-muted/50 text-muted-foreground mt-1 ml-4 rounded p-2 font-mono text-xs break-all">
           {data}
         </div>
       )}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16244.preview.langfuse.com](https://pr-16244.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

PostHog session replay currently captures the full DOM, including customer trace/observation **input and output**, prompt contents, and rendered chat messages. This PR masks that content by adding posthog-js's `ph-no-capture` block class to the components that render it. Blocked elements are recorded as size-only placeholders, so replays still show navigation, layout, and UI interactions without exposing customer payloads.

## Where the class was added

- **PrettyJsonView** – all five `io-message-content` body branches (trace/observation IO + metadata in pretty, table, and markdown modes)
- **JSONView** (CodeJsonViewer) – the IO body (raw JSON rendering everywhere, incl. raw prompts)
- **CodeView** (CodeJsonViewer) – the `<code>` element (text prompt contents; also masks the SDK snippet tabs, over-broad but harmless)
- **MarkdownView** – the rendered message body (chat prompts/completions, comments)
- **IOTableCell** – the single-line preview (its `title` tooltip attribute sits on the same blocked element) and the portalled `HoverCardContent` expansion, which does not inherit classes from the cell
- **IOPreviewJSON** – the advanced JSON viewer wrapper, which bypasses the components above

Headers/chrome (section titles, copy buttons) stay visible so replays remain interpretable.

## Notes for review

- `ph-no-capture` is posthog-js's **default** blockClass; no init config change needed, and it takes effect for new recordings immediately on deploy. Existing recordings are unchanged.
- Adds `ph-no-capture` to the `tailwindcss/no-custom-classname` whitelist in `web/eslint.config.mjs`, alongside the existing marker classes — please confirm you're happy with that config addition.
- Not covered (by design of the CSS-class approach): text that customer data might leak into outside these components, e.g. document titles or URLs. Network payload capture is already redacted in the init config.

## Verification

Pre-commit hook ran Prettier ("All matched files use Prettier code style!") and `turbo run lint` (`Tasks: 7 successful, 7 total`). No tests were added: the change is presentation-layer class additions with no behavioral code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PostHog session-replay blocking markers to shared renderers for trace IO, prompts, chat messages, table previews, and advanced JSON views. It also permits the marker class in the web ESLint configuration.

- Masks standard JSON, code, Markdown, table, hover-card, and advanced IO-preview content.
- Leaves `PrettyJsonView`'s large-string fallback outside the masking boundary.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until the large-string PrettyJsonView branch is also masked, because it can continue exposing customer IO in session recordings.

Standard IO rendering paths are blocked, but top-level strings over two million characters take an earlier fallback branch whose visible payload preview has neither the marker nor a blocked ancestor.

**Files Needing Attention:** web/src/components/ui/PrettyJsonView.tsx and web/src/components/ui/LargeStringFallback.tsx
</details>

<details open><summary><h3>Security Review</h3></summary>

Customer IO represented as a top-level string longer than 2,000,000 characters can still expose its rendered preview in PostHog session recordings because `LargeStringFallback` is not masked. **How this was verified:** The large-string branch was traced to an unmasked fallback that renders the first 4,000 payload characters without a blocked ancestor.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/ui/PrettyJsonView.tsx:1274-1277
**Large-string payload bypasses masking**

When trace or observation IO is a top-level string longer than 2,000,000 characters, this branch renders `LargeStringFallback` outside the newly added `ph-no-capture` boundaries, causing the first 4,000 characters of the customer payload to remain visible in PostHog session recordings. **How this was verified:** The large-string branch was traced to a fallback that renders the payload preview without a blocked ancestor.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): mask customer IO content in P..."](https://github.com/langfuse/langfuse/commit/2f5d9c3c2ec7fce90658cb90583e0c234b351f5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54372072)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->