### PR TITLE
chore: disable prod-jp from cloud deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
                 return `["staging"]`
               }
               if (context.ref === "refs/heads/production") {
-                return `["prod-eu", "prod-us", "prod-hipaa", "prod-jp"]`
+                return `["prod-eu", "prod-us", "prod-hipaa"]`
               }
             }
             return "[]"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes `prod-jp` from the automatic ECS deployment matrix used for production-branch pushes.

- Production pushes continue deploying to `prod-eu`, `prod-us`, and `prod-hipaa`.
- Manual `prod-jp` deployment remains available through workflow dispatch.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it cleanly implements the stated removal of prod-jp from automatic cloud deployments.

The reduced environment matrix remains valid JSON, downstream deployment jobs accept any resulting environment set, and no accepted blocking or non-blocking defect remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: disable prod-jp from cloud deploy..."](https://github.com/langfuse/langfuse/commit/ebef4d638aca021f2a9c73d3169bc216ba49c9e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55550639)</sub>

<!-- /greptile_comment -->