### PR TITLE
fix(automations): bind webhook secret headers to the webhook URL

### DIFF
--- a/web/src/__tests__/server/automations-trpc.servertest.ts
+++ b/web/src/__tests__/server/automations-trpc.servertest.ts
@@ -1576,7 +1576,7 @@ describe("automations trpc", () => {
       });
     });
 
-    it("should allow URL update without requiring secret header values", async () => {
+    it("should allow a same-URL update without requiring secret header values", async () => {
       const { project, caller } = await prepare();
 
       // Create initial automation with secret headers
@@ -1625,15 +1625,15 @@ describe("automations trpc", () => {
           projectId: project.id,
           triggerId: trigger.id,
           actionId: action.id,
-          name: "URL Update Test",
+          name: "Same URL Update Test",
         },
       });
 
-      // Update only the URL without providing secret header values
+      // Update everything but the URL without providing secret header values
       const response = await caller.automations.updateAutomation({
         projectId: project.id,
         automationId: automation.id,
-        name: "Updated URL Automation",
+        name: "Renamed Automation",
         eventSource: "prompt",
         eventAction: ["created"],
         filter: [],
@@ -1641,15 +1641,15 @@ describe("automations trpc", () => {
         actionType: "WEBHOOK",
         actionConfig: {
           type: "WEBHOOK",
-          url: "https://example.com/new-webhook-url",
+          url: "https://example.com/webhook",
           requestHeaders: {}, // No headers provided
           apiVersion: { prompt: "v1" },
         },
       });
       const actionConfig = response.action.config as SafeWebhookActionConfig;
 
-      // Verify the URL was updated
-      expect(actionConfig.url).toBe("https://example.com/new-webhook-url");
+      // Verify the URL is unchanged
+      expect(actionConfig.url).toBe("https://example.com/webhook");
 
       // Verify secret headers were preserved
       expect(actionConfig.displayHeaders).toMatchObject({
@@ -1665,8 +1665,8 @@ describe("automations trpc", () => {
 
       const config = updatedAction?.config as WebhookActionConfigWithSecrets;
 
-      // URL should be updated
-      expect(config.url).toBe("https://example.com/new-webhook-url");
+      // URL should be unchanged
+      expect(config.url).toBe("https://example.com/webhook");
 
       // Secret headers should still be encrypted and preserved
       expect(config.requestHeaders!["x-api-key"].value).not.toBe(
@@ -1682,6 +1682,257 @@ describe("automations trpc", () => {
         "x-api-key": { secret: true, value: "secr...-123" },
         authorization: { secret: true, value: "Bear...-456" },
       });
+    });
+
+    it.each<{
+      name: string;
+      requestHeaders?: Record<string, { secret: boolean; value: string }>;
+    }>([
+      { name: "omitted headers", requestHeaders: undefined },
+      { name: "an empty header map", requestHeaders: {} },
+      {
+        name: "an empty masked value",
+        requestHeaders: {
+          authorization: { secret: true, value: "" },
+        },
+      },
+    ])(
+      "rejects reusing secret headers across a URL change with $name",
+      async ({ requestHeaders }) => {
+        const { project, caller } = await prepare();
+
+        const trigger = await prisma.trigger.create({
+          data: {
+            id: v4(),
+            projectId: project.id,
+            eventSource: "prompt",
+            eventActions: ["created"],
+            filter: [],
+            status: JobConfigState.ACTIVE,
+          },
+        });
+
+        const { secretKey, displaySecretKey } = generateWebhookSecret();
+        const action = await prisma.action.create({
+          data: {
+            id: v4(),
+            projectId: project.id,
+            type: "WEBHOOK",
+            config: {
+              type: "WEBHOOK",
+              url: "https://example.com/webhook",
+              requestHeaders: {
+                authorization: {
+                  secret: true,
+                  value: encrypt("Bearer token-456"),
+                },
+              },
+              displayHeaders: {
+                authorization: { secret: true, value: "Bear...-456" },
+              },
+              apiVersion: { prompt: "v1" },
+              secretKey: encrypt(secretKey),
+              displaySecretKey,
+            },
+          },
+        });
+
+        const automation = await prisma.automation.create({
+          data: {
+            projectId: project.id,
+            triggerId: trigger.id,
+            actionId: action.id,
+            name: "Secret Header URL Binding Test",
+          },
+        });
+
+        await expect(
+          caller.automations.updateAutomation({
+            projectId: project.id,
+            automationId: automation.id,
+            name: "Secret Header URL Binding Test",
+            eventSource: "prompt",
+            eventAction: ["created"],
+            filter: [],
+            status: JobConfigState.ACTIVE,
+            actionType: "WEBHOOK",
+            actionConfig: {
+              type: "WEBHOOK",
+              url: "https://example.com/collect",
+              requestHeaders,
+              apiVersion: { prompt: "v1" },
+            },
+          }),
+        ).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+          message: expect.stringContaining(
+            "Secret headers must be re-entered when changing the webhook URL",
+          ),
+        });
+
+        // The rejected update must leave both the URL and the secret in place
+        const stored = await prisma.action.findUnique({
+          where: { id: action.id },
+        });
+        const config = stored?.config as WebhookActionConfigWithSecrets;
+
+        expect(config.url).toBe("https://example.com/webhook");
+        expect(decrypt(config.requestHeaders!["authorization"].value)).toBe(
+          "Bearer token-456",
+        );
+      },
+    );
+
+    it("allows a URL change when secret headers are re-entered", async () => {
+      const { project, caller } = await prepare();
+
+      const trigger = await prisma.trigger.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          eventSource: "prompt",
+          eventActions: ["created"],
+          filter: [],
+          status: JobConfigState.ACTIVE,
+        },
+      });
+
+      const { secretKey, displaySecretKey } = generateWebhookSecret();
+      const action = await prisma.action.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          type: "WEBHOOK",
+          config: {
+            type: "WEBHOOK",
+            url: "https://example.com/webhook",
+            requestHeaders: {
+              authorization: {
+                secret: true,
+                value: encrypt("Bearer token-456"),
+              },
+            },
+            displayHeaders: {
+              authorization: { secret: true, value: "Bear...-456" },
+            },
+            apiVersion: { prompt: "v1" },
+            secretKey: encrypt(secretKey),
+            displaySecretKey,
+          },
+        },
+      });
+
+      const automation = await prisma.automation.create({
+        data: {
+          projectId: project.id,
+          triggerId: trigger.id,
+          actionId: action.id,
+          name: "Secret Header Re-entry Test",
+        },
+      });
+
+      await caller.automations.updateAutomation({
+        projectId: project.id,
+        automationId: automation.id,
+        name: "Secret Header Re-entry Test",
+        eventSource: "prompt",
+        eventAction: ["created"],
+        filter: [],
+        status: JobConfigState.ACTIVE,
+        actionType: "WEBHOOK",
+        actionConfig: {
+          type: "WEBHOOK",
+          url: "https://example.com/collect",
+          requestHeaders: {
+            authorization: { secret: true, value: "Bearer rotated-789" },
+          },
+          apiVersion: { prompt: "v1" },
+        },
+      });
+
+      const stored = await prisma.action.findUnique({
+        where: { id: action.id },
+      });
+      const config = stored?.config as WebhookActionConfigWithSecrets;
+
+      expect(config.url).toBe("https://example.com/collect");
+      expect(decrypt(config.requestHeaders!["authorization"].value)).toBe(
+        "Bearer rotated-789",
+      );
+    });
+
+    it("allows a URL change with omitted headers when no stored header is secret", async () => {
+      const { project, caller } = await prepare();
+
+      const trigger = await prisma.trigger.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          eventSource: "prompt",
+          eventActions: ["created"],
+          filter: [],
+          status: JobConfigState.ACTIVE,
+        },
+      });
+
+      const { secretKey, displaySecretKey } = generateWebhookSecret();
+      const action = await prisma.action.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          type: "WEBHOOK",
+          config: {
+            type: "WEBHOOK",
+            url: "https://example.com/webhook",
+            requestHeaders: {
+              "content-type": { secret: false, value: "application/json" },
+            },
+            displayHeaders: {
+              "content-type": { secret: false, value: "application/json" },
+            },
+            apiVersion: { prompt: "v1" },
+            secretKey: encrypt(secretKey),
+            displaySecretKey,
+          },
+        },
+      });
+
+      const automation = await prisma.automation.create({
+        data: {
+          projectId: project.id,
+          triggerId: trigger.id,
+          actionId: action.id,
+          name: "Non-secret URL Change Test",
+        },
+      });
+
+      await caller.automations.updateAutomation({
+        projectId: project.id,
+        automationId: automation.id,
+        name: "Non-secret URL Change Test",
+        eventSource: "prompt",
+        eventAction: ["created"],
+        filter: [],
+        status: JobConfigState.ACTIVE,
+        actionType: "WEBHOOK",
+        actionConfig: {
+          type: "WEBHOOK",
+          url: "https://example.com/collect",
+          requestHeaders: {},
+          apiVersion: { prompt: "v1" },
+        },
+      });
+
+      const stored = await prisma.action.findUnique({
+        where: { id: action.id },
+      });
+      const config = stored?.config as WebhookActionConfigWithSecrets;
+
+      // A URL-only edit must stay possible whenever nothing secret is stored
+      expect(config.url).toBe("https://example.com/collect");
+      expect(config.requestHeaders!["content-type"].value).toBe(
+        "application/json",
+      );
     });
 
     it("should migrate legacy headers to new format on update", async () => {

--- a/web/src/features/automations/server/webhookHelpers.ts
+++ b/web/src/features/automations/server/webhookHelpers.ts
@@ -84,7 +84,8 @@ export async function processWebhookActionConfig({
  * Processes webhook headers by:
  * 1. Merging legacy headers with new requestHeaders
  * 2. Handling header removal (headers not in input are removed)
- * 3. Preserving existing values when empty values are submitted
+ * 3. Preserving existing values when empty values are submitted, but only
+ *    while the webhook URL stays the same
  * 4. Encrypting secret headers based on secret flag
  * 5. Generating display values for secret headers
  */
@@ -109,8 +110,9 @@ function processWebhookHeaders(
     { secret: boolean; value: string }
   > = {};
 
-  // If no headers are provided in input, preserve all existing headers
-  // This allows URL-only updates without requiring all headers to be resent
+  // If no headers are provided in input, preserve all existing headers.
+  // Non-secret headers still survive a URL-only update this way; stored
+  // secrets do not, because the URL check below rejects that case.
   if (Object.keys(inputRequestHeaders).length === 0) {
     for (const [key, headerObj] of Object.entries(mergedExistingHeaders)) {
       finalRequestHeaders[key] = headerObj;
@@ -152,6 +154,35 @@ function processWebhookHeaders(
         finalRequestHeaders[key] = headerObj;
       }
       // If value is empty and no existing header, skip it (effectively removing it)
+    }
+  }
+
+  // Stored secrets are scoped to the URL they were entered for. Reusing them
+  // across a URL change would forward the plaintext secret to a destination
+  // the submitter never proved they hold a credential for, so require a
+  // re-entry instead. Mirrors the remote-experiment header rule.
+  //
+  // Deliberately placed after the per-header loop rather than before it, as
+  // the dataset router does: the loop raises more specific errors for a
+  // secret-status flip, and an existing test pins one of those messages for a
+  // submission that also changes the URL. The dataset router has no
+  // equivalent per-header validation to preserve.
+  if (existingConfig && actionConfig.url !== existingConfig.url) {
+    // An empty input map preserves every existing header; a submitted empty
+    // value preserves that one header.
+    const preservesAllHeaders = Object.keys(inputRequestHeaders).length === 0;
+    const reusesStoredSecret = Object.entries(mergedExistingHeaders).some(
+      ([key, existingHeader]) =>
+        existingHeader.secret &&
+        (preservesAllHeaders || inputRequestHeaders[key]?.value.trim() === ""),
+    );
+
+    if (reusesStoredSecret) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message:
+          "Secret headers must be re-entered when changing the webhook URL",
+      });
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

`updateAutomation` let a webhook's stored secret headers follow the webhook to a
new URL.

`processWebhookHeaders` preserves the existing headers whenever the submitted
`requestHeaders` map is empty, and preserves an individual header whenever its
submitted value is empty. The webhook form submits exactly that shape for a
secret header the user did not retype — `formatWebhookHeaders` sends
`value: ""`, since the masked value only ever lives in `displayValue`, and
`validateFormData` deliberately permits an empty value when `isSecret` is set.
Nothing compared the submitted URL against the stored one, so changing only the
URL re-pointed the automation at a new host while keeping the previously entered
`Authorization` — or any other secret — header. The next delivery sent that
plaintext secret to the new destination.

This applies the rule already established for dataset remote experiments in
#16307: secret headers are scoped to the URL they were entered for, so a URL
change now requires them to be re-entered.

Three deliberate details, all of which differ from the sibling fix and are
easier to review if called out:

- **Guard placement.** #16307 checks before header processing. Here the check
  sits *after* the per-header loop, because that loop raises more specific
  errors and an existing test pins one of them
  (`secret status can only be changed when providing a value`) for a submission
  that also changes the URL. The dataset router has no equivalent per-header
  validation to preserve. This ordering is now stated in a comment so it is not
  refactored away by accident.
- **Exact-key lookup.** The predicate matches header keys exactly rather than
  case-insensitively, matching the surrounding loop — webhook header semantics
  are already case-sensitive here, pinned by the existing `x-case-key` /
  `x-Case-KEY` test.
- **Server-only.** Like #16307 and #15401, this ships as a router rule plus
  servertests, with no companion form change.

`regenerateWebhookSecret` writes the stored config directly and never goes
through this path, so secret rotation is unaffected.

## Testing

Tests added to `web/src/__tests__/server/automations-trpc.servertest.ts`:

- `rejects reusing secret headers across a URL change with $name` — omitted
  headers, empty header map, empty masked value; asserts both the URL and the
  stored secret are left untouched.
- `allows a URL change when secret headers are re-entered` — the positive
  counterpart #16307 also shipped.
- `allows a URL change with omitted headers when no stored header is secret` —
  pins that ordinary URL-only edits stay possible, so the `existingHeader.secret`
  part of the predicate cannot be dropped without a test going red.
- `should allow URL update without requiring secret header values` was
  retargeted to a same-URL update and renamed, the same way #16307 retargeted
  its remote-experiment counterpart.

Verified locally against the DB-backed suite (Postgres, ClickHouse, Redis and
MinIO from `docker-compose.dev.yml`):

| run | result |
| --- | --- |
| with the fix | `Tests  49 passed (49)` |
| with only `webhookHelpers.ts` reverted, tests kept | `Tests  3 failed \| 46 passed (49)` |

The three failures are exactly the three new rejection cases. The 46 that stay
green include every pre-existing test, the retargeted same-URL one, and both new
positive cases — so the behaviour change is confined to the three scenarios this
PR is about, and the positive tests genuinely guard the predicate rather than
just restating it.

Also green: `pnpm run lint` (`Tasks: 7 successful, 7 total`),
`pnpm --filter web run typecheck`, and `prettier --check` on both files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR binds stored secret webhook headers to their configured URL, rejecting URL changes unless those secrets are re-entered.
- Adds URL-change detection after existing per-header validation.
- Preserves same-URL updates and URL changes involving only non-secret headers.
- Adds server tests for rejected reuse, successful secret re-entry, and non-secret updates.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking edge case where equivalent URL spellings can unnecessarily require secret re-entry.

The new guard correctly covers the existing stored-header preservation paths, but its raw-string URL comparison rejects updates when canonical URL identity is unchanged.

**Files Needing Attention:** web/src/features/automations/server/webhookHelpers.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/automations/server/webhookHelpers.ts:174
**Raw URL identity comparison**

Equivalent URL spellings, such as an uppercase hostname or explicit default port, are submitted and stored without canonicalization, so this raw-string comparison rejects an unchanged destination and unnecessarily requires users to re-enter its secret headers.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): bind webhook secret he..."](https://github.com/langfuse/langfuse/commit/c353646953fd1d8ab3ccb3f8c3a5f7069e4c660a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55167388)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->