### PR TITLE
fix(otel): map flattened invocation parameters

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.modelParameters.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.modelParameters.test.ts
@@ -167,4 +167,68 @@ describe("OtelIngestionProcessor model parameters", () => {
       service_tier: "priority",
     });
   });
+
+  it("maps flattened OpenInference invocation parameters", () => {
+    const batch: ResourceSpan[] = [
+      {
+        scopeSpans: [
+          {
+            scope: { name: "config-task-service-ai", version: "0.1.0" },
+            spans: [
+              {
+                traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+                spanId: Buffer.from("0123456789abcdef", "hex"),
+                name: "gen_ai.client.operation",
+                kind: 3,
+                startTimeUnixNano: "1752384000000000000",
+                endTimeUnixNano: "1752384001000000000",
+                attributes: [
+                  {
+                    key: "openinference.span.kind",
+                    value: { stringValue: "LLM" },
+                  },
+                  {
+                    key: "llm.model_name",
+                    value: { stringValue: "gpt-5.6-luna" },
+                  },
+                  {
+                    key: "llm.invocation_parameters.temperature",
+                    value: { doubleValue: 0.1 },
+                  },
+                  {
+                    key: "llm.invocation_parameters.max_tokens",
+                    value: { intValue: { low: 6000, high: 0 } },
+                  },
+                  {
+                    key: "llm.invocation_parameters.reasoning_effort",
+                    value: { stringValue: "high" },
+                  },
+                  {
+                    key: "llm.invocation_parameters.service_tier",
+                    value: { stringValue: "priority" },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const events = new OtelIngestionProcessor({
+      projectId: "project-1",
+      publicKey: "pk-test",
+      sdkName: "opentelemetry",
+      sdkVersion: "1.31.0",
+    }).processToEvent(batch);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].modelParameters).toEqual({
+      temperature: 0.1,
+      max_tokens: 6000,
+      reasoning_effort: "high",
+      service_tier: "priority",
+    });
+  });
 });

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2542,13 +2542,19 @@ export class OtelIngestionProcessor {
       }
     }
 
-    const modelParameters = Object.keys(attributes).filter((key) =>
-      key.startsWith("gen_ai.request."),
+    const modelParameterPrefixes = [
+      "gen_ai.request.",
+      "llm.invocation_parameters.",
+    ];
+    const modelParameters = modelParameterPrefixes.flatMap((prefix) =>
+      Object.keys(attributes)
+        .filter((key) => key.startsWith(prefix))
+        .map((key) => ({ key, prefix })),
     );
 
     return this.sanitizeModelParams(
-      modelParameters.reduce((acc: any, key) => {
-        const modelParamKey = key.replace("gen_ai.request.", "");
+      modelParameters.reduce((acc: any, { key, prefix }) => {
+        const modelParamKey = key.replace(prefix, "");
         if (modelParamKey !== "model") {
           acc[modelParamKey] = attributes[key];
         }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16249.preview.langfuse.com](https://pr-16249.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Context

OpenInference-instrumented OpenAI generations can emit invocation parameters as flattened OTLP attributes such as `llm.invocation_parameters.service_tier`. Langfuse currently keeps these values in metadata but leaves `modelParameters` empty, so pricing tier matching cannot select priority pricing.

## Solution

- Map flattened `llm.invocation_parameters.*` attributes into `modelParameters` in the shared OTLP ingestion processor.
- Preserve the existing precedence for explicit Langfuse parameters, canonical JSON `llm.invocation_parameters`, and `model_config`.
- Cover the observed OpenAI shape for temperature, max tokens, reasoning effort, and priority service tier.

## Validation

- `pnpm exec dotenv -e '.env.dev.example' -- pnpm --filter @langfuse/shared run test OtelIngestionProcessor.modelParameters.test.ts` — 4 passed
- `pnpm exec dotenv -e '.env.dev.example' -- pnpm --filter web run test otelMapping.servertest.ts` — 245 passed, 1 skipped
- `pnpm exec dotenv -e '.env.dev.example' -- pnpm --filter worker run test pricing-tier-matcher.test.ts` — 64 passed
- `pnpm run lint` — 7 successful, 7 total
- `pnpm --filter @langfuse/shared run typecheck` — passed
- `git diff --check` — passed

## Scope

Impacted package: `@langfuse/shared`. No pricing catalog, schema, SDK, or historical recalculation changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends shared OTLP ingestion to map flattened OpenInference invocation attributes into model parameters while retaining the existing higher-level parameter-source precedence.
- Recognizes both `gen_ai.request.*` and `llm.invocation_parameters.*` attribute prefixes.
- Strips each recognized prefix before sanitizing the resulting model parameters.
- Adds coverage for temperature, maximum tokens, reasoning effort, and priority service tier.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The new prefix mapping feeds flattened OpenInference attributes through the same extraction and sanitization path used by existing model parameters, and the added test covers the intended observed input shape.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): map flattened invocation para..."](https://github.com/langfuse/langfuse/commit/076ad6d8c5973154402e12c982d7370ec21c6ccd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54374534)</sub>

<!-- /greptile_comment -->