### PR TITLE
refactor(worker): name the blob export terminal-failure outcomes

### DIFF
--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -404,6 +404,89 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       expect(row.lastError).toMatch(/connection refused/i);
       expect(row.lastFailureNotificationSentAt).toBeNull();
     });
+
+    // A concurrent run (distinct jobId, so not queue-deduped) can win the
+    // disable claim first. The loser must stay silent: the winner already sent
+    // the terminal "disabled" email, and the loser's only fallback is the
+    // informational "will retry at the next scheduled export" variant, which is
+    // false for an integration that is now off.
+    it("does not notify when a concurrent run won the customer-fault disable claim", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      await createIntegration(projectId);
+      mockRecordIncrement.mockClear();
+      // Land the winner's disable between the handler's enabled check and the
+      // terminal catch, then raise the same fault the winner disabled on.
+      mockValidateBlobStorageEndpoint.mockImplementationOnce(async () => {
+        await prisma.blobStorageIntegration.updateMany({
+          where: { projectId },
+          data: { enabled: false },
+        });
+        throw accessDeniedError();
+      });
+
+      await expect(runAttempt(projectId, 4)).rejects.toThrow(/access denied/i);
+      await settleBackgroundTasks();
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.enabled).toBe(false);
+      expect(row.lastError).toMatch(/access denied/i);
+      // Null proves the loser suppressed its email: the informational fallback
+      // would have taken the cooldown claim and stamped this.
+      expect(row.lastFailureNotificationSentAt).toBeNull();
+      // Only the worker that actually flipped enabled true->false counts it.
+      expect(mockRecordIncrement).not.toHaveBeenCalledWith(
+        BLOB_INTEGRATION_DISABLED_METRIC,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    // When the failure can't even be written down (Postgres unavailable), the
+    // run knows nothing about the row's state. It must not claim a disable it
+    // failed to persist, but it must still say something rather than dropping
+    // the failure silently. `update` is only called on this terminal path, so
+    // spying on it isolates the persistence failure from the export itself.
+    it("falls back to the informational email when persisting the failure fails", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      await createIntegration(projectId);
+      mockRecordIncrement.mockClear();
+      mockValidateBlobStorageEndpoint.mockRejectedValueOnce(
+        accessDeniedError(),
+      );
+      const updateSpy = vi
+        .spyOn(prisma.blobStorageIntegration, "update")
+        .mockRejectedValueOnce(new Error("database unavailable"));
+
+      try {
+        await expect(runAttempt(projectId, 4)).rejects.toThrow(
+          /access denied/i,
+        );
+        await settleBackgroundTasks();
+      } finally {
+        updateSpy.mockRestore();
+      }
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      // Nothing was written, so the fault is invisible to the row and the
+      // integration keeps running — even though this was a classified fault on
+      // the final attempt, which would otherwise have disabled it.
+      expect(row.enabled).toBe(true);
+      expect(row.lastError).toBeNull();
+      expect(mockRecordIncrement).not.toHaveBeenCalledWith(
+        BLOB_INTEGRATION_DISABLED_METRIC,
+        expect.anything(),
+        expect.anything(),
+      );
+      // The informational email still goes out, observable via its cooldown
+      // claim, so an unwritable failure is not a silent one.
+      expect(row.lastFailureNotificationSentAt).not.toBeNull();
+    });
   });
 
   // LFE-14894: an integration deleted mid-run makes the job obsolete — it must

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1525,8 +1525,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
     // 0-based, so the final attempt is attempts - 1.
     const isFinalAttempt =
       (job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1;
-    // The reason bucket doubles as the disable decision (defined => disable) and
-    // as the tag on the disable log + metric.
+    // Defined => disable; also tags the disable log + metric.
     const customerFaultReason = classifyCustomerFault(error);
 
     const outcome = await recordTerminalExportError({
@@ -1536,44 +1535,33 @@ export const handleBlobStorageIntegrationProjectJob = async (
     });
 
     if (outcome.kind === "integration-deleted") {
-      // Nothing to persist, nobody to notify: complete the obsolete job
-      // instead of failing it.
-      return;
+      return; // obsolete job: complete it rather than fail it
     }
 
-    // Which email to send is a property of the outcome, so every case is named
-    // rather than derived from a conjunction. Only the informational variants
-    // wait for BullMQ to exhaust its retries — sent on an earlier attempt it
-    // fires even when a later retry succeeds. The disable outcomes are already
-    // terminal by construction and so don't consult the attempt count.
+    // Only the informational email waits for the retries to run out; sent
+    // earlier it fires even when a later attempt succeeds. A disable is already
+    // terminal, so it ignores the attempt count.
     switch (outcome.kind) {
       case "disabled-by-us":
-        // This worker flipped the integration off, so it owns the terminal
-        // "export disabled" email.
         notifyBlobStorageExportFailedInBackground(projectId, true);
         break;
       case "lost-disable-race":
-        // A concurrent terminal failure disabled the integration and has
-        // already sent that email; a second one would duplicate it, and the
-        // informational variant would contradict it.
-        break;
+        break; // the winner sent the terminal email; ours would contradict it
       case "error-recorded":
-        // The informational email promises a retry at the next scheduled run,
-        // which is false once the integration is off (a concurrent run's
-        // customer-fault disable or a user toggle mid-run) — skip it then.
+        // Skipped once the integration is off: "will retry at the next
+        // scheduled export" is no longer true.
         if (isFinalAttempt && outcome.stillEnabled) {
           notifyBlobStorageExportFailedInBackground(projectId, false);
         }
         break;
       case "persist-failed":
-        // The row's state is unknown, so fall back to the informational email
-        // rather than letting the failure go out silently.
+        // Row state unknown, so say something rather than nothing.
         if (isFinalAttempt) {
           notifyBlobStorageExportFailedInBackground(projectId, false);
         }
         break;
-      // Without this a new outcome kind would silently send no notification:
-      // a plain switch over a union is not checked for exhaustiveness.
+      // A plain switch over a union is not exhaustiveness-checked; the never
+      // assignment below is what makes a missing case fail to compile.
       default: {
         const _exhaustiveCheck: never = outcome;
         throw new Error(
@@ -1597,31 +1585,22 @@ export const handleBlobStorageIntegrationProjectJob = async (
   }
 };
 
-// What the terminal bookkeeping for a failed run actually did. The notification
-// decision switches over these named situations instead of recombining booleans,
-// so each case an earlier revision guarded against stays individually visible.
+// What the terminal bookkeeping for a failed run did. Each case is a situation
+// some earlier revision guarded against, named so the notification decision can
+// switch over them instead of recombining flags.
 type TerminalExportErrorOutcome =
-  // The integration row is gone: deleted mid-run, so the job is obsolete.
-  | { kind: "integration-deleted" }
-  // Writing the failure failed for an infra reason (e.g. Postgres unavailable),
-  // leaving the row's state unknown.
-  | { kind: "persist-failed" }
-  // Failure recorded, no disable attempted — either not a customer fault, or
-  // BullMQ still has retries left. `stillEnabled` is the row's state as we wrote
-  // it: false means a concurrent disable or a user toggle landed mid-run.
+  | { kind: "integration-deleted" } // deleted mid-run: job is obsolete
+  | { kind: "persist-failed" } // write failed, so the row's state is unknown
+  // No disable attempted: not a customer fault, or retries remain. stillEnabled
+  // false means a concurrent disable or user toggle landed mid-run.
   | { kind: "error-recorded"; stillEnabled: boolean }
-  // This worker flipped enabled true→false and owns the terminal notification.
   | { kind: "disabled-by-us" }
-  // A concurrent terminal failure won the disable claim; it notifies, not us.
   | { kind: "lost-disable-race" };
 
-// Persists the failure and, when the caller asked for a disable, makes the
-// atomic enabled true→false claim. Returns what happened rather than reporting it
-// through mutable flags, so the caller's notification decision is total over
-// named cases. The claim dedups concurrent terminal failures — e.g. a scheduled
-// run racing a manual Run Now across pods, which have distinct jobIds and so
-// aren't queue-deduped — and guarantees the "disabled" email (which bypasses the
-// cooldown) is sent exactly once and never claims a state we failed to write.
+// Persists the failure and, when asked, makes the atomic enabled true→false
+// claim. That claim is what keeps the terminal email exactly-once across runs
+// racing the same fault (distinct jobIds, so not queue-deduped) and stops it
+// claiming a state we failed to write.
 async function recordTerminalExportError({
   projectId,
   errorMessage,
@@ -1629,7 +1608,6 @@ async function recordTerminalExportError({
 }: {
   projectId: string;
   errorMessage: string;
-  // Defined => disable the integration, and tag the disable log + metric.
   disableReason: CustomerFaultReason | undefined;
 }): Promise<TerminalExportErrorOutcome> {
   try {
@@ -1665,7 +1643,6 @@ async function recordTerminalExportError({
     return { kind: "disabled-by-us" };
   } catch (persistError) {
     if (isRecordNotFoundError(persistError)) {
-      // The notification would reference a config that no longer exists.
       logger.info(
         `[BLOB INTEGRATION] Blob storage integration for project ${projectId} was deleted mid-run; dropping obsolete job after error: ${errorMessage}`,
       );

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -49,6 +49,7 @@ import { TimedGzip, ZLIB_DEFAULT_LEVEL, type GzipStats } from "./gzipStream";
 import {
   BLOB_INTEGRATION_DISABLED_METRIC,
   classifyCustomerFault,
+  type CustomerFaultReason,
 } from "./isCustomerFaultError";
 import { isRecordNotFoundError } from "../integrations/prismaErrors";
 import { ByteCounter, TimedByteCounter } from "./byteCounters";
@@ -1525,84 +1526,52 @@ export const handleBlobStorageIntegrationProjectJob = async (
     const isFinalAttempt =
       (job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1;
     // The reason bucket doubles as the disable decision (defined => disable) and
-    // as the tag on the disable log + metric below.
+    // as the tag on the disable log + metric.
     const customerFaultReason = classifyCustomerFault(error);
-    const disableForCustomerFault =
-      isFinalAttempt && customerFaultReason !== undefined;
 
-    // True only for the worker that actually flips enabled true→false, so the
-    // "disabled" email (which bypasses the cooldown) is sent exactly once and
-    // never claims a state we failed to write. The atomic claim also dedups
-    // concurrent terminal failures — e.g. a scheduled run racing a manual Run
-    // Now across pods, which have distinct jobIds and so aren't queue-deduped.
-    let persistedDisable = false;
-    let disableClaimRan = false;
-    // Assume enabled when the read-back fails; worst case is today's email.
-    let enabledAfterPersist = true;
-    try {
-      const updated = await prisma.blobStorageIntegration.update({
-        where: { projectId },
-        data: {
-          lastError: errorMessage,
-          lastErrorAt: new Date(),
-          runStartedAt: null,
-        },
-      });
-      enabledAfterPersist = updated.enabled;
-      if (disableForCustomerFault) {
-        const { count } = await prisma.blobStorageIntegration.updateMany({
-          where: { projectId, enabled: true },
-          data: { enabled: false },
-        });
-        disableClaimRan = true;
-        persistedDisable = count === 1;
-        if (persistedDisable) {
-          // Tag by reason so SSRF/abuse disables (ssrf_blocked_endpoint) can be
-          // separated from customer misconfig, and a mass-disable regression is
-          // visible as a spike in the non-SSRF buckets after rollout.
-          const reason = customerFaultReason ?? "unknown";
-          recordIncrement(BLOB_INTEGRATION_DISABLED_METRIC, 1, { reason });
-          logger.warn(
-            `[BLOB INTEGRATION] Disabled blob storage integration for project ${projectId} after a customer fault (reason=${reason}): ${errorMessage}`,
-            { blobStorageDisableReason: reason, projectId },
-          );
-        }
-      }
-    } catch (persistError) {
-      if (isRecordNotFoundError(persistError)) {
-        // Integration deleted mid-run: nothing to persist, nobody to notify —
-        // the notification would reference a config that no longer exists.
-        // Complete the obsolete job instead of failing it.
-        logger.info(
-          `[BLOB INTEGRATION] Blob storage integration for project ${projectId} was deleted mid-run; dropping obsolete job after error: ${errorMessage}`,
-        );
-        return;
-      }
-      logger.error(
-        `[BLOB INTEGRATION] Failed to persist blob storage error for project ${projectId}`,
-        persistError,
-      );
+    const outcome = await recordTerminalExportError({
+      projectId,
+      errorMessage,
+      disableReason: isFinalAttempt ? customerFaultReason : undefined,
+    });
+
+    if (outcome.kind === "integration-deleted") {
+      // Nothing to persist, nobody to notify: complete the obsolete job
+      // instead of failing it.
+      return;
     }
 
-    // Notify only after BullMQ exhausts its retries — an email on an earlier
-    // attempt fires even when a later retry succeeds, and would double up
-    // with the "disabled" email on customer faults. Skip only when a
-    // concurrent terminal failure won the disable claim (the winner already
-    // notified); if the claim never ran because persistence threw, fall back
-    // to the informational email so the failure isn't silent.
-    const lostDisableRaceToConcurrentRun =
-      disableForCustomerFault && disableClaimRan && !persistedDisable;
-    // The informational email promises a retry at the next scheduled run,
-    // which is false once the integration is disabled (a concurrent run's
-    // customer-fault disable or a user toggle mid-run) — skip it then.
-    const disabledOutFromUnderUs =
-      !disableForCustomerFault && !enabledAfterPersist;
-    if (
-      isFinalAttempt &&
-      !lostDisableRaceToConcurrentRun &&
-      !disabledOutFromUnderUs
-    ) {
-      notifyBlobStorageExportFailedInBackground(projectId, persistedDisable);
+    // Which email to send is a property of the outcome, so every case is named
+    // rather than derived from a conjunction. Only the informational variants
+    // wait for BullMQ to exhaust its retries — sent on an earlier attempt it
+    // fires even when a later retry succeeds. The disable outcomes are already
+    // terminal by construction and so don't consult the attempt count.
+    switch (outcome.kind) {
+      case "disabled-by-us":
+        // This worker flipped the integration off, so it owns the terminal
+        // "export disabled" email.
+        notifyBlobStorageExportFailedInBackground(projectId, true);
+        break;
+      case "lost-disable-race":
+        // A concurrent terminal failure disabled the integration and has
+        // already sent that email; a second one would duplicate it, and the
+        // informational variant would contradict it.
+        break;
+      case "error-recorded":
+        // The informational email promises a retry at the next scheduled run,
+        // which is false once the integration is off (a concurrent run's
+        // customer-fault disable or a user toggle mid-run) — skip it then.
+        if (isFinalAttempt && outcome.stillEnabled) {
+          notifyBlobStorageExportFailedInBackground(projectId, false);
+        }
+        break;
+      case "persist-failed":
+        // The row's state is unknown, so fall back to the informational email
+        // rather than letting the failure go out silently.
+        if (isFinalAttempt) {
+          notifyBlobStorageExportFailedInBackground(projectId, false);
+        }
+        break;
     }
 
     const chain = errorChainText(error);
@@ -1619,6 +1588,88 @@ export const handleBlobStorageIntegrationProjectJob = async (
     throw rethrown;
   }
 };
+
+// What the terminal bookkeeping for a failed run actually did. The notification
+// decision switches over these named situations instead of recombining booleans,
+// so each case an earlier revision guarded against stays individually visible.
+type TerminalExportErrorOutcome =
+  // The integration row is gone: deleted mid-run, so the job is obsolete.
+  | { kind: "integration-deleted" }
+  // Writing the failure failed for an infra reason (e.g. Postgres unavailable),
+  // leaving the row's state unknown.
+  | { kind: "persist-failed" }
+  // Failure recorded, no disable attempted — either not a customer fault, or
+  // BullMQ still has retries left. `stillEnabled` is the row's state as we wrote
+  // it: false means a concurrent disable or a user toggle landed mid-run.
+  | { kind: "error-recorded"; stillEnabled: boolean }
+  // This worker flipped enabled true→false and owns the terminal notification.
+  | { kind: "disabled-by-us" }
+  // A concurrent terminal failure won the disable claim; it notifies, not us.
+  | { kind: "lost-disable-race" };
+
+// Persists the failure and, when the caller asked for a disable, makes the
+// atomic enabled true→false claim. Returns what happened rather than reporting it
+// through mutable flags, so the caller's notification decision is total over
+// named cases. The claim dedups concurrent terminal failures — e.g. a scheduled
+// run racing a manual Run Now across pods, which have distinct jobIds and so
+// aren't queue-deduped — and guarantees the "disabled" email (which bypasses the
+// cooldown) is sent exactly once and never claims a state we failed to write.
+async function recordTerminalExportError({
+  projectId,
+  errorMessage,
+  disableReason,
+}: {
+  projectId: string;
+  errorMessage: string;
+  // Defined => disable the integration, and tag the disable log + metric.
+  disableReason: CustomerFaultReason | undefined;
+}): Promise<TerminalExportErrorOutcome> {
+  try {
+    const updated = await prisma.blobStorageIntegration.update({
+      where: { projectId },
+      data: {
+        lastError: errorMessage,
+        lastErrorAt: new Date(),
+        runStartedAt: null,
+      },
+    });
+
+    if (disableReason === undefined) {
+      return { kind: "error-recorded", stillEnabled: updated.enabled };
+    }
+
+    const { count } = await prisma.blobStorageIntegration.updateMany({
+      where: { projectId, enabled: true },
+      data: { enabled: false },
+    });
+    if (count !== 1) return { kind: "lost-disable-race" };
+
+    // Tag by reason so SSRF/abuse disables (ssrf_blocked_endpoint) can be
+    // separated from customer misconfig, and a mass-disable regression is
+    // visible as a spike in the non-SSRF buckets after rollout.
+    recordIncrement(BLOB_INTEGRATION_DISABLED_METRIC, 1, {
+      reason: disableReason,
+    });
+    logger.warn(
+      `[BLOB INTEGRATION] Disabled blob storage integration for project ${projectId} after a customer fault (reason=${disableReason}): ${errorMessage}`,
+      { blobStorageDisableReason: disableReason, projectId },
+    );
+    return { kind: "disabled-by-us" };
+  } catch (persistError) {
+    if (isRecordNotFoundError(persistError)) {
+      // The notification would reference a config that no longer exists.
+      logger.info(
+        `[BLOB INTEGRATION] Blob storage integration for project ${projectId} was deleted mid-run; dropping obsolete job after error: ${errorMessage}`,
+      );
+      return { kind: "integration-deleted" };
+    }
+    logger.error(
+      `[BLOB INTEGRATION] Failed to persist blob storage error for project ${projectId}`,
+      persistError,
+    );
+    return { kind: "persist-failed" };
+  }
+}
 
 function notifyBlobStorageExportFailedInBackground(
   projectId: string,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1572,6 +1572,14 @@ export const handleBlobStorageIntegrationProjectJob = async (
           notifyBlobStorageExportFailedInBackground(projectId, false);
         }
         break;
+      // Without this a new outcome kind would silently send no notification:
+      // a plain switch over a union is not checked for exhaustiveness.
+      default: {
+        const _exhaustiveCheck: never = outcome;
+        throw new Error(
+          `Unhandled terminal export outcome: ${JSON.stringify(_exhaustiveCheck)}`,
+        );
+      }
     }
 
     const chain = errorChainText(error);


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16257.preview.langfuse.com](https://pr-16257.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Preparatory refactor of the terminal error path in the blob storage export
handler. No behavior change.

That `catch` block decides which failure email to send by recombining three
mutable flags (`persistedDisable`, `disableClaimRan`, `enabledAfterPersist`,
each with a fallback initializer) into negated conjunctions. Several earlier
changes each layered one more guard onto the same straight-line body, so the
result is correct but opaque: which flag combinations are actually reachable is
not apparent from reading it. That makes any edit to the path a re-derivation of
the races each guard was defending rather than a code move — which is the
expensive part of the follow-up that puts blob export on the same fail-fast
handling as the PostHog export.

Four commits, meant to be reviewed in order:

**1. Pin the unguarded cases** (test-only). Two situations the flag logic guards
against had no coverage: a concurrent run winning the customer-fault disable
claim, and the failure being unwritable because Postgres is unavailable. Either
guard could be deleted and the whole suite stayed green. Both new tests
discriminate rather than merely pass — the race one was verified by neutering the
guard, where it and only it fails — and both pass against the unmodified
handler, so they characterize existing behavior.

**2. Name the outcomes.** The database bookkeeping is extracted and now returns a
discriminated union describing what happened (row deleted, failure unwritable,
failure recorded plus the row's enabled state, disabled by this worker, disable
claim lost to a concurrent run). The caller switches over it, so every guard is
one named case.

Two incidental simplifications fall out: the disable reason tag no longer needs
its `"unknown"` fallback, because the type proves the branch is only reachable
with a defined reason; and the exhausted-retries condition moves onto the two
informational cases that actually need it, making it visible that a disable is
terminal by construction and never consults the attempt count.

**3. Make the switch actually exhaustiveness-checked.** Review correctly caught
that commit 2 claimed compiler-enforced totality it did not have: a plain switch
over a union compiles clean with cases missing, and no lint rule here catches it.
The `never` assignment in a `default` branch is what makes the check bite,
verified by adding a sixth variant and watching typecheck fail on it. Braces
scope the declaration, so unlike the two older exhaustiveness-checked switches in
this file it needs no `no-case-declarations` disable.

**4. Tighten the comments** down to what a reader cannot recover from the code.

All five outcomes are under test.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

Behavior preservation is the whole point, so it is what I verified: each commit
is green against the suite the first commit strengthened, including all five
terminal outcomes.

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `blobStorageIntegrationProcessing` — `Tests 35 passed (35)`, run 5x to rule
  out flakiness
- `blobExport*` — `Tests 19 passed (19)`; `blobStorageTuningWiring` —
  `Tests 3 passed (3)`

One note for the reviewer: on the first cold run of the suite I saw the file's
first two tests fail on a 5s timeout, which did not reproduce in 5 subsequent
runs. Those tests exercise no decision this PR changes, and the failure mode was
a timeout rather than an assertion mismatch, consistent with cold-start cost on
a network-bound test. Flagging it rather than burying it.
