### PR TITLE
fix(datasets): bind secret headers to remote URL

### DIFF
--- a/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
+++ b/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "crypto";
 
 const orgIds: string[] = [];
 
-const prepare = async () => {
+const prepare = async (projectRole: "ADMIN" | "MEMBER" = "ADMIN") => {
   const setup = await createOrgProjectAndApiKey();
   orgIds.push(setup.orgId);
 
@@ -31,7 +31,7 @@ const prepare = async () => {
           projects: [
             {
               id: setup.projectId,
-              role: "ADMIN",
+              role: projectRole,
               name: "Test Project",
               deletedAt: null,
               retentionDays: null,
@@ -50,7 +50,7 @@ const prepare = async () => {
         observationEvals: false,
         experimentsV4Enabled: false,
       },
-      admin: true,
+      admin: false,
     },
     environment: {} as any,
   };
@@ -157,6 +157,7 @@ describe("remote experiment auth headers and signing secret", () => {
     prisma.dataset.findUniqueOrThrow({
       where: { id_projectId: { id: datasetId, projectId } },
       select: {
+        remoteExperimentUrl: true,
         remoteExperimentSecretKey: true,
         remoteExperimentDisplaySecretKey: true,
         remoteExperimentRequestHeaders: true,
@@ -270,16 +271,116 @@ describe("remote experiment auth headers and signing secret", () => {
     // The plaintext secret must not appear anywhere in the safe read
     expect(JSON.stringify(config)).not.toContain("token-123");
 
-    // URL-only update (no requestHeaders) preserves the headers
+    // Same-URL update (no requestHeaders) preserves the headers
     await caller.datasets.upsertRemoteExperiment({
       projectId,
       datasetId,
-      url: "https://example.com/hook-updated",
+      url: "https://example.com/hook",
       defaultPayload: "{}",
       enabled: true,
     });
     const preserved = await selectSecretColumns(datasetId, projectId);
     expect(preserved.remoteExperimentRequestHeaders).toEqual(storedHeaders);
+  });
+
+  it.each([
+    {
+      name: "omitted headers",
+      requestHeaders: undefined,
+    },
+    {
+      name: "an empty masked value",
+      requestHeaders: {
+        authorization: { secret: true, value: "" },
+      },
+    },
+  ])(
+    "rejects reusing secret headers across a URL change with $name",
+    async ({ requestHeaders }) => {
+      const { caller, projectId } = await prepare("MEMBER");
+      const datasetId = await createDataset(projectId);
+
+      await caller.datasets.upsertRemoteExperiment({
+        projectId,
+        datasetId,
+        url: "https://example.com/hook",
+        defaultPayload: "{}",
+        enabled: true,
+        requestHeaders: {
+          authorization: { secret: true, value: "Bearer token-123" },
+        },
+      });
+
+      await expect(
+        caller.datasets.upsertRemoteExperiment({
+          projectId,
+          datasetId,
+          url: "https://example.com/collect",
+          defaultPayload: "{}",
+          enabled: true,
+          requestHeaders,
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: expect.stringContaining(
+          "Secret headers must be re-entered when changing the remote experiment URL",
+        ),
+      });
+
+      const stored = await selectSecretColumns(datasetId, projectId);
+      expect(stored.remoteExperimentUrl).toBe("https://example.com/hook");
+      expect(stored.remoteExperimentRequestHeaders).toBeDefined();
+      expect(
+        decrypt(
+          (
+            stored.remoteExperimentRequestHeaders as Record<
+              string,
+              { secret: boolean; value: string }
+            >
+          ).authorization.value,
+        ),
+      ).toBe("Bearer token-123");
+    },
+  );
+
+  it("allows a URL change when secret headers are replaced", async () => {
+    const { caller, projectId } = await prepare("MEMBER");
+    const datasetId = await createDataset(projectId);
+
+    await caller.datasets.upsertRemoteExperiment({
+      projectId,
+      datasetId,
+      url: "https://example.com/hook",
+      defaultPayload: "{}",
+      enabled: true,
+      requestHeaders: {
+        authorization: { secret: true, value: "Bearer token-123" },
+      },
+    });
+
+    await caller.datasets.upsertRemoteExperiment({
+      projectId,
+      datasetId,
+      url: "https://example.com/replacement",
+      defaultPayload: "{}",
+      enabled: true,
+      requestHeaders: {
+        authorization: { secret: true, value: "Bearer replacement-token" },
+      },
+    });
+
+    const stored = await selectSecretColumns(datasetId, projectId);
+    expect(stored.remoteExperimentUrl).toBe("https://example.com/replacement");
+    expect(
+      decrypt(
+        (
+          stored.remoteExperimentRequestHeaders as Record<
+            string,
+            { secret: boolean; value: string }
+          >
+        ).authorization.value,
+      ),
+    ).toBe("Bearer replacement-token");
   });
 
   it("excludes secret columns from generic dataset reads via the global Prisma omit", async () => {

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -2197,7 +2197,7 @@ export const datasetRouter = createTRPCRouter({
           }
 
           const normalizedKey = key.trim().toLowerCase();
-          const submittedHeader = submittedHeadersByLowerKey[normalizedKey];
+          const submittedHeader = submittedHeadersByLowerKey?.[normalizedKey];
 
           // An empty submitted value preserves the existing secret.
           return submittedHeader?.value.trim() === "";

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -2186,12 +2186,22 @@ export const datasetRouter = createTRPCRouter({
           )
         : undefined;
       const reusesSecretHeader = Object.entries(existingHeaders).some(
-        ([key, header]) =>
-          header.secret &&
-          (input.requestHeaders === undefined ||
-            submittedHeadersByLowerKey?.[
-              key.trim().toLowerCase()
-            ]?.value.trim() === ""),
+        ([key, existingHeader]) => {
+          if (!existingHeader.secret) {
+            return false;
+          }
+
+          // Omitting requestHeaders preserves every existing header.
+          if (input.requestHeaders === undefined) {
+            return true;
+          }
+
+          const normalizedKey = key.trim().toLowerCase();
+          const submittedHeader = submittedHeadersByLowerKey[normalizedKey];
+
+          // An empty submitted value preserves the existing secret.
+          return submittedHeader?.value.trim() === "";
+        },
       );
 
       if (input.url !== dataset.remoteExperimentUrl && reusesSecretHeader) {

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -2174,11 +2174,37 @@ export const datasetRouter = createTRPCRouter({
         });
       }
 
+      const existingHeaders = parseStoredRemoteExperimentHeaders(
+        dataset.remoteExperimentRequestHeaders,
+      );
+      const submittedHeadersByLowerKey = input.requestHeaders
+        ? Object.fromEntries(
+            Object.entries(input.requestHeaders).map(([key, value]) => [
+              key.trim().toLowerCase(),
+              value,
+            ]),
+          )
+        : undefined;
+      const reusesSecretHeader = Object.entries(existingHeaders).some(
+        ([key, header]) =>
+          header.secret &&
+          (input.requestHeaders === undefined ||
+            submittedHeadersByLowerKey?.[
+              key.trim().toLowerCase()
+            ]?.value.trim() === ""),
+      );
+
+      if (input.url !== dataset.remoteExperimentUrl && reusesSecretHeader) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Secret headers must be re-entered when changing the remote experiment URL",
+        });
+      }
+
       const { requestHeaders, displayHeaders } = processRemoteExperimentHeaders(
         input.requestHeaders,
-        parseStoredRemoteExperimentHeaders(
-          dataset.remoteExperimentRequestHeaders,
-        ),
+        existingHeaders,
       );
 
       const signingSecret =


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16307.preview.langfuse.com](https://pr-16307.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- reject remote experiment URL changes that would reuse an existing secret request header
- continue allowing same-URL masked-value updates
- continue allowing URL changes when credentials are explicitly replaced or removed
- cover the behavior through the MEMBER-authorized tRPC path

## Why

Remote experiment headers use empty or omitted values to preserve encrypted credentials during ordinary edits. The update mutation applied that preservation even when the remote URL changed, which could send an existing credential to a different destination.

The guard now runs in the authoritative update mutation before any stored secret is decrypted for header processing.

## Validation

- `pnpm --filter web run test 'src/__tests__/server/datasets-remote-experiment.servertest.ts'`
  - `Test Files  1 passed (1)`
  - `Tests  12 passed (12)`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- Prettier check passed
- `git diff --check` passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents stored secret request headers from being reused after a remote experiment URL change while retaining masked-secret updates for an unchanged URL.
- Adds an authoritative pre-processing guard to the dataset update mutation.
- Adds MEMBER-authorized server tests for rejected reuse and explicit secret replacement.
- Extends test reads to verify that rejected updates leave the original URL and encrypted header intact.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking usability issue where an equivalent URL spelling can unnecessarily require secret re-entry.

The new guard closes the credential-reuse path and preserves stored state on rejection, but literal URL comparison can over-reject updates when only a destination-insensitive spelling detail changes.

**Files Needing Attention:** web/src/features/datasets/server/dataset-router.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/server/dataset-router.ts:2197
**Raw URL comparison over-rejects**

The literal URL comparison treats an equivalent spelling, such as changing only the hostname's letter case, as a new destination. With a masked secret header, this unnecessarily rejects the update and requires the user to re-enter every secret.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): bind secret headers to re..."](https://github.com/langfuse/langfuse/commit/1fb7bea00bc2299f4d28c20a2c6da98d9769e2ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54796677)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->