### PR TITLE
fix(posthog): mask session replay content

### DIFF
--- a/web/src/__tests__/posthog-session-replay-mask.clienttest.ts
+++ b/web/src/__tests__/posthog-session-replay-mask.clienttest.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import type { PostHogConfig } from "posthog-js";
+
+const { initMock } = vi.hoisted(() => ({
+  initMock: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: initMock,
+  },
+}));
+
+vi.mock("posthog-js/react", () => ({
+  PostHogProvider: vi.fn(),
+}));
+
+describe("PostHog session replay privacy", () => {
+  it("masks all rendered text and input values", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.i.posthog.com");
+
+    await import("@/src/pages/_app");
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const config = initMock.mock.calls[0]![1] as Partial<PostHogConfig>;
+    expect(config.session_recording).toMatchObject({
+      maskAllInputs: true,
+      maskTextSelector: "*",
+    });
+  });
+});

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -103,6 +103,8 @@ if (
       if (process.env.NODE_ENV === "development") posthog.debug();
     },
     session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: "*",
       maskCapturedNetworkRequestFn(request) {
         request.requestBody = request.requestBody ? "REDACTED" : undefined;
         request.responseBody = request.responseBody ? "REDACTED" : undefined;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16302.preview.langfuse.com](https://pr-16302.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- mask all rendered text in PostHog session recordings
- explicitly mask all input values so SDK default changes cannot weaken privacy
- preserve request and response body redaction
- add a regression test against the real app-shell PostHog initialization

## Why

PostHog session replay redacted captured network bodies but did not configure DOM text masking. Rendered customer content could therefore remain visible in recordings.

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client posthog-session-replay-mask.clienttest.ts` — `Tests 1 passed (1)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` — passed
- pre-commit Prettier check — `All matched files use Prettier code style!`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR strengthens PostHog session-replay privacy and adds a regression test for the global app-shell configuration.

- Masks all rendered text and input values in session recordings.
- Preserves existing request and response body redaction.
- Verifies the initialization options through the real `_app.tsx` import path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The changed initialization adds explicit replay masking while retaining existing network redaction, and the regression test exercises the browser-gated app-shell configuration.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(posthog): mask session replay conten..."](https://github.com/langfuse/langfuse/commit/74d339016a6a0d897bbbec3a518783542cb875d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54745091)</sub>

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->