### PR TITLE
fix(mcp): Use matches observation filters

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -943,9 +943,10 @@ describe("MCP Read Tools", () => {
     });
 
     it("should return public-compatible observation filter schema", async () => {
-      const { context } = await createMcpTestSetup();
-
-      const result = (await handleGetObservationFilterSchema({}, context)) as {
+      const result = (await handleGetObservationFilterSchema(
+        {},
+        mockServerContext(),
+      )) as {
         resource: string;
         columns: Record<string, { type: string; operators: string[] }>;
       };
@@ -956,9 +957,13 @@ describe("MCP Read Tools", () => {
       expect(result.columns.metadata).toEqual(
         expect.objectContaining({
           type: "stringObject",
+          operators: expect.arrayContaining(["matches"]),
           requiresKey: true,
         }),
       );
+      expect(result.columns.input.operators).toEqual(["=", "matches"]);
+      expect(result.columns.output.operators).toEqual(["=", "matches"]);
+      expect(result.columns.version.operators).not.toContain("matches");
       expect(result.columns.traceTags).toBeUndefined();
       expect(result.columns.comments).toBeUndefined();
       expect(result.columns.scores).toBeUndefined();
@@ -1007,6 +1012,29 @@ describe("MCP Read Tools", () => {
     );
   });
 
+  it.each([
+    ["input", "contains"],
+    ["version", "matches"],
+  ] as const)("should reject %s filters using %s", async (column, operator) => {
+    await expect(
+      handleListObservations(
+        {
+          traceId: randomUUID(),
+          filter: [
+            {
+              type: "string",
+              column,
+              operator,
+              value: "needle",
+            },
+          ],
+          fields: ["id"],
+          limit: 100,
+        },
+        mockServerContext(),
+      ),
+    ).rejects.toThrow();
+  });
   maybeEventsTable("listObservations tool", () => {
     it("should have readOnlyHint annotation", () => {
       verifyToolAnnotations(listObservationsTool, { readOnlyHint: true });
@@ -1394,7 +1422,7 @@ describe("MCP Read Tools", () => {
       const matchingObservation = createObservationEvent({
         projectId,
         traceId,
-        input: `${"x".repeat(250)}${needle}`,
+        input: `${"x".repeat(250)} ${needle}`,
       });
 
       await createEventsCh([
@@ -1413,7 +1441,7 @@ describe("MCP Read Tools", () => {
             {
               type: "string",
               column: "input",
-              operator: "contains",
+              operator: "matches",
               value: needle,
             },
           ],
@@ -1452,7 +1480,7 @@ describe("MCP Read Tools", () => {
               {
                 type: "string",
                 column: "input",
-                operator: "contains",
+                operator: "matches",
                 value: "secret",
               },
             ],

--- a/web/src/features/mcp/features/observations/tools/getObservationFilterSchema.ts
+++ b/web/src/features/mcp/features/observations/tools/getObservationFilterSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   eventsTableCols,
   filterOperators,
+  FTS_MATCH_OPERATOR,
   OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMNS,
 } from "@langfuse/shared";
 import { defineTool } from "../../../core/define-tool";
@@ -26,6 +27,14 @@ const OBSERVATION_MCP_FILTER_CONFIG_COLUMN_OVERRIDES: Record<string, string> = {
   tags: "traceTags",
 };
 
+export const OBSERVATION_MCP_FTS_COLUMNS = new Set([
+  "input",
+  "output",
+  "metadata",
+]);
+
+export const OBSERVATION_MCP_INDEXED_IO_COLUMNS = new Set(["input", "output"]);
+
 export const [
   getObservationFilterSchemaTool,
   handleGetObservationFilterSchema,
@@ -49,12 +58,20 @@ export const [
         .filter((column) => column.id in publicFilterColumnsByConfigColumn)
         .map((column) => {
           const publicColumn = publicFilterColumnsByConfigColumn[column.id];
+          const operators = OBSERVATION_MCP_INDEXED_IO_COLUMNS.has(publicColumn)
+            ? ["=", FTS_MATCH_OPERATOR]
+            : [
+                ...filterOperators[column.type],
+                ...(OBSERVATION_MCP_FTS_COLUMNS.has(publicColumn)
+                  ? [FTS_MATCH_OPERATOR]
+                  : []),
+              ];
 
           return [
             publicColumn,
             {
               type: column.type,
-              operators: filterOperators[column.type],
+              operators,
               nullable: Boolean(column.nullable),
               requiresKey:
                 column.type === "stringObject" ||

--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -2,12 +2,15 @@ import {
   InvalidRequestError,
   OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMNS,
   booleanFilter,
+  eventsTableSingleFilter,
+  eventsTableStringFilter,
+  eventsTableStringObjectFilter,
   eventsTableCols,
   filterOperators,
+  FTS_MATCH_OPERATOR,
   numberFilter,
   ObservationLevelDomain,
   ObservationTypeDomain,
-  singleFilter,
   stringFilter,
   stringObjectFilter,
   stringOptionsFilter,
@@ -35,6 +38,10 @@ import {
   ObservationLimitSchema,
   projectObservation,
 } from "../schema";
+import {
+  OBSERVATION_MCP_FTS_COLUMNS,
+  OBSERVATION_MCP_INDEXED_IO_COLUMNS,
+} from "./getObservationFilterSchema";
 
 const ObservationCursorSchema =
   EncodedObservationsCursorV2String.optional().describe(
@@ -85,11 +92,18 @@ const OBSERVATION_MCP_FILTER_SCHEMA_BY_TYPE = {
         : z.literal("datetime").optional(),
       column: z.literal(column),
     }),
-  string: (column: string, requireType = false) =>
-    stringFilter.omit({ type: true, column: true }).extend({
+  string: (column: string, requireType = false) => {
+    const filterSchema = OBSERVATION_MCP_INDEXED_IO_COLUMNS.has(column)
+      ? eventsTableStringFilter.extend({
+          operator: z.enum(["=", FTS_MATCH_OPERATOR]),
+        })
+      : stringFilter;
+
+    return filterSchema.omit({ type: true, column: true }).extend({
       type: requireType ? z.literal("string") : z.literal("string").optional(),
       column: z.literal(column),
-    }),
+    });
+  },
   stringOptions: (column: string, requireType = false) =>
     stringOptionsFilter.omit({ type: true, column: true }).extend({
       type: requireType
@@ -111,13 +125,18 @@ const OBSERVATION_MCP_FILTER_SCHEMA_BY_TYPE = {
       type: requireType ? z.literal("number") : z.literal("number").optional(),
       column: z.literal(column),
     }),
-  stringObject: (column: string, requireType = false) =>
-    stringObjectFilter.omit({ type: true, column: true }).extend({
+  stringObject: (column: string, requireType = false) => {
+    const filterSchema = OBSERVATION_MCP_FTS_COLUMNS.has(column)
+      ? eventsTableStringObjectFilter
+      : stringObjectFilter;
+
+    return filterSchema.omit({ type: true, column: true }).extend({
       type: requireType
         ? z.literal("stringObject")
         : z.literal("stringObject").optional(),
       column: z.literal(column),
-    }),
+    });
+  },
   boolean: (column: string, requireType = false) =>
     booleanFilter.omit({ type: true, column: true }).extend({
       type: requireType
@@ -225,7 +244,7 @@ const ObservationMcpFilterSchema = z.preprocess(
       const type =
         filter.type ?? OBSERVATION_MCP_FILTER_COLUMN_TYPES.get(filter.column);
 
-      return singleFilter.parse(
+      return eventsTableSingleFilter.parse(
         filter.column === "tags"
           ? { ...filter, type, column: "traceTags" }
           : { ...filter, type },
@@ -369,36 +388,31 @@ export const [listObservationsTool, handleListObservations] = defineTool({
           "mcp.field_groups": fieldGroups.join(","),
         });
 
-        const items = await getObservationsV2FromEventsTableForPublicApi(
-          {
-            projectId: context.projectId,
-            page: 0,
-            limit: input.limit,
-            traceId: input.traceId,
-            userId: input.userId,
-            level: input.level,
-            name: input.name,
-            type: input.type,
-            environment: input.environment,
-            parentObservationId: input.parentObservationId,
-            isRootObservation: input.isRootObservation,
-            fromStartTime: input.fromStartTime,
-            toStartTime: input.toStartTime,
-            version: input.version,
-            advancedFilters: input.filter,
-            cursor: input.cursor
-              ? EncodedObservationsCursorV2.parse(input.cursor)
-              : undefined,
-            fields: fieldGroups,
-            expandMetadataKeys: getMetadataExpansionForProjection(
-              projectionFields,
-              input.expandMetadataKeys,
-            ),
-          },
-          // MCP keeps the legacy observation filter contract. Its separate
-          // selective-scope guard above limits expensive input/output filters.
-          { allowUnindexedIoFilters: true },
-        );
+        const items = await getObservationsV2FromEventsTableForPublicApi({
+          projectId: context.projectId,
+          page: 0,
+          limit: input.limit,
+          traceId: input.traceId,
+          userId: input.userId,
+          level: input.level,
+          name: input.name,
+          type: input.type,
+          environment: input.environment,
+          parentObservationId: input.parentObservationId,
+          isRootObservation: input.isRootObservation,
+          fromStartTime: input.fromStartTime,
+          toStartTime: input.toStartTime,
+          version: input.version,
+          advancedFilters: input.filter,
+          cursor: input.cursor
+            ? EncodedObservationsCursorV2.parse(input.cursor)
+            : undefined,
+          fields: fieldGroups,
+          expandMetadataKeys: getMetadataExpansionForProjection(
+            projectionFields,
+            input.expandMetadataKeys,
+          ),
+        });
 
         const hasMore = items.length > input.limit;
         const dataToReturn = hasMore ? items.slice(0, input.limit) : items;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16410.preview.langfuse.com](https://pr-16410.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates the observations MCP tools to accept and advertise the indexed `matches` operator for input, output, and metadata filters. It also removes the legacy unindexed I/O filter exception and adds regression coverage for the MCP schema and observation lookup behavior.

Impacted package: `web`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter @langfuse/shared run build`
- `pnpm run lint` (pre-commit hook): `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run test "src/__tests__/server/mcp-tools-read.servertest.ts" -t "should return public-compatible observation filter schema"`: `Tests 1 passed | 167 skipped (168)`

The end-to-end observation lookup case could not run because this agent environment cannot access its local Postgres/ClickHouse services; the schema-level regression runs without them.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-9995](https://linear.app/clickhouse/issue/LFE-9995/use-matches-in-observations-mcp)

<div><a href="https://cursor.com/agents/bc-14426eef-fcec-4a65-924e-db80a48a7fb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14426eef-fcec-4a65-924e-db80a48a7fb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns the observation MCP filter contract with indexed event-table filtering.
- Advertises and accepts `matches` for input, output, and metadata filters.
- Restricts input and output filters to the indexed `=` and `matches` operators.
- Removes the legacy unindexed-filter exception and adds regression coverage for schema and lookup behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported mismatch is fixed because input/output filters now advertise and accept only `=` and `matches`, matching the indexed query guard.
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix observation MCP filter operators"](https://github.com/langfuse/langfuse/commit/015065a85baf6d6ec95a0de39db4c0a0db610cff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55542608)</sub>

<!-- /greptile_comment -->