### PR TITLE
fix(shared): apply score pagination when offset is 0

### DIFF
--- a/packages/shared/src/server/repositories/scores.pagination.test.ts
+++ b/packages/shared/src/server/repositories/scores.pagination.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockQueryClickhouse = vi.hoisted(() => vi.fn());
+
+vi.mock("./clickhouse", () => ({
+  queryClickhouse: mockQueryClickhouse,
+  commandClickhouse: vi.fn(),
+  queryClickhouseStream: vi.fn(),
+  queryClickhouseExecRaw: vi.fn(),
+  upsertClickhouse: vi.fn(),
+  parseClickhouseUTCDateTimeFormat: vi.fn(),
+  clickhouseCompliantRandomCharacters: vi.fn(() => "x"),
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: {},
+}));
+
+import {
+  getScoresForTraces,
+  getScoresForSessions,
+  getScoresForExperiments,
+} from "../index";
+
+const PAGINATION_CLAUSE = "limit {limit: Int32} offset {offset: Int32}";
+
+const lastQuery = () => {
+  expect(mockQueryClickhouse).toHaveBeenCalledOnce();
+  return mockQueryClickhouse.mock.calls[0][0] as {
+    query: string;
+    params: Record<string, unknown>;
+  };
+};
+
+const callers = [
+  {
+    name: "getScoresForTraces",
+    call: (pagination: { limit?: number; offset?: number }) =>
+      getScoresForTraces({
+        projectId: "project-1",
+        traceIds: ["trace-1"],
+        ...pagination,
+      }),
+  },
+  {
+    name: "getScoresForSessions",
+    call: (pagination: { limit?: number; offset?: number }) =>
+      getScoresForSessions({
+        projectId: "project-1",
+        sessionIds: ["session-1"],
+        ...pagination,
+      }),
+  },
+  {
+    name: "getScoresForExperiments",
+    call: (pagination: { limit?: number; offset?: number }) =>
+      getScoresForExperiments({
+        projectId: "project-1",
+        runIds: ["run-1"],
+        ...pagination,
+      }),
+  },
+];
+
+describe("score repository pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryClickhouse.mockResolvedValue([]);
+  });
+
+  describe.each(callers)("$name", ({ call }) => {
+    it("applies the requested page size on the first page (offset 0)", async () => {
+      await call({ limit: 50, offset: 0 });
+
+      const { query, params } = lastQuery();
+      expect(query).toContain(PAGINATION_CLAUSE);
+      expect(params).toMatchObject({ limit: 50, offset: 0 });
+    });
+
+    it("applies pagination for a positive offset", async () => {
+      await call({ limit: 50, offset: 50 });
+
+      const { query, params } = lastQuery();
+      expect(query).toContain(PAGINATION_CLAUSE);
+      expect(params).toMatchObject({ limit: 50, offset: 50 });
+    });
+
+    it("omits pagination when limit and offset are not provided", async () => {
+      await call({});
+
+      expect(lastQuery().query).not.toContain(PAGINATION_CLAUSE);
+    });
+  });
+});

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -261,7 +261,7 @@ export const getScoresForSessions = async <
       AND s.data_type IN ({dataTypes: Array(String)})
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<ScoreRecordReadType>({
@@ -310,7 +310,7 @@ export const getScoresForExperiments = async <
       AND s.data_type IN ({dataTypes: Array(String)})
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<ScoreRecordReadType>({
@@ -529,7 +529,7 @@ const getScoresForTracesInternal = async <
       ${levelFilter}
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<


### PR DESCRIPTION
## What does this PR do?

Fixes #16368

`getScoresForTraces`, `getScoresForSessions` and `getScoresForExperiments` gate their `LIMIT/OFFSET` clause behind a truthiness check on both values:

```ts
${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
```

`0` is falsy, so `limit && offset` short-circuits on the **first page**. The generated ClickHouse query omits the clause entirely and the result set is not bounded by the caller-provided page size. A positive offset is unaffected, so the bug only shows up on page one.

This changes the guard to `limit !== undefined && offset !== undefined`, which is already the convention elsewhere in the same file — `getScoresForObservations` and `getScoresUiGeneric` both use it.

### Changes

- `packages/shared/src/server/repositories/scores.ts` — fix the guard in the three affected query builders (lines 264, 313, 532).
- `packages/shared/src/server/repositories/scores.pagination.test.ts` — new mocked-query regression test.

### Tests

The new test mocks `queryClickhouse` and asserts on the generated SQL, so it needs no ClickHouse service. It covers all three builders with three cases each:

- pagination clause emitted for `offset: 0` ← **fails on `main`**
- pagination clause emitted for a positive offset
- clause omitted when `limit`/`offset` are not supplied

Verified the red/green cycle — against the previous implementation exactly the three `offset: 0` cases fail:

```
Tests  3 failed | 6 passed (9)
AssertionError: expected '\n select\n *\n from…' to contain 'limit {limit: Int32} offset {offset: …'
```

With the fix applied:

```
Test Files  1 passed (1)
     Tests  9 passed (9)
```

Command: `pnpm --filter @langfuse/shared run test src/server/repositories/scores.pagination.test.ts`

Impacted package: `@langfuse/shared` only. No schema, contract, or public API change — the clause is additive and callers that omit `limit`/`offset` keep the current behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects score-query pagination so a zero offset still emits the ClickHouse LIMIT/OFFSET clause.
- Updates the session, experiment, and trace score query builders to check pagination parameters explicitly for `undefined`.
- Adds regression coverage for first-page, positive-offset, and omitted-pagination cases across all three builders.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or quality issues identified.

The explicit undefined checks match existing score-query conventions and restore the intended bounded first-page behavior while preserving unpaginated calls.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): apply score pagination when..."](https://github.com/langfuse/langfuse/commit/bf367d1fa262660a3aaf73b108e8c5475f5fb33e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55340500)</sub>

<!-- /greptile_comment -->