### PR TITLE
fix(shared,web): make project-notification dispatch exhaustive

### DIFF
--- a/packages/shared/src/server/notifications/dispatchProjectNotification.ts
+++ b/packages/shared/src/server/notifications/dispatchProjectNotification.ts
@@ -210,5 +210,11 @@ async function sendEventAdminEmails({
       );
       return;
     }
+    default: {
+      const _exhaustiveCheck: never = event;
+      throw new Error(
+        `sendEventAdminEmails: unhandled event type ${(_exhaustiveCheck as ProjectNotificationEvent).eventType}`,
+      );
+    }
   }
 }

--- a/web/src/features/notifications/components/ProjectNotificationChannels.clienttest.tsx
+++ b/web/src/features/notifications/components/ProjectNotificationChannels.clienttest.tsx
@@ -1,0 +1,18 @@
+import { ProjectNotificationEventTypeSchema } from "@langfuse/shared";
+
+import { NOTIFIED_EVENTS } from "@/src/features/notifications/components/ProjectNotificationChannels";
+
+describe("NOTIFIED_EVENTS", () => {
+  it("has exactly one entry per ProjectNotificationEventTypeSchema member", () => {
+    expect(NOTIFIED_EVENTS.map((event) => event.value).sort()).toEqual(
+      [...ProjectNotificationEventTypeSchema.options].sort(),
+    );
+  });
+
+  it("gives every entry a non-empty title and description", () => {
+    for (const event of NOTIFIED_EVENTS) {
+      expect(event.title).not.toBe("");
+      expect(event.description).not.toBe("");
+    }
+  });
+});

--- a/web/src/features/notifications/components/ProjectNotificationChannels.tsx
+++ b/web/src/features/notifications/components/ProjectNotificationChannels.tsx
@@ -16,6 +16,7 @@ import { ProjectNotificationChannelsList } from "@/src/features/notifications/co
 import { useProjectNotificationChannels } from "@/src/features/notifications/hooks/useProjectNotificationChannels";
 import { cn } from "@/src/utils/tailwind";
 import {
+  ProjectNotificationEventTypeSchema,
   TriggerEventSource,
   type ActionTypes,
   type ProjectNotificationEventType,
@@ -24,30 +25,35 @@ import {
 /** Project notifications route to webhooks or Slack; GitHub dispatch is not wired for this event source. */
 const PROJECT_NOTIFICATION_ACTION_TYPES: ActionTypes[] = ["WEBHOOK", "SLACK"];
 
-/** NOTIFIED_EVENTS lists the toggleable project-notification events, keyed by their eventType. */
-const NOTIFIED_EVENTS: {
-  value: ProjectNotificationEventType;
-  title: string;
-  description: string;
-}[] = [
-  {
-    value: "blob-export-failed",
+/**
+ * NOTIFIED_EVENT_COPY is a Record keyed by every ProjectNotificationEventType
+ * member, so TypeScript rejects the file if a new event type is added here
+ * without display copy.
+ */
+const NOTIFIED_EVENT_COPY: Record<
+  ProjectNotificationEventType,
+  { title: string; description: string }
+> = {
+  "blob-export-failed": {
     title: "Blob storage export failed",
     description: "Sent when a scheduled blob storage export fails.",
   },
-  {
-    value: "posthog-export-failed",
+  "posthog-export-failed": {
     title: "PostHog export failed",
     description:
       "Sent when a PostHog export is disabled after a configuration error, such as an unreachable host.",
   },
-  {
-    value: "evaluator-blocked",
+  "evaluator-blocked": {
     title: "Evaluator deactivated",
     description:
       "Sent when an evaluator is deactivated due to an unrecoverable error, such as a deleted model or LLM connection.",
   },
-];
+};
+
+/** NOTIFIED_EVENTS lists the toggleable project-notification events, in schema order. */
+export const NOTIFIED_EVENTS = ProjectNotificationEventTypeSchema.options.map(
+  (value) => ({ value, ...NOTIFIED_EVENT_COPY[value] }),
+);
 
 /**
  * ProjectNotificationChannels is the admin-only "Project Notifications"

--- a/web/src/features/notifications/components/ProjectNotificationChannels.tsx
+++ b/web/src/features/notifications/components/ProjectNotificationChannels.tsx
@@ -25,11 +25,6 @@ import {
 /** Project notifications route to webhooks or Slack; GitHub dispatch is not wired for this event source. */
 const PROJECT_NOTIFICATION_ACTION_TYPES: ActionTypes[] = ["WEBHOOK", "SLACK"];
 
-/**
- * NOTIFIED_EVENT_COPY is a Record keyed by every ProjectNotificationEventType
- * member, so TypeScript rejects the file if a new event type is added here
- * without display copy.
- */
 const NOTIFIED_EVENT_COPY: Record<
   ProjectNotificationEventType,
   { title: string; description: string }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16281.preview.langfuse.com](https://pr-16281.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

`sendEventAdminEmails` in `dispatchProjectNotification.ts` is a bare `switch (event.eventType)` with no `default` and no exhaustiveness check, in a function typed `Promise<void>`. If a future `ProjectNotificationEventType` member is added without a matching case, the switch falls through, resolves normally, and **no email is sent** — no compile error, no runtime error, no log line, while the webhook/Slack channel dispatch and everything else fires as usual. This is the one failure mode that would be invisible.

Adds a `default` arm asserting `never` (matching the existing precedent in `redis/getQueue.ts` and `services/sessions-ui-table-service.ts`), so a missing case is a compile-time error.

A structurally identical hazard existed in the settings UI: `NOTIFIED_EVENTS` (the list of events shown in project notification channel settings) was a hand-maintained array, so an omitted entry would silently mean a real event type never appears in settings, with no error anywhere. Replaced it with a `Record<ProjectNotificationEventType, {...}>` (exhaustive by TypeScript's own checking, matching `buildProjectNotificationSlackMessage.ts`'s label map) and derived the exported array from the schema's own member list, plus a runtime test asserting one entry per schema member.

No behavior change for the 3 existing event types (`blob-export-failed`, `posthog-export-failed`, `evaluator-blocked`).

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an exhaustive runtime guard to project-notification admin-email dispatch and derives the notification settings list from the shared event schema.
- Replaces the manually keyed UI event array with schema-ordered entries and exhaustive display-copy typing.
- Adds client tests for schema coverage and display copy.
- Throws explicitly if email dispatch receives an unhandled project-notification event.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only non-blocking test assertions that should be strengthened to verify defined, non-empty display copy.

The production changes preserve all current notification behavior and add compile-time exhaustiveness, while the sole accepted concern is that the new runtime tests provide weaker regression coverage than their descriptions imply.

**Files Needing Attention:** web/src/features/notifications/components/ProjectNotificationChannels.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/notifications/components/ProjectNotificationChannels.clienttest.tsx:5-18
**Assertions miss undefined display copy**

`NOTIFIED_EVENTS` is generated directly from the schema, making the schema comparison tautological, while `expect(undefined).not.toBe("")` passes. The tests therefore remain green when an entry has no title or description and do not provide the intended runtime regression coverage.

```suggestion
describe("NOTIFIED_EVENTS", () => {
  it("gives every schema member non-empty display copy", () => {
    for (const event of NOTIFIED_EVENTS) {
      expect(event.title).toEqual(expect.any(String));
      expect(event.title.length).toBeGreaterThan(0);
      expect(event.description).toEqual(expect.any(String));
      expect(event.description.length).toBeGreaterThan(0);
    }
  });
});
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): derive project notification ev..."](https://github.com/langfuse/langfuse/commit/1212ef37f56fd2b1562e61c6135fdecc83e63e60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54679608)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->