### PR TITLE
fix(pricing): add reasoning-token prices for GPT-5.4 mini and nano

### DIFF
--- a/worker/src/__tests__/pricing-tier-matcher.test.ts
+++ b/worker/src/__tests__/pricing-tier-matcher.test.ts
@@ -426,6 +426,71 @@ describe("default-model-prices.json", () => {
     ).toBe("Flex · Large context (>272K)");
   });
 
+  it("should price GPT-5.4 mini and nano reasoning tokens at the output rate", () => {
+    const modelNames = [
+      "gpt-5.4-mini",
+      "gpt-5.4-mini-2026-03-17",
+      "gpt-5.4-nano",
+      "gpt-5.4-nano-2026-03-17",
+    ];
+
+    for (const modelName of modelNames) {
+      const model = defaultModelPrices.find(
+        (candidate) => candidate.modelName === modelName,
+      );
+      expect(model, modelName).toBeDefined();
+
+      for (const tier of model!.pricingTiers) {
+        const prices = tier.prices as Record<string, number>;
+        expect(
+          prices.output_reasoning_tokens,
+          `${modelName}/${tier.name}`,
+        ).toBe(prices.output);
+        expect(prices.output_reasoning, `${modelName}/${tier.name}`).toBe(
+          prices.output,
+        );
+        expect(prices.reasoning_tokens, `${modelName}/${tier.name}`).toBe(
+          prices.output,
+        );
+      }
+    }
+
+    const mini = defaultModelPrices.find(
+      (model) => model.modelName === "gpt-5.4-mini",
+    );
+    expect(mini).toBeDefined();
+
+    const miniTiers: PricingTierWithPrices[] = mini!.pricingTiers.map(
+      (tier) => ({
+        id: tier.id,
+        name: tier.name,
+        isDefault: tier.isDefault,
+        priority: tier.priority,
+        conditions: tier.conditions,
+        prices: Object.entries(tier.prices).map(([usageType, price]) => ({
+          usageType,
+          price: new Decimal(price),
+        })),
+      }),
+    );
+
+    const reportedUsage = {
+      input: 1932,
+      output: 26,
+      output_reasoning: 45,
+      input_cache_read: 0,
+    };
+    const reportedResult = matchPricingTier(miniTiers, reportedUsage);
+    expect(reportedResult?.pricingTierName).toBe("Standard");
+
+    const reportedCost = Object.entries(reportedUsage).reduce(
+      (total, [usageType, units]) =>
+        total + (reportedResult?.prices[usageType]?.toNumber() ?? 0) * units,
+      0,
+    );
+    expect(reportedCost).toBeCloseTo(0.0017685, 12);
+  });
+
   it.each(["fast", "priority"])(
     "should match GPT-5.5 Fast mode for the %s service tier value",
     (serviceTier) => {

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -5314,7 +5314,7 @@
     "modelName": "gpt-5.4-mini",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-mini)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5333,6 +5333,9 @@
           "input_cached_tokens": 0.075e-6,
           "input_cache_read": 0.075e-6,
           "output": 4.5e-6,
+          "output_reasoning_tokens": 4.5e-6,
+          "output_reasoning": 4.5e-6,
+          "reasoning_tokens": 4.5e-6,
           "cache_read_input_tokens": 0.075e-6
         }
       },
@@ -5354,6 +5357,9 @@
           "input_cached_tokens": 0.15e-6,
           "input_cache_read": 0.15e-6,
           "output": 9e-6,
+          "output_reasoning_tokens": 9e-6,
+          "output_reasoning": 9e-6,
+          "reasoning_tokens": 9e-6,
           "cache_read_input_tokens": 0.15e-6
         }
       },
@@ -5375,6 +5381,9 @@
           "input_cached_tokens": 0.0375e-6,
           "input_cache_read": 0.0375e-6,
           "output": 2.25e-6,
+          "output_reasoning_tokens": 2.25e-6,
+          "output_reasoning": 2.25e-6,
+          "reasoning_tokens": 2.25e-6,
           "cache_read_input_tokens": 0.0375e-6
         }
       }
@@ -5385,7 +5394,7 @@
     "modelName": "gpt-5.4-mini-2026-03-17",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-mini-2026-03-17)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5404,6 +5413,9 @@
           "input_cached_tokens": 0.075e-6,
           "input_cache_read": 0.075e-6,
           "output": 4.5e-6,
+          "output_reasoning_tokens": 4.5e-6,
+          "output_reasoning": 4.5e-6,
+          "reasoning_tokens": 4.5e-6,
           "cache_read_input_tokens": 0.075e-6
         }
       },
@@ -5425,6 +5437,9 @@
           "input_cached_tokens": 0.15e-6,
           "input_cache_read": 0.15e-6,
           "output": 9e-6,
+          "output_reasoning_tokens": 9e-6,
+          "output_reasoning": 9e-6,
+          "reasoning_tokens": 9e-6,
           "cache_read_input_tokens": 0.15e-6
         }
       },
@@ -5446,6 +5461,9 @@
           "input_cached_tokens": 0.0375e-6,
           "input_cache_read": 0.0375e-6,
           "output": 2.25e-6,
+          "output_reasoning_tokens": 2.25e-6,
+          "output_reasoning": 2.25e-6,
+          "reasoning_tokens": 2.25e-6,
           "cache_read_input_tokens": 0.0375e-6
         }
       }
@@ -5456,7 +5474,7 @@
     "modelName": "gpt-5.4-nano",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-nano)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5475,6 +5493,9 @@
           "input_cached_tokens": 0.02e-6,
           "input_cache_read": 0.02e-6,
           "output": 1.25e-6,
+          "output_reasoning_tokens": 1.25e-6,
+          "output_reasoning": 1.25e-6,
+          "reasoning_tokens": 1.25e-6,
           "cache_read_input_tokens": 0.02e-6
         }
       },
@@ -5496,6 +5517,9 @@
           "input_cached_tokens": 0.01e-6,
           "input_cache_read": 0.01e-6,
           "output": 0.625e-6,
+          "output_reasoning_tokens": 0.625e-6,
+          "output_reasoning": 0.625e-6,
+          "reasoning_tokens": 0.625e-6,
           "cache_read_input_tokens": 0.01e-6
         }
       }
@@ -5506,7 +5530,7 @@
     "modelName": "gpt-5.4-nano-2026-03-17",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-nano-2026-03-17)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-21T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5525,6 +5549,9 @@
           "input_cached_tokens": 0.02e-6,
           "input_cache_read": 0.02e-6,
           "output": 1.25e-6,
+          "output_reasoning_tokens": 1.25e-6,
+          "output_reasoning": 1.25e-6,
+          "reasoning_tokens": 1.25e-6,
           "cache_read_input_tokens": 0.02e-6
         }
       },
@@ -5546,6 +5573,9 @@
           "input_cached_tokens": 0.01e-6,
           "input_cache_read": 0.01e-6,
           "output": 0.625e-6,
+          "output_reasoning_tokens": 0.625e-6,
+          "output_reasoning": 0.625e-6,
+          "reasoning_tokens": 0.625e-6,
           "cache_read_input_tokens": 0.01e-6
         }
       }


### PR DESCRIPTION
## What

Fixes #16425.

`gpt-5.4-mini` and `gpt-5.4-nano` (and their dated variants
`gpt-5.4-mini-2026-03-17` / `gpt-5.4-nano-2026-03-17`) had no
`output_reasoning`, `output_reasoning_tokens`, or `reasoning_tokens`
price keys in any of their pricing tiers, unlike every other model in
the GPT-5.4 family (`gpt-5.4`, `gpt-5.4-pro`, and their dated
variants), which already carry all three reasoning aliases at the
output rate.

Since price matching in `matchPricingTier` is exact by usage key,
reasoning tokens reported for these two models were priced at zero —
every generation that reasoned was under-costed by
`reasoning_tokens x output_rate`. The reporter measured an 18% cost
undercount over 10 traces, matching the unpriced reasoning bucket to
the last decimal.

## Fix

Added `output_reasoning`, `output_reasoning_tokens`, and
`reasoning_tokens` to every pricing tier of the four affected model
entries, each set to that tier's existing `output` rate — the same
pattern already used by the base `gpt-5.4` / `gpt-5.4-pro` entries and
by the prior fix for the GPT-5.6 family (#15139/#15177).

## Test plan

Added a regression test in
`worker/src/__tests__/pricing-tier-matcher.test.ts` that:
- asserts all three reasoning-token keys equal `output` across every
  tier of all four affected models, and
- reproduces the issue's exact reported usage
  (`input: 1932, output: 26, output_reasoning: 45, input_cache_read: 0`)
  against `gpt-5.4-mini` and checks the total cost now matches the
  issue's expected `0.0017685`.

Confirmed the test fails without the fix (checked out the pre-fix
`default-model-prices.json`, ran the test, saw it fail with `expected
undefined to be 0.0000045`), then restored the fix and reran:

```
$ pnpm --filter worker run test pricing-tier-matcher.test.ts
 ✓ src/__tests__/pricing-tier-matcher.test.ts (122 tests) 147ms
 Test Files  1 passed (1)
      Tests  122 passed (122)
```

```
$ pnpm run lint
 Tasks:    7 successful, 7 total
```

AI assistance disclosure: this change was drafted by an autonomous
Claude Code agent, with the pricing JSON edits and regression test
verified locally as described above.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds three reasoning-token pricing aliases to every pricing tier for GPT-5.4 mini, nano, and their dated variants, using each tier’s output rate.

- Updates all four affected default model-price entries and advances their update timestamps.
- Adds regression coverage for alias parity across every tier and for the reported GPT-5.4 mini cost calculation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with complete and consistent pricing coverage for the affected models.

The new aliases match each tier’s existing output rate, cover all four recognized GPT-5.4 mini/nano variants and every configured tier, and include a focused regression for the reported undercount.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): add reasoning-token prices..."](https://github.com/langfuse/langfuse/commit/e8b94f0c23657985ce364d36f94c372ab5085ae5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55588669)</sub>

<!-- /greptile_comment -->