### PR TITLE
fix(evals): restore sorting on the running evaluators table

### DIFF
--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -298,6 +298,110 @@ describe("evals trpc", () => {
       ]);
     });
 
+    it("should order evaluators by generated score name", async () => {
+      const { project, caller } = await prepare();
+
+      const createEvaluator = (scoreName: string) =>
+        prisma.jobConfiguration.create({
+          data: {
+            projectId: project.id,
+            jobType: "EVAL",
+            scoreName,
+            filter: [],
+            targetObject: EvalTargetObject.TRACE,
+            variableMapping: [],
+            sampling: 1,
+            delay: 0,
+            status: "ACTIVE",
+          },
+        });
+
+      const zeta = await createEvaluator("zeta-score");
+      const alpha = await createEvaluator("alpha-score");
+      const beta = await createEvaluator("beta-score");
+
+      const ascending = await caller.evals.allConfigs({
+        projectId: project.id,
+        filter: [],
+        orderBy: {
+          column: "scoreName",
+          order: "ASC",
+        },
+        limit: 10,
+        page: 0,
+      });
+
+      expect(ascending.configs.map((config) => config.id)).toEqual([
+        alpha.id,
+        beta.id,
+        zeta.id,
+      ]);
+
+      const descending = await caller.evals.allConfigs({
+        projectId: project.id,
+        filter: [],
+        orderBy: {
+          column: "scoreName",
+          order: "DESC",
+        },
+        limit: 10,
+        page: 0,
+      });
+
+      expect(descending.configs.map((config) => config.id)).toEqual([
+        zeta.id,
+        beta.id,
+        alpha.id,
+      ]);
+    });
+
+    it("falls back to created-at order when orderBy is cleared", async () => {
+      const { project, caller } = await prepare();
+
+      const older = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          scoreName: "older-score",
+          filter: [],
+          targetObject: EvalTargetObject.TRACE,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+        },
+      });
+
+      const newer = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          scoreName: "newer-score",
+          filter: [],
+          targetObject: EvalTargetObject.TRACE,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+          createdAt: new Date("2024-02-01T00:00:00.000Z"),
+        },
+      });
+
+      const response = await caller.evals.allConfigs({
+        projectId: project.id,
+        filter: [],
+        orderBy: null,
+        limit: 10,
+        page: 0,
+      });
+
+      expect(response.configs.map((config) => config.id)).toEqual([
+        newer.id,
+        older.id,
+      ]);
+    });
+
     it("filters evaluator configurations by time scope", async () => {
       const { project, caller } = await prepare();
 

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -355,6 +355,56 @@ describe("evals trpc", () => {
       ]);
     });
 
+    it("keeps duplicate score names in a stable order across pages", async () => {
+      const { project, caller } = await prepare();
+
+      const createEvaluator = () =>
+        prisma.jobConfiguration.create({
+          data: {
+            projectId: project.id,
+            jobType: "EVAL",
+            scoreName: "duplicate-score",
+            filter: [],
+            targetObject: EvalTargetObject.TRACE,
+            variableMapping: [],
+            sampling: 1,
+            delay: 0,
+            status: "ACTIVE",
+          },
+        });
+
+      const first = await createEvaluator();
+      const second = await createEvaluator();
+      const third = await createEvaluator();
+      const expectedIds = [first.id, second.id, third.id].toSorted();
+
+      const page0 = await caller.evals.allConfigs({
+        projectId: project.id,
+        filter: [],
+        orderBy: {
+          column: "scoreName",
+          order: "ASC",
+        },
+        limit: 2,
+        page: 0,
+      });
+      const page1 = await caller.evals.allConfigs({
+        projectId: project.id,
+        filter: [],
+        orderBy: {
+          column: "scoreName",
+          order: "ASC",
+        },
+        limit: 2,
+        page: 1,
+      });
+
+      expect([
+        ...page0.configs.map((config) => config.id),
+        ...page1.configs.map((config) => config.id),
+      ]).toEqual(expectedIds);
+    });
+
     it("falls back to created-at order when orderBy is cleared", async () => {
       const { project, caller } = await prepare();
 

--- a/web/src/__tests__/server/unit/eval-configs-order-by.servertest.ts
+++ b/web/src/__tests__/server/unit/eval-configs-order-by.servertest.ts
@@ -1,0 +1,23 @@
+import { InvalidRequestError } from "@langfuse/shared";
+import { orderByToPrismaSql } from "@langfuse/shared/src/server";
+import { evalConfigsTableCols } from "@/src/server/api/definitions/evalConfigsTable";
+
+describe("eval config orderBy columns", () => {
+  it("maps generated score name to job_configurations.score_name", () => {
+    const sql = orderByToPrismaSql(
+      { column: "scoreName", order: "ASC" },
+      evalConfigsTableCols,
+    );
+
+    expect(sql.strings.join("")).toContain('jc."score_name" ASC');
+  });
+
+  it("rejects columns that are not sortable on this table", () => {
+    expect(() =>
+      orderByToPrismaSql(
+        { column: "totalCost", order: "DESC" },
+        evalConfigsTableCols,
+      ),
+    ).toThrow(InvalidRequestError);
+  });
+});

--- a/web/src/components/table/data-table.clienttest.tsx
+++ b/web/src/components/table/data-table.clienttest.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { DataTable } from "@/src/components/table/data-table";
+import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { type OrderByState } from "@langfuse/shared";
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: {} }),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+type Row = { scoreName: string; status: string };
+
+const columns: LangfuseColumnDef<Row>[] = [
+  {
+    accessorKey: "scoreName",
+    id: "scoreName",
+    header: "Generated Score Name",
+    enableSorting: true,
+  },
+  {
+    accessorKey: "status",
+    id: "status",
+    header: "Status",
+  },
+];
+
+const rows: Row[] = [
+  { scoreName: "zeta-score", status: "ACTIVE" },
+  { scoreName: "alpha-score", status: "ACTIVE" },
+];
+
+function SortableTable({ initialOrderBy }: { initialOrderBy: OrderByState }) {
+  const [orderBy, setOrderBy] = useState<OrderByState>(initialOrderBy);
+
+  return (
+    <DataTable
+      tableName="evalConfigsTest"
+      columns={columns}
+      orderBy={orderBy}
+      setOrderBy={setOrderBy}
+      hidePagination
+      data={{
+        isLoading: false,
+        isError: false,
+        data: rows,
+      }}
+    />
+  );
+}
+
+describe("DataTable column sorting affordances", () => {
+  it("does not show a sort indicator on a non-sortable column even if orderBy points at it", () => {
+    render(
+      <SortableTable initialOrderBy={{ column: "status", order: "ASC" }} />,
+    );
+
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.queryByText("▲")).not.toBeInTheDocument();
+    expect(screen.queryByText("▼")).not.toBeInTheDocument();
+  });
+
+  it("shows a sort indicator on a sortable column and toggles order on click", () => {
+    render(
+      <SortableTable initialOrderBy={{ column: "scoreName", order: "ASC" }} />,
+    );
+
+    const nameHeader = screen.getByText("Generated Score Name").closest("th");
+    expect(nameHeader).toHaveTextContent("▲");
+
+    fireEvent.click(nameHeader!);
+    expect(nameHeader).not.toHaveTextContent("▲");
+    expect(nameHeader).not.toHaveTextContent("▼");
+
+    fireEvent.click(nameHeader!);
+    expect(nameHeader).toHaveTextContent("▼");
+  });
+
+  it("does not change orderBy when a non-sortable header is clicked", () => {
+    render(
+      <SortableTable initialOrderBy={{ column: "scoreName", order: "ASC" }} />,
+    );
+
+    const nameHeader = screen.getByText("Generated Score Name").closest("th");
+    const statusHeader = screen.getByText("Status").closest("th");
+
+    fireEvent.click(statusHeader!);
+
+    expect(nameHeader).toHaveTextContent("▲");
+    expect(statusHeader).not.toHaveTextContent("▲");
+    expect(statusHeader).not.toHaveTextContent("▼");
+  });
+});

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -550,7 +550,7 @@ export function DataTable<TData extends object, TValue>({
                                 href={columnDef.headerTooltip.href}
                               />
                             )}
-                            {orderBy?.column === columnDef.id
+                            {sortingEnabled && orderBy?.column === columnDef.id
                               ? renderOrderingIndicator(orderBy)
                               : null}
 

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -180,6 +180,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("scoreName", {
       id: "scoreName",
       header: "Generated Score Name",
+      enableSorting: true,
       size: 320,
       cell: (row) => {
         const scoreName = row.getValue();
@@ -209,6 +210,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("status", {
       header: "Status",
       id: "status",
+      enableSorting: true,
       size: 80,
       loadingCell: <TableBadgeLoadingCell />,
       cell: (row) => {
@@ -223,6 +225,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("totalCost", {
       header: "Total Cost (7d)",
       id: "totalCost",
+      enableSorting: false,
       size: 120,
       cell: (row) => {
         const totalCost = row.getValue();
@@ -239,6 +242,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("result", {
       header: "Result",
       id: "result",
+      enableSorting: false,
       size: 150,
       cell: (row) => {
         const result = row.getValue();
@@ -253,6 +257,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("logs", {
       header: "Logs",
       id: "logs",
+      enableSorting: false,
       size: 150,
       loadingCell: <Skeleton className="h-6 w-16 rounded-md" />,
       cell: ({ row }) => {
@@ -278,6 +283,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("template", {
       id: "template",
       header: "Referenced Evaluator",
+      enableSorting: false,
       size: 200,
       loadingCell: (
         <div className="flex items-center gap-2">
@@ -314,6 +320,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       id: "target",
       header: "Runs on",
       size: 150,
+      enableSorting: true,
       enableHiding: true,
       cell: (row) => {
         const targetObject = row.getValue();
@@ -327,6 +334,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       id: "filter",
       header: "Filter",
       size: 200,
+      enableSorting: false,
       enableHiding: true,
       cell: (row) => {
         const filterState = row.getValue();
@@ -357,6 +365,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       header: "Id",
       id: "id",
       size: 100,
+      enableSorting: false,
       enableHiding: true,
       cell: (row) => {
         const id = row.getValue();
@@ -366,6 +375,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     columnHelper.accessor("actions", {
       header: "Actions",
       id: "actions",
+      enableSorting: false,
       size: 100,
       loadingCell: <TableIconButtonLoadingCell />,
       cell: ({ row }) => {

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -2079,23 +2079,30 @@ const generateConfigsQuery = (
 const getEvaluatorConfigsOrderByCondition = (orderByState: OrderByState) => {
   // Clearing a column sort sets orderBy to null. The shared helper's
   // fallback (`t.timestamp`) is traces-specific and invalid here.
-  if (!orderByState) {
-    return orderByToPrismaSql(
-      { column: "createdAt", order: "DESC" },
-      evalConfigsTableCols,
-    );
-  }
+  const resolvedOrderBy = orderByState ?? {
+    column: "createdAt",
+    order: "DESC" as const,
+  };
 
   const orderByCondition = orderByToPrismaSql(
-    orderByState,
+    resolvedOrderBy,
     evalConfigsTableCols,
   );
+  // Duplicate score names / targets are common; OFFSET pagination needs a
+  // unique last key or rows can repeat or vanish across pages.
+  const idTieBreak =
+    resolvedOrderBy.order === "DESC"
+      ? Prisma.sql`jc.id DESC`
+      : Prisma.sql`jc.id ASC`;
 
-  if (orderByState.column !== "status" && orderByState.column !== "Status") {
-    return orderByCondition;
+  if (
+    resolvedOrderBy.column !== "status" &&
+    resolvedOrderBy.column !== "Status"
+  ) {
+    return Prisma.sql`${orderByCondition}, ${idTieBreak}`;
   }
 
-  return Prisma.sql`${orderByCondition}, jc.created_at DESC`;
+  return Prisma.sql`${orderByCondition}, jc.created_at DESC, ${idTieBreak}`;
 };
 
 const generateExecutionsQuery = (

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -2077,12 +2077,21 @@ const generateConfigsQuery = (
 };
 
 const getEvaluatorConfigsOrderByCondition = (orderByState: OrderByState) => {
+  // Clearing a column sort sets orderBy to null. The shared helper's
+  // fallback (`t.timestamp`) is traces-specific and invalid here.
+  if (!orderByState) {
+    return orderByToPrismaSql(
+      { column: "createdAt", order: "DESC" },
+      evalConfigsTableCols,
+    );
+  }
+
   const orderByCondition = orderByToPrismaSql(
     orderByState,
     evalConfigsTableCols,
   );
 
-  if (orderByState?.column !== "status" && orderByState?.column !== "Status") {
+  if (orderByState.column !== "status" && orderByState.column !== "Status") {
     return orderByCondition;
   }
 

--- a/web/src/server/api/definitions/evalConfigsTable.ts
+++ b/web/src/server/api/definitions/evalConfigsTable.ts
@@ -63,6 +63,12 @@ export const evalConfigsTableCols: ColumnDefinition[] = [
   evalConfigFilterColumns[1],
   evalConfigFilterColumns[2],
   {
+    name: "Generated Score Name",
+    id: "scoreName",
+    type: "string",
+    internal: 'jc."score_name"',
+  },
+  {
     name: "Updated At",
     id: "updatedAt",
     type: "datetime",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16270.preview.langfuse.com](https://pr-16270.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The running evaluators table showed a Status sort arrow by default, but most columns were not actually sortable. Clicking Status or Generated Score Name did nothing, so users could not arrange evaluators by name.

This change does both of the requested options:

1. **Honest UX:** `DataTable` now shows a sort arrow only when the column has sorting enabled. A leftover `orderBy` on a non-sortable column no longer looks like an active sort.
2. **Real sorting:** Generated Score Name, Status, Created At, Updated At, and Runs on are sortable. Cost, Result, Logs, Referenced Evaluator, Filter, Id, and Actions stay non-sortable and no longer pretend otherwise.

Clearing a column sort now falls back to `created_at DESC` instead of the traces-specific `t.timestamp` helper default, which is invalid for this query.

### Sort state architecture (bonus)

Table sorting is already modeled as route state via `useOrderByState` (`orderBy` query param). That matches the frontend rule that list sort belongs in the router, not a local Zustand store. I did not introduce a feature store for this.

Remaining global gaps, left for a follow-up:

- `enableSorting` is hand-copied per table and can drift from backend column defs.
- Saved-view validation treats `enableSorting !== false` as sortable; `DataTable` only treats `enableSorting === true` as sortable.
- `orderByToPrismaSql(null)` still hardcodes a traces `t.timestamp` fallback. Callers that allow a cleared sort need their own default, as this table now does.

Impacted package: `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented the code in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] Targeted unit and client tests pass locally

## Verification

- `pnpm --filter web run test-client src/components/table/data-table.clienttest.tsx` — `Tests 3 passed (3)`
- `pnpm --filter web run test src/__tests__/server/unit/eval-configs-order-by.servertest.ts` — `Tests 2 passed (2)`
- `pnpm exec eslint` on changed files — no findings
- Skipped `evals-trpc.servertest.ts` and browser review: Docker/Postgres were not available in this environment. Those integration tests should run in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14351](https://linear.app/clickhouse/issue/LFE-14351/evals-table-sorting-not-working)

<div><a href="https://cursor.com/agents/bc-7d6616a7-b25b-4265-80a5-680e79dc4e65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d6616a7-b25b-4265-80a5-680e79dc4e65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores server-backed sorting for the running evaluators table and hides sort indicators on columns that do not explicitly enable sorting.
- Adds sortable evaluator column definitions and a Generated Score Name SQL mapping.
- Uses created-at descending as the cleared-sort fallback.
- Adds client and server tests for sorting affordances, score-name ordering, and fallback ordering.
- The enabled Status sort does not match the derived status displayed to users, and newly enabled non-unique sorts lack stable pagination tie-breakers.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until Status ordering matches the displayed status and newly enabled sorts provide stable pagination.

User-selected Status sorting can order by a different value than the badge users see, while repeated values in newly sortable columns can produce duplicate or missing evaluators across offset-paginated pages.

**Files Needing Attention:** web/src/features/evals/components/evaluator-table.tsx, web/src/features/evals/server/router.ts, web/src/server/api/definitions/evalConfigsTable.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/components/evaluator-table.tsx:213
**Status sorting uses hidden state**

When evaluators have derived display states such as `FINISHED` or `PAUSED`, sorting this column orders the persisted `status` and `blocked_at` fields instead of the badge value rendered here. For example, `FINISHED` receives the same SQL rank as `ACTIVE`, causing visibly different statuses to remain interleaved despite the selected sort direction.

### Issue 2
web/src/features/evals/components/evaluator-table.tsx:183
**Non-unique sorts destabilize pagination**

When multiple pages contain evaluators sharing a Generated Score Name or another newly sortable value, the backend emits only that non-unique `ORDER BY` expression before applying `LIMIT` and `OFFSET`. Equal rows therefore lack stable positions across page requests, causing configurations to be duplicated on one page or skipped on another; append a unique secondary key to these sort orders.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): make the running evaluators ..."](https://github.com/langfuse/langfuse/commit/e79afedb6e994ab6f96d4ebd2602ed844fa5ab51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54447386)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)

<!-- /greptile_comment -->