### PR TITLE
fix(traces): preserve search in annotation queue batch actions

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -105,6 +105,7 @@ import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTabl
 import { useScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
 import TagList from "@/src/features/tag/components/TagList";
+import { buildTraceBatchActionQuery } from "@/src/features/traces/fns/buildTraceBatchActionQuery";
 
 export type TracesTableRow = {
   // Shown by default
@@ -580,12 +581,12 @@ export default function TracesTable({
     await traceDeleteMutation.mutateAsync({
       projectId,
       traceIds: selectedTraceIds,
-      query: {
+      query: buildTraceBatchActionQuery({
         filter: filterState,
         orderBy: orderByState,
-        searchQuery: searchQuery || undefined,
+        searchQuery,
         searchType,
-      },
+      }),
       isBatchAction: selectAll,
     });
     setSelectedRows({});
@@ -608,10 +609,12 @@ export default function TracesTable({
       objectType: AnnotationQueueObjectType.TRACE,
       queueId: targetId,
       isBatchAction: selectAll,
-      query: {
+      query: buildTraceBatchActionQuery({
         filter: filterState,
         orderBy: orderByState,
-      },
+        searchQuery,
+        searchType,
+      }),
     });
     setSelectedRows({});
   };

--- a/web/src/features/traces/fns/buildTraceBatchActionQuery.clienttest.ts
+++ b/web/src/features/traces/fns/buildTraceBatchActionQuery.clienttest.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildTraceBatchActionQuery } from "./buildTraceBatchActionQuery";
+
+describe("buildTraceBatchActionQuery", () => {
+  it("preserves the active full-text search for select-all actions", () => {
+    const query = buildTraceBatchActionQuery({
+      filter: [],
+      orderBy: { column: "timestamp", order: "DESC" },
+      searchQuery: "customer-ref",
+      searchType: ["id", "content"],
+    });
+
+    expect(query).toEqual({
+      filter: [],
+      orderBy: { column: "timestamp", order: "DESC" },
+      searchQuery: "customer-ref",
+      searchType: ["id", "content"],
+    });
+  });
+
+  it("omits an empty search query", () => {
+    const query = buildTraceBatchActionQuery({
+      filter: [],
+      orderBy: null,
+      searchQuery: "",
+      searchType: ["id"],
+    });
+
+    expect(query).toEqual({
+      filter: [],
+      orderBy: null,
+      searchQuery: undefined,
+      searchType: ["id"],
+    });
+  });
+});

--- a/web/src/features/traces/fns/buildTraceBatchActionQuery.ts
+++ b/web/src/features/traces/fns/buildTraceBatchActionQuery.ts
@@ -1,0 +1,27 @@
+import type {
+  BatchActionQuery,
+  FilterState,
+  OrderByState,
+  TracingSearchType,
+} from "@langfuse/shared";
+
+type BuildTraceBatchActionQueryInput = {
+  filter: FilterState;
+  orderBy: OrderByState;
+  searchQuery?: string | null;
+  searchType: TracingSearchType[];
+};
+
+export function buildTraceBatchActionQuery({
+  filter,
+  orderBy,
+  searchQuery,
+  searchType,
+}: BuildTraceBatchActionQueryInput): BatchActionQuery {
+  return {
+    filter,
+    orderBy,
+    searchQuery: searchQuery || undefined,
+    searchType,
+  };
+}


### PR DESCRIPTION
## What does this PR do?

Preserves the active trace full-text search when "Select all items across pages" is used to add traces to an annotation queue.

This centralizes trace batch-action query construction so deletion and annotation-queue actions keep the same `filter`, `orderBy`, `searchQuery`, and `searchType` contract.

Fixes #16237

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] I have self-reviewed the code.

## Verification

- `pnpm --filter web run test-client src/features/traces/fns/buildTraceBatchActionQuery.clienttest.ts` - `Tests  2 passed (2)`
- Targeted ESLint for the three changed files - passed
- Prettier check for the three changed files - `All matched files use Prettier code style!`
- `git diff --check` - passed

The full web lint does not pass in this local environment: `441 problems (0 errors, 441 warnings)` are reported outside the changed files. The changed files pass targeted ESLint.

The full web typecheck does not pass in this local environment because of unrelated Prisma/shared typing errors; no errors were reported in the changed files.

Browser verification was not run because Docker and a local Langfuse stack were unavailable.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes trace batch-action query construction and preserves active full-text search criteria when selecting all matching traces for an annotation queue.

- Adds a shared helper carrying `filter`, `orderBy`, `searchQuery`, and `searchType`.
- Uses the helper for trace deletion and annotation-queue batch actions.
- Adds focused tests for active and empty search queries.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The shared helper preserves the existing trace-deletion query behavior, and the newly forwarded annotation-queue search fields are accepted and consistently consumed by the existing batch-action pipeline.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): preserve search in annotati..."](https://github.com/langfuse/langfuse/commit/ebccf36cd237fb68a30ac6809ef37ee241d9779b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55075052)</sub>

**Context used:**

- Knowledge Base — [Batch Actions and Data Exports](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/batch-actions-exports.md)

<!-- /greptile_comment -->