### PR TITLE
feat(in-app-agent): log failed runs with error message for Datadog

### DIFF
--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -260,6 +260,10 @@ export async function appendRunEvents(params: {
     recordRunTerminalOutcome({
       status: params.finish.status,
       errorCode: params.finish.errorCode ?? null,
+      projectId: params.projectId,
+      runId: params.runId,
+      conversationId: params.conversationId,
+      errorMessage: params.finish.errorMessage ?? null,
     });
   }
 

--- a/packages/shared/src/in-app-agent/server/runLifecycle.test.ts
+++ b/packages/shared/src/in-app-agent/server/runLifecycle.test.ts
@@ -197,12 +197,20 @@ describe("in-app agent run lifecycle races", () => {
         conversationId: "conversation-1",
       }),
     ).resolves.toEqual([
-      { runId: "run-1", errorCode: InAppAgentRunErrorCode.QUEUE_TIMEOUT },
+      {
+        runId: "run-1",
+        errorCode: InAppAgentRunErrorCode.QUEUE_TIMEOUT,
+        errorMessage: "No worker picked this run up",
+      },
     ]);
     expect(metricMocks.recordRunTerminalOutcome).toHaveBeenCalledTimes(1);
     expect(metricMocks.recordRunTerminalOutcome).toHaveBeenCalledWith({
       status: InAppAgentRunStatus.FAILED,
       errorCode: InAppAgentRunErrorCode.QUEUE_TIMEOUT,
+      projectId: "project-1",
+      runId: "run-1",
+      conversationId: "conversation-1",
+      errorMessage: "No worker picked this run up",
     });
   });
 
@@ -294,6 +302,10 @@ describe("in-app agent run lifecycle races", () => {
     expect(metricMocks.recordRunTerminalOutcome).toHaveBeenCalledWith({
       status: InAppAgentRunStatus.FAILED,
       errorCode: InAppAgentRunErrorCode.QUEUE_TIMEOUT,
+      projectId: "project-1",
+      runId: "run-old",
+      conversationId: "conversation-1",
+      errorMessage: "No worker picked this run up",
     });
   });
 

--- a/packages/shared/src/in-app-agent/server/runLifecycle.ts
+++ b/packages/shared/src/in-app-agent/server/runLifecycle.ts
@@ -117,6 +117,9 @@ export async function finishClaimedRun(params: {
     recordRunTerminalOutcome({
       status: params.status,
       errorCode: params.errorCode ?? null,
+      projectId: params.projectId,
+      runId: params.runId,
+      errorMessage: params.errorMessage ?? null,
     });
   }
 
@@ -207,7 +210,11 @@ export async function createQueuedRun(params: {
     },
   );
 
-  recordReconciledOutcomes(reconciled);
+  recordReconciledOutcomes({
+    projectId: params.projectId,
+    conversationId: params.conversationId,
+    reconciled,
+  });
   for (let i = 0; i < supersededCount; i++) {
     recordRunTerminalOutcome({
       status: InAppAgentRunStatus.CANCELLED,
@@ -384,6 +391,10 @@ export async function decideToolApproval(params: {
       recordRunTerminalOutcome({
         status: InAppAgentRunStatus.FAILED,
         errorCode: InAppAgentRunErrorCode.APPROVAL_EXPIRED,
+        projectId: params.projectId,
+        runId: params.parentRunId,
+        conversationId: params.conversationId,
+        errorMessage: "The approval request expired",
       });
     }
     throw new LangfuseConflictError("The approval request expired.");
@@ -594,6 +605,7 @@ async function cancelRunInTransaction(params: {
 export type ReconciledRun = {
   runId: string;
   errorCode: InAppAgentRunErrorCode;
+  errorMessage: string;
 };
 
 /** Reconcile stale lifecycle states on conversation reads (dispatch option C). */
@@ -610,16 +622,28 @@ export async function reconcileConversationRuns(params: {
     }),
   );
 
-  recordReconciledOutcomes(reconciled);
+  recordReconciledOutcomes({
+    projectId: params.projectId,
+    conversationId: params.conversationId,
+    reconciled,
+  });
 
   return reconciled;
 }
 
-function recordReconciledOutcomes(reconciled: ReconciledRun[]): void {
-  for (const run of reconciled) {
+function recordReconciledOutcomes(params: {
+  projectId: string;
+  conversationId: string;
+  reconciled: ReconciledRun[];
+}): void {
+  for (const run of params.reconciled) {
     recordRunTerminalOutcome({
       status: InAppAgentRunStatus.FAILED,
       errorCode: run.errorCode,
+      projectId: params.projectId,
+      runId: run.runId,
+      conversationId: params.conversationId,
+      errorMessage: run.errorMessage,
     });
   }
 }
@@ -677,7 +701,11 @@ async function reconcileConversationRunsInTransaction(params: {
     });
 
     if (count > 0) {
-      reconciled.push({ runId: run.id, errorCode: failure.errorCode });
+      reconciled.push({
+        runId: run.id,
+        errorCode: failure.errorCode,
+        errorMessage: failure.errorMessage,
+      });
     }
   }
 

--- a/packages/shared/src/in-app-agent/server/runMetrics.ts
+++ b/packages/shared/src/in-app-agent/server/runMetrics.ts
@@ -1,5 +1,8 @@
-import { InAppAgentRunErrorCode } from "../../features/inAppAgent/types";
-import { recordIncrement } from "../../server";
+import {
+  InAppAgentRunErrorCode,
+  InAppAgentRunStatus,
+} from "../../features/inAppAgent/types";
+import { logger, recordIncrement } from "../../server";
 import type { SettledInAppAgentRunStatus } from "../constants";
 
 const RUN_COMPLETED_METRIC = "langfuse.in_app_agent.run.completed";
@@ -15,13 +18,33 @@ const RUN_COMPLETED_METRIC = "langfuse.in_app_agent.run.completed";
  *
  * `error_code` is "none" rather than absent so Datadog can group every outcome
  * on one tag key.
+ *
+ * Failed outcomes also emit one structured info log. The metric cannot carry
+ * the error text; the log is what the Datadog failed-run table queries, and
+ * Winston attaches `dd.trace_id` so a row can jump to the APM trace.
  */
 export function recordRunTerminalOutcome(params: {
   status: SettledInAppAgentRunStatus;
   errorCode?: InAppAgentRunErrorCode | null;
+  projectId?: string;
+  runId?: string;
+  conversationId?: string;
+  errorMessage?: string | null;
 }): void {
   recordIncrement(RUN_COMPLETED_METRIC, 1, {
     status: params.status,
     error_code: params.errorCode ?? "none",
+  });
+
+  if (params.status !== InAppAgentRunStatus.FAILED) {
+    return;
+  }
+
+  logger.info("In-app agent run failed", {
+    projectId: params.projectId,
+    runId: params.runId,
+    conversationId: params.conversationId,
+    errorCode: params.errorCode ?? "none",
+    errorMessage: params.errorMessage ?? undefined,
   });
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16402.preview.langfuse.com](https://pr-16402.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Emit one structured `In-app agent run failed` info log after a failed run's terminal CAS, with `projectId`, `runId`, `conversationId`, `errorCode`, and `errorMessage`.
- Winston already attaches `dd.trace_id`, so the Datadog failed-run table can show the message and open the APM trace.
- The completion metric still only carries `status` / `error_code`; it cannot hold the error text.

## Test plan
- [ ] `pnpm --filter @langfuse/shared run test runLifecycle.test.ts`
- [ ] After deploy, fail a background run and confirm a worker/web log `In-app agent run failed` with `errorMessage` and a clickable trace.
- [ ] Confirm succeeded/cancelled runs do not emit this log.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds structured failed-run logging alongside terminal outcome metrics so Datadog can display failure details and trace links.

- Threads run and conversation identifiers plus error messages through persistence and stale-run reconciliation paths.
- Extends lifecycle tests to verify reconciled failure telemetry.
- Leaves the direct worker terminal-failure path without its conversation identifier.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The direct worker failure path should be fixed before merging because its new structured log omits the conversation identifier promised by this feature.

finishClaimedRun can emit a failed outcome from normal worker error handling, but its API does not carry conversationId, causing the resulting Datadog log to contain an undefined conversationId.

**Files Needing Attention:** packages/shared/src/in-app-agent/server/runLifecycle.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/in-app-agent/server/runLifecycle.ts:117-123
**Missing conversation ID on failures**

When the worker finishes a claimed run as failed after an execution, initialization, or shutdown error, `finishClaimedRun` emits the new structured log without a `conversationId`, causing the Datadog failed-run row to lose the conversation association this feature intends to provide.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(in-app-agent): log failed runs with..."](https://github.com/langfuse/langfuse/commit/7400f2157b0d76df87f3b851f516fb049c7a2adb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55525254)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)

<!-- /greptile_comment -->