### PR TITLE
fix(worker): reject malformed OTEL prompt versions

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -76,8 +76,8 @@ import { applyObservationFieldOverflow } from "../../features/observation-field-
  * Returns undefined if the value is nullish or not a valid UInt16 integer.
  */
 function parseUInt16(value: string | null | undefined): number | undefined {
-  if (value == null) return undefined;
-  const num = parseInt(value, 10);
+  if (value == null || !/^\d+$/.test(value)) return undefined;
+  const num = Number(value);
   if (!Number.isInteger(num) || num < 0 || num > 65535) return undefined;
   return num;
 }
@@ -303,6 +303,7 @@ export class IngestionService {
     const modelParameters = parseEventModelParameters(
       eventData.modelParameters,
     );
+    const promptVersion = parseUInt16(eventData.promptVersion);
 
     // Runs outside the modelName gate below so model-less events with provided
     // usage are still checked.
@@ -320,14 +321,11 @@ export class IngestionService {
     // Perform lookups for prompt and model/usage enrichment
     const [prompt, generationUsage] = await Promise.all([
       // Lookup prompt by name and version
-      eventData.promptName && eventData.promptVersion
+      eventData.promptName && promptVersion !== undefined
         ? this.promptService.getPrompt({
             projectId: eventData.projectId,
             promptName: eventData.promptName,
-            version:
-              typeof eventData.promptVersion === "string"
-                ? parseInt(eventData.promptVersion, 10)
-                : eventData.promptVersion,
+            version: promptVersion,
             label: undefined,
           })
         : null,
@@ -405,7 +403,7 @@ export class IngestionService {
       // Prompt
       prompt_id: prompt?.id || "",
       prompt_name: eventData.promptName,
-      prompt_version: parseUInt16(eventData.promptVersion),
+      prompt_version: promptVersion,
 
       // Model
       model_id: generationUsage?.internal_model_id || "",

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -185,6 +185,39 @@ describe("IngestionService unit tests", () => {
     expect(eventRecord.model_parameters).toBe("not-json");
   });
 
+  it("does not link malformed string prompt versions", async () => {
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+    const getPrompt = vi
+      .spyOn((ingestionService as any).promptService, "getPrompt")
+      .mockResolvedValue(null);
+
+    const eventRecord = await ingestionService.createEventRecord(
+      {
+        projectId: "project-id",
+        traceId: "trace-id",
+        spanId: "observation-id",
+        name: "malformed-prompt-version",
+        type: "GENERATION",
+        environment: "default",
+        startTimeISO: "2026-08-19T00:00:00.000Z",
+        endTimeISO: "2026-08-19T00:00:01.000Z",
+        promptName: "prompt-name",
+        promptVersion: "12suffix",
+        metadata: {},
+        source: "otel",
+      },
+      "otel/project-id/raw-event.json",
+    );
+
+    expect(getPrompt).not.toHaveBeenCalled();
+    expect(eventRecord.prompt_version).toBeUndefined();
+  });
+
   it("passes direct-event attribute values to pricing", async () => {
     const ingestionService = new IngestionService(
       {} as any,


### PR DESCRIPTION
## What does this PR do?

OTEL prompt-version attributes reach the ingestion worker as strings. The worker previously used `parseInt`, which accepts a valid numeric prefix and silently turns malformed values such as `12suffix` or `12.5` into version `12`. When a prompt named by the same event has a real version 12, this can both query that prompt and persist an incorrect prompt association.

This change validates the complete prompt-version string as a UInt16-compatible decimal integer, parses it once, and reuses the result for both prompt lookup and the event record. Invalid versions remain unlinked and are stored as `undefined`.

A production-path unit test covers a malformed OTEL value and verifies that no prompt lookup or prompt version is recorded. No new dependencies are required, and no matching issue or pull request was found.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] I have self-reviewed the complete diff.

## Validation

- Before the production fix, the regression test failed because `getPrompt` was called with `version: 12`.
- `pnpm --filter worker run test src/services/IngestionService/tests/IngestionService.unit.test.ts` — `Tests 13 passed (13)`.
- `pnpm --filter worker run typecheck` — passed.
- `pnpm run lint` — `Tasks: 7 successful, 7 total`.
- Prettier check for both changed files — passed.
- `git diff --check` — passed.

This PR was prepared with OpenAI Codex assistance. The malformed-value path was traced from the OTEL attribute through ingestion, the complete diff was independently reviewed, and the listed checks were run locally with the repository's Node 24 environment.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens worker-side OTEL prompt-version parsing so malformed strings cannot be truncated into valid prompt associations.
- Validates the complete value as a decimal UInt16 before prompt lookup.
- Reuses the parsed version for lookup and event persistence.
- Adds a regression test ensuring malformed versions remain unlinked.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking edge case where version zero triggers misleading invalid-parameter logging.

Strict parsing consistently prevents malformed prompt associations, while the newly widened lookup gate admits zero even though PromptService rejects it.

**Files Needing Attention:** worker/src/services/IngestionService/index.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/services/IngestionService/index.ts:324
**Zero version triggers invalid lookup**

For prompt version `0`, the changed condition invokes `getPrompt`, but `PromptService` rejects zero as invalid parameters and emits a misleading ingestion error log; the previous truthiness gate skipped this lookup.

```suggestion
      eventData.promptName && promptVersion !== undefined && promptVersion !== 0
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): reject malformed OTEL promp..."](https://github.com/langfuse/langfuse/commit/a48c52874809f7b5fcbd68673e6578c7e24ee218) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54633715)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->