### PR TITLE
fix(worker): classify Mixpanel customer-config faults for observability

### DIFF
--- a/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
@@ -43,9 +43,6 @@ const h = vi.hoisted(() => {
 
   const mixpanelIntegrationUpdate = vi.fn();
 
-  // Set by a test to make the mocked MixpanelClient's flush() reject once,
-  // simulating a classified-fault-shaped HTTP error (e.g. 401) from the
-  // Mixpanel API. Cleared in beforeEach so it never leaks between tests.
   const flushError: { value: Error | undefined } = { value: undefined };
 
   const defaultIntegration = () => ({
@@ -151,12 +148,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { env } from "../env";
 
-// opts.attempts: 5 mirrors the real queue's defaultJobOptions (see
-// packages/shared/src/server/redis/mixpanelIntegrationProcessingQueue.ts) so
-// this fixture matches what BullMQ actually hands the handler, now that
-// PR2's disable-on-fault wiring will read job.opts/attemptsMade via the
-// shared bullmqAttempts predicate. The original fixture had no `opts` field
-// at all, which silently modeled a job shape BullMQ never produces.
+// Mirrors the real queue's defaultJobOptions (mixpanelIntegrationProcessingQueue.ts).
 function makeJob(attemptsMade = 0) {
   return {
     data: { id: "job-1", payload: { projectId: "project-1" } },
@@ -165,8 +157,6 @@ function makeJob(attemptsMade = 0) {
   } as unknown as Parameters<typeof handleMixpanelIntegrationProjectJob>[0];
 }
 
-// Deliberately mirrors the pre-fix fixture shape (no `opts` at all) for the
-// negative case below: a job missing its attempts budget must not disable.
 function makeJobWithoutOpts() {
   return {
     data: { id: "job-1", payload: { projectId: "project-1" } },
@@ -301,15 +291,7 @@ describe("handleMixpanelIntegrationProjectJob legacy-mode enriched guard (LFE-11
   });
 });
 
-// PR1 of the customer-fault auto-disable work is entirely non-behavioral:
-// classifier + shared disable handler + fail-closed attempt predicate are
-// introduced as building blocks (see customerFaultClassification.test.ts,
-// disableIntegrationOnCustomerFault.test.ts, bullmqAttempts.test.ts), but
-// nothing wires them into this handler yet — that lands in a separate PR.
-// These pin today's (and this PR's) actual behavior: a classified-fault-
-// shaped error still just propagates, and the integration is never disabled,
-// regardless of what job.opts looks like.
-describe("handleMixpanelIntegrationProjectJob customer-fault wiring (PR1: not yet wired)", () => {
+describe("handleMixpanelIntegrationProjectJob customer-fault observation (no disable)", () => {
   beforeEach(() => {
     h.timeline.length = 0;
     h.mixpanelIntegrationUpdate.mockClear();
@@ -327,15 +309,9 @@ describe("handleMixpanelIntegrationProjectJob customer-fault wiring (PR1: not ye
       unauthorized,
     );
 
-    // The only prisma.mixpanelIntegration.update call site today is the
-    // success path (advancing lastSyncAt) — an error before that point means
-    // update is never reached at all, disable or otherwise.
     expect(h.mixpanelIntegrationUpdate).not.toHaveBeenCalled();
   });
 
-  // Pins the fail-closed predicate decision at the job level: a job built
-  // without `opts` at all (the shape the original, pre-fix `makeJob()` used)
-  // must not be treated any differently — it must not disable either.
   it("a job with no opts still does not disable on a classified-fault-shaped error", async () => {
     const unauthorized = new Error("Mixpanel API error: 401 Unauthorized");
     Object.assign(unauthorized, { statusCode: 401 });

--- a/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/mixpanelIntegrationProjectJob.test.ts
@@ -43,6 +43,11 @@ const h = vi.hoisted(() => {
 
   const mixpanelIntegrationUpdate = vi.fn();
 
+  // Set by a test to make the mocked MixpanelClient's flush() reject once,
+  // simulating a classified-fault-shaped HTTP error (e.g. 401) from the
+  // Mixpanel API. Cleared in beforeEach so it never leaks between tests.
+  const flushError: { value: Error | undefined } = { value: undefined };
+
   const defaultIntegration = () => ({
     projectId: "project-1",
     enabled: true,
@@ -65,6 +70,7 @@ const h = vi.hoisted(() => {
     mixpanelIntegrationUpdate,
     defaultIntegration,
     db,
+    flushError,
   };
 });
 
@@ -72,6 +78,11 @@ vi.mock("../features/mixpanel/mixpanelClient", () => ({
   MixpanelClient: class {
     addEvent = vi.fn();
     flush = vi.fn().mockImplementation(async () => {
+      if (h.flushError.value) {
+        const err = h.flushError.value;
+        h.flushError.value = undefined; // reject once, then behave
+        throw err;
+      }
       h.timeline.push("flush");
     });
     getBatchSize = vi.fn().mockReturnValue(0);
@@ -130,11 +141,33 @@ vi.mock("@langfuse/shared/src/server", () => ({
 }));
 
 // Import after mocks are registered.
-import { handleMixpanelIntegrationProjectJob } from "../features/mixpanel/handleMixpanelIntegrationProjectJob";
-import { getScoresForAnalyticsIntegrations } from "@langfuse/shared/src/server";
+import {
+  handleMixpanelIntegrationProjectJob,
+  MIXPANEL_INTEGRATION_CUSTOMER_FAULT_METRIC,
+} from "../features/mixpanel/handleMixpanelIntegrationProjectJob";
+import {
+  getScoresForAnalyticsIntegrations,
+  recordIncrement,
+} from "@langfuse/shared/src/server";
 import { env } from "../env";
 
-function makeJob() {
+// opts.attempts: 5 mirrors the real queue's defaultJobOptions (see
+// packages/shared/src/server/redis/mixpanelIntegrationProcessingQueue.ts) so
+// this fixture matches what BullMQ actually hands the handler, now that
+// PR2's disable-on-fault wiring will read job.opts/attemptsMade via the
+// shared bullmqAttempts predicate. The original fixture had no `opts` field
+// at all, which silently modeled a job shape BullMQ never produces.
+function makeJob(attemptsMade = 0) {
+  return {
+    data: { id: "job-1", payload: { projectId: "project-1" } },
+    attemptsMade,
+    opts: { attempts: 5 },
+  } as unknown as Parameters<typeof handleMixpanelIntegrationProjectJob>[0];
+}
+
+// Deliberately mirrors the pre-fix fixture shape (no `opts` at all) for the
+// negative case below: a job missing its attempts budget must not disable.
+function makeJobWithoutOpts() {
   return {
     data: { id: "job-1", payload: { projectId: "project-1" } },
     attemptsMade: 0,
@@ -265,5 +298,92 @@ describe("handleMixpanelIntegrationProjectJob legacy-mode enriched guard (LFE-11
     await handleMixpanelIntegrationProjectJob(makeJob());
 
     expect(h.mixpanelIntegrationUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// PR1 of the customer-fault auto-disable work is entirely non-behavioral:
+// classifier + shared disable handler + fail-closed attempt predicate are
+// introduced as building blocks (see customerFaultClassification.test.ts,
+// disableIntegrationOnCustomerFault.test.ts, bullmqAttempts.test.ts), but
+// nothing wires them into this handler yet — that lands in a separate PR.
+// These pin today's (and this PR's) actual behavior: a classified-fault-
+// shaped error still just propagates, and the integration is never disabled,
+// regardless of what job.opts looks like.
+describe("handleMixpanelIntegrationProjectJob customer-fault wiring (PR1: not yet wired)", () => {
+  beforeEach(() => {
+    h.timeline.length = 0;
+    h.mixpanelIntegrationUpdate.mockClear();
+    h.db.integration = h.defaultIntegration();
+    h.flushError.value = undefined;
+    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+  });
+
+  it("still throws a 401-shaped error and never calls update to disable the integration", async () => {
+    const unauthorized = new Error("Mixpanel API error: 401 Unauthorized");
+    Object.assign(unauthorized, { statusCode: 401 });
+    h.flushError.value = unauthorized;
+
+    await expect(handleMixpanelIntegrationProjectJob(makeJob())).rejects.toBe(
+      unauthorized,
+    );
+
+    // The only prisma.mixpanelIntegration.update call site today is the
+    // success path (advancing lastSyncAt) — an error before that point means
+    // update is never reached at all, disable or otherwise.
+    expect(h.mixpanelIntegrationUpdate).not.toHaveBeenCalled();
+  });
+
+  // Pins the fail-closed predicate decision at the job level: a job built
+  // without `opts` at all (the shape the original, pre-fix `makeJob()` used)
+  // must not be treated any differently — it must not disable either.
+  it("a job with no opts still does not disable on a classified-fault-shaped error", async () => {
+    const unauthorized = new Error("Mixpanel API error: 401 Unauthorized");
+    Object.assign(unauthorized, { statusCode: 401 });
+    h.flushError.value = unauthorized;
+
+    await expect(
+      handleMixpanelIntegrationProjectJob(makeJobWithoutOpts()),
+    ).rejects.toBe(unauthorized);
+
+    expect(h.mixpanelIntegrationUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleMixpanelIntegrationProjectJob customer-fault observability", () => {
+  beforeEach(() => {
+    h.timeline.length = 0;
+    h.mixpanelIntegrationUpdate.mockClear();
+    h.db.integration = h.defaultIntegration();
+    h.flushError.value = undefined;
+    vi.mocked(recordIncrement).mockClear();
+    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+  });
+
+  it("records the customer-fault metric with reason and attempt, then still rethrows", async () => {
+    const unauthorized = new Error("Mixpanel API error: 401 Unauthorized");
+    Object.assign(unauthorized, { statusCode: 401 });
+    h.flushError.value = unauthorized;
+
+    await expect(handleMixpanelIntegrationProjectJob(makeJob(2))).rejects.toBe(
+      unauthorized,
+    );
+
+    expect(recordIncrement).toHaveBeenCalledWith(
+      MIXPANEL_INTEGRATION_CUSTOMER_FAULT_METRIC,
+      1,
+      { reason: "credentials", attempt: 2 },
+    );
+  });
+
+  it("does not record the customer-fault metric for an unclassified error", async () => {
+    const infraError = new Error("connection reset");
+    Object.assign(infraError, { code: "ECONNRESET" });
+    h.flushError.value = infraError;
+
+    await expect(handleMixpanelIntegrationProjectJob(makeJob())).rejects.toBe(
+      infraError,
+    );
+
+    expect(recordIncrement).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/features/integrations/customerFaultClassification.test.ts
+++ b/worker/src/features/integrations/customerFaultClassification.test.ts
@@ -112,12 +112,6 @@ describe("isCustomerFaultError", () => {
       expect(isCustomerFaultError(wrapped(err))).toBe(true);
     });
 
-    // Mixpanel (and any future integration whose SDK/fetch error surfaces the
-    // status on a plain `.statusCode`, not `$metadata.httpStatusCode`) must
-    // classify through this same generic extractHttpStatus path — no
-    // Mixpanel-specific branch. Red-first control: a bare Error with no status
-    // field at all must NOT classify, so the statusCode-attached case below is
-    // proven to be doing the work rather than passing on message content.
     it("classifies a bare Error with no statusCode as other (control)", () => {
       const err = new Error("Unauthorized");
       expect(isCustomerFaultError(err)).toBe(false);
@@ -291,9 +285,6 @@ describe("classifyCustomerFault — disable reason buckets", () => {
     );
   });
 
-  // Mixpanel's fetch-based client (and any provider reporting status on a
-  // plain `.statusCode`) must classify to "credentials" via this same generic
-  // path, bare and cause-wrapped, with no per-integration branch.
   it("maps a bare .statusCode of 401 to credentials, bare and cause-wrapped", () => {
     const unauthorized = new Error("Unauthorized");
     Object.assign(unauthorized, { statusCode: 401 });

--- a/worker/src/features/integrations/customerFaultClassification.test.ts
+++ b/worker/src/features/integrations/customerFaultClassification.test.ts
@@ -111,6 +111,30 @@ describe("isCustomerFaultError", () => {
       Object.assign(err, { $metadata: { httpStatusCode: 401 } });
       expect(isCustomerFaultError(wrapped(err))).toBe(true);
     });
+
+    // Mixpanel (and any future integration whose SDK/fetch error surfaces the
+    // status on a plain `.statusCode`, not `$metadata.httpStatusCode`) must
+    // classify through this same generic extractHttpStatus path — no
+    // Mixpanel-specific branch. Red-first control: a bare Error with no status
+    // field at all must NOT classify, so the statusCode-attached case below is
+    // proven to be doing the work rather than passing on message content.
+    it("classifies a bare Error with no statusCode as other (control)", () => {
+      const err = new Error("Unauthorized");
+      expect(isCustomerFaultError(err)).toBe(false);
+      expect(isCustomerFaultError(wrapped(err))).toBe(false);
+    });
+
+    it("classifies a raw .statusCode of 401 as customer_fault (unwrapped)", () => {
+      const err = new Error("Unauthorized");
+      Object.assign(err, { statusCode: 401 });
+      expect(isCustomerFaultError(err)).toBe(true);
+    });
+
+    it("classifies a .statusCode of 401 wrapped in { cause } as customer_fault", () => {
+      const err = new Error("Unauthorized");
+      Object.assign(err, { statusCode: 401 });
+      expect(isCustomerFaultError(wrapped(err))).toBe(true);
+    });
   });
 
   describe("other — transient / infra / unknown (bias toward investigation)", () => {
@@ -265,6 +289,16 @@ describe("classifyCustomerFault — disable reason buckets", () => {
     expect(classifyCustomerFault(wrapped(gcsError(403, "forbidden")))).toBe(
       "credentials",
     );
+  });
+
+  // Mixpanel's fetch-based client (and any provider reporting status on a
+  // plain `.statusCode`) must classify to "credentials" via this same generic
+  // path, bare and cause-wrapped, with no per-integration branch.
+  it("maps a bare .statusCode of 401 to credentials, bare and cause-wrapped", () => {
+    const unauthorized = new Error("Unauthorized");
+    Object.assign(unauthorized, { statusCode: 401 });
+    expect(classifyCustomerFault(unauthorized)).toBe("credentials");
+    expect(classifyCustomerFault(wrapped(unauthorized))).toBe("credentials");
   });
 
   it.each([

--- a/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
@@ -321,7 +321,13 @@ export const handleMixpanelIntegrationProjectJob = async (
     }
     logger.error(
       `[MIXPANEL] Error processing Mixpanel integration for project ${projectId}`,
-      { error, mixpanelFaultReason, attempt: job.attemptsMade },
+      {
+        error,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        errorStack: error instanceof Error ? error.stack : undefined,
+        mixpanelFaultReason,
+        attempt: job.attemptsMade,
+      },
     );
     throw error;
   }

--- a/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
@@ -9,6 +9,7 @@ import {
   getScoresForAnalyticsIntegrations,
   getEventsForAnalyticsIntegrations,
   getCurrentSpan,
+  recordIncrement,
 } from "@langfuse/shared/src/server";
 import { decrypt } from "@langfuse/shared/encryption";
 import { MixpanelClient } from "./mixpanelClient";
@@ -21,6 +22,13 @@ import {
 } from "./transformers";
 import { env, v4WritesToLegacyTables } from "../../env";
 import { assertExportSourceWritable } from "../exportWriteModeGuard";
+import { classifyCustomerFault } from "../integrations/customerFaultClassification";
+
+// Counter for classified customer-config faults on the Mixpanel export job,
+// tagged by `reason`. This PR only observes the fault (metric + log fields);
+// nothing is disabled and the job still throws/retries unconditionally.
+export const MIXPANEL_INTEGRATION_CUSTOMER_FAULT_METRIC =
+  "langfuse.mixpanel.integration_customer_fault.count";
 
 const sleep = (ms: number) =>
   ms > 0
@@ -307,9 +315,16 @@ export const handleMixpanelIntegrationProjectJob = async (
       `[MIXPANEL] Mixpanel integration processing complete for project ${projectId}`,
     );
   } catch (error) {
+    const mixpanelFaultReason = classifyCustomerFault(error);
+    if (mixpanelFaultReason !== undefined) {
+      recordIncrement(MIXPANEL_INTEGRATION_CUSTOMER_FAULT_METRIC, 1, {
+        reason: mixpanelFaultReason,
+        attempt: job.attemptsMade,
+      });
+    }
     logger.error(
       `[MIXPANEL] Error processing Mixpanel integration for project ${projectId}`,
-      error,
+      { error, mixpanelFaultReason, attempt: job.attemptsMade },
     );
     throw error;
   }

--- a/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
@@ -24,9 +24,6 @@ import { env, v4WritesToLegacyTables } from "../../env";
 import { assertExportSourceWritable } from "../exportWriteModeGuard";
 import { classifyCustomerFault } from "../integrations/customerFaultClassification";
 
-// Counter for classified customer-config faults on the Mixpanel export job,
-// tagged by `reason`. This PR only observes the fault (metric + log fields);
-// nothing is disabled and the job still throws/retries unconditionally.
 export const MIXPANEL_INTEGRATION_CUSTOMER_FAULT_METRIC =
   "langfuse.mixpanel.integration_customer_fault.count";
 

--- a/worker/src/features/mixpanel/mixpanelClient.test.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Unit tests for MixpanelClient's HTTP error handling — the layer where the
-// customer-fault classifier's "no Mixpanel-specific branch" promise actually
-// gets exercised: sendBatch's thrown Error must carry a plain, classifiable
-// shape (a status the shared classifier's extractHttpStatus reads), and must
-// never leak the request's Basic-Auth project token or the raw response body
-// into anything the job's catch block subsequently logs/persists/rethrows.
-
 const { fetchWithSecureRedirects } = vi.hoisted(() => ({
   fetchWithSecureRedirects: vi.fn(),
 }));
@@ -16,10 +9,8 @@ vi.mock("@langfuse/shared/src/server", () => ({
   fetchWithSecureRedirects,
 }));
 
-// Real analyticsIntegrationEgress pulls in validateWebhookURL/whitelistFromEnv
-// from the (mocked-above) server barrel; stub it directly instead so this
-// file only has to model the one seam it exercises (a non-SSRF error is a
-// no-op here, so the original error keeps propagating).
+// Stubbed directly rather than through the real module, which pulls in
+// validateWebhookURL/whitelistFromEnv from the mocked server barrel above.
 vi.mock("../analyticsIntegrationEgress", () => ({
   buildAnalyticsRedirectOptions: () => ({
     maxRedirects: 10,

--- a/worker/src/features/mixpanel/mixpanelClient.test.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Unit tests for MixpanelClient's HTTP error handling — the layer where the
+// customer-fault classifier's "no Mixpanel-specific branch" promise actually
+// gets exercised: sendBatch's thrown Error must carry a plain, classifiable
+// shape (a status the shared classifier's extractHttpStatus reads), and must
+// never leak the request's Basic-Auth project token or the raw response body
+// into anything the job's catch block subsequently logs/persists/rethrows.
+
+const { fetchWithSecureRedirects } = vi.hoisted(() => ({
+  fetchWithSecureRedirects: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  fetchWithSecureRedirects,
+}));
+
+// Real analyticsIntegrationEgress pulls in validateWebhookURL/whitelistFromEnv
+// from the (mocked-above) server barrel; stub it directly instead so this
+// file only has to model the one seam it exercises (a non-SSRF error is a
+// no-op here, so the original error keeps propagating).
+vi.mock("../analyticsIntegrationEgress", () => ({
+  buildAnalyticsRedirectOptions: () => ({
+    maxRedirects: 10,
+    redirectValidation: { validateUrl: () => {} },
+  }),
+  rethrowIfOutboundValidationFailure: () => undefined,
+}));
+
+vi.mock("../../env", () => ({
+  env: { LANGFUSE_MIXPANEL_TIMEOUT_MS: 5000 },
+}));
+
+import { MixpanelClient } from "./mixpanelClient";
+
+const FAKE_PROJECT_TOKEN = "sk-mp-secret-token-abcdef123456";
+
+const fakeResponse = (
+  overrides: Partial<{
+    ok: boolean;
+    status: number;
+    statusText: string;
+    text: () => Promise<string>;
+    json: () => Promise<unknown>;
+  }>,
+) => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  text: async () => "",
+  json: async () => ({}),
+  ...overrides,
+});
+
+const buildClient = () =>
+  new MixpanelClient({ projectToken: FAKE_PROJECT_TOKEN, region: "api" });
+
+const addOneEvent = (client: MixpanelClient) =>
+  client.addEvent({
+    event: "trace",
+    properties: {
+      time: Date.now(),
+      distinct_id: "user-1",
+      $insert_id: "insert-1",
+    },
+  });
+
+describe("MixpanelClient.flush error handling", () => {
+  beforeEach(() => {
+    fetchWithSecureRedirects.mockReset();
+  });
+
+  it("throws on a 401 response with a plain, classifiable shape", async () => {
+    fetchWithSecureRedirects.mockResolvedValue({
+      response: fakeResponse({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: async () => "unauthorized",
+      }),
+    });
+
+    const client = buildClient();
+    addOneEvent(client);
+
+    await expect(client.flush()).rejects.toThrow(/401/);
+  });
+
+  it("resolves (does not throw) on a 400 with partial success", async () => {
+    // Mixpanel's /import can report some records imported and some rejected
+    // on a 400; only a zero-imported batch is a hard failure.
+    fetchWithSecureRedirects.mockResolvedValue({
+      response: fakeResponse({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: async () =>
+          JSON.stringify({
+            code: 400,
+            num_records_imported: 1,
+            failed_records: [
+              { index: 1, insert_id: "x", field: "time", message: "bad" },
+            ],
+          }),
+      }),
+    });
+
+    const client = buildClient();
+    addOneEvent(client);
+
+    await expect(client.flush()).resolves.toBeUndefined();
+  });
+
+  it("throws on a 400 where zero records were imported", async () => {
+    fetchWithSecureRedirects.mockResolvedValue({
+      response: fakeResponse({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: async () =>
+          JSON.stringify({ code: 400, num_records_imported: 0 }),
+      }),
+    });
+
+    const client = buildClient();
+    addOneEvent(client);
+
+    await expect(client.flush()).rejects.toThrow(/400/);
+  });
+
+  it("thrown message on a 401 carries neither the project token nor the response body", async () => {
+    const responseBody = "leaky-response-body-marker";
+    fetchWithSecureRedirects.mockResolvedValue({
+      response: fakeResponse({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: async () => responseBody,
+      }),
+    });
+
+    const client = buildClient();
+    addOneEvent(client);
+
+    let caught: unknown;
+    try {
+      await client.flush();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).not.toContain(FAKE_PROJECT_TOKEN);
+    expect(message).not.toContain(responseBody);
+  });
+
+  it("thrown message on a fully-rejected 400 carries neither the project token nor the response body", async () => {
+    const failureDetail = "very-specific-field-validation-failure-detail";
+    fetchWithSecureRedirects.mockResolvedValue({
+      response: fakeResponse({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: async () =>
+          JSON.stringify({
+            code: 400,
+            num_records_imported: 0,
+            failed_records: [
+              {
+                index: 0,
+                insert_id: "x",
+                field: "time",
+                message: failureDetail,
+              },
+            ],
+          }),
+      }),
+    });
+
+    const client = buildClient();
+    addOneEvent(client);
+
+    let caught: unknown;
+    try {
+      await client.flush();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).not.toContain(FAKE_PROJECT_TOKEN);
+    expect(message).not.toContain(failureDetail);
+  });
+});

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -147,8 +147,14 @@ export class MixpanelClient {
           `Failed to send events to Mixpanel: ${response.status} ${response.statusText}`,
           { body: errorText },
         );
-        throw new Error(
-          `Mixpanel API error: ${response.status} ${response.statusText}`,
+        // statusCode lets the shared customer-fault classifier's generic
+        // status-extraction path recognize this error without a
+        // Mixpanel-specific branch (see classifyCustomerFault).
+        throw Object.assign(
+          new Error(
+            `Mixpanel API error: ${response.status} ${response.statusText}`,
+          ),
+          { statusCode: response.status },
         );
       }
 

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -147,9 +147,6 @@ export class MixpanelClient {
           `Failed to send events to Mixpanel: ${response.status} ${response.statusText}`,
           { body: errorText },
         );
-        // statusCode lets the shared customer-fault classifier's generic
-        // status-extraction path recognize this error without a
-        // Mixpanel-specific branch (see classifyCustomerFault).
         throw Object.assign(
           new Error(
             `Mixpanel API error: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16283.preview.langfuse.com](https://pr-16283.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

A prod-eu Mixpanel integration has been retrying a `401 Unauthorized` hourly for over a week, showing up only as ~115/day generic, unclassified log lines — indistinguishable from any transient error. Blob storage and PostHog both share a fault classifier (`classifyCustomerFault`) that recognizes structured error shapes (e.g. a `.statusCode` field) and buckets known customer-fixable faults (a `401` → `"credentials"`). Mixpanel's client throws a bare `Error` with no structured fields, so the classifier can't see it.

Attaches `statusCode: response.status` to the error `MixpanelClient` throws on a non-2xx response — the classifier's existing generic status-extraction path then recognizes it with **no Mixpanel-specific branch added to the classifier** (the classifier stays provider-agnostic; Mixpanel adapts to its shape, not the reverse). The thrown message stays the existing bounded static string — never the raw response body, which can echo submitted event payloads.

In the job handler's catch block, classifies the error and — when classified — records a `langfuse.mixpanel.integration_customer_fault.count` metric tagged `{reason, attempt}` and enriches the existing error log line with the same fields.

**No behavior change**: the job still throws and BullMQ still retries unconditionally, classified or not. Nothing is disabled, nothing new is persisted. This just makes the fault visible instead of anonymous — a foundational step toward eventually auto-disabling on this pattern (as blob storage and PostHog already do), tracked separately.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR attaches Mixpanel HTTP response statuses to sanitized errors and records classified customer-fault metrics from the project job while preserving its existing retry behavior.

- Adds `statusCode` to errors thrown for failed Mixpanel API responses.
- Classifies caught job errors and records reason and attempt tags.
- Adds classifier, handler, and client error-path tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking test gap around the core error-shape contract.

The production path preserves sanitized errors and existing retries, but the new client test could pass after removal of the `statusCode` property because it only checks the error message.

**Files Needing Attention:** worker/src/features/mixpanel/mixpanelClient.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/mixpanel/mixpanelClient.test.ts:88
**Assert the classifiable error shape**

This assertion only checks that the message contains `401`, so removing or renaming the new `statusCode` property would leave the test passing while breaking customer-fault classification. Assert the property directly or classify the error produced by `MixpanelClient` to cover the contract introduced here.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): observe classified custome..."](https://github.com/langfuse/langfuse/commit/1381a7e8c1829ea1f12c31593c9d0363d6488635) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54681254)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->