### PR TITLE
feat(in-app-agent): route traces through v4 OTel ingestion

### DIFF
--- a/packages/shared/src/in-app-agent/server/agent.ts
+++ b/packages/shared/src/in-app-agent/server/agent.ts
@@ -244,14 +244,21 @@ export async function createAgUiStream(params: {
     operation: string,
     callback: (
       activeInstrumentation: NonNullable<typeof instrumentation>,
-    ) => void,
-  ) => {
+    ) => void | Promise<void>,
+  ): Promise<void> => {
     if (!instrumentation) {
-      return;
+      return Promise.resolve();
     }
 
     try {
-      callback(instrumentation);
+      return Promise.resolve(callback(instrumentation)).catch((error) => {
+        logger.warn("Failed to record in-app agent Langfuse tracing", {
+          error,
+          operation,
+          runId: params.input.runId,
+          threadId: params.input.threadId,
+        });
+      });
     } catch (error) {
       logger.warn("Failed to record in-app agent Langfuse tracing", {
         error,
@@ -259,6 +266,7 @@ export async function createAgUiStream(params: {
         runId: params.input.runId,
         threadId: params.input.threadId,
       });
+      return Promise.resolve();
     }
   };
   recordInstrumentation("recordAvailableSkills", (instrumentation) =>
@@ -376,7 +384,7 @@ export async function createAgUiStream(params: {
         recordInstrumentation("endWithError", (instrumentation) =>
           instrumentation.endWithError(error),
         );
-        recordInstrumentation("flush", (instrumentation) =>
+        const flushPromise = recordInstrumentation("flush", (instrumentation) =>
           instrumentation.flush(),
         );
         ending = true;
@@ -394,9 +402,15 @@ export async function createAgUiStream(params: {
         });
 
         runTerminalCallback(
-          () => params.options.onError?.(error),
-          "Error while marking agent stream as failed",
+          () => flushPromise,
+          "Error while flushing agent stream tracing after failure",
         )
+          .then(() =>
+            runTerminalCallback(
+              () => params.options.onError?.(error),
+              "Error while marking agent stream as failed",
+            ),
+          )
           .then(() =>
             runTerminalCallback(
               runOnFinish,
@@ -485,15 +499,21 @@ export async function createAgUiStream(params: {
         recordInstrumentation("end", (instrumentation) =>
           instrumentation.end({ aborted: true }),
         );
-        recordInstrumentation("flush", (instrumentation) =>
-          instrumentation.flush(),
-        );
         ending = true;
         shouldEnqueue = false;
         removeAbortHandler();
         interruptAdapter?.();
         subscription?.unsubscribe();
         eventQueue
+          .then(() =>
+            runTerminalCallback(
+              () =>
+                recordInstrumentation("flush", (instrumentation) =>
+                  instrumentation.flush(),
+                ),
+              "Error while flushing agent stream tracing after abort",
+            ),
+          )
           .then(() =>
             runTerminalCallback(
               () => params.options.onAbort?.(),
@@ -711,12 +731,11 @@ export async function createAgUiStream(params: {
               }
 
               if (streamedRunError !== null) {
-                closeController(() => {
+                closeController(() =>
                   recordInstrumentation("flush", (instrumentation) =>
                     instrumentation.flush(),
-                  );
-                  return handleStreamedRunError();
-                });
+                  ).then(() => handleStreamedRunError()),
+                );
                 return;
               }
 
@@ -755,16 +774,14 @@ export async function createAgUiStream(params: {
                       recordInstrumentation("end", (instrumentation) =>
                         instrumentation.end({}),
                       );
-                      recordInstrumentation("flush", (instrumentation) =>
+                      return recordInstrumentation("flush", (instrumentation) =>
                         instrumentation.flush(),
-                      );
-                      return params.options.onComplete?.();
+                      ).then(() => params.options.onComplete?.());
                     }
                   : () => {
-                      recordInstrumentation("flush", (instrumentation) =>
+                      return recordInstrumentation("flush", (instrumentation) =>
                         instrumentation.flush(),
-                      );
-                      return handleStreamedRunError();
+                      ).then(() => handleStreamedRunError());
                     },
               );
             },
@@ -807,14 +824,20 @@ export async function createAgUiStream(params: {
       recordInstrumentation("end", (instrumentation) =>
         instrumentation.end({ aborted: true }),
       );
-      recordInstrumentation("flush", (instrumentation) =>
-        instrumentation.flush(),
-      );
       shouldEnqueue = false;
       removeAbortHandler();
       interruptAdapter?.();
       subscription?.unsubscribe();
       eventQueue
+        .then(() =>
+          runTerminalCallback(
+            () =>
+              recordInstrumentation("flush", (instrumentation) =>
+                instrumentation.flush(),
+              ),
+            "Error while flushing agent stream tracing after cancel",
+          ),
+        )
         .then(() =>
           runTerminalCallback(
             () => params.options.onAbort?.(),

--- a/packages/shared/src/in-app-agent/server/instrumentation.test.ts
+++ b/packages/shared/src/in-app-agent/server/instrumentation.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetInternalTracingHandler, mockProcessTracedEvents } = vi.hoisted(
+  () => ({
+    mockGetInternalTracingHandler: vi.fn(),
+    mockProcessTracedEvents: vi.fn(),
+  }),
+);
+
+vi.mock("../../server", () => ({
+  getInternalTracingHandler: mockGetInternalTracingHandler,
+  logger: {
+    warn: vi.fn(),
+  },
+}));
+
+import { createInAppAgentInstrumentation } from "./instrumentation";
+
+describe("in-app agent instrumentation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInternalTracingHandler.mockReturnValue({
+      handler: {
+        langfuse: {
+          trace: vi.fn(() => ({ update: vi.fn() })),
+          enqueue: vi.fn(),
+        },
+      },
+      processTracedEvents: mockProcessTracedEvents,
+    });
+  });
+
+  it("shares one promise when terminal flushes race", async () => {
+    let resolveFlush!: () => void;
+    mockProcessTracedEvents.mockImplementation(
+      () => new Promise<void>((resolve) => (resolveFlush = resolve)),
+    );
+
+    const instrumentation = createInAppAgentInstrumentation({
+      input: {
+        threadId: "thread-1",
+        runId: "run-1",
+        messages: [],
+        tools: [],
+        context: [],
+      },
+      tracing: {
+        targetProjectId: "project-1",
+        environment: "langfuse-in-app-agent",
+        metadata: {},
+        runId: "run-1",
+        user: {
+          id: "user-1",
+          isAdmin: false,
+        },
+      },
+    });
+
+    const firstFlush = instrumentation!.flush();
+    const secondFlush = instrumentation!.flush();
+
+    expect(firstFlush).toBe(secondFlush);
+    expect(mockProcessTracedEvents).toHaveBeenCalledTimes(1);
+
+    resolveFlush();
+    await firstFlush;
+  });
+});

--- a/packages/shared/src/in-app-agent/server/instrumentation.ts
+++ b/packages/shared/src/in-app-agent/server/instrumentation.ts
@@ -35,6 +35,7 @@ export type InAppAgentTracingConfig = {
   };
   runId: string;
   targetProjectId: string;
+  ingestionMode?: "legacy" | "otel-v4";
   prompt?: InAppAgentPromptMetadata;
 };
 
@@ -168,6 +169,7 @@ export function createInAppAgentInstrumentation({
       runId: tracing.runId,
       targetProjectId: tracing.targetProjectId,
       environment: tracing.environment,
+      ingestionMode: tracing.ingestionMode,
       prompt: tracing.prompt,
       model,
     });
@@ -179,6 +181,7 @@ export function createInAppAgentInstrumentation({
 
 export class InAppAgentInstrumentation {
   private readonly processTracedEvents: () => Promise<void>;
+  private flushPromise?: Promise<void>;
   private readonly langfuse: InAppAgentLangfuse;
   private readonly trace: InAppAgentTrace;
   private readonly runId: string;
@@ -216,6 +219,7 @@ export class InAppAgentInstrumentation {
     runId: string;
     targetProjectId: string;
     environment: string;
+    ingestionMode?: "legacy" | "otel-v4";
     prompt?: InAppAgentPromptMetadata;
     model?: string;
   }) {
@@ -260,6 +264,7 @@ export class InAppAgentInstrumentation {
       userId: params.userId,
       metadata: this.metadata,
       prompt: params.prompt,
+      ingestionMode: params.ingestionMode,
     };
     const { handler, processTracedEvents } =
       getInternalTracingHandler(traceSinkParams);
@@ -481,10 +486,12 @@ export class InAppAgentInstrumentation {
     this.ended = true;
   }
 
-  flush() {
-    this.processTracedEvents().catch((error) => {
+  flush(): Promise<void> {
+    this.flushPromise ??= this.processTracedEvents().catch((error) => {
       logger.warn("Failed to flush in-app agent Langfuse tracing", error);
     });
+
+    return this.flushPromise;
   }
 
   private recordEvent(event: AgUiEvent) {

--- a/packages/shared/src/server/llm/getInternalTracingHandler.ts
+++ b/packages/shared/src/server/llm/getInternalTracingHandler.ts
@@ -4,7 +4,9 @@ import { buildInternalTraceEventInputs } from "./internalTraceEvents";
 import { processEventBatch } from "../ingestion/processEventBatch";
 import { createUnknownSdkIngestionAttribution } from "../ingestion/ingestionAttribution";
 import { logger } from "../logger";
-import { traceException } from "../instrumentation";
+import { recordIncrement, traceException } from "../instrumentation";
+import { env } from "../../env";
+import { publishInternalTraceInputsViaOtelIngestion } from "../otel/internalTraceOtelWriter";
 
 export function prepareInternalTraceEvents(params: {
   events: Array<{
@@ -76,8 +78,14 @@ export function getInternalTracingHandler(traceSinkParams: TraceSinkParams): {
   handler: CallbackHandler;
   processTracedEvents: () => Promise<void>;
 } {
-  const { prompt, targetProjectId, environment, userId, eventsWriter } =
-    traceSinkParams;
+  const {
+    prompt,
+    targetProjectId,
+    environment,
+    userId,
+    eventsWriter,
+    ingestionMode = "legacy",
+  } = traceSinkParams;
   const handler = new CallbackHandler({
     _projectId: targetProjectId,
     _isLocalEventExportEnabled: true,
@@ -95,6 +103,38 @@ export function getInternalTracingHandler(traceSinkParams: TraceSinkParams): {
         environment,
         prompt,
       });
+
+      if (ingestionMode === "otel-v4") {
+        if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "legacy") {
+          recordIncrement("langfuse.internal_trace.v4_required_legacy_mode");
+          logger.warn(
+            "Skipping in-app agent tracing because v4 ingestion is disabled",
+            { projectId: targetProjectId },
+          );
+          return;
+        }
+
+        try {
+          const { eventInputs } = buildInternalTraceEventInputs({
+            processedEvents,
+            traceId: traceSinkParams.traceId,
+            projectId: targetProjectId,
+          });
+
+          await publishInternalTraceInputsViaOtelIngestion({
+            eventInputs,
+            projectId: targetProjectId,
+          });
+        } catch (writeError) {
+          traceException(writeError);
+          logger.error("Failed to publish internal traced events via OTel", {
+            error: writeError,
+            projectId: targetProjectId,
+          });
+        }
+
+        return;
+      }
 
       // Legacy write to traces/observations tables
       try {

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -547,6 +547,11 @@ export type TraceSinkParams = {
     version: number;
   };
   /**
+   * Internal ingestion path for the trace sink. The in-app agent uses the
+   * v4 OTel queue; other internal tracing consumers keep the legacy default.
+   */
+  ingestionMode?: "legacy" | "otel-v4";
+  /**
    * When provided, traced events are written directly to the events table,
    * bypassing the legacy traces/observations ingestion pipeline for the events write.
    * Used for internal tracing (prompt experiments, LLM-as-a-judge evaluations). Traced

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -197,9 +197,9 @@ export interface ResourceSpan {
       attributes?: Array<{ key: string; value: any }>;
     };
     spans?: Array<{
-      traceId: { data?: Buffer } | Buffer;
-      spanId: { data?: Buffer } | Buffer;
-      parentSpanId?: { data?: Buffer } | Buffer;
+      traceId: string | { data?: Buffer } | Buffer;
+      spanId: string | { data?: Buffer } | Buffer;
+      parentSpanId?: string | { data?: Buffer } | Buffer;
       name: string;
       kind: number;
       startTimeUnixNano?: NanoTimestamp;

--- a/packages/shared/src/server/otel/internalTraceOtelWriter.test.ts
+++ b/packages/shared/src/server/otel/internalTraceOtelWriter.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  publishInternalTraceInputsViaOtelIngestion,
   writeInternalTraceViaOtelIngestion,
   type InternalOtelSpanInput,
 } from "./internalTraceOtelWriter";
 
 const publishToOtelIngestionQueue = vi.fn().mockResolvedValue(undefined);
+let processorConfig: Record<string, unknown> | undefined;
 
 vi.mock("./OtelIngestionProcessor", async (importOriginal) => {
   const actual =
@@ -14,6 +16,10 @@ vi.mock("./OtelIngestionProcessor", async (importOriginal) => {
     ...actual,
     OtelIngestionProcessor: class {
       publishToOtelIngestionQueue = publishToOtelIngestionQueue;
+
+      constructor(config: Record<string, unknown>) {
+        processorConfig = config;
+      }
     },
   };
 });
@@ -62,6 +68,7 @@ const processPublishedSpans = async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  processorConfig = undefined;
 });
 
 describe("writeInternalTraceViaOtelIngestion", () => {
@@ -149,5 +156,107 @@ describe("writeInternalTraceViaOtelIngestion", () => {
     });
 
     expect(publishToOtelIngestionQueue).not.toHaveBeenCalled();
+  });
+});
+
+describe("publishInternalTraceInputsViaOtelIngestion", () => {
+  it("preserves in-app trace and observation IDs through the real OTel converter", async () => {
+    const inAppTraceId = "arun_run-123-trace";
+    const rootObservationId = "arun_run-123";
+    const generationId = "arun_run-123-llm-1";
+
+    await publishInternalTraceInputsViaOtelIngestion({
+      projectId: "project-1",
+      eventInputs: [
+        {
+          projectId: "project-1",
+          traceId: inAppTraceId,
+          spanId: rootObservationId,
+          startTimeISO: START_ISO,
+          endTimeISO: END_ISO,
+          name: "agent-turn",
+          type: "SPAN",
+          environment: "langfuse-in-app-agent",
+          traceName: "agent-turn",
+          level: "ERROR",
+          statusMessage: "agent failed",
+          userId: "user-1",
+          sessionId: "conversation-1",
+          tags: ["in-app-agent"],
+          metadata: { feature: "assistant" },
+          input: '{"messages":[]}',
+          output: '{"text":"hello"}',
+          source: "in-app-agent",
+        },
+        {
+          projectId: "project-1",
+          traceId: inAppTraceId,
+          spanId: generationId,
+          parentSpanId: rootObservationId,
+          startTimeISO: START_ISO,
+          endTimeISO: END_ISO,
+          name: "invoke-model",
+          type: "GENERATION",
+          environment: "langfuse-in-app-agent",
+          metadata: {},
+          modelName: "claude-test",
+          modelParameters: { temperature: 0.2 },
+          providedUsageDetails: { input: 10, output: 5, total: 15 },
+          providedCostDetails: { input: 0.01, output: 0.02, total: 0.03 },
+          promptName: "assistant-prompt",
+          promptVersion: "3",
+          completionStartTime: START_ISO,
+          input: '{"messages":[]}',
+          output: '{"text":"hello"}',
+          source: "in-app-agent",
+        },
+      ],
+    });
+
+    expect(processorConfig).toMatchObject({
+      ingestionVersion: "4",
+      isLangfuseInternal: true,
+    });
+
+    const events = await processPublishedSpans();
+    const root = events.find(
+      (event: any) => event.spanId === rootObservationId,
+    );
+    const generation = events.find(
+      (event: any) => event.spanId === generationId,
+    );
+
+    expect(root).toMatchObject({
+      traceId: inAppTraceId,
+      spanId: rootObservationId,
+      parentSpanId: null,
+      traceName: "agent-turn",
+      userId: "user-1",
+      sessionId: "conversation-1",
+      environment: "langfuse-in-app-agent",
+      level: "ERROR",
+      statusMessage: "agent failed",
+      input: '{"messages":[]}',
+      output: '{"text":"hello"}',
+      startTimeISO: START_ISO,
+      endTimeISO: END_ISO,
+    });
+    expect(root.metadata).toMatchObject({ feature: "assistant" });
+    expect(generation).toMatchObject({
+      traceId: inAppTraceId,
+      spanId: generationId,
+      parentSpanId: rootObservationId,
+      modelName: "claude-test",
+      modelParameters: { temperature: 0.2 },
+      promptName: "assistant-prompt",
+      promptVersion: "3",
+      providedUsageDetails: { input: 10, output: 5, total: 15 },
+      providedCostDetails: { input: 0.01, output: 0.02, total: 0.03 },
+      input: '{"messages":[]}',
+      output: '{"text":"hello"}',
+      startTimeISO: START_ISO,
+      endTimeISO: END_ISO,
+      completionStartTime: START_ISO,
+    });
   });
 });

--- a/packages/shared/src/server/otel/internalTraceOtelWriter.ts
+++ b/packages/shared/src/server/otel/internalTraceOtelWriter.ts
@@ -18,7 +18,10 @@ import {
 import type { InternalTraceEventInput } from "../llm/internalTraceEvents";
 import { logger } from "../logger";
 import { LangfuseOtelSpanAttributes } from "./attributes";
-import { OtelIngestionProcessor } from "./OtelIngestionProcessor";
+import {
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "./OtelIngestionProcessor";
 
 const INTERNAL_TRACE_WRITER_SDK_NAME = "langfuse-internal-otel-writer";
 const INTERNAL_TRACE_WRITER_SCOPE = "langfuse-internal-trace-writer";
@@ -44,6 +47,25 @@ export async function publishInternalOtelSpans(params: {
 
   if (!resourceSpans || resourceSpans.length === 0) return;
 
+  await publishInternalOtelResourceSpans({
+    resourceSpans,
+    projectId: params.projectId,
+    sdkName: params.sdkName,
+  });
+}
+
+/**
+ * Publishes already-shaped internal resource spans through the v4 OTel queue.
+ * This intentionally bypasses OTLP serialization so internal producers can
+ * preserve Langfuse observation IDs that are not W3C hexadecimal span IDs.
+ */
+export async function publishInternalOtelResourceSpans(params: {
+  resourceSpans: ResourceSpan[];
+  projectId: string;
+  sdkName: string;
+}): Promise<void> {
+  if (params.resourceSpans.length === 0) return;
+
   const processor = new OtelIngestionProcessor({
     projectId: params.projectId,
     publicKey: "", // internal ingestion has no API key; mirrors internal event writes
@@ -64,7 +86,222 @@ export async function publishInternalOtelSpans(params: {
     isLangfuseInternal: true,
   });
 
-  await processor.publishToOtelIngestionQueue(resourceSpans);
+  await processor.publishToOtelIngestionQueue(params.resourceSpans);
+}
+
+type InternalOtelAttribute = {
+  key: string;
+  value: { stringValue: string };
+};
+
+function stringAttribute(
+  key: string,
+  value: string | undefined | null,
+): InternalOtelAttribute | undefined {
+  return value === undefined || value === null
+    ? undefined
+    : { key, value: { stringValue: value } };
+}
+
+function jsonAttribute(
+  key: string,
+  value: unknown,
+): InternalOtelAttribute | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  return stringAttribute(key, JSON.stringify(value));
+}
+
+function timestampToUnixNano(timestamp: string): string {
+  const milliseconds = Date.parse(timestamp);
+  if (Number.isNaN(milliseconds)) {
+    throw new Error(`Invalid internal trace timestamp: ${timestamp}`);
+  }
+
+  return `${BigInt(milliseconds) * 1_000_000n}`;
+}
+
+function observationTypeToOtelType(type: string | undefined): string {
+  switch (type?.toUpperCase()) {
+    case "GENERATION":
+      return "generation";
+    case "EVENT":
+      return "event";
+    case "EMBEDDING":
+      return "embedding";
+    case "AGENT":
+      return "agent";
+    case "TOOL":
+      return "tool";
+    case "CHAIN":
+      return "chain";
+    case "RETRIEVER":
+      return "retriever";
+    case "GUARDRAIL":
+      return "guardrail";
+    case "EVALUATOR":
+      return "evaluator";
+    default:
+      return "span";
+  }
+}
+
+function internalTraceInputsToResourceSpans(
+  eventInputs: InternalTraceEventInput[],
+): ResourceSpan[] {
+  const spans = eventInputs.map((eventInput) => {
+    const isRoot = !eventInput.parentSpanId;
+    const attributes = [
+      stringAttribute(
+        LangfuseOtelSpanAttributes.ENVIRONMENT,
+        eventInput.environment,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_TYPE,
+        observationTypeToOtelType(eventInput.type),
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_LEVEL,
+        eventInput.level,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE,
+        eventInput.statusMessage,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+        eventInput.input,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+        eventInput.output,
+      ),
+      jsonAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_METADATA,
+        eventInput.metadata,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
+        eventInput.modelName,
+      ),
+      jsonAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS,
+        eventInput.modelParameters,
+      ),
+      jsonAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS,
+        eventInput.providedUsageDetails,
+      ),
+      jsonAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS,
+        eventInput.providedCostDetails,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME,
+        eventInput.promptName,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION,
+        eventInput.promptVersion,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME,
+        eventInput.completionStartTime,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.TRACE_USER_ID,
+        eventInput.userId,
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.TRACE_SESSION_ID,
+        eventInput.sessionId,
+      ),
+      jsonAttribute(LangfuseOtelSpanAttributes.TRACE_TAGS, eventInput.tags),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.TRACE_PUBLIC,
+        eventInput.public === undefined ? undefined : String(eventInput.public),
+      ),
+      stringAttribute(
+        LangfuseOtelSpanAttributes.IS_APP_ROOT,
+        eventInput.isAppRoot === undefined || eventInput.isAppRoot === null
+          ? undefined
+          : String(eventInput.isAppRoot),
+      ),
+      stringAttribute(LangfuseOtelSpanAttributes.RELEASE, eventInput.release),
+      ...(isRoot
+        ? [
+            stringAttribute(
+              LangfuseOtelSpanAttributes.TRACE_NAME,
+              eventInput.traceName,
+            ),
+            jsonAttribute(
+              LangfuseOtelSpanAttributes.TRACE_METADATA,
+              eventInput.metadata,
+            ),
+          ]
+        : []),
+    ].filter((attribute): attribute is InternalOtelAttribute =>
+      Boolean(attribute),
+    );
+
+    return {
+      traceId: eventInput.traceId,
+      spanId: eventInput.spanId,
+      ...(eventInput.parentSpanId
+        ? { parentSpanId: eventInput.parentSpanId }
+        : {}),
+      name: eventInput.name ?? "span",
+      kind: 1,
+      startTimeUnixNano: timestampToUnixNano(eventInput.startTimeISO),
+      endTimeUnixNano: timestampToUnixNano(eventInput.endTimeISO),
+      attributes,
+      status: {
+        ...(eventInput.level === "ERROR" ? { code: 2 } : {}),
+        ...(eventInput.statusMessage
+          ? { message: eventInput.statusMessage }
+          : {}),
+      },
+    };
+  });
+
+  return [
+    {
+      resource: {
+        attributes: [
+          {
+            key: "service.name",
+            value: { stringValue: "langfuse-in-app-agent" },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: {
+            name: INTERNAL_TRACE_WRITER_SCOPE,
+            version: "unknown",
+          },
+          spans,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Publishes normalized internal trace inputs through the v4 OTel ingestion
+ * queue while preserving Langfuse's existing trace and observation IDs.
+ */
+export async function publishInternalTraceInputsViaOtelIngestion(params: {
+  eventInputs: InternalTraceEventInput[];
+  projectId: string;
+}): Promise<void> {
+  if (params.eventInputs.length === 0) return;
+
+  await publishInternalOtelResourceSpans({
+    resourceSpans: internalTraceInputsToResourceSpans(params.eventInputs),
+    projectId: params.projectId,
+    sdkName: INTERNAL_TRACE_WRITER_SDK_NAME,
+  });
 }
 
 /**

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -697,6 +697,7 @@ function buildTracingConfig(params: {
         targetProjectId: traceSinkParams.targetProjectId,
         environment: traceSinkParams.environment,
         runId: params.runId,
+        ingestionMode: "otel-v4" as const,
         user: {
           id: params.user.id,
           email: params.user.email,

--- a/worker/src/features/internal-tracing/__tests__/getInternalTracingHandler.test.ts
+++ b/worker/src/features/internal-tracing/__tests__/getInternalTracingHandler.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockExportLocalEvents, mockProcessEventBatch, mockWrite } = vi.hoisted(
-  () => ({
-    mockExportLocalEvents: vi.fn(),
-    mockProcessEventBatch: vi.fn(),
-    mockWrite: vi.fn(),
-  }),
-);
+const {
+  mockExportLocalEvents,
+  mockProcessEventBatch,
+  mockPublishInternalTraceInputsViaOtelIngestion,
+  mockWrite,
+} = vi.hoisted(() => ({
+  mockExportLocalEvents: vi.fn(),
+  mockProcessEventBatch: vi.fn(),
+  mockPublishInternalTraceInputsViaOtelIngestion: vi.fn(),
+  mockWrite: vi.fn(),
+}));
 
 vi.mock("langfuse-langchain", () => {
   return {
@@ -27,7 +31,16 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "../../../../../packages/shared/src/server/otel/internalTraceOtelWriter",
+  () => ({
+    publishInternalTraceInputsViaOtelIngestion:
+      mockPublishInternalTraceInputsViaOtelIngestion,
+  }),
+);
+
 import { getInternalTracingHandler } from "../../../../../packages/shared/src/server/llm/getInternalTracingHandler";
+import { env } from "../../../../../packages/shared/src/env";
 import { LangfuseInternalTraceEnvironment } from "@langfuse/shared";
 
 const traceId = "trace-123";
@@ -83,7 +96,52 @@ describe("getInternalTracingHandler", () => {
       successes: [],
       errors: [],
     });
+    mockPublishInternalTraceInputsViaOtelIngestion.mockResolvedValue(undefined);
     mockWrite.mockResolvedValue(undefined);
+  });
+
+  it("publishes v4 OTel traces without entering legacy ingestion", async () => {
+    const { processTracedEvents } = getInternalTracingHandler({
+      targetProjectId: "project-123",
+      traceId,
+      traceName: "internal-trace",
+      environment: LangfuseInternalTraceEnvironment.InAppAgent,
+      ingestionMode: "otel-v4",
+    });
+
+    await processTracedEvents();
+
+    expect(mockProcessEventBatch).not.toHaveBeenCalled();
+    expect(mockPublishInternalTraceInputsViaOtelIngestion).toHaveBeenCalledWith(
+      {
+        projectId: "project-123",
+        eventInputs: expect.any(Array),
+      },
+    );
+  });
+
+  it("skips v4 tracing instead of falling back in legacy mode", async () => {
+    const previousMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+    env.LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+
+    try {
+      const { processTracedEvents } = getInternalTracingHandler({
+        targetProjectId: "project-123",
+        traceId,
+        traceName: "internal-trace",
+        environment: LangfuseInternalTraceEnvironment.InAppAgent,
+        ingestionMode: "otel-v4",
+      });
+
+      await processTracedEvents();
+
+      expect(
+        mockPublishInternalTraceInputsViaOtelIngestion,
+      ).not.toHaveBeenCalled();
+      expect(mockProcessEventBatch).not.toHaveBeenCalled();
+    } finally {
+      env.LANGFUSE_MIGRATION_V4_WRITE_MODE = previousMode;
+    }
   });
 
   it("disables staging propagation when direct event write is enabled", async () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16250.preview.langfuse.com](https://pr-16250.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Route in-app agent traces through the internal v4 OTel ingestion queue.
- Preserve existing Langfuse trace, observation, generation, and parent IDs plus trace metadata, inputs/outputs, model data, usage, prompts, timestamps, and status.
- Await terminal tracing flushes with single-flight protection.
- Skip tracing in legacy migration mode without falling back to legacy ingestion.

This bypasses the Public API/HTTP layer and marks internal jobs with ingestion version 4 and internal-ingestion metadata.

## Validation

- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm run typecheck` — Tasks: 7 successful, 7 total
- Shared focused tests — 5 passed
- Worker routing tests — 4 passed
- Web in-app-agent stream regression — 19 passed
- OTel direct-write tests — 69 passed

The database-backed worker/events_only integration was not run because local Postgres, Redis, and ClickHouse services were unavailable.