### PR TITLE
ci(assistant): Publish sandbox image during cloud releases

### DIFF
--- a/.github/workflows/build-sandbox-microvm-image.yml
+++ b/.github/workflows/build-sandbox-microvm-image.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - production
     paths:
       - packages/in-app-agent-sandbox-runtime/**
 
@@ -39,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: ${{ fromJSON(github.event_name == 'push' && '["staging"]' || inputs.environment == 'all-production' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || format('["{0}"]', inputs.environment)) }}
+        environment: ${{ fromJSON(github.event_name == 'push' && github.ref == 'refs/heads/main' && '["staging"]' || github.event_name == 'push' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || inputs.environment == 'all-production' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || format('["{0}"]', inputs.environment)) }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_MICROVM_BUILD_ROLE_ARN: ${{ vars.AWS_MICROVM_BUILD_ROLE_ARN }}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16342.preview.langfuse.com](https://pr-16342.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Publishes the in-app agent sandbox MicroVM image to every production environment when the sandbox runtime changes reach the `production` branch. The existing path filter keeps cloud releases without runtime changes from rebuilding the image, while `main` changes continue to publish only to staging.

Impacted package: CI workflow for `@repo/in-app-agent-sandbox-runtime`.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm run lint` (pre-commit hook)
- Workflow syntax validation with actionlint
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15359](https://linear.app/clickhouse/issue/LFE-15359/include-sandbox-image-build-in-cloud-release-ci)

<div><a href="https://cursor.com/agents/bc-4ca367af-ee72-4920-b671-8156af18d8a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca367af-ee72-4920-b671-8156af18d8a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the sandbox MicroVM image workflow to production releases while preserving staging-only publication from `main`.

- Adds `production` as a path-filtered push trigger.
- Maps `main` pushes to staging and production pushes to all four production environments.
- Preserves existing manual dispatch behavior for individual and all-production targets.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with production and staging push events mapped to their intended publication targets.

The workflow continues to publish `main` changes only to staging, while matching sandbox runtime changes promoted to `production` now publish to the existing four-environment production matrix without altering manual dispatch semantics.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): publish sandbox image during c..."](https://github.com/langfuse/langfuse/commit/3d16f3fa611c3898e8c13fcae0589ade3fd36375) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55078741)</sub>

<!-- /greptile_comment -->