### PR TITLE
feat(session): More filter options in span list

### DIFF
--- a/web/src/components/session/ModernSession.tsx
+++ b/web/src/components/session/ModernSession.tsx
@@ -39,8 +39,10 @@ type ModernSessionProps = {
   showInlineToolCalls: boolean;
   showSystemPrompt: boolean;
   sidebarFilterControls: ModernSessionSidebarFilterControls;
-  onExcludeObservation: (name: string) => void;
-  onIncludeObservation: (name: string) => void;
+  onFilterObservationByName: (
+    name: string,
+    operator: "any of" | "none of",
+  ) => void;
 };
 
 export function ModernSession({
@@ -57,8 +59,7 @@ export function ModernSession({
   showInlineToolCalls,
   showSystemPrompt,
   sidebarFilterControls,
-  onExcludeObservation,
-  onIncludeObservation,
+  onFilterObservationByName,
 }: ModernSessionProps) {
   const traces =
     tracesState.type === "loaded" ? tracesState.traces : EMPTY_TRACES;
@@ -407,8 +408,7 @@ export function ModernSession({
           onSearchChange={handleSearchChange}
           expandedTraceIds={expandedTraceIds}
           onToggleTraceExpanded={toggleTraceExpanded}
-          onExcludeObservation={onExcludeObservation}
-          onIncludeObservation={onIncludeObservation}
+          onFilterObservationByName={onFilterObservationByName}
           onSelect={handleSelect}
           onVisibleTraceIdsChange={handleVisibleTraceIdsChange}
           hasMoreObservations={hasMoreObservations}

--- a/web/src/components/session/ModernSession.tsx
+++ b/web/src/components/session/ModernSession.tsx
@@ -40,6 +40,7 @@ type ModernSessionProps = {
   showSystemPrompt: boolean;
   sidebarFilterControls: ModernSessionSidebarFilterControls;
   onExcludeObservation: (name: string) => void;
+  onIncludeObservation: (name: string) => void;
 };
 
 export function ModernSession({
@@ -57,6 +58,7 @@ export function ModernSession({
   showSystemPrompt,
   sidebarFilterControls,
   onExcludeObservation,
+  onIncludeObservation,
 }: ModernSessionProps) {
   const traces =
     tracesState.type === "loaded" ? tracesState.traces : EMPTY_TRACES;
@@ -406,6 +408,7 @@ export function ModernSession({
           expandedTraceIds={expandedTraceIds}
           onToggleTraceExpanded={toggleTraceExpanded}
           onExcludeObservation={onExcludeObservation}
+          onIncludeObservation={onIncludeObservation}
           onSelect={handleSelect}
           onVisibleTraceIdsChange={handleVisibleTraceIdsChange}
           hasMoreObservations={hasMoreObservations}

--- a/web/src/components/session/ModernSessionSidebar.stories.tsx
+++ b/web/src/components/session/ModernSessionSidebar.stories.tsx
@@ -178,6 +178,7 @@ const largeSessionObservationsByTraceId = Object.fromEntries(
   largeSessionData.map(({ trace, observations }) => [trace.id, observations]),
 );
 const onExcludeObservation = fn();
+const onIncludeObservation = fn();
 
 const toSidebarTraces = (
   sourceTraces: EventSessionTrace[],
@@ -241,6 +242,7 @@ const loadedArgs = {
   expandedTraceIds: new Set(traces.map((trace) => trace.id)),
   onToggleTraceExpanded: fn(),
   onExcludeObservation,
+  onIncludeObservation,
   onSelect: fn(),
   onVisibleTraceIdsChange: fn(),
   hasMoreObservations: false,
@@ -516,6 +518,72 @@ export const TestSelectsObservation = meta.story({
       canvas.getByRole("button", { name: /^Search knowledge base 0.70s$/i }),
     );
     await expect(args.onSelect).toHaveBeenCalledWith(1, "tool-1");
+  },
+});
+
+export const TestOnlyShowsObservationsByName = meta.story({
+  name: "(Test) Only shows observations by name",
+  args: {
+    ...loadedArgs,
+    onExcludeObservation: fn(),
+    onIncludeObservation: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    assertLoadedArgs(args);
+    const canvas = within(canvasElement);
+    const page = within(document.body);
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Actions for Search knowledge base" }),
+    );
+    await userEvent.click(
+      page.getByRole("menuitem", {
+        name: "Only show observations with the same name",
+      }),
+    );
+    await expect(args.onIncludeObservation).toHaveBeenCalledWith(
+      "Search knowledge base",
+    );
+    await waitFor(() =>
+      expect(
+        page.queryByRole("menuitem", {
+          name: "Only show observations with the same name",
+        }),
+      ).not.toBeInTheDocument(),
+    );
+  },
+});
+
+export const TestExcludesObservationsByName = meta.story({
+  name: "(Test) Excludes observations by name",
+  args: {
+    ...loadedArgs,
+    onExcludeObservation: fn(),
+    onIncludeObservation: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    assertLoadedArgs(args);
+    const canvas = within(canvasElement);
+    const page = within(document.body);
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Actions for Search knowledge base" }),
+    );
+    await userEvent.click(
+      page.getByRole("menuitem", {
+        name: "Exclude observations with the same name",
+      }),
+    );
+    await expect(args.onExcludeObservation).toHaveBeenCalledWith(
+      "Search knowledge base",
+    );
+    await waitFor(() =>
+      expect(
+        page.queryByRole("menuitem", {
+          name: "Exclude observations with the same name",
+        }),
+      ).not.toBeInTheDocument(),
+    );
   },
 });
 

--- a/web/src/components/session/ModernSessionSidebar.stories.tsx
+++ b/web/src/components/session/ModernSessionSidebar.stories.tsx
@@ -177,8 +177,7 @@ const largeSessionTraces = largeSessionData.map(({ trace }) => trace);
 const largeSessionObservationsByTraceId = Object.fromEntries(
   largeSessionData.map(({ trace, observations }) => [trace.id, observations]),
 );
-const onExcludeObservation = fn();
-const onIncludeObservation = fn();
+const onFilterObservationByName = fn();
 
 const toSidebarTraces = (
   sourceTraces: EventSessionTrace[],
@@ -241,8 +240,7 @@ const loadedArgs = {
   onSearchChange: fn(),
   expandedTraceIds: new Set(traces.map((trace) => trace.id)),
   onToggleTraceExpanded: fn(),
-  onExcludeObservation,
-  onIncludeObservation,
+  onFilterObservationByName,
   onSelect: fn(),
   onVisibleTraceIdsChange: fn(),
   hasMoreObservations: false,
@@ -518,72 +516,6 @@ export const TestSelectsObservation = meta.story({
       canvas.getByRole("button", { name: /^Search knowledge base 0.70s$/i }),
     );
     await expect(args.onSelect).toHaveBeenCalledWith(1, "tool-1");
-  },
-});
-
-export const TestOnlyShowsObservationsByName = meta.story({
-  name: "(Test) Only shows observations by name",
-  args: {
-    ...loadedArgs,
-    onExcludeObservation: fn(),
-    onIncludeObservation: fn(),
-  },
-  play: async ({ args, canvasElement }) => {
-    assertLoadedArgs(args);
-    const canvas = within(canvasElement);
-    const page = within(document.body);
-
-    await userEvent.click(
-      canvas.getByRole("button", { name: "Actions for Search knowledge base" }),
-    );
-    await userEvent.click(
-      page.getByRole("menuitem", {
-        name: "Only show observations with the same name",
-      }),
-    );
-    await expect(args.onIncludeObservation).toHaveBeenCalledWith(
-      "Search knowledge base",
-    );
-    await waitFor(() =>
-      expect(
-        page.queryByRole("menuitem", {
-          name: "Only show observations with the same name",
-        }),
-      ).not.toBeInTheDocument(),
-    );
-  },
-});
-
-export const TestExcludesObservationsByName = meta.story({
-  name: "(Test) Excludes observations by name",
-  args: {
-    ...loadedArgs,
-    onExcludeObservation: fn(),
-    onIncludeObservation: fn(),
-  },
-  play: async ({ args, canvasElement }) => {
-    assertLoadedArgs(args);
-    const canvas = within(canvasElement);
-    const page = within(document.body);
-
-    await userEvent.click(
-      canvas.getByRole("button", { name: "Actions for Search knowledge base" }),
-    );
-    await userEvent.click(
-      page.getByRole("menuitem", {
-        name: "Exclude observations with the same name",
-      }),
-    );
-    await expect(args.onExcludeObservation).toHaveBeenCalledWith(
-      "Search knowledge base",
-    );
-    await waitFor(() =>
-      expect(
-        page.queryByRole("menuitem", {
-          name: "Exclude observations with the same name",
-        }),
-      ).not.toBeInTheDocument(),
-    );
   },
 });
 

--- a/web/src/components/session/ModernSessionSidebar.tsx
+++ b/web/src/components/session/ModernSessionSidebar.tsx
@@ -82,6 +82,7 @@ function ObservationListRows({
   state,
   onSelectObservation,
   onExcludeObservation,
+  onIncludeObservation,
 }:
   | {
       state: Extract<
@@ -90,11 +91,13 @@ function ObservationListRows({
       >;
       onSelectObservation?: never;
       onExcludeObservation?: never;
+      onIncludeObservation?: never;
     }
   | {
       state: Extract<ObservationListRowsState, { type: "loaded" }>;
       onSelectObservation: (observationId: string) => void;
       onExcludeObservation?: (name: string) => void;
+      onIncludeObservation?: (name: string) => void;
     }) {
   if (state.type === "loading") {
     return (
@@ -160,7 +163,8 @@ function ObservationListRows({
               </span>
             ) : null}
           </button>
-          {observation.name && onExcludeObservation ? (
+          {observation.name &&
+          (onExcludeObservation || onIncludeObservation) ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -174,13 +178,24 @@ function ObservationListRows({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" sideOffset={0}>
-                <DropdownMenuItem
-                  onSelect={() =>
-                    onExcludeObservation(observation.name as string)
-                  }
-                >
-                  Exclude similar observations
-                </DropdownMenuItem>
+                {onIncludeObservation ? (
+                  <DropdownMenuItem
+                    onSelect={() =>
+                      onIncludeObservation(observation.name as string)
+                    }
+                  >
+                    Only show observations with the same name
+                  </DropdownMenuItem>
+                ) : null}
+                {onExcludeObservation ? (
+                  <DropdownMenuItem
+                    onSelect={() =>
+                      onExcludeObservation(observation.name as string)
+                    }
+                  >
+                    Exclude observations with the same name
+                  </DropdownMenuItem>
+                ) : null}
               </DropdownMenuContent>
             </DropdownMenu>
           ) : null}
@@ -200,6 +215,7 @@ const TurnCard = React.memo(
     onSelect,
     hasFilters,
     onExcludeObservation,
+    onIncludeObservation,
   }: {
     sidebarTrace: ModernSessionSidebarTrace;
     selectIndex: number;
@@ -209,6 +225,7 @@ const TurnCard = React.memo(
     onSelect: (index: number, observationId?: string) => void;
     hasFilters: boolean;
     onExcludeObservation: (name: string) => void;
+    onIncludeObservation: (name: string) => void;
   }) => {
     const { trace, turnNumber, observations, hasMatchingTraceLevelIO } =
       sidebarTrace;
@@ -283,6 +300,7 @@ const TurnCard = React.memo(
                 onSelect(selectIndex, observationId)
               }
               onExcludeObservation={onExcludeObservation}
+              onIncludeObservation={onIncludeObservation}
             />
           )
         ) : null}
@@ -305,6 +323,7 @@ export function ModernSessionSidebar(
         expandedTraceIds: ReadonlySet<string>;
         onToggleTraceExpanded: (traceId: string) => void;
         onExcludeObservation: (name: string) => void;
+        onIncludeObservation: (name: string) => void;
         onSelect: (index: number, observationId?: string) => void;
         onVisibleTraceIdsChange: (traceIds: string[]) => void;
         hasMoreObservations: boolean;
@@ -442,6 +461,7 @@ export function ModernSessionSidebar(
     expandedTraceIds,
     onToggleTraceExpanded,
     onExcludeObservation,
+    onIncludeObservation,
     onSelect,
   } = props;
   const handleSearchChange = (nextSearch: string) => {
@@ -656,6 +676,7 @@ export function ModernSessionSidebar(
                         filterControls.activeFilterCount > 0
                       }
                       onExcludeObservation={onExcludeObservation}
+                      onIncludeObservation={onIncludeObservation}
                     />
                   </div>
                 </SessionVirtualizedRow>

--- a/web/src/components/session/ModernSessionSidebar.tsx
+++ b/web/src/components/session/ModernSessionSidebar.tsx
@@ -81,8 +81,7 @@ export type ModernSessionSidebarFilterControls =
 function ObservationListRows({
   state,
   onSelectObservation,
-  onExcludeObservation,
-  onIncludeObservation,
+  onFilterObservationByName,
 }:
   | {
       state: Extract<
@@ -90,14 +89,15 @@ function ObservationListRows({
         { type: "loading" | "error" | "trace-io-only" | "empty" }
       >;
       onSelectObservation?: never;
-      onExcludeObservation?: never;
-      onIncludeObservation?: never;
+      onFilterObservationByName?: never;
     }
   | {
       state: Extract<ObservationListRowsState, { type: "loaded" }>;
       onSelectObservation: (observationId: string) => void;
-      onExcludeObservation?: (name: string) => void;
-      onIncludeObservation?: (name: string) => void;
+      onFilterObservationByName?: (
+        name: string,
+        operator: "any of" | "none of",
+      ) => void;
     }) {
   if (state.type === "loading") {
     return (
@@ -163,8 +163,7 @@ function ObservationListRows({
               </span>
             ) : null}
           </button>
-          {observation.name &&
-          (onExcludeObservation || onIncludeObservation) ? (
+          {observation.name && onFilterObservationByName ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -178,24 +177,26 @@ function ObservationListRows({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" sideOffset={0}>
-                {onIncludeObservation ? (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      onIncludeObservation(observation.name as string)
-                    }
-                  >
-                    Only show observations with the same name
-                  </DropdownMenuItem>
-                ) : null}
-                {onExcludeObservation ? (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      onExcludeObservation(observation.name as string)
-                    }
-                  >
-                    Exclude observations with the same name
-                  </DropdownMenuItem>
-                ) : null}
+                <DropdownMenuItem
+                  onSelect={() =>
+                    onFilterObservationByName(
+                      observation.name as string,
+                      "any of",
+                    )
+                  }
+                >
+                  Only show observations with the same name
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() =>
+                    onFilterObservationByName(
+                      observation.name as string,
+                      "none of",
+                    )
+                  }
+                >
+                  Exclude observations with the same name
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : null}
@@ -214,8 +215,7 @@ const TurnCard = React.memo(
     onToggleCollapse,
     onSelect,
     hasFilters,
-    onExcludeObservation,
-    onIncludeObservation,
+    onFilterObservationByName,
   }: {
     sidebarTrace: ModernSessionSidebarTrace;
     selectIndex: number;
@@ -224,8 +224,10 @@ const TurnCard = React.memo(
     onToggleCollapse: (traceId: string) => void;
     onSelect: (index: number, observationId?: string) => void;
     hasFilters: boolean;
-    onExcludeObservation: (name: string) => void;
-    onIncludeObservation: (name: string) => void;
+    onFilterObservationByName: (
+      name: string,
+      operator: "any of" | "none of",
+    ) => void;
   }) => {
     const { trace, turnNumber, observations, hasMatchingTraceLevelIO } =
       sidebarTrace;
@@ -299,8 +301,7 @@ const TurnCard = React.memo(
               onSelectObservation={(observationId) =>
                 onSelect(selectIndex, observationId)
               }
-              onExcludeObservation={onExcludeObservation}
-              onIncludeObservation={onIncludeObservation}
+              onFilterObservationByName={onFilterObservationByName}
             />
           )
         ) : null}
@@ -322,8 +323,10 @@ export function ModernSessionSidebar(
         onSearchChange: (search: string) => void;
         expandedTraceIds: ReadonlySet<string>;
         onToggleTraceExpanded: (traceId: string) => void;
-        onExcludeObservation: (name: string) => void;
-        onIncludeObservation: (name: string) => void;
+        onFilterObservationByName: (
+          name: string,
+          operator: "any of" | "none of",
+        ) => void;
         onSelect: (index: number, observationId?: string) => void;
         onVisibleTraceIdsChange: (traceIds: string[]) => void;
         hasMoreObservations: boolean;
@@ -460,8 +463,7 @@ export function ModernSessionSidebar(
     onSearchChange,
     expandedTraceIds,
     onToggleTraceExpanded,
-    onExcludeObservation,
-    onIncludeObservation,
+    onFilterObservationByName,
     onSelect,
   } = props;
   const handleSearchChange = (nextSearch: string) => {
@@ -675,8 +677,7 @@ export function ModernSessionSidebar(
                         search.trim() !== "" ||
                         filterControls.activeFilterCount > 0
                       }
-                      onExcludeObservation={onExcludeObservation}
-                      onIncludeObservation={onIncludeObservation}
+                      onFilterObservationByName={onFilterObservationByName}
                     />
                   </div>
                 </SessionVirtualizedRow>

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -1278,6 +1278,32 @@ const LoadedSessionEventsPage: React.FC<{
     },
     [capture, queryFilter],
   );
+  const includeObservationsByName = useCallback(
+    (name: string) => {
+      const nextFilters = queryFilter.filterState
+        .filter((filter) => filter.column !== "name")
+        .concat({
+          column: "name",
+          type: "stringOptions",
+          operator: "any of",
+          value: [name],
+        });
+
+      queryFilter.setFilterState(nextFilters);
+      capture("filters:applied", {
+        surface: "filter_builder",
+        tableName: "session-detail",
+        column: "name",
+        filterType: "stringOptions",
+        operator: "any of",
+        valueCount: 1,
+        conditionCount: nextFilters.length,
+        columnConditionCount: 1,
+        isV4: true,
+      });
+    },
+    [capture, queryFilter],
+  );
 
   // Recover the system-preset viewId the view manager strips from the URL on
   // reload/shared-link (frontend presets aren't backend-fetchable). Idempotent
@@ -1708,6 +1734,7 @@ const LoadedSessionEventsPage: React.FC<{
                   showSystemPrompt={showSystemPrompt}
                   sidebarFilterControls={sidebarFilterControls}
                   onExcludeObservation={excludeObservationsByName}
+                  onIncludeObservation={includeObservationsByName}
                 />
               )}
             </ModernSessionFilterControls>

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -1238,8 +1238,33 @@ const LoadedSessionEventsPage: React.FC<{
   const hasSessionControls =
     !isModernSessionEnabled ||
     Boolean(session.users?.length || session.scores.length);
-  const excludeObservationsByName = useCallback(
-    (name: string) => {
+  const filterObservationsByName = useCallback(
+    (name: string, operator: "any of" | "none of") => {
+      if (operator === "any of") {
+        const nextFilters = queryFilter.filterState
+          .filter((filter) => filter.column !== "name")
+          .concat({
+            column: "name",
+            type: "stringOptions",
+            operator,
+            value: [name],
+          });
+
+        queryFilter.setFilterState(nextFilters);
+        capture("filters:applied", {
+          surface: "filter_builder",
+          tableName: "session-detail",
+          column: "name",
+          filterType: "stringOptions",
+          operator,
+          valueCount: 1,
+          conditionCount: nextFilters.length,
+          columnConditionCount: 1,
+          isV4: true,
+        });
+        return;
+      }
+
       const existingFilter = queryFilter.filterState.find(
         (
           filter,
@@ -1259,7 +1284,7 @@ const LoadedSessionEventsPage: React.FC<{
         : queryFilter.filterState.concat({
             column: "name",
             type: "stringOptions",
-            operator: "none of",
+            operator,
             value: [name],
           });
 
@@ -1269,33 +1294,7 @@ const LoadedSessionEventsPage: React.FC<{
         tableName: "session-detail",
         column: "name",
         filterType: "stringOptions",
-        operator: "none of",
-        valueCount: 1,
-        conditionCount: nextFilters.length,
-        columnConditionCount: 1,
-        isV4: true,
-      });
-    },
-    [capture, queryFilter],
-  );
-  const includeObservationsByName = useCallback(
-    (name: string) => {
-      const nextFilters = queryFilter.filterState
-        .filter((filter) => filter.column !== "name")
-        .concat({
-          column: "name",
-          type: "stringOptions",
-          operator: "any of",
-          value: [name],
-        });
-
-      queryFilter.setFilterState(nextFilters);
-      capture("filters:applied", {
-        surface: "filter_builder",
-        tableName: "session-detail",
-        column: "name",
-        filterType: "stringOptions",
-        operator: "any of",
+        operator,
         valueCount: 1,
         conditionCount: nextFilters.length,
         columnConditionCount: 1,
@@ -1733,8 +1732,7 @@ const LoadedSessionEventsPage: React.FC<{
                   showInlineToolCalls={showInlineToolCalls}
                   showSystemPrompt={showSystemPrompt}
                   sidebarFilterControls={sidebarFilterControls}
-                  onExcludeObservation={excludeObservationsByName}
-                  onIncludeObservation={includeObservationsByName}
+                  onFilterObservationByName={filterObservationsByName}
                 />
               )}
             </ModernSessionFilterControls>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16359.preview.langfuse.com](https://pr-16359.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates the session observation row action menu to:
- rename the exclusion action to “Exclude observations with the same name”
- add “Only show observations with the same name”

The new inclusion action replaces existing name filters with an `any of` filter for the selected name while preserving filters on other columns. It reuses the existing metadata-only `filters:applied` analytics event.

Impacted package: `web`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-reviewed the code

## Verification

- `pnpm --filter web run test-storybook "src/components/session/ModernSessionSidebar.stories.tsx"` — 16 tests passed
- `pnpm run lint` — 7 tasks successful
- `pnpm --filter web run typecheck` — blocked by missing prebuilt `@langfuse/shared` output in this environment

[Session observation name actions](https://cursor.com/agents/bc-25f651c0-f3af-4b63-a80d-e233098d9003/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_observation_name_actions.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15265](https://linear.app/clickhouse/issue/LFE-15265/session-span-list-improvements)

<div><a href="https://cursor.com/agents/bc-25f651c0-f3af-4b63-a80d-e233098d9003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25f651c0-f3af-4b63-a80d-e233098d9003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an observation-row action that replaces existing observation-name filters with an `any of` filter for the selected name, while preserving filters on other columns.
- Propagates the new inclusion callback through the session and sidebar components.
- Adds “Only show observations with the same name” and clarifies the exclusion action label.
- Adds Storybook interaction coverage for both name-based actions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The new action consistently replaces literal `name` filters, preserves other filter columns, and is propagated through the updated production and story call sites without an established stale-callback or component-contract failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(session): filter observations by ma..."](https://github.com/langfuse/langfuse/commit/3e3f3edd7f912523d47e5e835751c4d05d6c6e75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55155967)</sub>

<!-- /greptile_comment -->