### PR TITLE
fix(worker): fail fast and auto-disable the blob export on config faults

### DIFF
--- a/packages/shared/src/server/notifications/types.ts
+++ b/packages/shared/src/server/notifications/types.ts
@@ -46,8 +46,8 @@ export const ProjectNotificationEventSchema = z.discriminatedUnion(
       eventType: z.literal(
         ProjectNotificationEventTypeSchema.enum["blob-export-failed"],
       ),
-      // true when the integration was auto-disabled after repeated failures
-      // (terminal event; selects the "disabled" email variant).
+      // true when the integration was auto-disabled after a configuration
+      // fault (terminal event; selects the "disabled" email variant).
       disabled: z.boolean().optional(),
     }),
     projectNotificationEventBaseSchema.extend({

--- a/packages/shared/src/server/services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail.tsx
+++ b/packages/shared/src/server/services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail.tsx
@@ -16,9 +16,9 @@ export const blobStorageExportFailedEmailCopy: IntegrationExportFailedEmailCopy 
     disabledBody: (projectName) => (
       <>
         The blob storage export for project &quot;{projectName}
-        &quot; has been disabled after repeated failures. This usually means the
-        destination configuration or credentials are no longer valid. Once you
-        have updated them, simply re-enable the export in the integration
+        &quot; has been disabled after a configuration fault. This usually means
+        the destination configuration or credentials are no longer valid. Once
+        you have updated them, simply re-enable the export in the integration
         settings and it will pick up right where it left off.
       </>
     ),

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -238,8 +238,8 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     });
   });
 
-  // After BullMQ exhausts its retries, a customer-fault error disables the
-  // integration; everything else keeps retrying as before.
+  // A classified customer fault disables the integration on its first
+  // occurrence and resolves the job; everything else keeps retrying as before.
   describe("customer-fault disable", () => {
     const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
 
@@ -292,37 +292,19 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     const settleBackgroundTasks = () =>
       new Promise((resolve) => setTimeout(resolve, 200));
 
-    it("keeps the integration enabled and does not notify on a non-final customer-fault attempt", async () => {
+    // Resolving is the point: the queue's failure counter is incremented per
+    // failed attempt, so a throw here would light the processing-failures
+    // monitor for a fault that no retry can clear.
+    it("disables the integration and resolves on the first customer-fault attempt", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
       s3Prefix = projectId;
       await createIntegration(projectId);
+      mockRecordIncrement.mockClear();
       mockValidateBlobStorageEndpoint.mockRejectedValueOnce(
         accessDeniedError(),
       );
 
-      await expect(runAttempt(projectId, 0)).rejects.toThrow(/access denied/i);
-      await settleBackgroundTasks();
-
-      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
-        where: { projectId },
-      });
-      // BullMQ still has retries left, so we let it retry — no disable yet,
-      // and no email either: a later retry may still succeed.
-      expect(row.enabled).toBe(true);
-      expect(row.lastError).toMatch(/access denied/i);
-      expect(row.lastFailureNotificationSentAt).toBeNull();
-    });
-
-    it("disables the integration on the final exhausted customer-fault attempt", async () => {
-      const { projectId } = await createOrgProjectAndApiKey();
-      s3Prefix = projectId;
-      await createIntegration(projectId);
-      mockValidateBlobStorageEndpoint.mockRejectedValueOnce(
-        accessDeniedError(),
-      );
-
-      await expect(runAttempt(projectId, 4)).rejects.toThrow(/access denied/i);
-      await settleBackgroundTasks();
+      await expect(runAttempt(projectId, 0)).resolves.toBeUndefined();
 
       const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
         where: { projectId },
@@ -331,6 +313,30 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       expect(row.lastError).toMatch(/access denied/i);
       expect(row.lastErrorAt).not.toBeNull();
       // The "disabled" email bypasses the cooldown, so it must not claim it.
+      expect(row.lastFailureNotificationSentAt).toBeNull();
+      // Tagged by reason so an SSRF/abuse disable stays separable from a
+      // misconfiguration one.
+      expect(mockRecordIncrement).toHaveBeenCalledWith(
+        BLOB_INTEGRATION_DISABLED_METRIC,
+        1,
+        { reason: "credentials" },
+      );
+    });
+
+    it("still disables and resolves when the fault first appears on the final attempt", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      await createIntegration(projectId);
+      mockValidateBlobStorageEndpoint.mockRejectedValueOnce(
+        accessDeniedError(),
+      );
+
+      await expect(runAttempt(projectId, 4)).resolves.toBeUndefined();
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.enabled).toBe(false);
       expect(row.lastFailureNotificationSentAt).toBeNull();
     });
 
@@ -425,7 +431,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         throw accessDeniedError();
       });
 
-      await expect(runAttempt(projectId, 4)).rejects.toThrow(/access denied/i);
+      await expect(runAttempt(projectId, 4)).resolves.toBeUndefined();
       await settleBackgroundTasks();
 
       const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
@@ -445,11 +451,11 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     });
 
     // When the failure can't even be written down (Postgres unavailable), the
-    // run knows nothing about the row's state. It must not claim a disable it
-    // failed to persist, but it must still say something rather than dropping
-    // the failure silently. `update` is only called on this terminal path, so
-    // spying on it isolates the persistence failure from the export itself.
-    it("falls back to the informational email when persisting the failure fails", async () => {
+    // run knows nothing about the row's state, so it must not claim the fault is
+    // handled: it stays on the retry path and sends no email. `update` is only
+    // called on this terminal path, so spying on it isolates the persistence
+    // failure from the export itself.
+    it("keeps retrying without notifying when persisting the failure fails", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
       s3Prefix = projectId;
       await createIntegration(projectId);
@@ -474,8 +480,8 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         where: { projectId },
       });
       // Nothing was written, so the fault is invisible to the row and the
-      // integration keeps running — even though this was a classified fault on
-      // the final attempt, which would otherwise have disabled it.
+      // integration keeps running — even though this was a classified fault
+      // that would otherwise have disabled it.
       expect(row.enabled).toBe(true);
       expect(row.lastError).toBeNull();
       expect(mockRecordIncrement).not.toHaveBeenCalledWith(
@@ -483,9 +489,9 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         expect.anything(),
         expect.anything(),
       );
-      // The informational email still goes out, observable via its cooldown
-      // claim, so an unwritable failure is not a silent one.
-      expect(row.lastFailureNotificationSentAt).not.toBeNull();
+      // No email either: its "will retry at the next scheduled export" text is
+      // the only thing we can still vouch for, and the rethrow delivers that.
+      expect(row.lastFailureNotificationSentAt).toBeNull();
     });
   });
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1524,40 +1524,44 @@ export const handleBlobStorageIntegrationProjectJob = async (
     // customer fixes it. Once BullMQ exhausts its retries, disable the
     // integration so it stops re-scheduling and spamming.
     const isFinalAttempt = isFinalBullmqAttempt(job, error);
-    // Defined => disable; also tags the disable log + metric.
+    // Defined => disable; also tags the disable log + metric. No attempt-count
+    // gate: a deterministic fault cannot succeed on a retry, and the failures
+    // metric is emitted per failed attempt, so retrying one only lights the
+    // monitor for a fault nothing will clear.
     const customerFaultReason = classifyCustomerFault(error);
 
     const outcome = await recordTerminalExportError({
       projectId,
       errorMessage,
-      disableReason: isFinalAttempt ? customerFaultReason : undefined,
+      disableReason: customerFaultReason,
     });
 
     if (outcome.kind === "integration-deleted") {
       return; // obsolete job: complete it rather than fail it
     }
 
-    // Only the informational email waits for the retries to run out; sent
-    // earlier it fires even when a later attempt succeeds. A disable is already
-    // terminal, so it ignores the attempt count.
     switch (outcome.kind) {
       case "disabled-by-us":
-        notifyBlobStorageExportFailedInBackground(projectId, true);
-        break;
+        // Awaited, not fire-and-forget: the job resolves next, and the
+        // scheduler only enqueues enabled integrations, so an interrupted
+        // dispatch would leave the export off with nobody told and no retry.
+        await notifyBlobStorageExportFailed(projectId, true);
+        return; // resolve: retrying a config fault only lights the monitor
       case "lost-disable-race":
-        break; // the winner sent the terminal email; ours would contradict it
+        return; // the winner sent the terminal email; ours would contradict it
       case "error-recorded":
-        // Skipped once the integration is off: "will retry at the next
-        // scheduled export" is no longer true.
+        // Transient or unclassified, so it keeps retrying. The email waits for
+        // the retries to run out — sent earlier it fires even when a later
+        // attempt succeeds — and is skipped once the integration is off, where
+        // "will retry at the next scheduled export" is no longer true.
         if (isFinalAttempt && outcome.stillEnabled) {
           notifyBlobStorageExportFailedInBackground(projectId, false);
         }
         break;
       case "persist-failed":
-        // Row state unknown, so say something rather than nothing.
-        if (isFinalAttempt) {
-          notifyBlobStorageExportFailedInBackground(projectId, false);
-        }
+        // Nothing was written, so we cannot claim the fault is handled. Stay on
+        // the retry path and reclassify; no email, because its "will retry"
+        // text is the one thing we do know is true.
         break;
       // A plain switch over a union is not exhaustiveness-checked; the never
       // assignment below is what makes a missing case fail to compile.
@@ -1655,95 +1659,104 @@ async function recordTerminalExportError({
   }
 }
 
+// Fire-and-forget variant for the paths that rethrow: the job is about to fail
+// and BullMQ will retry, so nothing depends on the dispatch completing.
 function notifyBlobStorageExportFailedInBackground(
   projectId: string,
   disabled = false,
 ): void {
-  (async () => {
-    try {
-      // Called once per exhausted run. The cooldown gates across scheduled
-      // runs (the scheduler re-enqueues every frequency period, and each
-      // failing run would otherwise email again). The disable notification
-      // bypasses it: it is a one-time, terminal event — the integration
-      // won't run again until the customer re-enables it — and a cooldown
-      // claim could silently drop the one email that says it was turned off.
-      if (!disabled) {
-        const cooldownMs =
-          env.LANGFUSE_BLOB_STORAGE_FAILURE_NOTIFICATION_COOLDOWN_HOURS *
-          60 *
-          60 *
-          1000;
+  notifyBlobStorageExportFailed(projectId, disabled);
+}
 
-        // Atomic claim: set timestamp before sending to prevent duplicate emails on concurrent retries.
-        // If the email send subsequently fails, the cooldown still applies — the next failure
-        // after cooldown expiry will retry the notification.
-        const claimed = await prisma.blobStorageIntegration.updateMany({
-          where: {
-            projectId,
-            OR: [
-              { lastFailureNotificationSentAt: null },
-              {
-                lastFailureNotificationSentAt: {
-                  lt: new Date(Date.now() - cooldownMs),
-                },
-              },
-            ],
-          },
-          data: { lastFailureNotificationSentAt: new Date() },
-        });
+// Swallows every failure: notification trouble must not turn a deliberate
+// resolve back into a job failure.
+async function notifyBlobStorageExportFailed(
+  projectId: string,
+  disabled = false,
+): Promise<void> {
+  try {
+    // Called once per exhausted run. The cooldown gates across scheduled
+    // runs (the scheduler re-enqueues every frequency period, and each
+    // failing run would otherwise email again). The disable notification
+    // bypasses it: it is a one-time, terminal event — the integration
+    // won't run again until the customer re-enables it — and a cooldown
+    // claim could silently drop the one email that says it was turned off.
+    if (!disabled) {
+      const cooldownMs =
+        env.LANGFUSE_BLOB_STORAGE_FAILURE_NOTIFICATION_COOLDOWN_HOURS *
+        60 *
+        60 *
+        1000;
 
-        if (claimed.count === 0) {
-          logger.info(
-            `[BLOB INTEGRATION] Skipping failure notification for project ${projectId}, cooldown still active`,
-          );
-          return;
-        }
-      }
-
-      const [project, integration] = await Promise.all([
-        prisma.project.findUnique({
-          where: { id: projectId },
-          select: { name: true },
-        }),
-        prisma.blobStorageIntegration.findUnique({
-          where: { projectId },
-          select: { bucketName: true },
-        }),
-      ]);
-      const projectName = project?.name ?? projectId;
-      const settingsPath = `/project/${projectId}/settings/integrations/blobstorage`;
-
-      // Route to configured notification channels and admin emails. The
-      // cooldown claim above already deduped, so no extra throttle is needed.
-      // `disabled` marks the terminal "export turned off" notification, which
-      // selects the disabled email/subject variant downstream.
-      await dispatchProjectNotification({
-        projectId,
-        event: {
-          eventType: "blob-export-failed",
-          severity: "ALERT",
+      // Atomic claim: set timestamp before sending to prevent duplicate emails on concurrent retries.
+      // If the email send subsequently fails, the cooldown still applies — the next failure
+      // after cooldown expiry will retry the notification.
+      const claimed = await prisma.blobStorageIntegration.updateMany({
+        where: {
           projectId,
-          projectName,
-          // The integration is keyed by projectId (1:1); the bucket name is
-          // the most useful human label for the failing export destination.
-          resourceId: projectId,
-          resourceName: integration?.bucketName ?? "Blob storage integration",
-          message: disabled
-            ? `Blob storage export disabled for project "${projectName}" after repeated failures.`
-            : `Blob storage export failed for project "${projectName}".`,
-          url: env.NEXTAUTH_URL
-            ? `${env.NEXTAUTH_URL}${settingsPath}`
-            : undefined,
-          disabled,
+          OR: [
+            { lastFailureNotificationSentAt: null },
+            {
+              lastFailureNotificationSentAt: {
+                lt: new Date(Date.now() - cooldownMs),
+              },
+            },
+          ],
         },
+        data: { lastFailureNotificationSentAt: new Date() },
       });
-    } catch (error) {
-      logger.error(
-        `[BLOB INTEGRATION] Failed to send failure notification for project ${projectId}`,
-        error,
-      );
+
+      if (claimed.count === 0) {
+        logger.info(
+          `[BLOB INTEGRATION] Skipping failure notification for project ${projectId}, cooldown still active`,
+        );
+        return;
+      }
     }
-  })();
+
+    const [project, integration] = await Promise.all([
+      prisma.project.findUnique({
+        where: { id: projectId },
+        select: { name: true },
+      }),
+      prisma.blobStorageIntegration.findUnique({
+        where: { projectId },
+        select: { bucketName: true },
+      }),
+    ]);
+    const projectName = project?.name ?? projectId;
+    const settingsPath = `/project/${projectId}/settings/integrations/blobstorage`;
+
+    // Route to configured notification channels and admin emails. The
+    // cooldown claim above already deduped, so no extra throttle is needed.
+    // `disabled` marks the terminal "export turned off" notification, which
+    // selects the disabled email/subject variant downstream.
+    await dispatchProjectNotification({
+      projectId,
+      event: {
+        eventType: "blob-export-failed",
+        severity: "ALERT",
+        projectId,
+        projectName,
+        // The integration is keyed by projectId (1:1); the bucket name is
+        // the most useful human label for the failing export destination.
+        resourceId: projectId,
+        resourceName: integration?.bucketName ?? "Blob storage integration",
+        message: disabled
+          ? `Blob storage export disabled for project "${projectName}" after a configuration fault.`
+          : `Blob storage export failed for project "${projectName}".`,
+        url: env.NEXTAUTH_URL
+          ? `${env.NEXTAUTH_URL}${settingsPath}`
+          : undefined,
+        disabled,
+      },
+    });
+  } catch (error) {
+    logger.error(
+      `[BLOB INTEGRATION] Failed to send failure notification for project ${projectId}`,
+      error,
+    );
+  }
 }
 
 function extractStorageErrorMessage(error: unknown): string {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1545,9 +1545,10 @@ export const handleBlobStorageIntegrationProjectJob = async (
         return; // the winner sent the terminal email
       case "error-recorded":
         // Skipped once the integration is off: "will retry at the next
-        // scheduled export" is no longer true.
+        // scheduled export" is no longer true. Not awaited: this path rethrows,
+        // so the job is about to fail and be retried regardless.
         if (isFinalAttempt && outcome.stillEnabled) {
-          notifyBlobStorageExportFailedInBackground(projectId);
+          notifyBlobStorageExportFailed(projectId, false);
         }
         break;
       case "persist-failed":
@@ -1648,12 +1649,6 @@ async function recordTerminalExportError({
     );
     return { kind: "persist-failed" };
   }
-}
-
-// Informational variant for the paths that rethrow: the job is about to fail and
-// be retried, so nothing depends on the dispatch completing.
-function notifyBlobStorageExportFailedInBackground(projectId: string): void {
-  notifyBlobStorageExportFailed(projectId, false);
 }
 
 // Logs and swallows every failure: notification trouble must not turn a

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1520,14 +1520,9 @@ export const handleBlobStorageIntegrationProjectJob = async (
   } catch (error) {
     const errorMessage = extractStorageErrorMessage(error);
 
-    // A deterministic customer-config/credential fault can't succeed until the
-    // customer fixes it. Once BullMQ exhausts its retries, disable the
-    // integration so it stops re-scheduling and spamming.
     const isFinalAttempt = isFinalBullmqAttempt(job, error);
-    // Defined => disable; also tags the disable log + metric. No attempt-count
-    // gate: a deterministic fault cannot succeed on a retry, and the failures
-    // metric is emitted per failed attempt, so retrying one only lights the
-    // monitor for a fault nothing will clear.
+    // Defined => disable, on the first occurrence: a config fault cannot succeed
+    // on a retry, and the failures metric counts every failed attempt.
     const customerFaultReason = classifyCustomerFault(error);
 
     const outcome = await recordTerminalExportError({
@@ -1542,26 +1537,22 @@ export const handleBlobStorageIntegrationProjectJob = async (
 
     switch (outcome.kind) {
       case "disabled-by-us":
-        // Awaited, not fire-and-forget: the job resolves next, and the
-        // scheduler only enqueues enabled integrations, so an interrupted
-        // dispatch would leave the export off with nobody told and no retry.
+        // Awaited: the integration is now off, so the scheduler never revisits
+        // it and nothing would carry an interrupted dispatch.
         await notifyBlobStorageExportFailed(projectId, true);
-        return; // resolve: retrying a config fault only lights the monitor
+        return; // resolving is the point; a throw would light the monitor
       case "lost-disable-race":
-        return; // the winner sent the terminal email; ours would contradict it
+        return; // the winner sent the terminal email
       case "error-recorded":
-        // Transient or unclassified, so it keeps retrying. The email waits for
-        // the retries to run out — sent earlier it fires even when a later
-        // attempt succeeds — and is skipped once the integration is off, where
-        // "will retry at the next scheduled export" is no longer true.
+        // Skipped once the integration is off: "will retry at the next
+        // scheduled export" is no longer true.
         if (isFinalAttempt && outcome.stillEnabled) {
           notifyBlobStorageExportFailedInBackground(projectId, false);
         }
         break;
       case "persist-failed":
-        // Nothing was written, so we cannot claim the fault is handled. Stay on
-        // the retry path and reclassify; no email, because its "will retry"
-        // text is the one thing we do know is true.
+        // Nothing was written, so we cannot claim the fault is handled: retry
+        // and reclassify. No email — "will retry" is all we could honestly say.
         break;
       // A plain switch over a union is not exhaustiveness-checked; the never
       // assignment below is what makes a missing case fail to compile.
@@ -1659,8 +1650,8 @@ async function recordTerminalExportError({
   }
 }
 
-// Fire-and-forget variant for the paths that rethrow: the job is about to fail
-// and BullMQ will retry, so nothing depends on the dispatch completing.
+// Fire-and-forget variant for the paths that rethrow: the job is about to fail and
+// be retried, so nothing depends on the dispatch completing.
 function notifyBlobStorageExportFailedInBackground(
   projectId: string,
   disabled = false,
@@ -1668,8 +1659,9 @@ function notifyBlobStorageExportFailedInBackground(
   notifyBlobStorageExportFailed(projectId, disabled);
 }
 
-// Swallows every failure: notification trouble must not turn a deliberate
-// resolve back into a job failure.
+// Logs and swallows every failure: notification trouble must not turn a
+// deliberate resolve back into a job failure. Delivery is therefore best-effort
+// even on the awaited path; the persisted lastError is the durable signal.
 async function notifyBlobStorageExportFailed(
   projectId: string,
   disabled = false,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1547,7 +1547,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
         // Skipped once the integration is off: "will retry at the next
         // scheduled export" is no longer true.
         if (isFinalAttempt && outcome.stillEnabled) {
-          notifyBlobStorageExportFailedInBackground(projectId, false);
+          notifyBlobStorageExportFailedInBackground(projectId);
         }
         break;
       case "persist-failed":
@@ -1650,13 +1650,10 @@ async function recordTerminalExportError({
   }
 }
 
-// Fire-and-forget variant for the paths that rethrow: the job is about to fail and
+// Informational variant for the paths that rethrow: the job is about to fail and
 // be retried, so nothing depends on the dispatch completing.
-function notifyBlobStorageExportFailedInBackground(
-  projectId: string,
-  disabled = false,
-): void {
-  notifyBlobStorageExportFailed(projectId, disabled);
+function notifyBlobStorageExportFailedInBackground(projectId: string): void {
+  notifyBlobStorageExportFailed(projectId, false);
 }
 
 // Logs and swallows every failure: notification trouble must not turn a


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16261.preview.langfuse.com](https://pr-16261.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Makes the blob storage export fail fast on deterministic customer-config faults,
matching the behavior the PostHog export already has.

A rejected bucket, credential, or endpoint cannot succeed until the customer
fixes it. The handler already classified these correctly, but still rethrew and
relied on retry-then-disable-on-the-final-attempt. The queue's failure counter is
emitted per *failed attempt*, so every scheduled run of a misconfigured export
lit the processing-failures monitor about five times before anything turned it
off — alert noise for a condition no retry can clear. Silencing it requires the
job to *complete*, not merely to stop retrying.

On a classified fault the handler now disables on first occurrence and resolves
the job. Unclassified and transient errors are untouched: they record the error,
notify once the retries run out, and rethrow. `dns-lookup-failed` stays off the
allowlist, so a DNS outage cannot disable a working integration.

Builds on #16257 (now merged), which named these outcomes and pinned them under
test; that is what reduces this change to the control-flow edit it should be.

Reviewer note: splitting the notification helper into an awaited function and a
fire-and-forget wrapper reindents about 80 lines of its body without changing
them. Review with whitespace changes hidden — the real edit is the two-line
wrapper plus the `await` at the call site.

Three consequences worth calling out:

- **The terminal notification is now awaited** rather than fired and forgotten.
  The job resolves immediately afterwards and the scheduler only enqueues enabled
  integrations, so a dispatch cut off mid-flight would leave the export off with
  nobody told and no retry path. The informational variant stays fire-and-forget,
  since its job is about to fail and be retried anyway.

  To be precise about what this buys: sequencing, not delivery. Dispatch failures
  are still logged and swallowed — as in the PostHog handler — because letting
  them fail the job would relight the monitor without redelivering the email (the
  integration is disabled by then, so a retry returns early and never notifies).
  The persisted `lastError`, surfaced in the integration settings, stays the
  durable signal. Raised by review; left open rather than papered over.

- **Losing the disable claim to a concurrent run also resolves.** The integration
  is already off and the winner already notified; throwing would light the
  monitor for a fault that has been handled.

- **An unwritable failure keeps retrying and no longer emails.** Nothing was
  persisted, so the run cannot claim the fault is handled — and the informational
  email's "will retry" text is the one thing the rethrow makes true.

The second commit fixes a customer-visible string this change invalidates: the
disabled-export email said the integration was turned off "after repeated
failures", which described a retry history the customer no longer has. It now
names the cause, matching the PostHog copy's "after a configuration fault".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

The tests that changed direction are the deliverable, so they are worth reading
as the spec: a classified fault now resolves and disables on the first attempt,
the race loser resolves silently, and an unwritable failure retries without
emailing. Each of those assertions was inverted from a test that pinned the old
behavior in #16257, so the change of intent is visible in the diff rather than
implied.

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `blobStorageIntegrationProcessing` — `Tests 35 passed (35)`
- `blobExport*` — `Tests 19 passed (19)`; `blobStorageTuningWiring` —
  `Tests 3 passed (3)`
- `dispatchProjectNotification` (shared, for the email copy) —
  `Tests 3 passed (3)`

Not done, flagging rather than assuming: the hosted docs describe the export
failure/disable behavior and live in a separate repo, so if they state the
retry-then-disable sequence they will need a matching edit.
