### PR TITLE
fix(analytics): cache backend activity hourly

### DIFF
--- a/web/src/__tests__/server/unit/backendActivity.servertest.ts
+++ b/web/src/__tests__/server/unit/backendActivity.servertest.ts
@@ -45,7 +45,7 @@ const createTracker = (
 };
 
 describe("backend activity tracking", () => {
-  it("deduplicates project activity within the one-hour cache window", async () => {
+  it("captures a project-scoped activity event once per UTC hour", async () => {
     const { capture, setIfAbsent, tracker } = createTracker();
 
     await tracker({
@@ -61,7 +61,7 @@ describe("backend activity tracking", () => {
 
     expect(setIfAbsent).toHaveBeenCalledOnce();
     expect(setIfAbsent).toHaveBeenCalledWith(
-      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
+      "langfuse:backend-activity:v2:2026-08-10T12:user-1:project:project-1",
       3_600,
     );
     expect(capture).toHaveBeenCalledOnce();
@@ -116,8 +116,8 @@ describe("backend activity tracking", () => {
     );
   });
 
-  it("captures the same project again after the one-hour cache expires", async () => {
-    let now = new Date("2026-08-10T12:00:00.000Z");
+  it("captures the same project again in the next UTC hour", async () => {
+    let now = new Date("2026-08-10T12:59:59.000Z");
     const capture = vi.fn();
     const setIfAbsent = vi.fn().mockResolvedValue(true);
     const tracker = createBackendActivityTracker({
@@ -132,13 +132,7 @@ describe("backend activity tracking", () => {
       organizationId: "org-1",
       projectId: "project-1",
     });
-    now = new Date("2026-08-10T12:59:59.000Z");
-    await tracker({
-      userId: "user-1",
-      organizationId: "org-1",
-      projectId: "project-1",
-    });
-    now = new Date("2026-08-10T13:00:00.000Z");
+    now = new Date("2026-08-10T13:00:01.000Z");
     await tracker({
       userId: "user-1",
       organizationId: "org-1",
@@ -148,12 +142,12 @@ describe("backend activity tracking", () => {
     expect(setIfAbsent).toHaveBeenCalledTimes(2);
     expect(setIfAbsent).toHaveBeenNthCalledWith(
       1,
-      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
+      "langfuse:backend-activity:v2:2026-08-10T12:user-1:project:project-1",
       3_600,
     );
     expect(setIfAbsent).toHaveBeenNthCalledWith(
       2,
-      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
+      "langfuse:backend-activity:v2:2026-08-10T13:user-1:project:project-1",
       3_600,
     );
     expect(capture).toHaveBeenCalledTimes(2);

--- a/web/src/__tests__/server/unit/backendActivity.servertest.ts
+++ b/web/src/__tests__/server/unit/backendActivity.servertest.ts
@@ -45,7 +45,7 @@ const createTracker = (
 };
 
 describe("backend activity tracking", () => {
-  it("captures a project-scoped activity event once per UTC hour", async () => {
+  it("deduplicates project activity within the one-hour cache window", async () => {
     const { capture, setIfAbsent, tracker } = createTracker();
 
     await tracker({
@@ -61,7 +61,7 @@ describe("backend activity tracking", () => {
 
     expect(setIfAbsent).toHaveBeenCalledOnce();
     expect(setIfAbsent).toHaveBeenCalledWith(
-      "langfuse:backend-activity:2026-08-10T12:user-1:project:project-1",
+      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
       3_600,
     );
     expect(capture).toHaveBeenCalledOnce();
@@ -116,8 +116,8 @@ describe("backend activity tracking", () => {
     );
   });
 
-  it("captures the same project again in the next UTC hour", async () => {
-    let now = new Date("2026-08-10T12:59:59.000Z");
+  it("captures the same project again after the one-hour cache expires", async () => {
+    let now = new Date("2026-08-10T12:00:00.000Z");
     const capture = vi.fn();
     const setIfAbsent = vi.fn().mockResolvedValue(true);
     const tracker = createBackendActivityTracker({
@@ -132,7 +132,13 @@ describe("backend activity tracking", () => {
       organizationId: "org-1",
       projectId: "project-1",
     });
-    now = new Date("2026-08-10T13:00:01.000Z");
+    now = new Date("2026-08-10T12:59:59.000Z");
+    await tracker({
+      userId: "user-1",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+    now = new Date("2026-08-10T13:00:00.000Z");
     await tracker({
       userId: "user-1",
       organizationId: "org-1",
@@ -142,12 +148,12 @@ describe("backend activity tracking", () => {
     expect(setIfAbsent).toHaveBeenCalledTimes(2);
     expect(setIfAbsent).toHaveBeenNthCalledWith(
       1,
-      "langfuse:backend-activity:2026-08-10T12:user-1:project:project-1",
+      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
       3_600,
     );
     expect(setIfAbsent).toHaveBeenNthCalledWith(
       2,
-      "langfuse:backend-activity:2026-08-10T13:user-1:project:project-1",
+      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
       3_600,
     );
     expect(capture).toHaveBeenCalledTimes(2);

--- a/web/src/__tests__/server/unit/backendActivity.servertest.ts
+++ b/web/src/__tests__/server/unit/backendActivity.servertest.ts
@@ -45,7 +45,7 @@ const createTracker = (
 };
 
 describe("backend activity tracking", () => {
-  it("captures a project-scoped activity event once per UTC day", async () => {
+  it("captures a project-scoped activity event once per UTC hour", async () => {
     const { capture, setIfAbsent, tracker } = createTracker();
 
     await tracker({
@@ -61,8 +61,8 @@ describe("backend activity tracking", () => {
 
     expect(setIfAbsent).toHaveBeenCalledOnce();
     expect(setIfAbsent).toHaveBeenCalledWith(
-      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
-      172_800,
+      "langfuse:backend-activity:2026-08-10T12:user-1:project:project-1",
+      3_600,
     );
     expect(capture).toHaveBeenCalledOnce();
     expect(capture).toHaveBeenCalledWith({
@@ -116,8 +116,8 @@ describe("backend activity tracking", () => {
     );
   });
 
-  it("captures the same project again on the next UTC day", async () => {
-    let now = new Date("2026-08-10T23:59:59.000Z");
+  it("captures the same project again in the next UTC hour", async () => {
+    let now = new Date("2026-08-10T12:59:59.000Z");
     const capture = vi.fn();
     const setIfAbsent = vi.fn().mockResolvedValue(true);
     const tracker = createBackendActivityTracker({
@@ -132,7 +132,7 @@ describe("backend activity tracking", () => {
       organizationId: "org-1",
       projectId: "project-1",
     });
-    now = new Date("2026-08-11T00:00:01.000Z");
+    now = new Date("2026-08-10T13:00:01.000Z");
     await tracker({
       userId: "user-1",
       organizationId: "org-1",
@@ -142,13 +142,13 @@ describe("backend activity tracking", () => {
     expect(setIfAbsent).toHaveBeenCalledTimes(2);
     expect(setIfAbsent).toHaveBeenNthCalledWith(
       1,
-      "langfuse:backend-activity:2026-08-10:user-1:project:project-1",
-      172_800,
+      "langfuse:backend-activity:2026-08-10T12:user-1:project:project-1",
+      3_600,
     );
     expect(setIfAbsent).toHaveBeenNthCalledWith(
       2,
-      "langfuse:backend-activity:2026-08-11:user-1:project:project-1",
-      172_800,
+      "langfuse:backend-activity:2026-08-10T13:user-1:project:project-1",
+      3_600,
     );
     expect(capture).toHaveBeenCalledTimes(2);
   });

--- a/web/src/features/posthog-analytics/server/backendActivity.ts
+++ b/web/src/features/posthog-analytics/server/backendActivity.ts
@@ -26,29 +26,14 @@ export const createBackendActivityTracker = ({
   now,
   setIfAbsent,
 }: BackendActivityTrackerDependencies) => {
-  const localCache = new Map<string, number>();
+  const localCache = new Set<string>();
 
-  const isCachedLocally = (key: string, timestamp: Date) => {
-    const expiresAt = localCache.get(key);
-    if (expiresAt === undefined) return false;
-
-    if (timestamp.getTime() >= expiresAt) {
-      localCache.delete(key);
-      return false;
-    }
-
-    return true;
-  };
-
-  const cacheLocally = (key: string, timestamp: Date) => {
+  const cacheLocally = (key: string) => {
     if (localCache.size >= LOCAL_CACHE_MAX_ENTRIES) {
-      const oldestKey = localCache.keys().next().value;
+      const oldestKey = localCache.values().next().value;
       if (oldestKey) localCache.delete(oldestKey);
     }
-    localCache.set(
-      key,
-      timestamp.getTime() + DEDUPLICATION_TTL_SECONDS * 1_000,
-    );
+    localCache.add(key);
   };
 
   return async ({
@@ -61,22 +46,21 @@ export const createBackendActivityTracker = ({
     const timestamp = now();
     const activityScope = projectId ? "project" : "organization";
     const scopeId = projectId ?? organizationId;
-    // Keep the existing key format so old and new web instances share the
-    // Redis lock during rolling deployments. The TTL owns the cache window.
-    const utcDate = timestamp.toISOString().slice(0, 10);
+    const utcHour = timestamp.toISOString().slice(0, 13);
     const deduplicationKey = [
       "langfuse",
       "backend-activity",
-      utcDate,
+      "v2",
+      utcHour,
       userId,
       activityScope,
       scopeId,
     ].join(":");
 
-    if (isCachedLocally(deduplicationKey, timestamp)) return;
+    if (localCache.has(deduplicationKey)) return;
     // Mark the attempt before the first await so concurrent requests and Redis
     // outages cannot create an analytics retry storm in this web process.
-    cacheLocally(deduplicationKey, timestamp);
+    cacheLocally(deduplicationKey);
 
     try {
       const isFirstActivity = await setIfAbsent(

--- a/web/src/features/posthog-analytics/server/backendActivity.ts
+++ b/web/src/features/posthog-analytics/server/backendActivity.ts
@@ -4,7 +4,7 @@ import { env } from "@/src/env.mjs";
 import { ServerPosthog } from "@/src/features/posthog-analytics/ServerPosthog";
 
 const BACKEND_ACTIVITY_EVENT = "backend:activity";
-const DEDUPLICATION_TTL_SECONDS = 2 * 24 * 60 * 60;
+const DEDUPLICATION_TTL_SECONDS = 60 * 60;
 const LOCAL_CACHE_MAX_ENTRIES = 100_000;
 
 type BackendActivity = {
@@ -46,11 +46,11 @@ export const createBackendActivityTracker = ({
     const timestamp = now();
     const activityScope = projectId ? "project" : "organization";
     const scopeId = projectId ?? organizationId;
-    const utcDate = timestamp.toISOString().slice(0, 10);
+    const utcHour = timestamp.toISOString().slice(0, 13);
     const deduplicationKey = [
       "langfuse",
       "backend-activity",
-      utcDate,
+      utcHour,
       userId,
       activityScope,
       scopeId,

--- a/web/src/features/posthog-analytics/server/backendActivity.ts
+++ b/web/src/features/posthog-analytics/server/backendActivity.ts
@@ -26,14 +26,29 @@ export const createBackendActivityTracker = ({
   now,
   setIfAbsent,
 }: BackendActivityTrackerDependencies) => {
-  const localCache = new Set<string>();
+  const localCache = new Map<string, number>();
 
-  const cacheLocally = (key: string) => {
+  const isCachedLocally = (key: string, timestamp: Date) => {
+    const expiresAt = localCache.get(key);
+    if (expiresAt === undefined) return false;
+
+    if (timestamp.getTime() >= expiresAt) {
+      localCache.delete(key);
+      return false;
+    }
+
+    return true;
+  };
+
+  const cacheLocally = (key: string, timestamp: Date) => {
     if (localCache.size >= LOCAL_CACHE_MAX_ENTRIES) {
-      const oldestKey = localCache.values().next().value;
+      const oldestKey = localCache.keys().next().value;
       if (oldestKey) localCache.delete(oldestKey);
     }
-    localCache.add(key);
+    localCache.set(
+      key,
+      timestamp.getTime() + DEDUPLICATION_TTL_SECONDS * 1_000,
+    );
   };
 
   return async ({
@@ -46,20 +61,22 @@ export const createBackendActivityTracker = ({
     const timestamp = now();
     const activityScope = projectId ? "project" : "organization";
     const scopeId = projectId ?? organizationId;
-    const utcHour = timestamp.toISOString().slice(0, 13);
+    // Keep the existing key format so old and new web instances share the
+    // Redis lock during rolling deployments. The TTL owns the cache window.
+    const utcDate = timestamp.toISOString().slice(0, 10);
     const deduplicationKey = [
       "langfuse",
       "backend-activity",
-      utcHour,
+      utcDate,
       userId,
       activityScope,
       scopeId,
     ].join(":");
 
-    if (localCache.has(deduplicationKey)) return;
+    if (isCachedLocally(deduplicationKey, timestamp)) return;
     // Mark the attempt before the first await so concurrent requests and Redis
     // outages cannot create an analytics retry storm in this web process.
-    cacheLocally(deduplicationKey);
+    cacheLocally(deduplicationKey, timestamp);
 
     try {
       const isFirstActivity = await setIfAbsent(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16332.preview.langfuse.com](https://pr-16332.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- move backend activity deduplication to versioned v2 Redis keys with UTC-hour buckets
- expire Redis deduplication keys after one hour
- cover same-hour suppression and next-hour capture behavior

## Why

Backend activity events were deduplicated per UTC day with a 48-hour Redis TTL. Versioned hourly keys let PostHog observe activity once per user and scope each hour without adding local cache-expiration machinery.

During a rolling deployment, old and v2 instances may each emit the event once because their key formats intentionally differ. This temporary analytics duplication is an accepted tradeoff for the simpler cache migration.

## Impacted package

- web

## Verification

- `pnpm exec dotenv -e .env.dev.example -- pnpm --filter web run test src/__tests__/server/unit/backendActivity.servertest.ts`
- `pnpm exec dotenv -e .env.dev.example -- pnpm run lint`
- `git diff --check`