### PR TITLE
fix(scores): apply LIMIT/OFFSET when offset is 0

### DIFF
--- a/packages/shared/src/server/repositories/scores.test.ts
+++ b/packages/shared/src/server/repositories/scores.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockQueryClickhouse = vi.hoisted(() => vi.fn());
+
+vi.mock("./clickhouse", () => ({
+  queryClickhouse: mockQueryClickhouse,
+  commandClickhouse: vi.fn(),
+  queryClickhouseStream: vi.fn(),
+  queryClickhouseExecRaw: vi.fn(),
+  upsertClickhouse: vi.fn(),
+  parseClickhouseUTCDateTimeFormat: vi.fn(),
+  clickhouseCompliantRandomCharacters: vi.fn(() => "x1"),
+}));
+
+vi.mock("../queries/clickhouse-sql/query-options", () => ({
+  shouldSkipObservationsFinal: vi.fn().mockResolvedValue(false),
+}));
+
+// Avoid pulling in the full server barrel (../../db -> ./server -> ...)
+// which is unrelated to these pagination-only query builders.
+vi.mock("../../db", () => ({ prisma: {} }));
+
+// clickhouse-filter.ts pulls in the repositories barrel (./index) just for
+// clickhouseCompliantRandomCharacters, which drags in events.ts and a
+// pre-existing circular-import ordering issue unrelated to pagination.
+vi.mock("./index", () => ({
+  clickhouseCompliantRandomCharacters: vi.fn(() => "x1"),
+}));
+
+import {
+  getScoresForSessions,
+  getScoresForExperiments,
+  getScoresForTraces,
+} from "./scores";
+
+describe("score repository pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryClickhouse.mockResolvedValue([]);
+  });
+
+  it("applies LIMIT/OFFSET for getScoresForSessions when offset is 0", async () => {
+    await getScoresForSessions({
+      projectId: "proj-1",
+      sessionIds: ["s1"],
+      limit: 10,
+      offset: 0,
+    });
+
+    const { query } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).toContain("limit {limit: Int32} offset {offset: Int32}");
+  });
+
+  it("applies LIMIT/OFFSET for getScoresForExperiments when offset is 0", async () => {
+    await getScoresForExperiments({
+      projectId: "proj-1",
+      runIds: ["r1"],
+      limit: 10,
+      offset: 0,
+    });
+
+    const { query } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).toContain("limit {limit: Int32} offset {offset: Int32}");
+  });
+
+  it("applies LIMIT/OFFSET for getScoresForTraces when offset is 0", async () => {
+    await getScoresForTraces({
+      projectId: "proj-1",
+      traceIds: ["t1"],
+      limit: 10,
+      offset: 0,
+    });
+
+    const { query } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).toContain("limit {limit: Int32} offset {offset: Int32}");
+  });
+});

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -261,7 +261,7 @@ export const getScoresForSessions = async <
       AND s.data_type IN ({dataTypes: Array(String)})
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<ScoreRecordReadType>({
@@ -310,7 +310,7 @@ export const getScoresForExperiments = async <
       AND s.data_type IN ({dataTypes: Array(String)})
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<ScoreRecordReadType>({
@@ -529,7 +529,7 @@ const getScoresForTracesInternal = async <
       ${levelFilter}
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<


### PR DESCRIPTION
## Summary
- `getScoresForSessions`, `getScoresForExperiments`, and `getScoresForTracesInternal` in `packages/shared/src/server/repositories/scores.ts` guarded pagination with a truthy check (`limit && offset`), so `offset: 0` (a valid first page) silently dropped the `LIMIT/OFFSET` clause and returned unbounded results
- Changed the guard to `limit !== undefined && offset !== undefined` in all three query builders, matching the pattern already used correctly in `getScoresForObservations` and `getScoresUiGeneric`

Fixes #16368

## Test plan
- [x] Added mocked-query unit tests (`scores.test.ts`) covering all three paths at `offset: 0`; confirmed they fail against the pre-fix code and pass after
- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter @langfuse/shared run typecheck`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates three ClickHouse score query builders so the first page (`offset: 0`) correctly applies bounded pagination.

- Replaces truthiness checks with explicit `undefined` checks for session, experiment, and trace score queries.
- Adds focused unit tests confirming each query includes `LIMIT/OFFSET` at offset zero.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the pagination fix consistently applied and covered by focused tests.

The changed guards restore bounded first-page queries without altering parameterization or the behavior when either pagination value is omitted, and no actionable failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scores): apply LIMIT/OFFSET when off..."](https://github.com/langfuse/langfuse/commit/608b3a7bee5fe8465361ee78395bf002915680bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55378982)</sub>

<!-- /greptile_comment -->