### PR TITLE
fix(annotation-queues): Don't reset trace expansion state between traces

### DIFF
--- a/web/src/features/traces/components/Trace.tsx
+++ b/web/src/features/traces/components/Trace.tsx
@@ -46,14 +46,17 @@ const DESKTOP_LAYOUT_BY_CONTEXT = {
   fullscreen: {
     groupId: "trace-layout-v3",
     defaultNavigationCollapsed: false,
+    expandDetailOnMount: false,
   },
   peek: {
     groupId: "trace-layout-peek-v1",
     defaultNavigationCollapsed: false,
+    expandDetailOnMount: false,
   },
   annotation: {
     groupId: "trace-layout-annotation-v1",
     defaultNavigationCollapsed: true,
+    expandDetailOnMount: true,
   },
 } as const;
 
@@ -213,7 +216,7 @@ function DesktopTraceContent({
   desktopLayout: DesktopLayout;
 }) {
   return (
-    <TraceLayoutDesktop {...desktopLayout}>
+    <TraceLayoutDesktop key={desktopLayout.groupId} {...desktopLayout}>
       <TraceLayoutDesktop.NavigationPanel>
         <TracePanelNavigationLayoutDesktop
           secondaryContent={shouldShowGraph ? <TraceGraphView /> : undefined}

--- a/web/src/features/traces/components/Trace.tsx
+++ b/web/src/features/traces/components/Trace.tsx
@@ -42,16 +42,39 @@ export type TraceProps = {
   truncatedAtObservations?: number;
 };
 
+const DESKTOP_LAYOUT_BY_CONTEXT = {
+  fullscreen: {
+    groupId: "trace-layout-v3",
+    defaultNavigationCollapsed: false,
+  },
+  peek: {
+    groupId: "trace-layout-peek-v1",
+    defaultNavigationCollapsed: false,
+  },
+  annotation: {
+    groupId: "trace-layout-annotation-v1",
+    defaultNavigationCollapsed: true,
+  },
+} as const;
+
+type DesktopLayout =
+  (typeof DESKTOP_LAYOUT_BY_CONTEXT)[keyof typeof DESKTOP_LAYOUT_BY_CONTEXT];
+
 /**
  * SelectionProvider sits ABOVE the trace data so the selected observation can be
  * resolved before the tree is built: past the observation cap the selected row is
  * missing from the loaded list and has to be fetched and merged in.
  */
 export function Trace({ context, ...props }: TraceProps) {
+  const traceContext = context ?? "fullscreen";
+
   return (
-    <ViewPreferencesProvider traceContext={context}>
+    <ViewPreferencesProvider traceContext={traceContext}>
       <SelectionProvider>
-        <TraceWithSelection {...props} />
+        <TraceWithSelection
+          {...props}
+          desktopLayout={DESKTOP_LAYOUT_BY_CONTEXT[traceContext]}
+        />
       </SelectionProvider>
     </ViewPreferencesProvider>
   );
@@ -64,7 +87,10 @@ function TraceWithSelection({
   corrections,
   projectId,
   truncatedAtObservations,
-}: Omit<TraceProps, "context">) {
+  desktopLayout,
+}: Omit<TraceProps, "context"> & {
+  desktopLayout: DesktopLayout;
+}) {
   const { selectedNodeId } = useSelection();
 
   // Fetch comment counts using existing hook
@@ -133,7 +159,7 @@ function TraceWithSelection({
         <SearchProvider>
           <JsonExpansionProvider>
             <PlayheadProvider>
-              <TraceContent />
+              <TraceContent desktopLayout={desktopLayout} />
             </PlayheadProvider>
           </JsonExpansionProvider>
         </SearchProvider>
@@ -155,7 +181,7 @@ function TraceWithSelection({
  * - useViewPreferences() - for graph toggle state
  * - useTraceGraphData() - for graph availability
  */
-function TraceContent() {
+function TraceContent({ desktopLayout }: { desktopLayout: DesktopLayout }) {
   const isMobile = useIsMobile();
   const { showGraph } = useViewPreferences();
   const { isGraphViewAvailable } = useTraceGraphData();
@@ -164,7 +190,10 @@ function TraceContent() {
   return isMobile ? (
     <MobileTraceContent shouldShowGraph={shouldShowGraph} />
   ) : (
-    <DesktopTraceContent shouldShowGraph={shouldShowGraph} />
+    <DesktopTraceContent
+      shouldShowGraph={shouldShowGraph}
+      desktopLayout={desktopLayout}
+    />
   );
 }
 
@@ -178,11 +207,13 @@ function TraceContent() {
  */
 function DesktopTraceContent({
   shouldShowGraph,
+  desktopLayout,
 }: {
   shouldShowGraph: boolean;
+  desktopLayout: DesktopLayout;
 }) {
   return (
-    <TraceLayoutDesktop>
+    <TraceLayoutDesktop {...desktopLayout}>
       <TraceLayoutDesktop.NavigationPanel>
         <TracePanelNavigationLayoutDesktop
           secondaryContent={shouldShowGraph ? <TraceGraphView /> : undefined}

--- a/web/src/features/traces/components/TraceLayoutDesktop.tsx
+++ b/web/src/features/traces/components/TraceLayoutDesktop.tsx
@@ -174,10 +174,12 @@ export function TraceLayoutDesktop({
   children,
   groupId,
   defaultNavigationCollapsed,
+  expandDetailOnMount,
 }: {
   children: ReactNode;
   groupId: string;
   defaultNavigationCollapsed: boolean;
+  expandDetailOnMount: boolean;
 }) {
   // Get current view mode from URL
   const [viewMode] = useQueryParam("view", StringParam);
@@ -392,14 +394,15 @@ export function TraceLayoutDesktop({
   };
 
   // Selecting another node (timeline/tree) while the detail panel is collapsed
-  // reopens it. This covers selection CHANGES (incl. the search list); re-
+  // reopens it. Annotation items also reopen it on mount so a collapsed layout
+  // cannot hide the trace overview on the next trace-level queue item. Re-
   // selecting the same node is handled at the row click via expandDetailPanel,
   // since the URL param — and thus this effect — doesn't change on re-click.
   const { selectedNodeId } = useSelection();
   useEffect(() => {
     // Guard on selectedNodeId so a deliberately-collapsed panel isn't reopened
     // on mount/refresh when there's no selection (effects always run once).
-    if (selectedNodeId) expandDetailPanel();
+    if (selectedNodeId || expandDetailOnMount) expandDetailPanel();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedNodeId]);
 

--- a/web/src/features/traces/components/TraceLayoutDesktop.tsx
+++ b/web/src/features/traces/components/TraceLayoutDesktop.tsx
@@ -23,16 +23,6 @@ import { useViewPreferences } from "@/src/features/traces/contexts/ViewPreferenc
 import { useSelection } from "@/src/features/traces/contexts/SelectionContext";
 import { resolveEffectiveWidthFraction } from "@/src/components/table/peek/store/peekPanelStore";
 
-// Full-page trace view's layout group. v3: the full-page view gets the same
-// computed info-favoring default + localStorage persistence as the peek
-// (LFE-10729); bumped from v2 so stale saved layouts from the old 60/40-share
-// era don't mask the new default.
-const RESIZABLE_PANEL_GROUP_ID = "trace-layout-v3";
-// Peek keeps a distinct group id so the two surfaces remember their sizes
-// independently — a split dragged in a ~50vw peek is rarely right for a
-// full-page trace, and vice versa. Same panels, different layout scope
-// (LFE-10601).
-const PEEK_RESIZABLE_PANEL_GROUP_ID = "trace-layout-peek-v1";
 const RESIZABLE_PANEL_HANDLE_ID = "trace-layout-handle";
 const RESIZABLE_PANEL_NAVIGATION_ID = "trace-layout-panel-navigation";
 const RESIZABLE_PANEL_PREVIEW_ID = "trace-layout-panel-preview";
@@ -180,36 +170,27 @@ export function useDesktopLayoutContextOptional() {
   return useContext(LayoutContext);
 }
 
-export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
+export function TraceLayoutDesktop({
+  children,
+  groupId,
+  defaultNavigationCollapsed,
+}: {
+  children: ReactNode;
+  groupId: string;
+  defaultNavigationCollapsed: boolean;
+}) {
   // Get current view mode from URL
   const [viewMode] = useQueryParam("view", StringParam);
   const isTimelineView = viewMode === "timeline";
 
-  // Get annotation mode + peek mode from context. Peek scopes the layout to its
-  // own group so a split dragged there doesn't leak into the full-page view and
-  // vice versa (LFE-10601).
-  const { isAnnotationMode, isPeekMode } = useViewPreferences();
+  // Peek sizing depends on the drawer width; persistence scope is caller-owned.
+  const { isPeekMode } = useViewPreferences();
 
-  const groupId = isPeekMode
-    ? PEEK_RESIZABLE_PANEL_GROUP_ID
-    : RESIZABLE_PANEL_GROUP_ID;
-  // Both views persist their split in localStorage (like the peek's outer
-  // width), so a resized tree/info ratio sticks across tabs and reloads instead
-  // of resetting per tab (the peek's old sessionStorage behavior, fixed in
-  // LFE-10601; the full-page's in LFE-10729). Guarded so SSR / DOM-less tests
-  // fall back to a no-op store instead of throwing on the bare global.
-  //
-  // Annotation mode is an opinionated workspace — nav on its rail, detail
-  // full-width — that never SAVES a layout (onLayoutChanged below), so it must
-  // not INHERIT one either: it shares the full-page group id, and a full-page
-  // session that parked the detail panel on its 40px rail would otherwise open
-  // annotation with BOTH panels collapsed (trace-level queue items have no
-  // selection to auto-expand the detail panel). No-op storage keeps it on the
-  // computed default.
+  // The caller owns the persistence scope and first-use default. Keeping that
+  // policy outside this layout lets annotation queues retain their workspace
+  // across keyed trace remounts without inheriting the full-page trace layout.
   const storage =
-    typeof window === "undefined" || isAnnotationMode
-      ? NOOP_LAYOUT_STORAGE
-      : window.localStorage;
+    typeof window === "undefined" ? NOOP_LAYOUT_STORAGE : window.localStorage;
 
   // The width the trace container actually opens at, driving the computed
   // default split. Peek: the drawer width — when expanded (a shared/reloaded
@@ -262,7 +243,7 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
 
   const [isNavigationPanelCollapsed, setIsNavigationPanelCollapsed] = useState(
     () =>
-      isAnnotationMode ||
+      (defaultNavigationCollapsed && !defaultLayout) ||
       isPanelCollapsedInLayout(
         defaultLayout,
         RESIZABLE_PANEL_NAVIGATION_ID,
@@ -422,10 +403,11 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedNodeId]);
 
-  // Collapse panel on initial mount if in annotation mode
+  // Apply the caller's first-use default. A restored layout always wins.
   useEffect(() => {
     if (
-      isAnnotationMode &&
+      defaultNavigationCollapsed &&
+      !defaultLayout &&
       panelRef.current &&
       !panelRef.current.isCollapsed()
     ) {
@@ -492,7 +474,7 @@ export function TraceLayoutDesktop({ children }: { children: ReactNode }) {
           id={groupId}
           groupRef={groupRef}
           defaultLayout={defaultLayout ?? computedDefaultLayout}
-          onLayoutChanged={isAnnotationMode ? undefined : onLayoutChanged}
+          onLayoutChanged={onLayoutChanged}
           className={bothPanelsOpen ? undefined : "min-w-0"}
           style={
             bothPanelsOpen


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16417.preview.langfuse.com](https://pr-16417.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR gives fullscreen, peek, and annotation trace layouts separate persistence policies so annotation panel expansion survives trace remounts.

- Moves layout group IDs and first-use navigation defaults into context-specific configuration.
- Enables localStorage persistence for annotation layouts.
- Passes the selected desktop layout policy through the trace component hierarchy.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until layout state is reset when an existing trace switches between fullscreen and peek contexts.

Context can change while TraceLayoutDesktop remains mounted, leaving mount-initialized collapse state associated with the previous persistence group and allowing it to leak into the newly selected layout scope.

**Files Needing Attention:** web/src/features/traces/components/TraceLayoutDesktop.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/components/TraceLayoutDesktop.tsx:244-249
**Context switch retains panel state**

When the same trace switches between fullscreen and peek through the `peek` query parameter, these mount-only state initializers retain the previous context's collapse state while `groupId` changes, causing one surface's panel state to be displayed and subsequently persisted under the other surface's layout group.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Persist trace layout across annotation i..."](https://github.com/langfuse/langfuse/commit/f2e6703e33aefd1fa8b5e00e872ff5a81ab93236) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55553264)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->