### PR TITLE
fix(ui): hug content on mobile bottom drawers

### DIFF
--- a/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.clienttest.tsx
+++ b/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.clienttest.tsx
@@ -1,0 +1,64 @@
+import { render } from "@testing-library/react";
+import { MobileRightDrawer } from "@/src/components/layouts/app-layout/right-drawer/MobileRightDrawer";
+
+vi.mock("@/src/features/support-chat/SupportDrawerProvider", () => ({
+  useSupportDrawer: () => ({
+    open: true,
+    setOpen: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/features/v4-migration/V4MigrationPanelProvider", () => ({
+  useV4MigrationPanel: () => ({
+    open: false,
+    setOpen: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/features/support-chat/SupportDrawer", () => ({
+  SupportDrawer: () => <div>Email a Support Engineer</div>,
+}));
+
+vi.mock("@/src/features/v4-migration/V4MigrationPanel", () => ({
+  V4MigrationPanel: () => null,
+}));
+
+function mountOverlayRoot() {
+  const overlayRoot = document.createElement("div");
+  overlayRoot.setAttribute("data-overlay-root", "");
+  for (const layer of [
+    "panel",
+    "agent",
+    "modal",
+    "popover",
+    "tooltip",
+    "toast",
+  ]) {
+    const layerNode = document.createElement("div");
+    layerNode.setAttribute("data-layer", layer);
+    overlayRoot.appendChild(layerNode);
+  }
+  document.body.appendChild(overlayRoot);
+}
+
+describe("MobileRightDrawer", () => {
+  beforeEach(() => {
+    mountOverlayRoot();
+  });
+
+  afterEach(() => {
+    document.querySelector("[data-overlay-root]")?.remove();
+  });
+
+  it("does not stretch the support sheet to the full viewport", () => {
+    render(
+      <MobileRightDrawer>
+        <div>page</div>
+      </MobileRightDrawer>,
+    );
+
+    const drawer = document.querySelector("#support-drawer");
+    expect(drawer).not.toBeNull();
+    expect(drawer?.className).not.toContain("min-h-screen-with-banner");
+  });
+});

--- a/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx
+++ b/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx
@@ -31,12 +31,8 @@ export function MobileRightDrawer({ children }: PropsWithChildren) {
         }}
         forceDirection="bottom"
       >
-        <DrawerContent
-          id="support-drawer"
-          className="min-h-screen-with-banner inset-x-0 top-[calc(var(--banner-offset)+10px)] bottom-0"
-          size="full"
-        >
-          <DrawerHeader className="absolute inset-x-0 top-0 p-0 text-left">
+        <DrawerContent id="support-drawer" size="full">
+          <DrawerHeader className="p-0 text-left">
             <div className="flex w-full items-center justify-center pt-3">
               <div className="bg-muted h-2 w-20 rounded-full" />
             </div>
@@ -46,9 +42,10 @@ export function MobileRightDrawer({ children }: PropsWithChildren) {
               A list of resources and options to help you with your questions.
             </DrawerDescription>
           </DrawerHeader>
-          <div className="mt-4 max-h-full">
-            <SupportDrawer showCloseButton={false} className="h-full pb-20" />
-          </div>
+          <SupportDrawer
+            showCloseButton={false}
+            className="min-h-0 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]"
+          />
         </DrawerContent>
       </Drawer>
 
@@ -61,12 +58,8 @@ export function MobileRightDrawer({ children }: PropsWithChildren) {
         }}
         forceDirection="bottom"
       >
-        <DrawerContent
-          id="v4-migration-drawer"
-          className="min-h-screen-with-banner inset-x-0 top-[calc(var(--banner-offset)+10px)] bottom-0"
-          size="full"
-        >
-          <DrawerHeader className="absolute inset-x-0 top-0 p-0 text-left">
+        <DrawerContent id="v4-migration-drawer" size="full">
+          <DrawerHeader className="p-0 text-left">
             <div className="flex w-full items-center justify-center pt-3">
               <div className="bg-muted h-2 w-20 rounded-full" />
             </div>
@@ -77,12 +70,10 @@ export function MobileRightDrawer({ children }: PropsWithChildren) {
               deprecations.
             </DrawerDescription>
           </DrawerHeader>
-          <div className="mt-4 max-h-full">
-            <V4MigrationPanel
-              showCloseButton={false}
-              className="h-full pb-20"
-            />
-          </div>
+          <V4MigrationPanel
+            showCloseButton={false}
+            className="min-h-0 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]"
+          />
         </DrawerContent>
       </Drawer>
     </>

--- a/web/src/components/ui/drawer.clienttest.tsx
+++ b/web/src/components/ui/drawer.clienttest.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import { Drawer, DrawerContent, DrawerTitle } from "@/src/components/ui/drawer";
+
+function mountOverlayRoot() {
+  const overlayRoot = document.createElement("div");
+  overlayRoot.setAttribute("data-overlay-root", "");
+  for (const layer of [
+    "panel",
+    "agent",
+    "modal",
+    "popover",
+    "tooltip",
+    "toast",
+  ]) {
+    const layerNode = document.createElement("div");
+    layerNode.setAttribute("data-layer", layer);
+    overlayRoot.appendChild(layerNode);
+  }
+  document.body.appendChild(overlayRoot);
+}
+
+describe("Drawer", () => {
+  beforeEach(() => {
+    mountOverlayRoot();
+  });
+
+  afterEach(() => {
+    document.querySelector("[data-overlay-root]")?.remove();
+  });
+
+  it("sizes compact bottom drawers to their content instead of a third of the viewport", () => {
+    render(
+      <Drawer open forceDirection="bottom" shouldScaleBackground={false}>
+        <DrawerContent id="compact-drawer">
+          <DrawerTitle>Support</DrawerTitle>
+          <button type="button">Email a Support Engineer</button>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    const drawer = document.querySelector("#compact-drawer");
+    expect(drawer).not.toBeNull();
+    const classes = drawer?.className.split(/\s+/) ?? [];
+    expect(classes).not.toContain("h-1/3");
+    expect(classes).toContain("h-auto");
+  });
+});

--- a/web/src/components/ui/drawer.clienttest.tsx
+++ b/web/src/components/ui/drawer.clienttest.tsx
@@ -43,5 +43,9 @@ describe("Drawer", () => {
     const classes = drawer?.className.split(/\s+/) ?? [];
     expect(classes).not.toContain("h-1/3");
     expect(classes).toContain("h-auto");
+    // Vaul paints a 200%-tall ::after below the sheet so a drag doesn't
+    // expose a gap. `overflow-y-auto` would turn that into a hollow
+    // scroll region under the last action.
+    expect(classes).not.toContain("overflow-y-auto");
   });
 });

--- a/web/src/components/ui/drawer.stories.tsx
+++ b/web/src/components/ui/drawer.stories.tsx
@@ -13,7 +13,7 @@ const meta = preview.meta({
 export const Compact = meta.story({
   render: () => (
     <Drawer open forceDirection="bottom" shouldScaleBackground={false}>
-      <DrawerContent>
+      <DrawerContent size="full">
         <DrawerHeader className="p-4 text-left">
           <div className="flex w-full items-center justify-center">
             <div className="bg-muted h-2 w-20 rounded-full" />

--- a/web/src/components/ui/drawer.stories.tsx
+++ b/web/src/components/ui/drawer.stories.tsx
@@ -1,0 +1,34 @@
+import preview from "../../../.storybook/preview";
+import { Button } from "./button";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "./drawer";
+
+const meta = preview.meta({
+  component: Drawer,
+});
+
+/**
+ * Short bottom-sheet content should hug its children. A forced `h-1/3` or
+ * full-viewport height leaves a hollow band under the last action on phones.
+ */
+export const Compact = meta.story({
+  render: () => (
+    <Drawer open forceDirection="bottom" shouldScaleBackground={false}>
+      <DrawerContent>
+        <DrawerHeader className="p-4 text-left">
+          <div className="flex w-full items-center justify-center">
+            <div className="bg-muted h-2 w-20 rounded-full" />
+          </div>
+          <DrawerTitle>Support</DrawerTitle>
+        </DrawerHeader>
+        <div className="flex flex-col gap-3 px-4 pb-4">
+          <p className="text-muted-foreground text-sm">
+            Get instant, helpful answers from docs and examples.
+          </p>
+          <Button variant="outline">Chat with AI</Button>
+          <Button variant="outline">View documentation</Button>
+          <Button variant="outline">Email a Support Engineer</Button>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ),
+});

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -40,7 +40,8 @@ const TAILWIND_MD_MEDIA_QUERY = 768;
 const drawerVariants = cva("fixed flex flex-col border bg-modal", {
   variants: {
     direction: {
-      bottom: "inset-x-0 bottom-0 rounded-t-lg",
+      bottom:
+        "inset-x-0 bottom-0 h-auto max-h-screen-with-banner min-h-0 overflow-y-auto rounded-t-lg",
       left: "bottom-0 left-0 top-banner-offset h-screen-with-banner rounded-r-lg",
       right:
         "bottom-0 right-0 top-banner-offset h-screen-with-banner rounded-l-lg",
@@ -55,7 +56,7 @@ const drawerVariants = cva("fixed flex flex-col border bg-modal", {
       top: "",
     },
     height: {
-      default: "h-1/3 md:h-full",
+      default: "",
       md: "md:h-1/2",
     },
   },
@@ -151,7 +152,8 @@ const DrawerContent = React.forwardRef<
         <DrawerPrimitive.Content
           ref={ref}
           className={cn(
-            drawerVariants({ direction, size, className, height, position }),
+            drawerVariants({ direction, size, height, position }),
+            className,
           )}
           data-allow-text-selection={!blockTextSelection}
           data-direction={direction}

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -41,7 +41,7 @@ const drawerVariants = cva("fixed flex flex-col border bg-modal", {
   variants: {
     direction: {
       bottom:
-        "inset-x-0 bottom-0 h-auto max-h-screen-with-banner min-h-0 overflow-y-auto rounded-t-lg",
+        "inset-x-0 bottom-0 h-auto max-h-screen-with-banner min-h-0 rounded-t-lg",
       left: "bottom-0 left-0 top-banner-offset h-screen-with-banner rounded-r-lg",
       right:
         "bottom-0 right-0 top-banner-offset h-screen-with-banner rounded-l-lg",

--- a/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -181,11 +181,11 @@ export function InAppAgentWindowShell({
           id="in-app-agent-drawer"
           size="full"
           // `h-auto` at every breakpoint so top/bottom anchoring owns the
-          // geometry: the drawer's default height variant is `h-1/3 md:h-full`,
-          // and the `md:` half survives tailwind-merge — a landscape phone is
-          // both handheld and wider than `md`, and `top` + `bottom` + `height`
-          // over-constrains the box, dropping `bottom` and pushing the composer
-          // off-screen by the banner offset.
+          // geometry. Bottom drawers default to content height; a leftover
+          // `md:h-full` used to survive tailwind-merge on a landscape phone
+          // (handheld and wider than `md`), so `top` + `bottom` + `height`
+          // over-constrained the box, dropping `bottom` and pushing the
+          // composer off-screen by the banner offset.
           className="top-banner-offset inset-x-0 bottom-0 h-auto rounded-none border-0 md:h-auto"
           onEscapeKeyDown={(event) => {
             event.preventDefault();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16279.preview.langfuse.com](https://pr-16279.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Mobile bottom drawers were given a fixed `h-1/3` height, and the support/migration sheets were additionally stretched with `min-h-screen-with-banner`. Short content sat at the top with a large empty band below the last action.

Bottom drawers now size to their children, capped at the banner-aware viewport height so long content still scrolls. The mobile support and v4 migration sheets no longer force a full-screen shell. The sheet does not use `overflow-y-auto` on the Vaul root, because that turned Vaul's below-sheet `::after` filler into a hollow scroll region.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client src/components/ui/drawer.clienttest.tsx src/components/layouts/app-layout/right-drawer/MobileRightDrawer.clienttest.tsx` — Tests 2 passed (2)
- `pnpm --filter web run test-client src/features/in-app-agent/components/InAppAgentWindowHost.clienttest.tsx` — Tests 3 passed (3)
- `pnpm --filter web exec eslint --max-warnings 0` on the changed files — clean
- Full `pnpm --filter web run lint` was skipped in this environment: the ESLint plugin dist was missing from the snapshot, and rebuilding it surfaced 419 unrelated pre-existing warnings (`max-warnings 0`)

## Checklist

- [x] Make sure you have self-reviewed the code.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-10117](https://linear.app/clickhouse/issue/LFE-10117/empty-bottom-space-on-a-mobile-drawer)

<div><a href="https://cursor.com/agents/bc-ed8f7447-8f55-4b6a-b26a-34c8dcef8296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed8f7447-8f55-4b6a-b26a-34c8dcef8296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

