### PR TITLE
feat(annotation-queues): create queues from events table

### DIFF
--- a/web/src/features/annotation-queues/components/AddTracesToAnnotationQueueDialogController.tsx
+++ b/web/src/features/annotation-queues/components/AddTracesToAnnotationQueueDialogController.tsx
@@ -13,6 +13,7 @@ type AddTracesToAnnotationQueueDialogControllerProps = {
   description: string;
   actionId?: ActionId;
   tableName?: BatchExportTableName;
+  alternateTableName?: BatchExportTableName;
   objectLabel?: string;
   onAddToQueue: (params: {
     projectId: string;
@@ -30,6 +31,7 @@ export function AddTracesToAnnotationQueueDialogController({
   description,
   actionId = ActionId.TraceAddToAnnotationQueue,
   tableName = BatchExportTableName.Traces,
+  alternateTableName,
   objectLabel = "traces",
   onAddToQueue,
   children,
@@ -71,6 +73,17 @@ export function AddTracesToAnnotationQueueDialogController({
     },
     {
       enabled: open,
+      refetchInterval: 2 * 60 * 1000,
+    },
+  );
+  const isAlternateInProgress = api.table.getIsBatchActionInProgress.useQuery(
+    {
+      projectId,
+      tableName: alternateTableName ?? tableName,
+      actionId,
+    },
+    {
+      enabled: open && alternateTableName !== undefined,
       refetchInterval: 2 * 60 * 1000,
     },
   );
@@ -134,9 +147,9 @@ export function AddTracesToAnnotationQueueDialogController({
                 createQueueState={createQueueState}
                 hasAccess={hasQueueAccess}
                 batchActionState={
-                  isInProgress.isLoading
+                  isInProgress.isLoading || isAlternateInProgress.isLoading
                     ? { status: "checking" }
-                    : isInProgress.data
+                    : isInProgress.data || isAlternateInProgress.data
                       ? { status: "inProgress" }
                       : { status: "ready" }
                 }

--- a/web/src/features/annotation-queues/components/AddTracesToAnnotationQueueDialogController.tsx
+++ b/web/src/features/annotation-queues/components/AddTracesToAnnotationQueueDialogController.tsx
@@ -11,6 +11,9 @@ type AddTracesToAnnotationQueueDialogControllerProps = {
   projectId: string;
   onSuccess: () => void;
   description: string;
+  actionId?: ActionId;
+  tableName?: BatchExportTableName;
+  objectLabel?: string;
   onAddToQueue: (params: {
     projectId: string;
     targetId: string;
@@ -25,6 +28,9 @@ export function AddTracesToAnnotationQueueDialogController({
   projectId,
   onSuccess,
   description,
+  actionId = ActionId.TraceAddToAnnotationQueue,
+  tableName = BatchExportTableName.Traces,
+  objectLabel = "traces",
   onAddToQueue,
   children,
 }: AddTracesToAnnotationQueueDialogControllerProps) {
@@ -39,7 +45,7 @@ export function AddTracesToAnnotationQueueDialogController({
   const disabled = hasQueueAccess
     ? undefined
     : {
-        reason: "You don't have permission to add traces to annotation queues.",
+        reason: `You don't have permission to add ${objectLabel} to annotation queues.`,
       };
   const openDialog = () => {
     if (!hasQueueAccess) return;
@@ -60,8 +66,8 @@ export function AddTracesToAnnotationQueueDialogController({
   const isInProgress = api.table.getIsBatchActionInProgress.useQuery(
     {
       projectId,
-      tableName: BatchExportTableName.Traces,
-      actionId: ActionId.TraceAddToAnnotationQueue,
+      tableName,
+      actionId,
     },
     {
       enabled: open,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -2148,6 +2148,7 @@ export default function ObservationsEventsTable({
                     projectId={projectId}
                     actionId={ActionId.ObservationAddToAnnotationQueue}
                     tableName={BatchExportTableName.Events}
+                    alternateTableName={BatchExportTableName.Observations}
                     objectLabel="observations"
                     description={`Add ${itemCountDisplay} selected observations to an annotation queue.`}
                     onAddToQueue={handleAddToAnnotationQueue}

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -154,6 +154,7 @@ import {
   useObservedMetadataPaths,
   useObservedMetadataRecorder,
 } from "@/src/hooks/useObservedMetadata";
+import { AddTracesToAnnotationQueueDialogController } from "@/src/features/annotation-queues/components/AddTracesToAnnotationQueueDialogController";
 
 export type EventsTableRow = {
   // Identity fields
@@ -1079,9 +1080,8 @@ export default function ObservationsEventsTable({
       id: ActionId.ObservationAddToAnnotationQueue,
       type: BatchActionType.Create,
       label: "Add to Annotation Queue",
-      description: "Add selected observations to an annotation queue.",
-      targetLabel: "Annotation Queue",
-      execute: handleAddToAnnotationQueue,
+      description: `Add ${selectedObservationCount ?? "..."} selected observations to an annotation queue.`,
+      customDialog: true,
       accessCheck: {
         scope: "annotationQueues:CUD",
       },
@@ -2143,25 +2143,48 @@ export default function ObservationsEventsTable({
                 />,
                 !chartActive &&
                 (selectedObservationIds.length > 0 || selectAll) ? (
-                  <TableActionMenu
+                  <AddTracesToAnnotationQueueDialogController
                     key="observations-multi-select-actions"
                     projectId={projectId}
-                    actions={tableActions}
+                    actionId={ActionId.ObservationAddToAnnotationQueue}
                     tableName={BatchExportTableName.Observations}
-                    selectedCount={selectedObservationCount}
-                    onClearSelection={() => {
+                    objectLabel="observations"
+                    description={`Add ${selectedObservationCount ?? "..."} selected observations to an annotation queue.`}
+                    onAddToQueue={handleAddToAnnotationQueue}
+                    onSuccess={() => {
                       setSelectedRows({});
                       setSelectAll(false);
                     }}
-                    onCustomAction={(actionType) => {
-                      if (actionType === ActionId.ObservationBatchEvaluation) {
-                        setShowRunEvaluationDialog(true);
-                      }
-                      if (actionType === ActionId.ObservationAddToDataset) {
-                        setShowAddToDatasetDialog(true);
-                      }
-                    }}
-                  />
+                  >
+                    {({ openDialog }) => (
+                      <TableActionMenu
+                        projectId={projectId}
+                        actions={tableActions}
+                        tableName={BatchExportTableName.Observations}
+                        selectedCount={selectedObservationCount}
+                        onClearSelection={() => {
+                          setSelectedRows({});
+                          setSelectAll(false);
+                        }}
+                        onCustomAction={(actionType) => {
+                          if (
+                            actionType ===
+                            ActionId.ObservationAddToAnnotationQueue
+                          ) {
+                            openDialog();
+                          }
+                          if (
+                            actionType === ActionId.ObservationBatchEvaluation
+                          ) {
+                            setShowRunEvaluationDialog(true);
+                          }
+                          if (actionType === ActionId.ObservationAddToDataset) {
+                            setShowAddToDatasetDialog(true);
+                          }
+                        }}
+                      />
+                    )}
+                  </AddTracesToAnnotationQueueDialogController>
                 ) : null,
               ]}
               // No row selection in chart mode — the table (and its select-all

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -2147,9 +2147,9 @@ export default function ObservationsEventsTable({
                     key="observations-multi-select-actions"
                     projectId={projectId}
                     actionId={ActionId.ObservationAddToAnnotationQueue}
-                    tableName={BatchExportTableName.Observations}
+                    tableName={BatchExportTableName.Events}
                     objectLabel="observations"
-                    description={`Add ${selectedObservationCount ?? "..."} selected observations to an annotation queue.`}
+                    description={`Add ${itemCountDisplay} selected observations to an annotation queue.`}
                     onAddToQueue={handleAddToAnnotationQueue}
                     onSuccess={() => {
                       setSelectedRows({});

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1080,7 +1080,7 @@ export default function ObservationsEventsTable({
       id: ActionId.ObservationAddToAnnotationQueue,
       type: BatchActionType.Create,
       label: "Add to Annotation Queue",
-      description: `Add ${selectedObservationCount ?? "..."} selected observations to an annotation queue.`,
+      description: `Add ${itemCountDisplay} selected observations to an annotation queue.`,
       customDialog: true,
       accessCheck: {
         scope: "annotationQueues:CUD",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16427.preview.langfuse.com](https://pr-16427.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds inline annotation queue creation to the events table's “Add to Annotation Queue” batch action. The existing queue picker controller now accepts the batch action context and object label, allowing events-table observation selections to reuse the trace-table workflow while preserving the correct permissions and in-progress state.

The progress guard checks both observation batch-action table keys because the server key depends on the deployment's v4 preview configuration.

Impacted package: `web`

Verification:
- `pnpm run lint`: `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck`: passed
- Browser review blocked because the Cloud stack could not connect to the Docker daemon

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Reuses the existing inline queue creation workflow.
- Keeps observation selection and select-all behavior intact after successful submission.
- No backend or public API contract changes are required.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15440](https://linear.app/clickhouse/issue/LFE-15440/also-allow-inline-annotation-queue-creation-in-events-table)

<div><a href="https://cursor.com/agents/bc-02ed1aeb-6ee4-43c2-bab6-6831b482ea2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ed1aeb-6ee4-43c2-bab6-6831b482ea2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds inline annotation-queue creation to observation selections in the events table by generalizing the existing trace dialog controller.
- Passes action, table, and object-label context into the reusable controller.
- Routes the observation batch action through the custom queue dialog and clears selection after success.
- The progress-key correction remains incomplete for preview-opt-in-disabled events-table configurations.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the attempted progress-key fix still misses active observation batch jobs in preview-opt-in-disabled events-table deployments.

The events table always polls the Events identifier, while the server registers observation annotation jobs under Observations when preview opt-in is disabled; events_only deployments still render this table, leaving the duplicate-submission path reachable.

**Files Needing Attention:** web/src/features/events/components/EventsTable.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/events/components/EventsTable.tsx:2150
**Progress key still mismatches**

When `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` is false and the events table is enabled, the server registers observation annotation jobs under `Observations`, but this controller polls `Events`. The dialog therefore hides the active job and permits another submission.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(annotation-queues): align events bat..."](https://github.com/langfuse/langfuse/commit/c1f318328fa68527146fb28752cb74ea2f3fc685) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55584152)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->