### PR TITLE
feat(analytics): add user id to backend activity events

### DIFF
--- a/web/src/__tests__/server/unit/backendActivity.servertest.ts
+++ b/web/src/__tests__/server/unit/backendActivity.servertest.ts
@@ -73,6 +73,7 @@ describe("backend activity tracking", () => {
         cloudRegion: "US",
         organizationId: "org-1",
         projectId: "project-1",
+        userId: "user-1",
       },
       timestamp: new Date("2026-08-10T12:00:00.000Z"),
       disableGeoip: true,
@@ -97,6 +98,7 @@ describe("backend activity tracking", () => {
           activityScope: "organization",
           cloudRegion: "US",
           organizationId: "org-1",
+          userId: "user-1",
         },
       }),
     );
@@ -108,6 +110,7 @@ describe("backend activity tracking", () => {
           cloudRegion: "US",
           organizationId: "org-1",
           projectId: "project-1",
+          userId: "user-1",
         },
       }),
     );

--- a/web/src/features/posthog-analytics/server/backendActivity.ts
+++ b/web/src/features/posthog-analytics/server/backendActivity.ts
@@ -77,6 +77,7 @@ export const createBackendActivityTracker = ({
           cloudRegion,
           organizationId,
           ...(projectId ? { projectId } : {}),
+          userId,
         },
         timestamp,
         disableGeoip: true,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16318.preview.langfuse.com](https://pr-16318.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- add the authenticated internal user ID as `userId` on `backend:activity` event properties
- retain the existing PostHog `distinctId`, scope fields, and daily deduplication behavior
- cover both project- and organization-scoped payloads in the existing unit suite

## Tracking plan

| Question | Event | Properties | Key dimension |
| --- | --- | --- | --- |
| Which authenticated users generate backend activity? | `backend:activity` | `userId`, `activityScope`, `organizationId`, optional `projectId`, `cloudRegion` | `userId` and `activityScope` |

The value is the authenticated internal user ID already supplied to PostHog as `distinctId`; no user-provided content is added.

## Impacted package

- `web`

## Verification

- `pnpm dotenv -e '.env.test.example' -e '.env.dev.example' -- pnpm --filter web run test 'src/__tests__/server/unit/backendActivity.servertest.ts'`
  - `Tests  7 passed (7)`
- `pnpm dotenv -e '.env.test.example' -e '.env.dev.example' -- pnpm --filter web exec eslint 'src/features/posthog-analytics/server/backendActivity.ts' 'src/__tests__/server/unit/backendActivity.servertest.ts' --max-warnings 0`
  - passed
- `git diff --check`
  - passed
- `pnpm run lint`
  - repository-wide lint remains blocked by 419 pre-existing warnings elsewhere (`0 errors, 419 warnings`); neither changed file is reported

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the authenticated internal user ID to `backend:activity` event properties while retaining the existing identity, scope, and deduplication behavior.

- Adds `userId` to project- and organization-scoped activity payloads.
- Updates unit expectations for both activity scopes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

Current callers supply the authenticated internal user ID, the new property matches the existing PostHog distinct ID, and the unchanged deduplication key already includes that user ID.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): add user id to backend ..."](https://github.com/langfuse/langfuse/commit/402876e5f44981d187899f096a85d57cbb4dabf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54801354)</sub>

<!-- /greptile_comment -->