### PR TITLE
fix(worker,shared): auto-disable analytics exports on a redirect-hop SSRF block

### DIFF
--- a/packages/shared/src/server/outbound-url/fetch.test.ts
+++ b/packages/shared/src/server/outbound-url/fetch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { redactUrlCredentials } from "./fetch";
+
+describe("redactUrlCredentials", () => {
+  it("strips a user:password userinfo", () => {
+    expect(
+      redactUrlCredentials("http://exporter:hunter2@169.254.169.254/"),
+    ).toBe("http://***@169.254.169.254/");
+  });
+
+  it("strips a username-only userinfo", () => {
+    expect(
+      redactUrlCredentials("https://leaked-token@host.example/batch/"),
+    ).toBe("https://***@host.example/batch/");
+  });
+
+  // The redirect reporting paths embed URLs in a longer message, so a single
+  // replacement is not enough.
+  it("redacts every occurrence in a message", () => {
+    expect(
+      redactUrlCredentials(
+        "failed for url http://a:b@10.0.0.1/ from https://c:d@host.example/",
+      ),
+    ).toBe(
+      "failed for url http://***@10.0.0.1/ from https://***@host.example/",
+    );
+  });
+
+  it("leaves a credential-free URL untouched", () => {
+    expect(redactUrlCredentials("https://host.example/batch/?x=1#y")).toBe(
+      "https://host.example/batch/?x=1#y",
+    );
+  });
+
+  // Non-vacuity: an @ that is not userinfo must survive, or redaction would be
+  // mangling ordinary paths and prose.
+  it("does not touch an @ in the path or in bare text", () => {
+    expect(redactUrlCredentials("https://host.example/@handle")).toBe(
+      "https://host.example/@handle",
+    );
+    expect(redactUrlCredentials("contact user@host.example")).toBe(
+      "contact user@host.example",
+    );
+  });
+});

--- a/packages/shared/src/server/outbound-url/fetch.ts
+++ b/packages/shared/src/server/outbound-url/fetch.ts
@@ -11,16 +11,30 @@ const SENSITIVE_REDIRECT_HEADERS = new Set([
 ]);
 
 /**
- * Custom error for redirect validation failures
+ * Custom error for redirect validation failures.
+ *
+ * `cause` is required, not optional: consumers classify a rejection off the
+ * inner error's typed `code` (see OutboundUrlValidationErrorCode), and folding
+ * the inner failure into this message alone silently drops that code. An
+ * integration whose redirect target is a blocked host then reads as
+ * unclassifiable rather than as the customer-config fault it is, and stays
+ * enabled to retry the same blocked hop on every scheduled run.
+ *
+ * Passed through the `Error` options bag so `cause` lands as a NON-enumerable
+ * property: a structured logger copies every enumerable field of an error into
+ * its log line, and the rejected target embedded in the inner message may carry
+ * userinfo credentials from a `Location` header.
  */
 export class RedirectValidationError extends Error {
   constructor(
     message: string,
     public redirectUrl: string,
     public redirectDepth: number,
+    cause: unknown,
   ) {
     super(
       `Redirect validation failed at depth ${redirectDepth} for url ${redirectUrl}: ${message}`,
+      { cause },
     );
     this.name = "RedirectValidationError";
   }
@@ -239,6 +253,7 @@ export async function fetchWithSecureRedirects(
           error instanceof Error ? error.message : "Validation failed",
           redirectUrl,
           redirectDepth,
+          error,
         );
       }
     }

--- a/packages/shared/src/server/outbound-url/fetch.ts
+++ b/packages/shared/src/server/outbound-url/fetch.ts
@@ -12,10 +12,13 @@ const SENSITIVE_REDIRECT_HEADERS = new Set([
 
 // A Location header may carry userinfo, so a rejected target can hold a
 // password. Strip it before the URL reaches a log line or a retained error.
-const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^/?#\s@]*@/gi;
+// Anchored on `://` rather than on a scheme pattern: a leading `[a-z][a-z0-9+.-]*`
+// rescans and backtracks at every offset of an attacker-supplied string, which
+// is quadratic, and the scheme itself contributes nothing to the match.
+const URL_CREDENTIALS = /:\/\/[^/?#\s@]*@/g;
 
 export const redactUrlCredentials = (text: string): string =>
-  text.replace(URL_CREDENTIALS, "$1***@");
+  text.replace(URL_CREDENTIALS, "://***@");
 
 /**
  * Custom error for redirect validation failures. `cause` is required so the

--- a/packages/shared/src/server/outbound-url/fetch.ts
+++ b/packages/shared/src/server/outbound-url/fetch.ts
@@ -10,20 +10,18 @@ const SENSITIVE_REDIRECT_HEADERS = new Set([
   WebhookSignatureHeader,
 ]);
 
+// A Location header may carry userinfo, so a rejected target can hold a
+// password. Strip it before the URL reaches a log line or a retained error.
+const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^/?#\s@]*@/gi;
+
+export const redactUrlCredentials = (text: string): string =>
+  text.replace(URL_CREDENTIALS, "$1***@");
+
 /**
- * Custom error for redirect validation failures.
- *
- * `cause` is required, not optional: consumers classify a rejection off the
- * inner error's typed `code` (see OutboundUrlValidationErrorCode), and folding
- * the inner failure into this message alone silently drops that code. An
- * integration whose redirect target is a blocked host then reads as
- * unclassifiable rather than as the customer-config fault it is, and stays
- * enabled to retry the same blocked hop on every scheduled run.
- *
- * Passed through the `Error` options bag so `cause` lands as a NON-enumerable
- * property: a structured logger copies every enumerable field of an error into
- * its log line, and the rejected target embedded in the inner message may carry
- * userinfo credentials from a `Location` header.
+ * Custom error for redirect validation failures. `cause` is required so the
+ * inner error's typed `code` survives for classification, and goes through the
+ * options bag so it stays non-enumerable — a structured logger serializes every
+ * enumerable field, and the rejected target may carry credentials.
  */
 export class RedirectValidationError extends Error {
   constructor(
@@ -243,10 +241,13 @@ export async function fetchWithSecureRedirects(
         );
       } catch (error) {
         logger.warn("Redirect validation failed", {
-          from: currentUrl,
-          to: redirectUrl,
+          from: redactUrlCredentials(currentUrl),
+          to: redactUrlCredentials(redirectUrl),
           redirectDepth,
-          error: error instanceof Error ? error.message : "Unknown error",
+          error:
+            error instanceof Error
+              ? redactUrlCredentials(error.message)
+              : "Unknown error",
         });
 
         throw new RedirectValidationError(

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -226,13 +226,9 @@ describe("PostHog integration project job — SSRF connect-time pinning", () => 
 });
 
 /**
- * A redirect hop that lands on a blocked host is the same customer-config fault
- * as a blocked configured host: the deny-list is entirely private/reserved
- * space and the env whitelist is consulted first, so such a target can never be
- * a working endpoint, while leaving the integration enabled hands a prober a
- * fresh outbound attempt on every scheduled cycle. That makes the typed `code`
- * load-bearing — it has to survive the RedirectValidationError re-wrap, or the
- * handler's classifier cannot see the fault and the integration stays enabled.
+ * A blocked redirect target is the same customer-config fault as a blocked
+ * configured host, so it must disable too: the typed `code` has to survive the
+ * RedirectValidationError re-wrap for the classifier to see it.
  */
 describe("PostHog integration project job — SSRF block on a redirect hop", () => {
   const exporterHost = "https://exporter.analytics.example";
@@ -253,11 +249,9 @@ describe("PostHog integration project job — SSRF block on a redirect hop", () 
         new Response(null, { status: 302, headers: { Location: metadataUrl } }),
       );
 
-  // Only the pre-check for the harness host is stubbed — the same modelling
-  // choice the connect-time tests above make ("the host validated as public").
-  // Every other URL, i.e. the redirect target, goes through the REAL validator,
-  // so the fault the handler classifies is a genuine OutboundUrlValidationError
-  // and not a shape this test invented.
+  // Stub the pre-check for the harness host only (as the tests above do); the
+  // redirect target goes through the real validator, so the classified fault is
+  // a genuine OutboundUrlValidationError and not a shape invented here.
   async function useRealValidatorForRedirectTargets() {
     const actual = await vi.importActual<
       typeof import("@langfuse/shared/src/server")
@@ -271,8 +265,7 @@ describe("PostHog integration project job — SSRF block on a redirect hop", () 
   it("disables the integration when a redirect target is a blocked host", async () => {
     await useRealValidatorForRedirectTargets();
     h.db.integration.posthogHostName = exporterHost;
-    // Stubbed at the socket boundary, so no connect-time lookup runs and the
-    // only policy that can reject anything here is redirect-target validation.
+    // Stubbed at the socket boundary: only redirect validation can reject here.
     const fetchSpy = redirectOnce();
 
     let thrown: unknown;
@@ -282,11 +275,9 @@ describe("PostHog integration project job — SSRF block on a redirect hop", () 
       thrown = error;
     }
 
-    // Non-vacuous: the 302 really was served, so the block came from the
-    // redirect hop rather than from the configured host never being reached.
+    // Non-vacuous: the 302 was served, so the block came from the redirect hop.
     expect(fetchSpy).toHaveBeenCalled();
-    // Must not throw — a throw would increment type:failed and fire the monitor
-    // once an hour for a fault that cannot clear on its own.
+    // Must not throw: that would fire the Failures monitor every cycle.
     expect(thrown).toBeUndefined();
     expect(h.recordIncrement).toHaveBeenCalledWith(
       POSTHOG_INTEGRATION_DISABLED_METRIC,
@@ -299,9 +290,8 @@ describe("PostHog integration project job — SSRF block on a redirect hop", () 
     expect(h.dispatchProjectNotification).toHaveBeenCalled();
   }, 40_000);
 
-  // The contract the disable above rests on, asserted directly at the throw
-  // site: the re-wrap keeps the inner typed error reachable, and keeps it OFF
-  // the enumerable surface a structured logger copies into its log line.
+  // The contract the disable rests on: the inner typed error stays reachable,
+  // and stays off the enumerable surface a logger serializes.
   it("keeps the inner validation error reachable as a non-enumerable cause", async () => {
     const actual = await vi.importActual<
       typeof import("@langfuse/shared/src/server")

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -152,9 +152,11 @@ import {
 } from "../features/posthog/handlePostHogIntegrationProjectJob";
 import {
   CircularRedirectError,
+  fetchWithSecureRedirects,
   MaxRedirectsExceededError,
   OutboundUrlValidationError,
   RedirectValidationError,
+  validateWebhookURL,
 } from "@langfuse/shared/src/server";
 import { rethrowIfOutboundValidationFailure } from "../features/analyticsIntegrationEgress";
 import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
@@ -221,6 +223,111 @@ describe("PostHog integration project job — SSRF connect-time pinning", () => 
     );
     expect(h.dispatchProjectNotification).toHaveBeenCalled();
   }, 40_000);
+});
+
+/**
+ * A redirect hop that lands on a blocked host is the same customer-config fault
+ * as a blocked configured host: the deny-list is entirely private/reserved
+ * space and the env whitelist is consulted first, so such a target can never be
+ * a working endpoint, while leaving the integration enabled hands a prober a
+ * fresh outbound attempt on every scheduled cycle. That makes the typed `code`
+ * load-bearing — it has to survive the RedirectValidationError re-wrap, or the
+ * handler's classifier cannot see the fault and the integration stays enabled.
+ */
+describe("PostHog integration project job — SSRF block on a redirect hop", () => {
+  const exporterHost = "https://exporter.analytics.example";
+  const metadataUrl = "http://169.254.169.254/latest/meta-data/";
+
+  beforeEach(() => {
+    h.posthogIntegrationUpdate.mockClear();
+    h.posthogIntegrationUpdateMany.mockClear();
+    h.recordIncrement.mockClear();
+    h.dispatchProjectNotification.mockClear();
+    h.db.integration = h.integration();
+  });
+
+  const redirectOnce = () =>
+    vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(null, { status: 302, headers: { Location: metadataUrl } }),
+      );
+
+  // Only the pre-check for the harness host is stubbed — the same modelling
+  // choice the connect-time tests above make ("the host validated as public").
+  // Every other URL, i.e. the redirect target, goes through the REAL validator,
+  // so the fault the handler classifies is a genuine OutboundUrlValidationError
+  // and not a shape this test invented.
+  async function useRealValidatorForRedirectTargets() {
+    const actual = await vi.importActual<
+      typeof import("@langfuse/shared/src/server")
+    >("@langfuse/shared/src/server");
+    vi.mocked(validateWebhookURL).mockImplementation(async (url, whitelist) => {
+      if (url.startsWith(exporterHost)) return;
+      await actual.validateWebhookURL(url, whitelist);
+    });
+  }
+
+  it("disables the integration when a redirect target is a blocked host", async () => {
+    await useRealValidatorForRedirectTargets();
+    h.db.integration.posthogHostName = exporterHost;
+    // Stubbed at the socket boundary, so no connect-time lookup runs and the
+    // only policy that can reject anything here is redirect-target validation.
+    const fetchSpy = redirectOnce();
+
+    let thrown: unknown;
+    try {
+      await handlePostHogIntegrationProjectJob(makeJob());
+    } catch (error) {
+      thrown = error;
+    }
+
+    // Non-vacuous: the 302 really was served, so the block came from the
+    // redirect hop rather than from the configured host never being reached.
+    expect(fetchSpy).toHaveBeenCalled();
+    // Must not throw — a throw would increment type:failed and fire the monitor
+    // once an hour for a fault that cannot clear on its own.
+    expect(thrown).toBeUndefined();
+    expect(h.recordIncrement).toHaveBeenCalledWith(
+      POSTHOG_INTEGRATION_DISABLED_METRIC,
+      1,
+      { reason: "ssrf_blocked_endpoint" },
+    );
+    expect(h.posthogIntegrationUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { enabled: false } }),
+    );
+    expect(h.dispatchProjectNotification).toHaveBeenCalled();
+  }, 40_000);
+
+  // The contract the disable above rests on, asserted directly at the throw
+  // site: the re-wrap keeps the inner typed error reachable, and keeps it OFF
+  // the enumerable surface a structured logger copies into its log line.
+  it("keeps the inner validation error reachable as a non-enumerable cause", async () => {
+    const actual = await vi.importActual<
+      typeof import("@langfuse/shared/src/server")
+    >("@langfuse/shared/src/server");
+    redirectOnce();
+
+    const thrown = await fetchWithSecureRedirects(
+      `${exporterHost}/batch/`,
+      { method: "POST" },
+      {
+        maxRedirects: 3,
+        redirectValidation: { validateUrl: actual.validateWebhookURL },
+      },
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect((thrown as Error | undefined)?.name).toBe("RedirectValidationError");
+    const cause = (thrown as { cause?: unknown } | undefined)?.cause as
+      | { name?: string; code?: string }
+      | undefined;
+    expect(cause?.name).toBe("OutboundUrlValidationError");
+    expect(cause?.code).toBe("blocked-hostname");
+    expect(Object.keys(thrown as object)).not.toContain("cause");
+  });
 });
 
 describe("Mixpanel sender — SSRF connect-time pinning", () => {
@@ -352,6 +459,10 @@ describe("terminal outbound failure reporting", () => {
         "Blocked IP address detected: 169.254.169.254",
         "http://exporter:hunter2@169.254.169.254/",
         0,
+        new OutboundUrlValidationError(
+          "blocked-ip",
+          "Blocked IP address detected: 169.254.169.254",
+        ),
       ),
     });
 

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -256,8 +256,11 @@ describe("PostHog integration project job — SSRF block on a redirect hop", () 
     const actual = await vi.importActual<
       typeof import("@langfuse/shared/src/server")
     >("@langfuse/shared/src/server");
+    const exporterOrigin = new URL(exporterHost).origin;
     vi.mocked(validateWebhookURL).mockImplementation(async (url, whitelist) => {
-      if (url.startsWith(exporterHost)) return;
+      // Origin equality, not a prefix: exporter.analytics.example.evil.test
+      // starts with the harness host but is a different origin.
+      if (new URL(url).origin === exporterOrigin) return;
       await actual.validateWebhookURL(url, whitelist);
     });
   }

--- a/worker/src/errors/findOutboundUrlValidationError.ts
+++ b/worker/src/errors/findOutboundUrlValidationError.ts
@@ -34,10 +34,11 @@ const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
 ]);
 
 // A resolver hiccup is not a policy block: the host may be legitimate and the
-// next attempt may succeed, so it must stay retryable. RedirectValidationError
-// re-wraps the inner failure by message only — no code, no cause — so a DNS
-// failure on a redirect hop is recognisable only by its message text. The
-// substring is imported from the throw site so the two stay in sync.
+// next attempt may succeed, so it must stay retryable. A DNS failure on a
+// redirect hop arrives as RedirectValidationError, which restates the reason in
+// its own message and keeps the coded original as `cause`; matching the message
+// keeps this check independent of how deeply the chain is wrapped. The substring
+// is imported from the throw site so the two stay in sync.
 const isTransientDnsFailure = (error: Error): boolean =>
   (error as { code?: unknown }).code === "dns-lookup-failed" ||
   error.message.includes(DNS_LOOKUP_FAILED_MESSAGE_PREFIX);

--- a/worker/src/errors/findOutboundUrlValidationError.ts
+++ b/worker/src/errors/findOutboundUrlValidationError.ts
@@ -33,12 +33,9 @@ const OUTBOUND_VALIDATION_ERROR_NAMES = new Set([
   REDIRECT_LOOP_ERROR_NAME,
 ]);
 
-// A resolver hiccup is not a policy block: the host may be legitimate and the
-// next attempt may succeed, so it must stay retryable. A DNS failure on a
-// redirect hop arrives as RedirectValidationError, which restates the reason in
-// its own message and keeps the coded original as `cause`; matching the message
-// keeps this check independent of how deeply the chain is wrapped. The substring
-// is imported from the throw site so the two stay in sync.
+// A resolver hiccup may succeed on the next attempt, so it stays retryable. A
+// redirect hop restates the reason in its own message, so match that too;
+// substring imported from the throw site to stay in sync.
 const isTransientDnsFailure = (error: Error): boolean =>
   (error as { code?: unknown }).code === "dns-lookup-failed" ||
   error.message.includes(DNS_LOOKUP_FAILED_MESSAGE_PREFIX);

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -1,5 +1,6 @@
 import {
   logger,
+  redactUrlCredentials,
   validateWebhookURL,
   whitelistFromEnv,
   type RedirectOptions,
@@ -33,13 +34,6 @@ export const buildAnalyticsRedirectOptions = (
     logContext,
   },
 });
-
-// A rejected redirect target is reported with its URL embedded verbatim, and a
-// Location header may carry userinfo, so the message can hold a password.
-const URL_CREDENTIALS = /([a-z][a-z0-9+.-]*:\/\/)[^/?#\s@]*@/gi;
-
-const redactUrlCredentials = (text: string): string =>
-  text.replace(URL_CREDENTIALS, "$1***@");
 
 /**
  * A serialization-safe stand-in for the validation error. The original holds the

--- a/worker/src/features/integrations/customerFaultClassification.test.ts
+++ b/worker/src/features/integrations/customerFaultClassification.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { OutboundUrlValidationError } from "@langfuse/shared/src/server";
+import {
+  OutboundUrlValidationError,
+  RedirectValidationError,
+} from "@langfuse/shared/src/server";
 import {
   classifyCustomerFault,
   isCustomerFaultError,
@@ -196,6 +199,43 @@ describe("isCustomerFaultError", () => {
       );
       expect(isCustomerFaultError(err)).toBe(false);
       expect(isCustomerFaultError(wrapped(err))).toBe(false);
+    });
+
+    it("classifies an SSRF block raised on a redirect hop as customer_fault", () => {
+      // The rejection the analytics exporters actually hit in production: the
+      // configured host answers with a 3xx whose target is a blocked host. The
+      // typed code reaches this classifier only through the redirect error's
+      // `cause`; without it the fault reads as unclassifiable and the
+      // integration stays enabled, retrying the same blocked hop every cycle.
+      const redirectBlock = new RedirectValidationError(
+        "Blocked hostname detected",
+        "http://169.254.169.254/latest/meta-data/",
+        0,
+        new OutboundUrlValidationError(
+          "blocked-hostname",
+          "Blocked hostname detected",
+        ),
+      );
+      expect(classifyCustomerFault(wrapped(redirectBlock))).toBe(
+        "ssrf_blocked_endpoint",
+      );
+    });
+
+    it("keeps a dns-lookup-failed on a redirect hop out of customer_fault", () => {
+      // Same wrapper, transient inner code: reaching the inner error through
+      // `cause` must not turn a resolver hiccup into a permanent disable.
+      const redirectDnsFailure = new RedirectValidationError(
+        "DNS lookup failed for host.example",
+        "https://host.example/batch/",
+        0,
+        new OutboundUrlValidationError(
+          "dns-lookup-failed",
+          "DNS lookup failed for host.example",
+        ),
+      );
+      expect(
+        classifyCustomerFault(wrapped(redirectDnsFailure)),
+      ).toBeUndefined();
     });
 
     it("classifies a validation rejection re-wrapped with guidance (code preserved) as customer_fault", () => {

--- a/worker/src/features/integrations/customerFaultClassification.test.ts
+++ b/worker/src/features/integrations/customerFaultClassification.test.ts
@@ -202,11 +202,8 @@ describe("isCustomerFaultError", () => {
     });
 
     it("classifies an SSRF block raised on a redirect hop as customer_fault", () => {
-      // The rejection the analytics exporters actually hit in production: the
-      // configured host answers with a 3xx whose target is a blocked host. The
-      // typed code reaches this classifier only through the redirect error's
-      // `cause`; without it the fault reads as unclassifiable and the
-      // integration stays enabled, retrying the same blocked hop every cycle.
+      // The production shape: the configured host answers 3xx with a blocked
+      // target. The typed code reaches here only via the redirect `cause`.
       const redirectBlock = new RedirectValidationError(
         "Blocked hostname detected",
         "http://169.254.169.254/latest/meta-data/",
@@ -222,8 +219,7 @@ describe("isCustomerFaultError", () => {
     });
 
     it("keeps a dns-lookup-failed on a redirect hop out of customer_fault", () => {
-      // Same wrapper, transient inner code: reaching the inner error through
-      // `cause` must not turn a resolver hiccup into a permanent disable.
+      // Same wrapper, transient inner code: must not become a permanent disable.
       const redirectDnsFailure = new RedirectValidationError(
         "DNS lookup failed for host.example",
         "https://host.example/batch/",

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -444,15 +444,10 @@ export const handlePostHogIntegrationProjectJob = async (
     ).slice(0, 1000);
 
     if (reason === undefined) {
-      // Defensive fallback for a validation failure the classifier does not
-      // recognise. Every OutboundUrlValidationErrorCode that exists today either
-      // classifies above and disables the integration — including one raised on
-      // a redirect hop, which reaches the classifier through the redirect
-      // error's `cause` — or is transient (dns-lookup-failed), which this helper
-      // deliberately leaves on the retry path. So nothing should reach here; a
-      // future uncoded block stays terminal rather than retried, because a policy
-      // block cannot succeed on the next attempt, and leaves the integration
-      // enabled so a corrected endpoint recovers on the next scheduled run.
+      // Defensive fallback: every code today either classifies above and
+      // disables (including one raised on a redirect hop, reached through the
+      // redirect error's `cause`) or is transient. An unrecognised block stays
+      // terminal, but leaves the integration enabled to recover next run.
       rethrowIfOutboundValidationFailure(error, {
         logSubject: `[POSTHOG] Outbound send for project ${projectId}`,
         jobSubject: `PostHog integration for project ${projectId}`,

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -444,13 +444,15 @@ export const handlePostHogIntegrationProjectJob = async (
     ).slice(0, 1000);
 
     if (reason === undefined) {
-      // A connect-time SSRF block is a permanent misconfiguration of the
-      // integration host, not a transient failure, so skip the remaining BullMQ
-      // attempts for this job. Only reached for blocks the classifier above does
-      // not own (e.g. a rejected redirect target): a blocked hostname/IP is a
-      // customer fault and disables the integration instead. The integration
-      // stays enabled here, so the schedule re-enqueues the project next cycle,
-      // which is what lets a fixed endpoint recover on its own.
+      // Defensive fallback for a validation failure the classifier does not
+      // recognise. Every OutboundUrlValidationErrorCode that exists today either
+      // classifies above and disables the integration — including one raised on
+      // a redirect hop, which reaches the classifier through the redirect
+      // error's `cause` — or is transient (dns-lookup-failed), which this helper
+      // deliberately leaves on the retry path. So nothing should reach here; a
+      // future uncoded block stays terminal rather than retried, because a policy
+      // block cannot succeed on the next attempt, and leaves the integration
+      // enabled so a corrected endpoint recovers on the next scheduled run.
       rethrowIfOutboundValidationFailure(error, {
         logSubject: `[POSTHOG] Outbound send for project ${projectId}`,
         jobSubject: `PostHog integration for project ${projectId}`,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16259.preview.langfuse.com](https://pr-16259.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

An SSRF rejection raised while validating a **redirect target** never reached the customer-fault classifier, so an analytics integration whose endpoint redirects to a blocked host stayed enabled. The scheduler re-enqueued it every cycle, each run re-attempted the send — handing the redirecting endpoint a fresh batch of outbound requests indefinitely — and logged an error per attempt for a fault that can never clear by itself.

`RedirectValidationError` folded the inner failure into its own message and dropped the typed error, so the deterministic `code` the classifier keys on was gone by the time the handler saw it. It now carries the inner error as `cause`, which is all the classifier needs — it already walks the cause chain. A blocked hostname or IP on a redirect hop is therefore treated as the same customer-config fault as a directly configured blocked host: the integration is disabled, the error is persisted, and the project is notified once. This also makes the `ssrf_blocked_endpoint` disable reason reachable for the first time.

Two properties worth calling out:

- `cause` is passed through the `Error` options bag so it stays **non-enumerable**. A structured logger copies every enumerable field of an error into its log line, and a rejected `Location` target may carry userinfo credentials.
- A transient `dns-lookup-failed` on a redirect hop stays on the retry path. Resolvability depends on resolver state rather than on the endpoint config, so it must not permanently disable a working integration. Covered by a regression test.

The constructor parameter is required rather than optional so a future throw site cannot silently drop the code again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

Verification run locally:

- `pnpm run lint` — Tasks: 7 successful, 7 total
- `pnpm run typecheck` — Tasks: 7 successful, 7 total
- worker `analyticsIntegrationSsrfPinning` — Tests 9 passed (9), including 2 new cases that both fail without the fix
- worker `customerFaultClassification` + `posthogIntegrationProjectJob` — Tests 96 passed (96)
- worker `secureLlmFetch` + `outbound-connection-validation` — Tests 21 passed (21)
- web `remote-experiment-helpers` — Tests 15 passed (15)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves typed outbound-validation errors through redirect wrappers so analytics integrations can distinguish permanent SSRF blocks from transient DNS failures.
- Adds the original validation error as a non-enumerable `cause` on `RedirectValidationError`.
- Allows PostHog redirect-hop SSRF blocks to disable the affected integration instead of retrying indefinitely.
- Adds focused coverage for blocked redirects, transient DNS failures, cause visibility, and non-enumerability.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with redirect-hop SSRF blocks and transient DNS failures handled consistently by the existing analytics integration failure paths.

The redirect wrapper now retains the original typed validation error, all constructor callers were updated, and the worker classification paths correctly disable deterministic blocked endpoints while preserving retries for DNS failures.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Analytics export request] --> B{Redirect returned?}
  B -->|No| C[Continue export]
  B -->|Yes| D[Validate redirect target]
  D -->|Allowed| C
  D -->|Blocked host or IP| E[RedirectValidationError]
  D -->|DNS lookup failure| E
  E --> F[Preserved typed cause]
  F --> G{Validation code}
  G -->|blocked-hostname or blocked-ip| H[Classify customer fault]
  H --> I[Disable integration and notify]
  G -->|dns-lookup-failed| J[Keep retryable]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker,shared): auto-disable analyti..."](https://github.com/langfuse/langfuse/commit/927a980b6a8cfafac598073ccbad4704b4328a21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54420267)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->