### PR TITLE
chore(web): enforce test story conventions

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -9,6 +9,7 @@ import { default as requireTitleWithTruncate } from "./rules/require-title-with-
 import { default as noStyleProps } from "./rules/no-style-props.js";
 import { default as noSwitchStatements } from "./rules/no-switch-statements.js";
 import { default as noUnnecessaryCn } from "./rules/no-unnecessary-cn.js";
+import { default as storybookPlayRequiresTestName } from "./rules/storybook-play-requires-test-name.js";
 
 const plugin = {
   rules: {
@@ -23,6 +24,7 @@ const plugin = {
     "no-tailwind-overflow-scroll": noTailwindOverflowScroll,
     "no-unnecessary-cn": noUnnecessaryCn,
     "require-title-with-truncate": requireTitleWithTruncate,
+    "storybook-play-requires-test-name": storybookPlayRequiresTestName,
   },
 };
 

--- a/packages/eslint-plugin/src/rules/storybook-play-requires-test-name.test.ts
+++ b/packages/eslint-plugin/src/rules/storybook-play-requires-test-name.test.ts
@@ -1,0 +1,68 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as typescriptEslintParser from "@typescript-eslint/parser";
+import rule from "./storybook-play-requires-test-name.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptEslintParser,
+  },
+});
+
+ruleTester.run("storybook-play-requires-test-name", rule, {
+  valid: [
+    `export const Default = meta.story({ args: {} });`,
+    `const helper = { play: async () => {} };`,
+    `export const Default = meta.story({ nested: { play: async () => {} } });`,
+    `export const Default = meta.story({ 1: "one" });`,
+    `export const Interaction = other.factory({ play: async () => {} });`,
+    `export const Interaction = meta.story({
+      name: "(Test) Opens menu",
+      play: async () => {},
+    });`,
+    `export const Interaction = meta.story({
+      "name": "(Test) Opens menu",
+      "play": async () => {},
+    });`,
+    `export const Interaction = meta.story({
+      ["play"]: async () => {},
+    });`,
+    `export const Interaction = {
+      name: "(Test) Opens menu",
+      play: async () => {},
+    };`,
+  ],
+  invalid: [
+    {
+      code: `export const OpensMenu = meta.story({ play: async () => {} });`,
+      errors: [{ messageId: "testNameRequired" }],
+    },
+    {
+      code: `export const OpensMenu = meta.story({
+        name: "Opens menu",
+        play: async () => {},
+      });`,
+      errors: [{ messageId: "testNameRequired" }],
+    },
+    {
+      code: `export const OpensMenu = {
+        name: "Test Opens menu",
+        play: async () => {},
+      };`,
+      errors: [{ messageId: "testNameRequired" }],
+    },
+    {
+      code: `export const OpensMenu = meta.story({
+        name: \`(Test) Opens menu\`,
+        play: async () => {},
+      });`,
+      errors: [{ messageId: "testNameRequired" }],
+    },
+    {
+      code: `export const OpensMenu = meta.story({
+        name: 42,
+        play: async () => {},
+      });`,
+      errors: [{ messageId: "testNameRequired" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/storybook-play-requires-test-name.ts
+++ b/packages/eslint-plugin/src/rules/storybook-play-requires-test-name.ts
@@ -1,0 +1,88 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../util.js";
+
+const TEST_STORY_PREFIX = "(Test)";
+
+function getPropertyName(property: TSESTree.Property): string | null {
+  if (property.computed) return null;
+  if (property.key.type === AST_NODE_TYPES.Identifier) return property.key.name;
+  if (
+    property.key.type === AST_NODE_TYPES.Literal &&
+    typeof property.key.value === "string"
+  ) {
+    return property.key.value;
+  }
+  return null;
+}
+
+function isStoryObject(node: TSESTree.ObjectExpression): boolean {
+  const parent = node.parent;
+
+  if (
+    parent.type === AST_NODE_TYPES.CallExpression &&
+    parent.arguments[0] === node &&
+    parent.callee.type === AST_NODE_TYPES.MemberExpression &&
+    !parent.callee.computed &&
+    parent.callee.property.type === AST_NODE_TYPES.Identifier &&
+    parent.callee.property.name === "story"
+  ) {
+    return true;
+  }
+
+  return (
+    parent.type === AST_NODE_TYPES.VariableDeclarator &&
+    parent.init === node &&
+    parent.parent.parent.type === AST_NODE_TYPES.ExportNamedDeclaration
+  );
+}
+
+const rule = createRule({
+  name: "storybook-play-requires-test-name",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require stories with play functions to have names prefixed with (Test).",
+    },
+    schema: [],
+    messages: {
+      testNameRequired:
+        'Stories with play functions must set a display name prefixed with "(Test)".',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ObjectExpression(node) {
+        if (!isStoryObject(node)) return;
+
+        const properties = node.properties.filter(
+          (property): property is TSESTree.Property =>
+            property.type === AST_NODE_TYPES.Property,
+        );
+        const playProperty = properties.find(
+          (property) => getPropertyName(property) === "play",
+        );
+        if (!playProperty) return;
+
+        const nameProperty = properties.find(
+          (property) => getPropertyName(property) === "name",
+        );
+        const name =
+          nameProperty?.value.type === AST_NODE_TYPES.Literal &&
+          typeof nameProperty.value.value === "string"
+            ? nameProperty.value.value
+            : null;
+
+        if (!name?.startsWith(TEST_STORY_PREFIX)) {
+          context.report({
+            node: playProperty.key,
+            messageId: "testNameRequired",
+          });
+        }
+      },
+    };
+  },
+});
+
+export default rule;

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -174,8 +174,23 @@ export default definePreview({
       container: ThemedDocsContainer,
     },
     options: {
-      storySort: {
-        order: ["Design", "Playground"],
+      storySort: (a, b) => {
+        const sectionOrder = ["Design", "Playground"];
+        const sectionRank = (title: string) => {
+          const rank = sectionOrder.indexOf(title.split("/")[0] ?? "");
+          return rank === -1 ? sectionOrder.length : rank;
+        };
+        const sectionDifference = sectionRank(a.title) - sectionRank(b.title);
+        if (sectionDifference !== 0) return sectionDifference;
+
+        const titleDifference = a.title.localeCompare(b.title);
+        if (titleDifference !== 0) return titleDifference;
+
+        const aIsTest = a.name.startsWith("(Test)");
+        const bIsTest = b.name.startsWith("(Test)");
+        if (aIsTest !== bIsTest) return aIsTest ? 1 : -1;
+
+        return a.name.localeCompare(b.name);
       },
     },
   },

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -183,14 +183,15 @@ export default definePreview({
           (bSectionIndex === -1 ? sectionOrder.length : bSectionIndex);
         if (sectionDifference !== 0) return sectionDifference;
 
-        const titleDifference = a.title.localeCompare(b.title);
-        if (titleDifference !== 0) return titleDifference;
+        // Returning 0 preserves Storybook's existing stable order. Only
+        // partition test stories when both entries belong to the same component.
+        if (a.title !== b.title) return 0;
 
         const aIsTest = a.name.startsWith("(Test)");
         const bIsTest = b.name.startsWith("(Test)");
         if (aIsTest !== bIsTest) return aIsTest ? 1 : -1;
 
-        return a.name.localeCompare(b.name);
+        return 0;
       },
     },
   },

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -176,11 +176,11 @@ export default definePreview({
     options: {
       storySort: (a, b) => {
         const sectionOrder = ["Design", "Playground"];
-        const sectionRank = (title: string) => {
-          const rank = sectionOrder.indexOf(title.split("/")[0] ?? "");
-          return rank === -1 ? sectionOrder.length : rank;
-        };
-        const sectionDifference = sectionRank(a.title) - sectionRank(b.title);
+        const aSectionIndex = sectionOrder.indexOf(a.title.split("/")[0] ?? "");
+        const bSectionIndex = sectionOrder.indexOf(b.title.split("/")[0] ?? "");
+        const sectionDifference =
+          (aSectionIndex === -1 ? sectionOrder.length : aSectionIndex) -
+          (bSectionIndex === -1 ? sectionOrder.length : bSectionIndex);
         if (sectionDifference !== 0) return sectionDifference;
 
         const titleDifference = a.title.localeCompare(b.title);

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -63,6 +63,13 @@ export default [
   ...nextConfig,
   ...storybook.configs["flat/recommended"],
   {
+    name: "langfuse/web/storybook-test-story-names",
+    files: ["src/**/*.stories.{ts,tsx}"],
+    rules: {
+      "@repo/storybook-play-requires-test-name": "error",
+    },
+  },
+  {
     ...tailwindcssRecommendedConfig,
     settings: {
       tailwindcss: {

--- a/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
+++ b/web/src/components/nav/AppSidebar/AppSidebar.stories.tsx
@@ -164,6 +164,7 @@ export const LatestLaunchWeek = meta.story({
 });
 
 export const GitHubStar = meta.story({
+  name: "(Test) GitHub star",
   args: {
     v4UpgradeUiEnabled: false,
     notificationState: {

--- a/web/src/features/in-app-agent/components/InAppAgentToolCallCard.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentToolCallCard.stories.tsx
@@ -50,6 +50,7 @@ export const Error = meta.story({
 });
 
 export const SandboxBash = meta.story({
+  name: "(Test) Sandbox bash",
   args: {
     isCompact: true,
     tool: {
@@ -78,6 +79,7 @@ export const SandboxBash = meta.story({
 });
 
 export const SandboxRead = meta.story({
+  name: "(Test) Sandbox read",
   args: {
     isCompact: true,
     tool: {
@@ -100,6 +102,7 @@ export const SandboxRead = meta.story({
 });
 
 export const SandboxWrite = meta.story({
+  name: "(Test) Sandbox write",
   args: {
     isCompact: true,
     tool: {
@@ -125,6 +128,7 @@ export const SandboxWrite = meta.story({
 });
 
 export const SandboxEdit = meta.story({
+  name: "(Test) Sandbox edit",
   args: {
     isCompact: true,
     tool: {
@@ -203,6 +207,7 @@ export const ApprovalSubmitting = meta.story({
 });
 
 export const ApprovalDisabled = meta.story({
+  name: "(Test) Approval disabled",
   args: {
     isCompact: true,
     isDisabled: true,

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -727,6 +727,7 @@ const meta = preview.meta({
 });
 
 export const ToolApprovalRequired = meta.story({
+  name: "(Test) Tool approval required",
   args: {
     isAssistantTurnInProgress: true,
     isAwaitingApproval: true,
@@ -1133,6 +1134,7 @@ export const ProgressLogWorking = meta.story({
 });
 
 export const ProgressLogOpened = meta.story({
+  name: "(Test) Progress log opened",
   args: {
     isAssistantTurnInProgress: true,
     isExpanded: true,
@@ -1408,6 +1410,7 @@ export const LoadingAfterToolCall = meta.story({
 });
 
 export const Error = meta.story({
+  name: "(Test) Error",
   args: {
     error: {
       type: "generic",
@@ -1447,6 +1450,7 @@ const stepLimitRun = {
 };
 
 export const StepLimit = meta.story({
+  name: "(Test) Step limit",
   args: {
     selectedConversationId: "conversation-1",
     executionUi: {
@@ -1555,6 +1559,7 @@ const failedRun = {
 };
 
 export const Failed = meta.story({
+  name: "(Test) Failed",
   args: {
     selectedConversationId: "conversation-1",
     executionUi: {
@@ -1616,6 +1621,7 @@ const failedBeforeFirstTokenRun = {
 };
 
 export const FailedBeforeFirstToken = meta.story({
+  name: "(Test) Failed before first token",
   args: {
     selectedConversationId: "conversation-1",
     executionUi: {
@@ -1685,6 +1691,7 @@ export const FailedBeforeFirstToken = meta.story({
  * running conversation has nothing for the user to act on yet.
  */
 export const ConversationActivity = meta.story({
+  name: "(Test) Conversation activity",
   args: {
     conversations: activityConversations,
     activityByConversationId,
@@ -1714,6 +1721,7 @@ const STORY_RUN_MS = 3_000;
  * belongs to the first one only, and wait for the run to settle to see it go.
  */
 export const BackgroundHint = meta.story({
+  name: "(Test) Background hint",
   args: {
     messages: [],
   },
@@ -1830,6 +1838,7 @@ const backgroundStopReasoning = {
 };
 
 export const BackgroundRunStops = meta.story({
+  name: "(Test) Background run stops",
   args: {
     isAssistantTurnInProgress: true,
     selectedConversationId: "conversation-1",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16345.preview.langfuse.com](https://pr-16345.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Enforces that stories with `play` functions use the `(Test)` display-name prefix and stably partitions those interaction-test stories after showcase stories in each Storybook component group.

All existing relative ordering is preserved, including manually ordered narrative stories. Existing play-function stories are named consistently so the new lint rule passes.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter @repo/eslint-plugin test` — 24 files and 816 tests passed; 100% coverage
- `pnpm run lint` — 7 tasks successful
- `pnpm --filter web run build-storybook` — completed successfully
- Built index verification — AppSidebar declaration order preserved while its test moved last; InAppAgentWindow has 13 showcase stories followed by 22 test stories

`pnpm --filter web run typecheck` remains blocked by pre-existing repository-wide type errors under Node 22; the repository requires Node 24.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15323](https://linear.app/clickhouse/issue/LFE-15323/enforce-only-stories-with-the-test-prefix-to-have-play-functions-them)

<div><a href="https://cursor.com/agents/bc-8828bb08-45dc-40d6-87db-cae12007bd57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8828bb08-45dc-40d6-87db-cae12007bd57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds and enables an ESLint rule requiring interaction-test stories to use a `(Test)` display-name prefix, updates existing stories to comply, and adjusts Storybook navigation ordering.
- Registers and tests the new `storybook-play-requires-test-name` rule.
- Enables the rule for web story files.
- Sorts showcase stories before `(Test)` stories within each component group.
- Renames existing play-function stories to follow the convention.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The lint rule is registered and scoped to web story files, current play-function stories are renamed consistently, and the Storybook comparator implements the stated showcase-before-test ordering.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(storybook): enforce test story con..."](https://github.com/langfuse/langfuse/commit/7e2b74b7bf4d67ca7c2f129d7efdc1516dd6f327) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55092884)</sub>

<!-- /greptile_comment -->