### PR TITLE
fix(worker): stop retrying analytics export redirect loops, fix SSRF wording

### DIFF
--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -151,6 +151,8 @@ import {
   POSTHOG_INTEGRATION_DISABLED_METRIC,
 } from "../features/posthog/handlePostHogIntegrationProjectJob";
 import {
+  CircularRedirectError,
+  MaxRedirectsExceededError,
   OutboundUrlValidationError,
   RedirectValidationError,
 } from "@langfuse/shared/src/server";
@@ -290,6 +292,23 @@ describe("outbound validation classification", () => {
       ),
     ).toBeDefined();
   });
+
+  // A redirect loop or exhausted budget can never succeed on retry — the job
+  // would re-read the same events from ClickHouse and hit the same chain every
+  // attempt — so both must classify as terminal on the very first attempt.
+  it("treats an exhausted redirect budget and a redirect loop as terminal", () => {
+    expect(
+      findOutboundUrlValidationError(
+        new MaxRedirectsExceededError(10, ["http://a/", "http://b/"]),
+      ),
+    ).toBeDefined();
+
+    expect(
+      findOutboundUrlValidationError(
+        new CircularRedirectError(["http://a/", "http://b/", "http://a/"]),
+      ),
+    ).toBeDefined();
+  });
 });
 
 /**
@@ -388,5 +407,45 @@ describe("terminal outbound failure reporting", () => {
         { logSubject: "Mixpanel outbound send", jobSubject: "Mixpanel export" },
       ),
     ).toThrow("Blocked IP address detected: 127.0.0.1");
+  });
+
+  // Neither a redirect loop nor an exhausted budget was ever checked for
+  // safety — outbound-url/fetch.ts detects both before validating the hop that
+  // would have closed the loop or exceeded the budget — so the message must
+  // not claim a security block, and must not claim the destination was safe
+  // either.
+  it("labels an exhausted redirect budget distinctly from an SSRF block, and calls the destination unverified", () => {
+    const thrown = captureRethrow(
+      new MaxRedirectsExceededError(10, ["http://a/", "http://b/"]),
+    );
+
+    expect(isUnrecoverableError(thrown)).toBe(true);
+    const message = (thrown as Error).message;
+    expect(message).toContain("too many redirects");
+    expect(message).toContain("final destination not verified");
+    expect(message).not.toContain("blocked by SSRF protection");
+  });
+
+  it("labels a redirect loop distinctly from an SSRF block, and calls the destination unverified", () => {
+    const thrown = captureRethrow(
+      new CircularRedirectError(["http://a/", "http://b/", "http://a/"]),
+    );
+
+    expect(isUnrecoverableError(thrown)).toBe(true);
+    const message = (thrown as Error).message;
+    expect(message).toContain("redirect loop");
+    expect(message).toContain("final destination not verified");
+    expect(message).not.toContain("blocked by SSRF protection");
+  });
+
+  it("keeps calling an actual policy block a security block", () => {
+    const thrown = captureRethrow(
+      new OutboundUrlValidationError(
+        "blocked-ip",
+        "Blocked IP address detected: 127.0.0.1",
+      ),
+    );
+
+    expect((thrown as Error).message).toContain("blocked by SSRF protection");
   });
 });

--- a/worker/src/errors/findOutboundUrlValidationError.ts
+++ b/worker/src/errors/findOutboundUrlValidationError.ts
@@ -12,9 +12,25 @@
  */
 import { DNS_LOOKUP_FAILED_MESSAGE_PREFIX } from "@langfuse/shared/src/server";
 
-const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
+// Host/IP policy blocks — the SSRF signal proper. RedirectValidationError
+// belongs here: it means a redirect TARGET failed host validation.
+const POLICY_BLOCK_ERROR_NAMES = new Set([
   "OutboundUrlValidationError",
   "RedirectValidationError",
+]);
+
+// Redirect budget exhaustion and loops. Also permanent — retrying re-reads the
+// same events and hits the same chain — but the SSRF status is genuinely
+// UNKNOWN: outbound-url/fetch.ts detects both before validating the hop that
+// would have closed the loop or exceeded the budget, so that target was never
+// checked. Reporting must say so instead of claiming a security block.
+const REDIRECT_BUDGET_ERROR_NAME = "MaxRedirectsExceededError";
+const REDIRECT_LOOP_ERROR_NAME = "CircularRedirectError";
+
+const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
+  ...POLICY_BLOCK_ERROR_NAMES,
+  REDIRECT_BUDGET_ERROR_NAME,
+  REDIRECT_LOOP_ERROR_NAME,
 ]);
 
 // A resolver hiccup is not a policy block: the host may be legitimate and the
@@ -54,4 +70,23 @@ export function findOutboundUrlValidationError(
   }
 
   return undefined;
+}
+
+/**
+ * How to describe a terminal outbound failure in a log line and in the error
+ * that reaches BullMQ's `failedReason`.
+ *
+ * A host/IP policy block is stated as one. A redirect budget or loop fault is
+ * NOT: it only asserts that the chain stopped before its final target was
+ * validated, so it must not claim the destination was blocked (nothing checked
+ * it) or fine (it might be the metadata service).
+ */
+export function describeOutboundFailure(error: Error): string {
+  if (error.name === REDIRECT_BUDGET_ERROR_NAME) {
+    return "too many redirects; final destination not verified";
+  }
+  if (error.name === REDIRECT_LOOP_ERROR_NAME) {
+    return "redirect loop; final destination not verified";
+  }
+  return "blocked by SSRF protection";
 }

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -5,7 +5,10 @@ import {
   type RedirectOptions,
 } from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../errors/UnrecoverableError";
-import { findOutboundUrlValidationError } from "../errors/findOutboundUrlValidationError";
+import {
+  describeOutboundFailure,
+  findOutboundUrlValidationError,
+} from "../errors/findOutboundUrlValidationError";
 
 /**
  * Redirect budget for the analytics integration exporters. Both senders
@@ -55,9 +58,10 @@ const sanitizedCause = (validationError: Error): Error => {
 };
 
 /**
- * Rethrow a connect-time SSRF block as terminal, so BullMQ stops re-attempting
- * a send that cannot succeed; no-op for anything else, which the caller keeps
- * handling as retryable.
+ * Rethrow a permanent outbound-URL failure — a connect-time SSRF block, or a
+ * redirect chain that exhausted its budget or looped — as terminal, so BullMQ
+ * stops re-attempting a send that cannot succeed; no-op for anything else,
+ * which the caller keeps handling as retryable.
  *
  * Nothing the thrown error carries may hold a credential: the message, the
  * retained cause and that cause's own stack all outlive the job, via the log
@@ -71,12 +75,13 @@ export function rethrowIfOutboundValidationFailure(
   if (!validationError) return;
 
   const reason = redactUrlCredentials(validationError.message);
-  logger.error(`${labels.logSubject} blocked by SSRF protection: ${reason}`, {
+  const description = describeOutboundFailure(validationError);
+  logger.error(`${labels.logSubject} ${description}: ${reason}`, {
     errorName: validationError.name,
   });
 
   const unrecoverable = new UnrecoverableError(
-    `${labels.jobSubject} blocked by SSRF protection: ${reason}`,
+    `${labels.jobSubject} ${description}: ${reason}`,
   );
   // Non-enumerable, because a structured logger handed this error copies every
   // enumerable field into the log line — which is how the raw URL escaped a


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16258.preview.langfuse.com](https://pr-16258.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

A PostHog or Mixpanel export whose destination redirects too many times, or loops, threw `MaxRedirectsExceededError`/`CircularRedirectError`. Neither was recognised as permanent, so BullMQ retried the job — re-reading the same events from ClickHouse and failing the same way every time, since a redirect loop can never succeed on retry.

When the job did fail, the log line and stored failure reason always said `blocked by SSRF protection`, even though nothing was blocked for security reasons — the endpoint just redirects too much. Worse, when the redirect budget runs out, the code stops *before* checking where the last hop pointed, so it genuinely doesn't know whether the final destination was safe.

This PR:
- Adds `MaxRedirectsExceededError` and `CircularRedirectError` to the recognised-as-permanent list, so both stop the job on the first attempt with no retries.
- Distinguishes the failure message by what actually happened — "too many redirects", "redirect loop", or "blocked by SSRF protection" — instead of always claiming a security block.
- States that the final destination was not verified for the two redirect-chain cases, rather than implying either a block or a clean bill of health.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format`)
- I have checked if my changes generate no new warnings (`npm run lint`)
- I have added tests that prove my fix is effective
- I have checked that new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes analytics exports stop retrying when secure outbound fetching detects a redirect loop or exhausts its redirect budget, while distinguishing those outcomes from confirmed SSRF policy blocks.

- Adds terminal classification and tailored descriptions for redirect-loop and redirect-budget errors.
- Propagates sanitized terminal errors to PostHog and Mixpanel job handling.
- Adds tests for classification, reporting wording, and credential redaction.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The retry classification should be corrected before merging because a transient redirect loop or over-budget chain currently terminates the job's remaining retry attempts.

Redirect errors are derived from remote HTTP responses that may vary between attempts, but the new classifier always converts them into an unrecoverable job failure and therefore delays otherwise recoverable exports until a later schedule cycle.

**Files Needing Attention:** worker/src/errors/findOutboundUrlValidationError.ts
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[PostHog or Mixpanel export] --> B[Secure outbound fetch]
  B --> C{Fetch outcome}
  C -->|Policy block| D[SSRF-block description]
  C -->|Redirect loop or budget exhausted| E[Destination-unverified description]
  D --> F[UnrecoverableError]
  E --> F
  F --> G[BullMQ stops current job retries]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/errors/findOutboundUrlValidationError.ts:30-34
**Transient redirects become terminal**

If an analytics endpoint's redirect responses vary between requests, a transient loop or over-budget chain is classified as permanent and converted to `UnrecoverableError`, causing BullMQ to skip the remaining retries and delaying the export until a later scheduled job.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): stop retrying analytics exp..."](https://github.com/langfuse/langfuse/commit/626f3734dc62d2e65977cf6190ec421cb6daf03c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54418561)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->