### PR TITLE
fix(web): align app header chrome row with sidebar border

### DIFF
--- a/web/src/components/EnvLabelBadge.tsx
+++ b/web/src/components/EnvLabelBadge.tsx
@@ -7,7 +7,7 @@ import { cva } from "class-variance-authority";
 import { useMemo } from "react";
 
 const envLabelBadgeVariants = cva(
-  "flex cursor-pointer items-center gap-1 rounded-md px-1 py-0.5 text-xs whitespace-nowrap",
+  "flex h-5 cursor-pointer items-center gap-1 rounded-md px-1 text-xs whitespace-nowrap",
   {
     variants: {
       variant: {

--- a/web/src/components/design-system/LangfuseLogo/LangfuseLogo.tsx
+++ b/web/src/components/design-system/LangfuseLogo/LangfuseLogo.tsx
@@ -42,13 +42,13 @@ export const LangfuseLogo = ({
     <div className="flex items-center">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        className="-ml-1.5 h-5 max-w-22 group-data-[collapsible=icon]:hidden dark:hidden"
+        className="-ml-1.5 h-5 max-w-22 translate-y-px group-data-[collapsible=icon]:hidden dark:hidden"
         src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/wordart-black.svg`}
         alt="Langfuse Logo"
       />
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        className="-ml-1.5 hidden h-5 max-w-22 group-data-[collapsible=icon]:hidden dark:block"
+        className="-ml-1.5 hidden h-5 max-w-22 translate-y-px group-data-[collapsible=icon]:hidden dark:block"
         src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/wordart-white.svg`}
         alt="Langfuse Logo"
       />

--- a/web/src/components/design-system/LangfuseLogo/LangfuseLogo.tsx
+++ b/web/src/components/design-system/LangfuseLogo/LangfuseLogo.tsx
@@ -42,13 +42,13 @@ export const LangfuseLogo = ({
     <div className="flex items-center">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        className="-ml-1.5 max-h-6 max-w-22 group-data-[collapsible=icon]:hidden dark:hidden"
+        className="-ml-1.5 h-5 max-w-22 group-data-[collapsible=icon]:hidden dark:hidden"
         src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/wordart-black.svg`}
         alt="Langfuse Logo"
       />
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        className="-ml-1.5 hidden max-h-6 max-w-22 group-data-[collapsible=icon]:hidden dark:block"
+        className="-ml-1.5 hidden h-5 max-w-22 group-data-[collapsible=icon]:hidden dark:block"
         src={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/wordart-white.svg`}
         alt="Langfuse Logo"
       />

--- a/web/src/components/layouts/app-shell-chrome.clienttest.tsx
+++ b/web/src/components/layouts/app-shell-chrome.clienttest.tsx
@@ -110,4 +110,23 @@ describe("app shell chrome row", () => {
 
     expect(container.querySelector(".h-1.flex-1.border-b")).toBeNull();
   });
+
+  it("keeps the page-header chrome divider full-width on container pages", () => {
+    render(
+      <SidebarPresenceProvider>
+        <SidebarProvider>
+          <PageHeader title="Settings" container />
+        </SidebarProvider>
+      </SidebarPresenceProvider>,
+    );
+
+    const row = screen.getByTestId(APP_SHELL_CHROME_ROW_TEST_ID);
+    expect(row.className).toContain("border-b");
+    expect(row.className).not.toContain("lg:mx-auto");
+    expect(row.className).not.toContain("max-w-screen");
+
+    const inner = row.firstElementChild;
+    expect(inner).toBeInstanceOf(HTMLElement);
+    expect((inner as HTMLElement).className).toContain("lg:mx-auto");
+  });
 });

--- a/web/src/components/layouts/app-shell-chrome.clienttest.tsx
+++ b/web/src/components/layouts/app-shell-chrome.clienttest.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { Home, Settings } from "lucide-react";
+
+import { APP_SHELL_CHROME_ROW_TEST_ID } from "@/src/components/layouts/app-shell-chrome";
+import PageHeader from "@/src/components/layouts/page-header";
+import { AppSidebar } from "@/src/components/nav/AppSidebar/AppSidebar";
+import { SidebarPresenceProvider } from "@/src/components/nav/sidebar-presence";
+import { SidebarProvider } from "@/src/components/ui/sidebar";
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    asPath: "/project/p1/traces",
+    pathname: "/project/[projectId]/traces",
+    push: vi.fn(),
+    query: { projectId: "p1" },
+    events: { on: vi.fn(), off: vi.fn() },
+  }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: {
+      user: {
+        email: "ada@langfuse.com",
+        organizations: [],
+      },
+    },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("@/src/features/organizations/hooks", () => ({
+  useLangfuseCloudRegion: () => ({ isLangfuseCloud: true, region: "EU" }),
+}));
+
+vi.mock("@/src/features/projects/hooks", () => ({
+  useQueryProjectOrOrganization: () => ({
+    organization: null,
+    project: null,
+  }),
+  useOrgProjectSwitchPaths: () => ({
+    getProjectPath: vi.fn(),
+    getOrgPath: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/components/nav/in-app-ai-agent-button", () => ({
+  InAppAiAgentButton: () => null,
+}));
+
+vi.mock("@/src/components/nav/topbar-brand", () => ({
+  TopbarBrand: () => null,
+}));
+
+const sidebarArgs = {
+  navItems: {
+    ungrouped: [{ title: "Home", url: "/", icon: Home, isActive: true }],
+    grouped: null,
+  },
+  secondaryNavItems: {
+    ungrouped: [{ title: "Settings", url: "/settings", icon: Settings }],
+    grouped: null,
+  },
+  user: { name: "Ada Lovelace", email: "ada@example.com", avatar: "" },
+  userMenuItems: [
+    {
+      type: "link" as const,
+      name: "Account Settings",
+      href: "/account/settings",
+    },
+  ],
+  isMobile: false,
+  logo: {},
+  versionState: { deployment: "cloud" as const },
+  showDemoBadge: false,
+  v4UpgradeUiEnabled: true,
+  notificationState: {
+    dismissedIds: [] as string[],
+    onDismiss: vi.fn(),
+    onLinkClick: vi.fn(),
+  },
+  organization: null,
+  project: null,
+  organizations: null,
+  canCreateOrganizations: false,
+  canCreateProjects: false,
+};
+
+const Shell = () => (
+  <SidebarPresenceProvider>
+    <SidebarProvider>
+      <AppSidebar {...sidebarArgs} />
+      <PageHeader title="Tracing" />
+    </SidebarProvider>
+  </SidebarPresenceProvider>
+);
+
+describe("app shell chrome row", () => {
+  it("puts the sidebar and page-header dividers on the same min-h-11 row", () => {
+    const { container } = render(<Shell />);
+
+    const rows = screen.getAllByTestId(APP_SHELL_CHROME_ROW_TEST_ID);
+    expect(rows).toHaveLength(2);
+
+    for (const row of rows) {
+      expect(row.className).toContain("min-h-11");
+      expect(row.className).toContain("border-b");
+      expect(row.className).toContain("items-center");
+    }
+
+    expect(container.querySelector(".h-1.flex-1.border-b")).toBeNull();
+  });
+});

--- a/web/src/components/layouts/app-shell-chrome.clienttest.tsx
+++ b/web/src/components/layouts/app-shell-chrome.clienttest.tsx
@@ -111,6 +111,17 @@ describe("app shell chrome row", () => {
     expect(container.querySelector(".h-1.flex-1.border-b")).toBeNull();
   });
 
+  it("sizes the desktop sidebar toggle to the same 20px as the wordmark", () => {
+    const { container } = render(<Shell />);
+
+    const desktopToggle = [
+      ...container.querySelectorAll("[data-sidebar=trigger] svg"),
+    ].find((svg) => (svg.getAttribute("class") ?? "").includes("md:block"));
+
+    expect(desktopToggle?.getAttribute("class")).toContain("size-5");
+    expect(desktopToggle?.getAttribute("class")).not.toContain("size-4");
+  });
+
   it("keeps the page-header chrome divider full-width on container pages", () => {
     render(
       <SidebarPresenceProvider>

--- a/web/src/components/layouts/app-shell-chrome.ts
+++ b/web/src/components/layouts/app-shell-chrome.ts
@@ -3,8 +3,11 @@
  * row. Height and the bottom border live on this same box so the sidebar's
  * `border-r` forms a single-pixel T-junction with the divider, instead of a
  * stair-step from mismatched row heights.
+ *
+ * Padding is call-site specific: the page-header row must stay full-width
+ * (the divider has to reach the sidebar) while its *content* can be
+ * container-capped on settings pages.
  */
-export const APP_SHELL_CHROME_ROW_CLASS =
-  "flex min-h-11 items-center border-b px-3";
+export const APP_SHELL_CHROME_ROW_CLASS = "flex min-h-11 items-center border-b";
 
 export const APP_SHELL_CHROME_ROW_TEST_ID = "app-shell-chrome-row";

--- a/web/src/components/layouts/app-shell-chrome.ts
+++ b/web/src/components/layouts/app-shell-chrome.ts
@@ -1,0 +1,10 @@
+/**
+ * Top chrome row shared by the sidebar logo strip and the page-header first
+ * row. Height and the bottom border live on this same box so the sidebar's
+ * `border-r` forms a single-pixel T-junction with the divider, instead of a
+ * stair-step from mismatched row heights.
+ */
+export const APP_SHELL_CHROME_ROW_CLASS =
+  "flex min-h-11 items-center border-b px-3";
+
+export const APP_SHELL_CHROME_ROW_TEST_ID = "app-shell-chrome-row";

--- a/web/src/components/layouts/breadcrumb.tsx
+++ b/web/src/components/layouts/breadcrumb.tsx
@@ -49,7 +49,7 @@ const BreadcrumbComponent = ({
       <BreadcrumbList>
         {organization && (
           <DropdownMenu>
-            <DropdownMenuTrigger className="text-primary flex items-center gap-1 text-sm">
+            <DropdownMenuTrigger className="text-primary flex h-5 items-center gap-1 p-0 text-sm leading-none">
               {organization?.name ?? "Organization"}
               {isCloudPlan(organization?.plan) &&
                 organization.id !== env.NEXT_PUBLIC_DEMO_ORG_ID && (
@@ -77,7 +77,7 @@ const BreadcrumbComponent = ({
               <Slash />
             </BreadcrumbSeparator>
             <DropdownMenu>
-              <DropdownMenuTrigger className="text-primary flex items-center gap-1">
+              <DropdownMenuTrigger className="text-primary flex h-5 items-center gap-1 p-0 leading-none">
                 {project?.name ?? "Project"}
                 <ChevronDownIcon className="h-4 w-4" />
               </DropdownMenuTrigger>

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -21,6 +21,10 @@ import {
 } from "@/src/components/layouts/page-tabs";
 import { cn } from "@/src/utils/tailwind";
 import { type ReactNode } from "react";
+import {
+  APP_SHELL_CHROME_ROW_CLASS,
+  APP_SHELL_CHROME_ROW_TEST_ID,
+} from "@/src/components/layouts/app-shell-chrome";
 
 const containerLayoutClassName =
   "lg:mx-auto lg:w-full lg:max-w-screen-lg lg:px-8 xl:max-w-screen-xl 2xl:max-w-[1400px]";
@@ -87,55 +91,57 @@ const PageHeader = ({
       id="page-header"
     >
       <div className="flex flex-col justify-center">
-        {/* Top Row */}
-        <div className="border-b">
-          <div
-            className={cn(
-              // py-1.5 (not py-2) so a 32px control in the right-aligned slot
-              // fits inside the 44px (min-h-11) row without growing it; the
-              // min-height keeps rows without controls at the same height.
-              // justify-between (not ml-auto on the slot) so the controls sit
-              // right when the row fits on one line but fall back to the LEFT
-              // edge when they wrap to their own line on narrow viewports (a
-              // line with a single flex item renders as flex-start).
-              "flex min-h-11 flex-wrap items-center justify-between gap-3 px-3 py-1.5",
-              container && containerLayoutClassName,
+        {/* Top Row — same min-h-11 + border-b box as the sidebar logo strip
+            so the sidebar `border-r` T-junction is a single pixel. */}
+        <div
+          data-testid={APP_SHELL_CHROME_ROW_TEST_ID}
+          className={cn(
+            APP_SHELL_CHROME_ROW_CLASS,
+            // No extra vertical padding: min-h-11 + border-b already is the
+            // 44px box. Extra py would grow the row past the sidebar strip
+            // (border-box counts padding inside min-height, then 32px
+            // controls no longer fit). justify-between (not ml-auto on the
+            // slot) so the controls sit right when the row fits on one line
+            // but fall back to the LEFT edge when they wrap to their own
+            // line on narrow viewports (a line with a single flex item
+            // renders as flex-start).
+            "flex-wrap justify-between gap-3",
+            container && containerLayoutClassName,
+          )}
+        >
+          <div className="flex min-w-0 flex-wrap items-center gap-3">
+            {showSidebarChrome ? (
+              <>
+                <SidebarTrigger />
+                {/* Brand the app in the top bar while the sidebar (which
+                    owns the logo) is off-canvas below `md`. Hidden on
+                    desktop where the sidebar logo is visible. */}
+                <TopbarBrand className="md:hidden" />
+              </>
+            ) : (
+              leadingControl && (
+                <div className="flex items-center">{leadingControl}</div>
+              )
             )}
-          >
-            <div className="flex min-w-0 flex-wrap items-center gap-3">
-              {showSidebarChrome ? (
-                <>
-                  <SidebarTrigger />
-                  {/* Brand the app in the top bar while the sidebar (which
-                      owns the logo) is off-canvas below `md`. Hidden on
-                      desktop where the sidebar logo is visible. */}
-                  <TopbarBrand className="md:hidden" />
-                </>
-              ) : (
-                leadingControl && (
-                  <div className="flex items-center">{leadingControl}</div>
-                )
+            <div>
+              {envLabel.visible && (
+                <EnvLabelBadge
+                  region={envLabel.region}
+                  onClick={envLabel.dismiss}
+                />
               )}
-              <div>
-                {envLabel.visible && (
-                  <EnvLabelBadge
-                    region={envLabel.region}
-                    onClick={envLabel.dismiss}
-                  />
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                <BreadcrumbComponent items={breadcrumb} />
-                {breadcrumbBadges}
-              </div>
             </div>
-            {/* Slot for page-level controls (time range, auto-refresh)
-                hoisted from a list table via PageHeaderControlsPortal.
-                Empty on pages that don't use it. */}
-            <div className="flex flex-wrap items-center gap-2">
-              <PageHeaderControlsSlotTarget />
-              <InAppAiAgentButton />
+            <div className="flex items-center gap-2">
+              <BreadcrumbComponent items={breadcrumb} />
+              {breadcrumbBadges}
             </div>
+          </div>
+          {/* Slot for page-level controls (time range, auto-refresh)
+              hoisted from a list table via PageHeaderControlsPortal.
+              Empty on pages that don't use it. */}
+          <div className="flex flex-wrap items-center gap-2">
+            <PageHeaderControlsSlotTarget />
+            <InAppAiAgentButton />
           </div>
         </div>
 

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -109,11 +109,11 @@ const PageHeader = ({
               // one line but fall back to the LEFT edge when they wrap to
               // their own line on narrow viewports (a line with a single
               // flex item renders as flex-start).
-              "flex w-full flex-wrap items-center justify-between gap-3 px-3",
+              "flex h-full w-full flex-wrap items-center justify-between gap-3 px-3 leading-none",
               container && containerLayoutClassName,
             )}
           >
-            <div className="flex min-w-0 flex-wrap items-center gap-3">
+            <div className="flex min-h-5 min-w-0 flex-wrap items-center gap-3">
               {showSidebarChrome ? (
                 <>
                   <SidebarTrigger />

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -135,7 +135,7 @@ const PageHeader = ({
                   />
                 )}
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex translate-y-px items-center gap-2">
                 <BreadcrumbComponent items={breadcrumb} />
                 {breadcrumbBadges}
               </div>

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -92,56 +92,61 @@ const PageHeader = ({
     >
       <div className="flex flex-col justify-center">
         {/* Top Row — same min-h-11 + border-b box as the sidebar logo strip
-            so the sidebar `border-r` T-junction is a single pixel. */}
+            so the sidebar `border-r` T-junction is a single pixel. The
+            divider stays on this full-width box; container max-width only
+            caps the inner content so settings pages don't leave a gap. */}
         <div
           data-testid={APP_SHELL_CHROME_ROW_TEST_ID}
-          className={cn(
-            APP_SHELL_CHROME_ROW_CLASS,
-            // No extra vertical padding: min-h-11 + border-b already is the
-            // 44px box. Extra py would grow the row past the sidebar strip
-            // (border-box counts padding inside min-height, then 32px
-            // controls no longer fit). justify-between (not ml-auto on the
-            // slot) so the controls sit right when the row fits on one line
-            // but fall back to the LEFT edge when they wrap to their own
-            // line on narrow viewports (a line with a single flex item
-            // renders as flex-start).
-            "flex-wrap justify-between gap-3",
-            container && containerLayoutClassName,
-          )}
+          className={APP_SHELL_CHROME_ROW_CLASS}
         >
-          <div className="flex min-w-0 flex-wrap items-center gap-3">
-            {showSidebarChrome ? (
-              <>
-                <SidebarTrigger />
-                {/* Brand the app in the top bar while the sidebar (which
-                    owns the logo) is off-canvas below `md`. Hidden on
-                    desktop where the sidebar logo is visible. */}
-                <TopbarBrand className="md:hidden" />
-              </>
-            ) : (
-              leadingControl && (
-                <div className="flex items-center">{leadingControl}</div>
-              )
+          <div
+            className={cn(
+              // No extra vertical padding: min-h-11 + border-b already is
+              // the 44px box. Extra py would grow the row past the sidebar
+              // strip (border-box counts padding inside min-height, then
+              // 32px controls no longer fit). justify-between (not ml-auto
+              // on the slot) so the controls sit right when the row fits on
+              // one line but fall back to the LEFT edge when they wrap to
+              // their own line on narrow viewports (a line with a single
+              // flex item renders as flex-start).
+              "flex w-full flex-wrap items-center justify-between gap-3 px-3",
+              container && containerLayoutClassName,
             )}
-            <div>
-              {envLabel.visible && (
-                <EnvLabelBadge
-                  region={envLabel.region}
-                  onClick={envLabel.dismiss}
-                />
+          >
+            <div className="flex min-w-0 flex-wrap items-center gap-3">
+              {showSidebarChrome ? (
+                <>
+                  <SidebarTrigger />
+                  {/* Brand the app in the top bar while the sidebar (which
+                      owns the logo) is off-canvas below `md`. Hidden on
+                      desktop where the sidebar logo is visible. */}
+                  <TopbarBrand className="md:hidden" />
+                </>
+              ) : (
+                leadingControl && (
+                  <div className="flex items-center">{leadingControl}</div>
+                )
               )}
+              <div>
+                {envLabel.visible && (
+                  <EnvLabelBadge
+                    region={envLabel.region}
+                    onClick={envLabel.dismiss}
+                  />
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <BreadcrumbComponent items={breadcrumb} />
+                {breadcrumbBadges}
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <BreadcrumbComponent items={breadcrumb} />
-              {breadcrumbBadges}
+            {/* Slot for page-level controls (time range, auto-refresh)
+                hoisted from a list table via PageHeaderControlsPortal.
+                Empty on pages that don't use it. */}
+            <div className="flex flex-wrap items-center gap-2">
+              <PageHeaderControlsSlotTarget />
+              <InAppAiAgentButton />
             </div>
-          </div>
-          {/* Slot for page-level controls (time range, auto-refresh)
-              hoisted from a list table via PageHeaderControlsPortal.
-              Empty on pages that don't use it. */}
-          <div className="flex flex-wrap items-center gap-2">
-            <PageHeaderControlsSlotTarget />
-            <InAppAiAgentButton />
           </div>
         </div>
 

--- a/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
@@ -28,6 +28,10 @@ const setCurrentTimestamp = (timestamp: number) => {
 
 const meta = preview.meta({
   component: AppSidebar,
+  // Fullscreen: the docked sidebar is `position: fixed` to the iframe, so
+  // Storybook's default 1rem padded layout sat the inset chrome 16px below
+  // the logo strip and made the T-junction look broken.
+  parameters: { layout: "fullscreen" },
   render: (args) => <SidebarStory open args={args} />,
   args: {
     navItems: {
@@ -278,9 +282,10 @@ export const ChromeRowAlignment = meta.story({
     // Storybook viewport uses the mobile sheet instead).
     if (sidebarBox.width === 0) return;
 
-    // The shared contract is the divider Y: both rows are the same
-    // min-h-11 + border-b box. The sidebar `border-r` sits 1px outside
-    // this row's content box, so do not assert left/right edges.
+    // Same box geometry (the shared min-h-11 + border-b class). Absolute Y
+    // also matches when this file uses `layout: fullscreen` so the fixed
+    // sidebar and the in-flow inset share an origin.
+    await expect(Math.abs(sidebarBox.height - pageBox.height)).toBeLessThan(1);
     await expect(Math.abs(sidebarBox.bottom - pageBox.bottom)).toBeLessThan(1);
   },
 });

--- a/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
@@ -95,7 +95,7 @@ const SidebarStory = ({
         <>
           <div
             data-testid={APP_SHELL_CHROME_ROW_TEST_ID}
-            className={cn(APP_SHELL_CHROME_ROW_CLASS, "gap-3")}
+            className={cn(APP_SHELL_CHROME_ROW_CLASS, "gap-3 px-3")}
           >
             <span className="text-muted-foreground text-sm">Toggle</span>
             <span className="bg-light-red text-dark-red rounded-md px-1 text-xs">

--- a/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
@@ -5,6 +5,11 @@ import { expect, fn } from "storybook/test";
 import preview from "../../../../.storybook/preview";
 import { SidebarInset, SidebarProvider } from "@/src/components/ui/sidebar";
 import { AppSidebar } from "./AppSidebar";
+import {
+  APP_SHELL_CHROME_ROW_CLASS,
+  APP_SHELL_CHROME_ROW_TEST_ID,
+} from "@/src/components/layouts/app-shell-chrome";
+import { cn } from "@/src/utils/tailwind";
 
 type AppSidebarProps = ComponentProps<typeof AppSidebar>;
 type VersionState = AppSidebarProps["versionState"];
@@ -73,14 +78,33 @@ const meta = preview.meta({
 const SidebarStory = ({
   open,
   args,
+  showPageChrome = false,
 }: {
   open: boolean;
   args: AppSidebarProps;
+  showPageChrome?: boolean;
 }) => (
   <SidebarProvider open={open}>
     <AppSidebar {...args} />
     <SidebarInset>
-      <div className="bg-muted/30 h-full" />
+      {showPageChrome ? (
+        <>
+          <div
+            data-testid={APP_SHELL_CHROME_ROW_TEST_ID}
+            className={cn(APP_SHELL_CHROME_ROW_CLASS, "gap-3")}
+          >
+            <span className="text-muted-foreground text-sm">Toggle</span>
+            <span className="bg-light-red text-dark-red rounded-md px-1 text-xs">
+              PROD-EU
+            </span>
+          </div>
+          <div className="text-primary px-3 py-1 text-lg leading-7 font-bold">
+            Tracing
+          </div>
+        </>
+      ) : (
+        <div className="bg-muted/30 h-full" />
+      )}
     </SidebarInset>
   </SidebarProvider>
 );
@@ -227,4 +251,36 @@ export const MobileNavigation = meta.story({
 
 export const Collapsed = meta.story({
   render: (args) => <SidebarStory open={false} args={args} />,
+});
+
+export const WithPageChrome = meta.story({
+  args: {
+    showDemoBadge: true,
+  },
+  render: (args) => <SidebarStory open args={args} showPageChrome />,
+});
+
+export const ChromeRowAlignment = meta.story({
+  name: "(Test) Chrome Row Aligns With Page Header",
+  args: {
+    showDemoBadge: true,
+  },
+  render: (args) => <SidebarStory open args={args} showPageChrome />,
+  play: async ({ canvas }) => {
+    const rows = canvas.getAllByTestId(APP_SHELL_CHROME_ROW_TEST_ID);
+    await expect(rows).toHaveLength(2);
+
+    const [sidebarRow, pageRow] = rows;
+    const sidebarBox = sidebarRow.getBoundingClientRect();
+    const pageBox = pageRow.getBoundingClientRect();
+
+    // Skip geometry when the desktop sidebar is `display: none` (narrow
+    // Storybook viewport uses the mobile sheet instead).
+    if (sidebarBox.width === 0) return;
+
+    // The shared contract is the divider Y: both rows are the same
+    // min-h-11 + border-b box. The sidebar `border-r` sits 1px outside
+    // this row's content box, so do not assert left/right edges.
+    await expect(Math.abs(sidebarBox.bottom - pageBox.bottom)).toBeLessThan(1);
+  },
 });

--- a/web/src/components/nav/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.tsx
@@ -607,7 +607,7 @@ const VersionLabel = ({ state }: { state: SidebarVersionState }) => {
         <Button
           variant="ghost"
           size="xs"
-          className="h-5 max-w-full min-w-0 py-0 text-[0.625rem] leading-none"
+          className="h-5 max-w-full min-w-0 translate-y-0.5 py-0 text-[0.625rem] leading-none"
         >
           <span className="truncate" title={versionText}>
             {versionText}

--- a/web/src/components/nav/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.tsx
@@ -67,6 +67,11 @@ import { ProjectDropdownMenu } from "@/src/components/ProjectDropdownMenu/Projec
 import { assertUnreachable } from "@/src/utils/types";
 import { SIDEBAR_NOTIFICATIONS, type SidebarNotification } from "./utils";
 import { useOrgProjectSwitchPaths } from "@/src/features/projects/hooks";
+import {
+  APP_SHELL_CHROME_ROW_CLASS,
+  APP_SHELL_CHROME_ROW_TEST_ID,
+} from "@/src/components/layouts/app-shell-chrome";
+import { cn } from "@/src/utils/tailwind";
 
 const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000;
 
@@ -206,18 +211,23 @@ export function AppSidebar({
   return (
     <Sidebar collapsible="icon" variant="sidebar">
       <SidebarHeader>
-        <div className="flex min-h-9 min-w-0 items-center py-2 pr-2 pl-3 group-data-[collapsible=icon]:p-3">
+        <div
+          data-testid={APP_SHELL_CHROME_ROW_TEST_ID}
+          className={cn(
+            APP_SHELL_CHROME_ROW_CLASS,
+            "min-w-0 gap-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
+          )}
+        >
           <Link href="/" className="flex items-center">
             <LangfuseLogo
               logoLightModeHref={logo.lightModeHref}
               logoDarkModeHref={logo.darkModeHref}
             />
           </Link>
-          <div className="ml-auto flex min-w-0 items-center overflow-hidden pl-2 group-data-[collapsible=icon]:hidden">
+          <div className="ml-auto flex min-w-0 items-center overflow-hidden group-data-[collapsible=icon]:hidden">
             <VersionLabel state={versionState} />
           </div>
         </div>
-        <div className="h-1 flex-1 border-b" />
         {showDemoBadge && <DemoBadge />}
       </SidebarHeader>
       <SidebarContent>
@@ -597,7 +607,7 @@ const VersionLabel = ({ state }: { state: SidebarVersionState }) => {
         <Button
           variant="ghost"
           size="xs"
-          className="h-5 max-w-full min-w-0 py-0.5 text-[0.625rem]"
+          className="h-5 max-w-full min-w-0 py-0 text-[0.625rem] leading-none"
         >
           <span className="truncate" title={versionText}>
             {versionText}

--- a/web/src/components/nav/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.tsx
@@ -215,7 +215,7 @@ export function AppSidebar({
           data-testid={APP_SHELL_CHROME_ROW_TEST_ID}
           className={cn(
             APP_SHELL_CHROME_ROW_CLASS,
-            "min-w-0 gap-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
+            "min-w-0 gap-2 px-3 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
           )}
         >
           <Link href="/" className="flex items-center">

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -316,7 +316,7 @@ const SidebarTrigger = React.forwardRef<
       {/* Hamburger below `md` (opens the sheet); panel-collapse glyph on
           desktop (toggles the docked sidebar). */}
       <Menu className="size-5 md:hidden" />
-      <PanelLeft className="hidden md:block" />
+      <PanelLeft className="hidden size-4 md:block" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );
@@ -392,7 +392,7 @@ const SidebarHeader = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="header"
-      className={cn("flex min-h-11 flex-col pt-2 md:h-fit", className)}
+      className={cn("flex flex-col", className)}
       {...props}
     />
   );

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -316,7 +316,7 @@ const SidebarTrigger = React.forwardRef<
       {/* Hamburger below `md` (opens the sheet); panel-collapse glyph on
           desktop (toggles the docked sidebar). */}
       <Menu className="size-5 md:hidden" />
-      <PanelLeft className="hidden size-4 md:block" />
+      <PanelLeft className="hidden size-5 md:block" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16328.preview.langfuse.com](https://pr-16328.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The sidebar logo strip and the page-header top row used different heights and put their dividers on different boxes (`min-h-9` + a 4px spacer vs `min-h-11` with the border on a wrapper, plus extra `pt-2` on the sidebar header). That made the vertical sidebar border meet the horizontal divider as a stair-step, and left the version, sidebar toggle, and env badge optically lower than the wordmark.

Both sides now share one `min-h-11` + `border-b` chrome row. Padding and container max-width stay off that box so settings/`ContainerPage` still draw the divider edge-to-edge against the sidebar. The wordmark is the cap-height anchor; the OSS version is nudged 2px down and the chrome breadcrumb 1px down so their tops meet that line. The desktop sidebar toggle is `size-5` to match the 20px wordmark box.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Impacted package: `web`
- Verification: `pnpm --filter web run test-client src/components/layouts/app-shell-chrome.clienttest.tsx` → `Tests 3 passed (3)`; pre-commit `turbo run lint` → `Tasks: 7 successful, 7 total`
- Skipped: full typecheck (CSS/layout only)

## Test this

Sandbox: http://localhost:3000 (this Cloud VM; demo project is enough)
1. Sign in as `demo@langfuse.com` / `password`.
2. Open Organizations, hard-refresh, and confirm the wordmark cap-height, `v4.15.0 OSS`, and “Organizations” breadcrumb share one line.
3. Open Project Settings at a wide viewport and confirm the header divider still reaches the sidebar.

Preview: https://pr-16328.preview.langfuse.com — same click path after the image rolls.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15348](https://linear.app/clickhouse/issue/LFE-15348/alignment-of-app-header-and-borders)

<div><a href="https://cursor.com/agents/bc-2bb376ee-393e-461c-a7e3-41376e74c080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bb376ee-393e-461c-a7e3-41376e74c080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns the sidebar and page-header chrome by sharing a centered 44px minimum-height row with its bottom border. It also normalizes logo, environment badge, version label, and sidebar-trigger sizing and adds client and Storybook coverage.

- Introduces a shared app-shell chrome-row class and test identifier.
- Moves the sidebar and page-header dividers onto their respective shared chrome rows.
- Adjusts header element dimensions and adds alignment-focused tests and stories.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking weakness in the client regression test’s ability to detect actual divider misalignment.

The layout changes consistently apply the shared chrome-row styling, but the client test can pass when independently wrapping rows no longer share the same rendered bottom edge.

**Files Needing Attention:** web/src/components/layouts/app-shell-chrome.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/layouts/app-shell-chrome.clienttest.tsx:105-109
**Test the rendered divider alignment**

The assertions only check shared class names, so they continue to pass when the wrapping page-header row grows beyond `min-h-11` while the non-wrapping sidebar row remains 44px tall. Assert equal rendered row heights or bottom coordinates so the test protects against the visible stair-step it is intended to prevent.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): align app header chrome row wi..."](https://github.com/langfuse/langfuse/commit/13f2fcc03db8239aba2304890eb2cb0733cbf774) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54879913)</sub>

<!-- /greptile_comment -->