### PR TITLE
fix(sentry): redact PII in all session replays

### DIFF
--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -122,15 +122,14 @@ ErrorEvent]` fingerprints with no stack. ⚠ The 5EX cluster (opaque non-Error
    user/session ids. This is not hygiene — it is the compliance boundary: ALL
    cloud regions, **including HIPAA**, report to the **same US Sentry org**,
    and error events are **never masked**, so this discipline is the only thing
-   keeping user content out of them. Session Replay is the one masked channel:
-   [`instrumentation-client.ts`](../../../web/instrumentation-client.ts) gates
-   `maskAllText`/`blockAllMedia` so replays are fully masked everywhere except
-   the EU/US non-HIPAA cloud regions. **Never remove or weaken that gate** —
-   the gate (`isEuOrUsRegionNonHipaa` → the `replayIntegration` options) must
-   be covered by a CI regression test asserting the masked/unmasked regions on
-   the real module (the mask-guard
+   keeping user content out of them. Session Replay is the masked channel:
+   [`instrumentation-client.ts`](../../../web/instrumentation-client.ts) sets
+   `maskAllText`, `maskAllInputs`, and `blockAllMedia` so every replay is fully
+   masked in every deployment. **Never remove or weaken that mask** — the
+   `replayIntegration` options must be covered by a CI regression test
+   asserting every region against the real module (the mask-guard
    `instrumentation-client-replay-mask.clienttest.ts`; landing with #15802).
-   Reject any diff that touches the gate without that guard passing, and run
+   Reject any diff that touches Replay masking without that guard passing, and run
    every diff touching `instrumentation-client.ts` or replay config through
    the reviewer checklist in the
    [reference](references/sentry-capture-contract.md#pii-and-the-hipaa-compliance-boundary).
@@ -171,7 +170,7 @@ ErrorEvent]` fingerprints with no stack. ⚠ The 5EX cluster (opaque non-Error
   that reads the wrong event field (Rule 6).
 - Interpolating ids/user data into the message → PII + grouping explosion
   (Rules 5, 7).
-- Removing/weakening the region-gated replay mask, or "fixing" the mask-guard
+- Removing/weakening the unconditional replay mask, or "fixing" the mask-guard
   test instead of the diff that tripped it (Rule 7).
 - Trusting a green jsdom test as proof the noise is gone (Rule 8).
 - An ad-hoc inline `beforeSend` check instead of a named, tested predicate in

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -18,7 +18,7 @@ the detail behind its rules.
 
 - **The only `Sentry.init`** is [`web/instrumentation-client.ts`](../../../../web/instrumentation-client.ts)
   — client-side only. It configures `beforeSend`, `captureConsoleIntegration({ levels: ["error"] })`,
-  `httpClientIntegration()`, `replayIntegration(...)` (masking gated on region/HIPAA),
+  `httpClientIntegration()`, `replayIntegration(...)` (unconditional masking),
   and `denyUrls` (browser-extension origins).
 - **The worker and web server have no Sentry SDK** — backend signal lives in the
   server-side observability/APM stack, not Sentry. Do not assume a backend error
@@ -42,18 +42,16 @@ ALL cloud regions — **including HIPAA** — report to the **same US Sentry org
 Two mechanisms keep user content (prompts, traces, PII/PHI) out of it, and they
 cover **different channels**. Do not conflate them.
 
-1. **Session Replay → the region-gated mask.**
+1. **Session Replay → the unconditional mask.**
    [`instrumentation-client.ts`](../../../../web/instrumentation-client.ts)
-   configures `replayIntegration({ maskAllText, blockAllMedia })` gated on the
-   cloud region via `isEuOrUsRegionNonHipaa`: replays are **fully masked
-   everywhere except the EU/US non-HIPAA cloud regions** (HIPAA, JP, STAGING,
-   DEV, and self-hosted/unset all mask — default-deny). The gate must never be
+   configures `replayIntegration({ maskAllText, maskAllInputs, blockAllMedia })`
+   so replays are **fully masked in every deployment**. The mask must never be
    removed or weakened, and it must be covered by a CI regression test that
-   executes the real module per region and fails on any change to the gate
+   executes the real module per region and fails on any change to the options
    (the mask-guard `instrumentation-client-replay-mask.clienttest.ts`; landing
    with #15802). A diff that trips that guard is a compliance change, not a
-   broken test; a diff that touches the gate without the guard passing must be
-   rejected.
+   broken test; a diff that touches Replay masking without the guard passing
+   must be rejected.
 2. **Error events → the capture discipline (SKILL rule 7).** The mask covers
    Session Replay ONLY. Error-event payloads — message, breadcrumbs, `extra`,
    tags — are **not masked in any region**. The rule "no user content in
@@ -62,14 +60,13 @@ cover **different channels**. Do not conflate them.
    so the SDK attaches no cookies, headers, request/response bodies, or user
    IP.
 
-**Reviewer checklist — any diff touching `instrumentation-client.ts`, the
-replay integration, or region gating:**
+**Reviewer checklist — any diff touching `instrumentation-client.ts` or the
+replay integration:**
 
-- `maskAllText`/`blockAllMedia` still derive from the region gate (masked
-  unless the region is exactly `EU` or `US`), and the mask-guard clienttest
-  (landing with #15802) asserts against the real module — not a copy of the
-  config or an uncalled predicate.
-- No new replay option weakens masking for masked regions (e.g.
+- `maskAllText`, `maskAllInputs`, and `blockAllMedia` remain `true` in every
+  deployment, and the mask-guard clienttest (landing with #15802) asserts
+  against the real module — not a copy of the config or an uncalled predicate.
+- No new replay option weakens masking (e.g.
   `maskAllInputs: false`, unmask/unblock selectors).
 - `sendDefaultPii` remains unset/false; no integration starts attaching
   bodies, headers, or cookies.

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -8,11 +8,6 @@ import {
   STALE_CHUNK_PARSE_FINGERPRINT,
 } from "@/src/utils/sentryFilters";
 
-const isEuOrUsRegionNonHipaa =
-  process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
-    ? ["EU", "US"].includes(process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
-    : false;
-
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
@@ -71,8 +66,9 @@ Sentry.init({
   // Replay may only be enabled for the client-side
   integrations: [
     Sentry.replayIntegration({
-      maskAllText: !isEuOrUsRegionNonHipaa,
-      blockAllMedia: !isEuOrUsRegionNonHipaa,
+      maskAllText: true,
+      maskAllInputs: true,
+      blockAllMedia: true,
     }),
     Sentry.browserTracingIntegration(),
     Sentry.httpClientIntegration(),

--- a/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
+++ b/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
@@ -1,15 +1,14 @@
 // @vitest-environment node
 
 /**
- * HIPAA / non-EU-US Session Replay masking guard.
+ * Session Replay masking guard.
  *
  * All cloud regions (including HIPAA) report to the same US Sentry org.
- * The compliance safeguard for Session Replay is the region-gated
- * `maskAllText` / `blockAllMedia` configuration in
- * `web/instrumentation-client.ts`: replays are masked everywhere EXCEPT the
- * EU and US non-HIPAA cloud regions. Removing or weakening that gate would
- * ship unmasked replay of user content (prompts, traces, PII/PHI) from
- * HIPAA and other regions to Sentry.
+ * The compliance safeguard for Session Replay is the unconditional
+ * `maskAllText` / `maskAllInputs` / `blockAllMedia` configuration in
+ * `web/instrumentation-client.ts`: replays are masked in every deployment.
+ * Removing or weakening that configuration would ship unmasked replay of
+ * user content (prompts, traces, PII/PHI) to Sentry.
  *
  * Scope note: the mask covers Session Replay ONLY. Error-event payloads
  * (message, breadcrumbs, extra, tags) are never masked — for those, the
@@ -25,16 +24,17 @@
  * change weakens the compliance mask — fix the change, not the test.
  */
 
-type ReplayOptions = { maskAllText: boolean; blockAllMedia: boolean };
+type ReplayOptions = {
+  maskAllText: boolean;
+  maskAllInputs: boolean;
+  blockAllMedia: boolean;
+};
 
 const { initMock, replayIntegrationMock, replaySentinel } = vi.hoisted(() => {
   const replaySentinel = { name: "Replay-sentinel" };
   return {
     initMock: vi.fn<(options: { integrations: unknown[] }) => void>(),
-    replayIntegrationMock: vi.fn(
-      (_options: { maskAllText: boolean; blockAllMedia: boolean }) =>
-        replaySentinel,
-    ),
+    replayIntegrationMock: vi.fn((_options: ReplayOptions) => replaySentinel),
     replaySentinel,
   };
 });
@@ -77,39 +77,29 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("Session Replay masking is region-gated (compliance guard)", () => {
-  // Regions that must ALWAYS be fully masked. `toStrictEqual` on the whole
+describe("Session Replay masking is unconditional (compliance guard)", () => {
+  // Every region must be fully masked. `toStrictEqual` on the whole
   // options object is deliberate: any new replay option must be reviewed
   // here for its compliance impact before it can ship.
-  const alwaysMaskedRegions: [string | undefined, string][] = [
+  const regions: [string | undefined, string][] = [
+    ["EU", "the EU cloud region"],
+    ["US", "the US cloud region"],
     ["HIPAA", "the HIPAA cloud region"],
     ["JP", "a non-EU/US cloud region"],
     ["STAGING", "the staging environment"],
     ["DEV", "the dev environment"],
     [undefined, "self-hosted (region unset)"],
     ["", "an empty region value"],
-    ["us", "a lowercase region value (gate must be exact-match)"],
+    ["us", "a lowercase region value"],
   ];
 
-  it.each(alwaysMaskedRegions)(
-    "region %j (%s) gets maskAllText + blockAllMedia",
+  it.each(regions)(
+    "region %j (%s) gets text, input, and media masking",
     async (region) => {
       await expect(loadReplayOptions(region)).resolves.toStrictEqual({
         maskAllText: true,
+        maskAllInputs: true,
         blockAllMedia: true,
-      });
-    },
-  );
-
-  // The ONLY regions where unmasked replay is permitted. If this case starts
-  // failing because masking became unconditional, that is a deliberate
-  // product decision to confirm — not a bug in this test.
-  it.each(["EU", "US"])(
-    "only the %s cloud region may run unmasked replay",
-    async (region) => {
-      await expect(loadReplayOptions(region)).resolves.toStrictEqual({
-        maskAllText: false,
-        blockAllMedia: false,
       });
     },
   );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16373.preview.langfuse.com](https://pr-16373.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- enable Sentry Replay text and input masking plus media blocking in every deployment
- remove the EU/US unmasked Replay exception
- enforce the privacy contract against the real instrumentation module and update the matching agent guidance

## Impacted packages

- web
- repository agent guidance

## Verification

- pnpm run lint — Tasks: 7 successful, 7 total
- pnpm --filter @langfuse/shared run build
- pnpm --filter web run typecheck
- pnpm --filter web run test-client instrumentation-client-replay-mask.clienttest.ts — Tests 9 passed (9)
- pnpm run agents:check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR strengthens Sentry Session Replay privacy by applying text, input, and media masking in every deployment.

- Removes region-dependent Replay masking behavior.
- Adds unconditional `maskAllInputs` protection alongside text and media masking.
- Updates the real-module regression test to verify every covered region.
- Aligns Sentry instrumentation guidance with the new privacy contract.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

The production configuration, regression test, and instrumentation guidance consistently enforce unconditional masking of Replay text, inputs, and media.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sentry): redact PII in all session r..."](https://github.com/langfuse/langfuse/commit/c82a2a8982bdc4b8644ddb67cb9ba522ad80a4f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55308821)</sub>

<!-- /greptile_comment -->