### PR TITLE
fix(worker): fail closed on unknown BullMQ attempt budget

### DIFF
--- a/packages/shared/src/server/redis/analyticsQueueAttempts.test.ts
+++ b/packages/shared/src/server/redis/analyticsQueueAttempts.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { MixpanelIntegrationProcessingQueue } from "./mixpanelIntegrationProcessingQueue";
+import { BlobStorageIntegrationProcessingQueue } from "./blobStorageIntegrationProcessingQueue";
+
+// Pins the one BullMQ setting standing between "the fail-closed final-attempt
+// gate (bullmqAttempts.ts) means anything" and "it silently stops mattering
+// because someone tidied a queue's defaultJobOptions" — both the Mixpanel and
+// blob storage processing queues must keep a bounded, known attempts budget so
+// job.opts.attempts is always a number the gate can compare against.
+describe("analytics/blob storage processing queue attempts budget", () => {
+  it("Mixpanel processing queue has a fixed 5-attempt budget", () => {
+    const queue = MixpanelIntegrationProcessingQueue.getInstance();
+    // A null instance means no Redis connection was available to this test
+    // run, not that the budget is unset — skip only in that infra case rather
+    // than reporting a false pass.
+    if (!queue) {
+      throw new Error(
+        "MixpanelIntegrationProcessingQueue.getInstance() returned null — no Redis connection available to assert defaultJobOptions against",
+      );
+    }
+    expect(queue.opts.defaultJobOptions?.attempts).toBe(5);
+  });
+
+  it("Blob storage processing queue has a fixed 5-attempt budget", () => {
+    const queue = BlobStorageIntegrationProcessingQueue.getInstance();
+    if (!queue) {
+      throw new Error(
+        "BlobStorageIntegrationProcessingQueue.getInstance() returned null — no Redis connection available to assert defaultJobOptions against",
+      );
+    }
+    expect(queue.opts.defaultJobOptions?.attempts).toBe(5);
+  });
+});

--- a/packages/shared/src/server/redis/analyticsQueueAttempts.test.ts
+++ b/packages/shared/src/server/redis/analyticsQueueAttempts.test.ts
@@ -1,25 +1,36 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+const constructed: { name: string; opts: any }[] = [];
+
+vi.mock("bullmq", () => ({
+  Queue: class {
+    opts: any;
+    on = vi.fn();
+    constructor(name: string, opts: any) {
+      this.opts = opts;
+      constructed.push({ name, opts });
+    }
+  },
+}));
+
+vi.mock("./redis", () => ({
+  createBullMQQueueOptionsWithRedis: vi.fn(() => ({
+    connection: {},
+    prefix: "test",
+  })),
+}));
+
 import { MixpanelIntegrationProcessingQueue } from "./mixpanelIntegrationProcessingQueue";
 import { BlobStorageIntegrationProcessingQueue } from "./blobStorageIntegrationProcessingQueue";
 
 describe("analytics/blob storage processing queue attempts budget", () => {
   it("Mixpanel processing queue has a fixed 5-attempt budget", () => {
     const queue = MixpanelIntegrationProcessingQueue.getInstance();
-    if (!queue) {
-      throw new Error(
-        "MixpanelIntegrationProcessingQueue.getInstance() returned null — no Redis connection available to assert defaultJobOptions against",
-      );
-    }
-    expect(queue.opts.defaultJobOptions?.attempts).toBe(5);
+    expect((queue as any)?.opts.defaultJobOptions?.attempts).toBe(5);
   });
 
   it("Blob storage processing queue has a fixed 5-attempt budget", () => {
     const queue = BlobStorageIntegrationProcessingQueue.getInstance();
-    if (!queue) {
-      throw new Error(
-        "BlobStorageIntegrationProcessingQueue.getInstance() returned null — no Redis connection available to assert defaultJobOptions against",
-      );
-    }
-    expect(queue.opts.defaultJobOptions?.attempts).toBe(5);
+    expect((queue as any)?.opts.defaultJobOptions?.attempts).toBe(5);
   });
 });

--- a/packages/shared/src/server/redis/analyticsQueueAttempts.test.ts
+++ b/packages/shared/src/server/redis/analyticsQueueAttempts.test.ts
@@ -2,17 +2,9 @@ import { describe, it, expect } from "vitest";
 import { MixpanelIntegrationProcessingQueue } from "./mixpanelIntegrationProcessingQueue";
 import { BlobStorageIntegrationProcessingQueue } from "./blobStorageIntegrationProcessingQueue";
 
-// Pins the one BullMQ setting standing between "the fail-closed final-attempt
-// gate (bullmqAttempts.ts) means anything" and "it silently stops mattering
-// because someone tidied a queue's defaultJobOptions" — both the Mixpanel and
-// blob storage processing queues must keep a bounded, known attempts budget so
-// job.opts.attempts is always a number the gate can compare against.
 describe("analytics/blob storage processing queue attempts budget", () => {
   it("Mixpanel processing queue has a fixed 5-attempt budget", () => {
     const queue = MixpanelIntegrationProcessingQueue.getInstance();
-    // A null instance means no Redis connection was available to this test
-    // run, not that the budget is unset — skip only in that infra case rather
-    // than reporting a false pass.
     if (!queue) {
       throw new Error(
         "MixpanelIntegrationProcessingQueue.getInstance() returned null — no Redis connection available to assert defaultJobOptions against",

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -52,6 +52,7 @@ import {
   type CustomerFaultReason,
 } from "./isCustomerFaultError";
 import { isRecordNotFoundError } from "../integrations/prismaErrors";
+import { isFinalBullmqAttempt } from "../integrations/bullmqAttempts";
 import { ByteCounter, TimedByteCounter } from "./byteCounters";
 import { WORKER_HOST_ID } from "../../utils/hostId";
 import {
@@ -1521,10 +1522,8 @@ export const handleBlobStorageIntegrationProjectJob = async (
 
     // A deterministic customer-config/credential fault can't succeed until the
     // customer fixes it. Once BullMQ exhausts its retries, disable the
-    // integration so it stops re-scheduling and spamming. attemptsMade is
-    // 0-based, so the final attempt is attempts - 1.
-    const isFinalAttempt =
-      (job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1;
+    // integration so it stops re-scheduling and spamming.
+    const isFinalAttempt = isFinalBullmqAttempt(job, error);
     // Defined => disable; also tags the disable log + metric.
     const customerFaultReason = classifyCustomerFault(error);
 

--- a/worker/src/features/integrations/bullmqAttempts.test.ts
+++ b/worker/src/features/integrations/bullmqAttempts.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { UnrecoverableError } from "../../errors/UnrecoverableError";
+import { isFinalBullmqAttempt } from "./bullmqAttempts";
+
+// Sole owner of the "is this the last BullMQ attempt" decision. Blob storage's
+// handler computed this inline as
+//   (job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1
+// which fails OPEN on a missing opts.attempts (falls back to `1`, i.e. treats
+// attempt 0 as already final). This module is the fixed, shared replacement:
+// an unknown/missing attempts budget must fail CLOSED (never final), because a
+// disable-on-fault handler gated on "final attempt" would otherwise disable an
+// integration on its very first try whenever the caller forgot to pass
+// `job.opts`.
+//
+// Mixpanel's own BullMQ jobs are never dispatched with an UnrecoverableError
+// in practice (its region is a fixed enum, not a customer-supplied host, so
+// there is no unreachable-host path that raises one) — but blob storage and
+// PostHog jobs do reach outbound-URL validation failures that raise one, and
+// this predicate is shared by all three, so the UnrecoverableError branch is
+// pinned here even though no Mixpanel fixture will ever exercise it.
+
+describe("isFinalBullmqAttempt", () => {
+  it("is false before the last attempt of a known budget", () => {
+    expect(
+      isFinalBullmqAttempt({ attemptsMade: 0, opts: { attempts: 5 } }),
+    ).toBe(false);
+    expect(
+      isFinalBullmqAttempt({ attemptsMade: 3, opts: { attempts: 5 } }),
+    ).toBe(false);
+  });
+
+  it("is true on the last attempt of a known budget (attemptsMade is 0-based)", () => {
+    expect(
+      isFinalBullmqAttempt({ attemptsMade: 4, opts: { attempts: 5 } }),
+    ).toBe(true);
+  });
+
+  it("is true past the budget, defensively", () => {
+    expect(
+      isFinalBullmqAttempt({ attemptsMade: 10, opts: { attempts: 5 } }),
+    ).toBe(true);
+  });
+
+  // The fail-closed decision this module exists to pin. A job shaped exactly
+  // like the pre-fix mixpanelIntegrationProjectJob.test.ts `makeJob()` fixture
+  // (no `opts` at all) must never be treated as the final attempt — the
+  // opposite of blob's old `?? 1` fallback, which made a missing budget look
+  // exhausted on attempt zero.
+  it("fails closed (never final) when opts is entirely absent", () => {
+    expect(isFinalBullmqAttempt({ attemptsMade: 0 })).toBe(false);
+    expect(isFinalBullmqAttempt({ attemptsMade: 0, opts: {} })).toBe(false);
+  });
+
+  it("fails closed (never final) when opts.attempts is undefined", () => {
+    expect(
+      isFinalBullmqAttempt({
+        attemptsMade: 0,
+        opts: { attempts: undefined },
+      }),
+    ).toBe(false);
+  });
+
+  // Named to flag: Mixpanel never builds this fixture in practice (see file
+  // header) — this exists solely because blob/PostHog can reach it.
+  it("treats an UnrecoverableError as an exhausted budget at attemptsMade 0 (unreachable-for-Mixpanel path, required for blob/PostHog)", () => {
+    const error = new UnrecoverableError("blocked by SSRF protection");
+    expect(
+      isFinalBullmqAttempt({ attemptsMade: 0, opts: { attempts: 5 } }, error),
+    ).toBe(true);
+  });
+
+  it("duck-types UnrecoverableError by .name, not instanceof", () => {
+    const lookalike = { name: "UnrecoverableError", message: "blocked" };
+    expect(
+      isFinalBullmqAttempt(
+        { attemptsMade: 0, opts: { attempts: 5 } },
+        lookalike,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat an ordinary Error as terminal on its own", () => {
+    expect(
+      isFinalBullmqAttempt(
+        { attemptsMade: 0, opts: { attempts: 5 } },
+        new Error("transient"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/worker/src/features/integrations/bullmqAttempts.test.ts
+++ b/worker/src/features/integrations/bullmqAttempts.test.ts
@@ -2,23 +2,6 @@ import { describe, it, expect } from "vitest";
 import { UnrecoverableError } from "../../errors/UnrecoverableError";
 import { isFinalBullmqAttempt } from "./bullmqAttempts";
 
-// Sole owner of the "is this the last BullMQ attempt" decision. Blob storage's
-// handler computed this inline as
-//   (job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1
-// which fails OPEN on a missing opts.attempts (falls back to `1`, i.e. treats
-// attempt 0 as already final). This module is the fixed, shared replacement:
-// an unknown/missing attempts budget must fail CLOSED (never final), because a
-// disable-on-fault handler gated on "final attempt" would otherwise disable an
-// integration on its very first try whenever the caller forgot to pass
-// `job.opts`.
-//
-// Mixpanel's own BullMQ jobs are never dispatched with an UnrecoverableError
-// in practice (its region is a fixed enum, not a customer-supplied host, so
-// there is no unreachable-host path that raises one) — but blob storage and
-// PostHog jobs do reach outbound-URL validation failures that raise one, and
-// this predicate is shared by all three, so the UnrecoverableError branch is
-// pinned here even though no Mixpanel fixture will ever exercise it.
-
 describe("isFinalBullmqAttempt", () => {
   it("is false before the last attempt of a known budget", () => {
     expect(
@@ -41,11 +24,6 @@ describe("isFinalBullmqAttempt", () => {
     ).toBe(true);
   });
 
-  // The fail-closed decision this module exists to pin. A job shaped exactly
-  // like the pre-fix mixpanelIntegrationProjectJob.test.ts `makeJob()` fixture
-  // (no `opts` at all) must never be treated as the final attempt — the
-  // opposite of blob's old `?? 1` fallback, which made a missing budget look
-  // exhausted on attempt zero.
   it("fails closed (never final) when opts is entirely absent", () => {
     expect(isFinalBullmqAttempt({ attemptsMade: 0 })).toBe(false);
     expect(isFinalBullmqAttempt({ attemptsMade: 0, opts: {} })).toBe(false);
@@ -60,9 +38,7 @@ describe("isFinalBullmqAttempt", () => {
     ).toBe(false);
   });
 
-  // Named to flag: Mixpanel never builds this fixture in practice (see file
-  // header) — this exists solely because blob/PostHog can reach it.
-  it("treats an UnrecoverableError as an exhausted budget at attemptsMade 0 (unreachable-for-Mixpanel path, required for blob/PostHog)", () => {
+  it("treats an UnrecoverableError as an exhausted budget at attemptsMade 0", () => {
     const error = new UnrecoverableError("blocked by SSRF protection");
     expect(
       isFinalBullmqAttempt({ attemptsMade: 0, opts: { attempts: 5 } }, error),

--- a/worker/src/features/integrations/bullmqAttempts.ts
+++ b/worker/src/features/integrations/bullmqAttempts.ts
@@ -1,0 +1,37 @@
+import { logger } from "@langfuse/shared/src/server";
+
+interface BullmqAttemptState {
+  attemptsMade?: number;
+  opts?: { attempts?: number };
+}
+
+// Fail-closed "is this the last BullMQ attempt" predicate for disable-on-fault
+// handlers. Blob storage, PostHog, and Mixpanel share this so a missing
+// attempts budget never gets misread as an already-exhausted one.
+export function isFinalBullmqAttempt(
+  job: BullmqAttemptState,
+  error?: unknown,
+): boolean {
+  // Duck-type on `.name` rather than `instanceof UnrecoverableError`: BullMQ
+  // and this worker can each hold their own copy of the error class across a
+  // module boundary, so `instanceof` can silently miss a real
+  // UnrecoverableError and let the loop keep retrying an unretriable job.
+  if (
+    error &&
+    typeof error === "object" &&
+    (error as { name?: unknown }).name === "UnrecoverableError"
+  ) {
+    return true;
+  }
+
+  const attempts = job.opts?.attempts;
+  if (typeof attempts !== "number") {
+    logger.warn(
+      "[BULLMQ ATTEMPTS] job.opts.attempts is missing; treating as not the final attempt (fail closed)",
+    );
+    return false;
+  }
+
+  const attemptsMade = job.attemptsMade ?? 0;
+  return attemptsMade >= attempts - 1;
+}

--- a/worker/src/features/integrations/bullmqAttempts.ts
+++ b/worker/src/features/integrations/bullmqAttempts.ts
@@ -5,17 +5,12 @@ interface BullmqAttemptState {
   opts?: { attempts?: number };
 }
 
-// Fail-closed "is this the last BullMQ attempt" predicate for disable-on-fault
-// handlers. Blob storage, PostHog, and Mixpanel share this so a missing
-// attempts budget never gets misread as an already-exhausted one.
 export function isFinalBullmqAttempt(
   job: BullmqAttemptState,
   error?: unknown,
 ): boolean {
-  // Duck-type on `.name` rather than `instanceof UnrecoverableError`: BullMQ
-  // and this worker can each hold their own copy of the error class across a
-  // module boundary, so `instanceof` can silently miss a real
-  // UnrecoverableError and let the loop keep retrying an unretriable job.
+  // Duck-type on `.name`: instanceof can miss a real UnrecoverableError
+  // across a module boundary and let the loop keep retrying it.
   if (
     error &&
     typeof error === "object" &&


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16280.preview.langfuse.com](https://pr-16280.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Blob storage's final-BullMQ-attempt check inlines `(job.attemptsMade ?? 0) >= (job.opts?.attempts ?? 1) - 1`. If `job.opts.attempts` is ever absent (e.g. the queue's `defaultJobOptions` loses `attempts`), the `?? 1` fallback makes attempt 0 look final, so the disable gate would fire on the very first transient fault instead of after retries are exhausted — silently, with no log line or metric.

Extracts a fail-closed `isFinalBullmqAttempt` predicate: an unknown/missing attempt budget is treated as *not* final (logged via `logger.warn`), and a BullMQ `UnrecoverableError` is treated as an exhausted budget regardless of `attemptsMade`. Repoints blob storage's handler at it.

Production no-op: all of blob storage's enqueue paths go through a singleton queue with `defaultJobOptions.attempts: 5` always present, and blob's own existing tests already pass `opts: { attempts: 5 }` explicitly — the fallback this fixes was never actually exercised. Also pins `defaultJobOptions.attempts === 5` for both the blob storage and Mixpanel processing queues as a regression guard.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extracts blob-storage retry-exhaustion detection into a fail-closed BullMQ predicate and adds tests for its behavior and queue attempt budgets.
- Missing attempt budgets are treated as non-final.
- UnrecoverableError-shaped failures are treated as terminal.
- Blob-storage customer-fault disabling and notifications now use the helper.
- Queue configuration tests pin Mixpanel and blob-storage processing queues to five attempts.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The Redis-backed queue test needs to be isolated or explicitly cleaned up before merging because the shared CI job does not provide Redis.

The production predicate and blob-storage migration appear sound, but the new shared-package test opens indefinitely reconnecting Redis clients in a test environment where no Redis service is started.

**Files Needing Attention:** packages/shared/src/server/redis/analyticsQueueAttempts.test.ts; worker/src/features/integrations/bullmqAttempts.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/redis/analyticsQueueAttempts.test.ts:12
**Redis clients outlive queue tests**

The shared-package CI job configures `REDIS_HOST` without starting Redis, so these real queue singletons create indefinitely reconnecting clients that are never closed, causing the Vitest worker to remain alive until the workflow times out.

### Issue 2
worker/src/features/integrations/bullmqAttempts.ts:8-10
**Shared-consumer comment is inaccurate**

This comment says Blob storage, PostHog, and Mixpanel share the predicate, but only the blob-storage handler calls it, giving maintainers an incorrect model of the sibling integrations' retry behavior.

```suggestion
// Fail-closed "is this the last BullMQ attempt" predicate for disable-on-fault
// handlers. A missing attempts budget is never misread as an already-exhausted
// one.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(shared): pin blob storage and mixpa..."](https://github.com/langfuse/langfuse/commit/bdccbbaf0b0c24987543ad455278c6a0b763f5ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54677832)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Worker Queues](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/worker-queues.md)
- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->