### PR TITLE
docs(structure): put the project-structure rules in the repo as a skill

### DIFF
--- a/.agents/skills/project-structure/SKILL.md
+++ b/.agents/skills/project-structure/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: project-structure
+description: |
+  The 26 project-structure rules for `web/src` and `ee/` — where a file goes,
+  what it is named, and how imports cross boundaries. Use when creating,
+  moving, renaming or splitting a frontend file; when deciding whether
+  something belongs in a feature or a shared folder; when `structure:stats`,
+  a CI check or a pre-write hook reports a rule number; or when picking
+  migration work off the violation counts.
+---
+
+# Project structure
+
+One goal: **by navigating the folders, a human must be able to tell where a
+change goes.** The test — given a URL or a feature name, you can name the
+folder without grepping. Agents navigate the same way humans do, so the same
+structure shrinks the context needed to work in it.
+
+## The one obligation
+
+New code follows the rules. Existing code is where it is — we stay relaxed
+about that, or the migration chases a moving target. What you must not do is
+add a new violation, and the sensor is what says whether you did:
+
+```sh
+pnpm --filter web run structure:stats --diff     # what this branch added or cleared
+```
+
+The sensor is the source of truth for counts, not this document.
+
+## Where a file goes, in four questions
+
+1. **Who uses it?** One feature → inside that feature. Two or more → the
+   top-level shared folders (`src/components`, `src/hooks`, `src/contexts`,
+   `src/stores`, `src/fns`, `src/constants`, `src/types`). There is no
+   `src/shared`, deliberately.
+2. **What kind is it?** The closed list: `components`, `hooks`, `contexts`,
+   `stores`, `fns`, `server`, `constants`, `types`. Never `utils/`, `lib/`,
+   `helpers/`, `shared/`, `config/`. `docs/` and `__tests__/` may sit anywhere
+   and are not kind folders.
+3. **What is it called?** Components PascalCase, filename = component name.
+   Everything else camelCase, filename = the export. One export per file.
+4. **Who may import it?** A feature is reached only through
+   `@/src/features/<feature>` or `@/src/features/<feature>/server`. Client code
+   never imports `server/` except for types. Relative imports stay inside their
+   own directory; anything crossing a boundary is `@/src/...`.
+
+Full reasoning and examples in `rules/`, one file per rule.
+
+## The 26 rules
+
+`mechanism` is how a rule is decided: **census** from the files themselves,
+**graph** from the import graph, **review** by a human, **process** by how the
+commit is made. Counts are a snapshot of `web/src` on 2026-08-21 (total
+**2,710**) — they move, so re-read them from the sensor rather than from here.
+
+| # | Rule | Mechanism | Count |
+| --- | --- | --- | --- |
+| [1](rules/01-one-component-per-file.md) | One component per file, PascalCase filename matching it | census | 196 |
+| [2](rules/02-component-file-exports-only-the-component.md) | A component file exports only the component and its types | census | 60 |
+| [3](rules/03-camelcase-named-after-the-export.md) | Hooks, fns, stores, contexts, constants, types: camelCase, named after the export | census | 43 |
+| [4](rules/04-one-function-per-file-in-fns.md) | One function per file in `fns/`, no dump files | census | 19 |
+| [5](rules/05-kind-folders-are-a-closed-list.md) | Kind folders are a closed list | census | 102 |
+| [6](rules/06-a-file-lives-where-it-is-used.md) | A file used by one feature lives in that feature | graph | 68 |
+| [7](rules/07-no-importing-component-internals.md) | A component never imports another component's internals | graph | 23 |
+| [8](rules/08-features-are-reached-through-a-surface.md) | Anything importing a feature goes through one of its surfaces | graph | 1,214 |
+| [9](rules/09-index-files-only-at-feature-surfaces.md) | `index.ts` only at a feature root and its `server/` root | census | 42 |
+| [10](rules/10-client-code-never-imports-server.md) | Client code does not import `server/`, types excepted | graph | 97 |
+| [11](rules/11-no-new-import-cycles.md) | No new import cycles | graph | 8 |
+| [12](rules/12-pages-are-thin-shims.md) | A `src/pages` file only imports a Page component and route config | graph | 616 |
+| [13](rules/13-components-ui-is-frozen.md) | `components/ui` is frozen | census | 73 |
+| [14](rules/14-design-system-components-stay-pure.md) | Design-system components hold no app state and fetch no data | review | — |
+| [15](rules/15-moves-preserve-git-history.md) | Moves preserve git history: `git mv`, move ≠ edit | process | — |
+| [16](rules/16-eslint-ignores-at-file-level.md) | ESLint ignores at file level only | census | 108 |
+| [17](rules/17-the-baseline-only-shrinks.md) | New code follows the rules; the baseline only shrinks | ratchet | — |
+| [18](rules/18-fn-and-hook-tests-colocate-flat.md) | Tests for fns and hooks sit flat next to their file | census | 24 |
+| [19](rules/19-only-tests-import-tests.md) | Only tests import from `__tests__` | graph | 0 |
+| [20](rules/20-no-unused-exports.md) | No unused exports | graph | 17 |
+| [21](rules/21-server-only-imports-stay-in-server.md) | `@langfuse/shared/src/server` only from server code | not yet counted | — |
+| [22](rules/22-shared-domain-never-imports-server.md) | In `packages/shared`, `domain/` never imports `server/` | not yet counted | — |
+| [23](rules/23-test-suffix-implies-the-import-rules.md) | The test suffix implies which import rules apply | not yet counted | — |
+| [24](rules/24-cross-package-moves-may-leave-a-shim.md) | Cross-package moves may leave a counted shim; inside `web`, none | not yet counted | — |
+| [25](rules/25-one-name-means-one-thing.md) | Inside a feature, one name means one thing | not yet counted | — |
+| [26](rules/26-relative-imports-stay-inside-their-directory.md) | Relative imports stay inside their own directory | not yet counted | — |
+
+Rules 21–26 have no detector yet: they are on reviewers, and a violation of
+one will not show up in any count.
+
+## The fix loop
+
+The migration is many small, boring PRs, each visibly dropping the count.
+
+```sh
+pnpm --filter web run structure:stats --next --scope src/features/traces
+```
+
+1. Take **item #1**. `--next` ranks by leverage (violations cleared × rule
+   weight) and each item is sized for one PR.
+2. Do the mechanical half with the codemod — it does the `git mv`, rewrites
+   every importer through the TypeScript language service, and brings colocated
+   tests and stories along:
+   ```sh
+   pnpm --filter web run structure:move <from...> <to-dir>
+   ```
+   The judgment half — splitting a file, renaming an export, authoring an
+   `index.ts` — is yours.
+3. Re-run stats. The PR body is the item headline plus the before/after counts
+   from `--diff` ("rule 6: 104 → 68"). One item per PR, and no baseline
+   regeneration unless that *is* the point of the PR.
+
+Two things about `--next` that read like bugs and are not:
+
+- A violation is attributed to where its **fix** lands, not where it is
+  observed — so `--scope src/features/traces` can return an item about
+  `src/features/comments`.
+- Ordering matters. Moving a single-feature file home (rule 6) creates a
+  cross-feature import (rule 8) if the destination feature has no `index.ts`
+  yet, so surfaces (rule 9) should lead moves (rule 6).
+
+## Enforcement today
+
+Measured, not gated. The tooling counts violations, points at them and proposes
+the rework; nothing blocks a merge on the total. Enforcement arrives one rule at
+a time: when a rule's count is small enough to finish, it graduates and CI
+starts failing on new violations of it.
+
+`web/.structure-baseline.json` is the committed snapshot every delta compares
+against. Re-snapshot it deliberately, as the point of its own PR.
+
+Mechanism details, the rule → detector map and the calibration notes live in
+[`web/scripts/structure/README.md`](../../../web/scripts/structure/README.md).

--- a/.agents/skills/project-structure/SKILL.md
+++ b/.agents/skills/project-structure/SKILL.md
@@ -51,8 +51,10 @@ Full reasoning and examples in `rules/`, one file per rule.
 
 `mechanism` is how a rule is decided: **census** from the files themselves,
 **graph** from the import graph, **review** by a human, **process** by how the
-commit is made. Counts are a snapshot of `web/src` on 2026-08-21 (total
-**2,710**) — they move, so re-read them from the sensor rather than from here.
+commit is made, **ratchet** by a committed count that may only shrink, and
+**not yet counted** by nobody — see below. Counts are a snapshot of `web/src`
+on 2026-08-21 (total **2,710**) — they move, so re-read them from the sensor
+rather than from here.
 
 | # | Rule | Mechanism | Count |
 | --- | --- | --- | --- |

--- a/.agents/skills/project-structure/rules/01-one-component-per-file.md
+++ b/.agents/skills/project-structure/rules/01-one-component-per-file.md
@@ -1,0 +1,40 @@
+---
+rule: 1
+title: One component per file, PascalCase filename matching the component
+mechanism: census
+---
+
+# Rule 1 — one component per file
+
+A component file holds exactly one component, and the filename is that
+component's name in PascalCase. `WarningDialog.tsx` contains `WarningDialog`.
+
+A single-file component can live flat as `components/WarningDialog.tsx`. The
+moment it gains a related file — a test, a story, a sub-fn — it becomes a
+folder of the same name: `components/WarningDialog/WarningDialog.tsx`.
+
+**Why.** The filename is the index. If you can't get from a component name to
+its file without grepping, the tree has stopped telling the truth. Six badges
+in one file also hide the fact that they want to be one component with props.
+
+**Wrong**
+
+```text
+components/deleteButton.tsx   → DeleteButton, DeleteTraceButton, DeleteDatasetButton, …
+components/date-picker.tsx    → DatePicker, DatePickerWithRange, TimeRangePicker
+```
+
+**Right**
+
+```text
+components/DeleteButton/DeleteButton.tsx
+components/DeleteTraceButton.tsx
+components/DatePicker/DatePicker.tsx
+```
+
+A family of near-identical tiny components splits flat into `components/`, not
+into a grouping folder — the pile of one-line files is the signal.
+
+Counted from a TS parse of every `.tsx` file: filename casing, and the number
+of PascalCase value exports. List them with
+`pnpm --filter web run structure:stats --rule 1`.

--- a/.agents/skills/project-structure/rules/02-component-file-exports-only-the-component.md
+++ b/.agents/skills/project-structure/rules/02-component-file-exports-only-the-component.md
@@ -1,0 +1,42 @@
+---
+rule: 2
+title: A component file exports only the component and its types
+mechanism: census
+---
+
+# Rule 2 — a component file exports only the component
+
+The only non-type export allowed from a component file is the component
+itself. Types are always allowed. Dot-notation compound components
+(`Modal.Header`, `Modal.Body`) count as one export.
+
+**Why.** A helper exported from a component file is a helper with no home. It
+gets imported from three places, none of which want the component, and the
+file becomes a module boundary nobody designed. Private helpers may stay in
+the file — just don't export them.
+
+**Wrong**
+
+```ts
+// components/TraceTable/TraceTable.tsx
+export function TraceTable() { … }
+export const formatLatency = (ms: number) => …   // wanted by two other files
+```
+
+**Right**
+
+```ts
+// fns/formatLatency.ts
+export const formatLatency = (ms: number) => …
+
+// components/TraceTable/TraceTable.tsx
+export function TraceTable() { … }
+```
+
+Exporting an internal only so a test can reach it is not allowed: either it
+becomes a real module with its own file, or the component's public API is what
+gets tested.
+
+Counted from a TS parse: non-PascalCase value exports in a file that also
+exports a component. List them with
+`pnpm --filter web run structure:stats --rule 2`.

--- a/.agents/skills/project-structure/rules/03-camelcase-named-after-the-export.md
+++ b/.agents/skills/project-structure/rules/03-camelcase-named-after-the-export.md
@@ -1,0 +1,46 @@
+---
+rule: 3
+title: Hooks, fns, stores, contexts, constants and types are camelCase, named after the export
+mechanism: census
+---
+
+# Rule 3 — camelCase, named after what is inside
+
+A file in `hooks/`, `fns/`, `stores/`, `contexts/`, `constants/` or `types/` is
+camelCase and named after its export. `useDialog` lives in `useDialog.ts`;
+`groupByKey` in `groupByKey.ts`; the `TreeNode` type in `types/treeNode.ts`.
+
+Two deliberate exceptions:
+
+- A constants file may be named after the subject it groups —
+  `constants/traceDownload.ts` — because what matters there is that the folder
+  makes the values visible as constants. Split it when two consumers start
+  pulling unrelated values out of it.
+- A context module is the canonical React trio in one unit:
+  `FooContext.tsx` may export `FooContext`, `FooProvider` and `useFoo*`.
+  Anything beyond that is a violation.
+
+**Why.** This is the largest source of new violations in the migration, and it
+costs nothing to get right: the name is decided before the file exists.
+kebab-case is the legacy spelling — 277 files still carry it, and they get
+renamed when touched.
+
+**Wrong**
+
+```text
+hooks/use-dialog.ts
+fns/tree-building.ts
+fns/types.ts          → a type is not a function, and a dump is not a module
+```
+
+**Right**
+
+```text
+hooks/useDialog.ts
+fns/buildTree.ts
+types/treeNode.ts
+```
+
+Counted from a TS parse: filename casing, plus whether an export matching the
+filename exists. List them with
+`pnpm --filter web run structure:stats --rule 3`.

--- a/.agents/skills/project-structure/rules/04-one-function-per-file-in-fns.md
+++ b/.agents/skills/project-structure/rules/04-one-function-per-file-in-fns.md
@@ -1,0 +1,41 @@
+---
+rule: 4
+title: One function per file in fns/, no dump files
+mechanism: census
+---
+
+# Rule 4 — one function per file in `fns/`
+
+Each file in `fns/` exports one function. No `utils.ts`, no `helpers.ts`, no
+`index.ts` collecting several. Many small files beat few large ones.
+
+When a set of functions is one engine rather than one function, group it in a
+module folder: `fns/searchJson/` holding `matchNode.ts`, `buildIndex.ts`,
+`rankHits.ts`. The grouping lives in the folder name, so every file still has
+one export and `fns/` doesn't become a hundred flat files. A module folder
+holds modules only — the moment it wants `components/`, it is a feature.
+
+**Why.** A dump file is a shared surface nobody designed: every consumer pulls
+the whole file's imports, and the file's history becomes unreadable because
+five unrelated functions change in it.
+
+**Wrong**
+
+```text
+fns/utils.ts        → formatCost, parseFilter, buildTree
+fns/index.ts        → re-exports the above
+```
+
+**Right**
+
+```text
+fns/formatCost.ts
+fns/parseFilter.ts
+fns/searchJson/matchNode.ts
+fns/searchJson/buildIndex.ts
+fns/searchJson/__tests__/matchNode.clienttest.ts
+```
+
+Counted from a TS parse: value-export count per file in `fns/`, plus a closed
+list of dump filenames. List them with
+`pnpm --filter web run structure:stats --rule 4`.

--- a/.agents/skills/project-structure/rules/05-kind-folders-are-a-closed-list.md
+++ b/.agents/skills/project-structure/rules/05-kind-folders-are-a-closed-list.md
@@ -1,0 +1,49 @@
+---
+rule: 5
+title: Kind folders are a closed list
+mechanism: census
+---
+
+# Rule 5 — kind folders are a closed list
+
+`components`, `hooks`, `contexts`, `stores`, `fns`, `server`, `constants`,
+`types`. Not `utils/`, not `lib/`, not `helpers/`, not `shared/`, not
+`config/`. `docs/` and `__tests__/` may sit at any level alongside them; they
+are not kind folders.
+
+A component folder is PascalCase and lives under `components/`. A component
+folder may recursively contain the same kind folders for things private to it.
+
+The kind says what the thing *is*, not what it talks to: a hook that calls the
+API is still a hook and lives in `hooks/`. There is deliberately no `api/`.
+
+**Why.** One word for one thing. Predictability dies when every feature
+invents its own folder names, and a folder called `shared` becomes the place
+everything ends up. Both `constants/` and `types/` earned their place the same
+way: traces had grown a `shared/` folder holding one constant and a `config/`
+folder holding one module, because the closed list had no home for a value or
+a type.
+
+`docs/` is where Markdown lives — it holds no code and nothing imports it. A
+`README.md` beside a component is prose loose in a code folder.
+
+**Wrong**
+
+```text
+features/traces/utils/formatCost.ts
+features/traces/config/columns.ts
+features/traces/shared/threshold.ts
+```
+
+**Right**
+
+```text
+features/traces/fns/formatCost.ts
+features/traces/constants/columns.ts
+features/traces/constants/threshold.ts
+features/traces/docs/README.md
+```
+
+Counted from a directory walk over `web/src`, feature scope only; `server/`
+internals are unspecified by the RFC and skipped. List them with
+`pnpm --filter web run structure:stats --rule 5`.

--- a/.agents/skills/project-structure/rules/06-a-file-lives-where-it-is-used.md
+++ b/.agents/skills/project-structure/rules/06-a-file-lives-where-it-is-used.md
@@ -1,0 +1,42 @@
+---
+rule: 6
+title: A file used by one feature lives in that feature
+mechanism: graph
+---
+
+# Rule 6 — a file lives where it is used
+
+Used by one feature: it belongs inside that feature. Used by two or more: it
+belongs in a top-level shared folder — `src/components`, `src/hooks`,
+`src/contexts`, `src/stores`, `src/fns`, `src/constants`, `src/types`.
+
+There is deliberately no `src/shared`. Whatever sits in `src/components` is
+shared *by definition*, because anything used by a single feature gets moved
+into that feature.
+
+**Why.** This makes the shared area self-cleaning. Over time the top-level
+folders become an actual inventory of shared code instead of a dumping ground,
+and a reader can trust that a file's location tells them who uses it.
+
+**Wrong**
+
+```text
+src/hooks/useFormPersistence.ts     → imported only by features/prompts
+```
+
+**Right**
+
+```text
+src/features/prompts/hooks/useFormPersistence.ts
+```
+
+Do the move with the codemod, never by hand:
+`pnpm --filter web run structure:move src/hooks/useFormPersistence.ts src/features/prompts/hooks`.
+
+Counted by inverting the dependency graph: for each file in a shared folder,
+the set of features importing it. List them with
+`pnpm --filter web run structure:stats --rule 6`.
+
+Note the ordering trap: moving a single-feature file home creates a
+cross-feature import (rule 8) when the destination feature has no `index.ts`
+yet. Give the feature a surface first — see [rule 9](09-index-files-only-at-feature-surfaces.md).

--- a/.agents/skills/project-structure/rules/07-no-importing-component-internals.md
+++ b/.agents/skills/project-structure/rules/07-no-importing-component-internals.md
@@ -1,0 +1,36 @@
+---
+rule: 7
+title: A component never imports another component's internals
+mechanism: graph
+---
+
+# Rule 7 — never reach inside another component
+
+A component may import another component's root entry. It may not reach past
+it into that component's `components/`, `fns/` or `hooks/`. If it wants
+something in there, promote that thing to a sibling of the importer first.
+
+A component boundary is any PascalCase directory; its public entry is
+`<Name>.tsx`.
+
+**Why.** Reaching inside makes the inner file public without anyone deciding
+that it should be. The owning component can no longer be refactored without
+breaking a stranger, which is exactly the coupling folders were supposed to
+prevent.
+
+**Wrong**
+
+```ts
+// components/TraceTable/TraceTable.tsx
+import { formatSpanLabel } from "@/src/features/traces/components/TraceGraphView/fns/formatSpanLabel";
+```
+
+**Right**
+
+```ts
+// promoted to the nearest common ancestor first
+import { formatSpanLabel } from "@/src/features/traces/fns/formatSpanLabel";
+```
+
+Counted on the dependency graph, walking component boundaries deepest-first.
+List them with `pnpm --filter web run structure:stats --rule 7`.

--- a/.agents/skills/project-structure/rules/08-features-are-reached-through-a-surface.md
+++ b/.agents/skills/project-structure/rules/08-features-are-reached-through-a-surface.md
@@ -1,0 +1,47 @@
+---
+rule: 8
+title: Anything that imports a feature goes through one of its surfaces
+mechanism: graph
+---
+
+# Rule 8 — features are reached through a surface
+
+A feature exposes two surfaces, because it is a full-stack slice:
+
+- `@/src/features/<feature>` — the root `index.ts`, client-safe exports.
+- `@/src/features/<feature>/server` — `server/index.ts`, server-only exports.
+
+Every importer binds to those, not just other features: the tRPC root, shared
+components, `src/pages`, all of them. Nothing else inside a feature is
+importable from outside it.
+
+**Why.** The surface is the only place where "what other people may use" is
+written down. Without it, every internal file is public by accident and no
+feature can be reorganised. It also keeps the client/server split structural:
+if the root index re-exported `server/`, every client importer would
+transitively evaluate Prisma, ClickHouse and ioredis — and nothing would
+crash, which is why prose alone cannot hold the line.
+
+**Wrong**
+
+```ts
+import { CommentableJsonView } from "@/src/features/comments/components/CommentableJsonView";
+```
+
+**Right**
+
+```ts
+// features/comments/index.ts
+export { CommentableJsonView } from "./components/CommentableJsonView";
+
+// the importer
+import { CommentableJsonView } from "@/src/features/comments";
+```
+
+This is the largest rule by count, and most of it predates the surfaces. It is
+counted and surfaced with a proposed fix, not blocked at merge.
+
+Counted on the dependency graph: any edge entering a feature at a path other
+than its two surfaces. List them with
+`pnpm --filter web run structure:stats --rule 8`, and see what a fix is worth
+with `--next --scope src/features/<feature>`.

--- a/.agents/skills/project-structure/rules/09-index-files-only-at-feature-surfaces.md
+++ b/.agents/skills/project-structure/rules/09-index-files-only-at-feature-surfaces.md
@@ -1,0 +1,51 @@
+---
+rule: 9
+title: index.ts lives at exactly two places — the feature root and the feature's server/ root
+mechanism: census
+---
+
+# Rule 9 — `index.ts` only at a feature surface
+
+Two legal locations, and no others:
+
+```text
+features/<feature>/index.ts          client-safe surface
+features/<feature>/server/index.ts   server-side surface
+```
+
+Both contain **named re-exports only** — no `export *`, no logic, no
+declarations of their own. The root index never re-exports from `server/`.
+Components don't get an `index.ts`; the shared folders don't either.
+
+**Why.** An `index.ts` anywhere else is an invisible module boundary: it makes
+a folder importable as a unit that nobody designed, and `export *` hides what
+is actually public. Surfaces should stay thin and shallow — a fat index means
+the feature wants splitting, and a deep one (reaching into a component's
+internals) means the module it reaches for should be promoted to feature level
+first.
+
+**Wrong**
+
+```text
+features/traces/components/index.ts
+features/traces/fns/index.ts
+```
+
+```ts
+// features/traces/index.ts
+export * from "./components/TraceTable/TraceTable";
+export const DEFAULT_LIMIT = 50;
+```
+
+**Right**
+
+```ts
+// features/traces/index.ts
+export { TraceTable } from "./components/TraceTable/TraceTable";
+export { TracesPage } from "./TracesPage";
+export type { TraceRow } from "./types/traceRow";
+```
+
+Counted from a TS parse of every `index.*` file in scope: location, plus
+`export *` and own declarations at the two legal ones. List them with
+`pnpm --filter web run structure:stats --rule 9`.

--- a/.agents/skills/project-structure/rules/10-client-code-never-imports-server.md
+++ b/.agents/skills/project-structure/rules/10-client-code-never-imports-server.md
@@ -1,0 +1,38 @@
+---
+rule: 10
+title: Client code does not import from server/, types excepted
+mechanism: graph
+---
+
+# Rule 10 — client code never imports `server/`
+
+A file outside a `server/` folder may not import a module inside one. Type-only
+imports are the exception.
+
+`server/` means node, wherever it sits — a feature's `server/`, a component's,
+`packages/shared/src/server`.
+
+**Why.** Nothing crashes when a client module imports server code: the bundler
+pulls Prisma, ClickHouse and ioredis into the browser graph, the import
+evaluates, and the boundary erodes silently. Type imports are erased at
+compile time, so they carry no runtime cost and stay allowed.
+
+**Wrong**
+
+```ts
+// features/traces/components/TraceTable/TraceTable.tsx
+import { deleteTrace } from "../../server/deleteTrace";
+```
+
+**Right**
+
+```ts
+import type { TraceRow } from "../../server/types";      // type-only: fine
+// and reach the behaviour through tRPC, not by importing the server module
+```
+
+Server code that sits *outside* `server/` — a `*Router.ts` next to components —
+shows up here as its imports. Moving it into `server/` clears them.
+
+Counted on the dependency graph, excluding type-only edges. List them with
+`pnpm --filter web run structure:stats --rule 10`.

--- a/.agents/skills/project-structure/rules/11-no-new-import-cycles.md
+++ b/.agents/skills/project-structure/rules/11-no-new-import-cycles.md
@@ -1,0 +1,35 @@
+---
+rule: 11
+title: No new import cycles
+mechanism: graph
+---
+
+# Rule 11 — no new import cycles
+
+No runtime import cycle. The mutually-importing feature pairs that exist today
+are grandfathered and form a worklist; nothing new joins them.
+
+Type-only cycles are reported separately as a survey metric — a cycle a type
+import closes carries no runtime hazard.
+
+**Why.** Before imports routed through surfaces, a cycle was a style problem.
+Once a feature is reached through its `index.ts`, a cycle means module
+evaluation order decides whether a binding exists — a real,
+initialisation-order runtime hazard.
+
+**Wrong**
+
+```text
+features/dashboards → features/widgets → features/dashboards
+```
+
+**Right** — one of three ways out, decided per pair:
+
+```text
+merge the two features
+invert the dependency
+move the piece they both need into the top-level shared folders
+```
+
+Counted on the dependency graph, runtime edges only. List them with
+`pnpm --filter web run structure:stats --rule 11`.

--- a/.agents/skills/project-structure/rules/12-pages-are-thin-shims.md
+++ b/.agents/skills/project-structure/rules/12-pages-are-thin-shims.md
@@ -1,0 +1,45 @@
+---
+rule: 12
+title: A src/pages file only imports a Page component and exports route config
+mechanism: graph
+---
+
+# Rule 12 — `src/pages` is routing, not code
+
+Next.js structure is a routing structure. A file in `src/pages` maps a URL to a
+Page component from a feature, plus route-level config. It should stay under
+roughly 20 lines.
+
+A Page is a big component responsible for an entire URL, living in its feature
+and named for what it does: `TracesPage.tsx`, not `IndexPage.tsx`.
+
+`pages/api` is the same idea for the public API: shims into
+`features/public-api` handlers.
+
+**Why.** Logic in `pages/` is logic no feature owns, reachable only through a
+URL. It also welds the app to Next.js: a thin routing layer is the seam that
+makes the framework replaceable.
+
+**Wrong**
+
+```ts
+// src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx — 1,404 lines
+```
+
+**Right**
+
+```ts
+// src/pages/project/[projectId]/traces/index.tsx
+import { TracesPage } from "@/src/features/traces";
+
+export default function Page() {
+  return <TracesPage />;
+}
+```
+
+Move a fat page with `git mv` into its feature so history follows, then write a
+fresh shim at the old path — see [rule 15](15-moves-preserve-git-history.md).
+
+Counted on the dependency graph: imports from a `src/pages` file that are not
+a feature Page component. List them with
+`pnpm --filter web run structure:stats --rule 12`.

--- a/.agents/skills/project-structure/rules/13-components-ui-is-frozen.md
+++ b/.agents/skills/project-structure/rules/13-components-ui-is-frozen.md
@@ -1,0 +1,34 @@
+---
+rule: 13
+title: src/components/ui is frozen — nothing new goes in
+mechanism: census
+---
+
+# Rule 13 — `components/ui` is frozen
+
+`src/components/ui` is the legacy shadcn folder. No new file goes into it, and
+its files move out one by one as they are touched:
+
+- used by one feature → into that feature
+- used by several and simple → into `src/components/design-system`
+- anything else → into `src/components`
+
+It keeps its kebab-case filenames until its files leave.
+
+**Why.** A frozen folder can only shrink, which turns "we should clean that up
+one day" into a number that goes down. It has drained by 45 files so far.
+
+**Wrong**
+
+```text
+src/components/ui/trace-status-badge.tsx     (new file)
+```
+
+**Right**
+
+```text
+src/features/traces/components/TraceStatusBadge.tsx
+```
+
+Counted as a file census of the folder; the baseline ratchets on additions.
+List them with `pnpm --filter web run structure:stats --rule 13`.

--- a/.agents/skills/project-structure/rules/14-design-system-components-stay-pure.md
+++ b/.agents/skills/project-structure/rules/14-design-system-components-stay-pure.md
@@ -1,0 +1,36 @@
+---
+rule: 14
+title: Design-system components hold no application state and fetch no data
+mechanism: review
+---
+
+# Rule 14 — the design system stays pure
+
+Foundational UI — buttons, accordions, dropdowns — lives in
+`src/components/design-system`. The bar for entry is that it is a *designed
+abstraction*, not merely shared.
+
+A design-system component may hold local UI state (open/closed). It must not
+hold application state and must not fetch data.
+
+Anything shared but not design-system-grade just lives in `src/components`.
+
+**Why.** A button that knows about traces cannot be reused by anything that
+isn't traces, and a component that fetches makes every consumer inherit a
+network dependency they can neither see nor mock.
+
+**Wrong**
+
+```tsx
+// components/design-system/ProjectPicker/ProjectPicker.tsx
+const { data } = api.projects.all.useQuery();
+```
+
+**Right**
+
+```tsx
+// components/design-system/Select/Select.tsx — options come in as props
+// the fetching wrapper lives in the feature that needs it
+```
+
+Not machine-counted: this one is decided in review.

--- a/.agents/skills/project-structure/rules/15-moves-preserve-git-history.md
+++ b/.agents/skills/project-structure/rules/15-moves-preserve-git-history.md
@@ -1,0 +1,45 @@
+---
+rule: 15
+title: Moves preserve git history — git mv, and a move is never an edit
+mechanism: process
+---
+
+# Rule 15 — move ≠ edit
+
+Git does not store renames; it detects them at diff and blame time by content
+similarity. So history survives a move only when the moved file's content stays
+near-identical in that commit. Everything else follows from that one fact.
+
+- A move PR contains `git mv` plus importer updates. Never a content edit of a
+  moved file — that goes in a follow-up PR.
+- This survives squash-merge: the moved file is a delete at the old path plus
+  an add with identical content at the new one, and rename detection still
+  works.
+- Absolute imports are what make it clean. A moved file's own `@/src/...`
+  imports stay valid, so the file itself does not change — see
+  [rule 26](26-relative-imports-stay-inside-their-directory.md).
+- Mass renames land as pure-rename commits listed in `.git-blame-ignore-revs`.
+
+**Why.** Preserving history is an explicit goal of the migration. A move that
+also edits the file reads as a rewrite, and `git blame` stops at the move.
+
+**Wrong**
+
+```text
+one commit: git mv + rename the exported symbol + fix a bug
+```
+
+**Right**
+
+```text
+commit 1: pnpm --filter web run structure:move <from> <to-dir>
+commit 2: rename the symbol
+commit 3: fix the bug
+```
+
+Use the codemod: it does the `git mv`, rewrites every importer through the
+TypeScript language service, brings colocated tests and stories along, and
+refuses to silently turn a move into an edit. Reading history after a move:
+`git log --follow`, `git blame -C -C -C`.
+
+Not machine-counted: this one is process.

--- a/.agents/skills/project-structure/rules/16-eslint-ignores-at-file-level.md
+++ b/.agents/skills/project-structure/rules/16-eslint-ignores-at-file-level.md
@@ -1,0 +1,38 @@
+---
+rule: 16
+title: ESLint ignores go at file level, and they are counted
+mechanism: census
+---
+
+# Rule 16 — ignores are visible or they don't exist
+
+An ESLint suppression goes at the top of the file as
+`/* eslint-disable <rule> */`. Not `eslint-disable-line`, not
+`eslint-disable-next-line`.
+
+File-level ignores are allowed and counted as a survey metric. Line-level ones
+are the violation.
+
+**Why.** A file-level ignore is in your face the moment you open the file. A
+line-level one is invisible until you happen to scroll past it, so it never
+gets revisited. Either way they are debt with a name on it, which is why the
+dashboard counts them.
+
+Do not add or widen a suppression without explicit approval for the exact rule
+and scope.
+
+**Wrong**
+
+```ts
+const x = compute(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+```
+
+**Right**
+
+```ts
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+// at the top of the file, so anyone opening it sees the exemption
+```
+
+Counted from a line scan of every file in `web/src`. List them with
+`pnpm --filter web run structure:stats --rule 16`.

--- a/.agents/skills/project-structure/rules/17-the-baseline-only-shrinks.md
+++ b/.agents/skills/project-structure/rules/17-the-baseline-only-shrinks.md
@@ -1,0 +1,35 @@
+---
+rule: 17
+title: New code follows the rules; the violations baseline only shrinks
+mechanism: ratchet
+---
+
+# Rule 17 — the baseline only shrinks
+
+Existing code is where it is; the migration would chase a moving target
+otherwise. New code follows all the rules, and `web/.structure-baseline.json`
+— the committed snapshot of today's violations — only ever goes down.
+
+**Why.** This is the one rule that makes the other 25 finishable. Enforcement
+arrives per rule, not all at once: when a rule's count is small enough to
+finish, it graduates and CI starts failing on new violations of it. The cheap
+local rules graduate first (naming, one export per file, kind folders); the
+ones that need surfaces to exist graduate last.
+
+**Wrong**
+
+```text
+re-snapshotting the baseline to make a regression disappear
+```
+
+**Right**
+
+```text
+pnpm --filter web run structure:stats --diff     # what this branch added or cleared
+```
+
+Re-snapshot deliberately, as the point of its own PR, after a fix batch —
+never as a side effect of unrelated work. A snapshot taken with a broken
+sensor is worse than a stale one.
+
+Counted by the baseline itself: `--diff` lists what a branch added and cleared.

--- a/.agents/skills/project-structure/rules/18-fn-and-hook-tests-colocate-flat.md
+++ b/.agents/skills/project-structure/rules/18-fn-and-hook-tests-colocate-flat.md
@@ -1,0 +1,46 @@
+---
+rule: 18
+title: Tests for fns and hooks sit flat next to the file they test
+mechanism: census
+---
+
+# Rule 18 — a test sits next to its subject
+
+```text
+fns/groupByKey.ts
+fns/groupByKey.clienttest.ts
+hooks/useDialog.ts
+hooks/useDialog.clienttest.ts
+```
+
+A folder appears only when something accumulates more than a test. A module
+folder keeps its tests together instead — `fns/searchJson/__tests__/` — because
+the group is tested as a group.
+
+**Why.** Flat colocation means the test is impossible to miss when you change
+the file, and impossible to orphan when you move it: the move codemod carries
+`X.clienttest.ts` along with `X.ts` automatically.
+
+**Wrong**
+
+```text
+fns/groupByKey.ts
+__tests__/groupByKey.clienttest.ts
+```
+
+**Right**
+
+```text
+fns/groupByKey.ts
+fns/groupByKey.clienttest.ts
+```
+
+Facet-named tests count as colocated when the subject sits beside them:
+`X.media.clienttest.tsx` next to `X.tsx` is fine.
+
+When you write the test before the module exists, create the module file first
+— the check looks for a subject next to the test, and cannot tell test-first
+from a misplaced test.
+
+Counted from the file census: a test file with no adjacent subject module.
+List them with `pnpm --filter web run structure:stats --rule 18`.

--- a/.agents/skills/project-structure/rules/19-only-tests-import-tests.md
+++ b/.agents/skills/project-structure/rules/19-only-tests-import-tests.md
@@ -1,0 +1,43 @@
+---
+rule: 19
+title: Only tests import from __tests__, at any level
+mechanism: graph
+---
+
+# Rule 19 — `__tests__` is for tests only
+
+`__tests__` is a pattern at every level: a component can have one, a feature
+can have one, and the global `src/__tests__` stays. It holds support material —
+builders, mocks, harnesses, fixtures, seed data — plus the tests that don't
+belong to a single module. Test files themselves still colocate next to what
+they test.
+
+Hard rule: only tests (and other `__tests__` modules) import from `__tests__`.
+Production code never does. The usual import directions apply on top — a
+feature's `__tests__` may use the global one, never the reverse, and one
+feature's tests don't reach into another feature's `__tests__`.
+
+Placement follows usage, like everything else: reusable across features → the
+global `src/__tests__`; used by one feature → that feature's.
+
+**Why.** A fixture imported by production code ships to users, and a shared
+mock imported across features couples two test suites that should be able to
+change independently.
+
+**Wrong**
+
+```ts
+// features/traces/fns/buildTree.ts
+import { traceFixture } from "@/src/__tests__/fixtures/trace";
+```
+
+**Right**
+
+```ts
+// features/traces/fns/buildTree.clienttest.ts
+import { traceFixture } from "@/src/__tests__/fixtures/trace";
+```
+
+Counted on the dependency graph: edges into `__tests__` from non-test modules,
+plus cross-feature test edges. List them with
+`pnpm --filter web run structure:stats --rule 19`.

--- a/.agents/skills/project-structure/rules/20-no-unused-exports.md
+++ b/.agents/skills/project-structure/rules/20-no-unused-exports.md
@@ -1,0 +1,38 @@
+---
+rule: 20
+title: No unused exports — if nothing imports it, it isn't exported
+mechanism: graph
+---
+
+# Rule 20 — an export nobody imports is not an export
+
+If nothing imports a symbol, it is either dead code or a private helper
+pretending to be public. Delete it, or drop the `export`.
+
+The converse of [rule 4](04-one-function-per-file-in-fns.md)'s split rule: we
+split a file when something new needs to be exported, and we unexport when
+nothing needs it any more.
+
+**Why.** Every export is a promise. An unread one still shows up in
+autocomplete, still gets imported by mistake, and still blocks a refactor that
+would otherwise be local. Exporting an internal purely so a test can reach it
+is the most common way this happens, and it is not allowed.
+
+**Wrong**
+
+```ts
+export const parseFilter = (raw: string) => …   // no importer; a test reaches for it
+```
+
+**Right**
+
+```ts
+const parseFilter = (raw: string) => …          // private, tested through the public API
+```
+
+Currently counted at file level — modules nothing imports. Symbol-level
+detection needs a knip config and is a follow-up; string-referenced modules
+(worker URLs, route strings) are invisible to the graph, so `src/workers`,
+`scripts/` and Next entry points are excluded.
+
+List them with `pnpm --filter web run structure:stats --rule 20`.

--- a/.agents/skills/project-structure/rules/21-server-only-imports-stay-in-server.md
+++ b/.agents/skills/project-structure/rules/21-server-only-imports-stay-in-server.md
@@ -1,0 +1,41 @@
+---
+rule: 21
+title: The shared server entrypoints may only be imported from server code
+mechanism: not yet counted
+---
+
+# Rule 21 — `@langfuse/shared/src/server` is server-only
+
+`@langfuse/shared/src/server` and `@langfuse/shared/src/db` may be imported
+only from:
+
+- inside a `server/` folder — `server/` means node, wherever it sits
+- `src/pages/api/**`
+- `*.servertest.*` files
+- `worker/**`
+
+Everything else imports `@langfuse/shared`.
+
+**Why.** Importing the server barrel evaluates Prisma, ClickHouse and ioredis.
+In a jsdom test that succeeds silently, so the boundary erodes without a single
+failure: one client test needed a plain-data preset catalogue whose only export
+path was the server barrel, and the fix was this RFC's own placement rule
+applied one layer down — the file was domain code living in a server folder.
+
+**Wrong**
+
+```ts
+// features/traces/components/TraceTable/TraceTable.tsx
+import { getTracesTable } from "@langfuse/shared/src/server";
+```
+
+**Right**
+
+```ts
+import type { TracesTableRow } from "@langfuse/shared";
+// behaviour comes through tRPC; the server import lives in features/traces/server/
+```
+
+No detector yet — this one is on reviewers. See
+[rule 22](22-shared-domain-never-imports-server.md) for the same boundary
+inside `packages/shared`.

--- a/.agents/skills/project-structure/rules/22-shared-domain-never-imports-server.md
+++ b/.agents/skills/project-structure/rules/22-shared-domain-never-imports-server.md
@@ -1,0 +1,37 @@
+---
+rule: 22
+title: Inside packages/shared, domain/ never imports from server/
+mechanism: not yet counted
+---
+
+# Rule 22 — in `packages/shared`, location encodes runtime
+
+`packages/shared` is consumed by two runtimes — browser and node — so there a
+file's location also encodes who may run it:
+
+- `domain/` — types, zod schemas, plain data, pure functions. Nothing that
+  reaches infra (Prisma, ClickHouse, Redis, S3, logger). Safe in any runtime.
+- `server/` — anything that may touch infra. Node only.
+
+`server/` may import `domain/`. `domain/` never imports `server/`. New
+domain-safe code lands in `domain/` even when a service is what ships it.
+
+**Why.** Same principle as everywhere else — location = usage — one layer down,
+where the axis is runtime instead of feature. And it is mechanically
+computable: a module in `server/` whose transitive dependencies are all
+domain-safe is misplaced, so misplaced domain code can become a number that
+shrinks like every other.
+
+**Wrong**
+
+```text
+packages/shared/src/server/presets/catalog.ts   → plain data, no infra imports
+```
+
+**Right**
+
+```text
+packages/shared/src/domain/presets/catalog.ts
+```
+
+No detector yet — this one is on reviewers.

--- a/.agents/skills/project-structure/rules/23-test-suffix-implies-the-import-rules.md
+++ b/.agents/skills/project-structure/rules/23-test-suffix-implies-the-import-rules.md
@@ -1,0 +1,33 @@
+---
+rule: 23
+title: The test suffix implies which import rules apply
+mechanism: not yet counted
+---
+
+# Rule 23 — the suffix is the contract
+
+- `*.clienttest.*` obeys the client rules: no server barrel, no `server/`
+  imports beyond types.
+- `*.servertest.*` may import `@langfuse/shared/src/server`.
+
+**Why.** The suffix already decides which vitest project runs the file and in
+which environment. Making it decide the import rules too means one visible
+token carries the whole contract, instead of a reader having to know which
+runtime a given test happens to boot.
+
+**Wrong**
+
+```ts
+// fns/buildTree.clienttest.ts
+import { getTracesTable } from "@langfuse/shared/src/server";
+```
+
+**Right**
+
+```ts
+// fns/buildTree.clienttest.ts — plain data in, plain data out
+import { buildTree } from "./buildTree";
+```
+
+No detector yet — this one is on reviewers. See
+[rule 21](21-server-only-imports-stay-in-server.md).

--- a/.agents/skills/project-structure/rules/24-cross-package-moves-may-leave-a-shim.md
+++ b/.agents/skills/project-structure/rules/24-cross-package-moves-may-leave-a-shim.md
@@ -1,0 +1,34 @@
+---
+rule: 24
+title: Cross-package moves may leave a one-line shim; inside web, none
+mechanism: not yet counted
+---
+
+# Rule 24 — shims are a cross-package concession, and they are counted
+
+A move between packages may leave a one-line `export *` shim at the old path,
+so importers in other packages don't all have to change in the same PR. Shims
+are counted in the baseline, so they drain instead of accumulating.
+
+Inside `web` there are no shims: the codemod rewrites every importer, so there
+is no reason to leave one.
+
+**Why.** A shim is a deliberate, temporary, *counted* exception. Uncounted, it
+is just a second path to the same module — which is how a dead duplicate of a
+file survives review for months, because greps for the name keep finding the
+live one.
+
+**Wrong**
+
+```ts
+// web/src/hooks/useFormPersistence.ts — after moving into features/prompts
+export * from "@/src/features/prompts/hooks/useFormPersistence";
+```
+
+**Right**
+
+```ts
+// nothing left behind; structure:move rewrote all 14 importers
+```
+
+No detector yet — this one is on reviewers.

--- a/.agents/skills/project-structure/rules/25-one-name-means-one-thing.md
+++ b/.agents/skills/project-structure/rules/25-one-name-means-one-thing.md
@@ -1,0 +1,37 @@
+---
+rule: 25
+title: Inside a feature, one name means one thing
+mechanism: not yet counted
+---
+
+# Rule 25 — one name, one thing
+
+Within a feature, no two modules export the same name, and a type never shares
+a name with a component.
+
+**Why.** `TraceSearchListItem` was both the component that renders a row and
+the type of that row's data. While the type sat inside the component file
+nobody noticed; extracting it into `types/` left two modules exporting the same
+name, so every consumer needing both had to alias one at the import site. That
+alias is the tell — the name was doing two jobs. Name the data for what it is
+(`SearchListRow`) and the imports read straight again.
+
+The same rule covers two components with the same name in different folders,
+and duplicate module names: a dead copy of `jsonExpansionUtils.ts` survived
+review for months because greps kept finding the live one.
+
+**Wrong**
+
+```ts
+import { TraceSearchListItem } from "./components/TraceSearchListItem";
+import { TraceSearchListItem as TraceSearchListItemData } from "./types/traceSearchListItem";
+```
+
+**Right**
+
+```ts
+import { TraceSearchListItem } from "./components/TraceSearchListItem";
+import type { SearchListRow } from "./types/searchListRow";
+```
+
+An import-site alias is the signal to look for. No detector yet.

--- a/.agents/skills/project-structure/rules/26-relative-imports-stay-inside-their-directory.md
+++ b/.agents/skills/project-structure/rules/26-relative-imports-stay-inside-their-directory.md
@@ -1,0 +1,34 @@
+---
+rule: 26
+title: Relative imports reach inside their own directory only
+mechanism: not yet counted
+---
+
+# Rule 26 — relative inside, absolute across
+
+A relative import may reach inside its own directory. Anything crossing a
+directory boundary is absolute — `@/src/...`.
+
+**Why.** This is what makes [rule 15](15-moves-preserve-git-history.md)
+possible. A moved file's absolute imports stay valid, so the file itself does
+not change when it moves — only its importers do, and those are different files
+with their own untouched history. A file whose relative imports reach out of
+its own directory cannot move without a content edit, which is precisely what
+a move is not allowed to contain. Five files in traces were blocked exactly
+that way; the move tool refuses to do that rewrite silently.
+
+**Wrong**
+
+```ts
+// features/traces/components/TraceTable/TraceTable.tsx
+import { formatCost } from "../../../fns/formatCost";
+```
+
+**Right**
+
+```ts
+import { formatCost } from "@/src/features/traces/fns/formatCost";
+import { TraceRow } from "./TraceRow";              // same directory: fine
+```
+
+Absolutise first, in its own commit, then move. No detector yet.

--- a/.agents/skills/project-structure/rules/_template.md
+++ b/.agents/skills/project-structure/rules/_template.md
@@ -1,0 +1,27 @@
+---
+rule: 0
+title: One line, imperative, what the rule requires
+mechanism: census | graph | review | process | ratchet
+---
+
+# Rule 0 — one line, imperative
+
+The rule in one or two sentences. No hedging: this is what the code must look
+like.
+
+**Why.** The failure it prevents, in one or two sentences. Prefer the concrete
+incident over the principle.
+
+**Wrong**
+
+```text
+the shape that is a violation
+```
+
+**Right**
+
+```text
+the shape that is not
+```
+
+How it is counted, and the command that lists the current offenders.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -58,6 +58,9 @@
 
 ## Package-Local Skills
 
+- Project structure — where a file goes, what it is named, and how imports
+  cross boundaries (26 rules, one file each):
+  [`../.agents/skills/project-structure/SKILL.md`](../.agents/skills/project-structure/SKILL.md)
 - Shared browser-review workflow for user-visible frontend changes:
   [`../.agents/skills/frontend-browser-review/SKILL.md`](../.agents/skills/frontend-browser-review/SKILL.md)
 - Large frontend feature, virtualized-list, local state, and React
@@ -105,8 +108,13 @@ Sentry instrumentation skill first and decide whether it should capture at all
 - When fixing an isolated styling issue in an individual component, create or
   update a component story first, following
   `../.agents/skills/storybook/SKILL.md`.
-- Put net-new feature code under `src/features/<feature>/*`; put broadly reusable
-  components under `src/components/*`.
+- **Before creating, moving or renaming a file under `src/`, read
+  `../.agents/skills/project-structure/SKILL.md`.** It owns the 26 structure
+  rules: placement (used by one feature → inside that feature, two or more →
+  the top-level shared folders), the closed list of kind folders, naming, and
+  the feature-surface import contract. Existing code is grandfathered — the one
+  obligation is not to add a new violation, and
+  `pnpm --filter web run structure:stats --diff` is what says whether you did.
 - We use tRPC for full-stack web features; register routers in
   `src/server/api/root.ts`.
 - RBAC lives in `src/features/rbac`: role definitions in

--- a/web/scripts/structure/README.md
+++ b/web/scripts/structure/README.md
@@ -11,10 +11,12 @@ many small, boring PRs, each visibly dropping the count:
    from `--diff` ("rule 6: 104 → 63"). One item per PR; no baseline
    regeneration unless it is the point of the PR.
 
-# structure:stats — the RFC dashboard
+# structure:stats — the rules dashboard
 
-Counts violations of the [web project-structure RFC](https://linear.app/clickhouse/document/langfuse-web-project-code-structure-rfc-ecbc304915d6)
-(meta LFE-14748) per rule, so migration progress is one visible number.
+Counts violations of the project-structure rules per rule, so migration
+progress is one visible number. The rules themselves, with the reasoning and
+examples for each, live in
+[`.agents/skills/project-structure/`](../../../.agents/skills/project-structure/SKILL.md).
 
 ```sh
 pnpm structure:stats                          # per-rule counts (+ Δ vs baseline)
@@ -115,8 +117,7 @@ is instant, which is why the CLI is batch-shaped.
   `AdvancedJsonViewer` calibration move left three `vi.mock()` paths behind and
   six tests failed under a green typecheck.
 
-Splitting a file and directory renames are not part of the surface
-(follow-up LFE-14806).
+Splitting a file and renaming a directory are not part of the surface yet.
 
 ## Rule → mechanism
 
@@ -145,9 +146,8 @@ approximations under-count some nested-component cases — see its header).
 
 ## RFC amendments the detectors now encode
 
-Found by migrating `features/traces` and approved in-flight; the Linear RFC is
-the source of truth and carries the prose (handed over via the LFE-14804
-mailbox).
+Found by migrating `features/traces` and approved in-flight; the rules skill
+carries the prose.
 
 - **`constants/` and `types/` are kind folders.** A constant is not a function,
   so it does not belong in `fns/`, and a per-feature `config/` or `shared/`
@@ -173,8 +173,8 @@ mailbox).
   exactly once). Lowercase dirs (`components/ui`, `components/table`) are
   legacy containers, not boundaries.
 - Context modules: `FooContext.tsx` exporting `FooContext` + `FooProvider` +
-  `useFoo*` counts as one unit; anything beyond flags rule 3. The RFC has no
-  explicit contexts pattern yet — policy gap, see the audit in LFE-14781.
+  `useFoo*` counts as one unit; anything beyond flags rule 3. The rules have
+  no explicit contexts pattern yet — the detector's shape is the policy.
 - Cycles that a type-only edge breaks are not runtime hazards; they are
   reported as a survey metric, not rule 11.
 - Server code placed outside `server/` (e.g. `*Router.ts` beside components)


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16391.preview.langfuse.com](https://pr-16391.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

> Stacked on #16390 (the sensor fix the counts in this PR depend on). Merge that first.

## TL;DR

The 26 project-structure rules lived in a document no agent working in a checkout can read. This puts them in the repo as a skill — `SKILL.md` for the decision and the fix loop, `rules/01..26.md` one rule per file — and points at it from `web/AGENTS.md` in six lines. No behaviour change.

## Why

What the repo told a contributor about structure, in full:

- `web/AGENTS.md` → *Quick Commands*: two lines for `structure:stats` and `structure:move`.
- `web/AGENTS.md` → *Web Conventions*: "put net-new feature code under `src/features/<feature>/*`".

That's it. So:

- A rule number reported by the sensor — "rule 8 violation" — pointed at nothing readable in the repo.
- The two rules growing fastest are **rule 3** (camelCase filenames, +15) and **rule 4** (one function per file in `fns/`, +14). Both are decided entirely by a filename and a destination folder, at the exact moment a file is created, and nothing in any contributor's or agent's context mentioned either.

Every later step in this series — a pre-write hook, a session briefing, a CI comment — needs somewhere to link when it says "no". This is that somewhere.

## What

`.agents/skills/project-structure/`, following the `clickhouse-best-practices` house pattern already in the repo (a `SKILL.md` plus `rules/<name>.md`, one rule per file, plus a `_template.md`):

- **`SKILL.md`** — the one obligation; "where a file goes" in four questions; the 26-rule index with each rule's mechanism (census / graph / review / process) and current count; and the fix loop (`--next --scope` → `structure:move` → re-run → one small PR).
- **`rules/01..26.md`** — one rule each: the rule, *why* it exists, a wrong and a right example, and the command that lists today's offenders. Filenames lead with the rule number so `--rule 8` maps to `rules/08-*.md` by eye.
- **`web/AGENTS.md`** — one line in *Package-Local Skills*, and the existing "put net-new feature code under…" bullet replaced by a pointer plus the obligation.

## Result

An agent that reads `web/AGENTS.md` now learns the rules exist, that the sensor is the source of truth for counts, and where to read the one that just fired. An agent handed a rule number can read that rule in one file.

<details>
<summary>Decisions worth knowing about</summary>

**The rules are not inlined into `web/AGENTS.md`.** That file is 2,300 words of flat mixed-altitude bullets loaded on every web task — the layer system sits in the same list as `gap-*` over `space-x-*`. Adding 26 rules (~3–4k tokens on every task) would make it the junk drawer the structure rules exist to argue against, one level up. Skill plus pointer instead.

**Counts live in one place, not 26.** `SKILL.md`'s index carries the per-rule counts with the date they were measured; the rule files carry the mechanism and the drill-down command but no number. Twenty-six hard-coded counts would be twenty-six things to keep true, in a document whose own pointer says the sensor is authoritative.

**Rules 21–26 are marked "not yet counted"** — `stats.mjs` implements 1–20, so a violation of 21–26 (shared-package layering, test suffixes, shims, one-name-one-thing, relative imports) shows up in no number and is on reviewers. Better said out loud than implied.

**The sensor README got scrubbed.** It linked the rules document and carried four internal ticket ids, which the root guidelines forbid in anything the repo publishes. It now points at the skill.

</details>

<details>
<summary>Verification</summary>

- `pnpm run agents:sync` → `Linked …/.claude/skills/project-structure`
- `pnpm run agents:check` → exit 0 (shims in sync, no broken path references)
- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `prettier --check "**/*.{js,jsx,ts,tsx,css}"` → `All matched files use Prettier code style!`
- Every relative markdown link in the new files, plus the two edited files, resolved on disk: none broken. (Markdown is not in the repo's prettier glob, and the existing `.agents/**/*.md` is not prettier-formatted either, so these files match the house style rather than prettier's.)

No tests: this PR adds markdown and changes no code.

</details>

## Next in this series

`check-path.mjs` plus a pre-write hook wired through `.agents/config.json` into all three tools, so the census rules this skill documents cannot be violated by a new file in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an in-repository project-structure skill containing 26 placement, naming, import-boundary, and migration rules, then links it from the web contributor guidance and structure sensor documentation.

- Adds a central skill index, rule-specific guidance, examples, and remediation workflow.
- Replaces external/internal references with repository-local documentation.
- Directs web contributors to consult the skill before creating, moving, or renaming source files.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness, security, or independently actionable documentation defect identified.

The change is documentation-only, its new files are present in the commit tree, the inspected structure command accepts the documented flags, and no broken contract was established.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(structure): put the project-structu..."](https://github.com/langfuse/langfuse/commit/128c5bd406a9e0e53d3aa7e66e0681dc035391f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55508306)</sub>

<!-- /greptile_comment -->