### PR TITLE
chore(ci): test pure client files without jsdom

### DIFF
--- a/web/src/__tests__/aggregateScores.clienttest.ts
+++ b/web/src/__tests__/aggregateScores.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   aggregateScores,
   type ScoreToAggregate,

--- a/web/src/__tests__/chart-loading-state-utils.clienttest.ts
+++ b/web/src/__tests__/chart-loading-state-utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { RESOURCE_LIMIT_ERROR_MESSAGE } from "@langfuse/shared";
 import {
   getChartLoadingProgress,

--- a/web/src/__tests__/eventsTablePaths.clienttest.ts
+++ b/web/src/__tests__/eventsTablePaths.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   buildEventsTablePathForObservationType,
   buildEventsTablePathForSpanName,

--- a/web/src/__tests__/heatmap-utils.clienttest.ts
+++ b/web/src/__tests__/heatmap-utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   generateNumericHeatmapData,
   generateConfusionMatrixData,

--- a/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
+++ b/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * HIPAA / non-EU-US Session Replay masking guard.
  *

--- a/web/src/__tests__/markdown.clienttest.ts
+++ b/web/src/__tests__/markdown.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { containsAnyMarkdown } from "@/src/components/schemas/MarkdownSchema";
 
 describe("containsAnyMarkdown Function", () => {

--- a/web/src/__tests__/mergeScoresWithCache.clienttest.ts
+++ b/web/src/__tests__/mergeScoresWithCache.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   mergeScoresWithCache,
   mergeAggregatesWithCache,

--- a/web/src/__tests__/navigation.clienttest.ts
+++ b/web/src/__tests__/navigation.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { buildTraceDetailPath } from "@/src/utils/navigation";
 
 describe("buildTraceDetailPath", () => {

--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getSafeRedirectPath, stripBasePath } from "@/src/utils/redirect";
 import { env } from "@/src/env.mjs";
 

--- a/web/src/__tests__/supportCaseSeverity.clienttest.ts
+++ b/web/src/__tests__/supportCaseSeverity.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // pylonClient imports the shared server logger at module load; stub it so this
 // stays a lightweight client-side unit test of the pure mapping functions.
 vi.mock("@langfuse/shared/src/server", () => ({

--- a/web/src/__tests__/table-view-presets.clienttest.ts
+++ b/web/src/__tests__/table-view-presets.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   validateOrderBy,
   validateFilters,

--- a/web/src/__tests__/transformScores.clienttest.ts
+++ b/web/src/__tests__/transformScores.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { transformToAnnotationScores } from "@/src/features/scores/lib/transformScores";
 import {
   type ScoreDomain,

--- a/web/src/__tests__/widget-default-view.clienttest.ts
+++ b/web/src/__tests__/widget-default-view.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   getDefaultView,
   shouldUseWidgetSSE,

--- a/web/src/__tests__/widget-metric-presentation.clienttest.ts
+++ b/web/src/__tests__/widget-metric-presentation.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getWidgetMetricPresentation } from "@/src/features/widgets/utils";
 
 describe("getWidgetMetricPresentation", () => {

--- a/web/src/components/editor/CodeMirrorEditor.clienttest.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.clienttest.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getPromptVariableDiagnostics } from "@/src/components/editor/CodeMirrorEditor";
 
 describe("getPromptVariableDiagnostics", () => {

--- a/web/src/components/level-colors.clienttest.ts
+++ b/web/src/components/level-colors.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getLevelColors, LevelColors } from "@/src/components/level-colors";
 
 describe("getLevelColors", () => {

--- a/web/src/components/session/sessionDetailStore.clienttest.ts
+++ b/web/src/components/session/sessionDetailStore.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import { createSessionDetailStore } from "@/src/components/session/sessionDetailStore";
 

--- a/web/src/components/session/sessionFilterOptions.clienttest.ts
+++ b/web/src/components/session/sessionFilterOptions.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import { type FilterState } from "@langfuse/shared";
 import { getSessionFilterOptionsStartTimeFilters } from "./sessionFilterOptions";

--- a/web/src/components/session/sessionIdleGap.clienttest.ts
+++ b/web/src/components/session/sessionIdleGap.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/components/table/peek/peekDeleteGuard.clienttest.tsx
+++ b/web/src/components/table/peek/peekDeleteGuard.clienttest.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { shouldClosePeekAfterDelete } from "@/src/components/table/peek";

--- a/web/src/components/table/peek/peekHeaderOverflow.clienttest.ts
+++ b/web/src/components/table/peek/peekHeaderOverflow.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { planPeekHeaderLayout } from "@/src/components/table/peek/peekHeaderOverflow";

--- a/web/src/components/table/peek/resolvePeekTraceParams.clienttest.ts
+++ b/web/src/components/table/peek/resolvePeekTraceParams.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";

--- a/web/src/components/table/use-cases/session-row-data.clienttest.ts
+++ b/web/src/components/table/use-cases/session-row-data.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { joinSessionCoreAndMetrics } from "@/src/components/table/use-cases/session-row-data";
 
 describe("joinSessionCoreAndMetrics", () => {

--- a/web/src/components/ui/PrettyJsonView.clienttest.ts
+++ b/web/src/components/ui/PrettyJsonView.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   decodeUnicodeInJson,
   DECODE_UNICODE_MAX_DEPTH,

--- a/web/src/components/ui/largeStringGate.clienttest.ts
+++ b/web/src/components/ui/largeStringGate.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   LARGE_STRING_RENDER_CHAR_LIMIT,
   isLargeRenderString,

--- a/web/src/components/ui/safe-url.clienttest.ts
+++ b/web/src/components/ui/safe-url.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getSafeImageUrl, getSafeLinkUrl } from "@/src/components/ui/safe-url";
 
 describe("safe URL helpers", () => {

--- a/web/src/features/analytics-integrations/exportSource.clienttest.ts
+++ b/web/src/features/analytics-integrations/exportSource.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   AnalyticsIntegrationExportSource,
   LEGACY_ANALYTICS_EXPORTER_CUTOFF,

--- a/web/src/features/auth/lib/expectedAuthErrors.clienttest.ts
+++ b/web/src/features/auth/lib/expectedAuthErrors.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   isExpectedSignInError,
   isExpectedAuthErrorPageMessage,

--- a/web/src/features/automations/components/actions/WebhookActionHandler.clienttest.ts
+++ b/web/src/features/automations/components/actions/WebhookActionHandler.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { TriggerEventSource } from "@langfuse/shared";

--- a/web/src/features/blobstorage-integration/validation.clienttest.ts
+++ b/web/src/features/blobstorage-integration/validation.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   AZURE_CONTAINER_NAME_REGEX,
   validateAzureContainerName,

--- a/web/src/features/chart-view-prototype/lib/aggregate.clienttest.ts
+++ b/web/src/features/chart-view-prototype/lib/aggregate.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { aggregateEvents, floorToGranularity } from "./aggregate";
 import { type PrototypeEvent } from "../types";
 import { DEFAULT_CONFIG } from "../vocab";

--- a/web/src/features/chart-view/lib/buildChartQuery.clienttest.ts
+++ b/web/src/features/chart-view/lib/buildChartQuery.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   buildChartQuery,
   metricField,

--- a/web/src/features/chart-view/lib/chartConfigToWidget.clienttest.ts
+++ b/web/src/features/chart-view/lib/chartConfigToWidget.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { chartConfigToWidgetInput } from "./chartConfigToWidget";
 import { DEFAULT_CONFIG } from "../vocab";
 import { type ChartViewConfig } from "../types";

--- a/web/src/features/chart-view/lib/chartFilterCompatibility.clienttest.ts
+++ b/web/src/features/chart-view/lib/chartFilterCompatibility.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   chartFilterExclusionReason,
   chartSearchFieldReason,

--- a/web/src/features/chart-view/vocab.clienttest.ts
+++ b/web/src/features/chart-view/vocab.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { coerceConfig, describeConfig, DEFAULT_CONFIG } from "./vocab";
 import { type ChartViewConfig } from "./types";
 

--- a/web/src/features/comments/lib/mentionParser.clienttest.ts
+++ b/web/src/features/comments/lib/mentionParser.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   extractUniqueMentionedUserIds,
   MENTION_USER_PREFIX,

--- a/web/src/features/dashboard/components/homePresetSuggestions.clienttest.ts
+++ b/web/src/features/dashboard/components/homePresetSuggestions.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import { HOME_DASHBOARD_PRESET_IDS } from "@langfuse/shared";
 import { getSuggestedHomePresetIds } from "@/src/features/dashboard/components/home-preset-registry";

--- a/web/src/features/dashboard/components/hooks.clienttest.ts
+++ b/web/src/features/dashboard/components/hooks.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/features/dashboard/lib/buildTableFilterHref.clienttest.ts
+++ b/web/src/features/dashboard/lib/buildTableFilterHref.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   type FilterState,
   observationsTableCols,

--- a/web/src/features/dashboard/lib/chart-data-adapters.clienttest.ts
+++ b/web/src/features/dashboard/lib/chart-data-adapters.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { timeSeriesToDataPoints } from "@/src/features/dashboard/lib/chart-data-adapters";

--- a/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.clienttest.ts
+++ b/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/features/dashboard/lib/viewFilterToTableFilter.clienttest.ts
+++ b/web/src/features/dashboard/lib/viewFilterToTableFilter.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   type FilterState,
   eventsTableCols,

--- a/web/src/features/dashboard/utils/dashboard-import-export.clienttest.ts
+++ b/web/src/features/dashboard/utils/dashboard-import-export.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { HOME_DASHBOARD_PRESET_IDS } from "@langfuse/shared";
 import {
   buildDashboardExport,

--- a/web/src/features/datasets/components/DatasetItemMediaAttachments.clienttest.ts
+++ b/web/src/features/datasets/components/DatasetItemMediaAttachments.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/features/datasets/lib/generateSchemaExample.clienttest.ts
+++ b/web/src/features/datasets/lib/generateSchemaExample.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { generateSchemaExample } from "./generateSchemaExample";
 
 describe("generateSchemaExample", () => {

--- a/web/src/features/datasets/utils/parseDatasetJson.clienttest.ts
+++ b/web/src/features/datasets/utils/parseDatasetJson.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import {
   isDatasetJsonParseFailure,

--- a/web/src/features/evals/eval-config-target-options.clienttest.ts
+++ b/web/src/features/evals/eval-config-target-options.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { EvalTargetObject } from "@langfuse/shared";
 import { resolveCheckboxOperator } from "@/src/features/filters/hooks/useSidebarFilterState";
 import { evalConfigFilterColumns } from "@/src/server/api/definitions/evalConfigsTable";

--- a/web/src/features/evals/utils/code-eval-template-starter-examples.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-starter-examples.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { beforeAll, describe, expect, it } from "vitest";

--- a/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PYTHON_CODE_EVAL_SOURCE,

--- a/web/src/features/evals/utils/template-output.clienttest.ts
+++ b/web/src/features/evals/utils/template-output.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   createBooleanEvalOutputDefinition,
   createCategoricalEvalOutputDefinition,

--- a/web/src/features/events/components/outlier-strip/lib/filterCompatibility.clienttest.ts
+++ b/web/src/features/events/components/outlier-strip/lib/filterCompatibility.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { type FilterState } from "@langfuse/shared";
 import { canApplyOutlierStripFilters } from "./filterCompatibility";
 

--- a/web/src/features/events/hooks/useMetadataValueOptions.clienttest.ts
+++ b/web/src/features/events/hooks/useMetadataValueOptions.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import { type FilterState } from "@langfuse/shared";
 

--- a/web/src/features/events/lib/appRootDefault.clienttest.ts
+++ b/web/src/features/events/lib/appRootDefault.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { FilterState } from "@langfuse/shared";
 
 import {

--- a/web/src/features/events/lib/eventsTablePaths.clienttest.ts
+++ b/web/src/features/events/lib/eventsTablePaths.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import {
   type FilterState,

--- a/web/src/features/events/lib/eventsTableStatePolicy.clienttest.ts
+++ b/web/src/features/events/lib/eventsTableStatePolicy.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getEventsTableStatePolicy } from "@/src/features/events/lib/eventsTableStatePolicy";
 
 describe("getEventsTableStatePolicy", () => {

--- a/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { deepParseJson } from "@langfuse/shared";
 
 import { adaptEventsToTraceFormat } from "./eventsToTraceAdapter";

--- a/web/src/features/events/lib/facet-query-plan.clienttest.ts
+++ b/web/src/features/events/lib/facet-query-plan.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import type { FilterState } from "@langfuse/shared";

--- a/web/src/features/events/lib/v4Rollout.clienttest.ts
+++ b/web/src/features/events/lib/v4Rollout.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { canToggleV4 } from "./v4Rollout";

--- a/web/src/features/events/systemPresetSearchBarRoundTrip.clienttest.ts
+++ b/web/src/features/events/systemPresetSearchBarRoundTrip.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import isEqual from "lodash/isEqual";
 import {
   TableViewPresetTableName,

--- a/web/src/features/feature-flags/utils.clienttest.ts
+++ b/web/src/features/feature-flags/utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { getFeaturePreviewOptOutFlag, parseFlags } from "./utils";

--- a/web/src/features/filters/config/scores-config.clienttest.ts
+++ b/web/src/features/filters/config/scores-config.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getScoreFilterConfig, observationScopeFilter } from "./scores-config";
 
 describe("getScoreFilterConfig", () => {

--- a/web/src/features/filters/filter-config.clienttest.ts
+++ b/web/src/features/filters/filter-config.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   omitFilterFacets,
   type FilterConfig,

--- a/web/src/features/filters/filter-integration.clienttest.ts
+++ b/web/src/features/filters/filter-integration.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Integration tests for filter query encoding/decoding through full URL lifecycle.
  * These tests verify the complete flow: FilterState → URL → FilterState

--- a/web/src/features/filters/lib/facet-display.clienttest.ts
+++ b/web/src/features/filters/lib/facet-display.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   getFacetSummary,
   rankFacetOptions,

--- a/web/src/features/filters/lib/filter-query-encoding-decoding.clienttest.ts
+++ b/web/src/features/filters/lib/filter-query-encoding-decoding.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   encodeFiltersGeneric,
   decodeFiltersGeneric,

--- a/web/src/features/filters/lib/filter-transform.clienttest.ts
+++ b/web/src/features/filters/lib/filter-transform.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import { getColumnOptionsForFilterRow } from "./filter-transform";
 

--- a/web/src/features/filters/lib/option-sort.clienttest.ts
+++ b/web/src/features/filters/lib/option-sort.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { sortOptionValues } from "@/src/features/filters/lib/option-sort";

--- a/web/src/features/filters/lib/sidebar-filter-actions.clienttest.ts
+++ b/web/src/features/filters/lib/sidebar-filter-actions.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { FilterState } from "@langfuse/shared";
 import {
   addTextFilterEntry,

--- a/web/src/features/global-time-range/globalDateRangeStore.clienttest.ts
+++ b/web/src/features/global-time-range/globalDateRangeStore.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { useGlobalDateRangeStore } from "@/src/features/global-time-range/globalDateRangeStore";

--- a/web/src/features/in-app-agent/context.clienttest.ts
+++ b/web/src/features/in-app-agent/context.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getInAppAgentScreenContextDescription } from "./context";
 
 describe("getInAppAgentScreenContextDescription", () => {

--- a/web/src/features/in-app-agent/lib/display.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/display.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { AgUiMessage } from "@langfuse/shared/in-app-agent";
 import type { InAppAgentUiMessage } from "../schema";
 import {

--- a/web/src/features/in-app-agent/lib/inAppAgentActivity.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/inAppAgentActivity.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { InAppAgentRunStatus } from "@langfuse/shared";

--- a/web/src/features/metrics/components/MetricsFilterBuilder.clienttest.ts
+++ b/web/src/features/metrics/components/MetricsFilterBuilder.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { type FilterState } from "@langfuse/shared";

--- a/web/src/features/monitors/helpers/renderMonitorLabels.clienttest.ts
+++ b/web/src/features/monitors/helpers/renderMonitorLabels.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { renderNamePlaceholder } from "./renderMonitorLabels";

--- a/web/src/features/monitors/monitorRoutes.clienttest.ts
+++ b/web/src/features/monitors/monitorRoutes.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { renamedRouteRedirects } from "@/redirects.mjs";

--- a/web/src/features/prompts/utils.clienttest.ts
+++ b/web/src/features/prompts/utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { getPromptDetailHref } from "@/src/features/prompts/utils";
 
 describe("getPromptDetailHref", () => {

--- a/web/src/features/rbac/utils/checkAccess.clienttest.ts
+++ b/web/src/features/rbac/utils/checkAccess.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { hasOrganizationAccess } from "./checkOrganizationAccess";
 import { hasProjectAccess } from "./checkProjectAccess";
 

--- a/web/src/features/scores-chart-view/fns/binning/scoreOutlierBinning.clienttest.ts
+++ b/web/src/features/scores-chart-view/fns/binning/scoreOutlierBinning.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   mergeScoreOutlierRows,
   prepareScoreOutlierSeries,

--- a/web/src/features/scores-chart-view/fns/outlierStripFilters.clienttest.ts
+++ b/web/src/features/scores-chart-view/fns/outlierStripFilters.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { canApplyScoreOutlierStripFilters } from "@/src/features/scores-chart-view/fns/outlierStripFilters";
 
 describe("canApplyScoreOutlierStripFilters", () => {

--- a/web/src/features/scores-chart-view/fns/scoreChartConfig.clienttest.ts
+++ b/web/src/features/scores-chart-view/fns/scoreChartConfig.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   coerceScoreChartConfig,
   describeScoreChartConfig,

--- a/web/src/features/sdk-version/lib/sdkVersionCapabilities.clienttest.ts
+++ b/web/src/features/sdk-version/lib/sdkVersionCapabilities.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { getSdkVersionCapabilityStatus } from "./sdkVersionCapabilities";

--- a/web/src/features/search-bar/components/presentation.clienttest.ts
+++ b/web/src/features/search-bar/components/presentation.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { optionDomId } from "./presentation";
 
 describe("optionDomId", () => {

--- a/web/src/features/search-bar/lib/ai-context.clienttest.ts
+++ b/web/src/features/search-bar/lib/ai-context.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { buildAiContext } from "./ai-context";

--- a/web/src/features/search-bar/lib/commit.clienttest.ts
+++ b/web/src/features/search-bar/lib/commit.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { planCommit } from "@/src/features/search-bar/lib/commit";
 
 describe("planCommit", () => {

--- a/web/src/features/search-bar/lib/completions.clienttest.ts
+++ b/web/src/features/search-bar/lib/completions.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   applyPick,
   flattenOptions,

--- a/web/src/features/search-bar/lib/edits.clienttest.ts
+++ b/web/src/features/search-bar/lib/edits.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { removeToken } from "./edits";

--- a/web/src/features/search-bar/lib/explain.clienttest.ts
+++ b/web/src/features/search-bar/lib/explain.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { deriveComposerSegments } from "@/src/features/search-bar/lib/composer-segments";
 import { explainSegment } from "@/src/features/search-bar/lib/explain";
 import { FIELDS } from "@/src/features/search-bar/lib/fields";

--- a/web/src/features/search-bar/lib/langQ.clienttest.ts
+++ b/web/src/features/search-bar/lib/langQ.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { ASTNode } from "@/src/features/search-bar/lib/ast";
 import { parse, serialize, termAt } from "@/src/features/search-bar/lib/langQ";
 import {

--- a/web/src/features/search-bar/lib/observed-options.clienttest.ts
+++ b/web/src/features/search-bar/lib/observed-options.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
+++ b/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { FIELDS } from "./fields";

--- a/web/src/features/search-bar/lib/validate.clienttest.ts
+++ b/web/src/features/search-bar/lib/validate.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { parse, serialize } from "./langQ";

--- a/web/src/features/trace-graph-view/layout/elkLayout.clienttest.ts
+++ b/web/src/features/trace-graph-view/layout/elkLayout.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { type GraphCanvasData, type GraphNodeData } from "../types";
 import {
   computeGraphLayout,

--- a/web/src/features/trace-graph-view/layout/measureNode.clienttest.ts
+++ b/web/src/features/trace-graph-view/layout/measureNode.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   APPROX_CHAR_WIDTH,
   MAX_LABEL_LENGTH,

--- a/web/src/features/traces/components/AdvancedJsonViewer/lazy/byteJsonIndex.clienttest.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/lazy/byteJsonIndex.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   ByteJsonIndexEngine,
   loadByteJsonIndex,

--- a/web/src/features/traces/components/AdvancedJsonViewer/utils/jsonTypes.clienttest.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/utils/jsonTypes.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Tests for jsonTypes.ts utilities
  *

--- a/web/src/features/traces/components/AdvancedJsonViewer/utils/pathUtils.clienttest.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/utils/pathUtils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Tests for pathUtils.ts utilities
  *

--- a/web/src/features/traces/components/AdvancedJsonViewer/utils/searchJson.clienttest.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/utils/searchJson.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Tests for searchJson.ts utilities
  *

--- a/web/src/features/traces/components/AdvancedJsonViewer/utils/treeExpansion.clienttest.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/utils/treeExpansion.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Tests for treeExpansion.ts utilities
  *

--- a/web/src/features/traces/components/AdvancedJsonViewer/utils/treeNavigation.clienttest.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/utils/treeNavigation.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // @vitest-environment jsdom
 
 import { buildTreeFromJSON } from "./treeStructure";

--- a/web/src/features/traces/components/AdvancedJsonViewer/utils/treeStructure.clienttest.ts
+++ b/web/src/features/traces/components/AdvancedJsonViewer/utils/treeStructure.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Comprehensive test suite for tree building functionality
  *

--- a/web/src/features/traces/components/IOPreview/fns/jsonViewSizeGate.clienttest.ts
+++ b/web/src/features/traces/components/IOPreview/fns/jsonViewSizeGate.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 import {
   JSON_VIEW_RENDER_CHAR_LIMIT,

--- a/web/src/features/traces/components/TraceLogView/fns/filterBySearch.clienttest.ts
+++ b/web/src/features/traces/components/TraceLogView/fns/filterBySearch.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // @vitest-environment jsdom
 
 import { filterBySearch } from "@/src/features/traces/components/TraceLogView/fns/filterBySearch";

--- a/web/src/features/traces/components/TraceLogView/fns/flattenChronological.clienttest.ts
+++ b/web/src/features/traces/components/TraceLogView/fns/flattenChronological.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // @vitest-environment jsdom
 
 import { type TreeNode } from "@/src/features/traces/types/treeNode";

--- a/web/src/features/traces/components/TraceLogView/fns/flattenTreeOrder.clienttest.ts
+++ b/web/src/features/traces/components/TraceLogView/fns/flattenTreeOrder.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // @vitest-environment jsdom
 
 import { type TreeNode } from "@/src/features/traces/types/treeNode";

--- a/web/src/features/traces/fns/chatMessageUtils.clienttest.ts
+++ b/web/src/features/traces/fns/chatMessageUtils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { type ChatMlMessage } from "./chatMessageUtils";
 import {
   getMessageTitle,

--- a/web/src/features/traces/fns/flattenTree.clienttest.ts
+++ b/web/src/features/traces/fns/flattenTree.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Tests for tree-flattening utilities.
  *

--- a/web/src/features/traces/fns/nodeScores.clienttest.ts
+++ b/web/src/features/traces/fns/nodeScores.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { selectNodeScores, traceLevelScoreOwnerIds } from "./nodeScores";
 
 const roots = (

--- a/web/src/features/tracing-tables/observations/observationsTableStore.clienttest.ts
+++ b/web/src/features/tracing-tables/observations/observationsTableStore.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 import { createObservationsTableStore } from "@/src/features/tracing-tables/observations/observationsTableStore";
 

--- a/web/src/features/v4-migration/evaluatorMigrationUrls.clienttest.ts
+++ b/web/src/features/v4-migration/evaluatorMigrationUrls.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { decodeFiltersGeneric } from "@langfuse/shared";
 import { describe, expect, it } from "vitest";
 

--- a/web/src/features/v4-migration/migrationData.clienttest.ts
+++ b/web/src/features/v4-migration/migrationData.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   getLegacyIntegrationLabels,
   getMigrationActionState,

--- a/web/src/features/v4-migration/useV4UpgradeAssistantSupport.clienttest.ts
+++ b/web/src/features/v4-migration/useV4UpgradeAssistantSupport.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 
 import { V4_CODING_AGENT_PROMPT } from "./useV4UpgradeAssistantSupport";

--- a/web/src/features/v4/utils.clienttest.ts
+++ b/web/src/features/v4/utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   countLegacyApiEntrypoints,
   normalizeLegacyApiEntrypoint,

--- a/web/src/features/version-update/useAppSettled.clienttest.ts
+++ b/web/src/features/version-update/useAppSettled.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createAppSettledGate, APP_SETTLE_DELAY_MS } from "./useAppSettled";
 

--- a/web/src/features/widgets/chart-library/prepareDenseSeries.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareDenseSeries.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/features/widgets/chart-library/utils.clienttest.ts
+++ b/web/src/features/widgets/chart-library/utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   formatMetric,
   getDimensionSummaries,

--- a/web/src/features/widgets/components/WidgetImporter.clienttest.tsx
+++ b/web/src/features/widgets/components/WidgetImporter.clienttest.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";

--- a/web/src/features/widgets/components/resolveAggregationAndChartType.clienttest.ts
+++ b/web/src/features/widgets/components/resolveAggregationAndChartType.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { resolveAggregationAndChartType } from "./WidgetForm";
 
 const allAggs = [

--- a/web/src/features/widgets/components/widgetFormAdapters.clienttest.ts
+++ b/web/src/features/widgets/components/widgetFormAdapters.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import startCase from "lodash/startCase";
 import { type z } from "zod";
 

--- a/web/src/features/widgets/components/widgetFormSchema.clienttest.ts
+++ b/web/src/features/widgets/components/widgetFormSchema.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   deriveSaveReason,
   makeWidgetFormSchema,

--- a/web/src/features/widgets/utils/grid-placement.clienttest.ts
+++ b/web/src/features/widgets/utils/grid-placement.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { pushDownForInsertion } from "./grid-placement";
 
 const tile = (id: string, x: number, y: number, x_size = 6, y_size = 6) => ({

--- a/web/src/features/widgets/utils/import-export-utils.clienttest.ts
+++ b/web/src/features/widgets/utils/import-export-utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import {
   buildWidgetExport,
   buildWidgetImportAllowedValues,

--- a/web/src/fns/observedMetadata/metadataPaths.clienttest.ts
+++ b/web/src/fns/observedMetadata/metadataPaths.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/fns/parseTraceTimestampFromQuery/parseTraceTimestampFromQuery.clienttest.ts
+++ b/web/src/fns/parseTraceTimestampFromQuery/parseTraceTimestampFromQuery.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { parseTraceTimestampFromQuery } from "@/src/fns/parseTraceTimestampFromQuery/parseTraceTimestampFromQuery";

--- a/web/src/hooks/parsedIoCacheKey.clienttest.ts
+++ b/web/src/hooks/parsedIoCacheKey.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { cheapHash } from "@/src/hooks/parsedIoCacheKey";
 
 /**

--- a/web/src/hooks/parserWorkerError.clienttest.ts
+++ b/web/src/hooks/parserWorkerError.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { reportParserWorkerError } from "@/src/hooks/parserWorkerError";
 
 const { mockCaptureException } = vi.hoisted(() => ({

--- a/web/src/polyfills/crypto-random-uuid.clienttest.ts
+++ b/web/src/polyfills/crypto-random-uuid.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 
 import { installCryptoRandomUUIDPolyfill } from "@/src/polyfills/crypto-random-uuid";

--- a/web/src/utils/api.clienttest.ts
+++ b/web/src/utils/api.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { TRPCClientError } from "@trpc/client";
 import { vi } from "vitest";
 import {

--- a/web/src/utils/arrays.clienttest.ts
+++ b/web/src/utils/arrays.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { deduplicateBy } from "@/src/utils/arrays";
 
 describe("deduplicateBy", () => {

--- a/web/src/utils/captureUnknownError.clienttest.ts
+++ b/web/src/utils/captureUnknownError.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { captureUnknownError } from "@/src/utils/captureUnknownError";
 
 const { captureExceptionMock } = vi.hoisted(() => ({

--- a/web/src/utils/date-range-utils.clienttest.ts
+++ b/web/src/utils/date-range-utils.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/web/src/utils/dates.clienttest.ts
+++ b/web/src/utils/dates.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // @vitest-environment jsdom
 
 import { describe, it, expect } from "vitest";

--- a/web/src/utils/numbers.clienttest.ts
+++ b/web/src/utils/numbers.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { costFormatter } from "@/src/utils/numbers";

--- a/web/src/utils/reportError.clienttest.ts
+++ b/web/src/utils/reportError.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { reportError } from "@/src/utils/reportError";
 
 const { captureExceptionMock, addBreadcrumbMock } = vi.hoisted(() => ({

--- a/web/src/utils/safe-random-uuid.clienttest.ts
+++ b/web/src/utils/safe-random-uuid.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 
 import { safeRandomUUID } from "@/src/utils/safe-random-uuid";

--- a/web/src/utils/unicode.clienttest.ts
+++ b/web/src/utils/unicode.clienttest.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { decodeUnicodeEscapesOnly } from "@/src/utils/unicode";
 
 describe("decodeUnicodeEscapesOnly", () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16282.preview.langfuse.com](https://pr-16282.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

This is an experiment to measure the real CI impact of running pure client tests without jsdom.

## What changed

- 136 client test files now run in Vitest's Node environment.
- 135 files receive a mechanical `@vitest-environment node` annotation in this PR; one file already used Node on `main`.
- The regular client suite still passes: 283 files passed / 1 skipped, with 3,367 tests passed / 51 skipped.

## Reasoning

The [CI runtime report](https://github.com/langfuse/langfuse/issues/16233) shows substantial summed environment time on the client shard. A source-level scan found 140 candidates. The full suite exposed four files with transitive browser dependencies, so those remain on jsdom.

Local timings were too noisy to support a decision. Merge this only if repeated CI runs show a clear improvement.

Trade-off: this adds broad mechanical annotations across 135 files. The explicit annotations are intentional - they avoid a source-scanning heuristic that could silently select the wrong environment.

## Measurement

- [ ] Record the client shard `run tests` duration from the first CI run.
- [ ] Repeat the CI workflow at least twice on the same commit.
- [ ] Compare the median against recent `main` runs on the same runner class.
- [ ] Merge only with a clear, repeatable improvement; otherwise close the experiment.
