### PR TITLE
fix(assistant): Optimize sandbox & silent mcp tool prompt guidance

### DIFF
--- a/packages/shared/src/in-app-agent/server/persistence.test.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.test.ts
@@ -2,7 +2,6 @@ import { EventType } from "@ag-ui/core";
 import { describe, expect, it } from "vitest";
 
 import type { PrismaClient } from "../../db";
-import { IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE } from "../constants";
 import {
   createSandboxToolCallFileAccumulator,
   getConversationMessages,
@@ -13,6 +12,8 @@ describe("getConversationMessages", () => {
     const content = JSON.stringify({
       type: "silent-mcp-output",
       output: { data: [{ id: "observation-1" }] },
+      toolCallId: "tool-call-1",
+      toolName: "langfuse_getHealth",
     });
     const prisma = {
       inAppAgentEvent: {
@@ -43,7 +44,8 @@ describe("getConversationMessages", () => {
         id: "tool-result-1",
         role: "tool",
         toolCallId: "tool-call-1",
-        content: IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE,
+        content:
+          "Output saved to /workspace/tool_calls/langfuse_getHealth_tool-call-1.json",
       },
     ]);
   });
@@ -93,7 +95,7 @@ describe("createSandboxToolCallFileAccumulator", () => {
 
     expect(accumulator.getFiles()).toEqual([
       {
-        path: "tool_calls/2026-08-05T00-00-00.000Z_langfuse_getHealth_tool-call-1.json",
+        path: "tool_calls/langfuse_getHealth_tool-call-1.json",
         content: JSON.stringify(
           {
             request: { projectId: "project-1" },

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -40,6 +40,7 @@ import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import { safeJsonParse } from "../../utils/json";
 import {
   type CompletedInAppAgentMcpToolCall,
+  getInAppAgentSilentMcpOutputFilePath,
   getPublicInAppAgentMcpToolResultContent,
   getSandboxInAppAgentMcpToolResultContent,
 } from "./toolResults";
@@ -325,7 +326,10 @@ export function createSandboxToolCallFileAccumulator(
     }
 
     files.push({
-      path: `tool_calls/${formatSandboxToolCallTimestamp(draft?.createdAt ?? toolCall.createdAt)}_${draft?.toolName ?? toolCall.toolName}_${toolCall.toolCallId}.json`,
+      path: getInAppAgentSilentMcpOutputFilePath(
+        draft?.toolName ?? toolCall.toolName,
+        toolCall.toolCallId,
+      ),
       content: JSON.stringify(
         {
           request: draft
@@ -400,7 +404,7 @@ export function createSandboxToolCallFileAccumulator(
     }
 
     files.push({
-      path: `tool_calls/${formatSandboxToolCallTimestamp(draft.createdAt)}_${draft.toolName}_${toolCallId}.json`,
+      path: getInAppAgentSilentMcpOutputFilePath(draft.toolName, toolCallId),
       content: JSON.stringify(
         {
           request: parseSandboxToolCallValue(draft.request),
@@ -1490,10 +1494,6 @@ function parseSandboxToolCallValue(
 
   const parsed = safeJsonParse(value);
   return parsed === undefined ? value : parsed;
-}
-
-function formatSandboxToolCallTimestamp(date: Date) {
-  return date.toISOString().replaceAll(":", "-");
 }
 
 function getDefaultConversationTitle(date: Date) {

--- a/packages/shared/src/in-app-agent/server/toolResults.ts
+++ b/packages/shared/src/in-app-agent/server/toolResults.ts
@@ -9,6 +9,8 @@ import type { AgUiEvent } from "../schema";
 export type SilentInAppAgentMcpToolOutput = {
   type: typeof IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE;
   output: unknown;
+  toolCallId?: string;
+  toolName?: string;
 };
 
 export type CompletedInAppAgentMcpToolCall = {
@@ -20,11 +22,32 @@ export type CompletedInAppAgentMcpToolCall = {
   createdAt: Date;
 };
 
+export const getInAppAgentSilentMcpOutputFilePath = (
+  toolName: string,
+  toolCallId: string,
+) => `tool_calls/${toolName}_${toolCallId}.json`;
+
+export const getInAppAgentSilentMcpOutputMessage = (
+  toolName: string,
+  toolCallId: string,
+) =>
+  `Output saved to /workspace/${getInAppAgentSilentMcpOutputFilePath(toolName, toolCallId)}`;
+
 export function getPublicInAppAgentMcpToolResultContent(content: string) {
   try {
-    return isSilentInAppAgentMcpToolOutput(JSON.parse(content) as unknown)
-      ? IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE
-      : content;
+    const output = JSON.parse(content) as unknown;
+    if (!isSilentInAppAgentMcpToolOutput(output)) {
+      return content;
+    }
+
+    if (!output.toolCallId || !output.toolName) {
+      return IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE;
+    }
+
+    return getInAppAgentSilentMcpOutputMessage(
+      output.toolName,
+      output.toolCallId,
+    );
   } catch {
     return content;
   }

--- a/worker/src/features/in-app-agent/runtime/agent.test.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.test.ts
@@ -957,6 +957,9 @@ describe("createAgUiStream", () => {
         ).join(", "),
       }),
     );
+    expect(
+      promptMocks.compile.mock.calls[0]?.[0].sandboxFilesystem,
+    ).not.toContain("tool_calls");
     expect(promptMocks.compile).toHaveBeenCalledWith(
       expect.objectContaining({
         screenContext: expect.stringContaining(
@@ -1180,8 +1183,11 @@ describe("createAgUiStream", () => {
     const agentConfig = vi.mocked(Agent).mock.calls.at(-1)?.[0];
     const runInstruction = (agentConfig?.defaultOptions as { system?: string })
       ?.system;
-    expect(runInstruction).toContain("has been replaced with an empty one");
-    expect(runInstruction).toContain("restored in full");
+    expect(runInstruction).toContain("has expired and been replaced");
+    expect(runInstruction).toContain(
+      "Persisted tool-output files explicitly named in tool results remain available",
+    );
+    expect(runInstruction).not.toContain("/workspace/tool_calls");
     expect(
       promptMocks.compile.mock.calls.at(-1)?.[0]?.sandboxFilesystem,
     ).not.toContain("has been replaced with an empty one");
@@ -1633,6 +1639,8 @@ describe("createAgUiStream", () => {
     const input = createToolApprovalResumeInput(true, { silent: true });
     adapterEvents.createScoreConfigExecute.mockResolvedValueOnce({
       type: "silent-mcp-output",
+      toolCallId: "tool-call-1",
+      toolName: "langfuse_createScoreConfig",
       output: {
         id: "score-config-1",
         name: "readiness",
@@ -1640,7 +1648,8 @@ describe("createAgUiStream", () => {
       },
     });
     adapterEvents.createScoreConfigToModelOutput.mockImplementationOnce(
-      async () => "Output saved to /workspace/tool_calls",
+      async () =>
+        "Output saved to /workspace/tool_calls/langfuse_createScoreConfig_tool-call-1.json",
     );
     adapterEvents.inputs = [];
     adapterEvents.items = [
@@ -1690,15 +1699,20 @@ describe("createAgUiStream", () => {
 
     expect(resumedToolMessage).toMatchObject({
       role: "tool",
-      content: "Output saved to /workspace/tool_calls",
+      content:
+        "Output saved to /workspace/tool_calls/langfuse_createScoreConfig_tool-call-1.json",
     });
-    expect(streamedText).toContain("Output saved to /workspace/tool_calls");
+    expect(streamedText).toContain(
+      "Output saved to /workspace/tool_calls/langfuse_createScoreConfig_tool-call-1.json",
+    );
     expect(streamedText).not.toContain("full-tool-output");
     expect(persistedEvents).toContainEqual(
       expect.objectContaining({
         type: EventType.TOOL_CALL_RESULT,
         content: JSON.stringify({
           type: "silent-mcp-output",
+          toolCallId: "tool-call-1",
+          toolName: "langfuse_createScoreConfig",
           output: {
             id: "score-config-1",
             name: "readiness",

--- a/worker/src/features/in-app-agent/runtime/agent.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.ts
@@ -141,17 +141,16 @@ function formatSandboxContext(sandbox?: InAppAgentSandbox): string {
 <sandbox_filesystem>
 When working in the sandbox filesystem, assume this layout:
 - "/workspace" is the current working directory for normal file operations and shell commands.
-- "/workspace/tool_calls" contains all past tool calls and their outputs, including full results requested with the silent argument. Treat this directory as read-only; any changes to it will be discarded before the next tool call.
 </sandbox_filesystem>
 `;
 }
 
 /** Run-scoped, not part of the managed prompt: it describes one turn's environment. */
 const SANDBOX_WORKSPACE_RESET_INSTRUCTION = `<sandbox_workspace_reset>
-The sandbox workspace from earlier turns in this conversation expired and has been replaced with an empty one.
-- Any file you created earlier with write, edit, or bash is gone, along with installed packages and all process state.
-- "/workspace/tool_calls" has been restored in full from the conversation history, so results of earlier successful tool calls are still readable there. Failed tool calls were never stored.
-- Do not assume a path exists because you created it earlier in this conversation. Read it first, and recreate what you still need.
+The sandbox session from earlier turns has expired and been replaced.
+- Files created earlier with write, edit, or bash are gone, along with installed packages and process state.
+- Persisted tool-output files explicitly named in tool results remain available.
+- Do not assume any other path exists; read it first and recreate it if needed.
 </sandbox_workspace_reset>`;
 
 const STEP_LIMIT_WRAP_UP_INSTRUCTION = `<step_limit_wrap_up>

--- a/worker/src/features/in-app-agent/runtime/sandbox/sandbox.test.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/sandbox.test.ts
@@ -146,7 +146,7 @@ describe("in-app agent sandbox", () => {
     });
   });
 
-  it("returns the sandbox tool-call directory for silent MCP output", async () => {
+  it("returns the exact sandbox file for silent MCP output", async () => {
     const execute = async (input: { query: string }) => ({
       result: input.query,
     });
@@ -171,17 +171,18 @@ describe("in-app agent sandbox", () => {
       tool.inputSchema.safeParse({ query: "test", silent: true }).success,
     ).toBe(true);
 
-    const output = await tool.execute?.(
-      { query: "test", silent: true },
-      {} as never,
-    );
+    const output = await tool.execute?.({ query: "test", silent: true }, {
+      agent: { toolCallId: "tool-call-1" },
+    } as never);
 
     expect(output).toEqual({
       type: "silent-mcp-output",
       output: { result: "test" },
+      toolCallId: "tool-call-1",
+      toolName: "search",
     });
     expect(tool.toModelOutput?.(output)).toBe(
-      "Output saved to /workspace/tool_calls",
+      "Output saved to /workspace/tool_calls/search_tool-call-1.json",
     );
   });
 
@@ -227,13 +228,14 @@ describe("in-app agent sandbox", () => {
     });
 
     await expect(
-      tools.listObservations.execute?.(
-        { limit: 10, silent: true },
-        {} as never,
-      ),
+      tools.listObservations.execute?.({ limit: 10, silent: true }, {
+        agent: { toolCallId: "tool-call-2" },
+      } as never),
     ).resolves.toEqual({
       type: "silent-mcp-output",
       output: { data: [] },
+      toolCallId: "tool-call-2",
+      toolName: "listObservations",
     });
     expect(receivedInput).toEqual({ limit: 10 });
   });

--- a/worker/src/features/in-app-agent/runtime/tools.ts
+++ b/worker/src/features/in-app-agent/runtime/tools.ts
@@ -36,10 +36,10 @@ import {
   InAppAgentSandboxReadArgsSchema,
   InAppAgentSandboxWriteArgsSchema,
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
-  IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE,
   IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE,
 } from "@langfuse/shared/in-app-agent";
 import {
+  getInAppAgentSilentMcpOutputMessage,
   isSilentInAppAgentMcpToolOutput,
   type CompletedInAppAgentMcpToolCall,
   type SilentInAppAgentMcpToolOutput,
@@ -205,7 +205,7 @@ export function withOptionalSilentMcpOutput(params: {
         // Never silence a failure. A tool that reports its error in the result
         // (the MCP `isError` convention) would otherwise be collapsed to a
         // pointer at a tool_calls file that is deliberately not written.
-        if (failureMessage || !silent) {
+        if (failureMessage || !silent || !toolCallId) {
           return result;
         }
 
@@ -213,11 +213,22 @@ export function withOptionalSilentMcpOutput(params: {
         return {
           type: IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE,
           output: result,
+          toolCallId,
+          toolName,
         } satisfies SilentInAppAgentMcpToolOutput;
       };
       tool.toModelOutput = (output) => {
         if (isSilentInAppAgentMcpToolOutput(output)) {
-          return IN_APP_AGENT_SILENT_MCP_OUTPUT_MESSAGE;
+          if (!output.toolCallId) {
+            return output.output;
+          }
+
+          return output.toolName
+            ? getInAppAgentSilentMcpOutputMessage(
+                output.toolName,
+                output.toolCallId,
+              )
+            : output.output;
         }
 
         return toModelOutput ? toModelOutput(output) : output;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16411.preview.langfuse.com](https://pr-16411.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Clarifies the in-app agent sandbox prompt so it reads persisted tool-call files only when the tool used silent output. Non-silent output is already present in the conversation and should not be read again.

Impacted package: `worker`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter worker run test src/features/in-app-agent/runtime/agent.test.ts`
- `pnpm run lint` (pre-commit hook)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15427](https://linear.app/clickhouse/issue/LFE-15427/avoid-reading-tool-output-file-if-output-was-non-silent)

<div><a href="https://cursor.com/agents/bc-fed325be-7ca6-451c-a1dd-bcad4002a992?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fed325be-7ca6-451c-a1dd-bcad4002a992&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Clarifies the in-app agent sandbox instructions so persisted tool-call files are read only when output was suppressed from the conversation.

- Distinguishes silent from non-silent tool output in the sandbox filesystem prompt.
- Adds focused assertions covering the revised prompt text.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The change only clarifies prompt guidance consistently with the existing behavior in which silent results are suppressed from conversation context and retained in sandbox files.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): clarify silent tool output a..."](https://github.com/langfuse/langfuse/commit/72e38b54a88bae2256a0d01562641011057a3441) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55542994)</sub>

**Context used:**

- Knowledge Base — [In-App Agent](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent.md)

<!-- /greptile_comment -->