### PR TITLE
fix(automations): preserve request headers when regenerating a webhook secret

### DIFF
--- a/web/src/__tests__/server/automations-trpc.servertest.ts
+++ b/web/src/__tests__/server/automations-trpc.servertest.ts
@@ -2394,6 +2394,59 @@ describe("automations trpc", () => {
       expect(decryptedStoredSecret).toBe(response.webhookSecret);
     });
 
+    it("should preserve custom request headers when regenerating the secret", async () => {
+      const { project, caller } = await prepare();
+
+      const { secretKey, displaySecretKey } = generateWebhookSecret();
+      const encryptedAuthHeader = encrypt("Bearer super-secret-token");
+      const action = await prisma.action.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          type: "WEBHOOK",
+          config: {
+            type: "WEBHOOK",
+            url: "https://example.com/webhook",
+            headers: { "X-Legacy": "legacy-value" },
+            requestHeaders: {
+              "Content-Type": { secret: false, value: "application/json" },
+              Authorization: { secret: true, value: encryptedAuthHeader },
+            },
+            displayHeaders: {
+              "X-Legacy": { secret: false, value: "legacy-value" },
+              "Content-Type": { secret: false, value: "application/json" },
+              Authorization: { secret: true, value: "Bear...oken" },
+            },
+            apiVersion: { prompt: "v1" },
+            secretKey: encrypt(secretKey),
+            displaySecretKey,
+          },
+        },
+      });
+
+      await caller.automations.regenerateWebhookSecret({
+        projectId: project.id,
+        actionId: action.id,
+      });
+
+      const updatedAction = await prisma.action.findUnique({
+        where: { id: action.id },
+      });
+      const updatedConfig =
+        updatedAction?.config as WebhookActionConfigWithSecrets;
+
+      // Rotating the signing secret must not drop the custom headers, and
+      // secret header values must stay encrypted at rest.
+      expect(updatedConfig.requestHeaders).toEqual({
+        "Content-Type": { secret: false, value: "application/json" },
+        Authorization: { secret: true, value: encryptedAuthHeader },
+      });
+      expect(updatedConfig.headers).toEqual({ "X-Legacy": "legacy-value" });
+      expect(decrypt(updatedConfig.requestHeaders!.Authorization.value)).toBe(
+        "Bearer super-secret-token",
+      );
+    });
+
     it("should throw error when action not found", async () => {
       const { project, caller } = await prepare();
 

--- a/web/src/features/automations/server/router.ts
+++ b/web/src/features/automations/server/router.ts
@@ -6,7 +6,7 @@ import {
   ActionType,
   JobConfigState,
   singleFilter,
-  isSafeWebhookActionConfig,
+  isWebhookActionConfig,
   TriggerEventSource,
   TriggerEventSourceSchema,
   ProjectNotificationEventTypeSchema,
@@ -15,7 +15,6 @@ import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAc
 import { v4 } from "uuid";
 import {
   convertActionToDomain,
-  getActionById,
   getAutomations,
   getAutomationById,
   getConsecutiveAutomationFailures,
@@ -85,9 +84,11 @@ export const automationsRouter = createTRPCRouter({
         scope: "automations:CUD",
       });
 
-      const existingAction = await getActionById({
-        projectId: input.projectId,
-        actionId: input.actionId,
+      // Read the raw row rather than going through getActionById: that returns
+      // the sanitized config (no `headers`/`requestHeaders`), and writing it
+      // back would silently drop the automation's custom request headers.
+      const existingAction = await ctx.prisma.action.findFirst({
+        where: { id: input.actionId, projectId: input.projectId },
       });
 
       if (!existingAction || existingAction.type !== "WEBHOOK") {
@@ -97,12 +98,14 @@ export const automationsRouter = createTRPCRouter({
         });
       }
 
-      if (!isSafeWebhookActionConfig(existingAction.config)) {
+      if (!isWebhookActionConfig(existingAction.config)) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: `Invalid webhook configuration for action ${input.actionId}`,
         });
       }
+
+      const existingConfig = existingAction.config;
 
       // Generate new webhook secret
       const { secretKey: newSecretKey, displaySecretKey: newDisplaySecretKey } =
@@ -114,16 +117,17 @@ export const automationsRouter = createTRPCRouter({
         resourceId: input.actionId,
         action: "update",
         before: {
-          displaySecretKey: existingAction.config.displaySecretKey,
+          displaySecretKey: existingConfig.displaySecretKey,
         },
         after: {
           displaySecretKey: newDisplaySecretKey,
         },
       });
 
-      // Update action config with new secret
+      // Keep the rest of the stored config (custom headers included) and only
+      // rotate the signing secret. Header values stay encrypted as stored.
       const updatedConfig = {
-        ...existingAction.config,
+        ...existingConfig,
         secretKey: encrypt(newSecretKey),
         displaySecretKey: newDisplaySecretKey,
       };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16315.preview.langfuse.com](https://pr-16315.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Rotating a webhook signing secret silently deleted the automation's custom request headers.

`regenerateWebhookSecret` read the action through `getActionById`, which returns the *sanitized* webhook config — `convertToSafeWebhookConfig` drops `secretKey`, `headers` and `requestHeaders` — and then wrote that object straight back to the database:

```ts
const updatedConfig = {
  ...existingAction.config,   // safe config: no headers, no requestHeaders
  secretKey: encrypt(newSecretKey),
  displaySecretKey: newDisplaySecretKey,
};
await ctx.prisma.action.update({ where: { ... }, data: { config: updatedConfig } });
```

So every regeneration dropped both the legacy `headers` map and the encrypted `requestHeaders` from the stored config, and subsequent webhook deliveries stopped sending them. `displayHeaders` survives the round trip, so the UI kept listing headers that were no longer being sent — the loss was invisible from the settings page.

**The fix:** read the raw row with `prisma.action.findFirst` and replace only `secretKey`/`displaySecretKey`. Stored header values carry through byte for byte — still encrypted, and never decrypted into memory on this path, which is why this reads the raw row rather than using `getActionByIdWithSecrets` (that one returns decrypted header values for execution, and round-tripping those into the database would store plaintext).

This is the pattern the repo's own security reference now prescribes, added in #16300: *"Writing a sanitized value back to the database […] Re-read the raw row for writes."*

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Notes for the reviewer

**The config guard changed** from `isSafeWebhookActionConfig` to `isWebhookActionConfig` — the guard `webhookHelpers`, `getActionByIdWithSecrets` and the worker execution path already use for a full webhook config. It additionally requires `secretKey`, so a webhook row missing one now returns the `INTERNAL_SERVER_ERROR` instead of silently being handed a fresh secret. That seemed like the right trade: the worker cannot execute such a row either, so the explicit error is the honest signal rather than a repair that hides a broken row.

**One behaviour is deliberately dropped.** The old code also persisted a `displayHeaders` map back-filled from legacy `headers`, as a side effect of `convertActionToDomain` mutating its input. That back-fill is derived on every read anyway, so writing the raw config loses nothing in the UI.

**This fix cannot restore headers already lost.** Any automation whose secret was rotated before this lands has already had its headers deleted. Affected rows are identifiable by a `displayHeaders` map with no matching `requestHeaders` — a cheap query if we want to find and notify affected projects, which is worth doing separately.

## Testing

Regression test added to the existing `describe("automations.regenerateWebhookSecret")` block: it creates a webhook action carrying a legacy `headers` map plus `requestHeaders` with one plain and one encrypted secret header, regenerates the secret, then asserts the stored config still holds both unchanged and that the secret header still decrypts.

Confirmed it fails against the unfixed code before fixing it:

```
× should preserve custom request headers when regenerating the secret
AssertionError: expected undefined to deeply equal { 'Content-Type': { …(2) }, …(1) }
```

Verified on top of current `main`:

- `pnpm --filter web run test src/__tests__/server/automations-trpc.servertest.ts` → `Tests  44 passed (44)`
- `pnpm run lint` → `Tasks:    7 successful, 7 total`
- `pnpm run typecheck` → `Tasks:    8 successful, 8 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes webhook secret rotation so it preserves the raw stored configuration rather than writing back a sanitized copy.
- Reads the project-scoped raw action row before rotating the signing secret.
- Preserves legacy and encrypted custom request headers byte-for-byte.
- Adds regression coverage verifying headers remain stored and secret header values remain encrypted.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The raw action lookup remains project-scoped, the full webhook configuration is validated before use, and the update preserves stored configuration while replacing only the signing-secret fields.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): preserve request heade..."](https://github.com/langfuse/langfuse/commit/16e7a9a375bc702dadb2ce0f85ed8282cc9a3e5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54788538)</sub>

<!-- /greptile_comment -->