### PR TITLE
fix(web): keep markdown code blocks mounted across re-renders

### DIFF
--- a/web/src/components/ui/MarkdownViewer.clienttest.tsx
+++ b/web/src/components/ui/MarkdownViewer.clienttest.tsx
@@ -69,6 +69,39 @@ describe("MarkdownView ordered lists", () => {
   });
 });
 
+describe("MarkdownView code blocks", () => {
+  // A random React key (and an inline `code` renderer, which is a new
+  // component type every parent render) remounted CodeBlock and dropped
+  // local state such as the copy-button checkmark and scroll position.
+  it("reuses the same code block instance across re-renders", () => {
+    const markdown = "```js\nconst x = 1;\n```";
+    const { container, rerender } = render(
+      <MarkdownContextProvider>
+        <MarkdownView markdown={markdown} />
+      </MarkdownContextProvider>,
+    );
+
+    const codeblock = container.querySelector(".codeblock");
+    expect(codeblock).not.toBeNull();
+
+    rerender(
+      <MarkdownContextProvider>
+        <MarkdownView markdown={markdown} />
+      </MarkdownContextProvider>,
+    );
+
+    expect(container.querySelector(".codeblock")).toBe(codeblock);
+  });
+
+  it("renders two identical fenced blocks as distinct instances", () => {
+    const { container } = renderMarkdown(
+      "```js\nconst x = 1;\n```\n\n```js\nconst x = 1;\n```",
+    );
+
+    expect(container.querySelectorAll(".codeblock")).toHaveLength(2);
+  });
+});
+
 describe("prependBasePathToInternalHref", () => {
   // A native <a> loses the NEXT_PUBLIC_BASE_PATH that <Link> used to prepend to
   // root-relative internal hrefs; this helper restores it for subpath deploys.

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -219,13 +219,181 @@ const remarkPromptReferences = () => (tree: MarkdownAstNode) => {
   transformPromptReferenceNodes(tree);
 };
 
+/**
+ * Stable `react-markdown` `code` renderer. Defined at module scope so React
+ * reuses the CodeBlock instance across parent re-renders (copy / scroll state).
+ */
+function MarkdownCode({
+  children,
+  className,
+}: {
+  children?: ReactNode;
+  className?: string;
+}) {
+  const { forcedTheme, resolvedTheme } = useTheme();
+  const theme = forcedTheme ?? resolvedTheme;
+  const languageMatch = /language-(\w+)/.exec(className || "");
+  const language = languageMatch ? languageMatch[1] : "";
+  const codeContent = String(children).replace(/\n$/, "");
+  const isMultiLine = codeContent.includes("\n");
+
+  return language || isMultiLine ? (
+    <CodeBlock
+      language={language}
+      value={codeContent}
+      theme={theme === "dark" ? "dark" : "light"}
+    />
+  ) : (
+    <code className="bg-secondary rounded border px-0.5">{codeContent}</code>
+  );
+}
+
+const remarkPluginsDefault = [remarkGfm];
+const remarkPluginsWithPromptRefs = [remarkGfm, remarkPromptReferences];
+
+// Module-level so custom-element types stay stable across parent re-renders.
+// Inline renderers (especially `pre`, which wraps fenced `code`) are a new
+// component type every render and remount CodeBlock, dropping local state.
+const markdownComponents: NonNullable<Options["components"]> = {
+  p({ children, node }) {
+    if (isImageNode(node)) {
+      return <>{children}</>;
+    }
+    return <p className="mb-2 whitespace-pre-wrap last:mb-0">{children}</p>;
+  },
+  a({ children, href }) {
+    const promptReference = parsePromptReferenceMarkdownHref(href);
+    if (promptReference) {
+      return (
+        <PromptReferenceButton
+          promptRef={promptReference}
+          fallbackText={getNodeTextContent(children)}
+        />
+      );
+    }
+
+    // Handle mention links
+    if (href?.startsWith(MENTION_USER_PREFIX)) {
+      const userId = href.replace(MENTION_USER_PREFIX, "");
+      const displayName = String(children);
+      return <MentionBadge userId={userId} displayName={displayName} />;
+    }
+
+    // Handle regular links. These are user-content URLs opened in a
+    // new tab (target="_blank"), so a native <a> is correct: a Next.js
+    // <Link> gives no client-routing benefit for an external new-tab
+    // navigation, but it DOES run the router's href validation, which
+    // throws "Invalid href '…' passed to next/router" for the many
+    // malformed URLs embedded in trace content (e.g. a URL containing
+    // a second `https://`). That was a top Sentry noise family
+    // (LANGFUSE-5DZ / 5EA / 5ER, ~40k lifetime events). getSafeLinkUrl
+    // already gates the protocol/shape; a native <a> never validates.
+    // Re-apply NEXT_PUBLIC_BASE_PATH for root-relative internal hrefs,
+    // which <Link> used to prepend automatically (subpath deploys).
+    const safeHref = getSafeLinkUrl(href);
+    if (safeHref) {
+      return (
+        <a
+          href={prependBasePathToInternalHref(
+            safeHref,
+            env.NEXT_PUBLIC_BASE_PATH ?? "",
+          )}
+          className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {children}
+        </a>
+      );
+    }
+    return <span className="text-muted-foreground underline">{children}</span>;
+  },
+  ul({ children }) {
+    if (isChecklist(children)) return <ul className="list-none">{children}</ul>;
+
+    return <ul className="list-inside list-disc">{children}</ul>;
+  },
+  ol({ children, start }) {
+    return (
+      <ol start={start} className="list-inside list-decimal">
+        {children}
+      </ol>
+    );
+  },
+  li({ children }) {
+    return (
+      <li className="mt-1 [&>ol]:pl-4 [&>ul]:pl-4">
+        {transformListItemChildren(children)}
+      </li>
+    );
+  },
+  pre({ children }) {
+    return <pre className="rounded p-2">{children}</pre>;
+  },
+  h1({ children }) {
+    return <h1 className="text-2xl font-bold">{children}</h1>;
+  },
+  h2({ children }) {
+    return <h2 className="text-xl font-bold">{children}</h2>;
+  },
+  h3({ children }) {
+    return <h3 className="text-lg font-bold">{children}</h3>;
+  },
+  h4({ children }) {
+    return <h4 className="text-base font-bold">{children}</h4>;
+  },
+  h5({ children }) {
+    return <h5 className="text-sm font-bold">{children}</h5>;
+  },
+  h6({ children }) {
+    return <h6 className="text-xs font-bold">{children}</h6>;
+  },
+  code: MarkdownCode,
+  blockquote({ children }) {
+    return (
+      <blockquote className="border-l-4 pl-4 italic">{children}</blockquote>
+    );
+  },
+  img({ src, alt }) {
+    const safeSrc = typeof src === "string" ? getSafeImageUrl(src) : null;
+    return safeSrc ? <ResizableImage src={safeSrc} alt={alt} /> : null;
+  },
+  hr() {
+    return <hr className="my-4" />;
+  },
+  table({ children }) {
+    return (
+      <div className="overflow-x-auto rounded border text-xs">
+        <table className="min-w-full divide-y">{children}</table>
+      </div>
+    );
+  },
+  thead({ children }) {
+    return <thead>{children}</thead>;
+  },
+  tbody({ children }) {
+    return <tbody className="divide-border divide-y">{children}</tbody>;
+  },
+  tr({ children }) {
+    return <tr>{children}</tr>;
+  },
+  th({ children }) {
+    return (
+      <th className="px-4 py-2 text-left text-xs font-bold tracking-wider uppercase">
+        {children}
+      </th>
+    );
+  },
+  td({ children }) {
+    return <td className="px-4 py-2 whitespace-nowrap">{children}</td>;
+  },
+};
+
 function MarkdownRenderer({
   markdown,
-  theme,
   className,
 }: {
   markdown: string;
-  theme?: string;
   className?: string;
 }) {
   const promptReferenceProjectId = usePromptReferenceProjectId();
@@ -268,181 +436,10 @@ function MarkdownRenderer({
         <MemoizedReactMarkdown
           remarkPlugins={
             promptReferenceProjectId
-              ? [remarkGfm, remarkPromptReferences]
-              : [remarkGfm]
+              ? remarkPluginsWithPromptRefs
+              : remarkPluginsDefault
           }
-          components={{
-            p({ children, node }) {
-              if (isImageNode(node)) {
-                return <>{children}</>;
-              }
-              return (
-                <p className="mb-2 whitespace-pre-wrap last:mb-0">{children}</p>
-              );
-            },
-            a({ children, href }) {
-              const promptReference = parsePromptReferenceMarkdownHref(href);
-              if (promptReference) {
-                return (
-                  <PromptReferenceButton
-                    promptRef={promptReference}
-                    fallbackText={getNodeTextContent(children)}
-                  />
-                );
-              }
-
-              // Handle mention links
-              if (href?.startsWith(MENTION_USER_PREFIX)) {
-                const userId = href.replace(MENTION_USER_PREFIX, "");
-                const displayName = String(children);
-                return (
-                  <MentionBadge userId={userId} displayName={displayName} />
-                );
-              }
-
-              // Handle regular links. These are user-content URLs opened in a
-              // new tab (target="_blank"), so a native <a> is correct: a Next.js
-              // <Link> gives no client-routing benefit for an external new-tab
-              // navigation, but it DOES run the router's href validation, which
-              // throws "Invalid href '…' passed to next/router" for the many
-              // malformed URLs embedded in trace content (e.g. a URL containing
-              // a second `https://`). That was a top Sentry noise family
-              // (LANGFUSE-5DZ / 5EA / 5ER, ~40k lifetime events). getSafeLinkUrl
-              // already gates the protocol/shape; a native <a> never validates.
-              // Re-apply NEXT_PUBLIC_BASE_PATH for root-relative internal hrefs,
-              // which <Link> used to prepend automatically (subpath deploys).
-              const safeHref = getSafeLinkUrl(href);
-              if (safeHref) {
-                return (
-                  <a
-                    href={prependBasePathToInternalHref(
-                      safeHref,
-                      env.NEXT_PUBLIC_BASE_PATH ?? "",
-                    )}
-                    className="underline"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {children}
-                  </a>
-                );
-              }
-              return (
-                <span className="text-muted-foreground underline">
-                  {children}
-                </span>
-              );
-            },
-            ul({ children }) {
-              if (isChecklist(children))
-                return <ul className="list-none">{children}</ul>;
-
-              return <ul className="list-inside list-disc">{children}</ul>;
-            },
-            ol({ children, start }) {
-              return (
-                <ol start={start} className="list-inside list-decimal">
-                  {children}
-                </ol>
-              );
-            },
-            li({ children }) {
-              return (
-                <li className="mt-1 [&>ol]:pl-4 [&>ul]:pl-4">
-                  {transformListItemChildren(children)}
-                </li>
-              );
-            },
-            pre({ children }) {
-              return <pre className="rounded p-2">{children}</pre>;
-            },
-            h1({ children }) {
-              return <h1 className="text-2xl font-bold">{children}</h1>;
-            },
-            h2({ children }) {
-              return <h2 className="text-xl font-bold">{children}</h2>;
-            },
-            h3({ children }) {
-              return <h3 className="text-lg font-bold">{children}</h3>;
-            },
-            h4({ children }) {
-              return <h4 className="text-base font-bold">{children}</h4>;
-            },
-            h5({ children }) {
-              return <h5 className="text-sm font-bold">{children}</h5>;
-            },
-            h6({ children }) {
-              return <h6 className="text-xs font-bold">{children}</h6>;
-            },
-            code({ children, className }) {
-              const languageMatch = /language-(\w+)/.exec(className || "");
-              const language = languageMatch ? languageMatch[1] : "";
-              const codeContent = String(children).replace(/\n$/, "");
-              const isMultiLine = codeContent.includes("\n");
-
-              return language || isMultiLine ? (
-                // code block
-                <CodeBlock
-                  key={Math.random()}
-                  language={language}
-                  value={codeContent}
-                  theme={theme === "dark" ? "dark" : "light"}
-                />
-              ) : (
-                // inline code
-                <code className="bg-secondary rounded border px-0.5">
-                  {codeContent}
-                </code>
-              );
-            },
-            blockquote({ children }) {
-              return (
-                <blockquote className="border-l-4 pl-4 italic">
-                  {children}
-                </blockquote>
-              );
-            },
-            img({ src, alt }) {
-              const safeSrc =
-                typeof src === "string" ? getSafeImageUrl(src) : null;
-              return safeSrc ? (
-                <ResizableImage src={safeSrc} alt={alt} />
-              ) : null;
-            },
-            hr() {
-              return <hr className="my-4" />;
-            },
-            table({ children }) {
-              return (
-                <div className="overflow-x-auto rounded border text-xs">
-                  <table className="min-w-full divide-y">{children}</table>
-                </div>
-              );
-            },
-            thead({ children }) {
-              return <thead>{children}</thead>;
-            },
-            tbody({ children }) {
-              return (
-                <tbody className="divide-border divide-y">{children}</tbody>
-              );
-            },
-            tr({ children }) {
-              return <tr>{children}</tr>;
-            },
-            th({ children }) {
-              return (
-                <th className="px-4 py-2 text-left text-xs font-bold tracking-wider uppercase">
-                  {children}
-                </th>
-              );
-            },
-            td({ children }) {
-              return (
-                <td className="px-4 py-2 whitespace-nowrap">{children}</td>
-              );
-            },
-          }}
+          components={markdownComponents}
         >
           {markdown}
         </MemoizedReactMarkdown>
@@ -606,7 +603,6 @@ export function MarkdownView({
             <>
               <MarkdownRenderer
                 markdown={isCollapsed ? truncatedContent : markdown}
-                theme={theme}
               />
               {collapseToggle}
             </>
@@ -619,7 +615,7 @@ export function MarkdownView({
           <>
             {isCollapsed ? (
               <>
-                <MarkdownRenderer markdown={truncatedContent} theme={theme} />
+                <MarkdownRenderer markdown={truncatedContent} />
                 {(markdown ?? []).map((content, index) =>
                   isOpenAITextContentPart(content)
                     ? null
@@ -636,7 +632,6 @@ export function MarkdownView({
           <>
             <MarkdownRenderer
               markdown={audio.transcript ? "[Audio] \n" + audio.transcript : ""}
-              theme={theme}
             />
             <LangfuseMediaView
               mediaReferenceString={audio.data.referenceString}
@@ -673,9 +668,7 @@ export function MarkdownView({
     }
 
     if (isOpenAITextContentPart(content)) {
-      return (
-        <MarkdownRenderer key={index} markdown={content.text} theme={theme} />
-      );
+      return <MarkdownRenderer key={index} markdown={content.text} />;
     }
 
     if (isOpenAIImageContentPart(content)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Markdown fenced code used `key={Math.random()}` and inline `react-markdown` renderers. Both forced `CodeBlock` to remount on every parent render, which dropped copy-button state, scroll position, and extra work.

This removes the random key and hoists the markdown component map (and remark plugin lists) to module scope so React reuses the same `CodeBlock` instance across re-renders.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have tested these changes locally by running the relevant tests
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client src/components/ui/MarkdownViewer.clienttest.tsx` — Tests 10 passed (10)
- `pnpm --filter web run lint` — clean (pre-commit turbo lint: Tasks: 7 successful, 7 total)
- Browser: signed in to `http://localhost:3000` as the demo user, posted a fenced python comment on a trace, copied it (checkmark), switched Comments → Scores → Comments; the CodeBlock stayed mounted.

Skipped worker tests: web-only UI change. Skipped `pnpm run typecheck` / full build: lint + targeted client tests cover this surface.

## How to test

Preview: https://pr-16358.preview.langfuse.com (demo project is enough)

1. Open any trace → Comments.
2. Post a comment with a fenced block, e.g. ` ```python ` then `print("hello")`.
3. Confirm it renders as a CodeBlock (language label + copy button), not raw backticks.
4. Click copy; the icon should become a checkmark.
5. Switch to Scores and back to Comments; the block should still be there without flashing.

Sandbox: same path on `http://localhost:3000` after the cloud stack is up.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9669](https://linear.app/clickhouse/issue/LFE-9669/codeblock-uses-mathrandom-as-react-key-forcing-remount-every-render)

<div><a href="https://cursor.com/agents/bc-ddc620c2-7418-4cdb-8650-4d1544a4468a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddc620c2-7418-4cdb-8650-4d1544a4468a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the React component identities used to render markdown code blocks, preventing unnecessary remounts during parent re-renders.
- Hoists markdown renderers and remark plugin arrays to module scope.
- Moves theme consumption into the stable code renderer and removes random code-block keys.
- Adds regression tests for instance reuse and identical sibling code blocks.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed behavior.

Theme updates continue to reach code blocks through context, while stable renderer identities preserve code-block state across ordinary parent rerenders as intended.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep markdown code blocks moun..."](https://github.com/langfuse/langfuse/commit/1bed71d62cefba1b08dae8f5957a011a97b57c52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55153288)</sub>

<!-- /greptile_comment -->