### PR TITLE
feat(llm): add OrcaRouter as a first-class LLM connection adapter

### DIFF
--- a/fern/apis/server/definition/llm-connections.yml
+++ b/fern/apis/server/definition/llm-connections.yml
@@ -122,3 +122,5 @@ types:
         name: GoogleVertexAI
       - value: google-ai-studio
         name: GoogleAIStudio
+      - value: orcarouter
+        name: OrcaRouter

--- a/packages/shared/src/server/llm/ai-sdk/providers/index.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providers/index.ts
@@ -8,6 +8,7 @@ import { buildAzureModel } from "./azure";
 import { buildBedrockModel } from "./bedrock";
 import { buildGoogleAIStudioModel } from "./google";
 import { buildOpenAIModel } from "./openai";
+import { buildOrcaRouterModel } from "./orcarouter";
 import type { LLMCredentialSource } from "./types";
 import { buildVertexModel, isClaudeModel } from "./vertex";
 
@@ -61,6 +62,15 @@ export async function buildAiSdkModel(params: {
         extraHeaders,
         apiMode: modelConfig.openAIApiMode ?? "chat-completions",
         fetch: createFetch("OpenAI LLM base URL"),
+      });
+
+    case LLMAdapter.OrcaRouter:
+      return buildOrcaRouterModel({
+        modelId: model.id,
+        apiKey,
+        baseURL,
+        extraHeaders,
+        fetch: createFetch("OrcaRouter LLM base URL"),
       });
 
     case LLMAdapter.Azure:

--- a/packages/shared/src/server/llm/ai-sdk/providers/orcarouter.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providers/orcarouter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ORCAROUTER_DEFAULT_BASE_URL,
+  isOrcaRouterEndpoint,
+  translateOrcaRouterProviderOptions,
+} from "./orcarouter";
+
+describe("isOrcaRouterEndpoint", () => {
+  it("recognizes the OrcaRouter default endpoint", () => {
+    expect(isOrcaRouterEndpoint(undefined)).toBe(false);
+    expect(isOrcaRouterEndpoint(null)).toBe(false);
+    expect(isOrcaRouterEndpoint("https://api.orcarouter.ai/v1")).toBe(true);
+    expect(isOrcaRouterEndpoint("https://api.orcarouter.ai./v1")).toBe(true);
+  });
+
+  it("rejects non-OrcaRouter endpoints", () => {
+    expect(isOrcaRouterEndpoint("https://api.openai.com/v1")).toBe(false);
+    expect(isOrcaRouterEndpoint("https://orcarouter.example.com/v1")).toBe(
+      false,
+    );
+    expect(isOrcaRouterEndpoint("localhost:8080")).toBe(false);
+  });
+
+  it("exposes the documented default base URL", () => {
+    expect(ORCAROUTER_DEFAULT_BASE_URL).toBe("https://api.orcarouter.ai/v1");
+  });
+});
+
+describe("translateOrcaRouterProviderOptions", () => {
+  it("returns undefined for empty input", () => {
+    expect(translateOrcaRouterProviderOptions(undefined)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+    expect(translateOrcaRouterProviderOptions({})).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("translates snake_case body params to wire shape", () => {
+    expect(
+      translateOrcaRouterProviderOptions({
+        parallel_tool_calls: false,
+        max_completion_tokens: 128,
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        parallel_tool_calls: false,
+        max_completion_tokens: 128,
+      },
+    });
+  });
+
+  it("passes through unknown gateway-specific options", () => {
+    expect(
+      translateOrcaRouterProviderOptions({
+        reasoning_effort: "high",
+        custom_gateway_option: "x",
+      }),
+    ).toEqual({
+      ok: true,
+      value: { reasoningEffort: "high", custom_gateway_option: "x" },
+    });
+  });
+
+  it("passes through unknown top-level gateway options", () => {
+    expect(
+      translateOrcaRouterProviderOptions({ custom_gateway_option: 1 }),
+    ).toEqual({
+      ok: true,
+      value: { custom_gateway_option: 1 },
+    });
+  });
+
+  it("merges a nested openai object verbatim", () => {
+    expect(
+      translateOrcaRouterProviderOptions({
+        openai: { reasoningEffort: "medium", store: false },
+      }),
+    ).toEqual({
+      ok: true,
+      value: { reasoningEffort: "medium", store: false },
+    });
+  });
+});

--- a/packages/shared/src/server/llm/ai-sdk/providers/orcarouter.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providers/orcarouter.ts
@@ -1,0 +1,114 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { LanguageModel } from "ai";
+
+import type { TranslatedProviderOptions } from "./types";
+import { isPlainObject } from "./utils";
+
+/**
+ * Default base URL for the OrcaRouter adapter. OrcaRouter is an
+ * OpenAI-compatible chat gateway; when a connection does not set a custom
+ * base URL, Langfuse points at this endpoint and sends requests through
+ * `POST /v1/chat/completions`.
+ */
+export const ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1";
+
+/**
+ * Translation of Langfuse `modelParams.providerOptions` to AI SDK OpenAI
+ * provider options for the OrcaRouter adapter. OrcaRouter follows the
+ * OpenAI-compatible wire format, so this mirrors the compatible-provider
+ * translation in `openai.ts` (wire-shaped snake_case keys, unknown-key
+ * passthrough for gateway-specific surfaces).
+ */
+const ORCAROUTER_PROVIDER_OPTION_KEY_MAP: Record<string, string> = {
+  service_tier: "service_tier",
+  parallel_tool_calls: "parallel_tool_calls",
+  logit_bias: "logit_bias",
+  max_completion_tokens: "max_completion_tokens",
+  store: "store",
+  user: "user",
+  serviceTier: "service_tier",
+  parallelToolCalls: "parallel_tool_calls",
+  logitBias: "logit_bias",
+  maxCompletionTokens: "max_completion_tokens",
+  reasoning_effort: "reasoningEffort",
+  reasoningEffort: "reasoningEffort",
+  text_verbosity: "textVerbosity",
+  verbosity: "textVerbosity",
+  textVerbosity: "textVerbosity",
+};
+
+export function buildOrcaRouterModel(params: {
+  modelId: string;
+  apiKey: string;
+  baseURL?: string | null;
+  extraHeaders?: Record<string, string>;
+  fetch: typeof fetch;
+}): LanguageModel {
+  const { apiKey, baseURL, extraHeaders, modelId } = params;
+
+  const provider = createOpenAICompatible({
+    name: "orcarouter",
+    apiKey,
+    baseURL: baseURL?.length ? baseURL : ORCAROUTER_DEFAULT_BASE_URL,
+    headers: extraHeaders,
+    fetch: params.fetch,
+    supportsStructuredOutputs: true,
+  });
+
+  return provider.languageModel(modelId);
+}
+
+export function isOrcaRouterEndpoint(
+  baseURL: string | null | undefined,
+): baseURL is string {
+  if (!baseURL) return false;
+
+  try {
+    const url = new URL(baseURL.replace("{model}", "model"));
+    if (!["http:", "https:"].includes(url.protocol) || !url.hostname) {
+      return false;
+    }
+
+    const hostname = url.hostname.replace(/\.$/, "");
+    return hostname === "api.orcarouter.ai";
+  } catch {
+    return false;
+  }
+}
+
+export function translateOrcaRouterProviderOptions(
+  providerOptions: Record<string, unknown> | undefined,
+): TranslatedProviderOptions {
+  if (!providerOptions || Object.keys(providerOptions).length === 0) {
+    return { ok: true, value: undefined };
+  }
+
+  const translated: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(providerOptions)) {
+    if (key === "openai" && isPlainObject(value)) {
+      for (const [nestedKey, nestedValue] of Object.entries(value)) {
+        const mappedKey = ORCAROUTER_PROVIDER_OPTION_KEY_MAP[nestedKey];
+        // OrcaRouter is a gateway, so unknown per-provider options are
+        // forwarded best-effort rather than rejected.
+        translated[mappedKey ?? nestedKey] = nestedValue;
+      }
+      continue;
+    }
+
+    const mappedKey = ORCAROUTER_PROVIDER_OPTION_KEY_MAP[key];
+    // Gateway-specific request-body keys are forwarded to the wire verbatim
+    // (mirrors the OpenAI-compatible passthrough in `openai.ts`).
+    if (mappedKey === undefined) {
+      translated[key] = value;
+      continue;
+    }
+
+    translated[mappedKey] = value;
+  }
+
+  return {
+    ok: true,
+    value: Object.keys(translated).length > 0 ? translated : undefined,
+  };
+}

--- a/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/requestShape.test.ts
@@ -765,4 +765,46 @@ describe("AI SDK request shapes", () => {
     // No merged server session token (would surface as this SigV4 header).
     expect(request.headers.get("x-amz-security-token")).toBeNull();
   });
+
+  it("OrcaRouter: default base URL, bearer auth, chat-completions wire shape", async () => {
+    const { result, request } = await runCompletion({
+      modelParams: {
+        provider: "orcarouter",
+        adapter: LLMAdapter.OrcaRouter,
+        model: "orcarouter/auto",
+        max_tokens: 128,
+        temperature: 0.2,
+        providerOptions: { reasoning_effort: "high" },
+      },
+      apiKey: "sk-orca-test",
+      response: OPENAI_CHAT_RESPONSE,
+    });
+
+    expect(result.text).toBe("ok");
+    expect(request.url).toBe("https://api.orcarouter.ai/v1/chat/completions");
+    expect(request.headers.get("authorization")).toBe("Bearer sk-orca-test");
+    expect(request.body.model).toBe("orcarouter/auto");
+    expect(request.body.reasoning_effort).toBe("high");
+    expect(request.body.temperature).toBe(0.2);
+    expect(request.body.max_tokens).toBe(128);
+    expect(request.body.messages).toEqual([
+      { role: "system", content: "You are terse." },
+      { role: "user", content: "Hi" },
+    ]);
+  });
+
+  it("OrcaRouter: custom base URL is honored when set", async () => {
+    const { request } = await runCompletion({
+      modelParams: {
+        provider: "orcarouter",
+        adapter: LLMAdapter.OrcaRouter,
+        model: "orcarouter/auto",
+      },
+      apiKey: "sk-orca-test",
+      baseURL: "https://gateway.example.com/v1",
+      response: OPENAI_CHAT_RESPONSE,
+    });
+
+    expect(request.url).toBe("https://gateway.example.com/v1/chat/completions");
+  });
 });

--- a/packages/shared/src/server/llm/ai-sdk/resolveAiSdkModelConfig.ts
+++ b/packages/shared/src/server/llm/ai-sdk/resolveAiSdkModelConfig.ts
@@ -93,6 +93,7 @@ export function resolveAiSdkModelConfig(params: {
 
       case LLMAdapter.Anthropic:
       case LLMAdapter.GoogleAIStudio:
+      case LLMAdapter.OrcaRouter:
         return { adapter: model.adapter };
 
       default: {

--- a/packages/shared/src/server/llm/llmText.ts
+++ b/packages/shared/src/server/llm/llmText.ts
@@ -34,6 +34,7 @@ import {
   isOpenRouterEndpoint,
   translateOpenAIProviderOptions,
 } from "./ai-sdk/providers/openai";
+import { translateOrcaRouterProviderOptions } from "./ai-sdk/providers/orcarouter";
 import type {
   LLMCredentialSource,
   TranslatedProviderOptions,
@@ -567,6 +568,14 @@ function translateLegacyProviderOptions(params: {
     case LLMAdapter.Anthropic:
       namespace = "anthropic";
       translated = translateAnthropicProviderOptions(
+        modelParams.providerOptions,
+      );
+      break;
+    case LLMAdapter.OrcaRouter:
+      // OrcaRouter is built on @ai-sdk/openai-compatible, which reads
+      // provider options from the `openaiCompatible` namespace.
+      namespace = "openaiCompatible";
+      translated = translateOrcaRouterProviderOptions(
         modelParams.providerOptions,
       );
       break;

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -250,6 +250,7 @@ export enum LLMAdapter {
   Bedrock = "bedrock",
   VertexAI = "google-vertex-ai",
   GoogleAIStudio = "google-ai-studio",
+  OrcaRouter = "orcarouter",
 }
 
 // Some providers require at least one user message. The persisted-message
@@ -454,6 +455,19 @@ export const googleAIStudioModels = [
   "gemini-1.5-flash-8b",
 ] as const;
 
+/**
+ * Default models exposed for the OrcaRouter adapter. OrcaRouter is an
+ * OpenAI-compatible chat gateway that routes model IDs through its own
+ * namespace (`orcarouter/auto` and the `orcarouter/fusion` family).
+ */
+export const orcarouterModels = [
+  "orcarouter/auto",
+  "orcarouter/fusion",
+  "orcarouter/fusion-flash",
+  "orcarouter/fusion-mini",
+] as const;
+
+export type OrcaRouterModel = (typeof orcarouterModels)[number];
 export type AnthropicModel = (typeof anthropicModels)[number];
 export type VertexAIModel = (typeof vertexAIModels)[number];
 export const supportedModels = {
@@ -461,6 +475,7 @@ export const supportedModels = {
   [LLMAdapter.OpenAI]: openAIModels,
   [LLMAdapter.VertexAI]: vertexAIModels,
   [LLMAdapter.GoogleAIStudio]: googleAIStudioModels,
+  [LLMAdapter.OrcaRouter]: orcarouterModels,
   [LLMAdapter.Azure]: [],
   [LLMAdapter.Bedrock]: [],
 } as const;

--- a/web/src/__tests__/server/llm-connections-api.servertest.ts
+++ b/web/src/__tests__/server/llm-connections-api.servertest.ts
@@ -400,6 +400,48 @@ describe("/api/public/llm-connections API Endpoints", () => {
       expect(response.body.extraHeaderKeys).toEqual([]);
     });
 
+    it("should create an OrcaRouter connection with its gateway adapter", async () => {
+      const createData = {
+        provider: generateUniqueProvider("orcarouter"),
+        adapter: LLMAdapter.OrcaRouter,
+        secretKey: "sk-orca-test",
+        baseURL: TEST_PUBLIC_LLM_BASE_URL,
+        customModels: ["orcarouter/auto"],
+        withDefaultModels: true,
+        extraHeaders: {
+          "X-Gateway-Trace": "enabled",
+        },
+      };
+
+      const response = await makeZodVerifiedAPICall(
+        PutLlmConnectionV1Response,
+        "PUT",
+        "/api/public/llm-connections",
+        createData,
+        auth,
+        201,
+      );
+
+      expect(response.status).toBe(201);
+      expect(response.body.provider).toBe(createData.provider);
+      expect(response.body.adapter).toBe(LLMAdapter.OrcaRouter);
+      expect(response.body.baseURL).toBe(TEST_PUBLIC_LLM_BASE_URL);
+      expect(response.body.customModels).toEqual(["orcarouter/auto"]);
+      expect(response.body.withDefaultModels).toBe(true);
+      expect(response.body.extraHeaderKeys).toEqual(["X-Gateway-Trace"]);
+      expect(response.body.config).toBeNull();
+
+      const dbConnection = await prisma.llmApiKeys.findUnique({
+        where: {
+          projectId_provider: {
+            projectId,
+            provider: createData.provider,
+          },
+        },
+      });
+      expect(dbConnection?.adapter).toBe(LLMAdapter.OrcaRouter);
+    });
+
     it("should reject creating a connection with a localhost baseURL", async () => {
       const response = await makeAPICall<{ message: string }>(
         "PUT",

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -330,7 +330,7 @@ export const env = createEnv({
     LANGFUSE_UI_LOGO_LIGHT_MODE_HREF: z.url().optional(),
     LANGFUSE_UI_LOGO_DARK_MODE_HREF: z.url().optional(),
     LANGFUSE_UI_DEFAULT_MODEL_ADAPTER: z
-      .enum(["OpenAI", "Anthropic", "Azure"])
+      .enum(["OpenAI", "Anthropic", "Azure", "OrcaRouter"])
       .optional(),
     LANGFUSE_UI_DEFAULT_BASE_URL_OPENAI: z.url().optional(),
     LANGFUSE_UI_DEFAULT_BASE_URL_ANTHROPIC: z.url().optional(),

--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -325,6 +325,22 @@ function getDefaultAdapterParams(
         providerOptions: { value: {}, enabled: false },
       };
 
+    // OrcaRouter is an OpenAI-compatible chat gateway, so it mirrors the
+    // OpenAI parameter surface.
+    case LLMAdapter.OrcaRouter:
+      return {
+        adapter: {
+          value: adapter,
+          enabled: true,
+        },
+        temperature: { value: 0, enabled: false },
+        maxTemperature: { value: 2, enabled: false },
+        max_tokens: { value: 4096, enabled: false },
+        top_p: { value: 1, enabled: false },
+        maxReasoningTokens: { value: 0, enabled: false },
+        providerOptions: { value: {}, enabled: false },
+      };
+
     // Docs: https://docs.anthropic.com/claude/reference/messages_post
     case LLMAdapter.Anthropic:
       return {

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -304,6 +304,8 @@ export function CreateLLMApiKeyForm({
         return customization?.defaultBaseUrlAzure ?? "";
       case LLMAdapter.Anthropic:
         return customization?.defaultBaseUrlAnthropic ?? "";
+      case LLMAdapter.OrcaRouter:
+        return "https://api.orcarouter.ai/v1";
       default:
         return "";
     }
@@ -389,7 +391,8 @@ export function CreateLLMApiKeyForm({
     adapter === LLMAdapter.OpenAI ||
     adapter === LLMAdapter.Anthropic ||
     adapter === LLMAdapter.VertexAI ||
-    adapter === LLMAdapter.GoogleAIStudio;
+    adapter === LLMAdapter.GoogleAIStudio ||
+    adapter === LLMAdapter.OrcaRouter;
 
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -1268,6 +1271,11 @@ export function CreateLLMApiKeyForm({
                               (excluding /v1/messages)
                             </span>
                           )}
+                          {currentAdapter === LLMAdapter.OrcaRouter && (
+                            <span>
+                              OrcaRouter default: https://api.orcarouter.ai/v1
+                            </span>
+                          )}
                         </FormDescription>
 
                         <FormControl>
@@ -1333,9 +1341,11 @@ export function CreateLLMApiKeyForm({
                   )}
 
                   {/* Extra Headers */}
-                  {[LLMAdapter.OpenAI, LLMAdapter.Anthropic].includes(
-                    currentAdapter,
-                  ) && renderExtraHeadersField()}
+                  {[
+                    LLMAdapter.OpenAI,
+                    LLMAdapter.Anthropic,
+                    LLMAdapter.OrcaRouter,
+                  ].includes(currentAdapter) && renderExtraHeadersField()}
 
                   {/* With default models */}
                   <FormField


### PR DESCRIPTION
## What does this PR do?

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class LLM connection adapter in Langfuse. OrcaRouter is an OpenAI-compatible chat gateway (API base `https://api.orcarouter.ai/v1`, key prefix `sk-orca-`). Today users can reach it only through the generic `openai` adapter with a manually filled base URL; this PR makes it a named adapter so it appears in the adapter dropdown, pre-fills the default gateway base URL, and exposes the gateway's default model namespace.

Concretely:

- New `LLMAdapter.OrcaRouter` enum value plus a default `orcarouterModels` list (`orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`) in `@langfuse/shared`.
- New `buildOrcaRouterModel` provider built on `@ai-sdk/openai-compatible` with a default base URL of `https://api.orcarouter.ai/v1` (custom base URLs still honored).
- `resolveAiSdkModelConfig`, `translateLegacyProviderOptions`, and the exhaustive adapter switches extended for the new adapter.
- UI: the "New LLM Connection" form now shows OrcaRouter in the adapter dropdown, pre-fills the default base URL, and enables advanced settings (custom base URL, extra headers, default models, custom models).
- Public API: `LlmAdapter` enum in the Fern definition (`fern/apis/server/definition/llm-connections.yml`) extended with `orcarouter`; servertest covers creating an OrcaRouter connection via `PUT /api/public/llm-connections`.
- Playground model picker and eval/experiment execution pick up the adapter automatically through `supportedModels`.

Closes #16380

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation (external docs site covers LLM connection providers; no in-repo docs list to update)
- [x] My changes generate no new warnings (`pnpm run lint` for web, shared, worker)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes

## Verification

- `@langfuse/shared` tests: 972 passed, 6 skipped (live-API tests without keys)
- New `orcarouter` provider unit tests: 8 passed
- New request-shape tests (wire format via real provider): 23 passed
- Typecheck: `web`, `worker`, `@langfuse/shared` all clean
- Lint: `web`, `worker`, `@langfuse/shared` all clean (0 warnings)
- Live: real key + real `generateLLMText` code path → `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` returned a successful completion

Disclosure: I'm an engineer on the OrcaRouter team.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds OrcaRouter as a first-class OpenAI-compatible LLM adapter across the shared execution layer, public API, connection UI, and Playground.

- Adds the OrcaRouter adapter enum, default model catalog, provider implementation, and provider-option translation.
- Extends public connection creation and the web form with OrcaRouter defaults and advanced settings.
- Adds unit, wire-format, and server tests covering connection persistence and completion requests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The new adapter is consistently represented across the public contract, runtime validators, model catalog, connection persistence, model construction, provider-option translation, and Playground configuration, with tests covering persistence and outgoing request shape.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant UI as Connection UI / Public API
  participant DB as LLM Connection Store
  participant Runtime as Shared LLM Runtime
  participant Adapter as OrcaRouter Adapter
  participant Orca as OrcaRouter API
  User->>UI: Configure OrcaRouter connection
  UI->>DB: Persist adapter, key, base URL, models
  User->>Runtime: Run Playground, eval, or experiment
  Runtime->>DB: Load encrypted connection
  Runtime->>Adapter: Resolve model and provider options
  Adapter->>Orca: POST /v1/chat/completions
  Orca-->>Runtime: Completion response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(llm): add OrcaRouter as a first-cla..."](https://github.com/langfuse/langfuse/commit/f17f6780457a794f35bb53b8108f7b9bcc05b111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55366984)</sub>

<!-- /greptile_comment -->