### PR TITLE
refactor(seeder): move `annotationQueueLink` to `verify.ts` to match the other link helpers

### DIFF
--- a/packages/shared/scripts/seeder/scenarios/annotation-queue.ts
+++ b/packages/shared/scripts/seeder/scenarios/annotation-queue.ts
@@ -21,7 +21,7 @@ import {
   SeedError,
   SeedSummary,
 } from "./types";
-import { countRows } from "./verify";
+import { annotationQueueLink, countRows } from "./verify";
 
 // ---------------------------------------------------------------------------
 // Score-config catalog — one of every shape the annotation form can render, so
@@ -170,9 +170,6 @@ const ANSWERS = [
   "Der Build schlug fehl; bitte erneut versuchen.",
   "1) Send the report 2) Schedule a follow-up call.",
 ] as const;
-
-const annotationQueueLink = (ctx: ScenarioContext, queueId: string): string =>
-  `${ctx.baseUrl}/project/${ctx.projectId}/annotation-queues/${encodeURIComponent(queueId)}/items`;
 
 const run = async (
   ctx: ScenarioContext,

--- a/packages/shared/scripts/seeder/scenarios/verify.ts
+++ b/packages/shared/scripts/seeder/scenarios/verify.ts
@@ -36,3 +36,9 @@ export const sessionLink = (ctx: ScenarioContext, sessionId: string): string =>
 
 export const tracesListLink = (ctx: ScenarioContext): string =>
   `${ctx.baseUrl}/project/${ctx.projectId}/traces`;
+
+export const annotationQueueLink = (
+  ctx: ScenarioContext,
+  queueId: string,
+): string =>
+  `${ctx.baseUrl}/project/${ctx.projectId}/annotation-queues/${encodeURIComponent(queueId)}/items`;


### PR DESCRIPTION
## refactor(seeder): move `annotationQueueLink` to `verify.ts` to match the other link helpers

Fixes #16431.

### Summary

The seeder has four URL-construction helpers used to build deep links for each scenario's `SeedSummary.links` field. Three of them — `traceLink`, `sessionLink`, `tracesListLink` — live in `packages/shared/scripts/seeder/scenarios/verify.ts`. The fourth, `annotationQueueLink`, lived locally in `annotation-queue.ts`. This commit moves it to `verify.ts` so all four live in the same place. Purely a consistency refactor; the generated URL is byte-identical.

### Before

```ts
// annotation-queue.ts:174-175
const annotationQueueLink = (ctx: ScenarioContext, queueId: string): string =>
  `${ctx.baseUrl}/project/${ctx.projectId}/annotation-queues/${encodeURIComponent(queueId)}/items`;
```

```ts
// verify.ts (no annotationQueueLink)
export const traceLink = (ctx, traceId, timestampMs) => /* ... */;
export const sessionLink = (ctx, sessionId) => /* ... */;
export const tracesListLink = (ctx) => /* ... */;
```

The 4 link helpers had 3 different definitions in `verify.ts` and 1 in the scenario file, even though all 4 follow the same one-liner pattern. A reader looking for a link helper had to grep both files.

### After

```ts
// verify.ts
export const traceLink = (ctx, traceId, timestampMs) => /* ... */;
export const sessionLink = (ctx, sessionId) => /* ... */;
export const tracesListLink = (ctx) => /* ... */;
export const annotationQueueLink = (ctx, queueId) => /* ... */;
```

```ts
// annotation-queue.ts
import { annotationQueueLink, countRows } from "./verify";
```

The 4 link helpers are all in `verify.ts`, the import pattern is the same as the existing `countRows` import, and the 4 call sites in the scenario are unchanged.

### Implementation

- `packages/shared/scripts/seeder/scenarios/verify.ts` — add `annotationQueueLink` (6 lines, same signature and body as the prior local definition).
- `packages/shared/scripts/seeder/scenarios/annotation-queue.ts` — replace the local definition with an import (4 lines removed, 1 line changed in the import). The 4 call sites are unchanged.

### Testing

- `pnpm --filter @langfuse/shared exec prettier --check scripts/seeder/scenarios/verify.ts scripts/seeder/scenarios/annotation-queue.ts` — clean
- The 4 call sites in `annotation-queue.ts` continue to work: `annotationQueueLink(ctx, coreQueueId)` and `annotationQueueLink(ctx, edgeQueueId)` (twice each)
- `pnpm --filter @langfuse/shared exec tsc --noEmit` — no new errors (pre-existing unrelated errors in `mediaService.ts` and `runLifecycle.ts` are not introduced by this PR)

### Backward compatibility

Purely internal refactor. No exports added or removed at the package boundary — the function is local to the seeder. No new contract.

### Why this matters

The seeder is the kind of code that's read by humans and agents unfamiliar with it. Every link helper that lives in a scenario file instead of the shared `verify.ts` is one more place to grep when looking for the helper. The cost of the refactor is 7 lines changed; the benefit is "all link helpers are in the same place" for the next reader.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates the annotation-queue URL helper with the other seeder link helpers without changing its behavior.

- Exports `annotationQueueLink` from `verify.ts`.
- Replaces the scenario-local definition with an import.
- Preserves the helper signature, URL encoding, generated path, and existing call sites.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The helper implementation and call sites remain equivalent, and adding it to the existing `verify.ts` import introduces no new module dependency or initialization behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(seeder): move \`annotationQueueL..."](https://github.com/langfuse/langfuse/commit/43f989a9aa41f71061ea8831d06a16c02ba641d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55591199)</sub>

<!-- /greptile_comment -->