### PR TITLE
fix(otel): do not cost AI SDK embeddings operation spans that duplicate model-call usage

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -172,6 +172,7 @@ interface CreateObservationEventParams {
   isLangfuseSDKSpans: boolean;
   startTimeISO: string;
   endTimeISO: string;
+  embeddingsOperationParentSpanIds: Set<string>;
 }
 
 type NanoTimestamp =
@@ -361,6 +362,9 @@ export class OtelIngestionProcessor {
           return [];
         }
 
+        const embeddingsOperationParentSpanIds =
+          this.collectAiSdkEmbeddingOperationParentSpanIds(resourceSpans);
+
         return resourceSpans
           .filter((r) => Boolean(r))
           .flatMap((resourceSpan) => {
@@ -479,11 +483,19 @@ export class OtelIngestionProcessor {
 
                 // AI SDK agent spans carry aggregate usage duplicating their
                 // child model-call spans — skip model/usage/cost for them.
-                const isAiSdkAgentSpan =
-                  this.isAiSdkAgentOperation(spanAttributes);
+                // The same applies to an AI SDK "embeddings" operation span
+                // that is the parent of another "embeddings" span in this
+                // batch (embed/embedMany's aggregate wrapper).
+                const skipModelUsageAndCost =
+                  this.isAiSdkAgentOperation(spanAttributes) ||
+                  this.isDuplicateAiSdkEmbeddingOperationSpan(
+                    spanAttributes,
+                    spanId,
+                    embeddingsOperationParentSpanIds,
+                  );
 
                 const usageDetails = UsageDetails.safeParse(
-                  isAiSdkAgentSpan
+                  skipModelUsageAndCost
                     ? {}
                     : this.extractUsageDetails(
                         spanAttributes,
@@ -582,7 +594,7 @@ export class OtelIngestionProcessor {
                     spanAttributes,
                     scopeSpan?.scope?.name ?? "",
                   ),
-                  modelName: isAiSdkAgentSpan
+                  modelName: skipModelUsageAndCost
                     ? undefined
                     : this.extractModelName(spanAttributes),
                   completionStartTime: this.extractCompletionStartTime(
@@ -594,7 +606,7 @@ export class OtelIngestionProcessor {
                   providedUsageDetails: usageDetails.success
                     ? usageDetails.data
                     : undefined,
-                  providedCostDetails: isAiSdkAgentSpan
+                  providedCostDetails: skipModelUsageAndCost
                     ? {}
                     : this.extractCostDetails(spanAttributes, spanContext),
 
@@ -696,10 +708,21 @@ export class OtelIngestionProcessor {
             return [];
           }
 
+          // The AI SDK OTel integration emits an aggregate-usage "embeddings"
+          // operation span whose child model-call span (same operation name)
+          // carries the same usage/cost — collect which spans are such
+          // duplicated parents before processing so the parent can be
+          // skipped below.
+          const embeddingsOperationParentSpanIds =
+            this.collectAiSdkEmbeddingOperationParentSpanIds(resourceSpans);
+
           // Process all events normally first
           const allEvents = resourceSpans.flatMap((resourceSpan) => {
             if (!resourceSpan) return [];
-            return this.processResourceSpan(resourceSpan);
+            return this.processResourceSpan(
+              resourceSpan,
+              embeddingsOperationParentSpanIds,
+            );
           });
 
           // Filter out redundant shallow trace events
@@ -861,6 +884,7 @@ export class OtelIngestionProcessor {
 
   private processResourceSpan(
     resourceSpan: ResourceSpan,
+    embeddingsOperationParentSpanIds: Set<string>,
   ): IngestionEventType[] {
     const resourceAttributes = this.extractResourceAttributes(resourceSpan);
     const events: IngestionEventType[] = [];
@@ -881,6 +905,7 @@ export class OtelIngestionProcessor {
           resourceAttributes,
           scopeAttributes,
           isLangfuseSDKSpans,
+          embeddingsOperationParentSpanIds,
         );
         events.push(...spanEvents);
       }
@@ -895,6 +920,7 @@ export class OtelIngestionProcessor {
     resourceAttributes: Record<string, unknown>,
     scopeAttributes: Record<string, unknown>,
     isLangfuseSDKSpans: boolean,
+    embeddingsOperationParentSpanIds: Set<string>,
   ): IngestionEventType[] {
     const events: IngestionEventType[] = [];
     const attributes = this.extractSpanAttributes(span);
@@ -963,6 +989,7 @@ export class OtelIngestionProcessor {
       isLangfuseSDKSpans,
       startTimeISO,
       endTimeISO,
+      embeddingsOperationParentSpanIds,
     });
     events.push(observationEvent);
 
@@ -1122,6 +1149,7 @@ export class OtelIngestionProcessor {
       isLangfuseSDKSpans,
       startTimeISO,
       endTimeISO,
+      embeddingsOperationParentSpanIds,
     } = params;
 
     const instrumentationScopeName = scopeSpan?.scope?.name;
@@ -1153,8 +1181,16 @@ export class OtelIngestionProcessor {
     );
 
     // AI SDK agent spans carry aggregate usage duplicating their child
-    // model-call spans — skip model/usage/cost for them.
-    const isAiSdkAgentSpan = this.isAiSdkAgentOperation(attributes);
+    // model-call spans — skip model/usage/cost for them. The same applies to
+    // an AI SDK "embeddings" operation span that is the parent of another
+    // "embeddings" span in this batch (embed/embedMany's aggregate wrapper).
+    const skipModelUsageAndCost =
+      this.isAiSdkAgentOperation(attributes) ||
+      this.isDuplicateAiSdkEmbeddingOperationSpan(
+        attributes,
+        observationSpanId,
+        embeddingsOperationParentSpanIds,
+      );
 
     const mappedObservationType = observationTypeMapper.mapToObservationType(
       attributes,
@@ -1200,7 +1236,9 @@ export class OtelIngestionProcessor {
         attributes,
         instrumentationScopeName,
       ) as any,
-      model: isAiSdkAgentSpan ? undefined : this.extractModelName(attributes),
+      model: skipModelUsageAndCost
+        ? undefined
+        : this.extractModelName(attributes),
       promptName: canLinkPrompt
         ? (attributes?.[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME] ??
           attributes["langfuse.prompt.name"] ??
@@ -1215,14 +1253,14 @@ export class OtelIngestionProcessor {
           this.parseLangfusePromptFromAISDK(attributes)?.version ??
           null)
         : null,
-      usageDetails: isAiSdkAgentSpan
+      usageDetails: skipModelUsageAndCost
         ? {}
         : this.extractUsageDetails(
             attributes,
             instrumentationScopeName,
             observationContext,
           ),
-      costDetails: isAiSdkAgentSpan
+      costDetails: skipModelUsageAndCost
         ? {}
         : this.extractCostDetails(attributes, observationContext),
       input: normalizedToolMetadata.input,
@@ -2597,6 +2635,53 @@ export class OtelIngestionProcessor {
       typeof operationName === "string" &&
       ["invoke_agent", "agent_step"].includes(operationName)
     );
+  }
+
+  /**
+   * The Vercel AI SDK OTel integration emits `embed()`/`embedMany()` as two
+   * nested spans that share the same `gen_ai.operation.name: "embeddings"`:
+   * an operation span (root) carrying aggregate usage, and a model-call span
+   * per provider call (child) carrying the same usage. Until the upstream
+   * integration gives the wrapper a distinct operation name
+   * (https://github.com/vercel/ai/issues/19250), the parent is identified
+   * structurally: it is an `embeddings` span that is also the parent of
+   * another `embeddings` span within the same ingestion batch.
+   */
+  private isDuplicateAiSdkEmbeddingOperationSpan(
+    attributes: Record<string, unknown>,
+    spanId: string,
+    embeddingsOperationParentSpanIds: Set<string>,
+  ): boolean {
+    return (
+      attributes["gen_ai.operation.name"] === "embeddings" &&
+      embeddingsOperationParentSpanIds.has(spanId)
+    );
+  }
+
+  /**
+   * Collects the spanIds of AI SDK `embeddings` operation spans that are the
+   * parent of another `embeddings` operation span within this batch.
+   */
+  private collectAiSdkEmbeddingOperationParentSpanIds(
+    resourceSpans: ResourceSpan[],
+  ): Set<string> {
+    const parentSpanIds = new Set<string>();
+
+    for (const resourceSpan of resourceSpans ?? []) {
+      for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {
+        for (const span of scopeSpan?.spans ?? []) {
+          if (!span?.parentSpanId) continue;
+
+          const attributes = this.extractSpanAttributes(span);
+          if (attributes["gen_ai.operation.name"] === "embeddings") {
+            const parentSpanId: any = span.parentSpanId;
+            parentSpanIds.add(this.parseId(parentSpanId?.data ?? parentSpanId));
+          }
+        }
+      }
+    }
+
+    return parentSpanIds;
   }
 
   private extractModelName(

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -490,6 +490,7 @@ export class OtelIngestionProcessor {
                   this.isAiSdkAgentOperation(spanAttributes) ||
                   this.isDuplicateAiSdkEmbeddingOperationSpan(
                     spanAttributes,
+                    traceId,
                     spanId,
                     embeddingsOperationParentSpanIds,
                   );
@@ -1188,6 +1189,7 @@ export class OtelIngestionProcessor {
       this.isAiSdkAgentOperation(attributes) ||
       this.isDuplicateAiSdkEmbeddingOperationSpan(
         attributes,
+        traceId,
         observationSpanId,
         embeddingsOperationParentSpanIds,
       );
@@ -2645,22 +2647,35 @@ export class OtelIngestionProcessor {
    * integration gives the wrapper a distinct operation name
    * (https://github.com/vercel/ai/issues/19250), the parent is identified
    * structurally: it is an `embeddings` span that is also the parent of
-   * another `embeddings` span within the same ingestion batch.
+   * another `embeddings` span within the same ingestion batch. The key is
+   * scoped to traceId+spanId since span IDs are only unique within a trace,
+   * not across an entire batch.
    */
   private isDuplicateAiSdkEmbeddingOperationSpan(
     attributes: Record<string, unknown>,
+    traceId: string,
     spanId: string,
     embeddingsOperationParentSpanIds: Set<string>,
   ): boolean {
     return (
       attributes["gen_ai.operation.name"] === "embeddings" &&
-      embeddingsOperationParentSpanIds.has(spanId)
+      embeddingsOperationParentSpanIds.has(
+        this.buildEmbeddingsOperationSpanKey(traceId, spanId),
+      )
     );
   }
 
+  private buildEmbeddingsOperationSpanKey(
+    traceId: string,
+    spanId: string,
+  ): string {
+    return `${traceId}:${spanId}`;
+  }
+
   /**
-   * Collects the spanIds of AI SDK `embeddings` operation spans that are the
-   * parent of another `embeddings` operation span within this batch.
+   * Collects the traceId+spanId keys of AI SDK `embeddings` operation spans
+   * that are the parent of another `embeddings` operation span within this
+   * batch.
    */
   private collectAiSdkEmbeddingOperationParentSpanIds(
     resourceSpans: ResourceSpan[],
@@ -2674,8 +2689,15 @@ export class OtelIngestionProcessor {
 
           const attributes = this.extractSpanAttributes(span);
           if (attributes["gen_ai.operation.name"] === "embeddings") {
+            const spanTraceId: any = span.traceId;
+            const traceId = this.parseId(spanTraceId?.data ?? spanTraceId);
             const parentSpanId: any = span.parentSpanId;
-            parentSpanIds.add(this.parseId(parentSpanId?.data ?? parentSpanId));
+            parentSpanIds.add(
+              this.buildEmbeddingsOperationSpanKey(
+                traceId,
+                this.parseId(parentSpanId?.data ?? parentSpanId),
+              ),
+            );
           }
         }
       }

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -9118,6 +9118,104 @@ describe("OTel Resource Span Mapping", () => {
       expect(childEvent?.body.usageDetails.input).toBe(28);
       expect(childEvent?.body.model).toBe("text-embedding-3-large");
     });
+
+    it("should not strip usage from an unrelated embeddings span in another trace that reuses the same raw span ID as an aggregate wrapper", async () => {
+      const traceIdA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const traceIdB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+      const collidingSpanId = "1234567890abcde1";
+      const childSpanId = "1234567890abcde2";
+
+      const embeddingAttributes = [
+        {
+          key: "gen_ai.operation.name",
+          value: { stringValue: "embeddings" },
+        },
+        {
+          key: "gen_ai.request.model",
+          value: { stringValue: "text-embedding-3-large" },
+        },
+        {
+          key: "gen_ai.usage.input_tokens",
+          value: { intValue: { low: 28, high: 0, unsigned: false } },
+        },
+      ];
+
+      const batch = {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "test-service" } },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: "ai", version: "7.0.0" },
+            spans: [
+              // Trace A: standalone embeddings span (no parent/child) that
+              // happens to reuse the same raw span ID as trace B's aggregate
+              // wrapper below.
+              {
+                traceId: Buffer.from(traceIdA, "hex"),
+                spanId: Buffer.from(collidingSpanId, "hex"),
+                name: "embeddings text-embedding-3-large",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000, high: 406528574 },
+                endTimeUnixNano: { low: 2000000, high: 406528574 },
+                attributes: embeddingAttributes,
+                status: {},
+              },
+              // Trace B: operation span (root), same raw span ID as trace A's
+              // span above but a different trace.
+              {
+                traceId: Buffer.from(traceIdB, "hex"),
+                spanId: Buffer.from(collidingSpanId, "hex"),
+                name: "embeddings text-embedding-3-large",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000, high: 406528574 },
+                endTimeUnixNano: { low: 3000000, high: 406528574 },
+                attributes: embeddingAttributes,
+                status: {},
+              },
+              // Trace B: model-call span (child), making the trace B root the
+              // real aggregate wrapper.
+              {
+                traceId: Buffer.from(traceIdB, "hex"),
+                spanId: Buffer.from(childSpanId, "hex"),
+                parentSpanId: Buffer.from(collidingSpanId, "hex"),
+                name: "embeddings text-embedding-3-large",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000, high: 406528574 },
+                endTimeUnixNano: { low: 2000000, high: 406528574 },
+                attributes: embeddingAttributes,
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(batch, new Set());
+      const embeddingEvents = events.filter(
+        (e) => e.type === "embedding-create",
+      );
+      expect(embeddingEvents).toHaveLength(3);
+
+      const traceASpan = embeddingEvents.find(
+        (e) => e.body.traceId === traceIdA,
+      );
+      const traceBRoot = embeddingEvents.find(
+        (e) => e.body.traceId === traceIdB && e.body.id === collidingSpanId,
+      );
+
+      // Trace A's span is unrelated to trace B's aggregate wrapper and must
+      // keep its usage despite sharing the same raw span ID.
+      expect(traceASpan?.body.usageDetails.input).toBe(28);
+      expect(traceASpan?.body.model).toBe("text-embedding-3-large");
+
+      // Trace B's root is still correctly identified as the aggregate
+      // wrapper and stays skipped.
+      expect(traceBRoot?.body.usageDetails.input).toBeUndefined();
+      expect(traceBRoot?.body.model).toBeUndefined();
+    });
   });
 
   describe("Input/Output attribute filtering from metadata", () => {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -9037,6 +9037,87 @@ describe("OTel Resource Span Mapping", () => {
         observationEvent?.body.usageDetails.input_cache_creation,
       ).toBeUndefined();
     });
+
+    it("should not cost the AI SDK embeddings operation span when a duplicate embeddings model-call span exists in the same batch", async () => {
+      const traceId = "abcdef1234567890abcdef1234567892";
+      const rootSpanId = "1234567890abcde1";
+      const childSpanId = "1234567890abcde2";
+
+      const embeddingAttributes = [
+        {
+          key: "gen_ai.operation.name",
+          value: { stringValue: "embeddings" },
+        },
+        {
+          key: "gen_ai.request.model",
+          value: { stringValue: "text-embedding-3-large" },
+        },
+        {
+          key: "gen_ai.usage.input_tokens",
+          value: { intValue: { low: 28, high: 0, unsigned: false } },
+        },
+      ];
+
+      const vercelAIEmbeddingSpans = {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "test-service" } },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: "ai", version: "7.0.0" },
+            spans: [
+              {
+                // Operation span (root): aggregate usage duplicated by the
+                // model-call span below.
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from(rootSpanId, "hex"),
+                name: "embeddings text-embedding-3-large",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000, high: 406528574 },
+                endTimeUnixNano: { low: 3000000, high: 406528574 },
+                attributes: embeddingAttributes,
+                status: {},
+              },
+              {
+                // Model-call span (child): the real per-call usage.
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from(childSpanId, "hex"),
+                parentSpanId: Buffer.from(rootSpanId, "hex"),
+                name: "embeddings text-embedding-3-large",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000, high: 406528574 },
+                endTimeUnixNano: { low: 2000000, high: 406528574 },
+                attributes: embeddingAttributes,
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        vercelAIEmbeddingSpans,
+        new Set(),
+      );
+
+      const embeddingEvents = events.filter(
+        (e) => e.type === "embedding-create",
+      );
+      expect(embeddingEvents).toHaveLength(2);
+
+      const rootEvent = embeddingEvents.find((e) => e.body.id === rootSpanId);
+      const childEvent = embeddingEvents.find((e) => e.body.id === childSpanId);
+
+      // Root operation span: usage/cost/model skipped to avoid double-costing.
+      expect(rootEvent?.body.usageDetails.input).toBeUndefined();
+      expect(rootEvent?.body.model).toBeUndefined();
+
+      // Model-call child span: usage/cost/model preserved.
+      expect(childEvent?.body.usageDetails.input).toBe(28);
+      expect(childEvent?.body.model).toBe("text-embedding-3-large");
+    });
   });
 
   describe("Input/Output attribute filtering from metadata", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #16409

With the Vercel AI SDK v7 OTel integration (`@ai-sdk/otel`, also what
`@langfuse/vercel-ai-sdk` delegates to), every `embed()` / `embedMany()` call
produces two nested spans sharing the same `gen_ai.operation.name:
"embeddings"`: an operation span (root) carrying **aggregate**
`gen_ai.usage.*`, and a model-call span per provider call (child) carrying the
same **per-call** usage. `OtelIngestionProcessor` mapped both to costed
`EMBEDDING` observations, so every embedding's tokens and cost were counted
twice (trace totals, dashboards, API aggregations).

Text generations already had this problem fixed for `invoke_agent` /
`agent_step` spans in #14808, but the embeddings case wasn't covered because
the root and child spans there are otherwise indistinguishable (same
operation name, same attributes) — the existing per-span gate can't tell them
apart without looking at siblings.

### Fix

In `packages/shared/src/server/otel/OtelIngestionProcessor.ts`, before
processing spans, collect the set of spanIds that are the parent of another
AI SDK `embeddings` span within the same ingestion batch
(`collectAiSdkEmbeddingOperationParentSpanIds`). An `embeddings` span whose own
spanId is in that set is the aggregate wrapper, so its model/usage/cost
extraction is skipped (name, timing, input/output, hierarchy, and observation
type are preserved) — mirroring the existing `invoke_agent`/`agent_step` gate.
Applied in both code paths that already carry the agent-span gate:
`processToIngestionEvents` → `createObservationEvent`, and the `processToEvent`
path.

If the two spans don't arrive in the same batch, this falls back to today's
(double-costed) behavior, same as the short-term mitigation the issue
describes — the real fix is upstream
(https://github.com/vercel/ai/issues/19250) giving the wrapper span its own
operation name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Extended the existing `Vercel AI SDK Usage details` suite in
`web/src/__tests__/server/api/otel/otelMapping.servertest.ts` with a case
that sends both the root `embeddings` operation span and a child `embeddings`
model-call span (parentSpanId pointing at the root) in one batch, and asserts:

- root span: `usageDetails.input` and `model` are both skipped
- child span: `usageDetails.input` (28) and `model` are preserved

Confirmed the new test fails without the fix (reverted just the processor
change locally, via `git checkout HEAD~1 -- packages/shared/src/server/otel/OtelIngestionProcessor.ts`):

```
AssertionError: expected 28 to be undefined
 ❯ expect(rootEvent?.body.usageDetails.input).toBeUndefined();
```

And passes with the fix restored.

## Impacted packages

- `@langfuse/shared`

## Verification

```
pnpm --filter @langfuse/shared run typecheck   # no new errors (OtelIngestionProcessor.ts clean)
pnpm --filter @langfuse/shared run lint         # clean
pnpm --filter web run lint                      # clean
pnpm --filter @langfuse/shared run test OtelIngestionProcessor
  Test Files  2 passed (2)
       Tests  28 passed (28)

pnpm --filter web run test src/__tests__/server/api/otel/otelMapping.servertest.ts
  Test Files  1 passed (1)
       Tests  246 passed | 1 skipped (247)

pnpm --filter worker run test otelMetadataProcessing otelFlueMapping otelDirectEventWrite
  Test Files  3 passed (3)
       Tests  82 passed (82)
```

Also ran `worker`'s `otelToObservationForEval.test.ts` / `otelConversionFailureLogging.test.ts`
suites; a subset of their cases time out (`Test timed out in 5000ms`) both
with and without this change (confirmed against unmodified `main` in the same
sandbox), so that appears to be a pre-existing environment issue unrelated to
this fix, not a regression.

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

---

🤖 This PR (including the linked test run) was authored by an autonomous Claude Code agent.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents duplicate AI SDK embedding costs by identifying aggregate embedding wrapper spans and omitting their model, usage, and cost fields.
- Collects embedding parent span IDs before processing each OTel batch.
- Applies duplicate-cost suppression in both event-conversion paths.
- Adds a same-trace wrapper/model-call regression test.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until embedding wrapper correlation is scoped by trace ID so unrelated observations cannot lose usage and cost.

The new batch-wide span-ID set can match an embeddings span against a child from another trace, silently removing legitimate billing data.

**Files Needing Attention:** packages/shared/src/server/otel/OtelIngestionProcessor.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  B[OTel ingestion batch] --> C[Collect parentSpanIds of embeddings children]
  C --> S[Batch-wide span-ID Set]
  B --> P[Process each embeddings span]
  S --> M{Current spanId in Set?}
  P --> M
  M -->|Yes| D[Drop model, usage, and cost]
  M -->|No| K[Preserve model, usage, and cost]
  X[Different trace reuses same spanId] --> M
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:2676-2678
**Cross-trace span IDs collide**

If different traces in one ingestion batch reuse a span ID, this batch-wide set marks an unrelated embeddings span as an aggregate wrapper, causing its model, token usage, and cost to be silently discarded. Key the relationship by both trace ID and span ID instead of treating span IDs as globally unique across the batch.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): do not cost AI SDK embeddings..."](https://github.com/langfuse/langfuse/commit/daa88f03ac294ed27c13a694cbb6c984fca71415) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55558287)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->