### PR TITLE
refactor(web): Extract `SearchInput` component with dropdown

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -16,6 +16,7 @@ const DESIGN_COMPONENT_STORIES = [
   "LangfuseIcon/LangfuseIcon",
   "LangfuseLogo/LangfuseLogo",
   "Progress/Progress",
+  "SearchInput/SearchInput",
   "Spinner/Spinner",
   "Switch/Switch",
 ] as const;

--- a/web/src/components/design-system/SearchInput/SearchInput.stories.tsx
+++ b/web/src/components/design-system/SearchInput/SearchInput.stories.tsx
@@ -1,0 +1,86 @@
+import { useState, type ComponentProps } from "react";
+import { expect, fn, userEvent, within } from "storybook/test";
+import preview from "../../../../.storybook/preview";
+import {
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+} from "@/src/components/ui/dropdown-menu";
+import { SearchInput } from "./SearchInput";
+
+function InteractiveSearchInput(props: ComponentProps<typeof SearchInput>) {
+  const [value, setValue] = useState(props.value);
+
+  return (
+    <SearchInput
+      {...props}
+      value={value}
+      onChange={(newValue) => {
+        setValue(newValue);
+        props.onChange(newValue);
+      }}
+    />
+  );
+}
+
+const dropdown = {
+  label: "Names, Tags",
+  content: (
+    <DropdownMenuRadioGroup value="metadata">
+      <DropdownMenuRadioItem value="metadata">
+        Names, Tags
+      </DropdownMenuRadioItem>
+      <DropdownMenuRadioItem value="content">Full Text</DropdownMenuRadioItem>
+    </DropdownMenuRadioGroup>
+  ),
+};
+
+const meta = preview.meta({
+  component: SearchInput,
+  render: (args) => <InteractiveSearchInput {...args} />,
+  args: {
+    disabled: false,
+    onSubmit: fn(),
+    onChange: fn(),
+    placeholder: "Search...",
+    value: "",
+  },
+});
+
+export const Default = meta.story({});
+
+export const WithDropdown = meta.story({
+  args: {
+    dropdown,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+    dropdown,
+  },
+});
+
+export const TestSubmitsOnEnter = meta.story({
+  name: "(Test) Submits on Enter",
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("searchbox");
+    await userEvent.type(input, "Prompt name{enter}");
+    await expect(input).toHaveValue("Prompt name");
+    await expect(args.onSubmit).toHaveBeenCalledWith("Prompt name");
+  },
+});
+
+export const TestOpensDropdown = meta.story({
+  name: "(Test) Opens Dropdown",
+  args: {
+    dropdown,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole("button", { name: "Names, Tags" });
+    await userEvent.click(trigger);
+    await expect(trigger).toHaveAttribute("data-state", "open");
+  },
+});

--- a/web/src/components/design-system/SearchInput/SearchInput.tsx
+++ b/web/src/components/design-system/SearchInput/SearchInput.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown, Search } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { cn } from "@/src/utils/tailwind";
+
+type SearchInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+  placeholder: string;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  onBlur?: (value: string) => void;
+  size?: "default" | "large";
+  dropdown?: {
+    label: React.ReactNode;
+    labelAccessory?: React.ReactNode;
+    content: React.ReactNode;
+  };
+};
+
+export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  (
+    {
+      value,
+      onChange,
+      onSubmit,
+      placeholder,
+      disabled = false,
+      autoFocus = false,
+      onBlur,
+      size = "default",
+      dropdown,
+    },
+    ref,
+  ) => (
+    <div
+      className={cn(
+        "border-input bg-background focus-within:ring-ring flex w-full min-w-0 items-stretch overflow-hidden rounded-md border focus-within:ring-2 focus-within:ring-offset-0",
+        size === "default" ? "h-8" : "h-9",
+      )}
+    >
+      <button
+        type="button"
+        aria-label="Search"
+        disabled={disabled}
+        onClick={() => onSubmit(value)}
+        className="text-foreground-tertiary hover:bg-accent hover:text-accent-foreground flex aspect-square shrink-0 items-center justify-center disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Search className="h-4 w-4" />
+      </button>
+      <input
+        ref={ref}
+        type="search"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        onBlur={() => onBlur?.(value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") onSubmit(value);
+        }}
+        className="placeholder:text-foreground-tertiary disabled:bg-muted/50 min-w-0 flex-1 appearance-none border-0 bg-transparent py-1 pr-2 pl-0 text-sm shadow-none outline-hidden focus:border-0 focus:shadow-none focus:ring-0 focus:ring-offset-0 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-search-cancel-button]:cursor-pointer"
+      />
+      {dropdown && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              className="hover:bg-accent hover:text-accent-foreground flex w-30 shrink-0 items-center justify-between gap-1 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="flex min-w-0 items-center gap-1">
+                <span
+                  className="truncate"
+                  title={
+                    typeof dropdown.label === "string"
+                      ? dropdown.label
+                      : undefined
+                  }
+                >
+                  {dropdown.label}
+                </span>
+                {dropdown.labelAccessory}
+              </span>
+              <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {dropdown.content}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  ),
+);
+
+SearchInput.displayName = "SearchInput";

--- a/web/src/components/design-system/SearchInput/SearchInput.tsx
+++ b/web/src/components/design-system/SearchInput/SearchInput.tsx
@@ -2,13 +2,28 @@
 
 import * as React from "react";
 import { ChevronDown, Search } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import { cn } from "@/src/utils/tailwind";
+
+const searchInputVariants = cva(
+  "border-input bg-background focus-within:ring-ring flex w-full min-w-0 items-stretch overflow-hidden rounded-md border focus-within:ring-2 focus-within:ring-offset-0",
+  {
+    variants: {
+      size: {
+        default: "h-8",
+        large: "h-9",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+);
 
 type SearchInputProps = {
   value: string;
@@ -18,13 +33,12 @@ type SearchInputProps = {
   disabled?: boolean;
   autoFocus?: boolean;
   onBlur?: (value: string) => void;
-  size?: "default" | "large";
   dropdown?: {
     label: React.ReactNode;
     labelAccessory?: React.ReactNode;
     content: React.ReactNode;
   };
-};
+} & VariantProps<typeof searchInputVariants>;
 
 export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
   (
@@ -41,12 +55,7 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
     },
     ref,
   ) => (
-    <div
-      className={cn(
-        "border-input bg-background focus-within:ring-ring flex w-full min-w-0 items-stretch overflow-hidden rounded-md border focus-within:ring-2 focus-within:ring-offset-0",
-        size === "default" ? "h-8" : "h-9",
-      )}
-    >
+    <div className={searchInputVariants({ size })}>
       <button
         type="button"
         aria-label="Search"
@@ -59,6 +68,7 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
       <input
         ref={ref}
         type="search"
+        data-1p-ignore
         value={value}
         placeholder={placeholder}
         disabled={disabled}

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @repo/no-style-props */
-import { Button } from "@/src/components/ui/button";
 import React, { type Dispatch, type SetStateAction, useState } from "react";
-import { Input } from "@/src/components/ui/input";
+import { SearchInput } from "@/src/components/design-system/SearchInput/SearchInput";
 import { DataTableColumnVisibilityFilter } from "@/src/components/table/data-table-column-visibility-filter";
 import { FilterToggleButton } from "@/src/components/table/FilterToggleButton";
 import { PopoverFilterBuilder } from "@/src/features/filters/components/filter-builder";
@@ -23,7 +22,6 @@ import {
   DataTableRowHeightSwitch,
   type RowHeight,
 } from "@/src/components/table/data-table-row-height-switch";
-import { Search, ChevronDown } from "lucide-react";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { TimeRangePicker } from "@/src/components/date-picker";
 import {
@@ -38,11 +36,8 @@ import {
   type SystemFilterPreset,
 } from "@/src/components/table/table-view-presets/components/data-table-view-presets-drawer";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
-  DropdownMenuTrigger,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
@@ -297,147 +292,118 @@ export function DataTableToolbar<TData, TValue>({
         )}
         {searchConfig && (
           <div className="flex max-w-120 shrink-0 items-stretch md:min-w-96">
-            <div
-              className={cn(
-                "border-input bg-background flex h-8 flex-1 items-center border pl-2",
-                showSearchTypeSelector
-                  ? "rounded-l-md rounded-r-none border-r-0"
-                  : "rounded-l-md rounded-r-md",
-              )}
-            >
-              <Button
-                variant="ghost"
-                size="icon"
-                className="mr-1"
-                onClick={() => {
-                  capture("table:search_submit");
-                  submitSearch(searchString);
-                }}
-              >
-                <Search className="h-4 w-4" />
-              </Button>
-              <Input
-                autoFocus
-                placeholder={
-                  searchConfig.tableAllowsFullTextSearch
-                    ? "Search..."
-                    : `Search (${searchConfig.metadataSearchFields?.join(", ")})`
+            <SearchInput
+              autoFocus
+              placeholder={
+                searchConfig.tableAllowsFullTextSearch
+                  ? "Search..."
+                  : `Search (${searchConfig.metadataSearchFields?.join(", ")})`
+              }
+              value={searchString}
+              onChange={(newValue) => {
+                setSearchString(newValue);
+                // If user cleared the search, update URL immediately
+                if (newValue === "") {
+                  submitSearch("");
                 }
-                value={searchString}
-                onChange={(event) => {
-                  const newValue = event.currentTarget.value;
-                  setSearchString(newValue);
-                  // If user cleared the search, update URL immediately
-                  if (newValue === "") {
-                    submitSearch("");
-                  }
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    capture("table:search_submit");
-                    submitSearch(searchString);
-                  }
-                }}
-                className="w-full border-none bg-transparent px-0 py-2 text-sm focus-visible:ring-0 focus-visible:outline-hidden"
-              />
-            </div>
-            {showSearchTypeSelector && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="default"
-                    className="flex w-30 items-center justify-between gap-1 rounded-l-none border-l-0"
-                  >
-                    <span
-                      className="flex items-center gap-1 truncate"
-                      title={searchButtonLabel}
-                    >
-                      {searchButtonLabel}
-                      <DocPopup
-                        description={getSearchDescription(
-                          searchConfig.searchType,
-                          searchConfig.metadataSearchFields,
-                          searchConfig.hidePerformanceWarning,
-                          searchConfig.tableAllowsFullTextSearch,
-                        )}
-                      />
-                    </span>
-                    <ChevronDown className="h-4 w-4 opacity-50" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuRadioGroup
-                    value={getSearchMode(
-                      searchConfig.searchType,
-                      searchConfig.tableAllowsFullTextSearch,
-                    )}
-                    onValueChange={(value) => {
-                      if (
-                        !searchConfig.tableAllowsFullTextSearch &&
-                        value.startsWith("metadata_fulltext")
-                      )
-                        return;
-                      searchConfig.setSearchType?.(searchModeToType(value));
-                    }}
-                  >
-                    <DropdownMenuRadioItem value="metadata">
-                      {searchConfig.customDropdownLabels?.metadata ??
-                        "IDs / Names"}
-                    </DropdownMenuRadioItem>
-                    <DropdownMenuSub>
-                      <DropdownMenuSubTrigger
-                        disabled={!searchConfig.tableAllowsFullTextSearch}
-                      >
-                        <span className="flex items-center gap-2">
-                          {getSearchMode(
+              }}
+              onSubmit={(value) => {
+                capture("table:search_submit");
+                submitSearch(value);
+              }}
+              dropdown={
+                showSearchTypeSelector
+                  ? {
+                      label: searchButtonLabel,
+                      labelAccessory: (
+                        <DocPopup
+                          description={getSearchDescription(
                             searchConfig.searchType,
+                            searchConfig.metadataSearchFields,
+                            searchConfig.hidePerformanceWarning,
                             searchConfig.tableAllowsFullTextSearch,
-                          ).startsWith("metadata_fulltext") && (
-                            <span className="h-2 w-2 shrink-0 rounded-full bg-current" />
                           )}
-                          {searchConfig.customDropdownLabels?.fullText ??
-                            "Full Text"}
-                        </span>
-                      </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent>
+                        />
+                      ),
+                      content: (
                         <DropdownMenuRadioGroup
                           value={getSearchMode(
                             searchConfig.searchType,
                             searchConfig.tableAllowsFullTextSearch,
                           )}
                           onValueChange={(value) => {
+                            if (
+                              !searchConfig.tableAllowsFullTextSearch &&
+                              value.startsWith("metadata_fulltext")
+                            )
+                              return;
                             searchConfig.setSearchType?.(
                               searchModeToType(value),
                             );
                           }}
                         >
-                          {/* Only show options that are explicitly available */}
-                          {(searchConfig.availableSearchTypes === undefined ||
-                            searchConfig.availableSearchTypes.content) && (
-                            <DropdownMenuRadioItem value="metadata_fulltext">
-                              Input/Output
-                            </DropdownMenuRadioItem>
-                          )}
-                          {(searchConfig.availableSearchTypes === undefined ||
-                            searchConfig.availableSearchTypes.input) && (
-                            <DropdownMenuRadioItem value="metadata_fulltext_input">
-                              Input
-                            </DropdownMenuRadioItem>
-                          )}
-                          {(searchConfig.availableSearchTypes === undefined ||
-                            searchConfig.availableSearchTypes.output) && (
-                            <DropdownMenuRadioItem value="metadata_fulltext_output">
-                              Output
-                            </DropdownMenuRadioItem>
-                          )}
+                          <DropdownMenuRadioItem value="metadata">
+                            {searchConfig.customDropdownLabels?.metadata ??
+                              "IDs / Names"}
+                          </DropdownMenuRadioItem>
+                          <DropdownMenuSub>
+                            <DropdownMenuSubTrigger
+                              disabled={!searchConfig.tableAllowsFullTextSearch}
+                            >
+                              <span className="flex items-center gap-2">
+                                {getSearchMode(
+                                  searchConfig.searchType,
+                                  searchConfig.tableAllowsFullTextSearch,
+                                ).startsWith("metadata_fulltext") && (
+                                  <span className="h-2 w-2 shrink-0 rounded-full bg-current" />
+                                )}
+                                {searchConfig.customDropdownLabels?.fullText ??
+                                  "Full Text"}
+                              </span>
+                            </DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent>
+                              <DropdownMenuRadioGroup
+                                value={getSearchMode(
+                                  searchConfig.searchType,
+                                  searchConfig.tableAllowsFullTextSearch,
+                                )}
+                                onValueChange={(value) => {
+                                  searchConfig.setSearchType?.(
+                                    searchModeToType(value),
+                                  );
+                                }}
+                              >
+                                {(searchConfig.availableSearchTypes ===
+                                  undefined ||
+                                  searchConfig.availableSearchTypes
+                                    .content) && (
+                                  <DropdownMenuRadioItem value="metadata_fulltext">
+                                    Input/Output
+                                  </DropdownMenuRadioItem>
+                                )}
+                                {(searchConfig.availableSearchTypes ===
+                                  undefined ||
+                                  searchConfig.availableSearchTypes.input) && (
+                                  <DropdownMenuRadioItem value="metadata_fulltext_input">
+                                    Input
+                                  </DropdownMenuRadioItem>
+                                )}
+                                {(searchConfig.availableSearchTypes ===
+                                  undefined ||
+                                  searchConfig.availableSearchTypes.output) && (
+                                  <DropdownMenuRadioItem value="metadata_fulltext_output">
+                                    Output
+                                  </DropdownMenuRadioItem>
+                                )}
+                              </DropdownMenuRadioGroup>
+                            </DropdownMenuSubContent>
+                          </DropdownMenuSub>
                         </DropdownMenuRadioGroup>
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+                      ),
+                    }
+                  : undefined
+              }
+            />
           </div>
         )}
         {viewModeToggle}

--- a/web/src/features/events/components/MobileFullTextSearch.tsx
+++ b/web/src/features/events/components/MobileFullTextSearch.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Search } from "lucide-react";
 
-import { Button } from "@/src/components/ui/button";
-import { Input } from "@/src/components/ui/input";
+import { SearchInput } from "@/src/components/design-system/SearchInput/SearchInput";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 /**
@@ -52,43 +50,29 @@ export function MobileFullTextSearch({
   };
 
   return (
-    <div className="border-input bg-background flex h-9 min-w-0 items-center rounded-md border pl-2">
-      <Button
-        variant="ghost"
-        size="icon"
-        aria-label="Search"
-        className="mr-1 h-7 w-7 shrink-0"
-        onClick={() => submit(draft)}
-      >
-        <Search className="h-4 w-4" />
-      </Button>
-      <Input
-        placeholder={
-          tableAllowsFullTextSearch
-            ? "Search…"
-            : `Search (${metadataSearchFields?.join(", ") ?? ""})`
-        }
-        value={draft}
-        onChange={(event) => {
-          const next = event.currentTarget.value;
-          setDraft(next);
-          // Match the toolbar: clearing the field applies immediately so the
-          // list unfilters without needing an explicit submit.
-          if (next === "") submit("");
-        }}
-        onKeyDown={(event) => {
-          if (event.key === "Enter") submit(draft);
-        }}
-        // Commit on blur too, so tapping the sheet's "Show results" (or anywhere
-        // outside the field) applies a typed-but-not-Entered query instead of
-        // discarding it — matching the grammar bar's commit-on-blur. Guarded so
-        // a focus/blur without changes (or right after an icon/Enter submit)
-        // doesn't re-fire.
-        onBlur={() => {
-          if (draft !== committed) submit(draft);
-        }}
-        className="w-full min-w-0 border-none bg-transparent px-0 text-sm focus-visible:ring-0 focus-visible:outline-hidden"
-      />
-    </div>
+    <SearchInput
+      size="large"
+      placeholder={
+        tableAllowsFullTextSearch
+          ? "Search…"
+          : `Search (${metadataSearchFields?.join(", ") ?? ""})`
+      }
+      value={draft}
+      onChange={(next) => {
+        setDraft(next);
+        // Match the toolbar: clearing the field applies immediately so the
+        // list unfilters without needing an explicit submit.
+        if (next === "") submit("");
+      }}
+      onSubmit={submit}
+      // Commit on blur too, so tapping the sheet's "Show results" (or anywhere
+      // outside the field) applies a typed-but-not-Entered query instead of
+      // discarding it — matching the grammar bar's commit-on-blur. Guarded so
+      // a focus/blur without changes (or right after an icon/Enter submit)
+      // doesn't re-fire.
+      onBlur={(value) => {
+        if (value !== committed) submit(value);
+      }}
+    />
   );
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16406.preview.langfuse.com](https://pr-16406.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extracts the table and mobile search controls into a reusable `SearchInput` design-system component while preserving their existing submit, clear, and search-mode behavior.
- Adds a controlled search input with optional dropdown, sizing, blur handling, disabled state, and forwarded ref.
- Migrates the shared data-table toolbar and mobile event search to the new component.
- Adds Storybook registration, interaction stories, and disabled/dropdown examples.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code failure identified.

The extracted component preserves the existing controlled values, submission paths, clear behavior, and reachable search-mode selection semantics in both migrated callers.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add SearchInput component"](https://github.com/langfuse/langfuse/commit/4487e69d7e682cdb4651d0bd883fa4b9a8bfe5ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55534563)</sub>

<!-- /greptile_comment -->