### PR TITLE
fix(entitlements): enforce plan limits atomically on member and monitor creation

### DIFF
--- a/packages/shared/src/features/monitors/service/service.ts
+++ b/packages/shared/src/features/monitors/service/service.ts
@@ -46,6 +46,12 @@ export class MonitorService {
   public static async create(
     session: SessionContext,
     input: CreateMonitor,
+    /**
+     * Optional transaction client, so a caller can create the monitor inside
+     * its own transaction (e.g. to enforce a plan limit atomically). Defaults
+     * to the shared client.
+     */
+    tx: Prisma.TransactionClient = prisma,
   ): Promise<Monitor> {
     const filters = sortFiltersCanonically(input.filters);
     const windowMs = windowToMs(input.window);
@@ -57,7 +63,7 @@ export class MonitorService {
       windowMs,
     });
 
-    const created = await prisma.monitor.create({
+    const created = await tx.monitor.create({
       data: {
         projectId: input.projectId,
         createdBy: session.userId,

--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -2,6 +2,7 @@ import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { prisma } from "@langfuse/shared/src/db";
 import { Role, type Plan } from "@langfuse/shared";
+import { entitlementAccess } from "@/src/features/entitlements/constants/entitlements";
 import type { Session } from "next-auth";
 
 // Session fixture sub-object types; casts keep the runtime fixtures unchanged
@@ -125,6 +126,16 @@ async function createTestUser() {
 
 describe("membersRouter.create - organization member limit enforcement", () => {
   describe("cloud:hobby plan (2 member limit)", () => {
+    const hobbyMemberLimit =
+      entitlementAccess["cloud:hobby"].entitlementLimits[
+        "organization-member-count"
+      ];
+    if (typeof hobbyMemberLimit !== "number" || hobbyMemberLimit < 2) {
+      throw new Error(
+        "expected cloud:hobby organization-member-count to be a number >= 2; the concurrency tests need one free seat above the owner",
+      );
+    }
+
     it("should allow adding a member when within limit", async () => {
       const { org, caller } = await prepare("cloud:hobby");
 
@@ -172,6 +183,74 @@ describe("membersRouter.create - organization member limit enforcement", () => {
         }),
       ).rejects.toThrow(/exceeds the limit/i);
     });
+
+    it("does not admit more members than the limit under concurrent requests", async () => {
+      // Counting outside a transaction lets concurrent requests all observe
+      // the same pre-insert count and all pass the check, so the limit only
+      // holds if the count-check-create sequence is serialized.
+      const { org, caller } = await prepare("cloud:hobby");
+
+      // Org already has 1 member (the owner), so exactly one of the
+      // concurrent requests may create a membership.
+      const users = await Promise.all(
+        Array.from({ length: 5 }, () => createTestUser()),
+      );
+
+      const results = await Promise.allSettled(
+        users.map((user) =>
+          caller.members.create({
+            orgId: org.id,
+            email: user.email!,
+            orgRole: Role.MEMBER,
+          }),
+        ),
+      );
+
+      const memberCount = await prisma.organizationMembership.count({
+        where: { orgId: org.id },
+      });
+      expect(memberCount).toBe(hobbyMemberLimit);
+
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(results.length - rejected.length).toBe(1);
+      // every loser lost to the limit check, not to an incidental error
+      for (const result of rejected) {
+        expect(String(result.reason)).toMatch(/exceeds the limit/i);
+      }
+    }, 25_000);
+
+    it("does not admit more invitations than the limit under concurrent requests", async () => {
+      // Same race on the invitation branch, which creates a different row
+      // type behind the same shared seat limit.
+      const { org, caller } = await prepare("cloud:hobby");
+
+      const emails = Array.from(
+        { length: 5 },
+        () => `concurrent-${uuidv4().substring(0, 8)}@test.com`,
+      );
+
+      const results = await Promise.allSettled(
+        emails.map((email) =>
+          caller.members.create({
+            orgId: org.id,
+            email,
+            orgRole: Role.MEMBER,
+          }),
+        ),
+      );
+
+      const inviteCount = await prisma.membershipInvitation.count({
+        where: { orgId: org.id },
+      });
+      // owner + 1 invitation = the hobby limit
+      expect(inviteCount).toBe(hobbyMemberLimit - 1);
+
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(results.length - rejected.length).toBe(1);
+      for (const result of rejected) {
+        expect(String(result.reason)).toMatch(/exceeds the limit/i);
+      }
+    }, 25_000);
 
     it("should throw FORBIDDEN when exceeding member limit with pending invitations", async () => {
       const { org, caller, ownerUser } = await prepare("cloud:hobby");

--- a/web/src/__tests__/server/monitors.servertest.ts
+++ b/web/src/__tests__/server/monitors.servertest.ts
@@ -457,6 +457,38 @@ describe("monitors trpc", () => {
       ).rejects.toThrow(/monitor-count/i);
     });
 
+    it("does not admit more monitors than the limit under concurrent requests", async () => {
+      // Counting outside a transaction lets concurrent requests all observe
+      // the same pre-insert count and all pass the check, so the limit only
+      // holds if the count-check-create sequence is serialized.
+      const { project, caller } = await prepare();
+      // Seed up to one seat below the limit, so exactly one of the concurrent
+      // requests may succeed — otherwise a race that admits `monitorLimit`
+      // rows would satisfy the limit by coincidence.
+      await seedMonitors(caller, project.id, monitorLimit - 1);
+
+      const results = await Promise.allSettled(
+        Array.from({ length: 5 }, (_, i) =>
+          caller.monitors.create({
+            ...validMonitorInput(project.id),
+            name: `Concurrent monitor ${i + 1}`,
+          }),
+        ),
+      );
+
+      const created = await prisma.monitor.count({
+        where: { projectId: project.id },
+      });
+      expect(created).toBe(monitorLimit);
+
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(results.length - rejected.length).toBe(1);
+      // every loser lost to the limit check, not to an incidental error
+      for (const result of rejected) {
+        expect(String(result.reason)).toMatch(/monitor-count/i);
+      }
+    }, 25_000);
+
     it("counts monitors with non-ACTIVE status toward the limit", async () => {
       const { project, caller } = await prepare();
       await seedMonitors(caller, project.id, monitorLimit);

--- a/web/src/features/entitlements/server/createWithinEntitlementLimit.ts
+++ b/web/src/features/entitlements/server/createWithinEntitlementLimit.ts
@@ -1,0 +1,80 @@
+import {
+  hasEntitlementLimit,
+  throwIfExceedsLimit,
+} from "@/src/features/entitlements/server/hasEntitlementLimit";
+import { type EntitlementLimit } from "@/src/features/entitlements/constants/entitlements";
+import { Prisma, type PrismaClient } from "@langfuse/shared/src/db";
+import { type Session } from "next-auth";
+
+/**
+ * Serializes the rest of the transaction against every other holder of this
+ * lock. Concurrent inserts of rows that reference the organization take
+ * FOR KEY SHARE on the same row via their foreign key, so they queue behind
+ * this lock too — keep the locked section to local database work only (no
+ * email, no outbound HTTP).
+ */
+async function lockOrganization({
+  tx,
+  orgId,
+}: {
+  tx: Prisma.TransactionClient;
+  orgId: string;
+}) {
+  await tx.$queryRaw(
+    Prisma.sql`
+      SELECT id
+      FROM organizations
+      WHERE id = ${orgId}
+      FOR UPDATE
+    `,
+  );
+}
+
+/**
+ * Creates a resource only if doing so keeps the organization within a numeric
+ * entitlement limit.
+ *
+ * Counting and creating in separate auto-committed statements is a
+ * time-of-check-to-time-of-use race: concurrent requests all read the same
+ * pre-insert count, all pass the check, and all insert — so a plan limit of N
+ * admits more than N rows. Serializing on the organization row means a
+ * request's count already includes every insert that committed before it, on
+ * a single instance and across instances alike.
+ *
+ * Orgs whose plan does not limit this entitlement skip the lock entirely, so
+ * unlimited plans keep creating resources concurrently.
+ */
+export async function createWithinEntitlementLimit<T>({
+  prisma,
+  orgId,
+  entitlementLimit,
+  sessionUser,
+  countCurrentUsage,
+  create,
+}: {
+  prisma: PrismaClient;
+  orgId: string;
+  entitlementLimit: EntitlementLimit;
+  sessionUser: NonNullable<Session["user"]>;
+  /** Counts existing usage towards the limit. Must read through `tx`. */
+  countCurrentUsage: (tx: Prisma.TransactionClient) => Promise<number>;
+  /** Creates the resource. Must write through `tx`. */
+  create: (tx: Prisma.TransactionClient) => Promise<T>;
+}): Promise<T> {
+  const isUnlimited =
+    hasEntitlementLimit({ entitlementLimit, sessionUser, orgId }) === false;
+  if (isUnlimited) return create(prisma);
+
+  return prisma.$transaction(async (tx) => {
+    await lockOrganization({ tx, orgId });
+
+    throwIfExceedsLimit({
+      entitlementLimit,
+      sessionUser,
+      orgId,
+      currentUsage: await countCurrentUsage(tx),
+    });
+
+    return create(tx);
+  });
+}

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -21,7 +21,7 @@ import { sendMembershipInvitationEmail } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 import { getSfdcService } from "@/src/ee/features/sfdc-sync/server";
 import { hasEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
-import { throwIfExceedsLimit } from "@/src/features/entitlements/server/hasEntitlementLimit";
+import { createWithinEntitlementLimit } from "@/src/features/entitlements/server/createWithinEntitlementLimit";
 import {
   hasProjectAccess,
   throwIfNoProjectAccess,
@@ -221,15 +221,18 @@ export const membersRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Org not found" });
       }
 
-      // Count current members + pending invitations for limit check
-      const [currentMemberCount, pendingInviteCount] = await Promise.all([
-        ctx.prisma.organizationMembership.count({
+      // Members and pending invitations both consume a seat, so the limit
+      // check counts them together. Reads through the caller-supplied client
+      // so it can run inside the limit transaction.
+      const countSeatsInUse = async (tx: Prisma.TransactionClient) => {
+        const memberCount = await tx.organizationMembership.count({
           where: { orgId: input.orgId },
-        }),
-        ctx.prisma.membershipInvitation.count({
+        });
+        const pendingInviteCount = await tx.membershipInvitation.count({
           where: { orgId: input.orgId },
-        }),
-      ]);
+        });
+        return memberCount + pendingInviteCount;
+      };
 
       if (user) {
         const existingOrgMembership =
@@ -276,21 +279,22 @@ export const membersRouter = createTRPCRouter({
           });
         }
 
-        // Check member limit before creating new membership
-        throwIfExceedsLimit({
+        // create org membership as user is not a member yet, unless that
+        // would exceed the member limit
+        const orgMembership = await createWithinEntitlementLimit({
+          prisma: ctx.prisma,
+          orgId: input.orgId,
           entitlementLimit: "organization-member-count",
           sessionUser: ctx.session.user,
-          orgId: input.orgId,
-          currentUsage: currentMemberCount + pendingInviteCount,
-        });
-
-        // create org membership as user is not a member yet
-        const orgMembership = await ctx.prisma.organizationMembership.create({
-          data: {
-            userId: user.id,
-            orgId: input.orgId,
-            role: input.orgRole,
-          },
+          countCurrentUsage: countSeatsInUse,
+          create: (tx) =>
+            tx.organizationMembership.create({
+              data: {
+                userId: user.id,
+                orgId: input.orgId,
+                role: input.orgRole,
+              },
+            }),
         });
         await auditLog({
           session: ctx.session,
@@ -334,30 +338,35 @@ export const membersRouter = createTRPCRouter({
           env: env,
         });
       } else {
-        // Check member limit before creating invitation
-        throwIfExceedsLimit({
-          entitlementLimit: "organization-member-count",
-          sessionUser: ctx.session.user,
-          orgId: input.orgId,
-          currentUsage: currentMemberCount + pendingInviteCount,
-        });
-
         try {
-          const invitation = await ctx.prisma.membershipInvitation.create({
-            data: {
-              orgId: input.orgId,
-              projectId:
-                project && input.projectRole && input.projectRole !== Role.NONE
-                  ? project.id
-                  : null,
-              email: input.email.toLowerCase(),
-              orgRole: input.orgRole,
-              projectRole:
-                input.projectRole && input.projectRole !== Role.NONE && project
-                  ? input.projectRole
-                  : null,
-              invitedByUserId: ctx.session.user.id,
-            },
+          // create the invitation unless that would exceed the member limit
+          const invitation = await createWithinEntitlementLimit({
+            prisma: ctx.prisma,
+            orgId: input.orgId,
+            entitlementLimit: "organization-member-count",
+            sessionUser: ctx.session.user,
+            countCurrentUsage: countSeatsInUse,
+            create: (tx) =>
+              tx.membershipInvitation.create({
+                data: {
+                  orgId: input.orgId,
+                  projectId:
+                    project &&
+                    input.projectRole &&
+                    input.projectRole !== Role.NONE
+                      ? project.id
+                      : null,
+                  email: input.email.toLowerCase(),
+                  orgRole: input.orgRole,
+                  projectRole:
+                    input.projectRole &&
+                    input.projectRole !== Role.NONE &&
+                    project
+                      ? input.projectRole
+                      : null,
+                  invitedByUserId: ctx.session.user.id,
+                },
+              }),
           });
 
           await auditLog({

--- a/web/src/server/api/routers/monitors.ts
+++ b/web/src/server/api/routers/monitors.ts
@@ -6,7 +6,7 @@ import {
   requireV4Writes,
 } from "@/src/server/api/trpc";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { throwIfExceedsLimit } from "@/src/features/entitlements/server/hasEntitlementLimit";
+import { createWithinEntitlementLimit } from "@/src/features/entitlements/server/createWithinEntitlementLimit";
 import {
   CreateMonitorSchema,
   DeleteMonitorSchema,
@@ -36,17 +36,18 @@ export const monitorsRouter = createTRPCRouter({
         scope: "alerts:CUD",
       });
 
-      const currentCount = await ctx.prisma.monitor.count({
-        where: { project: { orgId: ctx.session.orgId, deletedAt: null } },
-      });
-      throwIfExceedsLimit({
+      return createWithinEntitlementLimit({
+        prisma: ctx.prisma,
+        orgId: ctx.session.orgId,
         entitlementLimit: "monitor-count",
         sessionUser: ctx.session.user,
-        orgId: ctx.session.orgId,
-        currentUsage: currentCount,
+        countCurrentUsage: (tx) =>
+          tx.monitor.count({
+            where: { project: { orgId: ctx.session.orgId, deletedAt: null } },
+          }),
+        create: (tx) =>
+          MonitorService.create(sessionContextFromCtx(ctx), input, tx),
       });
-
-      return MonitorService.create(sessionContextFromCtx(ctx), input);
     }),
 
   update: monitorsProcedure


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16293.preview.langfuse.com](https://pr-16293.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Problem

Organization member creation and monitor creation both enforced their plan limit as three separate auto-committed steps: count existing rows, compare against the limit in memory, insert. Nothing serialized the sequence, so concurrent requests all read the same pre-insert count, all passed the check, and all inserted — a limit of N admitted more than N rows. Multi-instance deployments widen the window further, since the racing requests need not share a Node process.

`throwIfExceedsLimit` is a pure in-memory comparison, so the check itself could never close this.

Affected today: `organization-member-count` (`cloud:hobby`, limit 2) and `monitor-count` (2 on hobby up to 100 on enterprise).

## Fix

New `createWithinEntitlementLimit` helper owns the invariant in one place: lock the organization row with `SELECT ... FOR UPDATE`, count, check, create. Both limited creates now route through it — the membership branch and the invitation branch in `membersRouter.create`, and `monitors.create`.

Two deliberate properties:

- **Unlimited plans skip the lock entirely.** The helper consults `hasEntitlementLimit` first, so every self-hosted plan (all limits are `false`) and every admin session keeps exactly the current non-transactional path. No new serialization for deployments with no limit to enforce.
- **Only local database work runs inside the lock.** A `FOR UPDATE` on the organization row also blocks concurrent inserts that reference it through a foreign key, so holding it across outbound calls would be costly. The invitation email, the SFDC call, and the audit-log write all stay outside the transaction.

`MonitorService.create` used the module-level Prisma client, so it now takes an optional transaction client defaulting to that same client; its other callers are unchanged.

`SELECT ... FOR UPDATE` was chosen over an advisory lock to match the existing pattern in `onboardingService.ts`, `evaluatorRepository.ts`, and `updatePrompts.ts`.

## Impacted packages

- `web` — new entitlements helper, `membersRouter`, `monitors` router, two test suites
- `packages/shared` — `MonitorService.create` optional transaction client

## Tests

Both tests were written first and confirmed failing against the unfixed code:

- `members-trpc.servertest.ts` — 5 concurrent `members.create` calls on a hobby org with one free seat. Before: `expected 5 to be 2`, all five succeeded. Covers the membership branch and the invitation branch separately, since they insert into different tables behind the same shared seat limit.
- `monitors.servertest.ts` — before: `expected 3 to be 2`, failing 3/3 runs.

The monitors test seeds to `limit - 1` on purpose. With nothing seeded it passed against the unfixed code: Prisma's pool only lets about two of the five requests reach the count together, so the race created exactly 2 rows under a limit of 2 and looked compliant. Leaving exactly one free seat is the sensitive configuration.

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test members-trpc` — `Tests 25 passed (25)`, stable across 3 runs
- `pnpm --filter web run test monitors.servertest` — `Tests 23 passed (23)`, stable across 3 runs
- `pnpm --filter web run test monitorService` — 22 passed (shared-package check)

`memberships-api.servertest.ts` fails 11/11 locally with `TypeError: fetch failed`; these are HTTP tests needing a dev server, and they fail identically on a clean tree. Left to CI.

## Not in scope

SCIM (`scim/Users/index.ts`) and the admin API (`admin-api/server/memberships.ts`) create organization memberships with no member-limit check at all. That is unreachable today — both are gated behind the `admin-api` entitlement, and all three plans that have it (`cloud:team`, `cloud:enterprise`, `self-hosted:enterprise`) set `organization-member-count: false`. Worth noting as a latent coupling: giving a numeric member limit to an `admin-api` plan would bypass it outright.

Reported by [tonghuaroot](https://github.com/tonghuaroot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR atomically enforces numeric organization entitlement limits by serializing count-check-create operations on the organization row.

- Adds a reusable transaction helper that bypasses locking for unlimited plans.
- Routes member, invitation, and monitor creation through the helper.
- Allows `MonitorService.create` to use a caller-provided transaction client.
- Adds concurrent server tests for member, invitation, and monitor limits.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security defects identified.

The limited creation paths explicitly lock the same organization row, count and write through one transaction, and preserve the existing non-transactional behavior for unlimited plans.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(entitlements): enforce plan limits a..."](https://github.com/langfuse/langfuse/commit/926766f39cb36dd9053173f219bad06110e44477) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54716973)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)
- Knowledge Base — [Enterprise Edition (EE), Entitlements, and Billing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/ee-features.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->