### PR TITLE
fix(assistant): prefer MCP tools for data analysis

### DIFF
--- a/packages/shared/src/in-app-agent/server/systemPrompt.ts
+++ b/packages/shared/src/in-app-agent/server/systemPrompt.ts
@@ -28,6 +28,7 @@ IMPORTANT: You should NOT answer with unnecessary preamble or postamble (such as
 </behavioral_rules>
 
 <tools>
+Prefer Langfuse MCP tools over sandbox tools whenever an MCP tool can perform the task, especially the metrics tools for aggregations.
 Use the docs tools to find relevant general information about Langfuse or best practices.
 For questions about best practices or specific workflows (e.g. setting up evals), use the available Langfuse skills when they apply.
 If the skill ever tells you to reference the docs, always use the langfuse-docs-mcp server to access those docs.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16344.preview.langfuse.com](https://pr-16344.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates the in-app agent system prompt to prefer Langfuse MCP tools whenever they can perform the task, explicitly calling out metrics tools for aggregations. This keeps data analysis in the purpose-built tools instead of attempting it through the sandbox.

Impacted package: `@langfuse/shared`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- [x] Commit hooks: Prettier and repository lint (`Tasks: 7 successful, 7 total`)
- [x] `pnpm --filter worker run test agent.test.ts` (`Tests 33 passed (33)`)

## What to doubt in review

- The wording intentionally establishes preference rather than forbidding sandbox use, so the agent can still process files or MCP results there when appropriate.
- Production uses the managed prompt; deployment must sync this canonical template to prompt management.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15358](https://linear.app/clickhouse/issue/LFE-15358/agent-should-prefer-mcp-over-sandbox)

<div><a href="https://cursor.com/agents/bc-b769e271-3191-40af-bcb2-bbe7d4236ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b769e271-3191-40af-bcb2-bbe7d4236ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the in-app agent system prompt to prefer purpose-built Langfuse MCP tools over sandbox tools when either can perform a task, with particular emphasis on metrics aggregations.
- Adds a single tool-selection instruction to the shared in-app agent prompt.
- Leaves tool registration, authorization, approvals, and runtime enforcement unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The change only adjusts model guidance toward existing MCP tools and does not alter tool availability, authorization, runtime execution, or persisted contracts.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): prefer MCP tools for data an..."](https://github.com/langfuse/langfuse/commit/06cc23cd55ea9db73d9d08a5d3055f29012a8da6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55092383)</sub>

<!-- /greptile_comment -->