### PR TITLE
chore: Add design system code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Currently inactive
 # * @langfuse/maintainers
 
+# Design system
 /web/src/components/design-system/ @bezbac
 /web/.storybook/ @bezbac

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Currently inactive
 # * @langfuse/maintainers
+
+/web/src/components/design-system/ @bezbac
+/web/.storybook/ @bezbac


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16420.preview.langfuse.com](https://pr-16420.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Assigns `@bezbac` as code owner for the design system components and Storybook configuration so matching pull requests request their review.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `git diff --check`
- Commit hooks: Prettier and workspace lint (`Tasks: 7 successful, 7 total`)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15435](https://linear.app/clickhouse/issue/LFE-15435/setup-codeowner-for-design-system)

<div><a href="https://cursor.com/agents/bc-c49717ac-6fb9-4052-a690-7e04bd793cbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c49717ac-6fb9-4052-a690-7e04bd793cbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `@bezbac` as the code owner for the design-system components and Storybook configuration.

- Covers files recursively under `web/src/components/design-system/`.
- Covers files recursively under `web/.storybook/`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with the intended design-system and Storybook review routing correctly configured.

The added CODEOWNERS patterns target existing directories and recursively cover their contents, with no conflicting ownership entries or repository-rule violations identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add design system code owner"](https://github.com/langfuse/langfuse/commit/b866bbb746bdddcfae5cf5b3d7e1abd26ebb4e62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55563700)</sub>

<!-- /greptile_comment -->