### PR TITLE
chore(docker-compose): serve Langfuse images from docker.langfuse.com

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@
 # In addition, we recommend to restrict inbound traffic on the host to langfuse-web (port 3000) and minio (port 9090) only.
 # All other components are bound to localhost (127.0.0.1) to only accept connections from the local machine.
 # External connections from other machines will not be able to reach these services directly.
-# The Langfuse images below are served from docker.langfuse.com, a pull-through alias for Docker Hub.
-# If your environment only allows specific registries, replace it with docker.io/langfuse/... instead.
 services:
   langfuse-worker:
     image: docker.langfuse.com/langfuse/langfuse-worker:4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,11 @@
 # In addition, we recommend to restrict inbound traffic on the host to langfuse-web (port 3000) and minio (port 9090) only.
 # All other components are bound to localhost (127.0.0.1) to only accept connections from the local machine.
 # External connections from other machines will not be able to reach these services directly.
+# The Langfuse images below are served from docker.langfuse.com, a pull-through alias for Docker Hub.
+# If your environment only allows specific registries, replace it with docker.io/langfuse/... instead.
 services:
   langfuse-worker:
-    image: docker.io/langfuse/langfuse-worker:4
+    image: docker.langfuse.com/langfuse/langfuse-worker:4
     restart: always
     depends_on: &langfuse-depends-on
       postgres:
@@ -75,7 +77,7 @@ services:
       SMTP_CONNECTION_URL: ${SMTP_CONNECTION_URL:-}
 
   langfuse-web:
-    image: docker.io/langfuse/langfuse:4
+    image: docker.langfuse.com/langfuse/langfuse:4
     restart: always
     depends_on: *langfuse-depends-on
     ports:


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16265.preview.langfuse.com](https://pr-16265.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Points the two Langfuse services in `docker-compose.yml` at `docker.langfuse.com`, a pull-through alias for Docker Hub, so self-host image pulls can be attributed:

- `langfuse-worker`: `docker.io/langfuse/langfuse-worker:4` → `docker.langfuse.com/langfuse/langfuse-worker:4`
- `langfuse-web`: `docker.io/langfuse/langfuse:4` → `docker.langfuse.com/langfuse/langfuse:4`

This matches the equivalent change already made to `charts/langfuse/values.yaml` in `langfuse-k8s`. The Terraform modules (`-aws`, `-gcp`, `-azure`) install the chart via `helm_release` without overriding `image.repository`, so they inherit it with no change needed.

Blob requests through the alias redirect to Docker Hub's CDN, so bandwidth and the public pull counter stay with Docker Hub — the README's "Docker Pulls" badge keeps working unchanged.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Notes for reviewers

**Third-party images deliberately stay put.** The proxy is a generic Hub pass-through, so `clickhouse/clickhouse-server` and `redis` would also resolve through it — but routing other vendors' images through our vanity host adds a failure point for zero benefit. ClickHouse, Postgres, Redis and MinIO are unchanged.

**Escape hatch is documented in the file.** Self-hosters whose registry allowlists are scoped to `*.docker.io`, who run pull-through mirrors, or whose `docker login` credentials are keyed on `index.docker.io` would otherwise hit a confusing failure. The header comment names the alias and points back to `docker.io/langfuse/...`. `docker login docker.langfuse.com` does work — the auth challenge advertises `realm="https://auth.docker.io/token"` — but existing logins don't carry over.

**One follow-up in other repos, not fixed here.** `langfuse-js/.github/workflows/ci.yml:81` and `langfuse-python/.github/workflows/ci.yml:161` both `curl` this file by SHA and don't pin images in their compose overrides, so their CI runs will start pulling through the alias and count our own traffic as self-host pulls. That needs either a `sed` back to `docker.io` in those two workflows or confirmation that Actions egress is filtered out.

Also unchanged and worth noting: `pipeline.yml` still publishes every image to `ghcr.io/langfuse/*`, and those pulls are never attributed. The `snyk-web.yml` / `snyk-worker.yml` scans stay on Docker Hub on purpose — they're our own security CI, not user pulls.

## Verification

- `docker compose -f docker-compose.yml config` parses; rendered output confirms only the two Langfuse images moved.
- Manifest digests through the alias match Docker Hub exactly at tag `:4` — `sha256:a68afa29…` (web) and `sha256:f431ca2b…` (worker).
- `docker manifest inspect` resolves both through the new host using Docker's own auth flow.
- Real `docker pull docker.langfuse.com/langfuse/langfuse-worker:4` succeeded in 23s with a matching digest, exercising the full blob path rather than just the manifest handshake.
- `pnpm run format:check` clean; `pnpm run lint` → `Tasks: 7 successful, 7 total`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR redirects the default Langfuse web and worker images in Docker Compose through `docker.langfuse.com`, a Docker Hub pull-through alias, and documents how restricted environments can restore the original registry.

- Changes only the two first-party Langfuse image references.
- Leaves all third-party service images unchanged.
- Adds an inline compatibility note for registry-restricted installations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the registry migration is narrowly scoped and its known compatibility constraint is explicitly documented with a fallback.

The two changed image references preserve their repositories and tags, while existing source-building automation does not depend on pulling them and self-hosters with registry restrictions receive clear replacement guidance.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docker-compose): serve Langfuse im..."](https://github.com/langfuse/langfuse/commit/852d55a75e50cbf6504affaa5466549f9831a98a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54437823)</sub>

<!-- /greptile_comment -->