### PR TITLE
fix(assistant): preserve model prompts in traces

### DIFF
--- a/worker/src/features/in-app-agent/runtime/instrumentation.test.ts
+++ b/worker/src/features/in-app-agent/runtime/instrumentation.test.ts
@@ -1396,6 +1396,29 @@ describe("InAppAgentInstrumentation", () => {
     expect(finalAgentCreate).not.toHaveProperty("model");
   });
 
+  it("drops circular provider options from model call input", () => {
+    const instrumentation = createInstrumentation();
+    const providerOptions: Record<string, unknown> = {};
+    providerOptions.circular = providerOptions;
+
+    instrumentation.recordModelCallStart({
+      prompt: [{ role: "user", content: "hello" }],
+      providerOptions,
+    });
+    instrumentation.recordModelStreamPart({
+      type: "finish",
+      usage: { inputTokens: 100, outputTokens: 10, totalTokens: 110 },
+      finishReason: "stop",
+    });
+
+    const generation = mocks.handler.langfuse.enqueue.mock.calls.find(
+      ([type]) => type === "generation-create",
+    )?.[1];
+    expect(generation?.input).toEqual({
+      messages: [{ role: "user", content: "hello" }],
+    });
+  });
+
   it("emits tools after the generation using actual execution timing", () => {
     const instrumentation = createInstrumentation();
     const modelCallStart = new Date("2026-01-01T00:00:00.000Z");

--- a/worker/src/features/in-app-agent/runtime/instrumentation.ts
+++ b/worker/src/features/in-app-agent/runtime/instrumentation.ts
@@ -1283,8 +1283,7 @@ function getModelCallInput(options: unknown): unknown {
     return undefined;
   }
 
-  const input = {
-    messages: options.prompt,
+  const serializedOptions = toSerializableJson({
     maxOutputTokens: options.maxOutputTokens,
     temperature: options.temperature,
     stopSequences: options.stopSequences,
@@ -1297,9 +1296,14 @@ function getModelCallInput(options: unknown): unknown {
     tools: options.tools,
     toolChoice: options.toolChoice,
     providerOptions: options.providerOptions,
-  };
+  });
 
-  return toSerializableJson(input);
+  // The prompt is the exact provider-bound payload. Preserve it losslessly in
+  // tracing; this copy does not affect the options passed to the model.
+  return {
+    ...(options.prompt === undefined ? {} : { messages: options.prompt }),
+    ...(isRecord(serializedOptions) ? serializedOptions : {}),
+  };
 }
 
 function getModelUsageDetails(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16407.preview.langfuse.com](https://pr-16407.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves the exact provider-bound model prompt in in-app-agent generation traces while continuing to sanitize ancillary model options.
- Serializes model configuration and provider options separately from prompt messages.
- Adds coverage confirming circular provider options are omitted without dropping the prompt.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed tracing path preserves prompt messages while retaining serialization safeguards for ancillary options, and instrumentation failures remain isolated from agent execution.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): preserve model prompt..."](https://github.com/langfuse/langfuse/commit/166051525c85168d0be1f222ceb99c817c24ce90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55535523)</sub>

<!-- /greptile_comment -->