### PR TITLE
fix(in-app-agent): suspend the sandbox provider session when a turn ends

### DIFF
--- a/packages/shared/src/in-app-agent/server/sandbox/service.ts
+++ b/packages/shared/src/in-app-agent/server/sandbox/service.ts
@@ -112,6 +112,17 @@ export async function createInAppAgentSandbox(params: {
       }
 
       await persistState();
+
+      try {
+        await params.provider.suspendSession?.({ sessionId });
+      } catch (error) {
+        logger.error("In-app agent sandbox session suspend failed", {
+          projectId: params.projectId,
+          conversationId: params.conversationId,
+          sessionId,
+          error,
+        });
+      }
     },
   };
 }

--- a/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
@@ -127,6 +127,82 @@ describe("in-app agent sandbox", () => {
     });
   });
 
+  it("suspends the provider session when a turn ends", async () => {
+    const sandboxSession = {
+      async syncReadonlyFiles() {},
+      async read() {
+        return { path: "notes.txt", content: null };
+      },
+      async write() {
+        return { path: "notes.txt", bytesWritten: 0 };
+      },
+      async edit() {
+        return { path: "notes.txt", replaced: false };
+      },
+      async bash() {
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    };
+    const suspendedSessionIds: string[] = [];
+    const provider = {
+      async ensureSession() {
+        return { sessionId: "session-1", sandbox: sandboxSession };
+      },
+      async suspendSession({ sessionId }: { sessionId: string }) {
+        suspendedSessionIds.push(sessionId);
+      },
+    };
+    const sandbox = await createInAppAgentSandbox({
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      provider,
+      getToolCallFiles: async () => [],
+      saveState: async () => {},
+    });
+
+    await sandbox.sandbox.write({ path: "notes.txt", content: "hello" });
+    await sandbox.onTurnEnded();
+
+    expect(suspendedSessionIds).toEqual(["session-1"]);
+  });
+
+  it("does not throw when suspending the provider session fails", async () => {
+    const sandboxSession = {
+      async syncReadonlyFiles() {},
+      async read() {
+        return { path: "notes.txt", content: null };
+      },
+      async write() {
+        return { path: "notes.txt", bytesWritten: 0 };
+      },
+      async edit() {
+        return { path: "notes.txt", replaced: false };
+      },
+      async bash() {
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    };
+    const provider = {
+      async ensureSession() {
+        return { sessionId: "session-1", sandbox: sandboxSession };
+      },
+      async suspendSession() {
+        throw new Error("provider unavailable");
+      },
+    };
+    const sandbox = await createInAppAgentSandbox({
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      provider,
+      getToolCallFiles: async () => [],
+      saveState: async () => {},
+    });
+
+    await sandbox.sandbox.write({ path: "notes.txt", content: "hello" });
+
+    await expect(sandbox.onTurnEnded()).resolves.toBeUndefined();
+  });
+
   it("syncs same-turn silent tool output into sandbox tool-call files", async () => {
     const files = new Map<string, string>();
     const toolCallFiles = createSandboxToolCallFileAccumulator([]);

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
@@ -58,6 +58,44 @@ const scenarioRef = vi.hoisted(() => ({
   titleInferenceCalls: 0,
 }));
 
+// Disabled by default (mirrors the rest of this suite's mocked agent
+// execution); a test flips `enabled` to exercise sandbox suspension.
+const sandboxRef = vi.hoisted(() => ({
+  enabled: false,
+  suspendedSessionIds: [] as string[],
+}));
+
+vi.mock(
+  "@langfuse/shared/in-app-agent/server/sandbox/config",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@langfuse/shared/in-app-agent/server/sandbox/config")
+      >();
+
+    return {
+      ...actual,
+      getDefaultInAppAgentSandboxProviderType: () =>
+        sandboxRef.enabled ? "lambda-microvm" : null,
+      createInAppAgentSandboxProvider: async () => ({
+        ensureSession: async ({ sessionId }: { sessionId: string | null }) => ({
+          sessionId: sessionId ?? "provider-session-1",
+          sandbox: {
+            read: async () => ({ path: "notes.txt", content: null }),
+            write: async () => ({ path: "notes.txt", bytesWritten: 0 }),
+            edit: async () => ({ path: "notes.txt", replaced: false }),
+            bash: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+            syncReadonlyFiles: async () => {},
+          },
+        }),
+        suspendSession: async ({ sessionId }: { sessionId: string }) => {
+          sandboxRef.suspendedSessionIds.push(sessionId);
+        },
+      }),
+    };
+  },
+);
+
 vi.mock("@langfuse/shared/in-app-agent/server", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -266,6 +304,8 @@ async function seedApprovedContinuation(opts?: {
 describe("executeInAppAgentRun", () => {
   beforeEach(() => {
     scenarioRef.titleInferenceCalls = 0;
+    sandboxRef.enabled = false;
+    sandboxRef.suspendedSessionIds = [];
   });
 
   it("does not regenerate the conversation title after executing a user-message run", async () => {
@@ -516,8 +556,13 @@ describe("executeInAppAgentRun", () => {
     expect(await getInAppAgentApiKeys(projectId)).toHaveLength(0);
   });
 
-  it("stops writing when fenced: an externally reconciled run keeps its recorded outcome", async () => {
-    const { projectId, run } = await seedBackgroundRun();
+  it("stops writing when fenced: an externally reconciled run keeps its recorded outcome, and does not suspend a session a newer run may already own", async () => {
+    sandboxRef.enabled = true;
+    const { projectId, conversation, run } = await seedBackgroundRun();
+    await prisma.inAppAgentConversation.update({
+      where: { id_projectId: { id: conversation.id, projectId } },
+      data: { providerSessionId: "provider-session-1" },
+    });
 
     scenarioRef.current = async ({ signal, options }) => {
       // Simulate read-side reconciliation flipping the run away mid-loop.
@@ -546,6 +591,9 @@ describe("executeInAppAgentRun", () => {
     expect(fenced.errorCode).toBe("worker_lost");
     expect(fenced.errorMessage).toBe("The run was interrupted.");
     expect(await getInAppAgentApiKeys(projectId)).toHaveLength(0);
+    // A newer run already claimed ownership of the conversation; suspending
+    // here could race that run's own sandbox operations on the same session.
+    expect(sandboxRef.suspendedSessionIds).toEqual([]);
   });
 
   it("finishes an approved continuation without a persisted tool result as FAILED (outcome_unknown)", async () => {

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -495,6 +495,17 @@ export async function executeInAppAgentRun(params: {
         },
         onFinish: async () => {
           await cleanupMcpApiKeyLogged();
+
+          const reason = abortController.signal.reason as AbortReason;
+          if (reason === "fenced") {
+            // Reconciliation already admitted a newer run for this
+            // conversation, which may already be using the persisted
+            // session; suspending it here would race that run's own
+            // sandbox operations. The newer run's own onTurnEnded owns
+            // suspension instead.
+            return;
+          }
+
           await sandboxState?.onTurnEnded();
         },
         awsBedrock: {


### PR DESCRIPTION
## What does this PR do?

Fixes #15953

The in-app agent sandbox contract documents `suspendSession` as the hook a
provider uses to release live runtime resources while keeping the session
reusable (`packages/shared/src/in-app-agent/server/sandbox/types.ts`). Both
providers implement it: the Lambda MicroVM provider calls `SuspendMicrovmCommand`
(`packages/shared/src/in-app-agent/server/sandbox/providers/lambdaMicrovm.ts`),
and the Docker provider drops its in-memory session handle
(`packages/shared/src/in-app-agent/server/sandbox/providers/docker.ts`).

Nothing ever called it. `createInAppAgentSandbox`'s `onTurnEnded` callback
(`packages/shared/src/in-app-agent/server/sandbox/service.ts`) only persisted
`providerSessionId` to the database and returned — the provider hook was
unreachable from the one production caller
(`worker/src/features/in-app-agent/executeInAppAgentRun.ts`'s `onFinish`).
For the Lambda MicroVM provider this means a microVM is never asked to
suspend after a turn ends, so it keeps running until some other process
terminates it.

This PR wires `onTurnEnded` to call `provider.suspendSession` with the
persisted session id after saving state, with the failure logged (not
thrown) so a suspend error doesn't fail the run's cleanup path.

Terminating a session permanently (`terminateSession`) when a conversation is
deleted is a separate, larger change (deletion currently happens from `web`,
while sandbox providers are only ever constructed in `worker`) and is left
out of this PR to keep the fix minimal and reviewable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Testing

Added a test asserting the fix's own behavior — `suspendSession` is called
with the persisted session id when a turn ends — plus a test that a
`suspendSession` failure doesn't throw out of `onTurnEnded`.

Confirmed the new test fails without the fix:

```
git checkout HEAD~1 -- packages/shared/src/in-app-agent/server/sandbox/service.ts
pnpm exec dotenv -e ../.env.test -e ../.env -- pnpm exec vitest run --project server-unit --project server-shared-source-unit src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts

 × suspends the provider session when a turn ends 12ms (retry x3)
AssertionError: expected [] to deeply equal [ 'session-1' ]
 Tests  1 failed | 13 passed (14)
```

With the fix restored:

```
pnpm exec dotenv -e ../.env.test -e ../.env -- pnpm exec vitest run --project server-unit --project server-shared-source-unit src/__tests__/server/unit/in-app-agent-sandbox.servertest.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Also ran the surrounding suites to check for regressions:

```
pnpm exec dotenv -e ../.env.test -e ../.env -- pnpm exec vitest run --project server --project server-isolated --project server-shared-source --project server-unit --project server-shared-source-unit src/__tests__/server/unit/in-app-agent-lambda-microvm-provider.servertest.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)

pnpm exec dotenv -e ../.env.test -e ../.env -- pnpm exec vitest run --project server --project server-isolated --project server-shared-source --project server-unit --project server-shared-source-unit src/__tests__/server/in-app-agent-stream.servertest.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)

cd worker && pnpm exec dotenv -e ../.env.test -e ../.env -- pnpm run test src/features/in-app-agent/executeInAppAgentRun.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

`pnpm --filter @langfuse/shared run lint` and `pnpm --filter web run lint`
both pass with no new warnings.

## AI disclosure

This change was authored with AI assistance (Claude Code), reviewed and
verified by the human contributor before submission.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR invokes the sandbox provider's suspension hook after persisting turn state and logs suspension failures without failing cleanup.
- Suspends reusable Docker or Lambda MicroVM sessions when a turn ends.
- Adds unit coverage for successful suspension and suppressed provider failures.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until suspension is ordered or guarded so an old turn cannot suspend a microVM already used by the next turn.

Terminal persistence releases the conversation lock before the new suspension call executes, allowing a subsequent turn to acquire and use the same microVM before the previous turn suspends it.

**Files Needing Attention:** packages/shared/src/in-app-agent/server/sandbox/service.ts
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant T1 as Completed turn
  participant DB as Run lifecycle
  participant T2 as Next turn
  participant VM as Shared microVM
  T1->>DB: Persist finishedAt
  DB-->>T2: Active-run lock released
  T2->>VM: Ensure/resume and begin use
  T1->>VM: SuspendSession
  VM-->>T2: Sandbox operation fails
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/in-app-agent/server/sandbox/service.ts:117
**Late suspension races next turn**

If consecutive turns overlap during terminal cleanup, the completed turn calls `suspendSession` after `finishedAt` has already released the conversation lock, so it can suspend the shared microVM after the next turn has resumed and started using it, causing that turn's sandbox operations to fail.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): suspend the sandbox p..."](https://github.com/langfuse/langfuse/commit/362d338a22e25fb5cb5aef54bc26337389210583) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54368903)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)

<!-- /greptile_comment -->