### PR TITLE
feat(in-app-agent): emit sandbox lifecycle metrics for MicroVMs

### DIFF
--- a/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.test.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.test.ts
@@ -1,16 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const microvmSendMock = vi.fn();
-const recordIncrementMock = vi.hoisted(() => vi.fn());
-
-vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@langfuse/shared/src/server")>();
-  return {
-    ...actual,
-    recordIncrement: recordIncrementMock,
-  };
-});
 
 vi.mock("@aws-sdk/client-lambda-microvms", () => {
   class LambdaMicrovmsClient {
@@ -55,7 +45,6 @@ vi.mock("@aws-sdk/client-lambda-microvms", () => {
 describe("in-app agent lambda microvm sandbox provider", () => {
   beforeEach(() => {
     microvmSendMock.mockReset();
-    recordIncrementMock.mockReset();
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });
@@ -88,67 +77,6 @@ describe("in-app agent lambda microvm sandbox provider", () => {
     expect(microvmSendMock.mock.calls[1]?.[0]?.input).toEqual({
       microvmIdentifier: "microvm-1",
     });
-    expect(recordIncrementMock.mock.calls).toEqual([
-      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "suspended" }],
-      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "terminated" }],
-    ]);
-  });
-
-  it("emits sandbox.lifecycle created and resumed", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn<typeof fetch>()
-        .mockResolvedValue(new Response(null, { status: 200 })),
-    );
-    microvmSendMock.mockImplementation(async (command: { input: unknown }) => {
-      const input = command.input as { microvmIdentifier?: string };
-
-      if (command.constructor.name === "RunMicrovmCommand") {
-        return {
-          microvmId: "microvm-1",
-          endpoint: "https://microvm.example.com:8443",
-          state: "RUNNING",
-        };
-      }
-
-      if (command.constructor.name === "GetMicrovmCommand") {
-        return {
-          microvmId: input.microvmIdentifier,
-          endpoint: "https://microvm.example.com:8443",
-          state: "SUSPENDED",
-        };
-      }
-
-      if (command.constructor.name === "ResumeMicrovmCommand") {
-        return {};
-      }
-
-      if (command.constructor.name === "CreateMicrovmAuthTokenCommand") {
-        return { authToken: { "X-aws-proxy-auth": "token-1" } };
-      }
-
-      throw new Error(`Unexpected command ${command.constructor.name}`);
-    });
-
-    const { createLambdaMicrovmSandboxProvider } =
-      await import("./lambdaMicrovm");
-    const provider = createLambdaMicrovmSandboxProvider({
-      imageIdentifier: "image-1",
-      executionRoleArn: "arn:aws:iam::123456789012:role/sandbox",
-      region: "us-east-1",
-    });
-
-    await provider.ensureSession({ conversationId: "conversation-1" });
-    await provider.ensureSession({
-      conversationId: "conversation-1",
-      sessionId: "microvm-1",
-    });
-
-    expect(recordIncrementMock.mock.calls).toEqual([
-      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "created" }],
-      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "resumed" }],
-    ]);
   });
 
   it("omits egress network connectors when no connector ARN is configured", async () => {

--- a/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.test.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const microvmSendMock = vi.fn();
+const recordIncrementMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    recordIncrement: recordIncrementMock,
+  };
+});
 
 vi.mock("@aws-sdk/client-lambda-microvms", () => {
   class LambdaMicrovmsClient {
@@ -45,6 +55,7 @@ vi.mock("@aws-sdk/client-lambda-microvms", () => {
 describe("in-app agent lambda microvm sandbox provider", () => {
   beforeEach(() => {
     microvmSendMock.mockReset();
+    recordIncrementMock.mockReset();
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });
@@ -77,6 +88,67 @@ describe("in-app agent lambda microvm sandbox provider", () => {
     expect(microvmSendMock.mock.calls[1]?.[0]?.input).toEqual({
       microvmIdentifier: "microvm-1",
     });
+    expect(recordIncrementMock.mock.calls).toEqual([
+      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "suspended" }],
+      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "terminated" }],
+    ]);
+  });
+
+  it("emits sandbox.lifecycle created and resumed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 200 })),
+    );
+    microvmSendMock.mockImplementation(async (command: { input: unknown }) => {
+      const input = command.input as { microvmIdentifier?: string };
+
+      if (command.constructor.name === "RunMicrovmCommand") {
+        return {
+          microvmId: "microvm-1",
+          endpoint: "https://microvm.example.com:8443",
+          state: "RUNNING",
+        };
+      }
+
+      if (command.constructor.name === "GetMicrovmCommand") {
+        return {
+          microvmId: input.microvmIdentifier,
+          endpoint: "https://microvm.example.com:8443",
+          state: "SUSPENDED",
+        };
+      }
+
+      if (command.constructor.name === "ResumeMicrovmCommand") {
+        return {};
+      }
+
+      if (command.constructor.name === "CreateMicrovmAuthTokenCommand") {
+        return { authToken: { "X-aws-proxy-auth": "token-1" } };
+      }
+
+      throw new Error(`Unexpected command ${command.constructor.name}`);
+    });
+
+    const { createLambdaMicrovmSandboxProvider } =
+      await import("./lambdaMicrovm");
+    const provider = createLambdaMicrovmSandboxProvider({
+      imageIdentifier: "image-1",
+      executionRoleArn: "arn:aws:iam::123456789012:role/sandbox",
+      region: "us-east-1",
+    });
+
+    await provider.ensureSession({ conversationId: "conversation-1" });
+    await provider.ensureSession({
+      conversationId: "conversation-1",
+      sessionId: "microvm-1",
+    });
+
+    expect(recordIncrementMock.mock.calls).toEqual([
+      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "created" }],
+      ["langfuse.in_app_agent.sandbox.lifecycle", 1, { action: "resumed" }],
+    ]);
   });
 
   it("omits egress network connectors when no connector ARN is configured", async () => {

--- a/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts
@@ -10,7 +10,7 @@ import {
   TerminateMicrovmCommand,
   type RunMicrovmCommandInput,
 } from "@aws-sdk/client-lambda-microvms";
-import { logger } from "@langfuse/shared/src/server";
+import { logger, recordIncrement } from "@langfuse/shared/src/server";
 import { z } from "zod";
 
 import type {
@@ -85,7 +85,7 @@ export function createLambdaMicrovmSandboxProvider(params: {
   const createMicrovm = async (
     conversationId: string,
   ): Promise<EnsuredLambdaSession> => {
-    logger.debug("[Lambda MicroVM Sandbox] creating new session", {
+    logger.info("[Lambda MicroVM Sandbox] creating new session", {
       conversationId,
       imageIdentifier: params.imageIdentifier,
       hasExecutionRoleArn: Boolean(params.executionRoleArn),
@@ -119,15 +119,23 @@ export function createLambdaMicrovmSandboxProvider(params: {
       endpoint: microvm.endpoint,
     });
     if (ready.status !== "ready") {
+      logger.info("[Lambda MicroVM Sandbox] session startup failed", {
+        conversationId,
+        sessionId: microvm.microvmId,
+        reason: ready.reason,
+      });
       throw new Error(
         `[Lambda MicroVM Sandbox] startup failed before bridge became ready: ${ready.reason}`,
       );
     }
 
-    logger.debug("[Lambda MicroVM Sandbox] created new session", {
+    logger.info("[Lambda MicroVM Sandbox] created new session", {
       conversationId,
       sessionId: microvm.microvmId,
       state: microvm.state,
+    });
+    recordIncrement("langfuse.in_app_agent.sandbox.lifecycle", 1, {
+      action: "created",
     });
 
     return { sessionId: microvm.microvmId, endpoint: microvm.endpoint };
@@ -187,19 +195,21 @@ export function createLambdaMicrovmSandboxProvider(params: {
         );
       }
 
+      let resumed = false;
       try {
         if (existing.state === "SUSPENDED") {
-          logger.debug("[Lambda MicroVM Sandbox] resuming suspended session", {
+          logger.info("[Lambda MicroVM Sandbox] resuming suspended session", {
             conversationId: request.conversationId,
             sessionId: request.sessionId,
           });
           await client.send(
             new ResumeMicrovmCommand({ microvmIdentifier: request.sessionId }),
           );
+          resumed = true;
         }
       } catch (error) {
         if (isMissingMicrovmError(error)) {
-          logger.debug(
+          logger.info(
             "[Lambda MicroVM Sandbox] resume raced with session teardown",
             {
               conversationId: request.conversationId,
@@ -222,7 +232,7 @@ export function createLambdaMicrovmSandboxProvider(params: {
         endpoint: existing.endpoint,
       });
       if (ready.status !== "ready") {
-        logger.debug(
+        logger.info(
           "[Lambda MicroVM Sandbox] restored session became unavailable",
           {
             conversationId: request.conversationId,
@@ -243,11 +253,17 @@ export function createLambdaMicrovmSandboxProvider(params: {
         endpoint: existing.endpoint,
         toolCallFiles: session?.toolCallFiles ?? [],
       });
-      logger.debug("[Lambda MicroVM Sandbox] reusing existing session", {
+      logger.info("[Lambda MicroVM Sandbox] reusing existing session", {
         conversationId: request.conversationId,
         sessionId: request.sessionId,
         state: existing.state,
+        resumed,
       });
+      if (resumed) {
+        recordIncrement("langfuse.in_app_agent.sandbox.lifecycle", 1, {
+          action: "resumed",
+        });
+      }
       return { sessionId: request.sessionId, endpoint: existing.endpoint };
     }
 
@@ -386,15 +402,18 @@ export function createLambdaMicrovmSandboxProvider(params: {
         await client.send(
           new SuspendMicrovmCommand({ microvmIdentifier: sessionId }),
         );
-        logger.debug("[Lambda MicroVM Sandbox] suspended session", {
+        logger.info("[Lambda MicroVM Sandbox] suspended session", {
           sessionId,
+        });
+        recordIncrement("langfuse.in_app_agent.sandbox.lifecycle", 1, {
+          action: "suspended",
         });
       } catch (error) {
         if (!isMissingMicrovmError(error)) {
           throw error;
         }
 
-        logger.debug(
+        logger.info(
           "[Lambda MicroVM Sandbox] suspend skipped missing session",
           {
             sessionId,
@@ -405,7 +424,7 @@ export function createLambdaMicrovmSandboxProvider(params: {
       }
     },
     async terminateSession({ sessionId }) {
-      logger.debug("[Lambda MicroVM Sandbox] terminating session", {
+      logger.info("[Lambda MicroVM Sandbox] terminating session", {
         sessionId,
       });
       sessions.delete(sessionId);
@@ -414,15 +433,18 @@ export function createLambdaMicrovmSandboxProvider(params: {
         await client.send(
           new TerminateMicrovmCommand({ microvmIdentifier: sessionId }),
         );
-        logger.debug("[Lambda MicroVM Sandbox] terminated session", {
+        logger.info("[Lambda MicroVM Sandbox] terminated session", {
           sessionId,
+        });
+        recordIncrement("langfuse.in_app_agent.sandbox.lifecycle", 1, {
+          action: "terminated",
         });
       } catch (error) {
         if (!isMissingMicrovmError(error)) {
           throw error;
         }
 
-        logger.debug(
+        logger.info(
           "[Lambda MicroVM Sandbox] terminate skipped missing session",
           {
             sessionId,

--- a/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts
@@ -253,7 +253,7 @@ export function createLambdaMicrovmSandboxProvider(params: {
         endpoint: existing.endpoint,
         toolCallFiles: session?.toolCallFiles ?? [],
       });
-      logger.info("[Lambda MicroVM Sandbox] reusing existing session", {
+      logger.debug("[Lambda MicroVM Sandbox] reusing existing session", {
         conversationId: request.conversationId,
         sessionId: request.sessionId,
         state: existing.state,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16394.preview.langfuse.com](https://pr-16394.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- The Lambda MicroVM provider now increments `langfuse.in_app_agent.sandbox.lifecycle` with `action:created|resumed|suspended|terminated` after those AWS calls succeed.
- Create, resume, suspend, terminate, and related failure logs are info instead of debug. `session_replaced` is unchanged. There is still no “currently running” gauge.

## Test plan
- [x] `pnpm --filter worker run test lambdaMicrovm.test.ts` — `Tests 5 passed (5)`
- [x] `pnpm --filter worker run lint`
- [x] Pre-commit: `Tasks: 7 successful, 7 total` (turbo lint)

Impacted packages: `worker`.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds Lambda MicroVM lifecycle counters after successful create, resume, suspend, and terminate flows, and promotes related operational logging from debug to info.

- Adds `langfuse.in_app_agent.sandbox.lifecycle` increments with stable action tags.
- Adds tests covering all four lifecycle action values.
- Raises creation, reuse, recovery, suspension, and termination messages to info.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking concern that session reuse now emits an info log for every sandbox tool operation.

The lifecycle counters use bounded action tags and are covered by focused tests, but promoting the common reuse diagnostic creates avoidable production log volume on multi-tool turns.

**Files Needing Attention:** worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts:256-261
**Hot-path session reuse logging**

Every sandbox read, write, edit, or bash operation calls `ensureSession`, so logging the common existing-session branch at info produces a production log for every tool call and unnecessarily increases log ingestion volume and cost. Keep this routine diagnostic at debug while retaining lower-frequency lifecycle events at info.

```suggestion
      logger.debug("[Lambda MicroVM Sandbox] reusing existing session", {
        conversationId: request.conversationId,
        sessionId: request.sessionId,
        state: existing.state,
        resumed,
      });
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(in-app-agent): emit sandbox lifecyc..."](https://github.com/langfuse/langfuse/commit/39c3d47913798726bfceb25360ccdef067ebd37e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55514792)</sub>

**Context used:**

- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)

<!-- /greptile_comment -->