### PR TITLE
fix(web): keep peek open when dismissing toasts

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -2,6 +2,7 @@ import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { Sheet, SheetPortal } from "@/src/components/ui/sheet";
 import { Drawer, DrawerContent, DrawerTitle } from "@/src/components/ui/drawer";
 import { Separator } from "@/src/components/ui/separator";
+import { type LayerName } from "@/src/components/ui/layer";
 import { type LangfuseItemType } from "@/src/components/ItemBadge";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { cn } from "@/src/utils/tailwind";
@@ -102,6 +103,7 @@ type TablePeekViewProps = Pick<
 // below; this also covers the header "select all". Applied to every peek so
 // tables don't each have to redeclare it (which is easy to forget).
 const ALWAYS_KEEP_PEEK_OPEN_SELECTORS = ['[role="checkbox"]'];
+const TOAST_LAYER: LayerName = "toast";
 
 /**
  * Decide whether an outside interaction should keep the peek open instead of
@@ -135,7 +137,7 @@ export const shouldKeepPeekOpenOnOutsideInteraction = (
   if (shouldIgnoreOutsideInteraction(target)) return true;
   // Toasts portal into a higher overlay layer than the peek, so Radix reports
   // them as outside. Closing / clicking one must not dismiss the peek.
-  if (target.closest('[data-layer="toast"]')) return true;
+  if (target.closest(`[data-layer="${TOAST_LAYER}"]`)) return true;
   if (target.closest("[data-row-index]")) return true;
   return [...ALWAYS_KEEP_PEEK_OPEN_SELECTORS, ...ignoredSelectors].some(
     (selector) => target.closest(selector),

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -110,9 +110,12 @@ const ALWAYS_KEEP_PEEK_OPEN_SELECTORS = ['[role="checkbox"]'];
  * - clicking another table row (`[data-row-index]`) switches the peeked item in
  *   place rather than closing (handled by the row's own click handler),
  * - shared selection controls and any table-specific `ignoredSelectors`
- *   (row action buttons, etc.) don't close it, and
+ *   (row action buttons, etc.) don't close it,
  * - regions that opt out via `data-ignore-outside-interaction` (e.g. the in-app
- *   assistant) never trigger a close.
+ *   assistant) never trigger a close, and
+ * - toast-layer overlays (`[data-layer="toast"]` — version-update banner,
+ *   Sonner toasts) never trigger a close: dismissing a toast is not a peek
+ *   dismiss.
  *
  * All checks run against the pointer event's `target`, not
  * `document.activeElement` — `onPointerDownOutside` fires on pointer-down,
@@ -130,6 +133,9 @@ export const shouldKeepPeekOpenOnOutsideInteraction = (
   // the panel group. This guard keeps interactions within the peek safe.
   if (target.closest("[data-peek-content]")) return true;
   if (shouldIgnoreOutsideInteraction(target)) return true;
+  // Toasts portal into a higher overlay layer than the peek, so Radix reports
+  // them as outside. Closing / clicking one must not dismiss the peek.
+  if (target.closest('[data-layer="toast"]')) return true;
   if (target.closest("[data-row-index]")) return true;
   return [...ALWAYS_KEEP_PEEK_OPEN_SELECTORS, ...ignoredSelectors].some(
     (selector) => target.closest(selector),
@@ -221,6 +227,17 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
   // which is what resets nested-table state when the peek closes (see README).
   if (!itemId || !mounted) return null;
 
+  const preventDismissOnKeptOpen = (event: {
+    target: EventTarget | null;
+    preventDefault: () => void;
+  }) => {
+    if (
+      shouldKeepPeekOpenOnOutsideInteraction(event.target, ignoredSelectors)
+    ) {
+      event.preventDefault();
+    }
+  };
+
   const handleOpenChange = (open: boolean) => {
     // Open is driven by row clicks / detail-page navigation; we only react to
     // close requests (Escape, swipe-down, click-outside, the close button).
@@ -291,6 +308,8 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
           <DrawerContent
             size="full"
             className="min-h-screen-with-banner top-[calc(var(--banner-offset)+10px)] bottom-0 gap-0 p-0"
+            onPointerDownOutside={preventDismissOnKeptOpen}
+            onInteractOutside={preventDismissOnKeptOpen}
           >
             <DrawerTitle className="sr-only">{resolvedTitle}</DrawerTitle>
             <div className="flex w-full shrink-0 items-center justify-center pt-2 pb-1">
@@ -309,26 +328,8 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
               aria-describedby={undefined}
               data-peek-content=""
               style={panel.panelStyle}
-              onPointerDownOutside={(e) => {
-                if (
-                  shouldKeepPeekOpenOnOutsideInteraction(
-                    e.target,
-                    ignoredSelectors,
-                  )
-                ) {
-                  e.preventDefault();
-                }
-              }}
-              onInteractOutside={(e) => {
-                if (
-                  shouldKeepPeekOpenOnOutsideInteraction(
-                    e.target,
-                    ignoredSelectors,
-                  )
-                ) {
-                  e.preventDefault();
-                }
-              }}
+              onPointerDownOutside={preventDismissOnKeptOpen}
+              onInteractOutside={preventDismissOnKeptOpen}
               // Never close because focus moved out (e.g. into a portaled
               // popover or another input); only pointer/Escape/close-button
               // drive dismissal.

--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -25,7 +25,8 @@ Dismissal:
 - **Click-outside closes**, with exceptions: a target inside the peek
   (`[data-peek-content]`) never closes it; clicking another table row
   (`[data-row-index]`) **switches** the peeked item in place; and selection
-  checkboxes / `data-ignore-outside-interaction` regions / the table's
+  checkboxes / `data-ignore-outside-interaction` regions / toast-layer overlays
+  (`[data-layer="toast"]`, e.g. the version-update banner) / the table's
   `ignoredSelectors` don't close it. Nested Radix popovers/menus opened inside
   the peek don't close it (DismissableLayer stacking).
 - **Escape**, the close button, and (mobile) swipe-down also close.

--- a/web/src/components/table/peek/outsideInteraction.clienttest.tsx
+++ b/web/src/components/table/peek/outsideInteraction.clienttest.tsx
@@ -48,6 +48,13 @@ describe("shouldKeepPeekOpenOnOutsideInteraction", () => {
     expect(shouldKeepPeekOpenOnOutsideInteraction(target, IGNORED)).toBe(true);
   });
 
+  it("keeps open when interacting with a toast overlay", () => {
+    // Version-update banner and Sonner toasts portal into the `toast` layer.
+    // Dismissing one must not count as a peek click-outside.
+    const target = targetWith({}, { "data-layer": "toast" });
+    expect(shouldKeepPeekOpenOnOutsideInteraction(target, IGNORED)).toBe(true);
+  });
+
   it("keeps open for a selection checkbox even outside any row", () => {
     expect(
       shouldKeepPeekOpenOnOutsideInteraction(

--- a/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
+++ b/web/src/features/version-update/VersionUpdateBanner.clienttest.tsx
@@ -98,6 +98,19 @@ it("VersionUpdateBannerView renders both controls and invokes their callbacks", 
   expect(onDismiss).toHaveBeenCalledTimes(1);
 });
 
+it("VersionUpdateBannerView opts out of outside-interaction dismissal", () => {
+  render(
+    <VersionUpdateBannerView
+      onReload={() => undefined}
+      onDismiss={() => undefined}
+    />,
+  );
+
+  expect(screen.getByRole("status")).toHaveAttribute(
+    "data-ignore-outside-interaction",
+  );
+});
+
 describe("VersionUpdateBanner (connected)", () => {
   it("shows and reports banner_shown exactly once when available and settled", () => {
     render(<VersionUpdateBanner />);

--- a/web/src/features/version-update/VersionUpdateBannerView.tsx
+++ b/web/src/features/version-update/VersionUpdateBannerView.tsx
@@ -36,6 +36,9 @@ export function VersionUpdateBannerView({
     <div
       role="status"
       aria-live="polite"
+      // Peek (and any other dismissable overlay) must not close when this
+      // banner is dismissed — it lives in a higher overlay layer than the peek.
+      data-ignore-outside-interaction
       className={cn(
         // `top-banner-offset` = safe-area + any registered top banner's height,
         // so the pill sits below a full-width top banner (e.g. PaymentBanner)


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16267.preview.langfuse.com](https://pr-16267.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Dismissing the version-update banner ("Langfuse just got an update") — or any other overlay in the `toast` layer — was treated as a peek click-outside, so the table peek closed with the toast.

The peek now ignores pointer interactions that land in the toast overlay layer. The version-update banner also opts out via `data-ignore-outside-interaction`. The same guard is applied to the handheld drawer peek.

No visual interface changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Impacted package: `web`
- Verification:
  - `pnpm --filter web run test-client src/components/table/peek/` — `Test Files  8 passed (8)` / `Tests  48 passed (48)`
  - `pnpm --filter web run test-client src/features/version-update/VersionUpdateBanner.clienttest.tsx` — `Tests  7 passed (7)`
  - `turbo run lint` (pre-commit) — `Tasks: 7 successful, 7 total`
- Browser signoff of the live toast+peek path was skipped: the Cloud stack did not start (Docker daemon unavailable). Targeted client tests cover the dismiss-vs-peek contract instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14710](https://linear.app/clickhouse/issue/LFE-14710/closing-got-update-toast-also-closes-peek-view)

<div><a href="https://cursor.com/agents/bc-d83fa3df-4e1a-430f-a1b8-c6cc968512b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d83fa3df-4e1a-430f-a1b8-c6cc968512b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents interactions with toast-layer overlays from dismissing desktop and handheld table peeks.

- Recognizes toast-layer targets as outside-interaction exceptions.
- Applies the shared prevention handler to both sheet and drawer peeks.
- Marks the version-update banner as an ignored outside-interaction region.
- Adds focused tests and documents the dismissal contract.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The toast-layer guard is limited to interactive overlay descendants, and the shared handler preserves ordinary outside clicks, Escape, swipe-down, and explicit close actions.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep peek open when dismissing..."](https://github.com/langfuse/langfuse/commit/6479b703d218c774d362bcac1782611af34ca5b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54446746)</sub>

<!-- /greptile_comment -->