### PR TITLE
feat(web): tag Sentry browser transactions with v4BetaEnabled

### DIFF
--- a/web/src/features/events/hooks/useV4Beta.ts
+++ b/web/src/features/events/hooks/useV4Beta.ts
@@ -3,6 +3,7 @@ import { api } from "@/src/utils/api";
 import { useCallback, useState } from "react";
 import posthog from "posthog-js";
 import { V4_BETA_ENABLED_POSTHOG_PROPERTY } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { setV4BetaEnabledSentryTag } from "@/src/utils/sentryV4BetaTag";
 
 type SetV4EnabledOptions = {
   onSuccess?: () => void | Promise<void>;
@@ -38,6 +39,7 @@ export function useV4Beta() {
             posthog.register({
               [V4_BETA_ENABLED_POSTHOG_PROPERTY]: v4BetaEnabled,
             });
+            setV4BetaEnabledSentryTag(v4BetaEnabled);
             await updateSession();
             await options?.onSuccess?.();
           },

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -8,6 +8,10 @@ import Head from "next/head";
 import { type Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { setUser } from "@sentry/nextjs";
+import {
+  clearV4BetaEnabledSentryTag,
+  setV4BetaEnabledSentryTag,
+} from "@/src/utils/sentryV4BetaTag";
 import { useSession } from "next-auth/react";
 import { TooltipProvider } from "@/src/components/ui/tooltip";
 import { CommandMenuProvider } from "@/src/features/command-k-menu/CommandMenuProvider";
@@ -252,16 +256,18 @@ function UserTracking() {
         });
       }
 
-      // Sentry
+      // Sentry — user identity stays on setUser; v4 is a boolean tag only
       setUser({
         email: sessionUser.email ?? undefined,
         id: sessionUser.id ?? undefined,
       });
+      setV4BetaEnabledSentryTag(sessionUser.v4BetaEnabled);
     } else if (session.status === "unauthenticated") {
       lastIdentifiedUser.current = null;
       posthog.unregister(V4_BETA_ENABLED_POSTHOG_PROPERTY);
       // Sentry
       setUser(null);
+      clearV4BetaEnabledSentryTag();
     }
   }, [sessionUser, session.status, region]);
 

--- a/web/src/utils/sentryV4BetaTag.clienttest.ts
+++ b/web/src/utils/sentryV4BetaTag.clienttest.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+
+import {
+  V4_BETA_ENABLED_SENTRY_TAG,
+  clearV4BetaEnabledSentryTag,
+  setV4BetaEnabledSentryTag,
+} from "@/src/utils/sentryV4BetaTag";
+
+const { setTagMock, getActiveSpanMock, getRootSpanMock, setAttributeMock } =
+  vi.hoisted(() => ({
+    setTagMock: vi.fn(),
+    getActiveSpanMock: vi.fn(),
+    getRootSpanMock: vi.fn(),
+    setAttributeMock: vi.fn(),
+  }));
+
+vi.mock("@sentry/nextjs", () => ({
+  setTag: setTagMock,
+  getActiveSpan: getActiveSpanMock,
+  getRootSpan: getRootSpanMock,
+}));
+
+describe("setV4BetaEnabledSentryTag", () => {
+  beforeEach(() => {
+    setTagMock.mockClear();
+    getActiveSpanMock.mockClear();
+    getRootSpanMock.mockClear();
+    setAttributeMock.mockClear();
+    getRootSpanMock.mockReturnValue({ setAttribute: setAttributeMock });
+  });
+
+  it("sets a boolean true tag without user or project ids", () => {
+    getActiveSpanMock.mockReturnValue(undefined);
+
+    setV4BetaEnabledSentryTag(true);
+
+    expect(setTagMock).toHaveBeenCalledTimes(1);
+    expect(setTagMock).toHaveBeenCalledWith("v4BetaEnabled", true);
+    expect(typeof setTagMock.mock.calls[0]![1]).toBe("boolean");
+  });
+
+  it("coerces missing / false session values to boolean false", () => {
+    getActiveSpanMock.mockReturnValue(undefined);
+
+    setV4BetaEnabledSentryTag(false);
+    setV4BetaEnabledSentryTag(undefined);
+
+    expect(setTagMock).toHaveBeenNthCalledWith(
+      1,
+      V4_BETA_ENABLED_SENTRY_TAG,
+      false,
+    );
+    expect(setTagMock).toHaveBeenNthCalledWith(
+      2,
+      V4_BETA_ENABLED_SENTRY_TAG,
+      false,
+    );
+  });
+
+  it("stamps the in-flight root span so pageload spans pick up the tag after hydrate", () => {
+    const childSpan = { name: "child" };
+    getActiveSpanMock.mockReturnValue(childSpan);
+
+    setV4BetaEnabledSentryTag(true);
+
+    expect(getRootSpanMock).toHaveBeenCalledWith(childSpan);
+    expect(setAttributeMock).toHaveBeenCalledWith(
+      V4_BETA_ENABLED_SENTRY_TAG,
+      true,
+    );
+  });
+
+  it("skips span stamping when no pageload/navigation span is active", () => {
+    getActiveSpanMock.mockReturnValue(undefined);
+
+    setV4BetaEnabledSentryTag(true);
+
+    expect(getRootSpanMock).not.toHaveBeenCalled();
+    expect(setAttributeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearV4BetaEnabledSentryTag", () => {
+  beforeEach(() => {
+    setTagMock.mockClear();
+  });
+
+  it("unsets the tag instead of labeling anonymous events as v3", () => {
+    clearV4BetaEnabledSentryTag();
+
+    expect(setTagMock).toHaveBeenCalledTimes(1);
+    expect(setTagMock).toHaveBeenCalledWith(
+      V4_BETA_ENABLED_SENTRY_TAG,
+      undefined,
+    );
+  });
+});

--- a/web/src/utils/sentryV4BetaTag.clienttest.ts
+++ b/web/src/utils/sentryV4BetaTag.clienttest.ts
@@ -83,13 +83,32 @@ describe("setV4BetaEnabledSentryTag", () => {
 describe("clearV4BetaEnabledSentryTag", () => {
   beforeEach(() => {
     setTagMock.mockClear();
+    getActiveSpanMock.mockClear();
+    getRootSpanMock.mockClear();
+    setAttributeMock.mockClear();
+    getRootSpanMock.mockReturnValue({ setAttribute: setAttributeMock });
   });
 
   it("unsets the tag instead of labeling anonymous events as v3", () => {
+    getActiveSpanMock.mockReturnValue(undefined);
+
     clearV4BetaEnabledSentryTag();
 
     expect(setTagMock).toHaveBeenCalledTimes(1);
     expect(setTagMock).toHaveBeenCalledWith(
+      V4_BETA_ENABLED_SENTRY_TAG,
+      undefined,
+    );
+  });
+
+  it("removes the attribute from an in-flight root span on logout", () => {
+    const childSpan = { name: "child" };
+    getActiveSpanMock.mockReturnValue(childSpan);
+
+    clearV4BetaEnabledSentryTag();
+
+    expect(getRootSpanMock).toHaveBeenCalledWith(childSpan);
+    expect(setAttributeMock).toHaveBeenCalledWith(
       V4_BETA_ENABLED_SENTRY_TAG,
       undefined,
     );

--- a/web/src/utils/sentryV4BetaTag.ts
+++ b/web/src/utils/sentryV4BetaTag.ts
@@ -1,0 +1,32 @@
+import { getActiveSpan, getRootSpan, setTag } from "@sentry/nextjs";
+
+/**
+ * Isolation-scope tag so browser pageload/navigation metric alerts can split
+ * v3 vs v4. Boolean only — never user or project IDs (those stay on `setUser`).
+ */
+export const V4_BETA_ENABLED_SENTRY_TAG = "v4BetaEnabled";
+
+function stampActiveRootSpan(value: boolean): void {
+  const activeSpan = getActiveSpan();
+  if (!activeSpan) {
+    return;
+  }
+  getRootSpan(activeSpan).setAttribute(V4_BETA_ENABLED_SENTRY_TAG, value);
+}
+
+/**
+ * Apply `v4BetaEnabled` to the current Sentry isolation scope and, when a
+ * pageload/navigation span is still open, to that root span. Isolation-scope
+ * tags are copied onto the transaction event at send time, which is after
+ * session hydrate on idle-until-quiet pageloads such as `/traces`.
+ */
+export function setV4BetaEnabledSentryTag(enabled: boolean | undefined): void {
+  const value = enabled === true;
+  setTag(V4_BETA_ENABLED_SENTRY_TAG, value);
+  stampActiveRootSpan(value);
+}
+
+/** Drop the tag on logout so anonymous events are not labeled as v3. */
+export function clearV4BetaEnabledSentryTag(): void {
+  setTag(V4_BETA_ENABLED_SENTRY_TAG, undefined);
+}

--- a/web/src/utils/sentryV4BetaTag.ts
+++ b/web/src/utils/sentryV4BetaTag.ts
@@ -6,11 +6,13 @@ import { getActiveSpan, getRootSpan, setTag } from "@sentry/nextjs";
  */
 export const V4_BETA_ENABLED_SENTRY_TAG = "v4BetaEnabled";
 
-function stampActiveRootSpan(value: boolean): void {
+function stampActiveRootSpan(value: boolean | undefined): void {
   const activeSpan = getActiveSpan();
   if (!activeSpan) {
     return;
   }
+  // `undefined` removes the attribute so logout does not leave a stale v3/v4
+  // label on an in-flight pageload/navigation span.
   getRootSpan(activeSpan).setAttribute(V4_BETA_ENABLED_SENTRY_TAG, value);
 }
 
@@ -29,4 +31,5 @@ export function setV4BetaEnabledSentryTag(enabled: boolean | undefined): void {
 /** Drop the tag on logout so anonymous events are not labeled as v3. */
 export function clearV4BetaEnabledSentryTag(): void {
   setTag(V4_BETA_ENABLED_SENTRY_TAG, undefined);
+  stampActiveRootSpan(undefined);
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16348.preview.langfuse.com](https://pr-16348.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Browser pageload and navigation spans currently have empty tags, so `/traces` metric alerts cannot split v3 from v4. `v4BetaEnabled` already lives on the session and PostHog.

This stamps a **boolean** Sentry isolation-scope tag from the same `_app` session effect that calls `setUser`. When a pageload/navigation span is still open (idle-until-quiet), the helper also sets the attribute on the root span so the in-flight `/traces` pageload picks it up after session hydrate. Logout unsets both the isolation-scope tag and that root-span attribute, so an in-flight transaction is not left on the previous user's v3/v4 segment.

User and project IDs stay on `setUser` only — they are not copied into tags.

Toggle in the v4 beta UI updates the same tag immediately, matching the existing PostHog property write.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Targeted client tests cover boolean true/false, span stamping, logout unset of both the tag and the in-flight root-span attribute
- Targeted eslint on the changed files passed
- Full `pnpm --filter web run lint` was not used as a gate here: this environment reports 441 pre-existing warnings unrelated to this change

## Verification

```
pnpm --filter web run test-client src/utils/sentryV4BetaTag.clienttest.ts
# Tests 6 passed (6)

pnpm --filter web exec eslint --no-warn-ignored \
  src/utils/sentryV4BetaTag.ts \
  src/utils/sentryV4BetaTag.clienttest.ts \
  src/pages/_app.tsx \
  src/features/events/hooks/useV4Beta.ts
```

Skipped full web typecheck (no type surface change beyond existing Sentry helpers).

Local Playwright against `http://localhost:3000/project/<id>/traces` after session hydrate:

```json
isolationTags: { "v4BetaEnabled": true }
isolationUser: { "email": "demo@langfuse.com", "id": "user-1" }
```

The boolean is a tag; the user id stays on `setUser`.

## Test this

Preview: https://pr-16348.preview.langfuse.com/project/<id>/traces

1. Hard-refresh `/project/<id>/traces` while signed in.
2. In Sentry, open the pageload transaction (`transaction.op:pageload`).
3. Confirm tag `v4BetaEnabled` is `true` or `false`, and that tags do not include user or project IDs.

Data: demo project is enough.
Sandbox: same path on `http://localhost:3000` after the cloud stack is up.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15363](https://linear.app/clickhouse/issue/LFE-15363/tag-browser-sentry-transactions-with-v4betaenabled)

<div><a href="https://cursor.com/agents/bc-9083b230-5c51-40cc-8de2-b5497a02916d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9083b230-5c51-40cc-8de2-b5497a02916d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a boolean `v4BetaEnabled` Sentry tag during session hydration and beta toggles, including direct stamping of an active browser root span.
- Updates the global session tracking effect to set the tag for authenticated users and clear it on logout.
- Updates the v4 beta mutation flow to apply the new Sentry value immediately.
- Adds a focused Sentry helper and client tests for boolean values, root-span stamping, and logout.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The logout cleanup should be corrected before merging because an open browser transaction can retain the previous user's v4 metric classification.

The setter writes the beta state to both Sentry scope and active root-span state, while the logout path clears only the scope, leaving stale transaction attribution reachable during an in-flight span.

**Files Needing Attention:** web/src/utils/sentryV4BetaTag.ts, web/src/utils/sentryV4BetaTag.clienttest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/utils/sentryV4BetaTag.ts:30-32
**Logout leaves stale span state**

When a user logs out while a previously stamped pageload or navigation root span is still active, `clearV4BetaEnabledSentryTag` clears only the isolation-scope tag and leaves the independent root-span attribute unchanged, causing the anonymous transaction to remain attributed to the previous user's v3/v4 metric segment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): tag Sentry browser transactio..."](https://github.com/langfuse/langfuse/commit/91d61366be665973a7f0ad45ff450f89d5536e41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55097227)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)

<!-- /greptile_comment -->