### PR TITLE
fix(docker): pass the Redis TLS cert paths the app actually reads

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -53,9 +53,9 @@ services:
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_AUTH: ${REDIS_AUTH:-myredissecret}
       REDIS_TLS_ENABLED: ${REDIS_TLS_ENABLED:-false}
-      REDIS_TLS_CA: ${REDIS_TLS_CA:-/certs/ca.crt}
-      REDIS_TLS_CERT: ${REDIS_TLS_CERT:-/certs/redis.crt}
-      REDIS_TLS_KEY: ${REDIS_TLS_KEY:-/certs/redis.key}
+      REDIS_TLS_CA_PATH: ${REDIS_TLS_CA_PATH:-}
+      REDIS_TLS_CERT_PATH: ${REDIS_TLS_CERT_PATH:-}
+      REDIS_TLS_KEY_PATH: ${REDIS_TLS_KEY_PATH:-}
       # Shared AI features configuration. These apply to AI features that run
       # in both web and worker.
       LANGFUSE_AI_PROVIDER: ${LANGFUSE_AI_PROVIDER:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,9 +69,9 @@ services:
       REDIS_AUTH: ${REDIS_AUTH:-myredissecret} # CHANGEME
       LANGFUSE_BULLMQ_SKIP_REDIS_VERSION_CHECK: ${LANGFUSE_BULLMQ_SKIP_REDIS_VERSION_CHECK:-false}
       REDIS_TLS_ENABLED: ${REDIS_TLS_ENABLED:-false}
-      REDIS_TLS_CA: ${REDIS_TLS_CA:-/certs/ca.crt}
-      REDIS_TLS_CERT: ${REDIS_TLS_CERT:-/certs/redis.crt}
-      REDIS_TLS_KEY: ${REDIS_TLS_KEY:-/certs/redis.key}
+      REDIS_TLS_CA_PATH: ${REDIS_TLS_CA_PATH:-}
+      REDIS_TLS_CERT_PATH: ${REDIS_TLS_CERT_PATH:-}
+      REDIS_TLS_KEY_PATH: ${REDIS_TLS_KEY_PATH:-}
       EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-}
       SMTP_CONNECTION_URL: ${SMTP_CONNECTION_URL:-}
       # Shared AI features configuration. These apply to AI features that run


### PR DESCRIPTION
## What does this PR do?

`docker-compose.yml` and `docker-compose.build.yml` inject `REDIS_TLS_CA`,
`REDIS_TLS_CERT` and `REDIS_TLS_KEY`, but nothing in the codebase reads those
names. `packages/shared/src/env.ts` declares `REDIS_TLS_CA_PATH` /
`REDIS_TLS_CERT_PATH` / `REDIS_TLS_KEY_PATH`, and `buildTlsOptions` in
`packages/shared/src/server/redis/redis.ts` reads only those. A repo-wide
`grep -w REDIS_TLS_CA` hits nothing but the two Compose files — no Dockerfile,
entrypoint, or script translates between the two spellings.

Compose only passes through the keys listed under `environment:`, so on a
docker-compose self-host the operator's paths never reach the process. With
`REDIS_TLS_ENABLED=true`, `buildTlsOptions` returns `ca`/`cert`/`key` all
`undefined` and silently drops whatever was configured, so a Redis that needs a
private CA or client certificates cannot be reached and nothing names the cause.

Reproducible with Compose alone — before this change:

```console
$ REDIS_TLS_ENABLED=true REDIS_TLS_CA_PATH=/certs/my-ca.crt \
  REDIS_TLS_CERT_PATH=/certs/my.crt REDIS_TLS_KEY_PATH=/certs/my.key \
  docker compose -f docker-compose.yml config | grep REDIS_TLS
      REDIS_TLS_CA: /certs/ca.crt
      REDIS_TLS_CERT: /certs/redis.crt
      REDIS_TLS_ENABLED: "true"
      REDIS_TLS_KEY: /certs/redis.key
```

None of the three values the operator set appear; only the names the app never
reads. After this change all three arrive:

```console
      REDIS_TLS_CA_PATH: /certs/my-ca.crt
      REDIS_TLS_CERT_PATH: /certs/my.crt
      REDIS_TLS_ENABLED: "true"
      REDIS_TLS_KEY_PATH: /certs/my.key
```

Present since the feature landed in 2778be5ab ("feat: add TLS env variable
support for Redis"); the later TLS additions did not touch these three.

**Why the defaults become empty rather than keeping `/certs/...`:** an empty
value reproduces exactly what the code sees today, because `buildTlsOptions`
guards each path with a truthiness check and `z.string().optional()` accepts the
empty string. A non-empty default would instead make `fs.readFileSync` throw
`ENOENT` for everyone who enables TLS without mounting certs at those exact
paths — a regression for anyone using a Redis with a publicly trusted
certificate. `${VAR:-}` is the same shape #16014 used for the LLM-connection
whitelist keys in this file.

With nothing set, Compose now renders `REDIS_TLS_CA_PATH: ""` and
`buildTlsOptions` skips it, so behaviour is unchanged for every existing
deployment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the Redis TLS certificate environment-variable names passed through Docker Compose so they match the names consumed by the application.
- Renames the CA, client certificate, and key variables to their `_PATH` forms in both Compose configurations.
- Uses empty defaults to preserve existing behavior when optional certificate paths are not configured.
- Applies the corrected variables consistently to both web and worker services through their shared environment anchors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The renamed Compose variables match the application environment schema and Redis TLS option builder, empty defaults remain safely ignored, and both web and worker services receive the corrected configuration.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docker): pass the Redis TLS cert pat..."](https://github.com/langfuse/langfuse/commit/8366c220445e9dcb10656068f3608c595444b6d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55209846)</sub>

<!-- /greptile_comment -->