### PR TITLE
fix(web): allow local media uploads through CSP

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -14,7 +14,8 @@ import { renamedRouteRedirects } from "./redirects.mjs";
 // Dataset attachments PUT media directly to presigned storage URLs, so
 // connect-src must allow AWS S3, Azure Blob Storage, GCS, and the configured
 // S3-compatible endpoint. The endpoint env var is only present at runtime in
-// official Docker images, so static wildcards cover the common providers too.
+// official Docker images, so static wildcards cover the common providers and
+// the local Docker Compose MinIO endpoint too.
 const mediaUploadConnectSrc = (() => {
   const endpoint = env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT;
   if (!endpoint) return "";
@@ -38,7 +39,7 @@ const cspHeader = `
   base-uri 'self';
   form-action 'self' https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com;
   frame-ancestors 'none';
-  connect-src 'self' ${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://*.blob.core.windows.net https://storage.googleapis.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
+  connect-src 'self' http://localhost:* ${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://*.blob.core.windows.net https://storage.googleapis.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
   media-src 'self' https: http://localhost:*;
   ${env.LANGFUSE_CSP_ENFORCE_HTTPS === "true" ? "upgrade-insecure-requests; block-all-mixed-content;" : ""}
   ${env.SENTRY_CSP_REPORT_URI ? `report-uri ${env.SENTRY_CSP_REPORT_URI}; report-to csp-endpoint;` : ""}
@@ -324,6 +325,6 @@ const sentryConfig = withSentryConfig(nextConfig, {
       removeDebugLogging: true,
     },
   },
-  });
+});
 
 export default sentryConfig;

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -27,6 +27,10 @@ const mediaUploadConnectSrc = (() => {
     return "";
   }
 })();
+const localStorageConnectSrc =
+  env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === undefined
+    ? "http://localhost:* "
+    : "";
 const cspHeader = `
   default-src 'self' https://*.langfuse.com https://*.langfuse.dev https://*.posthog.com https://*.sentry.io;
   script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.langfuse.com https://*.langfuse.dev https://challenges.cloudflare.com https://*.sentry.io  https://static.cloudflareinsights.com https://*.stripe.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com;
@@ -39,7 +43,7 @@ const cspHeader = `
   base-uri 'self';
   form-action 'self' https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com;
   frame-ancestors 'none';
-  connect-src 'self' http://localhost:* ${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://*.blob.core.windows.net https://storage.googleapis.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
+  connect-src 'self' ${localStorageConnectSrc}${mediaUploadConnectSrc}https://*.langfuse.com https://*.langfuse.dev https://*.ingest.us.sentry.io https://*.sentry.io https://chat.uk.plain.com https://*.amazonaws.com https://*.blob.core.windows.net https://storage.googleapis.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com https://login.microsoftonline.com https://login.microsoft.com https://*.microsoftonline.com https://graph.microsoft.com;
   media-src 'self' https: http://localhost:*;
   ${env.LANGFUSE_CSP_ENFORCE_HTTPS === "true" ? "upgrade-insecure-requests; block-all-mixed-content;" : ""}
   ${env.SENTRY_CSP_REPORT_URI ? `report-uri ${env.SENTRY_CSP_REPORT_URI}; report-to csp-endpoint;` : ""}

--- a/web/src/__tests__/server/unit/csp.servertest.ts
+++ b/web/src/__tests__/server/unit/csp.servertest.ts
@@ -1,30 +1,36 @@
 import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
-describe("Content Security Policy", () => {
-  it("allows the local MinIO endpoint in Docker builds", () => {
-    const csp = execFileSync(
-      process.execPath,
-      [
-        "--input-type=module",
-        "--eval",
-        `
-          const config = (await import("./next.config.mjs")).default;
-          const headers = await config.headers();
-          console.log(headers.flatMap((rule) => rule.headers).find((header) => header.key === "Content-Security-Policy").value);
-        `,
-      ],
-      {
-        cwd: process.cwd(),
-        env: {
-          ...process.env,
-          DOCKER_BUILD: "1",
-          LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: "",
-        },
-        encoding: "utf8",
+const getCsp = (cloudRegion?: string) =>
+  execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `
+        const config = (await import("./next.config.mjs")).default;
+        const headers = await config.headers();
+        console.log(headers.flatMap((rule) => rule.headers).find((header) => header.key === "Content-Security-Policy").value);
+      `,
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DOCKER_BUILD: "1",
+        LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: "",
+        NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: cloudRegion,
       },
-    );
+      encoding: "utf8",
+    },
+  );
 
-    expect(csp).toContain("connect-src 'self' http://localhost:*");
+describe("Content Security Policy", () => {
+  it("allows the local MinIO endpoint in self-hosted Docker builds", () => {
+    expect(getCsp()).toContain("connect-src 'self' http://localhost:*");
+  });
+
+  it("does not allow local connections in Cloud", () => {
+    expect(getCsp("US")).not.toContain("connect-src 'self' http://localhost:*");
   });
 });

--- a/web/src/__tests__/server/unit/csp.servertest.ts
+++ b/web/src/__tests__/server/unit/csp.servertest.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("Content Security Policy", () => {
+  it("allows the local MinIO endpoint in Docker builds", () => {
+    const csp = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `
+          const config = (await import("./next.config.mjs")).default;
+          const headers = await config.headers();
+          console.log(headers.flatMap((rule) => rule.headers).find((header) => header.key === "Content-Security-Policy").value);
+        `,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          DOCKER_BUILD: "1",
+          LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: "",
+        },
+        encoding: "utf8",
+      },
+    );
+
+    expect(csp).toContain("connect-src 'self' http://localhost:*");
+  });
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16301.preview.langfuse.com](https://pr-16301.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- allow browser connections to local storage endpoints on any localhost port
- cover Docker image builds, where the configured media endpoint is unavailable while the CSP is generated

## Test plan
- pnpm --filter web run test src/__tests__/server/unit/csp.servertest.ts
- pnpm run lint

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR allows browser media uploads to the Docker Compose MinIO endpoint when that runtime endpoint is unavailable during image builds.
- Adds `http://localhost:*` to the CSP `connect-src` directive.
- Adds a server test confirming the localhost source remains present when the configured endpoint is empty during Docker builds.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable issue identified.

The CSP change covers the repository’s documented browser-facing local storage endpoints, and the test exercises the Docker-build condition that motivated the fallback.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): allow local media uploads thro..."](https://github.com/langfuse/langfuse/commit/a43c50058cd33bff114dc47fc7e6143cba879176) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54735846)</sub>

<!-- /greptile_comment -->