### PR TITLE
fix(automations): bind the GitHub dispatch token to its repository URL

### DIFF
--- a/web/src/__tests__/server/automations-trpc.servertest.ts
+++ b/web/src/__tests__/server/automations-trpc.servertest.ts
@@ -2657,7 +2657,7 @@ describe("automations trpc", () => {
   });
 
   describe("automations.updateAutomation with GITHUB_DISPATCH", () => {
-    it("should update GitHub dispatch automation URL without requiring token", async () => {
+    it("should update GitHub dispatch automation event type without requiring token", async () => {
       const { project, caller } = await prepare();
 
       // Create initial automation
@@ -2696,7 +2696,7 @@ describe("automations trpc", () => {
         },
       });
 
-      // Update URL and event type without providing new token
+      // Update the event type without providing a new token
       const response = await caller.automations.updateAutomation({
         projectId: project.id,
         automationId: automation.id,
@@ -2708,7 +2708,7 @@ describe("automations trpc", () => {
         actionType: "GITHUB_DISPATCH",
         actionConfig: {
           type: "GITHUB_DISPATCH",
-          url: "https://api.github.com/repos/owner/new-repo/dispatches",
+          url: "https://api.github.com/repos/owner/repo/dispatches",
           eventType: "new-event",
           githubToken: "", // Empty token means keep existing
         },
@@ -2719,7 +2719,7 @@ describe("automations trpc", () => {
 
       const config = response.action.config as any;
       expect(config.url).toBe(
-        "https://api.github.com/repos/owner/new-repo/dispatches",
+        "https://api.github.com/repos/owner/repo/dispatches",
       );
       expect(config.eventType).toBe("new-event");
       expect(config.displayGitHubToken).toBe("ghp_...ken"); // Preserved
@@ -2851,7 +2851,7 @@ describe("automations trpc", () => {
         },
       });
 
-      // Update URL without providing token
+      // Update the event type without providing a token
       await caller.automations.updateAutomation({
         projectId: project.id,
         automationId: automation.id,
@@ -2863,7 +2863,7 @@ describe("automations trpc", () => {
         actionType: "GITHUB_DISPATCH",
         actionConfig: {
           type: "GITHUB_DISPATCH",
-          url: "https://api.github.com/repos/new-owner/new-repo/dispatches",
+          url: "https://api.github.com/repos/owner/repo/dispatches",
           eventType: "new-event-type",
           // githubToken intentionally omitted
         },
@@ -2882,11 +2882,159 @@ describe("automations trpc", () => {
       // Should still decrypt to original plaintext
       expect(decrypt(dbConfig.githubToken)).toBe(originalToken);
 
-      // Verify URL and eventType were updated
+      // Verify eventType was updated and the URL is unchanged
       expect(dbConfig.url).toBe(
-        "https://api.github.com/repos/new-owner/new-repo/dispatches",
+        "https://api.github.com/repos/owner/repo/dispatches",
       );
       expect(dbConfig.eventType).toBe("new-event-type");
+    });
+
+    it.each<{ name: string; githubToken?: string }>([
+      { name: "an omitted token", githubToken: undefined },
+      { name: "an empty token", githubToken: "" },
+    ])(
+      "rejects reusing the stored GitHub token across a URL change with $name",
+      async ({ githubToken }) => {
+        const { project, caller } = await prepare();
+
+        const trigger = await prisma.trigger.create({
+          data: {
+            id: v4(),
+            projectId: project.id,
+            eventSource: "prompt",
+            eventActions: ["created"],
+            filter: [],
+            status: JobConfigState.ACTIVE,
+          },
+        });
+
+        const encryptedToken = encrypt("ghp_stored_token");
+        const action = await prisma.action.create({
+          data: {
+            id: v4(),
+            projectId: project.id,
+            type: "GITHUB_DISPATCH",
+            config: {
+              type: "GITHUB_DISPATCH",
+              url: "https://api.github.com/repos/owner/repo/dispatches",
+              eventType: "original-event",
+              githubToken: encryptedToken,
+              displayGitHubToken: "ghp_...ken",
+            },
+          },
+        });
+
+        const automation = await prisma.automation.create({
+          data: {
+            projectId: project.id,
+            triggerId: trigger.id,
+            actionId: action.id,
+            name: "Token URL Binding Test",
+          },
+        });
+
+        await expect(
+          caller.automations.updateAutomation({
+            projectId: project.id,
+            automationId: automation.id,
+            name: "Token URL Binding Test",
+            eventSource: "prompt",
+            eventAction: ["created"],
+            filter: [],
+            status: JobConfigState.ACTIVE,
+            actionType: "GITHUB_DISPATCH",
+            actionConfig: {
+              type: "GITHUB_DISPATCH",
+              url: "https://api.github.com/repos/attacker/repo/dispatches",
+              eventType: "original-event",
+              githubToken,
+            },
+          }),
+        ).rejects.toMatchObject({
+          code: "BAD_REQUEST",
+          message: expect.stringContaining(
+            "The GitHub token must be re-entered when changing the repository dispatch URL",
+          ),
+        });
+
+        // The rejected update must leave both the URL and the token in place
+        const stored = await prisma.action.findUnique({
+          where: { id: action.id },
+        });
+        const config = stored?.config as any;
+
+        expect(config.url).toBe(
+          "https://api.github.com/repos/owner/repo/dispatches",
+        );
+        expect(config.githubToken).toBe(encryptedToken);
+        expect(decrypt(config.githubToken)).toBe("ghp_stored_token");
+      },
+    );
+
+    it("allows a URL change when the GitHub token is re-entered", async () => {
+      const { project, caller } = await prepare();
+
+      const trigger = await prisma.trigger.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          eventSource: "prompt",
+          eventActions: ["created"],
+          filter: [],
+          status: JobConfigState.ACTIVE,
+        },
+      });
+
+      const action = await prisma.action.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          type: "GITHUB_DISPATCH",
+          config: {
+            type: "GITHUB_DISPATCH",
+            url: "https://api.github.com/repos/owner/repo/dispatches",
+            eventType: "original-event",
+            githubToken: encrypt("ghp_stored_token"),
+            displayGitHubToken: "ghp_...ken",
+          },
+        },
+      });
+
+      const automation = await prisma.automation.create({
+        data: {
+          projectId: project.id,
+          triggerId: trigger.id,
+          actionId: action.id,
+          name: "Token Re-entry Test",
+        },
+      });
+
+      await caller.automations.updateAutomation({
+        projectId: project.id,
+        automationId: automation.id,
+        name: "Token Re-entry Test",
+        eventSource: "prompt",
+        eventAction: ["created"],
+        filter: [],
+        status: JobConfigState.ACTIVE,
+        actionType: "GITHUB_DISPATCH",
+        actionConfig: {
+          type: "GITHUB_DISPATCH",
+          url: "https://api.github.com/repos/other-owner/other-repo/dispatches",
+          eventType: "original-event",
+          githubToken: "ghp_rotated_token",
+        },
+      });
+
+      const stored = await prisma.action.findUnique({
+        where: { id: action.id },
+      });
+      const config = stored?.config as any;
+
+      expect(config.url).toBe(
+        "https://api.github.com/repos/other-owner/other-repo/dispatches",
+      );
+      expect(decrypt(config.githubToken)).toBe("ghp_rotated_token");
     });
   });
 

--- a/web/src/features/automations/server/githubDispatchHelpers.ts
+++ b/web/src/features/automations/server/githubDispatchHelpers.ts
@@ -110,6 +110,20 @@ export async function processGitHubDispatchActionConfig({
     displayToken = maskGitHubToken(tokenToUse);
     returnToken = tokenToUse;
   } else if (existingActionConfig?.githubToken) {
+    // A stored token is scoped to the repository it was entered for. The
+    // enterprise pattern above accepts any host, and the worker sends the
+    // decrypted token as a bearer credential to whatever URL ends up stored,
+    // so carrying it across a URL change would hand a GitHub PAT to a
+    // destination the submitter never proved they hold a credential for.
+    // Same rule as the dataset remote-experiment and webhook headers.
+    if (urlToUse !== existingActionConfig.url) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message:
+          "The GitHub token must be re-entered when changing the repository dispatch URL",
+      });
+    }
+
     tokenToUse = existingActionConfig.githubToken;
     displayToken = existingActionConfig.displayGitHubToken;
     returnToken = undefined;


### PR DESCRIPTION
## What does this PR do?

`processGitHubDispatchActionConfig` reuses the stored GitHub token whenever the
submitted `githubToken` is empty or omitted, and never compares the submitted URL
against the stored one. The enterprise URL pattern it validates against —
`/^https:\/\/[^\/]+\/api\/v3\/repos\/[^\/]+\/[^\/]+\/dispatches$/` — accepts any
hostname in the `[^\/]+` segment, which it has to, since a GitHub Enterprise host
is site-specific. So an actor with `automations:CUD` can repoint an existing
automation at a different destination while keeping the previously entered token.

`worker/src/queues/webhooks.ts` then decrypts that token, sends it as
`Authorization: Bearer <token>`, and also uses it as the HMAC secret for
`x-langfuse-signature`. `validateWebhookURL` does run first, but it only rejects
private ranges and non-80/443 ports, so an ordinary public host passes.

This is the GITHUB_DISPATCH counterpart of the rule already applied to dataset
remote experiments in #16307 and to webhook request headers in #16361: a stored
credential is scoped to the destination it was entered for, so changing that
destination requires re-entering it.

Two deliberate choices:

- **The guard is on the credential, not the host.** Tightening the enterprise
  regex to an allowlist would break real GitHub Enterprise deployments, whose
  hostnames are arbitrary by design. Binding the token to the stored URL is the
  boundary that holds without constraining legitimate hosts.
- **Exact `!==` comparison**, matching #16307 and #16361, so all three surfaces
  behave identically.

## Testing

Two existing tests asserted the behaviour this PR removes, so both were
retargeted to same-URL updates — the same treatment #16307 gave its
remote-experiment counterpart:

- `should update GitHub dispatch automation URL without requiring token` →
  `should update GitHub dispatch automation event type without requiring token`
- `should preserve encrypted token when updating without providing new token` —
  its submitted config carried `// githubToken intentionally omitted` together
  with a changed repository URL; the URL is now unchanged, and the assertion that
  the token is preserved without double-encryption is untouched.

Added:

- `rejects reusing the stored GitHub token across a URL change with $name` —
  omitted token and empty token; asserts both the stored URL and the encrypted
  token are left intact after the rejection.
- `allows a URL change when the GitHub token is re-entered` — the positive
  counterpart, so the guard cannot be widened into blocking legitimate moves.

Measured against the DB-backed suite (Postgres, ClickHouse, Redis, MinIO from
`docker-compose.dev.yml`):

| run | result |
| --- | --- |
| with the fix | `Tests  47 passed (47)` |
| with only `githubDispatchHelpers.ts` reverted, tests kept | `Tests  2 failed \| 45 passed (47)` |

The two failures are exactly the new rejection cases. The 45 that stay green
include both retargeted tests and the new positive case, so the behaviour change
is confined to reusing a stored token across a URL change.

Also green: `pnpm run lint`, `pnpm --filter web run typecheck`, and
`prettier --check` on both files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents a stored GitHub dispatch token from being reused after the repository dispatch URL changes.

- Adds an exact URL-binding check when an update omits the GitHub token.
- Preserves token reuse for same-URL configuration updates.
- Adds negative tests for omitted and empty tokens and a positive test for explicit token re-entry.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new guard correctly preventing stored GitHub credentials from being carried across destination changes.

The helper continues to preserve the encrypted token for same-URL updates, rejects changed URLs when no replacement token is supplied, and permits legitimate URL changes when a token is explicitly re-entered.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): bind the GitHub dispat..."](https://github.com/langfuse/langfuse/commit/7fbbf47c7ea756fa5c8b2d9ca882a5ec4624ef54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55246850)</sub>

**Context used:**

- Knowledge Base — [Notifications, Automations, and Outbound Integrations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/notifications-integrations.md)

<!-- /greptile_comment -->