### PR TITLE
fix(seed): enable v4 traces view for demo users

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -54,12 +54,15 @@ async function main() {
   const seedUserId1 = "user-1"; // Owner of org
   const seedUserId2 = "user-2"; // Member of org, admin of project
 
+  // Seeded identities skip Cloud signup auto-enable; pin v4 on so local dx
+  // and PR previews land on the events traces view.
   const user = await prisma.user.upsert({
     where: { id: seedUserId1 },
     update: {
       name: "Demo User",
       email: "demo@langfuse.com",
       password: await hash("password", 12),
+      v4BetaEnabled: true,
     },
     create: {
       id: seedUserId1,
@@ -67,6 +70,7 @@ async function main() {
       email: "demo@langfuse.com",
       password: await hash("password", 12),
       image: "https://static.langfuse.com/langfuse-dev%2Fexample-avatar.png",
+      v4BetaEnabled: true,
     },
   });
   const user2 = await prisma.user.upsert({
@@ -75,12 +79,14 @@ async function main() {
       name: "Demo User 2",
       email: "member@langfuse.com",
       password: await hash("password", 12),
+      v4BetaEnabled: true,
     },
     create: {
       id: seedUserId2,
       name: "Demo User 2",
       email: "member@langfuse.com",
       password: await hash("password", 12),
+      v4BetaEnabled: true,
     },
   });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16347.preview.langfuse.com](https://pr-16347.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Pin `v4BetaEnabled` on the seeded demo users so PR previews and local dx land on the v4 traces/observations view.
- Seeded identities skip Cloud signup auto-enable; dual-write deployments only show v4 when that user flag is true.

## Test plan
- [ ] Open a **new** preview (existing ones keep the old user row) and go to `/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/traces`.
- [ ] Confirm the unified events table (no Traces / Observations tabs).
- [ ] Optional: local `pnpm run dx` / re-seed, then check the same path on `http://localhost:3000`.

## Impacted packages
- `@langfuse/shared` (seeder)

## Verification
- `pnpm --filter @langfuse/shared exec eslint scripts/seeder/seed-postgres.ts`
- Pre-commit: `Tasks: 7 successful, 7 total` (turbo lint)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Pins the v4 traces-view flag for both seeded demo users so new local and preview environments open the unified events view.
- Sets `v4BetaEnabled` during creation of both demo users.
- Reapplies the flag when existing seeded demo-user records are updated.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The create and update paths consistently apply the intended v4 flag to both fixed seeded identities, matching the documented behavior for fresh and repeated seed workflows.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seed): enable v4 traces view for dem..."](https://github.com/langfuse/langfuse/commit/d61bb6fe4cf0d7894ca30879bb280e1bbfca1e71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55095651)</sub>

<!-- /greptile_comment -->