### PR TITLE
chore(assistant): medium thinking with opus

### DIFF
--- a/worker/src/features/in-app-agent/runtime/agent.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.ts
@@ -195,6 +195,7 @@ export function getBedrockReasoningProviderOptions(modelId: string) {
       // the reasoning UI would render blank blocks.
       additionalModelRequestFields: {
         thinking: { type: "adaptive" as const, display: "summarized" },
+        output_config: { effort: "medium" as const },
       },
     },
   };

--- a/worker/src/features/in-app-agent/runtime/reasoning.test.ts
+++ b/worker/src/features/in-app-agent/runtime/reasoning.test.ts
@@ -2,7 +2,7 @@ import { getBedrockReasoningProviderOptions } from "./agent";
 import { describe, expect, it } from "vitest";
 
 describe("getBedrockReasoningProviderOptions", () => {
-  it("sends adaptive thinking with summarized display to Claude models by default", () => {
+  it("sends adaptive thinking with medium effort and summarized display to Claude models", () => {
     // Adaptive thinking is the default for every Claude model, including
     // unrecognized future generations, so no model list needs maintenance.
     // The config must go through additionalModelRequestFields, not
@@ -20,6 +20,7 @@ describe("getBedrockReasoningProviderOptions", () => {
         bedrock: {
           additionalModelRequestFields: {
             thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "medium" },
           },
         },
       });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16421.preview.langfuse.com](https://pr-16421.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR configures medium reasoning effort for Claude-powered in-app assistant runs and updates the reasoning-options test coverage.
- Adds `output_config.effort: "medium"` alongside adaptive, summarized thinking.
- Verifies Claude models receive the new Bedrock request field while non-Claude models remain unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect established.

The change consistently passes the new reasoning-effort field through the existing Claude provider-options path, and the accompanying tests cover both Claude and non-Claude behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(assistant): medium thinking with o..."](https://github.com/langfuse/langfuse/commit/3fb31dac5cb09976d1c3be203bb35291233b128d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55565744)</sub>

<!-- /greptile_comment -->