### PR TITLE
fix(assistant): Minor UI issues

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -304,7 +304,7 @@ function TextMessageWithActions({
     <>
       <button
         type="button"
-        className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-md p-1 outline-none focus-visible:ring-2"
+        className="text-muted-foreground/50 hover:text-muted-foreground focus-visible:ring-ring rounded-md p-1 outline-none focus-visible:ring-2"
         aria-label={isCopied ? "Message copied" : "Copy message"}
         title={isCopied ? "Copied" : "Copy message"}
         onClick={handleCopy}

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -1604,7 +1604,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                     executionStop?.onStop();
                   }}
                 >
-                  <Square className="size-3" />
+                  <Square className="text-muted-foreground size-3 fill-current" />
                 </Button>
               ) : (
                 <Button

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -1518,12 +1518,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
           </div>
         )}
         {isAssistantTurnInProgress && pendingToolCalls.length === 0 ? (
-          <div
-            className={cn(
-              "pointer-events-none relative h-px w-full shrink-0 select-none",
-              isExpanded && "mx-auto max-w-3xl",
-            )}
-          >
+          <div className="pointer-events-none relative mx-auto h-px w-[calc(100%-1.5rem)] max-w-[calc(48rem-0.75rem)] shrink-0 select-none">
             <div className="absolute top-0 h-4 w-full -translate-y-full overflow-hidden">
               <div className="absolute top-0 h-12 w-full bg-radial from-(--color-3) to-transparent to-60% bg-center opacity-25" />
             </div>
@@ -1532,18 +1527,18 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 aria-hidden="true"
                 className={cn("h-[4rem]", styles.loadingGradient)}
               />
-              {isExpanded && (
-                <>
-                  {/* Gradient overlays for expanded state so that the edges fade out */}
-                  {/* Match the assistant surface (bg-background) so edges fade cleanly */}
-                  <div className="from-background absolute top-0 right-0 h-full w-1/2 bg-linear-to-l to-transparent" />
-                  <div className="from-background absolute top-0 left-0 h-full w-1/2 bg-linear-to-r to-transparent" />
-                </>
-              )}
+              {/* Match the assistant surface so the loading animation fades at both edges. */}
+              <div className="from-background absolute top-0 right-0 h-full w-1/2 bg-linear-to-l to-transparent" />
+              <div className="from-background absolute top-0 left-0 h-full w-1/2 bg-linear-to-r to-transparent" />
             </div>
           </div>
         ) : null}
-        <div className={cn("p-1.5", isExpanded && "pt-0")}>
+        <div
+          className={cn(
+            "p-1.5",
+            (isExpanded || isAssistantTurnInProgress) && "pt-0",
+          )}
+        >
           {/* The composer separates from the transcript by elevation, not by a
               rule: one hairline edge, a lifted surface, and a footer band a
               step off the input. `overflow-hidden` keeps that band inside the


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16319.preview.langfuse.com](https://pr-16319.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adjusts visual details in the in-app assistant window and message controls.
- Restyles message copy and stop icons.
- Refines the running-state loading indicator’s width and edge fades.
- Removes composer top padding while an assistant turn is active.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking accessibility concern around the reduced visibility of the copy action.

The behavioral and layout changes have no established blocking failure, but the always-visible copy control now uses a substantially fainter idle foreground in the light theme.

**Files Needing Attention:** web/src/features/in-app-agent/components/InAppAgentMessage.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/in-app-agent/components/InAppAgentMessage.tsx:307
**Preserve copy action visibility**

The copy action is always visible, but `text-muted-foreground/50` halves the opacity of an already low-contrast foreground in the light theme, making this interactive control harder to discover and distinguish until hovered.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Style agent interrupt icon"](https://github.com/langfuse/langfuse/commit/d9aa24ceaec208c2e30438e5cd1ff9d4df4c9c2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54803957)</sub>

<!-- /greptile_comment -->