### PR TITLE
ci: run azure and redis-cluster deploy modes only where they matter

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -100,6 +100,57 @@ jobs:
               - 'packages/shared/src/server/llm/**'
               - 'worker/src/__tests__/llmConnections.test.ts'
 
+  # Resolves the deploy-mode fan-out for tests-web and tests-worker. The
+  # -azure and -redis-cluster shards replay both suites end to end against a
+  # different blob store and Redis topology, which triples the cost of the two
+  # most expensive jobs in this pipeline (~$600/month, of which ~$400 is spent
+  # on pull requests) for a narrow slice of extra coverage. Non-PR events
+  # (merge queue, main, v3, tags) always run all three modes, so nothing lands
+  # untested; pull requests pay for the extra modes only when they touch the
+  # code those modes exercise. About 1 in 8 commits does, so most PRs go from
+  # six mode shards to two. This job costs ~10s of wall clock ahead of the two
+  # test jobs, which fits inside test-docker-build's runtime.
+  deploy-mode-filter:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      modes: ${{ steps.select.outputs.modes }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name == 'pull_request'
+        with:
+          # Recommended for paths-filter action
+          # may save additional git fetch roundtrip if
+          # merge-base is found within latest N commits
+          fetch-depth: 20
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            deploy_modes:
+              - '.github/workflows/pipeline.yml'
+              - '.env.dev*.example'
+              - 'docker-compose.dev*.yml'
+              - 'packages/shared/src/server/redis/**'
+              - 'packages/shared/src/server/queues.ts'
+              - 'packages/shared/src/server/services/StorageService*'
+      - id: select
+        # Anything that is not a pull request runs the full matrix, including
+        # the merge queue that gates main.
+        env:
+          ALL_MODES: ${{ github.event_name != 'pull_request' || steps.filter.outputs.deploy_modes == 'true' }}
+        run: |
+          if [[ "$ALL_MODES" == "true" ]]; then
+            echo 'modes=["", "-azure", "-redis-cluster"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'modes=[""]' >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     timeout-minutes: 12
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -558,9 +609,10 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404
     needs:
       - pre-job
+      - deploy-mode-filter
     # pre-job only runs on push events; everywhere else it resolves as skipped
-    # at run creation, so this job starts immediately (!cancelled() lets the
-    # condition evaluate despite the skipped dependency).
+    # at run creation, so only deploy-mode-filter (~10s) gates this job
+    # (!cancelled() lets the condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
     name: tests-web (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.deploy-mode }})
     env:
@@ -569,7 +621,10 @@ jobs:
       matrix:
         node-version: [24]
         postgres-version: [15]
-        deploy-mode: ["", "-azure", "-redis-cluster"]
+        # ["", "-azure", "-redis-cluster"] on every non-PR event and on PRs
+        # that touch blob storage, Redis, or queue config; [""] otherwise.
+        # See the deploy-mode-filter job for the reasoning.
+        deploy-mode: ${{ fromJSON(needs.deploy-mode-filter.outputs.modes) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -613,6 +668,8 @@ jobs:
         run: |
           pnpm install
       - name: Load default env
+        env:
+          DEPLOY_MODE: ${{ matrix.deploy-mode }}
         run: |
           write_test_env() {
             {
@@ -632,7 +689,7 @@ jobs:
           # Compile once under the default test environment. Next's generate
           # phase below reapplies the mode-specific config and prerendering.
           write_test_env .env.dev.example .env
-          write_test_env .env.dev${{ matrix.deploy-mode }}.example .env.runtime
+          write_test_env ".env.dev${DEPLOY_MODE}.example" .env.runtime
       - name: Setup Turbo cache
         if: env.CI_CACHE_ALLOWED == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # zizmor: ignore[cache-poisoning] test job cache only; publish jobs rebuild artifacts and do not restore this cache
@@ -648,8 +705,9 @@ jobs:
         # Independent of the build, so let the build overlap the ~15-20s
         # container startup. "Wait for dev containers" collects the result.
         run: |
-          (set +e; docker compose --env-file .env.runtime -f docker-compose.dev${{ matrix.deploy-mode }}.yml up -d --wait --wait-timeout 180 > /tmp/compose-up.log 2>&1; echo $? > /tmp/compose-up.exit) &
+          (set +e; docker compose --env-file .env.runtime -f "docker-compose.dev${DEPLOY_MODE}.yml" up -d --wait --wait-timeout 180 > /tmp/compose-up.log 2>&1; echo $? > /tmp/compose-up.exit) &
         env:
+          DEPLOY_MODE: ${{ matrix.deploy-mode }}
           POSTGRES_VERSION: ${{ matrix.postgres-version }}
       - name: Build
         run: pnpm turbo run build:test
@@ -666,11 +724,13 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           NEXT_IGNORE_BUILD_ERRORS: "true"
       - name: Wait for dev containers
+        env:
+          DEPLOY_MODE: ${{ matrix.deploy-mode }}
         run: |
           timeout 300 bash -c 'until [ -f /tmp/compose-up.exit ]; do sleep 1; done' \
             || { echo "Timed out waiting for background docker compose up"; cat /tmp/compose-up.log; exit 1; }
           cat /tmp/compose-up.log
-          docker compose --env-file .env.runtime -f docker-compose.dev${{ matrix.deploy-mode }}.yml ps
+          docker compose --env-file .env.runtime -f "docker-compose.dev${DEPLOY_MODE}.yml" ps
           exit "$(cat /tmp/compose-up.exit)"
       - name: Migrate DB
         run: |
@@ -766,9 +826,10 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
+      - deploy-mode-filter
     # pre-job only runs on push events; everywhere else it resolves as skipped
-    # at run creation, so this job starts immediately (!cancelled() lets the
-    # condition evaluate despite the skipped dependency).
+    # at run creation, so only deploy-mode-filter (~10s) gates this job
+    # (!cancelled() lets the condition evaluate despite the skipped dependency).
     if: ${{ !cancelled() && (github.event_name != 'push' || needs.pre-job.outputs.should_skip != 'true') }}
     name: tests-worker (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.deploy-mode }})
     env:
@@ -777,7 +838,8 @@ jobs:
       matrix:
         node-version: [24]
         postgres-version: [15]
-        deploy-mode: ["", "-azure", "-redis-cluster"]
+        # Same fan-out rule as tests-web; see the deploy-mode-filter job.
+        deploy-mode: ${{ fromJSON(needs.deploy-mode-filter.outputs.modes) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -816,15 +878,18 @@ jobs:
           sudo mv migrate /usr/bin/migrate
           which migrate
       - name: Load default env
+        env:
+          DEPLOY_MODE: ${{ matrix.deploy-mode }}
         run: |
-          cp .env.dev${{ matrix.deploy-mode }}.example .env
-          cp .env.dev${{ matrix.deploy-mode }}.example web/.env
-          cp .env.dev${{ matrix.deploy-mode }}.example worker/.env
+          cp ".env.dev${DEPLOY_MODE}.example" .env
+          cp ".env.dev${DEPLOY_MODE}.example" web/.env
+          cp ".env.dev${DEPLOY_MODE}.example" worker/.env
       - name: Run + migrate
         run: |
-          docker compose -f docker-compose.dev${{ matrix.deploy-mode }}.yml up -d --wait --wait-timeout 180
+          docker compose -f "docker-compose.dev${DEPLOY_MODE}.yml" up -d --wait --wait-timeout 180
           docker compose ps
         env:
+          DEPLOY_MODE: ${{ matrix.deploy-mode }}
           # Only start the extra floci container for default worker tests to avoid overhead elsewhere.
           COMPOSE_PROFILES: ${{ matrix.deploy-mode == '' && 'worker-tests' || '' }}
       - name: Ensure no unhealthy status

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -132,13 +132,23 @@ jobs:
         id: filter
         with:
           filters: |
+            # pnpm-lock.yaml is deliberately absent: a lockfile-only change
+            # means a transitive bump, and adding it would run the full matrix
+            # on every dependency PR. Direct bumps of @azure/storage-blob,
+            # ioredis, and bullmq all touch one of the manifests below, and the
+            # merge queue runs all three modes regardless.
             deploy_modes:
               - '.github/workflows/pipeline.yml'
               - '.env.dev*.example'
               - 'docker-compose.dev*.yml'
+              - 'packages/shared/src/env.ts'
               - 'packages/shared/src/server/redis/**'
               - 'packages/shared/src/server/queues.ts'
               - 'packages/shared/src/server/services/StorageService*'
+              - 'packages/shared/package.json'
+              - 'worker/src/env.ts'
+              - 'worker/package.json'
+              - 'web/package.json'
       - id: select
         # Anything that is not a pull request runs the full matrix, including
         # the merge queue that gates main.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16343.preview.langfuse.com](https://pr-16343.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

`tests-web` and `tests-worker` are the two most expensive jobs in `CI/CD`, and both fan out over `deploy-mode: ["", "-azure", "-redis-cluster"]`. The variant shards replay the whole suite end to end against a different blob store (Azurite instead of MinIO) and a 6-node Redis cluster instead of a single Redis. Measured over the last 30 days on Blacksmith:

| job | 30d cost | p50 |
| --- | --- | --- |
| tests-web × 3 modes | $604 | 194 / 195 / 198s |
| tests-worker × 3 modes | $307 | ~165s each |

That is $911/month, 37% of all Blacksmith spend for the org, and $600 of it is the two variant shards. The shards are perfectly duration-balanced, so there is no sharding imbalance to fix; the cost is pure fan-out. About 71% of `CI/CD` runs are `pull_request` events (71 of the last 100, vs 13 `merge_group` and 16 `push`).

A new `deploy-mode-filter` job resolves the mode list instead of hardcoding it:

```yaml
      - id: select
        # Anything that is not a pull request runs the full matrix, including
        # the merge queue that gates main.
        env:
          ALL_MODES: ${{ github.event_name != 'pull_request' || steps.filter.outputs.deploy_modes == 'true' }}
        run: |
          if [[ "$ALL_MODES" == "true" ]]; then
            echo 'modes=["", "-azure", "-redis-cluster"]' >> "$GITHUB_OUTPUT"
          else
            echo 'modes=[""]' >> "$GITHUB_OUTPUT"
          fi
```

which both jobs consume as `deploy-mode: ${{ fromJSON(needs.deploy-mode-filter.outputs.modes) }}`.

Every non-PR event (merge queue, `main`, `v3`, tags) keeps all three modes, so nothing reaches `main` without full coverage: the merge queue already re-runs this pipeline on the merge commit before it lands. Pull requests get the full fan-out only when they touch the code those modes exercise, via `dorny/paths-filter` on `packages/shared/src/server/redis/**`, `queues.ts`, `StorageService*`, the `env.ts` schemas that own `REDIS_CLUSTER_*` and `LANGFUSE_USE_AZURE_BLOB`, the `package.json` manifests that pin `@azure/storage-blob`/`ioredis`/`bullmq`, `.env.dev*.example`, `docker-compose.dev*.yml`, and this workflow. `pnpm-lock.yaml` is deliberately excluded: a lockfile-only diff is a transitive bump, and including it would restore the full matrix on every dependency PR. `redis/**` is deliberately the whole directory: a new queue that is not cluster-safe (missing hash tag) only breaks in cluster mode. Over the last 100 commits on `main`, 12 touched that set, so roughly 7 of 8 PRs drop from six mode shards to two.

Two things worth doubting:

- **Wall clock.** `deploy-mode-filter` is a new gate in front of the pipeline's longest job. The comparable existing `llm-connections-filter` runs in 7-9s p50, and it skips both checkout and the filter on non-PR events. `test-docker-build` is p50 197s against `tests-web` p50 194s, so ~10s of gate should stay inside the existing critical path, but it is not free and it is the main argument against this change.
- **Feedback timing.** For the ~1 in 8 PRs the filter misses in some way, an azure/redis regression surfaces in the merge queue rather than on the PR, which bounces the PR out of the queue instead of failing its own checks.

Since matrix values now come from a job output, zizmor stops treating `matrix.deploy-mode` as a known-safe literal and flags all seven `${{ matrix.deploy-mode }}` expansions inside `run:` blocks as `template-injection` (the `zizmor` job runs at `min-severity: low`). Those are now passed through a `DEPLOY_MODE` env var, which is zizmor's own suggested fix.

Checks run locally: `actionlint` on `pipeline.yml` clean (runner-label warnings for `blacksmith-*` suppressed, no `actionlint.yaml` in the repo), and `zizmor .github/workflows/pipeline.yml` → `No findings to report. Good job! (17 ignored, 29 suppressed)`, matching the base branch's zero findings. Nothing else here is testable outside CI. Note that this PR edits `pipeline.yml`, which is in the filter list, so its own run exercises the full three-mode path; the reduced path is first exercised by the next unrelated PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces CI fan-out by dynamically selecting deploy modes for the web and worker test matrices while preserving full coverage for non-PR events and relevant pull requests.
- Adds a path-based deploy-mode filter job.
- Runs only the default mode for unrelated pull requests.
- Retains default, Azure, and Redis-cluster modes for matching changes and non-PR events.
- Moves dynamic matrix values into step environment variables before shell interpolation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The filter produces valid mode arrays for supported workflow events, non-PR runs retain the full matrix, and the changed shell commands preserve their previous deploy-mode values and file selection.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  E[Workflow event] --> P{Pull request?}
  P -->|No| F[All deploy modes]
  P -->|Yes| C[Check mode-sensitive paths]
  C -->|Matched| F
  C -->|Not matched| D[Default deploy mode only]
  F --> W[tests-web and tests-worker]
  D --> W
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run azure and redis-cluster deploy m..."](https://github.com/langfuse/langfuse/commit/f5b26aec2a93ba278dcb17a1572b7131354abce5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55080061)</sub>

<!-- /greptile_comment -->
