### PR TITLE
ci(assistant): publish sandbox MicroVM image to the preview account

### DIFF
--- a/.github/workflows/build-sandbox-microvm-image.yml
+++ b/.github/workflows/build-sandbox-microvm-image.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         default: staging
         options:
+          - preview
           - staging
           - all-production
           - prod-eu
@@ -40,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: ${{ fromJSON(github.event_name == 'push' && github.ref == 'refs/heads/main' && '["staging"]' || github.event_name == 'push' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || inputs.environment == 'all-production' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || format('["{0}"]', inputs.environment)) }}
+        environment: ${{ fromJSON(github.event_name == 'push' && github.ref == 'refs/heads/main' && '["staging","preview"]' || github.event_name == 'push' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || inputs.environment == 'all-production' && '["prod-eu","prod-us","prod-hipaa","prod-jp"]' || format('["{0}"]', inputs.environment)) }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_MICROVM_BUILD_ROLE_ARN: ${{ vars.AWS_MICROVM_BUILD_ROLE_ARN }}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16386.preview.langfuse.com](https://pr-16386.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Add `preview` to the sandbox MicroVM image workflow so PR previews can run in-app agent code tools.
- `workflow_dispatch` can target `preview`; pushes to `main` that touch `packages/in-app-agent-sandbox-runtime/**` now publish staging **and** preview.
- Bucket and build-role names already derive from the matrix entry (`langfuse-preview-in-app-agent-sandbox-artifacts`, `preview-in-app-agent-sandbox-microvm-build`).
- Paired with [langfuse/infrastructure#1256](https://github.com/langfuse/infrastructure/pull/1256). Supersedes #15590.

## Prerequisite

A GitHub **environment** named `preview` with `AWS_REGION` (`eu-west-1`) and `AWS_MICROVM_BUILD_ROLE_ARN` (the `preview-github-actions-microvm` OIDC role). Both are emitted by infrastructure#1256 as `github_actions_preview_environment_variables`.

Order: apply + merge the infrastructure PR first, create the GitHub environment, then dispatch this workflow for `preview` (or wait for the next sandbox-runtime push to `main`).

## Test plan
- [ ] Infrastructure#1256 applied (bucket, build role, OIDC role exist)
- [ ] GitHub environment `preview` has `AWS_REGION` and `AWS_MICROVM_BUILD_ROLE_ARN`
- [ ] Dispatch **Build Sandbox MicroVM Image** with environment `preview` — job succeeds and prints an image ARN
- [ ] On a live preview, as `demo@langfuse.com` / `password` in Seed Org → llm-app, ask the agent to run a `bash` command


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the preview AWS account as a sandbox MicroVM publishing target.
- Allows manual workflow dispatches to select `preview`.
- Publishes sandbox images to both staging and preview after relevant pushes to `main`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge after the explicitly documented preview infrastructure and GitHub environment prerequisites are in place.

The workflow consistently derives its GitHub environment, AWS variables, artifact bucket, and build role from the new preview matrix entry, and no unacknowledged blocking failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(assistant): publish sandbox MicroVM i..."](https://github.com/langfuse/langfuse/commit/33ac898bedbde7798e1183be612121085057584e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55479963)</sub>

<!-- /greptile_comment -->