### PR TITLE
fix(shared): apply score pagination when offset is 0

### DIFF
--- a/packages/shared/src/server/repositories/scores.test.ts
+++ b/packages/shared/src/server/repositories/scores.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockQueryClickhouse = vi.hoisted(() => vi.fn());
+
+vi.mock("./clickhouse", () => ({
+  queryClickhouse: mockQueryClickhouse,
+  queryClickhouseStream: vi.fn(),
+  queryClickhouseExecRaw: vi.fn(),
+  commandClickhouse: vi.fn(),
+  upsertClickhouse: vi.fn(),
+  parseClickhouseUTCDateTimeFormat: vi.fn(),
+  clickhouseCompliantRandomCharacters: vi.fn(() => "x"),
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: {},
+}));
+
+// Break the query-options -> server-barrel import cycle that otherwise fails
+// module initialization when the graph is entered from this repository file.
+vi.mock("../queries/clickhouse-sql/query-options", () => ({
+  shouldSkipObservationsFinal: vi.fn().mockResolvedValue(false),
+}));
+
+import {
+  getScoresForTraces,
+  getScoresForSessions,
+  getScoresForExperiments,
+} from "../index";
+
+const PAGINATION_CLAUSE = "limit {limit: Int32} offset {offset: Int32}";
+
+describe("score repository pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryClickhouse.mockResolvedValue([]);
+  });
+
+  const cases = [
+    {
+      name: "getScoresForTraces",
+      run: () =>
+        getScoresForTraces({
+          projectId: "proj-1",
+          traceIds: ["t-1"],
+          limit: 50,
+          offset: 0,
+        }),
+    },
+    {
+      name: "getScoresForSessions",
+      run: () =>
+        getScoresForSessions({
+          projectId: "proj-1",
+          sessionIds: ["s-1"],
+          limit: 50,
+          offset: 0,
+        }),
+    },
+    {
+      name: "getScoresForExperiments",
+      run: () =>
+        getScoresForExperiments({
+          projectId: "proj-1",
+          runIds: ["r-1"],
+          limit: 50,
+          offset: 0,
+        }),
+    },
+  ];
+
+  it.each(cases)(
+    "$name applies LIMIT/OFFSET when offset is 0",
+    async ({ run }) => {
+      await run();
+
+      const { query } = mockQueryClickhouse.mock.calls[0][0];
+      expect(query).toContain(PAGINATION_CLAUSE);
+    },
+  );
+
+  it("omits LIMIT/OFFSET when limit and offset are undefined", async () => {
+    await getScoresForTraces({ projectId: "proj-1", traceIds: ["t-1"] });
+
+    const { query } = mockQueryClickhouse.mock.calls[0][0];
+    expect(query).not.toContain(PAGINATION_CLAUSE);
+  });
+});

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -261,7 +261,7 @@ export const getScoresForSessions = async <
       AND s.data_type IN ({dataTypes: Array(String)})
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<ScoreRecordReadType>({
@@ -310,7 +310,7 @@ export const getScoresForExperiments = async <
       AND s.data_type IN ({dataTypes: Array(String)})
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<ScoreRecordReadType>({
@@ -529,7 +529,7 @@ const getScoresForTracesInternal = async <
       ${levelFilter}
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   const rows = await queryClickhouse<

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -426,8 +426,6 @@ export const sessionRouter = createTRPCRouter({
       const scores = await getScoresForSessions({
         projectId: ctx.session.projectId,
         sessionIds: sessions.map((s) => s.session_id),
-        limit: 1000,
-        offset: 0,
       });
 
       const validatedScores = filterAndValidateDbScoreList({
@@ -495,8 +493,6 @@ export const sessionRouter = createTRPCRouter({
       const scores = await getScoresForSessions({
         projectId: ctx.session.projectId,
         sessionIds: sessions.map((s) => s.session_id),
-        limit: 1000,
-        offset: 0,
       });
 
       const validatedScores = filterAndValidateDbScoreList({

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -264,8 +264,6 @@ export const traceRouter = createTRPCRouter({
       const traceScores = await getScoresForTraces({
         projectId: ctx.session.projectId,
         traceIds: res.map((r) => r.id),
-        limit: 1000,
-        offset: 0,
         excludeMetadata: true,
         includeHasMetadata: true,
       });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16405.preview.langfuse.com](https://pr-16405.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The trace, session, and experiment score query builders in `packages/shared/src/server/repositories/scores.ts` guarded the `LIMIT/OFFSET` clause with a truthiness check (`limit && offset`). Because `0` is falsy, a valid first page (`offset: 0`) dropped the clause entirely, so the response ignored the caller-provided page size. The guard now checks `limit !== undefined && offset !== undefined`, matching the pattern already used by the other score builders (`getScoresForObservations`, `getScoresUiGeneric`).

Two session-metrics callers (`sessions.metrics` / `sessions.metricsFromEvents`) passed `limit: 1000, offset: 0`. The bug had silently disabled that cap, so those endpoints have always fetched all scores for the visible page. To keep behavior identical, their `limit`/`offset` are dropped so per-page score aggregation stays unbounded rather than newly capping at 1000.

Fixes #16368

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Added tests that prove the fix (offset=0 now applies LIMIT/OFFSET for all three builders; unbounded case still omits it).
- [x] `pnpm --filter web run typecheck` and `pnpm --filter web run lint` pass; shared repository test passes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes first-page score pagination by treating zero offsets as defined and preserves the existing unbounded session-metrics aggregation behavior.
- Updates trace, session, and experiment score query builders to emit LIMIT/OFFSET when both values are defined.
- Removes ineffective pagination arguments from two session-metrics callers.
- Adds regression tests for zero-offset and unbounded query generation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The definedness checks correctly apply pagination for offset zero, match existing repository patterns, and the adjusted session callers preserve their documented prior behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): apply score pagination when..."](https://github.com/langfuse/langfuse/commit/e584069f755093967a9f90b91114ca3d73511c49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55533031)</sub>

<!-- /greptile_comment -->