### PR TITLE
fix(api): declare promptVersion metrics dimensions as number type

### DIFF
--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -443,7 +443,7 @@ export const observationsView: ViewDeclarationType = {
     promptVersion: {
       sql: "observations.prompt_version",
       alias: "promptVersion",
-      type: "string",
+      type: "number",
       description: "Version of the prompt used for the observation.",
     },
     userId: {
@@ -712,7 +712,7 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
   observationPromptVersion: {
     sql: "observations.prompt_version",
     alias: "observationPromptVersion",
-    type: "string",
+    type: "number",
     relationTable: "observations",
     description: "Version of the prompt used for the observation.",
   },
@@ -799,7 +799,7 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
   observationPromptVersion: {
     sql: "events_observations.prompt_version",
     alias: "observationPromptVersion",
-    type: "string",
+    type: "number",
     relationTable: "events_observations",
     description: "Version of the prompt used for the observation.",
   },
@@ -1288,7 +1288,7 @@ export const eventsObservationsView: ViewDeclarationType = {
     promptVersion: {
       sql: "events_observations.prompt_version",
       alias: "promptVersion",
-      type: "string",
+      type: "number",
       description: "Version of the prompt used for the observation.",
     },
     startTimeMonth: {

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -118,6 +118,20 @@ describe("queryBuilder filter type validation", () => {
       expectedMessage:
         "Filter type 'stringOptions' is not supported for dimension type 'string[]'. Expected 'arrayOptions'.",
     },
+    {
+      name: "string on observationPromptVersion (UInt16 column, not a string)",
+      filter: {
+        column: "observationPromptVersion",
+        operator: "=",
+        value: "2",
+        type: "string",
+      },
+      queryOverrides: {
+        view: "scores-numeric",
+      },
+      expectedMessage:
+        "Filter type 'string' is not supported for dimension type 'number'",
+    },
   ])(
     "rejects incompatible filter type: $name",
     async ({ filter, queryOverrides, expectedMessage }) => {
@@ -153,6 +167,21 @@ describe("queryBuilder filter type validation", () => {
     const { query } = await buildQueryWithFilter(filter as FilterCondition);
 
     expect(query).toContain("has");
+  });
+
+  it("lowers a numeric filter on observationPromptVersion to a NumberFilter SQL predicate", async () => {
+    const { query } = await buildQueryWithFilter(
+      {
+        column: "observationPromptVersion",
+        operator: "=",
+        value: 2,
+        type: "number",
+      },
+      { view: "scores-numeric" },
+    );
+
+    expect(query).toContain("observations.prompt_version = {numberFilter");
+    expect(query).toContain(": Decimal64(12)}");
   });
 
   it("lowers a compatible boolean score filter to a Boolean SQL predicate", async () => {


### PR DESCRIPTION
## Summary

Fixes #16351. On the public Metrics API (`GET /api/public/v2/metrics`), `observationPromptVersion` (on the `scores-numeric`/`scores-boolean`/`scores-categorical` views) and `promptVersion` (on the `observations` view) map to `prompt_version`, a ClickHouse `UInt16` column, but were declared with dimension `type: "string"` in `packages/shared/src/features/query/dataModel.ts`.

The query builder validates a filter's declared `type` against the dimension's declared type (`packages/shared/src/features/query/server/queryBuilder.ts`), so with the field mistyped as `string`:

- A filter with `type: "number"` was rejected with a 400 (`Filter type 'number' is not supported for dimension type 'string'`), even though the value is numeric.
- A filter with `type: "string"` and `operator: "contains"` passed validation and reached ClickHouse, which raised a 500 (`Illegal type UInt16 of argument of function position`).
- A filter with `type: "string"` and `operator: "="` passed validation and reached ClickHouse as `prompt_version = {stringFilter: String}` comparing a `UInt16` column against a `String` parameter — as the issue reports, this returns 200 but does not filter as expected.

Fix: declare all four `prompt_version`-backed dimension entries (`observations` v1/v2, and the score views' `observationPromptVersion` v1/v2) as `type: "number"`, matching the existing `value` dimension on the numeric score views, which already uses this type and lowers to a `NumberFilter`/`Decimal64(12)` comparison against ClickHouse — a pattern already proven to work.

## Scope note

The issue's report that `observationPromptVersion` "always returns null" as a **dimension** (no filter involved) is not explained by this type field: I traced the dimension SELECT/aggregation path in `queryBuilder.ts` and confirmed the declared `type` is only consulted for filter validation, never for SELECT generation. I could not reproduce that half of the report without a live ClickHouse instance with seeded prompt-linked observations (outside what's feasible in this sandbox), so this PR only fixes the filter-side behavior described and reproduced below. If the null-dimension symptom persists after this fix, it likely has a separate root cause worth its own issue.

## What changed

- `packages/shared/src/features/query/dataModel.ts`: `type: "string"` → `type: "number"` for the 4 `prompt_version` dimension declarations.
- `packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts`: added a rejection test (string filter on `observationPromptVersion` should now be rejected, not silently accepted) and a positive test (number filter on `observationPromptVersion` now lowers to a `NumberFilter` SQL predicate).

## Test plan

Added regression tests to the existing filter-validation suite and confirmed they fail on the pre-fix code and pass after the fix:

Pre-fix (`git checkout HEAD~1 -- packages/shared/src/features/query/dataModel.ts`):
```
❯ src/features/query/server/queryBuilder.filterValidation.test.ts (24 tests | 2 failed)
  × rejects incompatible filter type: 'string on observationPromptVersion (U…'
    AssertionError: promise resolved "{ …(2) }" instead of rejecting
    (query contains `observations.prompt_version = {stringFilterjaojm: String}` — passes validation instead of being rejected)
  × lowers a numeric filter on observationPromptVersion to a NumberFilter SQL predicate
    InvalidRequestError: Filter type 'number' is not supported for dimension type 'string'. Expected 'string' or 'stringOptions'.

 Test Files  1 failed (1)
      Tests  2 failed | 22 passed (24)
```

Post-fix:
```
$ pnpm --filter @langfuse/shared run test src/features/query/server/queryBuilder.filterValidation.test.ts
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

Full query-feature suite, lint, and typecheck (all green):
```
$ pnpm --filter @langfuse/shared run test src/features/query
 Test Files  4 passed (4)
      Tests  59 passed (59)

$ pnpm --filter @langfuse/shared run lint      # clean, no output
$ pnpm --filter @langfuse/shared run typecheck # clean, no output
$ pnpm --filter worker run typecheck           # clean, no output (worker does not reference this data model)
```

`pnpm --filter web run typecheck` currently fails on this sandbox checkout with ~90 pre-existing errors unrelated to this change (e.g. `TracePage.tsx`, `users.ts`, `chatml` adapters) — confirmed identical on the unmodified base commit, so not caused by this PR.

## AI disclosure

This change was written by an autonomous Claude Code agent, with the diagnosis, fix, and tests verified by re-running them against both the pre-fix and post-fix code as shown above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns all four prompt-version Metrics API dimensions with their underlying numeric ClickHouse columns.
- Changes legacy and events-table observation prompt-version dimensions from string to number.
- Applies the same correction to prompt-version dimensions shared by score views.
- Adds regression coverage rejecting string filters and lowering numeric filters through `NumberFilter`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the corrected metadata matching the numeric ClickHouse columns and targeted regression coverage.

Numeric prompt-version filters now pass dimension validation and reach `NumberFilter`, while incompatible string filters are rejected before producing invalid or ineffective ClickHouse predicates.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): declare promptVersion metrics ..."](https://github.com/langfuse/langfuse/commit/496f1799eae095f16bd56a2bc096414ecba074aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55111810)</sub>

<!-- /greptile_comment -->