### PR TITLE
fix(in-app-agent): refuse to delete user project keys during MCP cleanup

### DIFF
--- a/packages/shared/src/server/auth/apiKeys.ts
+++ b/packages/shared/src/server/auth/apiKeys.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 import * as crypto from "crypto";
 import type { Cluster, Redis } from "ioredis";
 import { env } from "../../env";
+import { logger } from "../logger";
 import { invalidateCachedApiKeys } from "./invalidateApiKeys";
 
 export function getDisplaySecretKey(secretKey: string) {
@@ -103,6 +104,11 @@ export async function deleteApiKeyFromDb(p: {
   entityId: string;
   scope: ApiKeyScope;
   redis?: Redis | Cluster | null;
+  /**
+   * When true, only delete keys minted for in-app agent MCP sessions.
+   * A matching project key that is not an agent key is left intact.
+   */
+  isInAppAgentKey?: boolean;
 }) {
   const entity =
     p.scope === "PROJECT" ? { projectId: p.entityId } : { orgId: p.entityId };
@@ -115,6 +121,18 @@ export async function deleteApiKeyFromDb(p: {
     },
   });
 
+  if (p.isInAppAgentKey === true && apiKey.isInAppAgentKey !== true) {
+    logger.warn(
+      "Refusing to delete API key that is not an in-app agent MCP key",
+      {
+        apiKeyId: p.id,
+        entityId: p.entityId,
+        scope: p.scope,
+      },
+    );
+    return false;
+  }
+
   await invalidateCachedApiKeys([apiKey], `key ${p.id}`, p.redis);
 
   await p.prisma.apiKey.delete({
@@ -124,4 +142,21 @@ export async function deleteApiKeyFromDb(p: {
   });
 
   return true;
+}
+
+/** Delete an in-app agent MCP session key. Skips user project keys. */
+export async function deleteInAppAgentMcpApiKeyFromDb(p: {
+  prisma: PrismaClient;
+  id: string;
+  projectId: string;
+  redis?: Redis | Cluster | null;
+}) {
+  return deleteApiKeyFromDb({
+    prisma: p.prisma,
+    id: p.id,
+    entityId: p.projectId,
+    scope: "PROJECT",
+    redis: p.redis,
+    isInAppAgentKey: true,
+  });
 }

--- a/web/src/features/in-app-agent/server/backgroundRunService.ts
+++ b/web/src/features/in-app-agent/server/backgroundRunService.ts
@@ -9,7 +9,7 @@ import {
   QueueJobs,
   redis,
 } from "@langfuse/shared/src/server";
-import { deleteApiKeyFromDb } from "@langfuse/shared/src/server/auth/apiKeys";
+import { deleteInAppAgentMcpApiKeyFromDb } from "@langfuse/shared/src/server/auth/apiKeys";
 import {
   InAppAgentRunErrorCode,
   InAppAgentRunStatus,
@@ -65,11 +65,10 @@ export async function getBackgroundConversationSnapshot(params: {
     projectId: params.projectId,
     conversationId: params.conversationId,
     deleteApiKey: async (apiKeyId) => {
-      await deleteApiKeyFromDb({
+      await deleteInAppAgentMcpApiKeyFromDb({
         prisma: params.prisma,
         id: apiKeyId,
-        entityId: params.projectId,
-        scope: "PROJECT",
+        projectId: params.projectId,
         redis,
       });
     },

--- a/worker/src/features/in-app-agent-integrity-runner/index.test.ts
+++ b/worker/src/features/in-app-agent-integrity-runner/index.test.ts
@@ -23,7 +23,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
 }));
 
 vi.mock("@langfuse/shared/src/server/auth/apiKeys", () => ({
-  deleteApiKeyFromDb: vi.fn(),
+  deleteInAppAgentMcpApiKeyFromDb: vi.fn(),
 }));
 
 vi.mock("@langfuse/shared/src/db", () => ({

--- a/worker/src/features/in-app-agent-integrity-runner/index.ts
+++ b/worker/src/features/in-app-agent-integrity-runner/index.ts
@@ -1,6 +1,6 @@
 import { prisma, type Prisma } from "@langfuse/shared/src/db";
 import { logger, recordGauge, redis } from "@langfuse/shared/src/server";
-import { deleteApiKeyFromDb } from "@langfuse/shared/src/server/auth/apiKeys";
+import { deleteInAppAgentMcpApiKeyFromDb } from "@langfuse/shared/src/server/auth/apiKeys";
 import {
   IN_APP_AGENT_UNSETTLED_RUN_STATUSES,
   InAppAgentRunErrorCode,
@@ -138,11 +138,10 @@ export class InAppAgentIntegrityRunner extends PeriodicExclusiveRunner {
           projectId,
           conversationId,
           deleteApiKey: async (apiKeyId) => {
-            await deleteApiKeyFromDb({
+            await deleteInAppAgentMcpApiKeyFromDb({
               prisma,
               id: apiKeyId,
-              entityId: projectId,
-              scope: "PROJECT",
+              projectId,
               redis,
             });
           },

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
@@ -170,14 +170,14 @@ vi.mock("@langfuse/shared/src/server/auth/apiKeys", async (importOriginal) => {
 
   return {
     ...actual,
-    deleteApiKeyFromDb: async (
-      ...args: Parameters<typeof actual.deleteApiKeyFromDb>
+    deleteInAppAgentMcpApiKeyFromDb: async (
+      ...args: Parameters<typeof actual.deleteInAppAgentMcpApiKeyFromDb>
     ) => {
       scenarioRef.apiKeyDeleteCalls += 1;
       if (scenarioRef.failApiKeyDelete) {
         throw new Error("simulated api key delete failure");
       }
-      return actual.deleteApiKeyFromDb(...args);
+      return actual.deleteInAppAgentMcpApiKeyFromDb(...args);
     },
   };
 });
@@ -912,6 +912,47 @@ describe("executeInAppAgentRun", () => {
         ),
       ),
     ).toHaveLength(0);
+  });
+
+  it("leaves a user project key intact when mcpApiKeyId points at it", async () => {
+    const { projectId, run, user } = await seedBackgroundRun({
+      status: "RUNNING",
+    });
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60_000);
+    const userKey = await createAndAddApiKeysToDb({
+      prisma,
+      entityId: projectId,
+      scope: "PROJECT",
+      note: "user project key",
+      isInAppAgentKey: false,
+      createdByUserId: user.id,
+    });
+    await prisma.inAppAgentRun.update({
+      where: { id_projectId: { id: run.id, projectId } },
+      data: {
+        claimedAt: twoMinutesAgo,
+        heartbeatAt: twoMinutesAgo,
+        mcpApiKeyId: userKey.id,
+      },
+    });
+
+    scenarioRef.current = async () => {
+      throw new Error(
+        "agent loop must not start on stale unclaimable delivery",
+      );
+    };
+
+    await expect(
+      executeInAppAgentRun({ projectId, runId: run.id }),
+    ).resolves.toBeUndefined();
+
+    const failed = await getRun(projectId, run.id);
+    expect(failed.status).toBe("FAILED");
+    expect(failed.errorCode).toBe("worker_lost");
+    expect(failed.mcpApiKeyId).toBeNull();
+    expect(
+      await prisma.apiKey.findUnique({ where: { id: userKey.id } }),
+    ).not.toBeNull();
   });
 
   it("acknowledges delivery against an already-FAILED run without changing it", async () => {

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.ts
@@ -9,7 +9,7 @@ import {
 } from "@langfuse/shared/src/server";
 import {
   createAndAddApiKeysToDb,
-  deleteApiKeyFromDb,
+  deleteInAppAgentMcpApiKeyFromDb,
 } from "@langfuse/shared/src/server/auth/apiKeys";
 import {
   InAppAgentRunErrorCode,
@@ -84,11 +84,10 @@ async function deleteInAppAgentMcpApiKey(params: {
   apiKeyId: string;
 }): Promise<void> {
   try {
-    await deleteApiKeyFromDb({
+    await deleteInAppAgentMcpApiKeyFromDb({
       prisma,
       id: params.apiKeyId,
-      entityId: params.projectId,
-      scope: "PROJECT",
+      projectId: params.projectId,
       redis,
     });
   } catch (error) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16393.preview.langfuse.com](https://pr-16393.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- In-app agent MCP cleanup now deletes only keys minted with `isInAppAgentKey`, so a corrupted `mcpApiKeyId` that happens to match a normal project key is left intact.
- The pointer is still cleared and a warning is logged. Worker, integrity runner, and web snapshot cleanup all use the same helper.

## Test plan
- [x] `pnpm --filter worker run test executeInAppAgentRun.test.ts` — `Tests 30 passed (30)`
- [x] `pnpm --filter worker run test` (integrity runner file) — `Tests 7 passed (7)` including the two integrity-runner cases
- [x] `pnpm --filter worker run lint` + `pnpm --filter web run lint` + `pnpm --filter @langfuse/shared run lint`
- [x] Pre-commit: `Tasks: 7 successful, 7 total` (turbo lint)

Impacted packages: `@langfuse/shared`, `worker`, `web`.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR protects ordinary project API keys from in-app-agent MCP cleanup by introducing a marker-aware shared deletion helper and routing worker, integrity-runner, and web snapshot cleanup through it.
- Refuses deletion when the referenced project key is not marked as an in-app-agent key.
- Preserves pointer clearing and warning behavior for corrupted references.
- Adds worker coverage confirming ordinary user project keys remain intact.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with cleanup consistently restricted to marked in-app-agent MCP keys.

Legitimate MCP keys are minted with the required marker, all affected cleanup paths use the guarded helper, and corrupted pointers preserve ordinary project keys while retaining the intended pointer-clearing behavior.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Cleanup[In-app-agent cleanup] --> Lookup[Look up project API key]
  Lookup --> Marked{isInAppAgentKey?}
  Marked -->|Yes| Invalidate[Invalidate cached key]
  Invalidate --> Delete[Delete temporary MCP key]
  Marked -->|No| Warn[Warn and preserve project key]
  Delete --> Clear[Clear run mcpApiKeyId]
  Warn --> Clear
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): refuse to delete user..."](https://github.com/langfuse/langfuse/commit/8c1e6cdec36617d3a493f78317e8d2bc861caa6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55514114)</sub>

**Context used:**

- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->