### PR TITLE
chore(assistant): remove beta label

### DIFF
--- a/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.clienttest.tsx
@@ -258,9 +258,8 @@ describe("InAppAgentWindow header", () => {
     );
 
     expect(screen.getByText("Latency outliers")).toBeInTheDocument();
-    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
 
-    // An unnamed conversation is where the product name and Beta tag belong.
+    // An unnamed conversation falls back to the product name.
     rerender(
       windowElement({
         selectedConversationId: "conversation-1",
@@ -269,7 +268,6 @@ describe("InAppAgentWindow header", () => {
     );
 
     expect(screen.getByText("Assistant")).toBeInTheDocument();
-    expect(screen.getByText("Beta")).toBeInTheDocument();
   });
 
   it("toggles expanded on a header double-click, but not from its actions", () => {

--- a/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -900,7 +900,7 @@ export type InAppAgentWindowProps = {
   quickActionResetKey: string;
   selectedConversationId: string | undefined;
   /** Titles the window. Null until the server has named the conversation,
-   * which is when the product name and its Beta tag show instead. */
+   * which is when the product name shows instead. */
   selectedConversationTitle: string | null;
 } & InAppAgentWindowCloseButtonProps;
 
@@ -1169,17 +1169,12 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               {conversationTitle}
             </p>
           ) : (
-            <>
-              <p
-                className="shrink-0 truncate text-sm font-bold"
-                title="Assistant"
-              >
-                Assistant
-              </p>
-              <span className="text-muted-foreground rounded border px-1.5 py-1 text-xs leading-none font-bold">
-                Beta
-              </span>
-            </>
+            <p
+              className="shrink-0 truncate text-sm font-bold"
+              title="Assistant"
+            >
+              Assistant
+            </p>
           )}
         </div>
         <div


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16388.preview.langfuse.com](https://pr-16388.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the Beta label from the in-app Assistant header now that the feature is no longer presented as beta.
- Simplifies the unnamed-conversation header to display only “Assistant.”
- Updates the corresponding component test and documentation comments.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it makes a narrowly scoped presentation change with matching test updates.

The changed component only removes the Beta badge and leaves the title fallback, interaction behavior, and public component contract intact.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(assistant): remove beta label"](https://github.com/langfuse/langfuse/commit/7a52f390f0af2f23d4ef67ddbd14395ffcef2db8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55495487)</sub>

<!-- /greptile_comment -->