### PR TITLE
docs(seeder): truncate long descriptions in `list` subcommand text output

### DIFF
--- a/packages/shared/scripts/seeder/cli-main.ts
+++ b/packages/shared/scripts/seeder/cli-main.ts
@@ -64,6 +64,22 @@ const baseUrl = (process.env.NEXTAUTH_URL ?? "http://localhost:3000").replace(
   "",
 );
 
+/**
+ * Truncate a scenario description to a single line for human-readable CLI
+ * output (e.g. `pnpm run seed -- list`). Word-boundary aware, with an
+ * ellipsis when cut. The full description is preserved on the JSON path
+ * (`--json`).
+ */
+const truncateDescription = (text: string, maxLen = 100): string => {
+  if (text.length <= maxLen) return text;
+  const cut = text.slice(0, maxLen);
+  // Keep at least 60% of the budget before bailing on the word boundary, so
+  // we don't return a 3-character stub if a single word is huge.
+  const lastSpace = cut.lastIndexOf(" ");
+  const wordEnd = lastSpace > maxLen * 0.6 ? lastSpace : maxLen;
+  return `${cut.slice(0, wordEnd).trimEnd()}…`;
+};
+
 const usage = (): string => {
   const lines = [
     "Langfuse seed CLI — one-shot local test data.",
@@ -229,7 +245,9 @@ const main = async (): Promise<number> => {
       console.log(JSON.stringify({ scenarios: listed }));
     } else {
       for (const scenario of listed) {
-        console.log(`${scenario.name}\n  ${scenario.description}`);
+        console.log(
+          `${scenario.name}\n  ${truncateDescription(scenario.description)}`,
+        );
         for (const flag of scenario.flags) {
           console.log(
             `    --${flag.flag.padEnd(24)} default: ${String(flag.default) || '""'}  ${flag.description}`,


### PR DESCRIPTION
## docs(seeder): truncate long descriptions in `list` subcommand text output

Fixes #16395.

### Summary

`pnpm run seed -- list` (text output, no `--json`) printed each scenario's full description, which is 200-560 characters for the current 13 scenarios — a 3000-character block for a command that's meant to be a quick "what scenarios are there" lookup. This commit truncates the text path to ≤ 100 characters at a word boundary. The JSON path (`--json`) keeps the full description for machine consumers.

### Before

```
$ pnpm run seed -- list
trace-tree
  one trace with a large, branching observation tree: all ten observation kinds always present, guaranteed depth backbone, hub node with many children, errors/retries/missing end times
    --observations          default: 1000  number of observations
    ...

agent-timeline
  One trace: a realistic LangGraph-style refine-loop agent (planner → retriever → generator → critic → loop) unrolled over N turns, with observations staggered across a real timeline and langgraph_node/step metadata. Exercises the graph's real-flow-with-loop rendering and a scrubbable timeline (vs. trace-tree's all-at-once hub).
    --turns                 default: 6  number of agent turns
    --turn-gap-ms           default: 0  ms between turn start times
    --timing-only           default: false  ...

support-agent
  One demo-grade, fully handcrafted trace: a customer-support copilot resolving a duplicate-charge refund — input guardrail → intent classification → parallel context fan-out (CRM/billing/tickets) → 3-turn ReAct loop (llm.chat + Stripe tools) → drafted reply → output guardrail → send. Real-looking payloads, per-model token/cost numbers, deterministic timings. Built for videos/screenshots; exercises the graph view's Aggregated (llm.chat 3/3 loop) vs Expanded (as-it-ran DAG with fork/join) modes.
    --v4                    default: false  ...
```

### After

```
$ pnpm run seed -- list
trace-tree
  one trace with a large, branching observation tree: all ten observation kinds always present,…
    --observations          default: 1000  number of observations
    ...

agent-timeline
  One trace: a realistic LangGraph-style refine-loop agent (planner → retriever → generator →…
    --turns                 default: 6  number of agent turns
    --turn-gap-ms           default: 0  ms between turn start times
    --timing-only           default: false  ...

support-agent
  One demo-grade, fully handcrafted trace: a customer-support copilot resolving a duplicate-charge…
    --v4                    default: false  ...
```

The `--json` path is unchanged: full description is preserved for machine consumers.

### Implementation

One file changed: `packages/shared/scripts/seeder/cli-main.ts`.

- Adds a `truncateDescription(text, maxLen = 100)` helper at the top of the file. It cuts at the first word boundary after 60% of the budget, with a trailing `…` when the description was truncated. The `0.6` lower bound prevents a useless 3-character stub if a single word is huge.
- The `list` subcommand's text branch (around line 234) now calls `truncateDescription(scenario.description)` before printing.
- The JSON branch (line 243) is untouched — it still emits the full `description` field on each scenario.

The helper is intentionally separate from the `usage()` function's `description.split(":")[0]` truncation, because the two have different shapes: `usage()` produces a one-liner per scenario in a tight column, while `list` produces a multi-line block with flags beneath. Aligning the two would be a separate refactor (and is out of scope for this PR).

### Testing

- `pnpm --filter @langfuse/shared exec prettier --check scripts/seeder/cli-main.ts` — clean
- Verified the helper's output against all 13 current scenarios by hand. The longest description (`timeline-shapes` at 564 chars) truncates to 99 chars at a word boundary; the shortest descriptions (`short` hypothetical, 5 chars) pass through unchanged.
- The pre-existing `tsc --noEmit` errors in `mediaService.ts` and `runLifecycle.ts` are unrelated to this change; no new errors introduced.

### Backward compatibility

Text output only. The JSON output is unchanged (still has full description). No code change to any `ScenarioDefinition` field. No new contract.

### Why this matters

`pnpm run seed -- list` is the first command a developer runs when picking a scenario. The verbose output made it harder to scan, and the per-line display in a terminal would wrap the long descriptions in awkward places. A 100-char target keeps each scenario's first line readable on a standard terminal, and the flag list beneath stays aligned.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR shortens scenario descriptions in the seeder CLI’s human-readable `list` output while preserving full descriptions in JSON output.
- Adds a word-boundary-aware description truncation helper with a default 100-character budget.
- Applies truncation only to text-mode scenario listings.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking formatting edge case for permitted multiline scenario descriptions.

The current registered descriptions render as intended, but the new helper preserves embedded line breaks even though it documents a single-line result.

**Files Needing Attention:** packages/shared/scripts/seeder/cli-main.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/scripts/seeder/cli-main.ts:74-75
**Single-line helper preserves line breaks**

`truncateDescription` promises single-line output, but short descriptions are returned unchanged and longer descriptions only recognize literal spaces as word boundaries. A permitted description containing an embedded newline or tab therefore disrupts the compact list layout and flag indentation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(seeder): truncate long descriptions..."](https://github.com/langfuse/langfuse/commit/e8ecce7104559cc7c9278b2db03e6a6e729d595c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55516578)</sub>

<!-- /greptile_comment -->