### PR TITLE
feat(in-app-agent): enable self-hosted availability

### DIFF
--- a/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-background-run.servertest.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type Plan } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
+import { env as sharedEnv } from "@langfuse/shared/src/env";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import {
   IN_APP_AGENT_APPROVAL_DECISION_EVENT_NAME,
@@ -96,6 +97,8 @@ vi.mock("@/src/server/auth", () => ({
 describe("in-app agent background runs", () => {
   const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
   const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
+  const originalSharedBedrockModel = sharedEnv.LANGFUSE_AWS_BEDROCK_MODEL;
+  const originalSharedBedrockRegion = sharedEnv.LANGFUSE_AWS_BEDROCK_REGION;
   const originalMaxActiveRunsPerUser =
     env.LANGFUSE_IN_APP_AGENT_MAX_ACTIVE_RUNS_PER_USER;
   const originalMaxActiveRunsPerOrg =
@@ -104,6 +107,8 @@ describe("in-app agent background runs", () => {
   beforeEach(() => {
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
     (env as any).LANGFUSE_AWS_BEDROCK_MODEL = "test-model";
+    (sharedEnv as any).LANGFUSE_AWS_BEDROCK_MODEL = "test-model";
+    (sharedEnv as any).LANGFUSE_AWS_BEDROCK_REGION = "eu-central-1";
     enqueuedJobs.length = 0;
     enqueueShouldFail = false;
     persistenceMocks.maybeInferAndPersistConversationTitle.mockClear();
@@ -117,6 +122,9 @@ describe("in-app agent background runs", () => {
     vi.useRealTimers();
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
     (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
+    (sharedEnv as any).LANGFUSE_AWS_BEDROCK_MODEL = originalSharedBedrockModel;
+    (sharedEnv as any).LANGFUSE_AWS_BEDROCK_REGION =
+      originalSharedBedrockRegion;
     (env as any).LANGFUSE_IN_APP_AGENT_MAX_ACTIVE_RUNS_PER_USER =
       originalMaxActiveRunsPerUser;
     (env as any).LANGFUSE_IN_APP_AGENT_MAX_ACTIVE_RUNS_PER_ORG =
@@ -193,6 +201,45 @@ describe("in-app agent background runs", () => {
       conversationId: createInAppAgentConversationId(),
       userId: params.userId,
     });
+
+  it("starts a run on self-hosted deployments after the organization opts in", async () => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    const { caller, projectId, userId } = await createCaller(
+      undefined,
+      "self-hosted:enterprise",
+    );
+    const conversation = await createConversation({ projectId, userId });
+
+    await expect(
+      caller.startRun({
+        projectId,
+        conversationId: conversation.id,
+        message: "Inspect a trace",
+      }),
+    ).resolves.toMatchObject({ conversationId: conversation.id });
+
+    expect(enqueuedJobs).toHaveLength(1);
+  });
+
+  it("rejects requests before queueing when the assistant model is not configured", async () => {
+    const { caller, projectId } = await createCaller();
+    (sharedEnv as any).LANGFUSE_AWS_BEDROCK_MODEL = undefined;
+    (sharedEnv as any).LANGFUSE_AWS_BEDROCK_REGION = undefined;
+
+    await expect(
+      caller.startRun({
+        projectId,
+        conversationId: createInAppAgentConversationId(),
+        message: "Do not queue this",
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Assistant Bedrock model is not configured. Set LANGFUSE_AWS_BEDROCK_MODEL and LANGFUSE_AWS_BEDROCK_REGION.",
+    });
+
+    expect(enqueuedJobs).toHaveLength(0);
+  });
 
   /** Park a run for approval the way the worker does: interrupt event, then CAS. */
   const parkRunForApproval = async (params: {

--- a/web/src/__tests__/server/organization-ai-features.servertest.ts
+++ b/web/src/__tests__/server/organization-ai-features.servertest.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "crypto";
+import type { Session } from "next-auth";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "@langfuse/shared/src/db";
+import { env } from "@/src/env.mjs";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+
+describe("organization AI feature settings", () => {
+  const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+
+  beforeEach(() => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+  });
+
+  afterEach(() => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+  });
+
+  it("allows a self-hosted organization administrator to opt in to AI features", async () => {
+    const { caller, orgId } = await createCaller();
+
+    await caller.organizations.update({
+      orgId,
+      aiFeaturesEnabled: true,
+    });
+
+    await expect(
+      prisma.organization.findUniqueOrThrow({
+        where: { id: orgId },
+        select: { aiFeaturesEnabled: true },
+      }),
+    ).resolves.toEqual({ aiFeaturesEnabled: true });
+  });
+
+  it("keeps AI telemetry controls Cloud-only", async () => {
+    const { caller, orgId } = await createCaller();
+
+    await expect(
+      caller.organizations.update({
+        orgId,
+        aiTelemetryEnabled: false,
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "AI telemetry controls are only available on Langfuse Cloud.",
+    });
+  });
+});
+
+async function createCaller() {
+  const id = randomUUID();
+  const orgId = `org-${id}`;
+  const projectId = `project-${id}`;
+  const userId = `user-${id}`;
+
+  const organization = await prisma.organization.create({
+    data: {
+      id: orgId,
+      name: `Organization AI Features Test ${id}`,
+    },
+  });
+  const project = await prisma.project.create({
+    data: {
+      id: projectId,
+      orgId,
+      name: "Organization AI Features Test Project",
+    },
+  });
+  const user = await prisma.user.create({
+    data: {
+      id: userId,
+      email: `${userId}@example.com`,
+      name: "Organization AI Features Test User",
+    },
+  });
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      canCreateOrganizations: true,
+      organizations: [
+        {
+          id: organization.id,
+          name: organization.name,
+          role: "OWNER",
+          plan: "self-hosted:enterprise",
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: false,
+          aiTelemetryEnabled: true,
+          projects: [
+            {
+              id: project.id,
+              name: project.name,
+              role: "ADMIN",
+              deletedAt: null,
+              retentionDays: null,
+              hasTraces: false,
+              metadata: {},
+              createdAt: project.createdAt.toISOString(),
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        searchBar: false,
+        templateFlag: false,
+        excludeClickhouseRead: false,
+        observationEvals: false,
+        v4BetaToggleVisible: false,
+        experimentsV4Enabled: false,
+      },
+      admin: false,
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: "self-hosted:enterprise",
+    },
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+
+  return {
+    orgId,
+    caller: appRouter.createCaller({ ...ctx, prisma }),
+  };
+}

--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -30,6 +30,7 @@ const cloudAllPlansEntitlements: Entitlement[] = [
 const selfHostedAllPlansEntitlements: Entitlement[] = [
   "trace-deletion",
   "scheduled-blob-exports",
+  "in-app-agent",
 ];
 
 // Entitlement Limits: Limits on the number of resources that can be created/used

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -54,7 +54,6 @@ import {
 import type { InAppAgentError } from "@/src/features/in-app-agent/components/utils/utils";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { api } from "@/src/utils/api";
 import {
@@ -1595,14 +1594,9 @@ export function useInAppAiAgent() {
  * for this project would be served, so callers can skip ones it would reject. */
 export function useIsInAppAgentEnabled() {
   const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
-  const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { organization } = useQueryProjectOrOrganization();
 
-  return (
-    isLangfuseCloud &&
-    hasInAppAgentEntitlement &&
-    Boolean(organization?.aiFeaturesEnabled)
-  );
+  return hasInAppAgentEntitlement && Boolean(organization?.aiFeaturesEnabled);
 }
 
 /** Whether the current user/context may use the in-app assistant at all. Shared
@@ -1612,13 +1606,7 @@ export function useIsInAppAgentEnabled() {
 export function useCanUseInAppAgent() {
   const { isAvailable } = useInAppAiAgent();
   const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
-  const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { organization } = useQueryProjectOrOrganization();
 
-  return (
-    isAvailable &&
-    hasInAppAgentEntitlement &&
-    isLangfuseCloud &&
-    Boolean(organization)
-  );
+  return isAvailable && hasInAppAgentEntitlement && Boolean(organization);
 }

--- a/web/src/features/in-app-agent/server/availability.ts
+++ b/web/src/features/in-app-agent/server/availability.ts
@@ -2,8 +2,8 @@ import type { Session } from "next-auth";
 
 import { BaseError, ForbiddenError } from "@langfuse/shared";
 import type { PrismaClient } from "@langfuse/shared/src/db";
+import { getInAppAgentModelConfig } from "@langfuse/shared/in-app-agent/server/modelProvider";
 
-import { env } from "@/src/env.mjs";
 import { hasEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 
 export async function assertInAppAgentAvailable({
@@ -15,16 +15,6 @@ export async function assertInAppAgentAvailable({
   projectId: string;
   user: NonNullable<Session["user"]>;
 }) {
-  // TODO(LFE-14555): Remove this guard once the OSS release strategy is ready.
-  if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
-    throw new BaseError(
-      "PreconditionFailedError",
-      412,
-      "In-app agent is not available in this environment yet.",
-      true,
-    );
-  }
-
   if (
     !hasEntitlement({
       entitlement: "in-app-agent",
@@ -53,6 +43,15 @@ export async function assertInAppAgentAvailable({
 
   if (!project?.organization.aiFeaturesEnabled) {
     throw new ForbiddenError("Assistant is not enabled for this organization");
+  }
+
+  if (!getInAppAgentModelConfig()) {
+    throw new BaseError(
+      "PreconditionFailedError",
+      412,
+      "Assistant Bedrock model is not configured. Set LANGFUSE_AWS_BEDROCK_MODEL and LANGFUSE_AWS_BEDROCK_REGION.",
+      true,
+    );
   }
 
   return project.organization;

--- a/web/src/features/organizations/components/AIFeatureSwitch.tsx
+++ b/web/src/features/organizations/components/AIFeatureSwitch.tsx
@@ -114,8 +114,6 @@ export default function AIFeatureSwitch() {
     });
   }
 
-  if (!isLangfuseCloud) return null;
-
   return (
     <div>
       <Header title="AI Features" />
@@ -125,22 +123,30 @@ export default function AIFeatureSwitch() {
             <h4 className="font-bold">
               Enable AI powered features for your organization
             </h4>
-            <p className="text-sm">
-              This setting applies to all users and projects. Any data{" "}
-              <i>can</i> be sent to AWS Bedrock within the Langfuse data region.
-              Traces are sent to Langfuse Cloud in your data region. Your data
-              will not be used for training models. Applicable HIPAA, SOC2,
-              GDPR, and ISO 27001 compliance remains intact.{" "}
-              <a
-                href="https://langfuse.com/security/ai-features"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary inline-flex items-center gap-1 hover:underline"
-              >
-                More details in the docs here.
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            </p>
+            {isLangfuseCloud ? (
+              <p className="text-sm">
+                This setting applies to all users and projects. Any data{" "}
+                <i>can</i> be sent to AWS Bedrock within the Langfuse data
+                region. Traces are sent to Langfuse Cloud in your data region.
+                Your data will not be used for training models. Applicable
+                HIPAA, SOC2, GDPR, and ISO 27001 compliance remains intact.{" "}
+                <a
+                  href="https://langfuse.com/security/ai-features"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary inline-flex items-center gap-1 hover:underline"
+                >
+                  More details in the docs here.
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </p>
+            ) : (
+              <p className="text-sm">
+                This setting applies to all users and projects. When enabled,
+                the assistant can send relevant project data to the model
+                provider configured by your instance administrator.
+              </p>
+            )}
           </div>
           <div className="relative">
             <Switch
@@ -155,7 +161,7 @@ export default function AIFeatureSwitch() {
             )}
           </div>
         </div>
-        {isAIFeatureSwitchEnabled && (
+        {isLangfuseCloud && isAIFeatureSwitchEnabled && (
           <div className="mt-4 flex flex-row items-center justify-between border-t pt-4">
             <div className="flex flex-col gap-1">
               <h4 className="font-bold">
@@ -200,20 +206,27 @@ export default function AIFeatureSwitch() {
               <strong>
                 {isAIFeatureSwitchEnabled ? "enable " : "disable"}
               </strong>{" "}
-              AI features for your organization. When enabled, any data{"  "}
-              <i>can</i> be sent to AWS Bedrock in your data region for
-              processing.
-              <br />
-              <br />{" "}
-              <a
-                href="https://langfuse.com/security/ai-features"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary inline-flex items-center gap-1 hover:underline"
-              >
-                Learn more in the docs.
-                <ExternalLink className="h-3 w-3" />
-              </a>
+              AI features for your organization. When enabled, relevant data can
+              be sent{" "}
+              {isLangfuseCloud
+                ? "to AWS Bedrock in your data region"
+                : "to the model provider configured by your instance administrator"}{" "}
+              for processing.
+              {isLangfuseCloud && (
+                <>
+                  <br />
+                  <br />{" "}
+                  <a
+                    href="https://langfuse.com/security/ai-features"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary inline-flex items-center gap-1 hover:underline"
+                  >
+                    Learn more in the docs.
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </>
+              )}
             </span>
             <p className="text-muted-foreground mt-3 text-sm">
               Are you sure you want to proceed?

--- a/web/src/features/organizations/server/organizationRouter.ts
+++ b/web/src/features/organizations/server/organizationRouter.ts
@@ -194,13 +194,13 @@ export const organizationsRouter = createTRPCRouter({
       });
 
       if (
-        (input.aiFeaturesEnabled !== undefined ||
-          input.aiTelemetryEnabled !== undefined) &&
+        input.aiTelemetryEnabled !== undefined &&
         !env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
       ) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
-          message: "AI features are not available in self-hosted deployments.",
+          message:
+            "AI telemetry controls are only available on Langfuse Cloud.",
         });
       }
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16255.preview.langfuse.com](https://pr-16255.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- grant the assistant entitlement to every self-hosted plan
- remove Cloud-only server and client availability gates
- keep the organization AI feature opt-in disabled by default and available to self-hosted organization administrators
- keep AI telemetry controls Cloud-only
- return an actionable precondition error before enqueueing when Bedrock model configuration is missing

## Verification
- pnpm --filter web run test in-app-agent-background-run.servertest.ts organization-ai-features.servertest.ts
- pnpm --filter web run typecheck
- pnpm --filter web run lint
- pre-commit hook: turbo lint (7 successful, 7 total)