### PR TITLE
fix(in-app-agent): explain failed background runs without leaking internals

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1602,7 +1602,10 @@ export const Failed = meta.story({
     const canvas = within(canvasElement);
 
     await expect(canvas.getByRole("status")).toHaveTextContent(
-      "The run exceeded the maximum duration.",
+      "The run hit the time limit.",
+    );
+    await expect(canvas.getByRole("status")).toHaveTextContent(
+      "Send another message",
     );
     await expect(
       canvas.getByRole("button", { name: "Failed after 51s" }),
@@ -1672,7 +1675,10 @@ export const FailedBeforeFirstToken = meta.story({
     const canvas = within(canvasElement);
 
     await expect(canvas.getByRole("status")).toHaveTextContent(
-      "No worker picked this up",
+      "failed to finish",
+    );
+    await expect(canvas.getByRole("status")).toHaveTextContent(
+      "Send another message",
     );
     await expect(
       canvas.getByRole("button", { name: "Worked for 12s" }),
@@ -1680,6 +1686,126 @@ export const FailedBeforeFirstToken = meta.story({
     await expect(
       canvas.queryByRole("button", { name: /Failed after/ }),
     ).not.toBeInTheDocument();
+  },
+});
+
+const failedWorkerLostRun = {
+  id: "run-1",
+  status: InAppAgentRunStatus.FAILED,
+  errorCode: InAppAgentRunErrorCode.WORKER_LOST,
+  cancelRequested: false,
+};
+
+export const FailedWorkerLost = meta.story({
+  name: "(Test) Failed to finish",
+  args: {
+    selectedConversationId: "conversation-1",
+    executionUi: {
+      notice: getBackgroundRunNotice(failedWorkerLostRun),
+      activityOutcome: getSettledActivityOutcome(failedWorkerLostRun),
+      stop: null,
+    },
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: {
+          type: "text",
+          text: "Investigate latency",
+        },
+      },
+      {
+        id: "assistant-answer",
+        runId: "run-1",
+        timestamp: new Date("2026-08-06T15:27:17.000Z").getTime(),
+        role: "assistant",
+        content: {
+          type: "text",
+          text: "Still inspecting the remaining traces.",
+        },
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole("status")).toHaveTextContent(
+      "failed to finish",
+    );
+    await expect(canvas.getByRole("status")).toHaveTextContent(
+      "Send another message",
+    );
+    await expect(
+      canvas.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeEnabled();
+  },
+});
+
+const expiredApprovalRun = {
+  id: "run-1",
+  status: InAppAgentRunStatus.FAILED,
+  errorCode: InAppAgentRunErrorCode.APPROVAL_EXPIRED,
+  cancelRequested: false,
+};
+
+export const ApprovalExpired = meta.story({
+  name: "(Test) Approval expired",
+  args: {
+    selectedConversationId: "conversation-1",
+    isAwaitingApproval: false,
+    isAssistantTurnInProgress: false,
+    executionUi: {
+      notice: getBackgroundRunNotice(expiredApprovalRun),
+      activityOutcome: getSettledActivityOutcome(expiredApprovalRun),
+      stop: null,
+    },
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: {
+          type: "text",
+          text: "Create a dataset for regression examples.",
+        },
+      },
+      {
+        id: "assistant-tool-1",
+        role: "assistant",
+        content: {
+          type: "toolGroup",
+          tools: [
+            {
+              type: "tool",
+              name: "langfuse_upsertDataset",
+              status: "running",
+              args: JSON.stringify({
+                name: "regression-examples",
+                description: "Examples used for release regression tests",
+              }),
+            },
+          ],
+        },
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole("status")).toHaveTextContent(
+      "The approval request expired. The action was not run. Send another message if you still want it.",
+    );
+    await expect(
+      canvas.queryByRole("button", { name: "Approve" }),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("button", { name: "Decline" }),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("button", { name: "Waiting for your approval…" }),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole("textbox", { name: "Message the assistant" }),
+    ).toBeEnabled();
   },
 });
 

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1675,7 +1675,7 @@ export const FailedBeforeFirstToken = meta.story({
     const canvas = within(canvasElement);
 
     await expect(canvas.getByRole("status")).toHaveTextContent(
-      "failed to finish",
+      "The assistant failed.",
     );
     await expect(canvas.getByRole("status")).toHaveTextContent(
       "Send another message",
@@ -1697,7 +1697,7 @@ const failedWorkerLostRun = {
 };
 
 export const FailedWorkerLost = meta.story({
-  name: "(Test) Failed to finish",
+  name: "(Test) Assistant failed",
   args: {
     selectedConversationId: "conversation-1",
     executionUi: {
@@ -1730,7 +1730,7 @@ export const FailedWorkerLost = meta.story({
     const canvas = within(canvasElement);
 
     await expect(canvas.getByRole("status")).toHaveTextContent(
-      "failed to finish",
+      "The assistant failed.",
     );
     await expect(canvas.getByRole("status")).toHaveTextContent(
       "Send another message",

--- a/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
@@ -17,6 +17,7 @@ import {
 import { BackgroundExecutionConnectionError } from "./backgroundExecutionErrors";
 import {
   BackgroundExecutionSessionController,
+  getBackgroundRunNotice,
   type BackgroundExecutionView,
 } from "./backgroundExecutionSession";
 
@@ -1360,6 +1361,48 @@ describe("InAppAgentBackgroundClient reconnect", () => {
     await expect(result).resolves.toMatchObject({
       message: "Assistant watch returned an invalid frame",
       retryable: false,
+    });
+  });
+});
+
+describe("getBackgroundRunNotice", () => {
+  const failedRun = (errorCode: string | null) => ({
+    id: "run-1",
+    status: InAppAgentRunStatus.FAILED,
+    errorCode,
+    cancelRequested: false,
+  });
+
+  const failedToFinishContinue =
+    "The assistant failed to finish. Send another message to continue.";
+  const failedToFinishTryAgain =
+    "The assistant failed to finish. Send another message to try again.";
+
+  it.each([
+    [InAppAgentRunErrorCode.WORKER_LOST, failedToFinishContinue],
+    [InAppAgentRunErrorCode.STALE, failedToFinishContinue],
+    [InAppAgentRunErrorCode.QUEUE_TIMEOUT, failedToFinishContinue],
+    [InAppAgentRunErrorCode.WORKER_SHUTDOWN, failedToFinishContinue],
+    [InAppAgentRunErrorCode.INIT_FAILED, failedToFinishTryAgain],
+    [InAppAgentRunErrorCode.OUTCOME_UNKNOWN, failedToFinishTryAgain],
+    [InAppAgentRunErrorCode.ENQUEUE_FAILED, failedToFinishTryAgain],
+    [
+      InAppAgentRunErrorCode.APPROVAL_EXPIRED,
+      "The approval request expired. The action was not run. Send another message if you still want it.",
+    ],
+    [
+      InAppAgentRunErrorCode.RUN_TIMEOUT,
+      "The run hit the time limit. Send another message to continue.",
+    ],
+    [
+      InAppAgentRunErrorCode.AGENT_ERROR,
+      "The assistant hit an error before finishing. Send another message to continue.",
+    ],
+    ["mystery_code", "The run failed. Try again."],
+  ] as const)("maps FAILED %s to the user-facing notice", (errorCode, text) => {
+    expect(getBackgroundRunNotice(failedRun(errorCode))).toEqual({
+      text,
+      tone: "info",
     });
   });
 });

--- a/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
@@ -1383,8 +1383,8 @@ describe("getBackgroundRunNotice", () => {
     [InAppAgentRunErrorCode.STALE, assistantFailedContinue],
     [InAppAgentRunErrorCode.QUEUE_TIMEOUT, assistantFailedContinue],
     [InAppAgentRunErrorCode.WORKER_SHUTDOWN, assistantFailedContinue],
+    [InAppAgentRunErrorCode.OUTCOME_UNKNOWN, assistantFailedContinue],
     [InAppAgentRunErrorCode.INIT_FAILED, assistantFailedTryAgain],
-    [InAppAgentRunErrorCode.OUTCOME_UNKNOWN, assistantFailedTryAgain],
     [InAppAgentRunErrorCode.ENQUEUE_FAILED, assistantFailedTryAgain],
     [
       InAppAgentRunErrorCode.APPROVAL_EXPIRED,

--- a/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionSession.clienttest.ts
@@ -1373,19 +1373,19 @@ describe("getBackgroundRunNotice", () => {
     cancelRequested: false,
   });
 
-  const failedToFinishContinue =
-    "The assistant failed to finish. Send another message to continue.";
-  const failedToFinishTryAgain =
-    "The assistant failed to finish. Send another message to try again.";
+  const assistantFailedContinue =
+    "The assistant failed. Send another message to continue.";
+  const assistantFailedTryAgain =
+    "The assistant failed. Send another message to try again.";
 
   it.each([
-    [InAppAgentRunErrorCode.WORKER_LOST, failedToFinishContinue],
-    [InAppAgentRunErrorCode.STALE, failedToFinishContinue],
-    [InAppAgentRunErrorCode.QUEUE_TIMEOUT, failedToFinishContinue],
-    [InAppAgentRunErrorCode.WORKER_SHUTDOWN, failedToFinishContinue],
-    [InAppAgentRunErrorCode.INIT_FAILED, failedToFinishTryAgain],
-    [InAppAgentRunErrorCode.OUTCOME_UNKNOWN, failedToFinishTryAgain],
-    [InAppAgentRunErrorCode.ENQUEUE_FAILED, failedToFinishTryAgain],
+    [InAppAgentRunErrorCode.WORKER_LOST, assistantFailedContinue],
+    [InAppAgentRunErrorCode.STALE, assistantFailedContinue],
+    [InAppAgentRunErrorCode.QUEUE_TIMEOUT, assistantFailedContinue],
+    [InAppAgentRunErrorCode.WORKER_SHUTDOWN, assistantFailedContinue],
+    [InAppAgentRunErrorCode.INIT_FAILED, assistantFailedTryAgain],
+    [InAppAgentRunErrorCode.OUTCOME_UNKNOWN, assistantFailedTryAgain],
+    [InAppAgentRunErrorCode.ENQUEUE_FAILED, assistantFailedTryAgain],
     [
       InAppAgentRunErrorCode.APPROVAL_EXPIRED,
       "The approval request expired. The action was not run. Send another message if you still want it.",

--- a/web/src/features/in-app-agent/lib/backgroundExecutionSession.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionSession.ts
@@ -567,19 +567,19 @@ export function isCancellableBackgroundRun(
   );
 }
 
-const FAILED_TO_FINISH_CONTINUE =
-  "The assistant failed to finish. Send another message to continue.";
-const FAILED_TO_FINISH_TRY_AGAIN =
-  "The assistant failed to finish. Send another message to try again.";
+const ASSISTANT_FAILED_CONTINUE =
+  "The assistant failed. Send another message to continue.";
+const ASSISTANT_FAILED_TRY_AGAIN =
+  "The assistant failed. Send another message to try again.";
 
 const BACKGROUND_RUN_FAILURE_MESSAGES: Readonly<Record<string, string>> = {
-  [InAppAgentRunErrorCode.WORKER_LOST]: FAILED_TO_FINISH_CONTINUE,
-  [InAppAgentRunErrorCode.STALE]: FAILED_TO_FINISH_CONTINUE,
-  [InAppAgentRunErrorCode.QUEUE_TIMEOUT]: FAILED_TO_FINISH_CONTINUE,
-  [InAppAgentRunErrorCode.WORKER_SHUTDOWN]: FAILED_TO_FINISH_CONTINUE,
-  [InAppAgentRunErrorCode.INIT_FAILED]: FAILED_TO_FINISH_TRY_AGAIN,
-  [InAppAgentRunErrorCode.OUTCOME_UNKNOWN]: FAILED_TO_FINISH_TRY_AGAIN,
-  [InAppAgentRunErrorCode.ENQUEUE_FAILED]: FAILED_TO_FINISH_TRY_AGAIN,
+  [InAppAgentRunErrorCode.WORKER_LOST]: ASSISTANT_FAILED_CONTINUE,
+  [InAppAgentRunErrorCode.STALE]: ASSISTANT_FAILED_CONTINUE,
+  [InAppAgentRunErrorCode.QUEUE_TIMEOUT]: ASSISTANT_FAILED_CONTINUE,
+  [InAppAgentRunErrorCode.WORKER_SHUTDOWN]: ASSISTANT_FAILED_CONTINUE,
+  [InAppAgentRunErrorCode.INIT_FAILED]: ASSISTANT_FAILED_TRY_AGAIN,
+  [InAppAgentRunErrorCode.OUTCOME_UNKNOWN]: ASSISTANT_FAILED_TRY_AGAIN,
+  [InAppAgentRunErrorCode.ENQUEUE_FAILED]: ASSISTANT_FAILED_TRY_AGAIN,
   [InAppAgentRunErrorCode.APPROVAL_EXPIRED]:
     "The approval request expired. The action was not run. Send another message if you still want it.",
   [InAppAgentRunErrorCode.RUN_TIMEOUT]:

--- a/web/src/features/in-app-agent/lib/backgroundExecutionSession.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionSession.ts
@@ -577,8 +577,8 @@ const BACKGROUND_RUN_FAILURE_MESSAGES: Readonly<Record<string, string>> = {
   [InAppAgentRunErrorCode.STALE]: ASSISTANT_FAILED_CONTINUE,
   [InAppAgentRunErrorCode.QUEUE_TIMEOUT]: ASSISTANT_FAILED_CONTINUE,
   [InAppAgentRunErrorCode.WORKER_SHUTDOWN]: ASSISTANT_FAILED_CONTINUE,
+  [InAppAgentRunErrorCode.OUTCOME_UNKNOWN]: ASSISTANT_FAILED_CONTINUE,
   [InAppAgentRunErrorCode.INIT_FAILED]: ASSISTANT_FAILED_TRY_AGAIN,
-  [InAppAgentRunErrorCode.OUTCOME_UNKNOWN]: ASSISTANT_FAILED_TRY_AGAIN,
   [InAppAgentRunErrorCode.ENQUEUE_FAILED]: ASSISTANT_FAILED_TRY_AGAIN,
   [InAppAgentRunErrorCode.APPROVAL_EXPIRED]:
     "The approval request expired. The action was not run. Send another message if you still want it.",

--- a/web/src/features/in-app-agent/lib/backgroundExecutionSession.ts
+++ b/web/src/features/in-app-agent/lib/backgroundExecutionSession.ts
@@ -567,6 +567,30 @@ export function isCancellableBackgroundRun(
   );
 }
 
+const FAILED_TO_FINISH_CONTINUE =
+  "The assistant failed to finish. Send another message to continue.";
+const FAILED_TO_FINISH_TRY_AGAIN =
+  "The assistant failed to finish. Send another message to try again.";
+
+const BACKGROUND_RUN_FAILURE_MESSAGES: Readonly<Record<string, string>> = {
+  [InAppAgentRunErrorCode.WORKER_LOST]: FAILED_TO_FINISH_CONTINUE,
+  [InAppAgentRunErrorCode.STALE]: FAILED_TO_FINISH_CONTINUE,
+  [InAppAgentRunErrorCode.QUEUE_TIMEOUT]: FAILED_TO_FINISH_CONTINUE,
+  [InAppAgentRunErrorCode.WORKER_SHUTDOWN]: FAILED_TO_FINISH_CONTINUE,
+  [InAppAgentRunErrorCode.INIT_FAILED]: FAILED_TO_FINISH_TRY_AGAIN,
+  [InAppAgentRunErrorCode.OUTCOME_UNKNOWN]: FAILED_TO_FINISH_TRY_AGAIN,
+  [InAppAgentRunErrorCode.ENQUEUE_FAILED]: FAILED_TO_FINISH_TRY_AGAIN,
+  [InAppAgentRunErrorCode.APPROVAL_EXPIRED]:
+    "The approval request expired. The action was not run. Send another message if you still want it.",
+  [InAppAgentRunErrorCode.RUN_TIMEOUT]:
+    "The run hit the time limit. Send another message to continue.",
+  [InAppAgentRunErrorCode.AGENT_ERROR]:
+    "The assistant hit an error before finishing. Send another message to continue.",
+  [InAppAgentRunErrorCode.APPROVAL_SUPERSEDED]: "Replaced by a newer message.",
+  [InAppAgentRunErrorCode.APPROVAL_CANCELLED]: "Approval cancelled.",
+  [InAppAgentRunErrorCode.CANCELLED]: "You stopped this run.",
+};
+
 export function getBackgroundRunFailureMessage(
   errorCode: string | null,
 ): string {
@@ -637,24 +661,6 @@ export function getSettledActivityOutcome(
 
   return "worked";
 }
-
-const BACKGROUND_RUN_FAILURE_MESSAGES: Readonly<Record<string, string>> = {
-  [InAppAgentRunErrorCode.ENQUEUE_FAILED]: "Couldn't start the run. Try again.",
-  [InAppAgentRunErrorCode.QUEUE_TIMEOUT]:
-    "No worker picked this up. Try again.",
-  [InAppAgentRunErrorCode.WORKER_LOST]: "The run was interrupted. Try again.",
-  [InAppAgentRunErrorCode.STALE]: "The run was interrupted. Try again.",
-  [InAppAgentRunErrorCode.RUN_TIMEOUT]:
-    "The run exceeded the maximum duration.",
-  [InAppAgentRunErrorCode.WORKER_SHUTDOWN]:
-    "The run was interrupted by a deploy. Try again.",
-  [InAppAgentRunErrorCode.OUTCOME_UNKNOWN]:
-    "The approved action may have completed. Verify before retrying.",
-  [InAppAgentRunErrorCode.APPROVAL_EXPIRED]: "The approval request expired.",
-  [InAppAgentRunErrorCode.APPROVAL_SUPERSEDED]: "Replaced by a newer message.",
-  [InAppAgentRunErrorCode.APPROVAL_CANCELLED]: "Approval cancelled.",
-  [InAppAgentRunErrorCode.CANCELLED]: "You stopped this run.",
-};
 
 function isExecutingRun(
   run: BackgroundExecutionRunView | null,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16387.preview.langfuse.com](https://pr-16387.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Rewrite drawer failure notices so they say what happened and how to continue, without mentioning workers, queues, or deploys.
- Map `agent_error` and `init_failed` instead of falling through to the generic fallback.
- Cover the copy with session client tests and drawer stories for a mid-run stop and an expired approval.

## Test plan
- [ ] Open Storybook **Failed**, **Failed before first token**, **Failed to finish**, and **Approval expired**.
- [ ] Confirm each status banner has a next-step line and no worker/deploy wording.
- [ ] Confirm **Approval expired** shows no Approve/Decline controls and the composer stays enabled.
- [ ] Sandbox: same stories, or send a message in the assistant drawer on `http://localhost:3000` after a failed background run.

Impacted packages: `web`

Verification:
- `pnpm --filter web run test-client backgroundExecutionSession` — Tests 34 passed (34)
- `pnpm --filter web exec eslint` on the three touched files — clean
- Pre-commit `turbo run lint` — Tasks: 7 successful, 7 total
- Skipped worker/integrity tests: they already persist the codes this map reads
- Skipped Storybook play run here: Playwright Chromium was not installed in this environment


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR rewrites in-app-agent background failure notices to avoid exposing worker and deployment details, adds explicit mappings for additional failure codes, and expands client and Storybook coverage.
- Centralizes user-facing failure messages for terminal background runs.
- Adds tailored notices for agent errors, initialization failures, timeouts, and expired approvals.
- Adds tests and stories for interrupted runs and expired approval UI behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the OUTCOME_UNKNOWN notice continues to tell users to verify whether the approved action completed before attempting it again.

OUTCOME_UNKNOWN specifically represents an approved mutation that may already have landed, but the revised browser-only notice hides the persisted verification warning and directs users toward a fresh attempt without any guard against repeating the side effect.

**Files Needing Attention:** web/src/features/in-app-agent/lib/backgroundExecutionSession.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/in-app-agent/lib/backgroundExecutionSession.ts:581
**Unknown outcome invites duplicate action**

When an approved mutation completes without its result being persisted, `OUTCOME_UNKNOWN` now tells the user to try again instead of verifying the outcome first. A subsequent message can propose and execute the same mutation without an outcome-verification or idempotency guard, duplicating an already-completed external side effect.

```suggestion
  [InAppAgentRunErrorCode.OUTCOME_UNKNOWN]:
    "The approved action may have completed. Verify before retrying.",
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): explain failed backgr..."](https://github.com/langfuse/langfuse/commit/c00ad1c2ccf4b1fdb8d3656a60f9514a1dbd9ae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55493128)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->