### PR TITLE
feat(pricing): price Anthropic server-side web search tool calls

### DIFF
--- a/.agents/skills/add-model-price/references/provider-sources-and-price-keys.md
+++ b/.agents/skills/add-model-price/references/provider-sources-and-price-keys.md
@@ -303,6 +303,17 @@ Formula:
 price_per_token = price_per_mtok / 1_000_000
 ```
 
+Per-request server-tool fees are not token-scaled. Convert them per call:
+
+| Provider Price          | JSON Value |
+| ----------------------- | ---------- |
+| `$10 / 1,000 searches`  | `10e-3`    |
+| `$14 / 1,000 queries`   | `14e-3`    |
+
+```text
+price_per_request = price_per_thousand / 1_000
+```
+
 ## Provider Usage Keys
 
 Use [provider-usage-key-matrix.md](provider-usage-key-matrix.md) as the single

--- a/.agents/skills/add-model-price/references/provider-usage-key-matrix.md
+++ b/.agents/skills/add-model-price/references/provider-usage-key-matrix.md
@@ -61,6 +61,21 @@ keys as equal-price aliases. Verify which TTLs the model supports. Current
 `claude-sonnet-4-6`, `claude-opus-4-6`, and `claude-opus-4-8` entries are mature
 templates and include direct Anthropic plus regional Bedrock model IDs.
 
+Server tools are billed per request rather than per token, so they need their
+own key:
+
+| Bucket            | Key                   | Source                                     |
+| ----------------- | --------------------- | ------------------------------------------ |
+| Web search request | `web_search_requests` | `usage.server_tool_use.web_search_requests` |
+
+Anthropic's Messages API reports `server_tool_use` counters in snake_case only,
+so this bucket takes a single key with no camelCase alias — unlike the Gemini
+grounding family. Add it only to entries whose model documents web-search
+support: Claude 3.5 and later carry it, and the Claude 1.x, 2.x, instant, and
+original Claude 3 (February–March 2024) entries do not. The key is safe on the
+shared Anthropic/Bedrock/Vertex entries because web search is unavailable on
+Bedrock, so the counter is simply never emitted there.
+
 ## Gemini
 
 Use these core aliases for priced text-generation models:

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1539,7 +1539,7 @@
     "modelName": "claude-3-5-sonnet-20240620",
     "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -1559,7 +1559,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -1749,7 +1750,7 @@
     "modelName": "claude-3.5-sonnet-20241022",
     "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -1769,7 +1770,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -1779,7 +1781,7 @@
     "modelName": "claude-3.5-sonnet-latest",
     "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-latest)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
-    "updatedAt": "2026-04-13T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -1799,7 +1801,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -1809,7 +1812,7 @@
     "modelName": "claude-3-5-haiku-20241022",
     "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -1829,7 +1832,8 @@
           "input_cache_creation_1h": 0.0000016,
           "cache_read_input_tokens": 8e-8,
           "input_cached_tokens": 8e-8,
-          "input_cache_read": 8e-8
+          "input_cache_read": 8e-8,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -1839,7 +1843,7 @@
     "modelName": "claude-3.5-haiku-latest",
     "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-latest)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
-    "updatedAt": "2026-04-13T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -1859,7 +1863,8 @@
           "input_cache_creation_1h": 0.0000016,
           "cache_read_input_tokens": 8e-8,
           "input_cached_tokens": 8e-8,
-          "input_cache_read": 8e-8
+          "input_cache_read": 8e-8,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -2159,7 +2164,7 @@
     "modelName": "claude-3.7-sonnet-20250219",
     "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -2179,7 +2184,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -2189,7 +2195,7 @@
     "modelName": "claude-3.7-sonnet-latest",
     "matchPattern": "(?i)^(anthropic\/)?(claude-3-7-sonnet-latest)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
-    "updatedAt": "2026-04-13T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -2209,7 +2215,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -2575,7 +2582,7 @@
     "modelName": "claude-sonnet-4-5-20250929",
     "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
-    "updatedAt": "2026-08-04T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -2595,7 +2602,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -2605,7 +2613,7 @@
     "modelName": "claude-sonnet-4-20250514",
     "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -2625,7 +2633,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -2635,7 +2644,7 @@
     "modelName": "claude-sonnet-4-latest",
     "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-latest)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
-    "updatedAt": "2026-04-13T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -2655,7 +2664,8 @@
           "input_cache_creation_1h": 0.000006,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -2665,7 +2675,7 @@
     "modelName": "claude-opus-4-20250514",
     "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -2685,7 +2695,8 @@
           "input_cache_creation_1h": 0.00003,
           "cache_read_input_tokens": 0.0000015,
           "input_cached_tokens": 0.0000015,
-          "input_cache_read": 0.0000015
+          "input_cache_read": 0.0000015,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -2853,7 +2864,7 @@
     "modelName": "claude-opus-4-1-20250805",
     "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -2873,7 +2884,8 @@
           "input_cache_creation_1h": 0.00003,
           "cache_read_input_tokens": 0.0000015,
           "input_cached_tokens": 0.0000015,
-          "input_cache_read": 0.0000015
+          "input_cache_read": 0.0000015,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3149,7 +3161,7 @@
     "modelName": "claude-haiku-4-5-20251001",
     "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
@@ -3169,7 +3181,8 @@
           "input_cache_creation_1h": 0.000002,
           "cache_read_input_tokens": 1e-7,
           "input_cached_tokens": 1e-7,
-          "input_cache_read": 1e-7
+          "input_cache_read": 1e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3239,7 +3252,7 @@
     "modelName": "claude-opus-4-5-20251101",
     "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
     "createdAt": "2025-11-24T20:53:27.571Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3260,7 +3273,8 @@
           "input_cache_creation_1h": 10e-6,
           "cache_read_input_tokens": 0.5e-6,
           "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input_cache_read": 0.5e-6,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3270,7 +3284,7 @@
     "modelName": "claude-sonnet-4-6",
     "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-v1(:0)?)?|claude-sonnet-4-6)$",
     "createdAt": "2026-02-18T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3291,7 +3305,8 @@
           "input_cache_creation_1h": 6e-6,
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input_cache_read": 3e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3301,7 +3316,7 @@
     "modelName": "claude-opus-4-6",
     "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
     "createdAt": "2026-02-09T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3322,7 +3337,8 @@
           "input_cache_creation_1h": 10e-6,
           "cache_read_input_tokens": 0.5e-6,
           "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input_cache_read": 0.5e-6,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3332,7 +3348,7 @@
     "modelName": "claude-opus-4-7",
     "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
     "createdAt": "2026-04-16T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3353,7 +3369,8 @@
           "input_cache_creation_1h": 10e-6,
           "cache_read_input_tokens": 0.5e-6,
           "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input_cache_read": 0.5e-6,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3363,7 +3380,7 @@
     "modelName": "claude-opus-4-8",
     "matchPattern": "(?i)^((anthropic\/)?claude-opus-4-8|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-4-8(-v1(:0)?)?)$",
     "createdAt": "2026-05-28T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3384,7 +3401,8 @@
           "input_cache_creation_1h": 10e-6,
           "cache_read_input_tokens": 0.5e-6,
           "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input_cache_read": 0.5e-6,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3394,7 +3412,7 @@
     "modelName": "claude-fable-5",
     "matchPattern": "(?i)^((anthropic\/)?claude-fable-5|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-fable-5(-v1(:0)?)?)$",
     "createdAt": "2026-06-09T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3415,7 +3433,8 @@
           "input_cache_creation_1h": 20e-6,
           "cache_read_input_tokens": 1e-6,
           "input_cached_tokens": 1e-6,
-          "input_cache_read": 1e-6
+          "input_cache_read": 1e-6,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3425,7 +3444,7 @@
     "modelName": "claude-mythos-5",
     "matchPattern": "(?i)^(anthropic\/)?claude-mythos-5$",
     "createdAt": "2026-06-09T00:00:00.000Z",
-    "updatedAt": "2026-06-09T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3446,7 +3465,8 @@
           "input_cache_creation_1h": 20e-6,
           "cache_read_input_tokens": 1e-6,
           "input_cached_tokens": 1e-6,
-          "input_cache_read": 1e-6
+          "input_cache_read": 1e-6,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3456,7 +3476,7 @@
     "modelName": "claude-sonnet-5",
     "matchPattern": "(?i)^((anthropic\\/)?claude-sonnet-5|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-sonnet-5(-v1(:0)?)?)$",
     "createdAt": "2026-07-01T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3477,7 +3497,8 @@
           "input_cache_creation_1h": 4e-6,
           "cache_read_input_tokens": 2e-7,
           "input_cached_tokens": 2e-7,
-          "input_cache_read": 2e-7
+          "input_cache_read": 2e-7,
+          "web_search_requests": 10e-3
         }
       }
     ]
@@ -3487,7 +3508,7 @@
     "modelName": "claude-opus-5",
     "matchPattern": "(?i)^((anthropic\\/)?claude-opus-5|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-opus-5(-v1(:0)?)?)$",
     "createdAt": "2026-07-25T00:00:00.000Z",
-    "updatedAt": "2026-07-28T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3508,7 +3529,8 @@
           "input_cache_creation_1h": 10e-6,
           "cache_read_input_tokens": 0.5e-6,
           "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input_cache_read": 0.5e-6,
+          "web_search_requests": 10e-3
         }
       }
     ]


### PR DESCRIPTION
## What does this PR do?

Refs #15856

Anthropic bills its `web_search` server tool as a flat **per-request** fee that no token count can express — **$10 per 1,000 searches** — and reports the count as an explicit integer on the Messages API response:

```json
"usage": {
  "input_tokens": 105,
  "output_tokens": 6039,
  "server_tool_use": { "web_search_requests": 1 }
}
```

Langfuse already models exactly this billing shape for Google: the managed Gemini entries carry `grounding_queries` / `web_search_queries` at $0.014. The Claude entries expose token keys only.

That matters because cost calculation matches usage keys against prices by **exact string equality** (`IngestionService.calculateUsageCosts` does `modelPrices.find((p) => p.usageType === key)`). A forwarded `web_search_requests` usage detail therefore matches nothing and silently contributes **$0** — the number is visible in the UI while its cost is not. On grounded search workloads the fee is routinely a large share of a generation's true cost, so those generations are under-priced by the entire search component.

### Changes

- `worker/src/constants/default-model-prices.json` — add `web_search_requests: 10e-3` ($0.01 per search) to the 22 Claude entries whose models document web-search support, and refresh their `updatedAt`.
- `.agents/skills/add-model-price/references/provider-usage-key-matrix.md` — record the Anthropic server-tool bucket so the next pricing change does not have to rediscover it.
- `.agents/skills/add-model-price/references/provider-sources-and-price-keys.md` — document per-request fee conversion next to the existing per-token formula.

**No code change is required.** The upsert script's `prices` map is an open `z.record(z.string(), z.number())`, and `upsertTierWithPrices` only deletes keys removed from the JSON — so a new key is purely additive. The moment the price row exists, the existing lookup picks it up.

### Scope

Priced (Claude 3.5 and later, 22 entries): `claude-3-5-sonnet-20240620`, `claude-3.5-sonnet-20241022`, `claude-3.5-sonnet-latest`, `claude-3-5-haiku-20241022`, `claude-3.5-haiku-latest`, `claude-3.7-sonnet-20250219`, `claude-3.7-sonnet-latest`, `claude-sonnet-4-20250514`, `claude-sonnet-4-latest`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-6`, `claude-opus-4-20250514`, `claude-opus-4-1-20250805`, `claude-opus-4-5-20251101`, `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8`, `claude-haiku-4-5-20251001`, `claude-fable-5`, `claude-mythos-5`, `claude-sonnet-5`, `claude-opus-5`.

Deliberately **not** priced: the Claude 1.x, 2.x, instant, and original Claude 3 (February–March 2024) entries, which predate the tool.

Two deliberate decisions worth a reviewer's eye:

1. **One key, no alias.** Anthropic's Messages API reports `server_tool_use` counters in snake_case only, so this bucket takes a single `web_search_requests` key. The Gemini grounding family needs four aliases because AI Studio and Vertex casing differ; Anthropic has no camelCase precedent anywhere in the file.
2. **Safe on the shared entries.** Each Claude entry's `matchPattern` also covers Bedrock and Vertex IDs. [Anthropic's docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool) state web search is unavailable on Amazon Bedrock, so the counter is simply never emitted there and the price never applies.

**OpenAI is intentionally left for a follow-up.** The issue also proposes `web_search_calls`, but OpenAI's web-search fee varies by model and search context size, which likely needs a tier condition rather than one flat per-model price. Keeping this PR to the clean case (an explicit integer in the provider's own usage object at a single published rate) keeps it reviewable.

Source: <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool> — "Web search is available on the Claude API for **$10 per 1,000 searches**, plus standard token costs" and "Each web search counts as one use, regardless of the number of results returned. If an error occurs during web search, the web search will not be billed."

### Tests

Followed the repo's `add-model-price` skill. All three of its validators pass:

```
node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
  -> Validated 167 pricing entries.

node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs --base <pre-change copy>
  -> Validated 167 pricing entries.
  -> Validated usage-key coverage for 22 changed or selected pricing entries.

node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs --usage-key-model claude-sonnet-4-6
  -> Validated usage-key coverage for 1 changed or selected pricing entries.
```

The edit was applied by a scripted, line-level transform rather than a `JSON.stringify` round-trip, so the file's exponent notation and formatting are preserved — the diff is exactly 22 × (`updatedAt` + `input_cache_read` comma + new key). A programmatic before/after comparison asserted that no existing price value changed, no non-target entry was touched, and every target gained exactly one key valued `0.01`.

Impacted package: `worker` (plus skill documentation). I could not run `pnpm --filter worker run test src/__tests__/pricing-tier-matcher.test.ts` locally because my registry mirror is missing `@posthog/core`, so worker dependencies would not install. I replicated that test's `describe("default-model-prices.json")` assertions standalone against the edited file instead — unique model/tier IDs, unique names, `updatedAt >= createdAt`, valid dates, one default tier at priority 0 with no conditions, `${modelId}_tier_default` ID form, unique priorities and tier names, non-negative finite prices, identical price-key sets across tiers, and valid `matchPattern` regexes — all pass. Please let CI run the real worker suite.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a $0.01 per-request `web_search_requests` price to 22 Claude model entries and documents Anthropic server-tool usage-key conventions and per-request conversion. The pricing rows are additive, but automatic Anthropic ingestion does not currently surface the nested counter under the new top-level key.
- Adds Anthropic web-search request pricing to supported Claude entries.
- Documents the provider usage key and per-thousand-to-per-request conversion.
- Refreshes the affected model-price timestamps.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until automatic Anthropic ingestion maps the nested web-search counter to the new priced usage key.

The price itself is correctly expressed, but the OTel, AI SDK, and in-app-agent paths omit `server_tool_use.web_search_requests`, leaving automatically ingested searches unpriced.

**Files Needing Attention:** worker/src/constants/default-model-prices.json and the Anthropic usage normalization paths
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/constants/default-model-prices.json:1563
**Automatic ingestion drops search usage**

When an Anthropic response reports `usage.server_tool_use.web_search_requests`, the OTel, AI SDK, and in-app-agent ingestion paths do not flatten that nested counter into the top-level `web_search_requests` key required by exact-match pricing. Automatically ingested web searches therefore still contribute $0 to generation cost despite these new price entries.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pricing): price Anthropic server-si..."](https://github.com/langfuse/langfuse/commit/7268dd852b8dfba25640be3370c82a723f66546b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55343800)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->