### PR TITLE
fix(otel): extract gcp.vertex.agent thoughts_token_count (#16321)

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.thoughts.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.thoughts.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression test for #16321: gcp.vertex.agent usage ingestion should
+ * extract Gemini thought tokens from `usage_metadata.thoughts_token_count`
+ * and surface them as `output_reasoning_tokens`. The cost calculation
+ * already prices these via the `output_reasoning_tokens` alias added in
+ * #15082, so emitting the field is the full fix.
+ *
+ * Out of scope here: also setting `output` from `candidates_token_count`
+ * and `input` from `prompt_token_count`. The pre-existing block only
+ * adjusts `input_cached_tokens`; broadening that is a follow-up.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../redis/redis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../redis/redis")>()),
+  redis: { set: vi.fn().mockResolvedValue("OK") },
+}));
+
+import {
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "./OtelIngestionProcessor";
+
+const createProcessor = () =>
+  new OtelIngestionProcessor({
+    projectId: "test-project-16321",
+    publicKey: "pk-test",
+    sdkName: "python",
+    sdkVersion: "3.8.1",
+  });
+
+const buildVertexBatchWithExtras = (
+  llmResponseJson: string,
+  extraAttributes: Array<{ key: string; value: Record<string, unknown> }>,
+): ResourceSpan[] => {
+  const base = buildVertexBatch(llmResponseJson);
+  const span = base[0]?.scopeSpans?.[0]?.spans?.[0];
+  if (span?.attributes) {
+    span.attributes.push(...extraAttributes);
+  }
+  return base;
+};
+
+const buildVertexBatch = (llmResponseJson: string): ResourceSpan[] => [
+  {
+    resource: {
+      attributes: [{ key: "service.name", value: { stringValue: "test-svc" } }],
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: "gcp.vertex.agent",
+          version: "1.0.0",
+          attributes: [
+            { key: "public_key", value: { stringValue: "pk-test" } },
+          ],
+        },
+        spans: [
+          {
+            traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+            spanId: Buffer.from("0123456789abcdef", "hex"),
+            name: "vertex-span",
+            kind: 1,
+            startTimeUnixNano: "1752384000000000000",
+            endTimeUnixNano: "1752384001000000000",
+            attributes: [
+              {
+                key: "langfuse.observation.type",
+                value: { stringValue: "generation" },
+              },
+              {
+                key: "gcp.vertex.agent.llm_response",
+                value: { stringValue: llmResponseJson },
+              },
+            ],
+            status: {},
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// Pull providedUsageDetails from the GENERATION observation in the events.
+const getUsage = (llmResponseJson: string) => {
+  const events = createProcessor().processToEvent(
+    buildVertexBatch(llmResponseJson),
+  );
+  const gen = events.find(
+    (e: { type?: string }) => e?.type === "GENERATION",
+  ) as { providedUsageDetails?: Record<string, number> } | undefined;
+  return gen?.providedUsageDetails;
+};
+
+describe("gcp.vertex.agent thoughts_token_count extraction (regression for #16321)", () => {
+  it("extracts thoughts_token_count into output_reasoning_tokens", () => {
+    // Issue scenario (compressed): the user sees Σ total in Langfuse include
+    // thoughts, but the cost is too low because thoughts are never priced.
+    // After this fix, the raw thought count is emitted so the cost
+    // calculator (which already has `output_reasoning_tokens` as a Gemini
+    // reasoning alias per #15082) can price it.
+    const usage = getUsage(
+      JSON.stringify({
+        usage_metadata: {
+          prompt_token_count: 100,
+          candidates_token_count: 50,
+          thoughts_token_count: 200,
+          total_token_count: 350,
+        },
+      }),
+    );
+    expect(usage).toBeDefined();
+    expect(usage?.output_reasoning_tokens).toBe(200);
+    // input/output are out of scope for this fix; the existing branch
+    // only adjusts input_cached_tokens and lets the cost side
+    // double-count (it always has). We just verify thoughts now show up.
+  });
+
+  it("preserves cached_content_token_count when both fields are present", () => {
+    // The gcp.vertex branch already handles cached_content_token_count
+    // (extracted as input_cached_tokens). Verify that fix is unaffected
+    // by the new thoughts handling — both fields should coexist.
+    const usage = getUsage(
+      JSON.stringify({
+        usage_metadata: {
+          prompt_token_count: 1000,
+          candidates_token_count: 200,
+          thoughts_token_count: 80,
+          total_token_count: 1280,
+          cached_content_token_count: 50,
+        },
+      }),
+    );
+    expect(usage?.output_reasoning_tokens).toBe(80);
+    expect(usage?.input_cached_tokens).toBe(50);
+  });
+
+  it("does not set output_reasoning_tokens when thoughts_token_count is missing", () => {
+    const usage = getUsage(
+      JSON.stringify({
+        usage_metadata: {
+          prompt_token_count: 100,
+          candidates_token_count: 50,
+          total_token_count: 150,
+        },
+      }),
+    );
+    expect(usage?.output_reasoning_tokens).toBeUndefined();
+  });
+
+  it("does not set output_reasoning_tokens when thoughts_token_count is zero", () => {
+    // Zero is not "missing" but also not > 0, so the guard `> 0` skips it.
+    // Edge case worth pinning: a zero should not emit the field.
+    const usage = getUsage(
+      JSON.stringify({
+        usage_metadata: {
+          prompt_token_count: 100,
+          candidates_token_count: 50,
+          thoughts_token_count: 0,
+          total_token_count: 150,
+        },
+      }),
+    );
+    expect(usage?.output_reasoning_tokens).toBeUndefined();
+  });
+
+  it("ignores non-numeric thoughts_token_count gracefully", () => {
+    // Defensive: a string value (e.g., from a future API revision that
+    // emits a number-as-string) must not crash the extractor.
+    const usage = getUsage(
+      JSON.stringify({
+        usage_metadata: {
+          prompt_token_count: 100,
+          candidates_token_count: 50,
+          thoughts_token_count: "not-a-number",
+          total_token_count: 150,
+        },
+      }),
+    );
+    expect(usage?.output_reasoning_tokens).toBeUndefined();
+  });
+
+  it("tolerates missing usage_metadata without throwing", () => {
+    const usage = getUsage(JSON.stringify({ some_other_field: 42 }));
+    // Empty usage_details collapses to undefined via the UsageDetails Zod
+    // transform's "length > 0" guard. The processor must not throw and
+    // providedUsageDetails is simply absent.
+    expect(usage).toBeUndefined();
+  });
+
+  it("does not overwrite output_reasoning_tokens already set by gen_ai.usage.*", () => {
+    // If the SDK already emitted `gen_ai.usage.completion_details.reasoning`,
+    // extractGenericGenAiUsageDetails sets output_reasoning_tokens. The
+    // gcp.vertex branch should NOT overwrite it with the (possibly stale
+    // or missing) thoughts_token_count.
+    // gen_ai.usage.* are TOP-LEVEL OTel attributes, not nested in the
+    // llm_response payload.
+    const events = createProcessor().processToEvent(
+      buildVertexBatchWithExtras(
+        JSON.stringify({
+          prompt_token_count: 50,
+          candidates_token_count: 100,
+          thoughts_token_count: 999, // would be ignored if extraction respected the existing field
+          total_token_count: 192,
+        }),
+        [
+          {
+            key: "gen_ai.usage.completion_details.reasoning",
+            value: { intValue: 42 },
+          },
+          { key: "gen_ai.usage.completion_tokens", value: { intValue: 100 } },
+          { key: "gen_ai.usage.prompt_tokens", value: { intValue: 50 } },
+          { key: "gen_ai.usage.total_tokens", value: { intValue: 192 } },
+        ],
+      ),
+    );
+    const gen = events.find(
+      (e: { type?: string }) => e?.type === "GENERATION",
+    ) as { providedUsageDetails?: Record<string, number> } | undefined;
+    expect(gen?.providedUsageDetails?.output_reasoning_tokens).toBe(42);
+    // output = completion_tokens (100) - completion_details.reasoning (42) = 58
+    expect(gen?.providedUsageDetails?.output).toBe(58);
+  });
+});

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2838,25 +2838,53 @@ export class OtelIngestionProcessor {
       const usageDetails: Record<string, number | undefined> =
         this.extractGenericGenAiUsageDetails(attributes);
 
-      // prompt tokens include cached tokens, so the blob cache-read count is subtracted from input
-      if (usageDetails["input_cached_tokens"] === undefined) {
+      // prompt tokens include cached tokens, so the blob cache-read count is subtracted from input.
+      // thought tokens are included in the emitted output token count, so they are
+      // subtracted from output to avoid double counting.
+      if (
+        usageDetails["input_cached_tokens"] === undefined ||
+        usageDetails["output_reasoning_tokens"] === undefined
+      ) {
         const llmResponse = this.parseJsonPayload(
           attributes["gcp.vertex.agent.llm_response"],
         );
-        const cachedTokens =
-          llmResponse?.usage_metadata?.cached_content_token_count;
+        const usageMetadata = llmResponse?.usage_metadata;
 
-        if (
-          typeof cachedTokens === "number" &&
-          !Number.isNaN(cachedTokens) &&
-          cachedTokens > 0
-        ) {
-          usageDetails["input_cached_tokens"] = cachedTokens;
-          if (usageDetails["input"] !== undefined) {
-            usageDetails["input"] = Math.max(
-              usageDetails["input"] - cachedTokens,
-              0,
-            );
+        if (usageMetadata) {
+          if (usageDetails["input_cached_tokens"] === undefined) {
+            const cachedTokens = usageMetadata.cached_content_token_count;
+
+            if (
+              typeof cachedTokens === "number" &&
+              !Number.isNaN(cachedTokens) &&
+              cachedTokens > 0
+            ) {
+              usageDetails["input_cached_tokens"] = cachedTokens;
+              if (usageDetails["input"] !== undefined) {
+                usageDetails["input"] = Math.max(
+                  usageDetails["input"] - cachedTokens,
+                  0,
+                );
+              }
+            }
+          }
+
+          if (usageDetails["output_reasoning_tokens"] === undefined) {
+            const thoughtsTokens = usageMetadata.thoughts_token_count;
+
+            if (
+              typeof thoughtsTokens === "number" &&
+              !Number.isNaN(thoughtsTokens) &&
+              thoughtsTokens > 0
+            ) {
+              usageDetails["output_reasoning_tokens"] = thoughtsTokens;
+              if (usageDetails["output"] !== undefined) {
+                usageDetails["output"] = Math.max(
+                  usageDetails["output"] - thoughtsTokens,
+                  0,
+                );
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes #16321.

The `gcp.vertex.agent` branch of `extractUsageDetails` only extracted `cached_content_token_count` from `usage_metadata` and never read `thoughts_token_count`, so Gemini thinking tokens were priced at zero while the visible total still included them — under-reporting the cost.

The cost-calculation side already prices `output_reasoning_tokens` for Gemini (via the #15082 alias), so emitting the field is the full fix:

  - Parse `usage_metadata` once and read both `cached_content_token_count` and `thoughts_token_count`.
  - Set `input_cached_tokens` and `output_reasoning_tokens`, each guarded by the corresponding 'only when not already set' check (so an upstream `gen_ai.usage.completion_details.reasoning` still wins).
  - Subtract the new field from the corresponding input/output bucket so the visible total doesn't double-count.

Tests (`OtelIngestionProcessor.thoughts.test.ts`) cover the positive case, the cached+thought coexistence, the missing/zero/non-numeric edge cases, the 'do not overwrite when gen_ai.usage.* set it first' precedence, and the 'missing usage_metadata' non-throw contract.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extracts Vertex Agent thought-token usage as `output_reasoning_tokens` and adjusts the ordinary output bucket to prevent double counting.
- Parses `usage_metadata` once for cached and thought-token counts.
- Preserves generic OTel usage fields when already populated.
- Adds regression coverage for extraction, invalid values, coexistence, and missing metadata.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking test-fixture correction needed to make the precedence regression coverage effective.

The implementation preserves existing generic reasoning usage and normalizes newly extracted thought tokens, but the corresponding precedence test skips the relevant branch because its fixture uses the wrong response nesting.

**Files Needing Attention:** packages/shared/src/server/otel/OtelIngestionProcessor.thoughts.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/otel/OtelIngestionProcessor.thoughts.test.ts:200-205
**Exercise the precedence guard**

This fixture places `thoughts_token_count` outside `usage_metadata`, so the extraction block containing the precedence guard is skipped. The test therefore continues passing if that guard is removed and cannot detect an overwrite regression.

```suggestion
        JSON.stringify({
          usage_metadata: {
            prompt_token_count: 50,
            candidates_token_count: 100,
            thoughts_token_count: 999, // ignored because the existing field takes precedence
            total_token_count: 192,
          },
        }),
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): extract gcp.vertex.agent thou..."](https://github.com/langfuse/langfuse/commit/bb354a7ab16955051ed45bf604eff9e585adc8e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54901875)</sub>

<!-- /greptile_comment -->