### PR TITLE
feat(structure): deny new files that would add a structure violation

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -19,10 +19,11 @@ or `.vscode/`.
 
 ## `config.json`
 
-`.agents/config.json` contains four kinds of data:
+`.agents/config.json` contains five kinds of data:
 
 - `shared`: defaults used across tools
 - `mcpServers`: project MCP servers and how to connect to them
+- `hooks`: tool-neutral agent hooks, one declaration per hook
 - `claude`: Claude-specific generated settings inputs
 - `codex`: Codex-specific generated settings inputs
 - `cursor`: Cursor-specific generated settings inputs
@@ -59,6 +60,16 @@ Current shape:
       "transport": "http",
       "url": "https://mcp.linear.app/mcp"
     }
+  },
+  "hooks": {
+    "preFileWrite": [
+      {
+        "name": "structure-path-guard",
+        "description": "...",
+        "script": "scripts/agents/hooks/structure-path-guard.mjs",
+        "timeoutSeconds": 10
+      }
+    ]
   },
   "claude": {
     "settings": {
@@ -118,9 +129,15 @@ Generated local artifacts:
 - `.codex/config.toml`
 - `.codex/environments/environment.toml`
 
+Generated and committed:
+
+- `.cursor/environment.json`
+- `.cursor/hooks.json`
+- `.codex/hooks.json`
+
 Cursor must read its environment contract before it can run the install script,
-so `.cursor/environment.json` is the one generated configuration file committed
-to the repository. Generate it from `.agents/config.json`; never edit it by
+and it reads its hooks before `pnpm install` can generate anything, so those
+files are committed. Generate it from `.agents/config.json`; never edit it by
 hand. `.cursor/Dockerfile` is also committed because it is an intentionally
 Cursor-specific runtime definition.
 
@@ -217,6 +234,38 @@ Update values in `shared`:
 - `setupScript`
 - `devCommand`
 - `devTerminalDescription`
+
+### Add a hook
+
+Declare it once under `hooks`, with a tool-neutral event name, and let the
+generator emit each tool's shape. Do not hand-write `.claude/settings.json`,
+`.cursor/hooks.json` or `.codex/hooks.json`.
+
+```json
+{
+  "hooks": {
+    "preFileWrite": [
+      {
+        "name": "example",
+        "description": "What it refuses, and how to get past it",
+        "script": "scripts/agents/hooks/example.mjs",
+        "timeoutSeconds": 10
+      }
+    ]
+  }
+}
+```
+
+`HOOK_EVENTS` in `scripts/agents/sync-agent-shims.mjs` maps a neutral event to
+each tool's event name and tool-name matcher; a tool with no mapping for an
+event simply gets no hook. One implementation per hook lives in
+`scripts/agents/hooks/`, receives the tool's payload on stdin, and writes that
+tool's response shape based on `--tool`.
+
+Two rules for any hook that can block: **fail open** — an unreadable payload,
+a throw or a timeout must allow the action — and **name an escape hatch** in
+the message it prints, following `LANGFUSE_PRE_COMMIT_SKIP_LINT` in
+`.husky/pre-commit`. A gate with no exit gets deleted.
 
 ### Add tool-specific generated inputs
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -19,7 +19,7 @@ or `.vscode/`.
 
 ## `config.json`
 
-`.agents/config.json` contains five kinds of data:
+`.agents/config.json` contains six kinds of data:
 
 - `shared`: defaults used across tools
 - `mcpServers`: project MCP servers and how to connect to them

--- a/.agents/config.json
+++ b/.agents/config.json
@@ -28,6 +28,16 @@
       "url": "https://mcp.linear.app/mcp"
     }
   },
+  "hooks": {
+    "preFileWrite": [
+      {
+        "name": "structure-path-guard",
+        "description": "Refuse a new file under web/src whose path would add a project-structure violation. Creation only, fails open, disabled by LANGFUSE_SKIP_STRUCTURE_HOOK.",
+        "script": "scripts/agents/hooks/structure-path-guard.mjs",
+        "timeoutSeconds": 10
+      }
+    ]
+  },
   "claude": {
     "settings": {
       "permissions": {

--- a/.agents/skills/project-structure/SKILL.md
+++ b/.agents/skills/project-structure/SKILL.md
@@ -121,8 +121,18 @@ Two things about `--next` that read like bugs and are not:
 
 ## Enforcement today
 
-Measured, not gated. The tooling counts violations, points at them and proposes
-the rework; nothing blocks a merge on the total. Enforcement arrives one rule at
+Measured, not gated — with one exception. A pre-write hook refuses to **create**
+a file whose path would add a violation of rules 1, 3, 4, 5, 9 or 13, and
+surfaces rule 18. It answers from the path alone, so it never has an opinion
+about a graph rule, it never fires on an edit to an existing file, it fails
+open, and `LANGFUSE_SKIP_STRUCTURE_HOOK=1` turns it off. Check a path yourself:
+
+```sh
+pnpm --filter web run structure:check-path src/features/traces/utils/formatCost.ts
+```
+
+Everything else is counted, not blocked: the tooling points at violations and
+proposes the rework; nothing blocks a merge on the total. Enforcement arrives one rule at
 a time: when a rule's count is small enough to finish, it graduates and CI
 starts failing on new violations of it.
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/agents/hooks/structure-path-guard.mjs --tool codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "node scripts/agents/hooks/structure-path-guard.mjs --tool cursor",
+        "matcher": "Write",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/scripts/agents/hooks/structure-path-guard.mjs
+++ b/scripts/agents/hooks/structure-path-guard.mjs
@@ -17,7 +17,7 @@
 // most of a full run. This calls the path check directly and costs a
 // directory read.
 import { existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -117,9 +117,12 @@ const targetPaths = (payload) => {
   return [...found];
 };
 
+// resolve() normalizes ".." whether or not the target is already absolute,
+// and ignores the base when it is. Branching on a leading "/" skipped that
+// normalization, so an absolute path carrying a ".." segment missed the
+// web/src scope filter below and was allowed.
 /** @type {(cwd: string | undefined, target: string) => string} */
-const absolute = (cwd, target) =>
-  target.startsWith("/") ? target : resolve(cwd || repoRoot, target);
+const absolute = (cwd, target) => resolve(cwd || repoRoot, target);
 
 /** @type {(results: {path: string, findings: any[]}[]) => string} */
 const message = (results) => {
@@ -175,20 +178,24 @@ async function main() {
     allow();
   }
 
-  const candidates = targetPaths(payload).filter((target) => {
-    const path = absolute(payload?.cwd, target);
+  // Resolve once: the scope filter, the check and the message all have to be
+  // talking about the same path, and the message reads better repo-relative
+  // than as whatever shape the tool happened to report.
+  const candidates = targetPaths(payload)
+    .map((target) => absolute(payload?.cwd, target))
     // Creation only: an existing file's name is not this hook's business.
-    return path.startsWith(`${repoRoot}/web/src/`) && !existsSync(path);
-  });
+    .filter(
+      (path) => path.startsWith(`${repoRoot}/web/src/`) && !existsSync(path),
+    );
   if (!candidates.length) allow();
 
   const { checkPath } = await import(
     `file://${repoRoot}/web/scripts/structure/check-path.mjs`
   );
   const results = candidates
-    .map((target) => ({
-      path: target,
-      findings: checkPath(absolute(payload?.cwd, target)),
+    .map((path) => ({
+      path: relative(repoRoot, path),
+      findings: checkPath(path),
     }))
     .filter(({ findings }) => findings.length);
   if (!results.length) allow();

--- a/scripts/agents/hooks/structure-path-guard.mjs
+++ b/scripts/agents/hooks/structure-path-guard.mjs
@@ -106,10 +106,13 @@ const targetPaths = (payload) => {
       if (typeof input[key] === "string" && input[key]) found.add(input[key]);
   // A patch-shaped tool (Codex `apply_patch`) carries the target inside the
   // patch text. Only consulted when no explicit path field was present, so a
-  // file's *contents* can never be mistaken for a path.
+  // file's *contents* can never be mistaken for a path. `Move to` matters as
+  // much as `Add File`: a rename lands the file at a path that did not exist.
   if (!found.size)
     for (const text of stringValues(input))
-      for (const match of text.matchAll(/^\*\*\* Add File: (.+)$/gm))
+      for (const match of text.matchAll(
+        /^\*\*\* (?:Add File|Move to): (.+)$/gm,
+      ))
         found.add(match[1].trim());
   return [...found];
 };

--- a/scripts/agents/hooks/structure-path-guard.mjs
+++ b/scripts/agents/hooks/structure-path-guard.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+// Pre-write hook: refuse a *new* file under `web/src` whose path would add a
+// project-structure violation. One implementation, three response shapes:
+//
+//   node scripts/agents/hooks/structure-path-guard.mjs --tool claude|cursor|codex
+//
+// Two invariants, both load-bearing:
+//
+//   1. Creation only. The check runs when the target path does not exist yet.
+//      An edit to a badly-named file is never blocked — the name is not the
+//      bug you were asked to fix.
+//   2. Fail open, always. Unreadable stdin, unparseable payload, a throw, a
+//      missing check — every one of them allows the write. A broken sensor
+//      must not be able to stop work.
+//
+// Never invoke the sensor through pnpm from here: package-manager startup is
+// most of a full run. This calls the path check directly and costs a
+// directory read.
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const STDIN_TIMEOUT_MS = 1500;
+const SKIP_ENV_VAR = "LANGFUSE_SKIP_STRUCTURE_HOOK";
+const PATH_KEYS = [
+  "file_path",
+  "filePath",
+  "path",
+  "target_file",
+  "notebook_path",
+];
+
+const tool = (() => {
+  const index = process.argv.indexOf("--tool");
+  const value = index >= 0 ? process.argv[index + 1] : undefined;
+  return value === "cursor" || value === "codex" ? value : "claude";
+})();
+
+/** Anything but a decision is an allow, expressed the way each tool expects. */
+const allow = () => {
+  if (tool === "cursor") process.stdout.write(JSON.stringify({}));
+  process.exit(0);
+};
+
+/** @type {(verdict: "deny" | "ask", message: string) => never} */
+const decide = (verdict, message) => {
+  if (tool === "cursor") {
+    // Cursor's preToolUse takes allow or deny only, so an "ask" becomes an
+    // allow carrying the note — it surfaces the rule without blocking.
+    process.stdout.write(
+      JSON.stringify(
+        verdict === "deny"
+          ? {
+              permission: "deny",
+              agent_message: message,
+              user_message: "Blocked by the project-structure path check.",
+            }
+          : { permission: "allow", agent_message: message },
+      ),
+    );
+  } else if (tool === "codex") {
+    // Codex has no native "ask" for PreToolUse, so an ask is returned as
+    // context and the tool's own approval flow is left alone.
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput:
+          verdict === "deny"
+            ? {
+                hookEventName: "PreToolUse",
+                permissionDecision: "deny",
+                permissionDecisionReason: message,
+              }
+            : { hookEventName: "PreToolUse", additionalContext: message },
+      }),
+    );
+  } else {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: verdict,
+          permissionDecisionReason: message,
+        },
+      }),
+    );
+  }
+  process.exit(0);
+};
+
+/** @type {(value: unknown, out?: string[]) => string[]} */
+const stringValues = (value, out = []) => {
+  if (typeof value === "string") out.push(value);
+  else if (Array.isArray(value)) for (const item of value) stringValues(item, out);
+  else if (value && typeof value === "object")
+    for (const item of Object.values(value)) stringValues(item, out);
+  return out;
+};
+
+/** @type {(payload: any) => string[]} */
+const targetPaths = (payload) => {
+  const input = payload?.tool_input;
+  const found = new Set();
+  if (input && typeof input === "object")
+    for (const key of PATH_KEYS)
+      if (typeof input[key] === "string" && input[key]) found.add(input[key]);
+  // A patch-shaped tool (Codex `apply_patch`) carries the target inside the
+  // patch text. Only consulted when no explicit path field was present, so a
+  // file's *contents* can never be mistaken for a path.
+  if (!found.size)
+    for (const text of stringValues(input))
+      for (const match of text.matchAll(/^\*\*\* Add File: (.+)$/gm))
+        found.add(match[1].trim());
+  return [...found];
+};
+
+/** @type {(cwd: string | undefined, target: string) => string} */
+const absolute = (cwd, target) =>
+  target.startsWith("/") ? target : resolve(cwd || repoRoot, target);
+
+/** @type {(results: {path: string, findings: any[]}[]) => string} */
+const message = (results) => {
+  const total = results.reduce((sum, r) => sum + r.findings.length, 0);
+  const lines = [
+    `Project structure: this path would add ${total} new violation${total === 1 ? "" : "s"}.`,
+    "",
+  ];
+  for (const { path, findings } of results) {
+    lines.push(path);
+    for (const f of findings) {
+      lines.push(`  rule ${f.rule} — ${f.title}`);
+      lines.push(`    ${f.detail}`);
+      if (f.correctPath) lines.push(`    correct path: web/${f.correctPath}`);
+      lines.push(`    rule file: ${f.ruleFile}`);
+    }
+    lines.push("");
+  }
+  lines.push(
+    "Existing files are grandfathered; this fires only on creating a new one.",
+    `Escape hatch: set ${SKIP_ENV_VAR}=1 to disable this hook.`,
+  );
+  return lines.join("\n");
+};
+
+const readStdin = () =>
+  new Promise((resolvePromise) => {
+    let raw = "";
+    const done = () => resolvePromise(raw);
+    const timer = setTimeout(done, STDIN_TIMEOUT_MS);
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (raw += chunk));
+    process.stdin.on("end", () => {
+      clearTimeout(timer);
+      done();
+    });
+    process.stdin.on("error", () => {
+      clearTimeout(timer);
+      done();
+    });
+  });
+
+async function main() {
+  if (process.env[SKIP_ENV_VAR]) allow();
+
+  const raw = await readStdin();
+  if (!raw.trim()) allow();
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    allow();
+  }
+
+  const candidates = targetPaths(payload).filter((target) => {
+    const path = absolute(payload?.cwd, target);
+    // Creation only: an existing file's name is not this hook's business.
+    return path.startsWith(`${repoRoot}/web/src/`) && !existsSync(path);
+  });
+  if (!candidates.length) allow();
+
+  const { checkPath } = await import(
+    `file://${repoRoot}/web/scripts/structure/check-path.mjs`
+  );
+  const results = candidates
+    .map((target) => ({
+      path: target,
+      findings: checkPath(absolute(payload?.cwd, target)),
+    }))
+    .filter(({ findings }) => findings.length);
+  if (!results.length) allow();
+
+  const verdict = results.some(({ findings }) =>
+    findings.some((f) => f.verdict === "deny"),
+  )
+    ? "deny"
+    : "ask";
+  decide(verdict, message(results));
+}
+
+// Fail open on anything at all: a hook that throws must not block a write.
+process.on("uncaughtException", allow);
+process.on("unhandledRejection", allow);
+main().catch(allow);

--- a/scripts/agents/hooks/structure-path-guard.mjs
+++ b/scripts/agents/hooks/structure-path-guard.mjs
@@ -9,7 +9,7 @@
 //   1. Creation only. The check runs when the target path does not exist yet.
 //      An edit to a badly-named file is never blocked — the name is not the
 //      bug you were asked to fix.
-//   2. Fail open, always. Unreadable stdin, unparseable payload, a throw, a
+//   2. Fail open, always. Unreadable stdin, unparsable payload, a throw, a
 //      missing check — every one of them allows the write. A broken sensor
 //      must not be able to stop work.
 //

--- a/scripts/agents/sync-agent-shims.mjs
+++ b/scripts/agents/sync-agent-shims.mjs
@@ -130,8 +130,99 @@ const formatCodexToml = () => {
   return lines.join("\n");
 };
 
-const formatClaudeSettings = () =>
-  JSON.stringify(config.claude.settings, null, 2) + "\n";
+// Hooks are declared once, tool-neutrally, in `.agents/config.json`. Each tool
+// names the same events differently and identifies a file write by a different
+// tool name, so the mapping lives here and the hook implementation stays one
+// script. Claude resolves the script through ${CLAUDE_PROJECT_DIR}; Cursor and
+// Codex run project hooks from the repo root.
+const HOOK_EVENTS = {
+  preFileWrite: {
+    claude: { event: "PreToolUse", matcher: "Write" },
+    cursor: { event: "preToolUse", matcher: "Write" },
+    codex: { event: "PreToolUse", matcher: "apply_patch|Edit|Write" },
+  },
+};
+
+/** @type {(tool: "claude" | "cursor" | "codex", hook: any) => string} */
+const hookCommand = (tool, hook) => {
+  const script =
+    tool === "claude" ? `"\${CLAUDE_PROJECT_DIR}/${hook.script}"` : hook.script;
+  return `node ${script} --tool ${tool}`;
+};
+
+/**
+ * Groups the declared hooks by a tool's event name, dropping any event that
+ * tool does not support.
+ * @type {(tool: "claude" | "cursor" | "codex") => [string, any[]][]}
+ */
+const hooksFor = (tool) => {
+  const byEvent = new Map();
+  for (const [neutralEvent, hooks] of Object.entries(config.hooks ?? {})) {
+    const mapping = HOOK_EVENTS[neutralEvent]?.[tool];
+    if (!mapping) continue;
+    for (const hook of hooks) {
+      const entries = byEvent.get(mapping.event) ?? [];
+      entries.push({ ...hook, matcher: mapping.matcher });
+      byEvent.set(mapping.event, entries);
+    }
+  }
+  return [...byEvent.entries()];
+};
+
+// Claude and Codex share the matcher-plus-nested-hooks shape.
+/** @type {(tool: "claude" | "codex") => object | undefined} */
+const nestedHookShape = (tool) => {
+  const events = hooksFor(tool);
+  if (!events.length) return undefined;
+  return Object.fromEntries(
+    events.map(([event, hooks]) => [
+      event,
+      hooks.map((hook) => ({
+        matcher: hook.matcher,
+        hooks: [
+          {
+            type: "command",
+            command: hookCommand(tool, hook),
+            ...(hook.timeoutSeconds ? { timeout: hook.timeoutSeconds } : {}),
+          },
+        ],
+      })),
+    ]),
+  );
+};
+
+const formatClaudeSettings = () => {
+  const hooks = nestedHookShape("claude");
+  return (
+    JSON.stringify(
+      { ...config.claude.settings, ...(hooks ? { hooks } : {}) },
+      null,
+      2,
+    ) + "\n"
+  );
+};
+
+const formatCursorHooks = () =>
+  JSON.stringify(
+    {
+      version: 1,
+      hooks: Object.fromEntries(
+        hooksFor("cursor").map(([event, hooks]) => [
+          event,
+          hooks.map((hook) => ({
+            command: hookCommand("cursor", hook),
+            matcher: hook.matcher,
+            ...(hook.timeoutSeconds ? { timeout: hook.timeoutSeconds } : {}),
+          })),
+        ]),
+      ),
+    },
+    null,
+    2,
+  ) + "\n";
+
+const formatCodexHooks = () =>
+  JSON.stringify({ hooks: nestedHookShape("codex") ?? {} }, null, 2) + "\n";
 
 const formatCursorEnvironment = () =>
   JSON.stringify(
@@ -180,6 +271,16 @@ const fileOutputs = [
   {
     path: resolve(repoRoot, ".cursor/mcp.json"),
     content: formatSharedJsonConfig(),
+  },
+  // Committed, unlike the generated MCP configs: Cursor reads hooks before
+  // `pnpm install` has had a chance to generate anything.
+  {
+    path: resolve(repoRoot, ".cursor/hooks.json"),
+    content: formatCursorHooks(),
+  },
+  {
+    path: resolve(repoRoot, ".codex/hooks.json"),
+    content: formatCodexHooks(),
   },
   {
     path: resolve(repoRoot, ".cursor/environment.json"),

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -248,6 +248,7 @@ Sentry instrumentation skill first and decide whether it should capture at all
 - Agent browser install to the default user-level Playwright cache: `pnpm run playwright:install`
 - Build: `pnpm --filter web run build`
 - Structure-RFC violation counts: `pnpm --filter web run structure:stats`
+- Would this path add a violation? `pnpm --filter web run structure:check-path <path>`
 - Move files/folders with every importer rewritten:
   `pnpm --filter web run structure:move <from...> <to-dir>` — never hand-edit
   import specifiers for a move, and never `mv` a source file without it

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "build-trace": "dotenv -e ../.env -- next internal trace .next/trace-turbopack",
     "storybook": "dotenv -e ../.env -- storybook dev -p 6006",
     "structure:stats": "node scripts/structure/stats.mjs",
+    "structure:check-path": "node scripts/structure/check-path.mjs",
     "structure:move": "node scripts/structure/move.mjs",
     "build-storybook": "dotenv -e ../.env -- storybook build",
     "sfdc:backfill": "dotenv -e ../.env -- tsx src/ee/features/sfdc-sync/scripts/backfillSfdcLeads.ts"

--- a/web/scripts/structure/README.md
+++ b/web/scripts/structure/README.md
@@ -119,6 +119,38 @@ is instant, which is why the CLI is batch-shaped.
 
 Splitting a file and renaming a directory are not part of the surface yet.
 
+# structure:check-path — the placement question, answered in one directory read
+
+```sh
+pnpm --filter web run structure:check-path src/features/traces/utils/formatCost.ts
+node scripts/structure/check-path.mjs --json <path...>          # from a hook
+```
+
+"Would creating this file add a violation?" — decided from the path alone. It
+is the fast lane of `structure:stats`: no dependency-cruiser graph, no TS
+parse, so it answers in a directory read (2,711 existing paths in 25 ms
+in-process; ~70 ms wall as a process, almost all of it node startup) instead of
+seconds.
+
+It therefore answers only for the census rules a path decides on its own — 1,
+3, 4, 5, 9, 13, 18 — and never for a graph rule, which cannot be known before
+the file's imports exist. Rule 5 calls `detectors.rule5` directly so the check
+and the dashboard cannot disagree about what a kind folder is; rules 1 and 3
+mirror only the naming half of their detectors, because "named after the
+export" needs the file's text.
+
+The verdict is a prediction of what the sensor would count, and it was
+calibrated against it: over all 2,711 existing files, 700 would be flagged and
+exactly one disagrees with `stats.mjs` — a kebab-case `.tsx` exporting no
+component, which no rule counts today but which is wrong under either naming
+rule. A rule the sensor does not count is not denied.
+
+`scripts/agents/hooks/structure-path-guard.mjs` wraps it as a pre-write hook
+for Claude Code, Cursor and Codex, declared once in `.agents/config.json`. That
+hook fires **only when the target path does not exist** — editing a badly-named
+file is never blocked — **fails open** on anything unexpected, and is disabled
+by `LANGFUSE_SKIP_STRUCTURE_HOOK=1`.
+
 ## Rule → mechanism
 
 | Rule   | What                                                                                          | Counted by                                                               |

--- a/web/scripts/structure/check-path.mjs
+++ b/web/scripts/structure/check-path.mjs
@@ -113,7 +113,10 @@ const toCamel = (s) => {
  */
 export function toWebPath(input) {
   const absolute = input.startsWith("/")
-    ? input
+    ? // resolve() collapses ".." here too: an already-absolute path still has
+      // to be normalized, or a traversal segment fails the scope test below
+      // and the caller reads "no findings" as "this placement is fine".
+      resolve(input)
     : existsSync(resolve(repoRoot, input))
       ? resolve(repoRoot, input)
       : resolve(repoRoot, input).startsWith(`${webRoot}/`)

--- a/web/scripts/structure/check-path.mjs
+++ b/web/scripts/structure/check-path.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+// Placement check for a single path — "would creating this file add a
+// project-structure violation?" — answered from the path alone.
+//
+//   node scripts/structure/check-path.mjs <path...>     human-readable findings
+//   node scripts/structure/check-path.mjs --json <path...>
+//
+// This is the fast lane of `structure:stats`: no dependency-cruiser graph, no
+// TS parse, so it costs a directory read instead of seconds. It therefore
+// answers only for the census rules a path decides on its own — 1, 3, 4, 5, 9,
+// 13, 18 — and never for a graph rule, which cannot be known before the
+// file's imports exist.
+//
+// The verdict is a prediction of what the sensor would count, so the checks
+// below reuse detectors.mjs where a detector is already path-only and mirror
+// only its naming half where it is not. A rule the sensor does not count is
+// not denied here.
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as d from "./detectors.mjs";
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const repoRoot = resolve(webRoot, "..");
+
+/** @typedef {{ rule: number, verdict: "deny" | "ask", title: string, detail: string, correctPath: string | null, ruleFile: string }} Finding */
+
+export const SKIP_ENV_VAR = "LANGFUSE_SKIP_STRUCTURE_HOOK";
+const SKILL_RULES = ".agents/skills/project-structure/rules";
+const KIND_DIRS = [
+  "components",
+  "hooks",
+  "contexts",
+  "stores",
+  "fns",
+  "server",
+  "constants",
+  "types",
+];
+/** @type {Record<number, string>} */
+const RULE_FILES = {
+  1: "01-one-component-per-file.md",
+  3: "03-camelcase-named-after-the-export.md",
+  4: "04-one-function-per-file-in-fns.md",
+  5: "05-kind-folders-are-a-closed-list.md",
+  9: "09-index-files-only-at-feature-surfaces.md",
+  13: "13-components-ui-is-frozen.md",
+  18: "18-fn-and-hook-tests-colocate-flat.md",
+};
+/** @type {Record<number, string>} */
+const RULE_TITLES = {
+  1: "one component per file, PascalCase filename matching the component",
+  3: "hooks, fns, stores and contexts are camelCase, named after the export",
+  4: "one function per file in fns/, no dump files",
+  5: `kind folders are a closed list: ${KIND_DIRS.join(", ")}`,
+  9: "index.ts only at a feature root and its server/ root",
+  13: "components/ui is frozen — nothing new goes in",
+  18: "tests for fns and hooks sit flat next to their file",
+};
+// Rule 18 cannot tell a misplaced test from a test written before its subject
+// exists, so it surfaces instead of blocking.
+const ASK_RULES = new Set([18]);
+
+const PASCAL = /^[A-Z][A-Za-z0-9]*$/;
+const CAMEL = /^[a-z][A-Za-z0-9]*$/;
+const CODE_FILE = /\.[jt]sx?$/;
+const NON_COMPONENT_KINDS =
+  /(^|\/)(fns|hooks|stores|contexts|constants|types|server)\//;
+const DUMP_STEMS = /^(helpers?|utils?|index|misc|common|fns|types|constants)$/;
+// Folder names that show up in place of a kind folder, and what they meant.
+/** @type {Record<string, string>} */
+const KIND_REPLACEMENTS = {
+  util: "fns",
+  utils: "fns",
+  helper: "fns",
+  helpers: "fns",
+  lib: "fns",
+  libs: "fns",
+  functions: "fns",
+  config: "constants",
+  configs: "constants",
+  constant: "constants",
+  type: "types",
+  hook: "hooks",
+  store: "stores",
+  context: "contexts",
+  component: "components",
+};
+
+/** @type {(p: string) => string} */
+const base = (p) => p.slice(p.lastIndexOf("/") + 1);
+/** @type {(p: string) => string} */
+const stemOf = (p) => base(p).replace(CODE_FILE, "");
+/** @type {(p: string) => string} */
+const dirOf = (p) => p.slice(0, p.length - base(p).length);
+/** @type {(s: string) => string} */
+const toPascal = (s) =>
+  s
+    .split(/[-_.\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+/** @type {(s: string) => string} */
+const toCamel = (s) => {
+  const pascal = toPascal(s);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+};
+
+/**
+ * Normalizes any spelling of a target file to a web-relative path
+ * (`src/...`), or null when it is outside `web/src`.
+ * @type {(input: string) => string | null}
+ */
+export function toWebPath(input) {
+  const absolute = input.startsWith("/")
+    ? input
+    : existsSync(resolve(repoRoot, input))
+      ? resolve(repoRoot, input)
+      : resolve(repoRoot, input).startsWith(`${webRoot}/`)
+        ? resolve(repoRoot, input)
+        : resolve(webRoot, input);
+  if (!absolute.startsWith(`${webRoot}/src/`)) return null;
+  return absolute.slice(webRoot.length + 1);
+}
+
+/** @type {(rule: number, detail: string, correctPath: string | null) => Finding} */
+const finding = (rule, detail, correctPath) => ({
+  rule,
+  verdict: ASK_RULES.has(rule) ? "ask" : "deny",
+  title: RULE_TITLES[rule],
+  detail,
+  correctPath,
+  ruleFile: `${SKILL_RULES}/${RULE_FILES[rule]}`,
+});
+
+// Rule 5 — reuse the detector so the hook and the dashboard cannot disagree
+// about what a kind folder is. It reads directories, so feed it the ancestors
+// of the new file.
+/** @type {(p: string) => Finding[]} */
+function checkKindFolders(p) {
+  const segments = dirOf(p).replace(/\/$/, "").split("/");
+  const dirs = segments
+    .map((_, i) => segments.slice(0, i + 1).join("/"))
+    .filter((dir) => dir !== "src");
+  return d.rule5(dirs).map((violation) => {
+    const dir = violation.paths[0];
+    const name = base(dir);
+    const replacement = KIND_REPLACEMENTS[name.toLowerCase()];
+    return finding(
+      5,
+      violation.key.slice(dir.length + 2),
+      replacement
+        ? p.replace(`/${name}/`, `/${replacement}/`)
+        : PASCAL.test(name)
+          ? p.replace(`/${name}/`, `/components/${name}/`)
+          : null,
+    );
+  });
+}
+
+// Rule 9 — mirrors the detector's location half; `export *` and stray
+// declarations need the file's text and stay with the dashboard.
+/** @type {(p: string) => Finding[]} */
+function checkIndexFile(p) {
+  if (!/(^|\/)index\.[jt]sx?$/.test(p)) return [];
+  const inScope =
+    /^src\/(?:ee\/)?(features|components|hooks|contexts|stores|fns|utils|constants|lib)\//.test(
+      p,
+    );
+  if (!inScope) return [];
+  const featureIndex = /^src\/(?:ee\/)?features\/[^/]+\/index\.tsx?$/.test(p);
+  const serverIndex = /^src\/(?:ee\/)?features\/[^/]+\/server\/index\.tsx?$/.test(
+    p,
+  );
+  if (featureIndex || serverIndex) return [];
+  // Anything deeper inside server/ is unspecified by the rules, as in rule 9.
+  if (/(^|\/)server\//.test(p)) return [];
+  const feature = p.match(/^src\/(?:ee\/)?features\/[^/]+\//);
+  return [
+    finding(
+      9,
+      "an index file here is a module boundary nobody designed — import the module directly",
+      feature ? `${feature[0]}index.ts` : null,
+    ),
+  ];
+}
+
+/** @type {(p: string) => Finding[]} */
+function checkFrozenUi(p) {
+  if (!/^src\/components\/ui\//.test(p) || d.isTestish(p)) return [];
+  return [
+    finding(
+      13,
+      "the shadcn folder only shrinks: new files go to the feature that uses it, or to design-system when it is a designed abstraction",
+      `src/components/design-system/${toPascal(stemOf(p))}/${toPascal(stemOf(p))}.tsx`,
+    ),
+  ];
+}
+
+// Rule 1 — the filename half only. Whether a `.tsx` exports one component
+// needs its text, so this fires where a component is the only thing the path
+// can mean. A camelCase stem is taken at its word — `showErrorToast.tsx` is a
+// function that returns JSX, which rule 3 governs, not a component.
+/** @type {(p: string) => Finding[]} */
+function checkComponentName(p) {
+  if (!p.endsWith(".tsx") || d.isTestish(p) || /^src\/pages\//.test(p))
+    return [];
+  const stem = stemOf(p);
+  if (/^use[A-Z]/.test(stem) || /^[A-Z][A-Za-z0-9]*Context\.tsx$/.test(base(p)))
+    return [];
+  if (NON_COMPONENT_KINDS.test(p)) return [];
+  const parent = base(dirOf(p).replace(/\/$/, ""));
+  const componentPosition =
+    parent === "components" ||
+    PASCAL.test(parent) ||
+    /^src\/(?:ee\/)?features\/[^/]+\/[^/]+$/.test(p);
+  if (!componentPosition || PASCAL.test(stem) || CAMEL.test(stem)) return [];
+  return [
+    finding(
+      1,
+      `filename '${stem}' is neither PascalCase (a component) nor camelCase (a module)`,
+      `${dirOf(p)}${toPascal(stem)}.tsx`,
+    ),
+  ];
+}
+
+// Rule 3 — the filename half only; "named after the export" needs the text.
+/** @type {(p: string) => Finding[]} */
+function checkModuleName(p) {
+  if (d.isTestish(p) || /(^|\/)server\//.test(p)) return [];
+  const stem = stemOf(p);
+  const inKind = /(^|\/)(hooks|fns|stores|contexts)\//.test(p);
+  if (!inKind && !/^use[A-Z]/.test(stem)) return [];
+  if (/^[A-Z][A-Za-z0-9]*Context\.tsx?$/.test(base(p))) return [];
+  if (/(^|\/)fns\/index\.[jt]s$/.test(p)) return [];
+  if (CAMEL.test(stem)) return [];
+  return [
+    finding(
+      3,
+      `filename '${stem}' is not camelCase`,
+      `${dirOf(p)}${toCamel(stem)}${p.endsWith(".tsx") ? ".tsx" : ".ts"}`,
+    ),
+  ];
+}
+
+/** @type {(p: string) => Finding[]} */
+function checkFnsDumpFile(p) {
+  if (d.isTestish(p) || !/(^|\/)fns\//.test(p)) return [];
+  if (!DUMP_STEMS.test(stemOf(p))) return [];
+  return [
+    finding(
+      4,
+      `'${stemOf(p)}' is a dump file — one function per file, named after it, or a module folder like fns/searchJson/`,
+      null,
+    ),
+  ];
+}
+
+// Rule 18 — the only check that reads the filesystem: a colocated test needs
+// its subject beside it.
+/** @type {(p: string) => Finding[]} */
+function checkTestColocation(p) {
+  const match = base(p).match(/^(.+)\.(clienttest|test|spec)\.(tsx?)$/);
+  if (!match || /(^|\/)(__tests__|__e2e__|__mocks__)\//.test(p)) return [];
+  const dir = dirOf(p);
+  let subject = match[1];
+  while (subject) {
+    if (
+      existsSync(`${webRoot}/${dir}${subject}.ts`) ||
+      existsSync(`${webRoot}/${dir}${subject}.tsx`)
+    )
+      return [];
+    const dot = subject.lastIndexOf(".");
+    subject = dot > 0 ? subject.slice(0, dot) : "";
+  }
+  return [
+    finding(
+      18,
+      `no ${match[1]}.ts(x) next to it — create the subject module first, or put the test beside the module it tests`,
+      `${dir}${match[1]}.${match[3]}`,
+    ),
+  ];
+}
+
+/**
+ * Findings for one path, in rule order. Empty means the path adds no
+ * violation this check can see.
+ * @type {(input: string) => Finding[]}
+ */
+export function checkPath(input) {
+  const p = toWebPath(input);
+  if (!p || !CODE_FILE.test(p)) return [];
+  return [
+    ...checkComponentName(p),
+    ...checkModuleName(p),
+    ...checkFnsDumpFile(p),
+    ...checkKindFolders(p),
+    ...checkIndexFile(p),
+    ...checkFrozenUi(p),
+    ...checkTestColocation(p),
+  ].sort((left, right) => left.rule - right.rule);
+}
+
+/** @type {(results: {path: string, findings: Finding[]}[]) => string} */
+export function formatFindings(results) {
+  const lines = [];
+  for (const { path, findings } of results) {
+    if (!findings.length) continue;
+    lines.push(path);
+    for (const f of findings) {
+      lines.push(`  rule ${f.rule} (${f.verdict}) — ${f.title}`);
+      lines.push(`    ${f.detail}`);
+      if (f.correctPath) lines.push(`    correct path: web/${f.correctPath}`);
+      lines.push(`    rule file: ${f.ruleFile}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const args = process.argv.slice(2);
+  const asJson = args.includes("--json");
+  const paths = args.filter((arg) => !arg.startsWith("--"));
+  if (!paths.length) {
+    console.error(
+      "usage: node scripts/structure/check-path.mjs [--json] <path...>",
+    );
+    process.exit(2);
+  }
+  const results = paths.map((path) => ({ path, findings: checkPath(path) }));
+  if (asJson) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    const report = formatFindings(results);
+    console.log(
+      report ||
+        `no placement problem in ${paths.length} path${paths.length === 1 ? "" : "s"}`,
+    );
+  }
+  const denied = results.some(({ findings }) =>
+    findings.some((f) => f.verdict === "deny"),
+  );
+  process.exit(denied ? 1 : 0);
+}

--- a/web/scripts/structure/check-path.mjs
+++ b/web/scripts/structure/check-path.mjs
@@ -135,9 +135,9 @@ const finding = (rule, detail, correctPath) => ({
 
 // Rule 5 — reuse the detector so the hook and the dashboard cannot disagree
 // about what a kind folder is. It reads directories, so feed it the ancestors
-// of the new file.
-/** @type {(p: string) => Finding[]} */
-function checkKindFolders(p) {
+// of the new file, shallowest first.
+/** @type {(p: string) => { violation: { key: string, paths: string[] }, dir: string, name: string, replacement: string | null }[]} */
+function kindFolderViolations(p) {
   const segments = dirOf(p).replace(/\/$/, "").split("/");
   const dirs = segments
     .map((_, i) => segments.slice(0, i + 1).join("/"))
@@ -145,17 +145,40 @@ function checkKindFolders(p) {
   return d.rule5(dirs).map((violation) => {
     const dir = violation.paths[0];
     const name = base(dir);
-    const replacement = KIND_REPLACEMENTS[name.toLowerCase()];
-    return finding(
-      5,
-      violation.key.slice(dir.length + 2),
-      replacement
-        ? p.replace(`/${name}/`, `/${replacement}/`)
-        : PASCAL.test(name)
-          ? p.replace(`/${name}/`, `/components/${name}/`)
-          : null,
-    );
+    return {
+      violation,
+      dir,
+      name,
+      replacement:
+        KIND_REPLACEMENTS[name.toLowerCase()] ??
+        (PASCAL.test(name) ? `components/${name}` : null),
+    };
   });
+}
+
+// Fixing the outermost folder can dissolve the ones below it: a non-kind name
+// inside `fns/` is a legal module folder, so `utils/helpers/` becomes
+// `fns/helpers/` and not `fns/fns/`. So rename outside-in and re-check, rather
+// than composing every rename at once.
+/** @type {(p: string, depth?: number) => string | null} */
+function suggestKindFolderPath(p, depth = 0) {
+  const flagged = kindFolderViolations(p);
+  if (!flagged.length) return p;
+  if (depth >= flagged.length + 2 || !flagged[0].replacement) return null;
+  return suggestKindFolderPath(
+    p.replace(`/${flagged[0].name}/`, `/${flagged[0].replacement}/`),
+    depth + 1,
+  );
+}
+
+/** @type {(p: string) => Finding[]} */
+function checkKindFolders(p) {
+  const flagged = kindFolderViolations(p);
+  if (!flagged.length) return [];
+  const correctPath = suggestKindFolderPath(p);
+  return flagged.map(({ violation, dir }) =>
+    finding(5, violation.key.slice(dir.length + 2), correctPath),
+  );
 }
 
 // Rule 9 — mirrors the detector's location half; `export *` and stray

--- a/web/scripts/structure/check-path.mjs
+++ b/web/scripts/structure/check-path.mjs
@@ -211,11 +211,18 @@ function checkIndexFile(p) {
 /** @type {(p: string) => Finding[]} */
 function checkFrozenUi(p) {
   if (!/^src\/components\/ui\//.test(p) || d.isTestish(p)) return [];
+  const stem = stemOf(p);
+  // A component gets its own folder; a plain module sits flat beside them.
+  // Suggesting a component shape for a `.ts` file sent agents to a path that
+  // is wrong for what they were writing.
+  const home = p.endsWith(".tsx")
+    ? `${toPascal(stem)}/${toPascal(stem)}.tsx`
+    : `${toCamel(stem)}.ts`;
   return [
     finding(
       13,
       "the shadcn folder only shrinks: new files go to the feature that uses it, or to design-system when it is a designed abstraction",
-      `src/components/design-system/${toPascal(stemOf(p))}/${toPascal(stemOf(p))}.tsx`,
+      `src/components/design-system/${home}`,
     ),
   ];
 }

--- a/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
+++ b/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
@@ -238,6 +238,39 @@ describe("structure path check", () => {
     }
   });
 
+  it("normalizes every spelling of a path it is handed directly", () => {
+    // The hook resolves before it calls checkPath, so this covers the other
+    // documented entry point: `structure:check-path` by hand. An unnormalized
+    // ".." used to fail the web/src scope test and report "no findings", which
+    // reads as approval.
+    const denied = "web/src/features/traces/utils/formatCost.ts";
+    const spellings = [
+      denied,
+      `${repoRoot}/${denied}`,
+      `${repoRoot}/worker/../${denied}`,
+      `worker/../${denied}`,
+    ];
+    // ...while a traversal that genuinely leaves web/src stays out of scope.
+    const outOfScope = [
+      `${repoRoot}/worker/src/queues/whatever.ts`,
+      `${repoRoot}/web/src/../../worker/src/queues/whatever.ts`,
+    ];
+
+    const result = spawnSync(
+      "node",
+      [CHECK, "--json", ...spellings, ...outOfScope],
+      { encoding: "utf8", cwd: repoRoot },
+    );
+    const parsed: { path: string; findings: { rule: number }[] }[] = JSON.parse(
+      result.stdout,
+    );
+
+    expect(parsed.map((r) => r.findings.map((f) => f.rule))).toEqual([
+      ...spellings.map(() => [5]),
+      ...outOfScope.map(() => []),
+    ]);
+  });
+
   it("fails open, and never fires on anything but a new file in scope", () => {
     const silent = [
       // an edit to an existing badly-named, frozen file

--- a/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
+++ b/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
@@ -50,6 +50,7 @@ describe("structure path check", () => {
       ["web/src/features/traces/fns/utils.ts", 4, "deny"],
       ["web/src/features/traces/components/index.ts", 9, "deny"],
       ["web/src/components/ui/newThing.tsx", 13, "deny"],
+      ["web/src/components/ui/exportCsvHelpers.ts", 13, "deny"],
       ["web/src/features/traces/fns/notThere.clienttest.ts", 18, "ask"],
       // legitimate placements
       ["web/src/features/traces/fns/formatCost.ts", null, null],
@@ -108,6 +109,17 @@ describe("structure path check", () => {
         (r) => r.path === "web/src/features/traces/utils/helpers/formatCost.ts",
       )?.findings[0].correctPath,
     ).toBe("src/features/traces/fns/helpers/formatCost.ts");
+    // A component earns a folder; a plain module does not, and neither turns
+    // into the other's extension on the way out of the frozen folder.
+    expect(
+      findings.find((r) => r.path === "web/src/components/ui/newThing.tsx")
+        ?.findings[0].correctPath,
+    ).toBe("src/components/design-system/NewThing/NewThing.tsx");
+    expect(
+      findings.find(
+        (r) => r.path === "web/src/components/ui/exportCsvHelpers.ts",
+      )?.findings[0].correctPath,
+    ).toBe("src/components/design-system/exportCsvHelpers.ts");
   });
 
   it("returns each tool's documented response shape", () => {
@@ -197,6 +209,33 @@ describe("structure path check", () => {
         permissionDecisionReason: expect.stringContaining("rule 5"),
       },
     });
+  });
+
+  it("judges a path by where it lands, not by the shape it arrives in", () => {
+    // An absolute target carrying ".." used to skip normalization, miss the
+    // web/src scope filter, and sail through. All three spellings of the same
+    // destination have to reach the same verdict.
+    const destination = "web/src/features/traces/utils/formatCost.ts";
+    const spellings = [
+      destination,
+      `${repoRoot}/${destination}`,
+      `${repoRoot}/worker/../${destination}`,
+      `worker/../${destination}`,
+    ];
+    for (const spelling of spellings) {
+      const { status, stdout } = runHook("claude", write(spelling));
+      expect({ spelling, status, empty: stdout === "" }).toEqual({
+        spelling,
+        status: 0,
+        empty: false,
+      });
+      const output = JSON.parse(stdout);
+      expect(output.hookSpecificOutput.permissionDecision).toBe("deny");
+      // The message names the path it actually judged, not the raw spelling.
+      expect(output.hookSpecificOutput.permissionDecisionReason).toContain(
+        `\n${destination}\n`,
+      );
+    }
   });
 
   it("fails open, and never fires on anything but a new file in scope", () => {

--- a/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
+++ b/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
@@ -1,0 +1,189 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// The hook is a stdin/stdout contract with three agent tools, so it is
+// exercised as the process they run rather than as an imported function.
+const repoRoot = (() => {
+  let dir = process.cwd();
+  while (!existsSync(resolve(dir, ".agents/config.json"))) {
+    const parent = dirname(dir);
+    if (parent === dir) throw new Error("repo root not found");
+    dir = parent;
+  }
+  return dir;
+})();
+
+const HOOK = resolve(repoRoot, "scripts/agents/hooks/structure-path-guard.mjs");
+const CHECK = resolve(repoRoot, "web/scripts/structure/check-path.mjs");
+
+const runHook = (
+  tool: "claude" | "cursor" | "codex",
+  payload: unknown,
+  env: Record<string, string> = {},
+) => {
+  const result = spawnSync("node", [HOOK, "--tool", tool], {
+    input: typeof payload === "string" ? payload : JSON.stringify(payload),
+    encoding: "utf8",
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+  });
+  return { status: result.status, stdout: result.stdout.trim() };
+};
+
+const write = (filePath: string) => ({
+  cwd: repoRoot,
+  hook_event_name: "PreToolUse",
+  tool_name: "Write",
+  tool_input: { file_path: filePath },
+});
+
+describe("structure path check", () => {
+  it("decides the census rules a path can decide, and stays out of the rest", () => {
+    const cases: [string, number | null, string | null][] = [
+      // path, expected rule, expected verdict
+      ["web/src/features/traces/utils/formatCost.ts", 5, "deny"],
+      ["web/src/features/traces/hooks/use-dialog.ts", 3, "deny"],
+      ["web/src/features/traces/components/trace-badge.tsx", 1, "deny"],
+      ["web/src/features/traces/fns/utils.ts", 4, "deny"],
+      ["web/src/features/traces/components/index.ts", 9, "deny"],
+      ["web/src/components/ui/newThing.tsx", 13, "deny"],
+      ["web/src/features/traces/fns/notThere.clienttest.ts", 18, "ask"],
+      // legitimate placements
+      ["web/src/features/traces/fns/formatCost.ts", null, null],
+      ["web/src/features/traces/hooks/useDialog.ts", null, null],
+      [
+        "web/src/features/traces/components/TraceBadge/TraceBadge.tsx",
+        null,
+        null,
+      ],
+      ["web/src/features/traces/index.ts", null, null],
+      ["web/src/features/traces/server/index.ts", null, null],
+      ["web/src/features/traces/constants/traceDownload.ts", null, null],
+      ["web/src/features/traces/contexts/TraceContext.tsx", null, null],
+      ["web/src/features/traces/fns/searchJson/matchNode.ts", null, null],
+      ["web/src/features/traces/docs/README.ts", null, null],
+      // outside the sensor's scope: no opinion
+      ["worker/src/queues/newThing.ts", null, null],
+      ["web/scripts/structure/new-script.mjs", null, null],
+    ];
+
+    const result = spawnSync(
+      "node",
+      [CHECK, "--json", ...cases.map(([path]) => path)],
+      { encoding: "utf8", cwd: repoRoot },
+    );
+    const findings: {
+      path: string;
+      findings: { rule: number; verdict: string }[];
+    }[] = JSON.parse(result.stdout);
+
+    expect(
+      findings.map((r) => [
+        r.path,
+        r.findings[0]?.rule ?? null,
+        r.findings[0]?.verdict ?? null,
+      ]),
+    ).toEqual(cases);
+  });
+
+  it("returns each tool's documented response shape", () => {
+    const claude = runHook(
+      "claude",
+      write("web/src/features/traces/utils/formatCost.ts"),
+    );
+    expect(JSON.parse(claude.stdout)).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining("rule 5"),
+      },
+    });
+    // Claude supports "ask" natively; the message names the correct path, the
+    // rule file and the escape hatch.
+    const claudeAsk = JSON.parse(
+      runHook(
+        "claude",
+        write("web/src/features/traces/fns/notThere.clienttest.ts"),
+      ).stdout,
+    );
+    expect(claudeAsk.hookSpecificOutput.permissionDecision).toBe("ask");
+    expect(claudeAsk.hookSpecificOutput.permissionDecisionReason).toContain(
+      "correct path: web/src/features/traces/fns/notThere.ts",
+    );
+    expect(claudeAsk.hookSpecificOutput.permissionDecisionReason).toContain(
+      ".agents/skills/project-structure/rules/18-fn-and-hook-tests-colocate-flat.md",
+    );
+    expect(claudeAsk.hookSpecificOutput.permissionDecisionReason).toContain(
+      "LANGFUSE_SKIP_STRUCTURE_HOOK",
+    );
+
+    expect(
+      JSON.parse(
+        runHook("cursor", write("web/src/components/ui/newThing.tsx")).stdout,
+      ),
+    ).toMatchObject({
+      permission: "deny",
+      agent_message: expect.stringContaining("rule 13"),
+    });
+    // Cursor's preToolUse has no "ask": the note rides along on an allow.
+    expect(
+      JSON.parse(
+        runHook(
+          "cursor",
+          write("web/src/features/traces/fns/notThere.clienttest.ts"),
+        ).stdout,
+      ),
+    ).toMatchObject({
+      permission: "allow",
+      agent_message: expect.stringContaining("rule 18"),
+    });
+
+    // Codex sends the target inside an apply_patch payload.
+    expect(
+      JSON.parse(
+        runHook("codex", {
+          cwd: repoRoot,
+          tool_name: "apply_patch",
+          tool_input: {
+            input:
+              "*** Begin Patch\n*** Add File: web/src/features/traces/hooks/use-thing.ts\n+export const useThing = () => 1;\n*** End Patch",
+          },
+        }).stdout,
+      ),
+    ).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining("rule 3"),
+      },
+    });
+  });
+
+  it("fails open, and never fires on anything but a new file in scope", () => {
+    const silent = [
+      // an edit to an existing badly-named, frozen file
+      runHook("claude", write("web/src/components/ui/button.tsx")),
+      // a path the rules say nothing about
+      runHook("claude", write("worker/src/queues/whatever.ts")),
+      // no path in the payload at all
+      runHook("claude", {
+        cwd: repoRoot,
+        tool_name: "Bash",
+        tool_input: { command: "ls" },
+      }),
+      // unparseable stdin, and no stdin
+      runHook("claude", "not json at all"),
+      runHook("claude", ""),
+      // the escape hatch
+      runHook("claude", write("web/src/features/traces/utils/formatCost.ts"), {
+        LANGFUSE_SKIP_STRUCTURE_HOOK: "1",
+      }),
+    ];
+
+    expect(silent.map((r) => [r.status, r.stdout])).toEqual(
+      silent.map(() => [0, ""]),
+    );
+  });
+});

--- a/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
+++ b/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
@@ -44,6 +44,7 @@ describe("structure path check", () => {
     const cases: [string, number | null, string | null][] = [
       // path, expected rule, expected verdict
       ["web/src/features/traces/utils/formatCost.ts", 5, "deny"],
+      ["web/src/features/traces/utils/helpers/formatCost.ts", 5, "deny"],
       ["web/src/features/traces/hooks/use-dialog.ts", 3, "deny"],
       ["web/src/features/traces/components/trace-badge.tsx", 1, "deny"],
       ["web/src/features/traces/fns/utils.ts", 4, "deny"],
@@ -76,7 +77,7 @@ describe("structure path check", () => {
     );
     const findings: {
       path: string;
-      findings: { rule: number; verdict: string }[];
+      findings: { rule: number; verdict: string; correctPath: string | null }[];
     }[] = JSON.parse(result.stdout);
 
     expect(
@@ -86,6 +87,27 @@ describe("structure path check", () => {
         r.findings[0]?.verdict ?? null,
       ]),
     ).toEqual(cases);
+
+    // Every suggested path must itself pass, or the agent just tries another
+    // denied path. Two nested bad folders collapse into one legal fix.
+    const suggested = findings
+      .flatMap((r) => r.findings)
+      .map((f) => f.correctPath)
+      .filter((path): path is string => Boolean(path));
+    const recheck = spawnSync("node", [CHECK, "--json", ...suggested], {
+      encoding: "utf8",
+      cwd: repoRoot,
+    });
+    expect(
+      JSON.parse(recheck.stdout)
+        .filter((r: { findings: unknown[] }) => r.findings.length)
+        .map((r: { path: string }) => r.path),
+    ).toEqual([]);
+    expect(
+      findings.find(
+        (r) => r.path === "web/src/features/traces/utils/helpers/formatCost.ts",
+      )?.findings[0].correctPath,
+    ).toBe("src/features/traces/fns/helpers/formatCost.ts");
   });
 
   it("returns each tool's documented response shape", () => {
@@ -140,23 +162,39 @@ describe("structure path check", () => {
       agent_message: expect.stringContaining("rule 18"),
     });
 
-    // Codex sends the target inside an apply_patch payload.
+    // Codex sends the target inside an apply_patch payload — as an added file,
+    // or as the destination of a rename, which lands at a new path just the
+    // same.
+    const patch = (body: string) =>
+      runHook("codex", {
+        cwd: repoRoot,
+        tool_name: "apply_patch",
+        tool_input: { input: `*** Begin Patch\n${body}\n*** End Patch` },
+      }).stdout;
+
     expect(
       JSON.parse(
-        runHook("codex", {
-          cwd: repoRoot,
-          tool_name: "apply_patch",
-          tool_input: {
-            input:
-              "*** Begin Patch\n*** Add File: web/src/features/traces/hooks/use-thing.ts\n+export const useThing = () => 1;\n*** End Patch",
-          },
-        }).stdout,
+        patch(
+          "*** Add File: web/src/features/traces/hooks/use-thing.ts\n+export const useThing = () => 1;",
+        ),
       ),
     ).toMatchObject({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
         permissionDecisionReason: expect.stringContaining("rule 3"),
+      },
+    });
+    expect(
+      JSON.parse(
+        patch(
+          "*** Update File: web/src/features/traces/scratch.ts\n*** Move to: web/src/features/traces/utils/scratch.ts\n@@\n-old\n+new",
+        ),
+      ),
+    ).toMatchObject({
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+        permissionDecisionReason: expect.stringContaining("rule 5"),
       },
     });
   });

--- a/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
+++ b/web/src/__tests__/server/unit/structure-path-guard.servertest.ts
@@ -173,7 +173,7 @@ describe("structure path check", () => {
         tool_name: "Bash",
         tool_input: { command: "ls" },
       }),
-      // unparseable stdin, and no stdin
+      // unparsable stdin, and no stdin
       runHook("claude", "not json at all"),
       runHook("claude", ""),
       // the escape hatch


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16392.preview.langfuse.com](https://pr-16392.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

> Stacked on #16391 (the rules skill every deny message links to). Merge #16390 → #16391 → this.

## TL;DR

An agent can no longer *create* a file whose path adds a project-structure violation. `structure:check-path` answers "would this path add a violation?" from the path alone — one directory read, ~70 ms as a process — and a pre-write hook wired into Claude Code, Cursor and Codex denies the write with the rule, the correct path, and a link to the rule file. Creation only, fails open, one env var turns it off.

## Why

The rules that keep growing are all decided at the moment a file is created:

| rule | what decides it | drift since the last baseline |
| --- | --- | --- |
| 3 | a filename | +15 |
| 4 | a filename in `fns/` | +14 |
| 5 | a folder name | — |

Nothing checked at that moment, so the sensor counted them afterwards and the number went up. Counting is not preventing.

A full `structure:stats` run cannot do this job: it needs a dependency-cruiser graph and a TS-parse census, and most of the wall time through `pnpm` is package-manager startup. So the check had to be a different, much smaller thing.

## What

**`web/scripts/structure/check-path.mjs`** — the placement question, path-only.

- Decides **rules 1, 3, 4, 5, 9, 13** (deny) and surfaces **rule 18** (ask).
- Never has an opinion about a graph rule — rule 8 cannot be known before the file's imports exist.
- Rule 5 calls `detectors.rule5` directly, so the check and the dashboard cannot disagree about what a kind folder is. Rules 1 and 3 mirror only the *naming* half of their detectors, because "named after the export" needs the file's text.
- Usable by hand: `pnpm --filter web run structure:check-path <path>`.

**`scripts/agents/hooks/structure-path-guard.mjs`** — one implementation, three response shapes behind `--tool`.

- **Creation only.** Fires only when the target path does not exist. An edit to a badly-named file is never blocked — its name is not the bug you were asked to fix.
- **Fails open, always.** Unreadable stdin, unparseable payload, a throw, a missing check, a 1.5 s stdin timeout: every one allows the write.
- **Escape hatch, named in the message.** `LANGFUSE_SKIP_STRUCTURE_HOOK=1`, following `LANGFUSE_PRE_COMMIT_SKIP_LINT` in `.husky/pre-commit`. A gate with no exit gets ripped out.
- Never calls `pnpm`.

**One declaration, three shims.** A new tool-neutral `hooks` key in `.agents/config.json`; `sync-agent-shims.mjs` maps it to each tool's event name and tool-name matcher and emits `.claude/settings.json`, `.cursor/hooks.json` and `.codex/hooks.json`. The two `hooks.json` files are committed, like `.cursor/environment.json`, because those tools read hooks before `pnpm install` can generate anything.

## Result

Every deny message carries the rule number, the rule in one line, the correct path, the rule file, and the escape hatch — because an agent told "no" without being told where the file goes just tries a different wrong place.

```
Project structure: this path would add 1 new violation.

web/src/features/traces/utils/formatCost.ts
  rule 5 — kind folders are a closed list: components, hooks, contexts, stores, fns, server, constants, types
    'utils' is not a kind folder (components|hooks|contexts|stores|fns|server|constants|types)
    correct path: web/src/features/traces/fns/formatCost.ts
    rule file: .agents/skills/project-structure/rules/05-kind-folders-are-a-closed-list.md

Existing files are grandfathered; this fires only on creating a new one.
Escape hatch: set LANGFUSE_SKIP_STRUCTURE_HOOK=1 to disable this hook.
```

<details>
<summary>Calibration — is it right?</summary>

The verdict is a prediction of what the sensor would count, so it was checked against the sensor over **every existing file** in `web/src`:

```
2712 existing files checked in 26 ms — 700 would be flagged
disagreements with the sensor: 1
rule 1  src/features/dashboard/components/home-preset-registry.tsx
```

That one is a kebab-case `.tsx` that exports no component. No rule counts it today, but the name is wrong under either naming rule, so it stays denied.

Getting there required one refinement worth knowing about: a path-only rule 1 initially flagged five files, four of them camelCase `.tsx` modules that return JSX (`showErrorToast.tsx`) rather than components. A camelCase stem is now taken at its word — it is asserting "I am a module", which rule 3 governs — and only a stem that is neither PascalCase nor camelCase is denied.

</details>

<details>
<summary>Latency — the measured number, not the estimated one</summary>

```
hook wall time over 10 runs: min 63 ms, median 69 ms, max 80 ms
bare `node -e ''` on the same machine: 60, 62, 68 ms
```

So the check itself is single-digit milliseconds and **the entire cost is node process startup** (in-process, 2,712 paths take 26 ms — 0.01 ms per path). The design estimate was ~20 ms; the honest number is ~70 ms, because node takes 60 ms to boot here. Still 50× cheaper than a scoped `structure:stats` and imperceptible inside a tool call. If you ever see this above ~150 ms, something is wrong.

</details>

<details>
<summary>Which tools were exercised live, and which by contract</summary>

**Claude Code — live, in a real session.** `.claude/settings.json` is picked up by the file watcher, so this was verified end-to-end:

| attempt | result |
| --- | --- |
| create `web/src/features/traces/utils/hookProbe.ts` | denied, rule 5, with the correct path |
| create `web/src/features/traces/hooks/use-hook-probe.ts` | denied, rule 3, `→ useHookProbe.ts` |
| create `web/src/features/traces/fns/hookProbe.ts` | allowed |
| **edit** `web/src/components/ui/button.tsx` (frozen folder, kebab name) | allowed — creation-only holds |

**Cursor and Codex — contract only. I did not launch either, and I am not claiming they work.** What was verified: the generated config matches each product's documented schema (Cursor `{"version": 1, "hooks": {"preToolUse": [{command, matcher, timeout}]}}`; Codex `{"hooks": {"PreToolUse": [{matcher, hooks: [{type, command, timeout}]}]}}`), and the hook was fed each tool's documented stdin payload and asserted to return its documented response shape, including Codex's `apply_patch` envelope with the target inside the patch text.

Two places where a tool has no native equivalent, so the hook approximates and says so in a comment:

- **Cursor's `preToolUse` takes `allow` or `deny` only** — no `ask`. Rule 18's ask becomes an allow carrying `agent_message`, so the note reaches the agent without blocking.
- **Codex has no `ask` for `PreToolUse` either.** The ask is returned as `additionalContext`, leaving Codex's own approval flow alone. If a Codex version ignores that field, the write proceeds — which is the fail-open direction.

</details>

<details>
<summary>Verification</summary>

- `pnpm --filter web run test src/__tests__/server/unit/structure-path-guard.servertest.ts` → `Tests  3 passed (3)`
- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` → `Tasks: 8 successful, 8 total` (`web/tsconfig.json` includes `**/*.mjs`, so `check-path.mjs` is type-checked through its JSDoc)
- `pnpm run agents:check` → exit 0, shims in sync
- `prettier --check "**/*.{js,jsx,ts,tsx,css}"` → `All matched files use Prettier code style!`

The test covers the check's verdicts as a table (18 paths, including the legitimate ones it must stay silent about), each tool's response shape, and the fail-open paths: an existing file, an out-of-scope path, a payload with no path at all, unparseable stdin, empty stdin, and the escape hatch.

</details>

## What a reviewer should doubt

1. **Rule 5 fires even when the bad folder already exists.** Adding a file to an existing `features/x/utils/` does not raise the sensor's count (rule 5 counts directories), but it is denied anyway — otherwise the blind spot grows, since a file in `utils/` also escapes rule 3's naming check. This is the one place the hook is deliberately stricter than the count.
2. **Rule 18 is `ask`, not `deny`.** At pre-write time "no adjacent subject" and "test written first" are the same observation, and this repo's own guidance says to write the failing test first. The message names both fixes. It also degrades to a note on Cursor and Codex.
3. **`Bash` is not hooked.** `cat > web/src/features/x/utils/foo.ts` bypasses everything. Matching `Bash` would mean parsing shell redirections; the CI ratchet is the real backstop for that.
4. **The tool-name matchers are the fragile part.** `Write` for Claude and Cursor, `apply_patch|Edit|Write` for Codex, from each product's current docs. A renamed tool means the hook silently stops firing — quiet, not broken, and it fails in the allowing direction.

## Next in this series

Not in this PR, deliberately: the `SessionStart` briefing from a cached snapshot, the CI `structure` job with a touched-files ratchet, and the pre-commit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a creation-only, fail-open structure guard for agent file writes and a fast path-based checker for selected project-structure rules.
- Declares one tool-neutral pre-write hook and generates Claude, Cursor, and Codex configurations.
- Adds path normalization, rule findings, corrective guidance, and an environment-variable escape hatch.
- Adds process-level tests for rule decisions, tool response shapes, and fail-open behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking import-placement cleanup in the hook implementation.

The structure guard and checker have no accepted behavioral or security failures, but the hook dynamically imports its checker from inside main instead of keeping module imports at the top level.

**Files Needing Attention:** scripts/agents/hooks/structure-path-guard.mjs
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Agent file-write request] --> B[Tool-specific hook shim]
  B --> C[Extract candidate paths]
  C --> D{Existing file or outside web/src?}
  D -->|Yes| E[Allow write]
  D -->|No| F[Run structure path checks]
  F --> G{Finding verdict}
  G -->|No finding| E
  G -->|Ask| H[Return tool-specific guidance]
  G -->|Deny| I[Block creation with corrective path]
  F -->|Error or invalid input| E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/agents/hooks/structure-path-guard.mjs:181-183
**Function-local checker import**

The structure checker is dynamically imported inside `main`, contrary to the repository convention that module dependencies remain at the top level; this makes initialization and dependency analysis less explicit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(structure): refuse new files that w..."](https://github.com/langfuse/langfuse/commit/0364fb57188c56d09afb75b7c2f7ad6476747653) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55510571)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->