### PR TITLE
fix(trace): stop the timeline describing its own geometry

### DIFF
--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.stories.tsx
@@ -2051,6 +2051,7 @@ export const TheToolbarDoesNotExplainItself = meta.story({
       expect(toolbar.innerText.toLowerCase()).toContain("window"),
     );
     await expect(toolbar.innerText.toLowerCase()).not.toContain("drag");
+    await expect(toolbar.innerText.toLowerCase()).not.toContain("px");
   },
 });
 

--- a/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
+++ b/web/src/features/traces/components/TraceTimelineDense/TimelineDense.tsx
@@ -1279,7 +1279,7 @@ export function TimelineDense({
     compression.toRealMs(current.time.start + current.time.duration) -
       compression.toRealMs(current.time.start),
   );
-  const windowHint = `${rowHeight.toFixed(1)}px rows · ${windowLabel} window`;
+  const windowHint = `${windowLabel} window`;
 
   return (
     <div


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16419.preview.langfuse.com](https://pr-16419.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The compact timeline's toolbar led with the row height in pixels — `40.0px rows · 2ms window`. That is the renderer describing its own geometry, in the one line of text the toolbar has. It now says only how much **time** is in view.

Follow-up to #16352.

## Why

Nobody reading a trace has a decision that turns on how many pixels tall a row happens to be. The number is accurate and unactionable, and it occupied the first half of the toolbar's only caption — ahead of the window, which is the part stated in the trace's own terms.

This is the same trade as the gesture caption that left in #16352: the toolbar is not where the renderer explains itself.

## What

- `40.0px rows · 2ms window` → `2ms window`, and still nothing at all when the whole trace is in view.
- The bottom readout keeps its px and its px/ms. It is `showReadout={false}` in the app — a Storybook strip for reviewing the layout across every size and shape, where those numbers are the entire point.

## Result

The toolbar is three buttons about the view and, when you are somewhere other than the whole trace, one phrase saying where. `(Test) The Toolbar Does Not Explain Itself` now also asserts the caption never contains `px`; restoring the row height fails it with `expected '22.7px rows · 15.83s window' not to contain 'px'`.

<details>
<summary>One thing deliberately left alone</summary>

A row whose span sits outside the current time window draws an edge caret whose title still reads `Outside the time window — starts at 1.2s`. That phrasing was removed from the tooltip in #16352 because the axis already answers it — but for a caret standing in for a span you *cannot* see, where it is is the only useful thing it can say, and it tells you which way to pan. Left as is.

### Checks

- `Tests 473 passed (473)` — Storybook tests in real Chromium.
- `Tasks: 7 successful, 7 total` turbo lint. Typecheck clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR simplifies the compact trace timeline toolbar so its caption reports only the visible time window, omitting internal row-height geometry.
- Replaces the combined pixel-height and time-window caption with a time-window-only caption.
- Adds a Storybook assertion preventing pixel measurements from returning to the toolbar.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable regressions identified.

The change narrowly removes intentionally unwanted geometry text from the toolbar, retains the time-window information, and adds coverage for the intended presentation contract.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): stop the timeline describing..."](https://github.com/langfuse/langfuse/commit/4936b2ffe1ca1d423f05f844ee44f081bc2a9e79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55559244)</sub>

<!-- /greptile_comment -->