### PR TITLE
test(assistant): Stabilize sandbox docker tests

### DIFF
--- a/packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts
+++ b/packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts
@@ -1,3 +1,5 @@
+// Never use fixed delays to establish operation ordering in these tests.
+// Synchronize through observable state; timeouts are failure bounds only.
 import { readdir } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -317,54 +319,73 @@ describe("sandbox runtime docker container", () => {
           ].join("; "),
         }),
       });
+      void first.catch(() => undefined);
+      let second: Promise<JsonResponse> | undefined;
 
-      await waitForContainerFile(container, "/workspace/queue-active");
+      try {
+        await waitForContainerFile(container, "/workspace/queue-active");
 
-      const second = requestJson(baseUrl, "/sandbox", {
-        method: "POST",
-        body: JSON.stringify({
-          operation: "bash",
-          command: [
-            "test ! -e queue-active",
-            "printf 'second\\n' >> queue-order.txt",
-          ].join("; "),
-        }),
-      });
+        second = requestJson(baseUrl, "/sandbox", {
+          method: "POST",
+          body: JSON.stringify({
+            operation: "bash",
+            command: [
+              "test ! -e queue-active",
+              "printf 'second\\n' >> queue-order.txt",
+            ].join("; "),
+          }),
+        });
+        void second.catch(() => undefined);
 
-      const releaseExec = await container.exec({
-        Cmd: ["touch", "/workspace/queue-release"],
-      });
-      await releaseExec.start({});
+        const releaseExec = await container.exec({
+          Cmd: ["touch", "/workspace/queue-release"],
+        });
+        await readStreamToString(await releaseExec.start({}));
 
-      const [firstResponse, secondResponse] = await Promise.all([
-        first,
-        second,
-      ]);
-      expect(firstResponse).toEqual({
-        status: 200,
-        body: { result: expect.objectContaining({ exitCode: 0 }) },
-      });
-      expect(secondResponse).toEqual({
-        status: 200,
-        body: { result: expect.objectContaining({ exitCode: 0 }) },
-      });
+        const [firstResponse, secondResponse] = await Promise.all([
+          first,
+          second,
+        ]);
+        expect(firstResponse).toEqual({
+          status: 200,
+          body: { result: expect.objectContaining({ exitCode: 0 }) },
+        });
+        expect(secondResponse).toEqual({
+          status: 200,
+          body: { result: expect.objectContaining({ exitCode: 0 }) },
+        });
 
-      const order = await requestJson(baseUrl, "/sandbox", {
-        method: "POST",
-        body: JSON.stringify({
-          operation: "read",
-          path: "queue-order.txt",
-        }),
-      });
-      expect(order).toEqual({
-        status: 200,
-        body: {
-          result: {
-            path: "/workspace/queue-order.txt",
-            content: "first\nsecond\n",
+        const order = await requestJson(baseUrl, "/sandbox", {
+          method: "POST",
+          body: JSON.stringify({
+            operation: "read",
+            path: "queue-order.txt",
+          }),
+        });
+        expect(order).toEqual({
+          status: 200,
+          body: {
+            result: {
+              path: "/workspace/queue-order.txt",
+              content: "first\nsecond\n",
+            },
           },
-        },
-      });
+        });
+      } finally {
+        let released = false;
+        try {
+          const releaseExec = await container.exec({
+            Cmd: ["touch", "/workspace/queue-release"],
+          });
+          await readStreamToString(await releaseExec.start({}));
+          released = true;
+        } catch {
+          // Teardown will reject the already-observed requests if release failed.
+        }
+        if (released) {
+          await Promise.allSettled(second ? [first, second] : [first]);
+        }
+      }
 
       const timedOut = requestJson(baseUrl, "/sandbox", {
         method: "POST",
@@ -375,32 +396,41 @@ describe("sandbox runtime docker container", () => {
           timeoutMs: 200,
         }),
       });
+      void timedOut.catch(() => undefined);
+      let afterTimeout: Promise<JsonResponse> | undefined;
 
-      await waitForContainerFile(container, "/workspace/timeout-process.pid");
+      try {
+        await waitForContainerFile(container, "/workspace/timeout-process.pid");
 
-      const afterTimeout = requestJson(baseUrl, "/sandbox", {
-        method: "POST",
-        body: JSON.stringify({
-          operation: "bash",
-          command: [
-            "test -d /proc/$(cat timeout-process.pid)",
-            "printf 'continued\\n' > after-timeout.txt",
-          ].join(" && "),
-        }),
-      });
+        afterTimeout = requestJson(baseUrl, "/sandbox", {
+          method: "POST",
+          body: JSON.stringify({
+            operation: "bash",
+            command: [
+              "test -d /proc/$(cat timeout-process.pid)",
+              "printf 'continued\\n' > after-timeout.txt",
+            ].join(" && "),
+          }),
+        });
+        void afterTimeout.catch(() => undefined);
 
-      const [timedOutResponse, afterTimeoutResponse] = await Promise.all([
-        timedOut,
-        afterTimeout,
-      ]);
-      expect(timedOutResponse).toEqual({
-        status: 200,
-        body: { result: expect.objectContaining({ exitCode: 124 }) },
-      });
-      expect(afterTimeoutResponse).toEqual({
-        status: 200,
-        body: { result: expect.objectContaining({ exitCode: 0 }) },
-      });
+        const [timedOutResponse, afterTimeoutResponse] = await Promise.all([
+          timedOut,
+          afterTimeout,
+        ]);
+        expect(timedOutResponse).toEqual({
+          status: 200,
+          body: { result: expect.objectContaining({ exitCode: 124 }) },
+        });
+        expect(afterTimeoutResponse).toEqual({
+          status: 200,
+          body: { result: expect.objectContaining({ exitCode: 0 }) },
+        });
+      } finally {
+        await Promise.allSettled(
+          afterTimeout ? [timedOut, afterTimeout] : [timedOut],
+        );
+      }
     },
   );
 });
@@ -492,7 +522,7 @@ async function waitForContainerFile(
 
   while (Date.now() - startedAt < HEALTH_TIMEOUT_MS) {
     const exec = await container.exec({ Cmd: ["test", "-e", filePath] });
-    await exec.start({});
+    await readStreamToString(await exec.start({}));
     if ((await exec.inspect()).ExitCode === 0) {
       return;
     }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16320.preview.langfuse.com](https://pr-16320.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Stabilizes Docker sandbox tests by replacing implicit timing assumptions with observable-state synchronization and by draining outstanding requests during failure cleanup.
- Consumes Docker exec streams before inspecting completion.
- Adds rejection handling and cleanup for queued and timed-out sandbox requests.
- Documents that fixed delays must not be used for operation ordering.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking cleanup issue that can turn an uncommon Docker failure into a 60-second test timeout.

The synchronization changes generally preserve request failures and drain outstanding work, but the queue-order cleanup suppresses failure of its only release operation before waiting indefinitely for requests that depend on that release.

**Files Needing Attention:** packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts:374-383
**Unbounded cleanup after failed release**

If the cleanup's one-shot Docker exec fails while the sandbox HTTP server remains reachable, the error is swallowed and `Promise.allSettled` waits for requests that cannot finish without `queue-release`, replacing the original failure with the test's 60-second timeout.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Stabilize sandbox Docker tests"](https://github.com/langfuse/langfuse/commit/5310911315917074744395a192c8c3f030da6689) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54823456)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->