### PR TITLE
fix(modern-session): format tokens with thousands

### DIFF
--- a/web/src/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/components/session/ModernSessionHeader.stories.tsx
@@ -306,3 +306,27 @@ export const TestConfiguresMultipleMetadataPaths = meta.story({
     await expect(getVisibleText("cloud_region")).toBeInTheDocument();
   },
 });
+
+export const TestCompactsTokenCounts = meta.story({
+  name: "(Test) Compacts token counts",
+  args: {
+    ...minimalArgs,
+    tokensIn: 648_714,
+    tokensOut: 6_697,
+    totalTokens: 655_411,
+  },
+  play: async ({ canvasElement }) => {
+    const tokenPill = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>(
+        "[data-overflow-visible-item='true'] [data-session-header-pill='true']",
+      ),
+    ).find((pill) => pill.textContent?.trim().startsWith("tokens "));
+
+    await expect(tokenPill).toBeInTheDocument();
+    await expect(tokenPill).toHaveTextContent("tokens 649k → 7k (Σ 655k)");
+    await expect(tokenPill).toHaveAttribute(
+      "title",
+      "tokens 648,714 → 6,697 (Σ 655,411)",
+    );
+  },
+});

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -24,7 +24,11 @@ import {
 } from "@/src/components/ui/popover";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
-import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
+import {
+  compactNumberFormatter,
+  numberFormatter,
+  usdFormatter,
+} from "@/src/utils/numbers";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 type ModernSessionHeaderProps = {
@@ -59,6 +63,9 @@ const ChipValue = ({ children }: { children: React.ReactNode }) => (
 );
 
 const ChipDot = () => <span className="text-foreground-tertiary">·</span>;
+
+const compactTokenFormatter = (tokens: number) =>
+  compactNumberFormatter(tokens, 0).toLowerCase();
 
 const scoreChipValue = (
   score: Pick<WithStringifiedMetadata<ScoreDomain>, "stringValue" | "value">,
@@ -354,16 +361,21 @@ export function ModernSessionHeader({
   }
 
   if (totalTokens > 0) {
+    const exactTokenCounts = `${numberFormatter(tokensIn, 0)} → ${numberFormatter(tokensOut, 0)} (Σ ${numberFormatter(totalTokens, 0)})`;
     pills.push({
       key: "tokens",
       searchText: `tokens ${tokensIn} ${tokensOut} ${totalTokens}`,
       content: (
-        <ModernSessionHeaderPill variant="display">
+        <ModernSessionHeaderPill
+          variant="display"
+          title={`tokens ${exactTokenCounts}`}
+        >
           <span>
             tokens{" "}
             <ChipValue>
-              {numberFormatter(tokensIn, 0)} → {numberFormatter(tokensOut, 0)}{" "}
-              (Σ {numberFormatter(totalTokens, 0)})
+              {compactTokenFormatter(tokensIn)} →{" "}
+              {compactTokenFormatter(tokensOut)} (Σ{" "}
+              {compactTokenFormatter(totalTokens)})
             </ChipValue>
           </span>
         </ModernSessionHeaderPill>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16423.preview.langfuse.com](https://pr-16423.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the modern session header to display compact, lowercase token counts while retaining exact counts in a native title.
- Adds a compact token formatter with zero fractional digits.
- Uses compact values in the token pill and exact formatted values in its title.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking accessibility issue around access to exact token counts.

The compact display preserves approximate usage and retains exact values, but those exact values are now exposed only through a native title on a non-focusable element.

**Files Needing Attention:** web/src/components/session/ModernSessionHeader.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/session/ModernSessionHeader.tsx:371
**Exact counts require pointer hover**

The exact token counts are now available only through the native `title` of a non-focusable display pill, so keyboard, touch, and assistive-technology users cannot reliably inspect the precise values that were previously visible.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(modern-session): format tokens with ..."](https://github.com/langfuse/langfuse/commit/a824cfac3cfac9dd13ca50c5ec5196f78ad3e287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55572235)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->