### PR TITLE
fix(automations): strip repository-dispatch token from the read path (v3 backport of #16300)

### DIFF
--- a/.agents/skills/code-review/references/review-checklist.md
+++ b/.agents/skills/code-review/references/review-checklist.md
@@ -59,6 +59,12 @@ This is the canonical shared review checklist for Langfuse.
 - For changes that add a new integration, secret-bearing field, redirect
   follower, or RBAC scope, run the rest of the
   [`security-review/references/checklist.md`](../../security-review/references/checklist.md).
+- For changes that shape what a read route returns — a repository or domain
+  converter, a `Safe*` type, a response projection — a catch-all branch that
+  returns the stored value for unhandled types, or an `as Safe*` assertion
+  standing in place of a sanitizer, is a finding: feature read scopes are held
+  by VIEWER. See
+  [`security-review/references/secret-read-paths.md`](../../security-review/references/secret-read-paths.md).
 
 ## JavaScript / TypeScript Style
 

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -38,6 +38,7 @@ correct validation surfaces land in the plan, not in a follow-up CVE.
 | Topic | Open when | File |
 | --- | --- | --- |
 | SSRF and outbound URL validation | The change accepts or fetches a user-supplied URL, host, or endpoint | [references/outbound-url-validation.md](references/outbound-url-validation.md) |
+| Secret read paths | The change shapes what a read route returns for an entity or config blob that also stores a credential | [references/secret-read-paths.md](references/secret-read-paths.md) |
 
 The catalog is intentionally short today. New topic files are added as new
 finding classes recur (see "Extending This Skill").
@@ -83,7 +84,6 @@ pointing at the new topic file, and add a row to the table above.
 Candidates for future references (do not add until a real finding recurs):
 
 - Tenant isolation (`projectId` filters across Prisma and ClickHouse)
-- Secret handling and encryption-at-rest read paths
 - Redirect mishandling and sensitive-header propagation
 - File upload validation and content-type sniffing
 - RBAC scope drift on new tRPC/public API endpoints

--- a/.agents/skills/security-review/references/checklist.md
+++ b/.agents/skills/security-review/references/checklist.md
@@ -53,6 +53,15 @@ restate them here so the security sweep stays self-contained.
 - Are new env vars added to `.env*.example` files and validated via the
   package `env.mjs/ts`, not read from `process.env` directly?
 
+- Does the change add a field to a config blob or entity that a read route
+  returns, or add a branch to a converter that shapes such a response?
+  - If yes, see [secret-read-paths.md](secret-read-paths.md).
+  - Required: one shared converter for every read route and mutation
+    response, exhaustive dispatch over the type union (`never` default), an
+    allowlist-built result, and a read-path negative test as VIEWER. A
+    catch-all branch that returns the stored value for "other types" is a
+    finding, as is `as Safe*` in place of a sanitizer.
+
 ## Audit Logging
 
 - Do sensitive mutations (integration config changes, role or scope changes,

--- a/.agents/skills/security-review/references/secret-read-paths.md
+++ b/.agents/skills/security-review/references/secret-read-paths.md
@@ -1,0 +1,102 @@
+# Secret Read Paths
+
+## Threat
+
+Feature read scopes (`automations:read`, `integrations:read`, and siblings) are
+held by **every** project role, VIEWER included. Anything a read path returns is
+therefore readable by the least-privileged member of the project and ships to
+the browser.
+
+Config blobs stored as JSON columns mix display fields with credentials in the
+same object: a webhook config carries `secretKey` next to `displaySecretKey`, a
+repository-dispatch config carries `githubToken` next to `displayGitHubToken`,
+integration configs carry encrypted request headers next to their display
+values. Encryption at rest does not make such a field safe to return. The
+ciphertext still widens the blast radius of an `ENCRYPTION_KEY` compromise, and
+the repo's own standard — visible in the sibling fields that are stripped — is
+that these never reach a client.
+
+The recurring shape of the bug: sanitization is written per type, wired into the
+write path, and the read path keeps a catch-all fallback for "other types". The
+fallback silently ships the next type's credentials, and the type assertion on
+it hides the omission from the compiler.
+
+## Canonical Helpers
+
+- Per-type allowlist sanitizers, e.g.
+  [`convertToSafeWebhookConfig` / `convertToSafeGitHubDispatchConfig`](../../../../packages/shared/src/domain/automations.ts)
+  — they name every field that may leave the server, so a newly added field is
+  absent from responses until someone adds it deliberately.
+- `Safe*` schemas defined as `FullSchema.omit({ <secret fields> })`, so the safe
+  type and the field allowlist (`Object.keys(SafeXSchema.shape)`) stay derived
+  from one declaration.
+- The paired-accessor convention in
+  [`automation-repository.ts`](../../../../packages/shared/src/server/repositories/automation-repository.ts):
+  `getActionById` returns the sanitized config for anything client-facing,
+  `getActionByIdWithSecrets` returns the raw row and is reserved for execution
+  paths (worker delivery, config helpers).
+- Column-level secrets: the client-wide `omit` block in
+  [`db.ts`](../../../../packages/shared/src/db.ts) excludes secret-bearing
+  columns from every Prisma result by default; delivery paths opt back in with
+  an explicit `select`. Prefer this over hand-stripping when the secret is its
+  own column rather than a JSON field.
+
+## Required Defenses
+
+1. **Sanitize in the shared repository or domain converter, not in the route.**
+   One converter must serve every read route *and* the create/update responses.
+   A router-level sanitizer only covers the surfaces its author remembered.
+2. **Dispatch exhaustively over the type union.** Use a `switch` whose `default`
+   assigns to `never`:
+
+   ```ts
+   default: {
+     const unhandledActionType: never = actionType;
+     throw new InternalServerError(`unhandled type ${unhandledActionType}`);
+   }
+   ```
+
+   A new union member is then a compile error until it has a sanitizer. Never
+   write a fallback that returns the stored value for "other or future types".
+3. **Build the safe object by allowlist, not by deleting known secrets.** A
+   deny-list is only as current as the last person who added a field.
+4. **Fail closed on values that do not parse.** Project the stored object onto
+   the safe schema's keys instead of passing it through — legacy and
+   hand-edited rows are exactly the ones that skip a parse-gated sanitizer.
+   Prefer projection over throwing: reads stay available while secrets still
+   cannot survive.
+5. **Add a negative test on the read path, as the least-privileged role.**
+   Assert `expect(config).not.toHaveProperty("<secret>")` for a VIEWER caller
+   against both the list route and the single-item route. A clean
+   create/update response proves nothing about the read path — that asymmetry
+   is how this class of bug survives review.
+
+## Known-Good Call Sites (Copy These)
+
+- [`convertActionToDomain`](../../../../packages/shared/src/server/repositories/automation-repository.ts)
+  — exhaustive switch, per-type allowlist sanitizer, allowlist projection as
+  the parse-failure fallback; the single converter behind the automations read
+  routes and the create/update responses in
+  [`router.ts`](../../../../web/src/features/automations/server/router.ts).
+- `describe("automations read path secret redaction")` in
+  [`automations-trpc.servertest.ts`](../../../../web/src/__tests__/server/automations-trpc.servertest.ts)
+  — VIEWER-role read-path negative tests, including a config that fails to
+  parse.
+
+## Anti-Patterns to Flag in Review
+
+- **A type assertion standing in for sanitization**: `config: row.config as
+  SafeActionConfig`. The name claims the invariant while the cast suppresses
+  the only check that would enforce it. Flag every `as Safe*`, `as Public*`,
+  `as Redacted*`. If the type carries a security invariant, consider branding
+  it so that only the converter can produce a value of that type and a bare
+  cast stops compiling.
+- **Fallback branches that admit what they do**: a comment along the lines of
+  "for X (or future types) return config as-is" is the finding, not context for
+  it.
+- **Writing a sanitized value back to the database.** Round-tripping a `Safe*`
+  config into `prisma.<model>.update({ data: { config } })` persists the
+  stripped shape and silently drops the fields the sanitizer removed
+  (encrypted headers, stored secrets). Re-read the raw row for writes.
+- **Tests that only cover the mutation response**, leaving the read route — the
+  one a read-only role can reach — unasserted.

--- a/packages/shared/src/server/repositories/automation-repository.ts
+++ b/packages/shared/src/server/repositories/automation-repository.ts
@@ -11,14 +11,22 @@ import {
   TriggerDomain,
   TriggerEventAction,
   ActionDomain,
+  ActionTypes,
   AutomationDomain,
   ActionDomainWithSecrets,
   SafeActionConfig,
   isWebhookActionConfig,
   WebhookActionConfigWithSecrets,
   isSafeWebhookActionConfig,
+  isSlackActionConfig,
+  isGitHubDispatchActionConfig,
   convertToSafeWebhookConfig,
+  convertToSafeGitHubDispatchConfig,
+  SafeWebhookActionConfigSchema,
+  SlackActionConfigSchema,
+  SafeGitHubDispatchActionConfigSchema,
 } from "../../domain/automations";
+import { InternalServerError } from "../../errors";
 import { FilterState } from "../../types";
 import { decryptSecretHeaders, mergeHeaders } from "../utils/headerUtils";
 
@@ -73,7 +81,9 @@ export const getActionByIdWithSecrets = async ({
     };
   }
 
-  // For SLACK and others, return as stored (already safe)
+  // SLACK and GITHUB_DISPATCH need no header decryption, so the stored config
+  // is returned verbatim. Secrets are included by design here - callers that
+  // hand configs to a client must use getActionById instead.
   return actionConfig as ActionDomainWithSecrets;
 };
 
@@ -165,23 +175,89 @@ const getDisplayHeaders = (config: WebhookActionConfigWithSecrets) => {
   return displayHeaders;
 };
 
-const convertActionToDomain = (action: Action): ActionDomain => {
-  if (isWebhookActionConfig(action.config)) {
-    const config = action.config;
-    config.displayHeaders = getDisplayHeaders(config);
+/**
+ * Fallback for a stored config that does not parse as its own action type:
+ * projects it onto the keys its safe schema declares. Every secret is omitted
+ * from those schemas, so no secret can survive the projection, while legacy or
+ * hand-edited rows still read back instead of failing the whole request.
+ */
+const pickSafeConfigFields = (
+  config: Action["config"],
+  type: ActionTypes,
+  safeKeys: string[],
+): SafeActionConfig => {
+  const storedFields =
+    typeof config === "object" && config !== null && !Array.isArray(config)
+      ? (config as Record<string, unknown>)
+      : {};
 
-    return {
-      ...action,
-      config: convertToSafeWebhookConfig(config),
-    };
-  }
-
-  // For SLACK (or future types) return config as-is
+  // The values are not schema-valid, hence the assertion. What it does not
+  // paper over is the secret: only `safeKeys` can appear in the result.
   return {
-    ...action,
-    config: action.config as SafeActionConfig,
-  } as ActionDomain;
+    ...Object.fromEntries(
+      safeKeys
+        .filter((key) => key in storedFields)
+        .map((key) => [key, storedFields[key]]),
+    ),
+    type,
+  } as SafeActionConfig;
 };
+
+/**
+ * Reduces a stored action config to the fields that may leave the server.
+ * `automations:read` is held by every project role, so anything returned here
+ * is readable by VIEWERs. The switch is exhaustive over `ActionTypes`: a new
+ * action type is a compile error until it has a sanitizer, rather than
+ * inheriting a pass-through that ships its credentials to all readers.
+ */
+const convertToSafeActionConfig = (action: Action): SafeActionConfig => {
+  const actionType: ActionTypes = action.type;
+
+  switch (actionType) {
+    case "WEBHOOK":
+      if (isWebhookActionConfig(action.config)) {
+        const config = action.config;
+        config.displayHeaders = getDisplayHeaders(config);
+
+        return convertToSafeWebhookConfig(config);
+      }
+      return pickSafeConfigFields(
+        action.config,
+        actionType,
+        Object.keys(SafeWebhookActionConfigSchema.shape),
+      );
+    case "SLACK":
+      // Slack configs hold no secrets, so the stored shape is already safe.
+      if (isSlackActionConfig(action.config)) {
+        return action.config;
+      }
+      return pickSafeConfigFields(
+        action.config,
+        actionType,
+        Object.keys(SlackActionConfigSchema.shape),
+      );
+    case "GITHUB_DISPATCH":
+      if (isGitHubDispatchActionConfig(action.config)) {
+        return convertToSafeGitHubDispatchConfig(action.config);
+      }
+      return pickSafeConfigFields(
+        action.config,
+        actionType,
+        Object.keys(SafeGitHubDispatchActionConfigSchema.shape),
+      );
+    default: {
+      const unhandledActionType: never = actionType;
+      throw new InternalServerError(
+        `Action ${action.id} has unhandled action type ${unhandledActionType}`,
+      );
+    }
+  }
+};
+
+export const convertActionToDomain = (action: Action): ActionDomain => ({
+  ...action,
+  config: convertToSafeActionConfig(action),
+});
 
 export const getAutomationById = async ({
   projectId,

--- a/web/src/__tests__/server/automations-trpc.servertest.ts
+++ b/web/src/__tests__/server/automations-trpc.servertest.ts
@@ -1,6 +1,6 @@
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import { prisma } from "@langfuse/shared/src/db";
+import { type Prisma, prisma } from "@langfuse/shared/src/db";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
 import { v4 } from "uuid";
@@ -2834,6 +2834,130 @@ describe("automations trpc", () => {
         "https://api.github.com/repos/new-owner/new-repo/dispatches",
       );
       expect(dbConfig.eventType).toBe("new-event-type");
+    });
+  });
+
+  describe("automations read path secret redaction", () => {
+    async function createGitHubDispatchAutomation(
+      projectId: string,
+      config: Prisma.InputJsonObject,
+    ) {
+      const trigger = await prisma.trigger.create({
+        data: {
+          id: v4(),
+          projectId,
+          eventSource: "prompt",
+          eventActions: ["created"],
+          filter: [],
+          status: JobConfigState.ACTIVE,
+        },
+      });
+
+      const action = await prisma.action.create({
+        data: {
+          id: v4(),
+          projectId,
+          type: "GITHUB_DISPATCH",
+          config,
+        },
+      });
+
+      return prisma.automation.create({
+        data: {
+          projectId,
+          triggerId: trigger.id,
+          actionId: action.id,
+          name: "GitHub Dispatch Read Path",
+        },
+      });
+    }
+
+    // VIEWER holds automations:read, the only scope both read routes require.
+    function viewerCaller(session: Session) {
+      const viewerSession: Session = {
+        ...session,
+        user: {
+          ...session.user!,
+          admin: false,
+          organizations: [
+            {
+              ...session.user!.organizations[0],
+              role: "MEMBER",
+              projects: [
+                {
+                  ...session.user!.organizations[0].projects[0],
+                  role: "VIEWER",
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      return appRouter.createCaller({
+        ...createInnerTRPCContext({ session: viewerSession, headers: {} }),
+        prisma,
+      });
+    }
+
+    it("should not expose the stored githubToken to a project VIEWER", async () => {
+      const { project, session } = await prepare();
+
+      const automation = await createGitHubDispatchAutomation(project.id, {
+        type: "GITHUB_DISPATCH",
+        url: "https://api.github.com/repos/owner/repo/dispatches",
+        eventType: "langfuse-prompt-created",
+        githubToken: encrypt("ghp_read_path_token_123"),
+        displayGitHubToken: "ghp_...123",
+      });
+
+      const caller = viewerCaller(session);
+
+      const automations = await caller.automations.getAutomations({
+        projectId: project.id,
+      });
+
+      expect(automations).toHaveLength(1);
+      const listedConfig = automations[0].action.config as Record<
+        string,
+        unknown
+      >;
+      expect(listedConfig).not.toHaveProperty("githubToken");
+      expect(listedConfig.displayGitHubToken).toBe("ghp_...123");
+
+      const single = await caller.automations.getAutomation({
+        projectId: project.id,
+        automationId: automation.id,
+      });
+
+      const singleConfig = single.action.config as Record<string, unknown>;
+      expect(singleConfig).not.toHaveProperty("githubToken");
+      expect(singleConfig.displayGitHubToken).toBe("ghp_...123");
+    });
+
+    it("should not expose the githubToken of a config that fails to parse", async () => {
+      const { project, session } = await prepare();
+
+      // displayGitHubToken is missing, so the config does not parse as a
+      // GITHUB_DISPATCH config and only the field allowlist can strip it.
+      const automation = await createGitHubDispatchAutomation(project.id, {
+        type: "GITHUB_DISPATCH",
+        url: "https://api.github.com/repos/owner/repo/dispatches",
+        eventType: "langfuse-prompt-created",
+        githubToken: encrypt("ghp_read_path_token_456"),
+      });
+
+      const caller = viewerCaller(session);
+
+      const single = await caller.automations.getAutomation({
+        projectId: project.id,
+        automationId: automation.id,
+      });
+
+      const config = single.action.config as Record<string, unknown>;
+      expect(config).not.toHaveProperty("githubToken");
+      expect(config.type).toBe("GITHUB_DISPATCH");
+      expect(config.eventType).toBe("langfuse-prompt-created");
     });
   });
 });

--- a/web/src/features/automations/server/router.ts
+++ b/web/src/features/automations/server/router.ts
@@ -7,10 +7,6 @@ import {
   JobConfigState,
   singleFilter,
   isSafeWebhookActionConfig,
-  isWebhookAction,
-  convertToSafeWebhookConfig,
-  isGitHubDispatchAction,
-  convertToSafeGitHubDispatchConfig,
   TriggerEventSource,
   TriggerEventSourceSchema,
   ProjectNotificationEventTypeSchema,
@@ -18,6 +14,7 @@ import {
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { v4 } from "uuid";
 import {
+  convertActionToDomain,
   getActionById,
   getAutomations,
   getAutomationById,
@@ -364,14 +361,7 @@ export const automationsRouter = createTRPCRouter({
       logger.info(`Created automation ${trigger.id} for action ${action.id}`);
 
       return {
-        action: {
-          ...action,
-          config: isWebhookAction(action)
-            ? convertToSafeWebhookConfig(action.config)
-            : isGitHubDispatchAction(action)
-              ? convertToSafeGitHubDispatchConfig(action.config)
-              : action.config,
-        },
+        action: convertActionToDomain(action),
         trigger,
         automation,
         webhookSecret: newUnencryptedWebhookSecret, // Return webhook secret at top level for one-time display
@@ -499,14 +489,7 @@ export const automationsRouter = createTRPCRouter({
       });
 
       return {
-        action: {
-          ...action,
-          config: isWebhookAction(action)
-            ? convertToSafeWebhookConfig(action.config)
-            : isGitHubDispatchAction(action)
-              ? convertToSafeGitHubDispatchConfig(action.config)
-              : action.config,
-        },
+        action: convertActionToDomain(action),
         trigger,
         automation,
       };


### PR DESCRIPTION
v3 backport of #16300 (mainline commit 0d9bbf66d0), cherry-picked clean.

`convertActionToDomain` sanitized webhook configs and returned every other action config verbatim, so a `GITHUB_DISPATCH` action config reached clients with its stored `githubToken`. Every project role holds `automations:read`, so a project VIEWER could read the credential through `automations.getAutomations` and `automations.getAutomation`. The fix replaces the fail-open fallback with a switch that is exhaustive over `ActionTypes`: each action type sanitizes through its own allowlist converter, configs that fail to parse are projected onto the keys their safe schema declares instead of passed through, and the create/update responses share the same single sanitizer. See #16300 for the full write-up.

## Backport verification

- **Patch identity**: the diff of this branch against `origin/v3` is byte-identical to the mainline commit's diff, except a one-line hunk-offset drift in `.agents/skills/code-review/references/review-checklist.md`.
- **Revert check**: with the two production files reverted to `origin/v3` (tests kept), exactly the two new redaction tests fail — `should not expose the stored githubToken to a project VIEWER` and `should not expose the githubToken of a config that fails to parse` — i.e. the leak reproduces on v3 and this change closes it.
- `pnpm --filter web run test automations-trpc.servertest.ts` (v3 schema DB): `Tests  43 passed (43)`
- Worker consumers of the changed `getActionById` read path: `slack-processor.test.ts` `Tests  11 passed (11)`, `webhooks.test.ts` `Tests  22 passed (22)`
- `pnpm tc`: `Tasks:    7 successful, 7 total`
- `pnpm run lint`: `Tasks:    7 successful, 7 total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR closes an automation credential disclosure by routing every client-facing action response through one exhaustive, allowlist-based sanitizer.

- Removes stored GitHub repository-dispatch tokens from list, detail, create, and update responses.
- Preserves raw-secret access through the explicitly named execution accessor.
- Fails closed for malformed stored configs by projecting only safe-schema fields.
- Adds VIEWER-level regression coverage for valid and malformed GitHub dispatch configurations.
- Documents the repository’s secret read-path review requirements.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and closes the reported credential read-path leak without breaking the worker execution path that requires the token.

Client-facing automation responses now consistently omit secret fields, malformed configurations fail closed, and GitHub dispatch execution continues to retrieve credentials through the dedicated raw-secret accessor.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  DB[(Stored action config)]
  Safe[convertActionToDomain]
  Raw[getActionByIdWithSecrets]
  Read[Viewer-accessible read and mutation responses]
  Worker[Webhook / GitHub dispatch execution]
  DB --> Safe
  Safe -->|Allowlisted config without credentials| Read
  DB --> Raw
  Raw -->|Full config with credentials| Worker
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): strip repository-dispa..."](https://github.com/langfuse/langfuse/commit/9e8818b5248f6ae3803f9b6158b71c1a9dcd7301) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55137310)</sub>

**Context used:**

- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)
- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->