### PR TITLE
fix(web): use pointer cursor on dropdown menu items

### DIFF
--- a/web/src/components/ui/dropdown-menu.stories.tsx
+++ b/web/src/components/ui/dropdown-menu.stories.tsx
@@ -1,0 +1,63 @@
+import { CopyIcon } from "lucide-react";
+import { expect, fn, within } from "storybook/test";
+import preview from "../../../.storybook/preview";
+import { Button } from "./button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+
+const meta = preview.meta({
+  component: DropdownMenu,
+  render: () => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger asChild>
+        <Button aria-label="Options" size="icon-xs" variant="ghost">
+          Options
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuItem className="text-xs" onSelect={fn()}>
+          <span>
+            filter by <span className="font-bold">name:SupportChatSession</span>
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="text-xs" onSelect={fn()}>
+          <span>
+            filter by <span className="font-bold">type:SPAN</span>
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-xs" onSelect={fn()}>
+          <CopyIcon className="mr-2 h-4 w-4" />
+          Copy Trace ID
+        </DropdownMenuItem>
+        <DropdownMenuItem className="text-xs" onSelect={fn()}>
+          <CopyIcon className="mr-2 h-4 w-4" />
+          Copy Observation ID
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+});
+
+export default meta;
+
+export const Default = meta.story({});
+
+export const TestMenuItemsUsePointerCursor = meta.story({
+  name: "(Test) Menu items use pointer cursor",
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const items = await body.findAllByRole("menuitem");
+
+    await expect(items.length).toBeGreaterThan(0);
+
+    for (const item of items) {
+      await expect(getComputedStyle(item).cursor).toBe("pointer");
+    }
+  },
+});

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -49,7 +49,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none",
+      "focus:bg-accent data-[state=open]:bg-accent flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none",
       inset && "pl-8",
       className,
     )}
@@ -265,7 +265,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:cursor-not-allowed data-disabled:opacity-50",
       !allowPointerEventsWhenDisabled && "data-disabled:pointer-events-none",
       inset && "pl-8",
       className,
@@ -464,7 +464,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     checked={checked}
@@ -489,7 +489,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     {...props}

--- a/web/src/features/scores/components/multi-select-key-values.tsx
+++ b/web/src/features/scores/components/multi-select-key-values.tsx
@@ -256,7 +256,7 @@ export function MultiSelectKeyValues<
 
             return (
               <DropdownMenuSub key={group.label}>
-                <DropdownMenuSubTrigger className="flex w-full cursor-default items-center select-none">
+                <DropdownMenuSubTrigger className="flex w-full items-center select-none">
                   <Component className="mr-2 h-4 w-4 opacity-50" />
                   <span>{group.label}</span>
                 </DropdownMenuSubTrigger>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16275.preview.langfuse.com](https://pr-16275.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Dropdown menu actions used `cursor-default`, so hover did not show a hand pointer. That included the trace detail overflow menu (filter by name/type, copy IDs).

This sets `cursor-pointer` on the shared dropdown item primitives so every dropdown action shows the pointer cursor. Disabled items keep `cursor-not-allowed`.

[Dropdown items with computed cursor pointer](https://cursor.com/agents/bc-78bfcf51-bfa9-437b-a67f-63ff82e47d48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdropdown_menu_computed_cursor.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-storybook src/components/ui/dropdown-menu.stories.tsx` — `Tests  2 passed (2)`
- Pre-commit `turbo run lint` — `Tasks:    7 successful, 7 total`
- Pre-commit Prettier — `All matched files use Prettier code style!`
- Playwright against the Storybook iframe: all four menuitems report `getComputedStyle(...).cursor === "pointer"`
- Skipped full `pnpm run typecheck` (CSS-only class change on existing primitives)
- Skipped the full web app stack (Docker daemon unavailable in this environment); reviewed the Storybook dropdown instead

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Code follows the style guidelines of this project (`pnpm run format`)
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-10082](https://linear.app/clickhouse/issue/LFE-10082/no-cursor-pointer-in-trace-actions-dropdown)

<div><a href="https://cursor.com/agents/bc-78bfcf51-bfa9-437b-a67f-63ff82e47d48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78bfcf51-bfa9-437b-a67f-63ff82e47d48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

