### PR TITLE
fix(assistant): make message feedback optimistic

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
@@ -645,7 +645,9 @@ export const OptimisticFeedbackInteraction = meta.story({
       type: "text",
       text: "Langfuse tracks traces, observations, scores, and metadata so teams can debug LLM applications.",
     },
-    onSubmitFeedback: fn(() => new Promise<void>(() => undefined)),
+    onSubmitFeedback: fn(
+      () => new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
+    ),
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
@@ -637,6 +637,32 @@ export const FeedbackPopoverInteraction = meta.story({
   },
 });
 
+export const OptimisticFeedbackInteraction = meta.story({
+  name: "(Test) Optimistic Feedback",
+  args: {
+    role: "assistant",
+    content: {
+      type: "text",
+      text: "Langfuse tracks traces, observations, scores, and metadata so teams can debug LLM applications.",
+    },
+    onSubmitFeedback: fn(() => new Promise<void>(() => undefined)),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    const goodResponseButton = await canvas.findByRole("button", {
+      name: "Good response",
+    });
+
+    await userEvent.click(goodResponseButton);
+
+    expect(goodResponseButton).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      body.findByPlaceholderText("Optional feedback comment"),
+    ).resolves.toBeInTheDocument();
+  },
+});
+
 export const CopyMessageInteraction = meta.story({
   name: "(Test) Copy Whole Message",
   args: {

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -517,26 +517,37 @@ function MessageFeedbackControls({
   };
 
   const handleSelectFeedback = (value: InAppAgentMessageFeedbackValue) => {
+    const previousValue = selectedValue;
+    const previousComment = comment;
+    const previousCommittedComment = committedComment;
+    const previousPopoverOpen = isCommentPopoverOpen;
+
     if (selectedValue === value) {
-      submitFeedback(null, "")
-        .then(() => {
-          setSelectedValue(undefined);
-          setComment("");
-          setCommittedComment("");
-          setIsCommentPopoverOpen(false);
-        })
-        .catch(() => undefined);
+      setSelectedValue(undefined);
+      setComment("");
+      setCommittedComment("");
+      setIsCommentPopoverOpen(false);
+
+      submitFeedback(null, "").catch(() => {
+        setSelectedValue(previousValue);
+        setComment(previousComment);
+        setCommittedComment(previousCommittedComment);
+        setIsCommentPopoverOpen(previousPopoverOpen);
+      });
       return;
     }
 
-    submitFeedback(value, "")
-      .then(() => {
-        setSelectedValue(value);
-        setComment("");
-        setCommittedComment("");
-        setIsCommentPopoverOpen(!isFeedbackDisabledRef.current);
-      })
-      .catch(() => undefined);
+    setSelectedValue(value);
+    setComment("");
+    setCommittedComment("");
+    setIsCommentPopoverOpen(!isFeedbackDisabledRef.current);
+
+    submitFeedback(value, "").catch(() => {
+      setSelectedValue(previousValue);
+      setComment(previousComment);
+      setCommittedComment(previousCommittedComment);
+      setIsCommentPopoverOpen(previousPopoverOpen);
+    });
   };
 
   const commentButtonText = `Comment: ${committedComment}`;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16306.preview.langfuse.com](https://pr-16306.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates the in-app assistant feedback controls immediately when users select or clear thumbs up/down feedback, while the request persists in the background. Failed requests roll the controls back to their prior state.

Adds a Storybook interaction test with one second of simulated persistence latency and verifies the selected state appears before the request completes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm --filter web run test-storybook "src/features/in-app-agent/components/InAppAgentMessage.stories.tsx"` — 28 passed
- `pnpm run lint` — 7 successful, 7 total
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-14505](https://linear.app/clickhouse/issue/LFE-14505/feedback-buttons-in-the-in-app-agent-should-be-optimistic)

<div><a href="https://cursor.com/agents/bc-a0689556-e1e9-4f4a-a66b-e25565eb31bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0689556-e1e9-4f4a-a66b-e25565eb31bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Makes message feedback controls update optimistically and restores their previous state if persistence fails.
- Applies thumbs-up, thumbs-down, and clear actions before the persistence request completes.
- Adds an interaction story verifying that optimistic selection and the feedback popover appear during simulated latency.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The pull request appears safe to merge, with no actionable defects identified in the optimistic feedback flow.

Pending persistence disables the relevant controls, and failed requests restore the prior selection, comment, and popover state.
</details>

<sub>Reviews (1): Last reviewed commit: ["test(agent): model feedback request late..."](https://github.com/langfuse/langfuse/commit/4accc47903a5273ad62d6d41f8400644ffb76739) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54760218)</sub>

<!-- /greptile_comment -->