### PR TITLE
fix(scripts): resolve repo root from file URLs with fileURLToPath

### DIFF
--- a/.agents/skills/add-model-price/scripts/validate-pricing-file.test.mjs
+++ b/.agents/skills/add-model-price/scripts/validate-pricing-file.test.mjs
@@ -4,8 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-const validatorPath = new URL("./validate-pricing-file.mjs", import.meta.url);
+const validatorPath = fileURLToPath(
+  new URL("./validate-pricing-file.mjs", import.meta.url),
+);
 
 function model({ id, modelName, matchPattern, tokenizerId = null, prices }) {
   return {
@@ -43,7 +46,7 @@ async function runValidator(currentModels, baseModels) {
     ]);
     return spawnSync(
       process.execPath,
-      [validatorPath.pathname, currentPath, "--base", basePath],
+      [validatorPath, currentPath, "--base", basePath],
       { encoding: "utf8" },
     );
   } finally {
@@ -193,7 +196,7 @@ test("rejects an unknown explicitly selected model", () => {
   const result = spawnSync(
     process.execPath,
     [
-      validatorPath.pathname,
+      validatorPath,
       "worker/src/constants/default-model-prices.json",
       "--usage-key-model",
       "not-a-catalog-model",

--- a/scripts/agents/sync-agent-shims.mjs
+++ b/scripts/agents/sync-agent-shims.mjs
@@ -11,8 +11,9 @@ import {
 } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(new URL("../..", import.meta.url).pathname);
+const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const sourcePath = resolve(repoRoot, ".agents/config.json");
 const config = JSON.parse(readFileSync(sourcePath, "utf8"));
 const servers = config.mcpServers;

--- a/scripts/in-app-agent/sync-raw-skills.mjs
+++ b/scripts/in-app-agent/sync-raw-skills.mjs
@@ -9,9 +9,10 @@ import {
 } from "node:fs";
 import { basename, resolve } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { format as formatWithPrettier } from "prettier";
 
-const repoRoot = resolve(new URL("../..", import.meta.url).pathname);
+const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const generatedDir = resolve(
   repoRoot,
   "worker/src/features/in-app-agent/runtime/skills/generated",


### PR DESCRIPTION
## What does this PR do?

`new URL(...).pathname` is not a filesystem path, but three repo scripts treat it as one.

On Windows the URL pathname keeps a leading slash — `file:///C:/repo/` gives `/C:/repo/` — so `resolve()` prepends the current drive and produces `C:\C:\repo`. Every path derived from the repo root then misses. The same call also leaves percent-encoding intact, so a checkout under a directory containing a space resolves to a `%20` path on **every** platform.

```
> node -e "const {resolve}=require('path'); const {fileURLToPath}=require('url');
  const u=new URL('file:///C:/Users/test/repo/scripts/a.mjs');
  console.log('pathname      =', new URL('../..', u).pathname);
  console.log('resolve       =', resolve(new URL('../..', u).pathname));
  console.log('fileURLToPath =', resolve(fileURLToPath(new URL('../..', u))));"

pathname      = /C:/Users/test/
resolve       = C:\C:\Users\test      <-- doubled drive root
fileURLToPath = C:\Users\test         <-- correct
```

### Impact

`scripts/agents/sync-agent-shims.mjs` is invoked by the root `postinstall` (via `scripts/postinstall.sh` → `pnpm run agents:sync`) and by `pnpm run agents:check` in the lint job. On Windows it aborted on its very first read, so agent shims could never be generated locally:

```
Error: ENOENT: no such file or directory, open
'C:\C:\Users\...\langfuse\.agents\config.json'
```

`scripts/in-app-agent/sync-raw-skills.mjs` failed identically:

```
Error: ENOENT: no such file or directory, mkdir
'C:\C:\Users\...\worker\src\features\in-app-agent\runtime\skills\generated\raw'
```

And the add-model-price validator's own self-test suite could not spawn the script under test, failing **all four** cases:

```
Error: Cannot find module
'C:\C:\Users\...\.agents\skills\add-model-price\scripts\validate-pricing-file.mjs'
# tests 4 | pass 0 | fail 4
```

### Changes

Use `fileURLToPath` — the documented way to convert a `file:` URL to a path — which handles both the drive-letter prefix and percent-decoding:

- `scripts/agents/sync-agent-shims.mjs`
- `scripts/in-app-agent/sync-raw-skills.mjs`
- `.agents/skills/add-model-price/scripts/validate-pricing-file.test.mjs` (also drops the now-redundant `.pathname` at both spawn sites)

### Tests

The validator's self-test suite is the direct regression check and goes from failing every case to green on Windows:

```
> node --test .agents/skills/add-model-price/scripts/validate-pricing-file.test.mjs

ok 1 - checks usage-key coverage only for changed pricing entries
ok 2 - accepts complete OpenAI, Anthropic, Gemini, and generic Bedrock entries
ok 3 - rejects unequal prices within a semantic alias family
ok 4 - rejects an unknown explicitly selected model
# tests 4 | pass 4 | fail 0
```

Both sync scripts now reach their real logic instead of aborting on a malformed path — `sync-agent-shims.mjs --check --check-paths` reports the shims it would generate, and `sync-raw-skills.mjs --check` reports its upstream diff, each with correctly-rooted absolute paths.

Behavior on Linux and macOS is unchanged for checkouts whose paths need no percent-decoding: there `pathname` and `fileURLToPath` already agree, which is why CI never caught this.

No generated shim output is included in this PR.

Impacted package: repo scripts and skill tooling only — no `web`, `worker`, or `packages/shared` code is touched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects filesystem path handling in repository scripts by converting module-relative file URLs with `fileURLToPath`.
- Fixes repository-root resolution on Windows and in percent-encoded checkout paths.
- Passes a decoded filesystem path to the pricing validator test processes.
- Leaves the scripts’ downstream path construction and behavior unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The changed URL-to-path conversions preserve the intended repository locations while correcting Windows drive-letter handling and percent decoding, and all affected consumers accept the resulting filesystem strings.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): resolve repo root from fil..."](https://github.com/langfuse/langfuse/commit/1ec353b1cdbac9844ec94f2b2ea46f4198ca11be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55345283)</sub>

<!-- /greptile_comment -->