### PR TITLE
chore(agents): teach Cursor agents Linear branches and human handoff

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -46,14 +46,17 @@ evaluating, and debugging AI applications.
 - For product or UI changes, give a preview URL
   (`pr-<N>.preview.langfuse.com`) and exact click-path test steps, including
   the seed command or sandbox URL (`http://localhost:3000`) to reproduce
-  the data. Humans can ask for more detail.
+  the data. Attach proof of the fix (screenshot, short video, or
+  before/after). Humans can ask for more detail.
 - After opening a PR, leave a short last comment on what a reviewer should
   doubt — the curious, questionable parts — not a changelog.
 - Open PRs as reviewable, not as drafts, unless a human asks for a draft.
-- When Claude or Greptile review comments appear on a PR you own: do not
-  reply. Keep each thread open until you either apply the fix and resolve
-  it, or skip it because you are sure, tell the human in plain language
-  (and invite them to doubt that skip), then resolve it.
+- When Claude, Greptile, or Codex (`chatgpt-codex-connector[bot]`) review
+  comments appear on a PR you own: do not reply. Keep each thread open
+  until you either apply the fix and resolve it, or skip it because you
+  are sure, tell the human in plain language (and invite them to doubt
+  that skip), then resolve it. Do not post `@claude review` again unless
+  a human asks for another pass.
 
 ## Project Structure
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -49,6 +49,7 @@ evaluating, and debugging AI applications.
   the data. Humans can ask for more detail.
 - After opening a PR, leave a short last comment on what a reviewer should
   doubt — the curious, questionable parts — not a changelog.
+- Open PRs as reviewable, not as drafts, unless a human asks for a draft.
 - When Claude or Greptile review comments appear on a PR you own: do not
   reply. Keep each thread open until you either apply the fix and resolve
   it, or skip the fix for a stated reason and still resolve it.
@@ -109,9 +110,9 @@ langfuse/
   not be used to interpolate container service configuration.
 - After changing web or worker production code, rerun
   `bash scripts/agents/start-cursor-cloud.sh` before browser signoff.
-- Open a same-repo draft PR after local verification and test the resulting
-  `pr-<N>.preview.langfuse.com` deployment with synthetic data before marking
-  the PR ready. Previews normally run Mon-Fri 08:00-24:00 Europe/Berlin.
+- Open a same-repo reviewable PR after local verification (not a draft) and
+  test the resulting `pr-<N>.preview.langfuse.com` deployment with synthetic
+  data. Previews normally run Mon-Fri 08:00-24:00 Europe/Berlin.
 - Use Linear's git branch name (`lfe-XXXX-short-title`). Never create a
   `cursor/` branch, even if a Cursor Cloud prompt suggests that prefix.
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -40,9 +40,9 @@ evaluating, and debugging AI applications.
 - Never commit secrets or credentials. Keep `.env*.example` files in
   sync with required env vars.
 - Human handoff: assume the reader does not remember the ticket. Lead with
-  a one-sentence TL;DR. Ask for at most one or two human actions per
-  message; if you need more, wait and sequence them. Do not dump long
-  agent-only reports by default.
+  a one-sentence TL;DR. Prefer one or two human actions per message; if
+  you need more, keep every point simple and super readable. Do not dump
+  long agent-only reports by default.
 - For product or UI changes, give a preview URL
   (`pr-<N>.preview.langfuse.com`) and exact click-path test steps, including
   the seed command or sandbox URL (`http://localhost:3000`) to reproduce
@@ -52,7 +52,8 @@ evaluating, and debugging AI applications.
 - Open PRs as reviewable, not as drafts, unless a human asks for a draft.
 - When Claude or Greptile review comments appear on a PR you own: do not
   reply. Keep each thread open until you either apply the fix and resolve
-  it, or skip the fix for a stated reason and still resolve it.
+  it, or skip it because you are sure, tell the human in plain language
+  (and invite them to doubt that skip), then resolve it.
 
 ## Project Structure
 
@@ -115,6 +116,7 @@ langfuse/
   data. Previews normally run Mon-Fri 08:00-24:00 Europe/Berlin.
 - Use Linear's git branch name (`lfe-XXXX-short-title`). Never create a
   `cursor/` branch, even if a Cursor Cloud prompt suggests that prefix.
+  Repo guidance wins.
 
 ## Local Data Inspection
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -39,6 +39,19 @@ evaluating, and debugging AI applications.
   ticket-prefixed branch name is the one place the identifier belongs.
 - Never commit secrets or credentials. Keep `.env*.example` files in
   sync with required env vars.
+- Human handoff: assume the reader does not remember the ticket. Lead with
+  a one-sentence TL;DR. Ask for at most one or two human actions per
+  message; if you need more, wait and sequence them. Do not dump long
+  agent-only reports by default.
+- For product or UI changes, give a preview URL
+  (`pr-<N>.preview.langfuse.com`) and exact click-path test steps, including
+  the seed command or sandbox URL (`http://localhost:3000`) to reproduce
+  the data. Humans can ask for more detail.
+- After opening a PR, leave a short last comment on what a reviewer should
+  doubt — the curious, questionable parts — not a changelog.
+- When Claude review comments appear on a PR you own: do not reply. Keep
+  each thread open until you either apply the fix and resolve it, or skip
+  the fix for a stated reason and still resolve it.
 
 ## Project Structure
 
@@ -99,6 +112,8 @@ langfuse/
 - Open a same-repo draft PR after local verification and test the resulting
   `pr-<N>.preview.langfuse.com` deployment with synthetic data before marking
   the PR ready. Previews normally run Mon-Fri 08:00-24:00 Europe/Berlin.
+- Use Linear's git branch name (`lfe-XXXX-short-title`). Never create a
+  `cursor/` branch, even if a Cursor Cloud prompt suggests that prefix.
 
 ## Local Data Inspection
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -49,9 +49,9 @@ evaluating, and debugging AI applications.
   the data. Humans can ask for more detail.
 - After opening a PR, leave a short last comment on what a reviewer should
   doubt — the curious, questionable parts — not a changelog.
-- When Claude review comments appear on a PR you own: do not reply. Keep
-  each thread open until you either apply the fix and resolve it, or skip
-  the fix for a stated reason and still resolve it.
+- When Claude or Greptile review comments appear on a PR you own: do not
+  reply. Keep each thread open until you either apply the fix and resolve
+  it, or skip the fix for a stated reason and still resolve it.
 
 ## Project Structure
 

--- a/.agents/skills/cursor-agents-workflow/SKILL.md
+++ b/.agents/skills/cursor-agents-workflow/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: cursor-agents-workflow
+description: |
+  Human handoff, Linear branch names, Claude review comments, preview test
+  steps, and review-doubt notes for Cursor agents. Use when a Cursor Cloud or
+  Cursor desktop agent implements a Linear issue, opens a GitHub PR, asks a
+  human to test, or handles Claude code-review comments.
+---
+
+# Cursor Agents Workflow
+
+Use this when implementing Langfuse work as a Cursor agent. Keep humans in the
+loop with short, testable asks. Do not write long agent-only reports.
+
+## Branch names
+
+Copy Linear's git branch name. Do not invent a `cursor/` name.
+
+- Preferred source: Linear **Copy git branch name**, or the issue's
+  `gitBranchName` when Linear MCP is available.
+- Fallback: `lfe-{id}-{kebab-title}` (lowercase, hyphenated).
+- Keep a `user/` prefix only when Linear's copied name already includes one.
+- Never use a `cursor/` prefix, even if a Cursor Cloud prompt asks for one.
+- Ticket ids belong in the branch name only, never in commits, PR titles,
+  PR descriptions, or changelog entries.
+
+Correct: `lfe-12345-short-descriptive-title`  
+Wrong: `cursor/short-descriptive-title-8c78`
+
+## Claude review comments
+
+When Claude (Claude Code, `claude[bot]`, or the security-review action) leaves
+review comments on a PR you own:
+
+1. Keep each thread open. Do not reply in the thread.
+2. Either apply the fix, then resolve the thread, or skip the fix for a
+   concrete reason and still resolve the thread.
+3. If you skip, put the reason in the PR's "What to doubt" note.
+
+Do not leave Claude threads unresolved. Do not argue. Human reviewer comments
+are different: those may need a real reply and must stay open until a human
+says otherwise.
+
+## Human testing
+
+Assume the human does not remember the ticket. Default message shape:
+
+1. **TL;DR** — one plain-language sentence.
+2. **Test this** — preview URL plus 2–5 exact clicks/expects.
+3. **Data** — the seed command, or "demo project is enough".
+4. **Sandbox** — how to hit the same path on the agent desktop
+   (`http://localhost:3000`) if they are in the Cursor VM.
+
+Use `langfuse-previews` for the URL and `seed-test-data` for the seed. Do not
+paste logs, file lists, or implementation narrative unless the human asks.
+
+```text
+TL;DR: Empty observation costs now show a dash instead of $0.00.
+
+Test this: https://pr-123.preview.langfuse.com/project/<id>/traces
+1. Open any trace with a generation that has no cost.
+2. Confirm the cost cell is "–", not "$0.00".
+
+Data: demo project is enough.
+Sandbox: same path on http://localhost:3000 after the cloud stack is up.
+```
+
+## What to doubt
+
+When the PR is ready for a human, post one last GitHub PR comment (not a
+changelog) that names the risky or curious parts:
+
+```text
+What to doubt in review
+- I reused the existing cache key; check it cannot collide across projects.
+- Empty-string tags are now dropped. Is that intended?
+```
+
+Two to five bullets. Trigger skepticism. Skip praise, file lists, and "LGTM".
+
+## One or two human actions
+
+Every human-facing message asks for at most one or two actions. If you need
+more, stop and wait.
+
+Wrong: review the PR, test preview, check Datadog, update Linear, approve.  
+Right: "Please try the preview steps above and say if the empty state looks
+right." After they reply, ask for the review-doubt pass.

--- a/.agents/skills/cursor-agents-workflow/SKILL.md
+++ b/.agents/skills/cursor-agents-workflow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cursor-agents-workflow
 description: |
-  Human handoff, Linear branch names, reviewable (non-draft) PRs, Claude and
-  Greptile review comments, preview test steps, and review-doubt notes for
-  Cursor agents. Use when a Cursor Cloud or Cursor desktop agent implements
-  a Linear issue, opens a GitHub PR, asks a human to test, or handles Claude
-  or Greptile code-review comments.
+  Human handoff, Linear branch names, reviewable (non-draft) PRs, Claude,
+  Greptile, and Codex review comments, preview test steps, and review-doubt
+  notes for Cursor agents. Use when a Cursor Cloud or Cursor desktop agent
+  implements a Linear issue, opens a GitHub PR, asks a human to test, or
+  handles Claude, Greptile, or Codex code-review comments.
 ---
 
 # Cursor Agents Workflow
@@ -35,10 +35,17 @@ Open the GitHub PR as reviewable, not as a draft. Draft PRs hide the work
 from reviewers and skip Claude/Greptile review workflows. Use a draft only
 when a human asks for one.
 
+Cursor Cloud PRs are opened as the Langfuse user who launched the agent. On
+a non-draft same-repo PR from a write-access user, github-actions posts
+`@claude review` automatically. Do not post that comment yourself on open.
+Do not post `@claude review` again after addressing comments unless a human
+asks for another pass.
+
 ## Bot review comments
 
-When Claude (Claude Code, `claude[bot]`, or the security-review action) or
-Greptile (`greptile-apps[bot]`) leaves review comments on a PR you own:
+When Claude (Claude Code, `claude[bot]`, or the security-review action),
+Greptile (`greptile-apps[bot]`), or Codex (`chatgpt-codex-connector[bot]`)
+leaves review comments on a PR you own:
 
 1. Keep each thread open. Do not reply in the thread.
 2. If the finding is right: apply the fix, then resolve the thread.
@@ -73,6 +80,9 @@ Test this: https://pr-123.preview.langfuse.com/project/<id>/traces
 Data: demo project is enough.
 Sandbox: same path on http://localhost:3000 after the cloud stack is up.
 ```
+
+For user-visible behavior, attach proof of the fix: a screenshot, short
+video, or before/after. Docs-only changes can skip this.
 
 ## What to doubt
 

--- a/.agents/skills/cursor-agents-workflow/SKILL.md
+++ b/.agents/skills/cursor-agents-workflow/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: cursor-agents-workflow
 description: |
-  Human handoff, Linear branch names, Claude review comments, preview test
-  steps, and review-doubt notes for Cursor agents. Use when a Cursor Cloud or
-  Cursor desktop agent implements a Linear issue, opens a GitHub PR, asks a
-  human to test, or handles Claude code-review comments.
+  Human handoff, Linear branch names, Claude and Greptile review comments,
+  preview test steps, and review-doubt notes for Cursor agents. Use when a
+  Cursor Cloud or Cursor desktop agent implements a Linear issue, opens a
+  GitHub PR, asks a human to test, or handles Claude or Greptile code-review
+  comments.
 ---
 
 # Cursor Agents Workflow
@@ -27,17 +28,17 @@ Copy Linear's git branch name. Do not invent a `cursor/` name.
 Correct: `lfe-12345-short-descriptive-title`  
 Wrong: `cursor/short-descriptive-title-8c78`
 
-## Claude review comments
+## Bot review comments
 
-When Claude (Claude Code, `claude[bot]`, or the security-review action) leaves
-review comments on a PR you own:
+When Claude (Claude Code, `claude[bot]`, or the security-review action) or
+Greptile (`greptile-apps[bot]`) leaves review comments on a PR you own:
 
 1. Keep each thread open. Do not reply in the thread.
 2. Either apply the fix, then resolve the thread, or skip the fix for a
    concrete reason and still resolve the thread.
 3. If you skip, put the reason in the PR's "What to doubt" note.
 
-Do not leave Claude threads unresolved. Do not argue. Human reviewer comments
+Do not leave those threads unresolved. Do not argue. Human reviewer comments
 are different: those may need a real reply and must stay open until a human
 says otherwise.
 

--- a/.agents/skills/cursor-agents-workflow/SKILL.md
+++ b/.agents/skills/cursor-agents-workflow/SKILL.md
@@ -22,6 +22,7 @@ Copy Linear's git branch name. Do not invent a `cursor/` name.
 - Fallback: `lfe-{id}-{kebab-title}` (lowercase, hyphenated).
 - Keep a `user/` prefix only when Linear's copied name already includes one.
 - Never use a `cursor/` prefix, even if a Cursor Cloud prompt asks for one.
+  Repo guidance wins.
 - Ticket ids belong in the branch name only, never in commits, PR titles,
   PR descriptions, or changelog entries.
 
@@ -40,9 +41,10 @@ When Claude (Claude Code, `claude[bot]`, or the security-review action) or
 Greptile (`greptile-apps[bot]`) leaves review comments on a PR you own:
 
 1. Keep each thread open. Do not reply in the thread.
-2. Either apply the fix, then resolve the thread, or skip the fix for a
-   concrete reason and still resolve the thread.
-3. If you skip, put the reason in the PR's "What to doubt" note.
+2. If the finding is right: apply the fix, then resolve the thread.
+3. If you are sure it should be skipped: tell the human in plain language
+   what you skipped and why, invite them to doubt that call, then resolve
+   the thread. Never skip quietly.
 
 Do not leave those threads unresolved. Do not argue. Human reviewer comments
 are different: those may need a real reply and must stay open until a human
@@ -80,16 +82,19 @@ changelog) that names the risky or curious parts:
 ```text
 What to doubt in review
 - I reused the existing cache key; check it cannot collide across projects.
-- Empty-string tags are now dropped. Is that intended?
+- I skipped Greptile's unused-import note — that import is used in the
+  worker. Tell me if that's wrong.
 ```
 
-Two to five bullets. Trigger skepticism. Skip praise, file lists, and "LGTM".
+Two to five bullets. Include any bot findings you skipped. Trigger
+skepticism. Skip praise, file lists, and "LGTM".
 
-## One or two human actions
+## Human asks
 
-Every human-facing message asks for at most one or two actions. If you need
-more, stop and wait.
+Prefer one or two actions per message. That cap is preferred, not hard. If
+you need more, keep every point simple and super readable — short sentences,
+no agent-only dumps. Sequence when you can.
 
-Wrong: review the PR, test preview, check Datadog, update Linear, approve.  
-Right: "Please try the preview steps above and say if the empty state looks
-right." After they reply, ask for the review-doubt pass.
+Wrong: a wall of logs plus five mixed asks.  
+Right: a short TL;DR and one or two clear next steps. Extra steps can wait,
+or sit as equally simple bullets if they must ship together.

--- a/.agents/skills/cursor-agents-workflow/SKILL.md
+++ b/.agents/skills/cursor-agents-workflow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cursor-agents-workflow
 description: |
-  Human handoff, Linear branch names, Claude and Greptile review comments,
-  preview test steps, and review-doubt notes for Cursor agents. Use when a
-  Cursor Cloud or Cursor desktop agent implements a Linear issue, opens a
-  GitHub PR, asks a human to test, or handles Claude or Greptile code-review
-  comments.
+  Human handoff, Linear branch names, reviewable (non-draft) PRs, Claude and
+  Greptile review comments, preview test steps, and review-doubt notes for
+  Cursor agents. Use when a Cursor Cloud or Cursor desktop agent implements
+  a Linear issue, opens a GitHub PR, asks a human to test, or handles Claude
+  or Greptile code-review comments.
 ---
 
 # Cursor Agents Workflow
@@ -27,6 +27,12 @@ Copy Linear's git branch name. Do not invent a `cursor/` name.
 
 Correct: `lfe-12345-short-descriptive-title`  
 Wrong: `cursor/short-descriptive-title-8c78`
+
+## Pull requests
+
+Open the GitHub PR as reviewable, not as a draft. Draft PRs hide the work
+from reviewers and skip Claude/Greptile review workflows. Use a draft only
+when a human asks for one.
 
 ## Bot review comments
 

--- a/.agents/skills/cursor-agents-workflow/agents/openai.yaml
+++ b/.agents/skills/cursor-agents-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Cursor Agents Workflow"
   short_description: "Linear branches, human test steps, and PR review notes"
-  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, Claude and Greptile review comments, human preview test steps, and review-doubt PR notes."
+  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, reviewable (non-draft) PRs, Claude and Greptile review comments, human preview test steps, and review-doubt PR notes."

--- a/.agents/skills/cursor-agents-workflow/agents/openai.yaml
+++ b/.agents/skills/cursor-agents-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cursor Agents Workflow"
+  short_description: "Linear branches, human test steps, and PR review notes"
+  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, Claude review comments, human preview test steps, and review-doubt PR notes."

--- a/.agents/skills/cursor-agents-workflow/agents/openai.yaml
+++ b/.agents/skills/cursor-agents-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Cursor Agents Workflow"
   short_description: "Linear branches, human test steps, and PR review notes"
-  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, reviewable (non-draft) PRs, Claude and Greptile review comments, human preview test steps, and review-doubt PR notes."
+  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, reviewable (non-draft) PRs, Claude/Greptile/Codex review comments, human preview test steps, and review-doubt PR notes."

--- a/.agents/skills/cursor-agents-workflow/agents/openai.yaml
+++ b/.agents/skills/cursor-agents-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Cursor Agents Workflow"
   short_description: "Linear branches, human test steps, and PR review notes"
-  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, Claude review comments, human preview test steps, and review-doubt PR notes."
+  default_prompt: "Use $cursor-agents-workflow for Cursor agent branch names, Claude and Greptile review comments, human preview test steps, and review-doubt PR notes."

--- a/.agents/skills/frontend-browser-review/SKILL.md
+++ b/.agents/skills/frontend-browser-review/SKILL.md
@@ -68,7 +68,8 @@ Report:
 3. Any visible regressions or follow-up risks
 4. If review was blocked, exactly what prevented browser verification
 5. For a human handoff, the preview or sandbox URL plus exact click-path
-   steps — not a long agent-only writeup
+   steps, and proof of the fix (screenshot, short video, or before/after)
+   — not a long agent-only writeup
 
 ## Scope Notes
 

--- a/.agents/skills/frontend-browser-review/SKILL.md
+++ b/.agents/skills/frontend-browser-review/SKILL.md
@@ -67,6 +67,8 @@ Report:
 2. Whether the primary flow worked
 3. Any visible regressions or follow-up risks
 4. If review was blocked, exactly what prevented browser verification
+5. For a human handoff, the preview or sandbox URL plus exact click-path
+   steps — not a long agent-only writeup
 
 ## Scope Notes
 

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -53,6 +53,7 @@ operations.
 - Use `gh search issues` for GitHub issue search.
 - Prefer non-interactive Git and GitHub commands where possible.
 - Keep PRs narrow enough to review without unrelated refactors.
+- Open PRs as reviewable, not as drafts, unless a human asks for a draft.
 - When the PR is ready for a human, post one last comment that names what
   to doubt in review (risky edges, not a summary of the diff).
 - Claude or Greptile review comments (`claude[bot]`, Claude Code,

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -3,8 +3,8 @@ name: git-workflow
 description: |
   Langfuse repo Git, GitHub, commit, branch, pull request, issue search,
   release, and production-promotion workflow. Use when staging, committing,
-  pushing, opening PRs, choosing a Linear git branch name, handling Claude
-  or Greptile review comments, searching GitHub issues, or changing
+  pushing, opening PRs, choosing a Linear git branch name, handling Claude,
+  Greptile, or Codex review comments, searching GitHub issues, or changing
   release/promotion behavior.
 ---
 
@@ -56,12 +56,14 @@ operations.
 - Open PRs as reviewable, not as drafts, unless a human asks for a draft.
 - When the PR is ready for a human, post one last comment that names what
   to doubt in review (risky edges, not a summary of the diff).
-- Claude or Greptile review comments (`claude[bot]`, Claude Code,
-  security-review action, `greptile-apps[bot]`): do not reply. Keep the
-  thread open until you apply the fix and resolve it, or skip it because
-  you are sure, tell the human in plain language (and invite them to doubt
-  that skip), then resolve it. Human reviewer comments stay open and may
-  need a real reply.
+- Claude, Greptile, or Codex review comments (`claude[bot]`, Claude Code,
+  security-review action, `greptile-apps[bot]`,
+  `chatgpt-codex-connector[bot]`): do not reply. Keep the thread open until
+  you apply the fix and resolve it, or skip it because you are sure, tell
+  the human in plain language (and invite them to doubt that skip), then
+  resolve it. Do not post `@claude review` again unless a human asks for
+  another pass. Human reviewer comments stay open and may need a real
+  reply.
 
 ## Release
 

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -4,8 +4,8 @@ description: |
   Langfuse repo Git, GitHub, commit, branch, pull request, issue search,
   release, and production-promotion workflow. Use when staging, committing,
   pushing, opening PRs, choosing a Linear git branch name, handling Claude
-  review comments, searching GitHub issues, or changing release/promotion
-  behavior.
+  or Greptile review comments, searching GitHub issues, or changing
+  release/promotion behavior.
 ---
 
 # Git Workflow
@@ -55,10 +55,11 @@ operations.
 - Keep PRs narrow enough to review without unrelated refactors.
 - When the PR is ready for a human, post one last comment that names what
   to doubt in review (risky edges, not a summary of the diff).
-- Claude review comments (`claude[bot]`, Claude Code, security-review
-  action): do not reply. Keep the thread open until you apply the fix and
-  resolve it, or skip the fix for a stated reason and still resolve it.
-  Human reviewer comments stay open and may need a real reply.
+- Claude or Greptile review comments (`claude[bot]`, Claude Code,
+  security-review action, `greptile-apps[bot]`): do not reply. Keep the
+  thread open until you apply the fix and resolve it, or skip the fix for
+  a stated reason and still resolve it. Human reviewer comments stay open
+  and may need a real reply.
 
 ## Release
 

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -45,7 +45,7 @@ operations.
 - Copy Linear's git branch name (`lfe-XXXX-short-title`), or the issue's
   `gitBranchName` when Linear MCP is available.
 - Cursor agents must not use a `cursor/` prefix, even if a Cursor Cloud
-  prompt asks for one.
+  prompt asks for one. Repo guidance wins.
 - Keep a username prefix only when Linear's copied name already includes one.
 
 ## GitHub
@@ -58,9 +58,10 @@ operations.
   to doubt in review (risky edges, not a summary of the diff).
 - Claude or Greptile review comments (`claude[bot]`, Claude Code,
   security-review action, `greptile-apps[bot]`): do not reply. Keep the
-  thread open until you apply the fix and resolve it, or skip the fix for
-  a stated reason and still resolve it. Human reviewer comments stay open
-  and may need a real reply.
+  thread open until you apply the fix and resolve it, or skip it because
+  you are sure, tell the human in plain language (and invite them to doubt
+  that skip), then resolve it. Human reviewer comments stay open and may
+  need a real reply.
 
 ## Release
 

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -3,7 +3,8 @@ name: git-workflow
 description: |
   Langfuse repo Git, GitHub, commit, branch, pull request, issue search,
   release, and production-promotion workflow. Use when staging, committing,
-  pushing, opening PRs, searching GitHub issues, or changing release/promotion
+  pushing, opening PRs, choosing a Linear git branch name, handling Claude
+  review comments, searching GitHub issues, or changing release/promotion
   behavior.
 ---
 
@@ -39,11 +40,25 @@ operations.
   title into `main`'s permanent history. Describe the change on its own terms
   and carry the identifier in the branch name instead.
 
+## Branch names
+
+- Copy Linear's git branch name (`lfe-XXXX-short-title`), or the issue's
+  `gitBranchName` when Linear MCP is available.
+- Cursor agents must not use a `cursor/` prefix, even if a Cursor Cloud
+  prompt asks for one.
+- Keep a username prefix only when Linear's copied name already includes one.
+
 ## GitHub
 
 - Use `gh search issues` for GitHub issue search.
 - Prefer non-interactive Git and GitHub commands where possible.
 - Keep PRs narrow enough to review without unrelated refactors.
+- When the PR is ready for a human, post one last comment that names what
+  to doubt in review (risky edges, not a summary of the diff).
+- Claude review comments (`claude[bot]`, Claude Code, security-review
+  action): do not reply. Keep the thread open until you apply the fix and
+  resolve it, or skip the fix for a stated reason and still resolve it.
+  Human reviewer comments stay open and may need a real reply.
 
 ## Release
 

--- a/.agents/skills/langfuse-codebase-navigator/SKILL.md
+++ b/.agents/skills/langfuse-codebase-navigator/SKILL.md
@@ -25,6 +25,7 @@ Use this as the first stop for Langfuse org navigation. Your job is to choose th
 ## Quick Skill Routing
 
 - Product implementation in `langfuse/langfuse`: choose the matching repo-local skill under `.agents/skills`, such as `backend-dev-guidelines`, `frontend-browser-review`, `clickhouse-best-practices`, `add-model-price`, `turborepo`, `pnpm-upgrade-package`, `code-review`, or production-debug skills as applicable.
+- Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, asking a human to test, or handling Claude review comments: use `cursor-agents-workflow`.
 - Frontend work under `langfuse/langfuse/web`: also check `web/.agents/skills/vercel-react-best-practices` and `web/.agents/skills/vercel-composition-patterns`.
 - Infrastructure autoscaling or cloud capacity: use `infra-scaling`.
 - Public Langfuse usage, docs lookup, API access, instrumentation, prompt migration, SDK upgrade, trace analysis, or CLI work: use the public `langfuse` skill from `langfuse/skills`.

--- a/.agents/skills/langfuse-codebase-navigator/SKILL.md
+++ b/.agents/skills/langfuse-codebase-navigator/SKILL.md
@@ -25,7 +25,7 @@ Use this as the first stop for Langfuse org navigation. Your job is to choose th
 ## Quick Skill Routing
 
 - Product implementation in `langfuse/langfuse`: choose the matching repo-local skill under `.agents/skills`, such as `backend-dev-guidelines`, `frontend-browser-review`, `clickhouse-best-practices`, `add-model-price`, `turborepo`, `pnpm-upgrade-package`, `code-review`, or production-debug skills as applicable.
-- Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, asking a human to test, or handling Claude or Greptile review comments: use `cursor-agents-workflow`.
+- Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, asking a human to test, or handling Claude, Greptile, or Codex review comments: use `cursor-agents-workflow`.
 - Frontend work under `langfuse/langfuse/web`: also check `web/.agents/skills/vercel-react-best-practices` and `web/.agents/skills/vercel-composition-patterns`.
 - Infrastructure autoscaling or cloud capacity: use `infra-scaling`.
 - Public Langfuse usage, docs lookup, API access, instrumentation, prompt migration, SDK upgrade, trace analysis, or CLI work: use the public `langfuse` skill from `langfuse/skills`.

--- a/.agents/skills/langfuse-codebase-navigator/SKILL.md
+++ b/.agents/skills/langfuse-codebase-navigator/SKILL.md
@@ -25,7 +25,7 @@ Use this as the first stop for Langfuse org navigation. Your job is to choose th
 ## Quick Skill Routing
 
 - Product implementation in `langfuse/langfuse`: choose the matching repo-local skill under `.agents/skills`, such as `backend-dev-guidelines`, `frontend-browser-review`, `clickhouse-best-practices`, `add-model-price`, `turborepo`, `pnpm-upgrade-package`, `code-review`, or production-debug skills as applicable.
-- Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, asking a human to test, or handling Claude review comments: use `cursor-agents-workflow`.
+- Cursor Cloud or Cursor desktop agents implementing a Linear issue, opening a PR, asking a human to test, or handling Claude or Greptile review comments: use `cursor-agents-workflow`.
 - Frontend work under `langfuse/langfuse/web`: also check `web/.agents/skills/vercel-react-best-practices` and `web/.agents/skills/vercel-composition-patterns`.
 - Infrastructure autoscaling or cloud capacity: use `infra-scaling`.
 - Public Langfuse usage, docs lookup, API access, instrumentation, prompt migration, SDK upgrade, trace analysis, or CLI work: use the public `langfuse` skill from `langfuse/skills`.

--- a/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
+++ b/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
@@ -93,6 +93,7 @@ Repo-local skills in `langfuse/.agents/skills`:
 - `changelog-writing`: user-facing release notes.
 - `clickhouse-best-practices`: ClickHouse schema/query/migration review.
 - `code-review`: repo-specific correctness/regression review.
+- `cursor-agents-workflow`: Cursor agent Linear branch names, human test steps, Claude review comments, and review-doubt PR notes.
 - `datadog-query-recipes`: reusable Datadog query shapes for production research.
 - `debug-issue-with-datadog`: production debugging tied to Langfuse code paths.
 - `frontend-browser-review`: user-visible `web/**` changes and browser verification.

--- a/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
+++ b/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
@@ -93,7 +93,7 @@ Repo-local skills in `langfuse/.agents/skills`:
 - `changelog-writing`: user-facing release notes.
 - `clickhouse-best-practices`: ClickHouse schema/query/migration review.
 - `code-review`: repo-specific correctness/regression review.
-- `cursor-agents-workflow`: Cursor agent Linear branch names, human test steps, Claude review comments, and review-doubt PR notes.
+- `cursor-agents-workflow`: Cursor agent Linear branch names, human test steps, Claude/Greptile review comments, and review-doubt PR notes.
 - `datadog-query-recipes`: reusable Datadog query shapes for production research.
 - `debug-issue-with-datadog`: production debugging tied to Langfuse code paths.
 - `frontend-browser-review`: user-visible `web/**` changes and browser verification.

--- a/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
+++ b/.agents/skills/langfuse-codebase-navigator/references/repository-map.md
@@ -93,7 +93,7 @@ Repo-local skills in `langfuse/.agents/skills`:
 - `changelog-writing`: user-facing release notes.
 - `clickhouse-best-practices`: ClickHouse schema/query/migration review.
 - `code-review`: repo-specific correctness/regression review.
-- `cursor-agents-workflow`: Cursor agent Linear branch names, human test steps, Claude/Greptile review comments, and review-doubt PR notes.
+- `cursor-agents-workflow`: Cursor agent Linear branch names, human test steps, Claude/Greptile/Codex review comments, and review-doubt PR notes.
 - `datadog-query-recipes`: reusable Datadog query shapes for production research.
 - `debug-issue-with-datadog`: production debugging tied to Langfuse code paths.
 - `frontend-browser-review`: user-visible `web/**` changes and browser verification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,9 @@ PR (not a draft) and test its `pr-<N>.preview.langfuse.com` deployment.
 Use Linear's git branch name (`lfe-XXXX-short-title`), not a `cursor/` prefix.
 When handing work to a human, give a one-sentence TL;DR, a preview URL with
 exact test steps (including how to seed or hit the same path on
-`http://localhost:3000`), and one PR comment on what a reviewer should doubt.
+`http://localhost:3000`), proof of the fix for user-visible changes
+(screenshot, video, or before/after), and one PR comment on what a reviewer
+should doubt.
 Prefer one or two human actions at a time; if you need more, keep each
 point simple and super readable. Preview data and any attached artifacts
 must remain synthetic. Previews normally run Mon-Fri 08:00-24:00

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,9 +186,10 @@ Use Linear's git branch name (`lfe-XXXX-short-title`), not a `cursor/` prefix.
 When handing work to a human, give a one-sentence TL;DR, a preview URL with
 exact test steps (including how to seed or hit the same path on
 `http://localhost:3000`), and one PR comment on what a reviewer should doubt.
-Ask for at most one or two human actions at a time. Preview data and any
-attached artifacts must remain synthetic. Previews normally run Mon-Fri
-08:00-24:00 Europe/Berlin and are not woken with Cursor credentials.
+Prefer one or two human actions at a time; if you need more, keep each
+point simple and super readable. Preview data and any attached artifacts
+must remain synthetic. Previews normally run Mon-Fri 08:00-24:00
+Europe/Berlin and are not woken with Cursor credentials.
 
 ### Shared Agent Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,8 +180,8 @@ endpoints. Cursor team administrators separately configure the read-only MCP
 catalog described in `.agents/README.md`; credentials and OAuth grants belong
 in Cursor, never in repository files.
 
-After local verification, a Cursor agent should open a same-repo draft PR and
-test its `pr-<N>.preview.langfuse.com` deployment before marking it ready.
+After local verification, a Cursor agent should open a same-repo reviewable
+PR (not a draft) and test its `pr-<N>.preview.langfuse.com` deployment.
 Use Linear's git branch name (`lfe-XXXX-short-title`), not a `cursor/` prefix.
 When handing work to a human, give a one-sentence TL;DR, a preview URL with
 exact test steps (including how to seed or hit the same path on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,8 +182,13 @@ in Cursor, never in repository files.
 
 After local verification, a Cursor agent should open a same-repo draft PR and
 test its `pr-<N>.preview.langfuse.com` deployment before marking it ready.
-Preview data and any attached artifacts must remain synthetic. Previews normally
-run Mon-Fri 08:00-24:00 Europe/Berlin and are not woken with Cursor credentials.
+Use Linear's git branch name (`lfe-XXXX-short-title`), not a `cursor/` prefix.
+When handing work to a human, give a one-sentence TL;DR, a preview URL with
+exact test steps (including how to seed or hit the same path on
+`http://localhost:3000`), and one PR comment on what a reviewer should doubt.
+Ask for at most one or two human actions at a time. Preview data and any
+attached artifacts must remain synthetic. Previews normally run Mon-Fri
+08:00-24:00 Europe/Berlin and are not woken with Cursor credentials.
 
 ### Shared Agent Setup
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16299.preview.langfuse.com](https://pr-16299.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Teaches Cursor agents to work more like a teammate handing work to a human: Linear-style branch names, reviewable (not draft) PRs, short test steps, Claude and Greptile review-thread handling, and a last PR note on what to doubt.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- My code follows the style guidelines of this project (`pnpm run format`)
- I have checked if my PR needs changes to the documentation
- I have checked if my changes generate no new warnings (`pnpm run agents:check`)

## Impacted packages

- `.agents/` (shared agent guidance and a new `cursor-agents-workflow` skill)
- `CONTRIBUTING.md` (Cursor Cloud handoff)

## Verification

- `pnpm run agents:sync`
- `pnpm run agents:check`
- Pre-commit: `Tasks: 7 successful, 7 total` (turbo lint)
- Skipped web/worker tests: docs-only, no runtime code

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15310](https://linear.app/clickhouse/issue/LFE-15310/cursor-agents-workflow-improvements)

<div><a href="https://cursor.com/agents/bc-57c386ea-b5de-4407-b18b-78692b5e8c78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57c386ea-b5de-4407-b18b-78692b5e8c78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates shared Cursor-agent guidance to use Linear branch names, open reviewable PRs, provide concise human test handoffs, handle automated review threads consistently, and leave a final “what to doubt” note.
- Adds the `cursor-agents-workflow` skill and its OpenAI interface metadata.
- Aligns shared Git, browser-review, navigation, and contributor guidance with the new workflow.
- Documents preview URLs, reproducible test steps, and concise human-action requests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete defects identified in the changed agent guidance or its skill registration.

The new skill follows the repository’s discovery conventions, referenced handoff skills exist, and the updated non-draft guidance is compatible with the checked review automation.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(agents): open Cursor agent PRs as ..."](https://github.com/langfuse/langfuse/commit/f75541bd2313d1bb1c46946ae58390b96dcdf953) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54741183)</sub>

<!-- /greptile_comment -->