### PR TITLE
fix(evals): clip overflowing filter pills in the evaluators table

### DIFF
--- a/web/src/features/evals/components/EvaluatorFilterCell.clienttest.tsx
+++ b/web/src/features/evals/components/EvaluatorFilterCell.clienttest.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { type FilterState } from "@langfuse/shared";
+import { EvaluatorFilterCell } from "@/src/features/evals/components/EvaluatorFilterCell";
+
+const ENVIRONMENT_FILTER = [
+  {
+    type: "stringOptions",
+    column: "environment",
+    operator: "any of",
+    value: ["prod"],
+  },
+] satisfies FilterState;
+
+const LONG_NAME_FILTER = [
+  {
+    type: "stringOptions",
+    column: "Name",
+    operator: "any of",
+    value: ["Chat about billing and account recovery"],
+  },
+] satisfies FilterState;
+
+describe("EvaluatorFilterCell", () => {
+  it("does not enable a per-cell horizontal scrollbar", () => {
+    const { container } = render(
+      <EvaluatorFilterCell filterState={ENVIRONMENT_FILTER} />,
+    );
+
+    expect(container.querySelector(".overflow-x-auto")).toBeNull();
+    expect(container.firstElementChild).toHaveClass("overflow-hidden");
+  });
+
+  it("renders the filter pill and exposes the full value on hover", () => {
+    render(<EvaluatorFilterCell filterState={LONG_NAME_FILTER} />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(
+      screen.getByTitle("Name any of Chat about billing and account recovery"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/evals/components/EvaluatorFilterCell.stories.tsx
+++ b/web/src/features/evals/components/EvaluatorFilterCell.stories.tsx
@@ -1,0 +1,50 @@
+import preview from "../../../../.storybook/preview";
+import type { FilterState } from "@langfuse/shared";
+import { EvaluatorFilterCell } from "@/src/features/evals/components/EvaluatorFilterCell";
+
+const SHORT_FILTER = [
+  {
+    type: "stringOptions",
+    column: "environment",
+    operator: "any of",
+    value: ["prod"],
+  },
+] satisfies FilterState;
+
+const LONG_FILTER = [
+  {
+    type: "stringOptions",
+    column: "Name",
+    operator: "any of",
+    value: ["Chat about billing and account recovery"],
+  },
+  {
+    type: "arrayOptions",
+    column: "Tags",
+    operator: "any of",
+    value: ["web_search_"],
+  },
+] satisfies FilterState;
+
+const meta = preview.meta({
+  component: EvaluatorFilterCell,
+});
+
+export default meta;
+
+export const Default = meta.story({
+  args: {
+    filterState: SHORT_FILTER,
+  },
+});
+
+export const Overflowing = meta.story({
+  args: {
+    filterState: LONG_FILTER,
+  },
+  render: (args) => (
+    <div className="w-[200px] overflow-hidden">
+      <EvaluatorFilterCell {...args} />
+    </div>
+  ),
+});

--- a/web/src/features/evals/components/EvaluatorFilterCell.tsx
+++ b/web/src/features/evals/components/EvaluatorFilterCell.tsx
@@ -1,0 +1,23 @@
+import type { FilterState } from "@langfuse/shared";
+import { formatFilterPreview } from "@/src/components/table/table-view-presets/lib/viewPreview";
+import { InlineFilterState } from "@/src/features/filters/components/filter-builder";
+
+export function EvaluatorFilterCell({
+  filterState,
+}: {
+  filterState: FilterState;
+}) {
+  const title =
+    filterState.length > 0
+      ? filterState.map(formatFilterPreview).join(" · ")
+      : undefined;
+
+  return (
+    <div
+      className="flex w-full max-w-full min-w-0 items-center gap-2 overflow-hidden"
+      title={title}
+    >
+      <InlineFilterState className="ml-0" filterState={filterState} />
+    </div>
+  );
+}

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -10,7 +10,7 @@ import {
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
-import { InlineFilterState } from "@/src/features/filters/components/filter-builder";
+import { EvaluatorFilterCell } from "@/src/features/evals/components/EvaluatorFilterCell";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
 import { evaluatorFilterConfig } from "@/src/features/filters/config/evaluators-config";
@@ -346,11 +346,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
           return filter;
         });
 
-        return (
-          <div className="flex h-full overflow-x-auto">
-            <InlineFilterState filterState={newFilterState} />
-          </div>
-        );
+        return <EvaluatorFilterCell filterState={newFilterState} />;
       },
     }),
     columnHelper.accessor("id", {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16264.preview.langfuse.com](https://pr-16264.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The evaluators table Filter column wrapped each cell in `overflow-x-auto`. Combined with `h-full`, that forced a native horizontal scrollbar on every row whenever a filter pill was even slightly wider than the column.

This clips overflowing filter pills instead, and exposes the full filter text via the native `title` tooltip on hover.

[Overflowing evaluator filter pills clipped without a scrollbar](https://cursor.com/agents/bc-9a401214-8bcd-4855-94c4-6d72d7a31122/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevaluator_filter_cell_overflowing_iframe.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Impacted packages: `web`
- Verification: `pnpm --filter web run test-client src/features/evals/components/EvaluatorFilterCell.clienttest.tsx` (`Tests  2 passed (2)`); pre-commit `turbo run lint` (`Tasks: 7 successful, 7 total`)
- Storybook Overflowing story: content width 443px in a 200px cell with `overflow-x: hidden` and no native scrollbar
- Full-app browser signoff was skipped because Docker was not available in this environment, so the complete stack could not be started

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15060](https://linear.app/clickhouse/issue/LFE-15060/horizontal-scroll-bars-here-for-filters-do-not-look-good)

<div><a href="https://cursor.com/agents/bc-9a401214-8bcd-4855-94c4-6d72d7a31122?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a401214-8bcd-4855-94c4-6d72d7a31122&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces horizontal scrolling in evaluator filter cells with clipped overflow and a native tooltip containing the complete filter description.
- Extracts evaluator-filter rendering into `EvaluatorFilterCell`.
- Adds focused component tests covering clipping and tooltip text.
- Adds Storybook examples for default and overflowing filter states.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new wrapper constrains overflowing filter pills as intended while retaining the complete formatted filter in a tooltip, and the table integration preserves the existing transformed filter state.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): clip overflowing filter pill..."](https://github.com/langfuse/langfuse/commit/4d5e71e1551cf786e086af9d54ba979a72c6936e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54446635)</sub>

<!-- /greptile_comment -->