### PR TITLE
fix(rbac): let project members view the API keys page

### DIFF
--- a/web/src/__tests__/server/project-api-key-trpc.servertest.ts
+++ b/web/src/__tests__/server/project-api-key-trpc.servertest.ts
@@ -28,7 +28,7 @@ describe("project API keys trpc", () => {
   async function createProjectCaller(
     projectRole: "ADMIN" | "MEMBER" = "ADMIN",
   ) {
-    const { projectId, orgId } = await createOrgProjectAndApiKey();
+    const { projectId, orgId, publicKey } = await createOrgProjectAndApiKey();
 
     const session: Session = {
       expires: "1",
@@ -76,7 +76,7 @@ describe("project API keys trpc", () => {
     const ctx = createInnerTRPCContext({ session, headers: {} });
     const caller = appRouter.createCaller({ ...ctx, prisma });
 
-    return { caller, projectId };
+    return { caller, projectId, publicKey };
   }
 
   describe("projectApiKeys.byProjectId", () => {
@@ -97,6 +97,17 @@ describe("project API keys trpc", () => {
       expect(apiKeys.map((key) => key.note)).not.toContain(
         "In-app agent key hidden from project UI",
       );
+    });
+
+    // The settings page gates the list view on apiKeys:read, which MEMBERs
+    // hold without apiKeys:CUD. Pin that this read path stays open to them.
+    it("lists keys for MEMBER callers, who only hold apiKeys:read", async () => {
+      const { caller, projectId, publicKey } =
+        await createProjectCaller("MEMBER");
+
+      const apiKeys = await caller.projectApiKeys.byProjectId({ projectId });
+
+      expect(apiKeys.map((key) => key.publicKey)).toContain(publicKey);
     });
   });
 

--- a/web/src/features/public-api/components/ApiKeyList.clienttest.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.clienttest.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { type Role } from "@langfuse/shared/src/db";
+
+const { projectApiKeys, mockSession } = vi.hoisted(() => ({
+  projectApiKeys: [
+    {
+      id: "key-1",
+      createdAt: new Date("2026-01-02T03:04:05.000Z"),
+      expiresAt: null,
+      lastUsedAt: null,
+      note: "Production key",
+      publicKey: "pk-lf-1234",
+      displaySecretKey: "sk-lf-...5678",
+      createdByUser: null,
+      createdByApiKey: null,
+    },
+  ],
+  mockSession: { data: null as unknown },
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+vi.mock("@/src/utils/api", () => {
+  const noopMutation = () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  });
+  return {
+    api: {
+      projectApiKeys: {
+        byProjectId: {
+          useQuery: (
+            _input: unknown,
+            options?: { enabled?: boolean },
+          ): { data?: typeof projectApiKeys } =>
+            options?.enabled ? { data: projectApiKeys } : {},
+        },
+        create: { useMutation: noopMutation },
+        updateNote: { useMutation: noopMutation },
+        delete: { useMutation: noopMutation },
+      },
+      organizationApiKeys: {
+        byOrganizationId: { useQuery: () => ({}) },
+        create: { useMutation: noopMutation },
+        updateNote: { useMutation: noopMutation },
+        delete: { useMutation: noopMutation },
+      },
+      useUtils: () => ({
+        projectApiKeys: { invalidate: vi.fn() },
+        organizationApiKeys: { invalidate: vi.fn() },
+      }),
+    },
+    reportNonTrpcError: vi.fn(),
+  };
+});
+
+vi.mock("@/src/features/public-api/hooks/useLangfuseEnvCode", () => ({
+  useLangfuseEnvCode: () => 'LANGFUSE_PUBLIC_KEY="pk-lf-..."',
+  useLangfuseBaseUrl: () => "http://localhost:3000",
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+import { ApiKeyList } from "./ApiKeyList";
+
+const PROJECT_ID = "project-1";
+
+function renderAsProjectRole(role: Role) {
+  mockSession.data = {
+    user: {
+      admin: false,
+      organizations: [{ id: "org-1", projects: [{ id: PROJECT_ID, role }] }],
+    },
+  };
+
+  return render(<ApiKeyList entityId={PROJECT_ID} scope="project" />);
+}
+
+describe("ApiKeyList project access gating", () => {
+  it("lists keys read-only for a MEMBER, who holds apiKeys:read but not apiKeys:CUD", () => {
+    renderAsProjectRole("MEMBER");
+
+    expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
+    expect(screen.getByTitle("pk-lf-1234")).toBeInTheDocument();
+    expect(screen.getByText("sk-lf-...5678")).toBeInTheDocument();
+    // Write controls stay behind apiKeys:CUD: no create button, and the note
+    // renders as plain text instead of the click-to-edit affordance.
+    expect(
+      screen.queryByRole("button", { name: /create new api keys/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Production key")).toBeInTheDocument();
+    expect(screen.queryByText("Click to add note")).not.toBeInTheDocument();
+  });
+
+  it("shows write controls for an ADMIN, who holds apiKeys:CUD", () => {
+    renderAsProjectRole("ADMIN");
+
+    expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
+    expect(screen.getByTitle("pk-lf-1234")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /create new api keys/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("denies access to a VIEWER, who holds neither api key scope", () => {
+    renderAsProjectRole("VIEWER");
+
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+    expect(screen.queryByTitle("pk-lf-1234")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -45,9 +45,12 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
     );
   }
 
-  const hasProjectAccess = useHasProjectAccess({
+  // Viewing the list only needs apiKeys:read, which project MEMBERs hold.
+  // Create, delete, and note editing stay behind apiKeys:CUD and are gated
+  // individually by CreateApiKeyButton, DeleteApiKeyButton, and ApiKeyNote.
+  const hasProjectReadAccess = useHasProjectAccess({
     projectId: props.entityId,
-    scope: "apiKeys:CUD",
+    scope: "apiKeys:read",
   });
   const hasOrganizationAccess = useHasOrganizationAccess({
     organizationId: props.entityId,
@@ -55,11 +58,11 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
   });
 
   const hasAccess =
-    props.scope === "project" ? hasProjectAccess : hasOrganizationAccess;
+    props.scope === "project" ? hasProjectReadAccess : hasOrganizationAccess;
 
   const projectApiKeysQuery = api.projectApiKeys.byProjectId.useQuery(
     { projectId: entityId },
-    { enabled: hasProjectAccess && props.scope === "project" },
+    { enabled: hasProjectReadAccess && props.scope === "project" },
   );
   const organizationApiKeysQuery =
     api.organizationApiKeys.byOrganizationId.useQuery(


### PR DESCRIPTION
🟡 **Live preview: [pr-16312.preview.langfuse.com](<https://pr-16312.preview.langfuse.com>)**

Fixes langfuse/langfuse#16285

## Problem

A user with the project `MEMBER` role sees **Access Denied — You do not have permission to view API keys for this project** on Project Settings → API Keys, even though:

* the RBAC definition grants `MEMBER` the `apiKeys:read` scope (`packages/shared/src/features/rbac/projectAccessRights.ts`), and
* the list query `projectApiKeys.byProjectId` only requires `apiKeys:read`.

`ApiKeyList` resolved a single access flag from `apiKeys:CUD` and used it for both the page render and the list query's `enabled` flag, so members were walled off and the query never fired.

## Fix

Gate the project list view on `apiKeys:read`. Write actions are untouched — `CreateApiKeyButton`, `DeleteApiKeyButton`, and `ApiKeyNote` each already check `apiKeys:CUD` themselves, so a member gets a read-only table with no create button, no delete button, and a plain-text note.

Organization keys are unchanged: there is only one org scope (`organization:CRUD_apiKeys`), so that branch still uses it.

Roles unaffected: `OWNER`/`ADMIN` hold both scopes; `VIEWER` and `NONE` hold neither and still get Access Denied.

## Tests

* `web/src/features/public-api/components/ApiKeyList.clienttest.tsx` (new) renders the component against the real RBAC map for three project roles: `MEMBER` sees the list without write controls, `ADMIN` sees the create button, `VIEWER` still gets Access Denied. The MEMBER case fails on `main` with exactly the reported "Access Denied".
* `web/src/__tests__/server/project-api-key-trpc.servertest.ts` gains a pin that a `MEMBER` caller can list keys through `projectApiKeys.byProjectId` — the server contract the UI now relies on. This one passes on `main` too; it is there so a future scope tightening on the router cannot silently re-break the page.

## Verification

Local dev stack, seeded via `pnpm run db:seed`, with `member@langfuse.com`'s project role set to Member through the Members settings UI, then signed in as that user:

* Before (with only the source change reverted, same session and same user): the page shows the "Access Denied" alert.
* After: the page shows **Project API Keys** with the seeded key row (created date, note `seeded key`, public key, masked secret) and no create or delete controls.

The click path below reproduces both states on the preview.

Checks:

* `pnpm --filter web run test-client` → `Test Files  287 passed | 1 skipped (288)`, `Tests  3356 passed | 51 skipped (3407)`
* `pnpm --filter web run test src/__tests__/server/project-api-key-trpc.servertest.ts` → `Tests  6 passed (6)`
* `pnpm run lint` → clean; pre-commit `turbo run lint` → `Tasks: 7 successful, 7 total`
* `pnpm --filter web run typecheck` → clean

## Test steps on the preview

1. Open `pr-<N>.preview.langfuse.com`, create/pick a project, and invite a second user with **project role Member** (Project Settings → Members).
2. Sign in as that user and open Project Settings → API Keys.
3. The key list renders; there is no "Create new API keys" button, no delete icon, and the note is not editable.

## Follow-up

The reporter asks whether this can also land on a 3.2xx release. The fix is a one-file frontend change with no schema or migration surface, so a v3 backport is cheap if we want one — happy to open it as a separate PR.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

<details><summary>Greptile Summary</summary>

This PR aligns the project API-key page with the existing read permission while preserving separate write authorization.

* Gates project API-key listing and its query on `apiKeys:read`.
* Adds client coverage for MEMBER, ADMIN, and VIEWER behavior.
* Adds server coverage confirming MEMBER callers can list project API keys.

</details>

<details><summary>Confidence Score: 5/5</summary>

The PR appears safe to merge because it aligns the UI with the existing read authorization while retaining independent write controls.

The newly reachable MEMBER path returns only the already-authorized API-key listing, while create, delete, and note-edit actions remain gated by `apiKeys:CUD`.

</details>

Reviews (1): Last reviewed commit: ["fix(rbac): let project members view the ..."](<https://github.com/langfuse/langfuse/commit/4fb76d51939e32ed86bd581031ce38fc82db882f>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=54779956>)