### PR TITLE
fix(analytics): emit cloud_signup_complete on all production cloud regions

### DIFF
--- a/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
+++ b/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
@@ -281,10 +281,14 @@ export async function createProjectMembershipsOnSignup(
     }
 
     // for conversion metric tracking in posthog: did a new user sign up?
+    // Fires on all production cloud regions (matching the signup webhook's
+    // gating); STAGING/DEV are excluded to keep test signups out of
+    // conversion metrics, and self-hosted deployments never emit this event
+    // as the region env is unset.
     if (
       isNewUser &&
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
-      ["EU", "US"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
+      !["STAGING", "DEV"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
     ) {
       try {
         const posthog = new ServerPosthog();

--- a/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
+++ b/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
@@ -281,14 +281,17 @@ export async function createProjectMembershipsOnSignup(
     }
 
     // for conversion metric tracking in posthog: did a new user sign up?
-    // Fires on all production cloud regions (matching the signup webhook's
-    // gating); STAGING/DEV are excluded to keep test signups out of
-    // conversion metrics, and self-hosted deployments never emit this event
-    // as the region env is unset.
+    // Fires on all production cloud regions, including ones added in the
+    // future. STAGING/DEV are excluded to keep test signups out of
+    // conversion metrics, HIPAA is excluded deliberately to keep product
+    // analytics off that deployment, and self-hosted deployments never emit
+    // this event as the region env is unset.
     if (
       isNewUser &&
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
-      !["STAGING", "DEV"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
+      !["STAGING", "DEV", "HIPAA"].includes(
+        env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+      )
     ) {
       try {
         const posthog = new ServerPosthog();


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16338.preview.langfuse.com](https://pr-16338.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

The server-side `cloud_signup_complete` PostHog event — the canonical signup conversion metric — was gated to `["EU", "US"]`, silently excluding the JP region. This flips the allowlist to an exclude-list (`!["STAGING", "DEV", "HIPAA"]`), so JP and any future cloud regions are tracked automatically. Self-hosted deployments remain unaffected (region env is unset → no event).

## Why this looks like an oversight, not a decision

- The allowlist was introduced in #11482 (**Jan 9, 2026**) as part of fixing the then-broken server-side PostHog init; the PR description documents no rationale for excluding regions beyond STAGING/DEV.
- The **JP region only launched Mar 12, 2026** (#12558) — two months *after* the allowlist was written. JP could never have been considered; production data confirms JP has never emitted a single signup event.
- The same signup flow's `LANGFUSE_NEW_USER_SIGNUP_WEBHOOK` excludes only STAGING/DEV — so JP signups fire the webhook but silently vanish from analytics.

## Region policy (now explicit in a code comment)

- **Tracked:** EU, US, JP, and any future production region by default.
- **Excluded:** STAGING/DEV (test signups), and **HIPAA — deliberately**, to keep product analytics signup events off that deployment.

## Impact (production PostHog data, last 30 days)

- JP users are fully present in client-side analytics — **5,775 active users** (~6% of cloud actives) — but never emit a signup event.
- This skews every consumer of `cloud_signup_complete`: 12+ saved insights (signup counts, visitor→signup conversion, signup→activation funnels, onboarding email rates), the signup→active conversion rate (numerator includes JP activity, denominator doesn't → reads too high), and the Google Ads conversion sync.

Expect a step-change in signup metrics when this deploys (JP signups appearing); consider a PostHog annotation on the deploy date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands the `cloud_signup_complete` analytics event from an EU/US allowlist to all validated production cloud regions except HIPAA, while continuing to exclude staging, development, and self-hosted deployments.
- Adds JP signup conversion tracking.
- Uses an exclusion list so future production regions can be tracked by default.
- Documents the intended deployment-region policy inline.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because validated non-production and HIPAA regions remain excluded while JP is intentionally added to signup conversion tracking.

The region environment variable is constrained to a closed enum, self-hosted installations leave it unset, preview deployments use DEV, and the changed condition therefore reaches only the intended non-excluded production regions.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(analytics): keep HIPAA excluded from..."](https://github.com/langfuse/langfuse/commit/550fff4daa39ff8079c1c3deb9757b092fc2522a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55073782)</sub>

**Context used:**

- Knowledge Base — [Authentication, Multi-Tenancy, and RBAC](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/auth-rbac.md)

<!-- /greptile_comment -->