### PR TITLE
fix(assistant): terminate timed out command descendants in sandbox

### DIFF
--- a/packages/in-app-agent-sandbox-runtime/package.json
+++ b/packages/in-app-agent-sandbox-runtime/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "build:test": "tsc",
-    "build:docker-image": "docker build . -t langfuse-in-app-agent-sandbox:latest && touch .local-image-built",
+    "build:docker-image": "tsc && docker build . -t langfuse-in-app-agent-sandbox:latest && touch .local-image-built",
     "start": "node ./dist/server.js",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/packages/in-app-agent-sandbox-runtime/src/server.ts
+++ b/packages/in-app-agent-sandbox-runtime/src/server.ts
@@ -306,7 +306,10 @@ function runCommand(
     startedAt: string;
     completedAt: string;
   }>((resolve, reject) => {
-    const child = spawn("sh", ["-lc", command], { cwd: WORKSPACE_ROOT });
+    const child = spawn("sh", ["-lc", command], {
+      cwd: WORKSPACE_ROOT,
+      detached: true,
+    });
     let stdout = "";
     let stderr = "";
     let settled = false;
@@ -350,7 +353,23 @@ function runCommand(
             }
 
             settled = true;
-            child.kill("SIGKILL");
+            if (child.pid) {
+              try {
+                // Process-group termination is best-effort:
+                // descendants can escape by creating a new session or process group.
+                // A sandbox should have lifetime limits as the final containment boundary.
+                process.kill(-child.pid, "SIGKILL");
+              } catch (error) {
+                logSandboxServer("bash.processGroupKillError", {
+                  requestId,
+                  pid: child.pid,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+                child.kill("SIGKILL");
+              }
+            } else {
+              child.kill("SIGKILL");
+            }
             resolve({
               stdout,
               stderr: `${stderr}Sandbox command timed out after ${timeoutMs}ms`,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16262.preview.langfuse.com](https://pr-16262.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Fixes most of the issue described in https://github.com/langfuse/langfuse/issues/15955. Complicating the timeout handling further is explicitly avoided and we rely on the sandbox having a finite duration and being monitored instead.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR strengthens sandbox command timeout cleanup by creating a dedicated process group and killing that group when the command times out.

- Compiles the sandbox runtime before building its Docker image.
- Starts shell commands as detached process-group leaders.
- Sends `SIGKILL` to the timed-out command’s process group, with direct-child termination as a fallback.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The timeout path targets the detached command’s Linux process group and safely falls back to killing the direct child, while the image-build change compiles the dist artifact consumed by the Dockerfile.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): terminate timed out comm..."](https://github.com/langfuse/langfuse/commit/cacaf322583da5934c58b9a4e5ec7bdd09cf2dba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54429655)</sub>

<!-- /greptile_comment -->