### PR TITLE
chore(ci): Update sandbox CI workflow

### DIFF
--- a/.github/workflows/build-sandbox-microvm-image.yml
+++ b/.github/workflows/build-sandbox-microvm-image.yml
@@ -2,6 +2,24 @@ name: Build Sandbox MicroVM Image
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to publish the MicroVM image to
+        required: true
+        type: choice
+        default: staging
+        options:
+          - staging
+          - all-production
+          - prod-eu
+          - prod-us
+          - prod-hipaa
+          - prod-jp
+  push:
+    branches:
+      - main
+    paths:
+      - packages/in-app-agent-sandbox-runtime/**
 
 permissions: {}
 
@@ -21,12 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - environment: staging
-          - environment: prod-eu
-          - environment: prod-us
-          - environment: prod-hipaa
-          - environment: prod-jp
+        environment: ${{ fromJSON(github.event_name == 'push' && '["staging"]' || inputs.environment == 'all-production' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || format('["{0}"]', inputs.environment)) }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_MICROVM_BUILD_ROLE_ARN: ${{ vars.AWS_MICROVM_BUILD_ROLE_ARN }}
@@ -198,10 +211,11 @@ jobs:
 
       - name: Write job summary
         env:
+          DEPLOYMENT_ENVIRONMENT: ${{ matrix.environment }}
           IMAGE_ARN: ${{ steps.publish.outputs.image_arn }}
           IMAGE_VERSION: ${{ steps.wait.outputs.image_version }}
         run: |
-          printf '## Sandbox MicroVM image (%s)\n\n' '${{ matrix.environment }}' >> "$GITHUB_STEP_SUMMARY"
+          printf '## Sandbox MicroVM image (%s)\n\n' "$DEPLOYMENT_ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
           printf -- '- Region: `%s`\n' "$AWS_REGION" >> "$GITHUB_STEP_SUMMARY"
           printf -- '- ARN: `%s`\n' "$IMAGE_ARN" >> "$GITHUB_STEP_SUMMARY"
           printf -- '- Version: `%s`\n' "$IMAGE_VERSION" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16290.preview.langfuse.com](https://pr-16290.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the sandbox MicroVM image workflow to support targeted manual publication and automatic staging builds.
- Adds a required environment selector with individual and all-production options.
- Triggers staging builds when the sandbox runtime changes on `main`.
- Dynamically expands the environment matrix based on the triggering event and selected target.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The workflow changes appear safe to merge, with manual and push events resolving to the intended publication environments.

The new event-dependent matrix yields staging for matching pushes, selected environments for targeted dispatches, and the four production environments for all-production dispatches; no concrete blocking or non-blocking defect remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): Update sandbox CI workflow"](https://github.com/langfuse/langfuse/commit/3a0cf243f80255b8dd174806324203f1edefeb71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54703087)</sub>

<!-- /greptile_comment -->