### PR TITLE
fix: batch trace/observation lookups in dataset run comparison grid

### DIFF
--- a/web/src/__tests__/server/observations-router-trpc.servertest.ts
+++ b/web/src/__tests__/server/observations-router-trpc.servertest.ts
@@ -1,0 +1,121 @@
+import type { Session } from "next-auth";
+import { prisma } from "@langfuse/shared/src/db";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import {
+  createTrace,
+  createTracesCh,
+  createObservation,
+  createObservationsCh,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+
+// Note: `observations-trpc.servertest.ts` already exists and covers the
+// `generations` router (a legacy alias), not the `observations` router
+// tested here — kept as a separate file to avoid colliding names.
+describe("observations router trpc", () => {
+  const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: "seed-org-id",
+          name: "Test Organization",
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: false,
+          aiTelemetryEnabled: false,
+          projects: [
+            {
+              id: projectId,
+              role: "ADMIN",
+              retentionDays: 30,
+              deletedAt: null,
+              name: "Test Project",
+              hasTraces: true,
+              metadata: {},
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+        searchBar: false,
+        v4BetaToggleVisible: false,
+        observationEvals: false,
+        experimentsV4Enabled: false,
+      },
+      admin: true,
+    },
+    environment: {} as any,
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  const caller = appRouter.createCaller({ ...ctx, prisma });
+
+  describe("observations.byIds", () => {
+    // Regression coverage for the dataset run comparison grid, which
+    // previously fired one `observations.byId` request per cell (one HTTP
+    // request per grid cell). `byIds` must resolve every requested
+    // observation from a single batched call.
+    it("returns an empty array for an empty id list", async () => {
+      const result = await caller.observations.byIds({
+        projectId,
+        observationIds: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("batches multiple observations into a single response", async () => {
+      const trace = createTrace({ project_id: projectId });
+      const observations = [
+        createObservation({ project_id: projectId, trace_id: trace.id }),
+        createObservation({ project_id: projectId, trace_id: trace.id }),
+        createObservation({ project_id: projectId, trace_id: trace.id }),
+      ];
+
+      await createTracesCh([trace]);
+      await createObservationsCh(observations);
+
+      const result = await caller.observations.byIds({
+        projectId,
+        observationIds: observations.map((o) => o.id),
+      });
+
+      expect(result.map((o) => o.id).sort()).toEqual(
+        observations.map((o) => o.id).sort(),
+      );
+      const first = result.find((o) => o.id === observations[0]!.id);
+      expect(first?.projectId).toEqual(projectId);
+      expect(first?.output).toEqual(observations[0]!.output);
+    });
+
+    it("omits ids that do not resolve to an observation in the project", async () => {
+      const trace = createTrace({ project_id: projectId });
+      const observation = createObservation({
+        project_id: projectId,
+        trace_id: trace.id,
+      });
+
+      await createTracesCh([trace]);
+      await createObservationsCh([observation]);
+
+      const result = await caller.observations.byIds({
+        projectId,
+        observationIds: [observation.id, randomUUID()],
+      });
+
+      expect(result.map((o) => o.id)).toEqual([observation.id]);
+    });
+  });
+});

--- a/web/src/__tests__/server/traces-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-trpc.servertest.ts
@@ -692,6 +692,54 @@ describe("traces trpc", () => {
     });
   });
 
+  describe("traces.byIds", () => {
+    it("returns an empty array for an empty id list", async () => {
+      const result = await caller.traces.byIds({
+        projectId,
+        traceIds: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("batches multiple traces into a single response", async () => {
+      // Regression coverage for the dataset run comparison grid, which
+      // previously fired one `traces.byId` request per cell. `byIds` must
+      // resolve every requested trace from one call.
+      const traces = [
+        createTrace({ project_id: projectId }),
+        createTrace({ project_id: projectId }),
+        createTrace({ project_id: projectId }),
+      ];
+
+      await createTracesCh(traces);
+
+      const result = await caller.traces.byIds({
+        projectId,
+        traceIds: traces.map((t) => t.id),
+      });
+
+      expect(result.map((t) => t.id).sort()).toEqual(
+        traces.map((t) => t.id).sort(),
+      );
+      const first = result.find((t) => t.id === traces[0]!.id);
+      expect(first?.projectId).toEqual(projectId);
+      expect(first?.name).toEqual(traces[0]!.name);
+    });
+
+    it("omits ids that do not resolve to a trace in the project", async () => {
+      const trace = createTrace({ project_id: projectId });
+      await createTracesCh([trace]);
+
+      const result = await caller.traces.byIds({
+        projectId,
+        traceIds: [trace.id, randomUUID()],
+      });
+
+      expect(result.map((t) => t.id)).toEqual([trace.id]);
+    });
+  });
+
   describe("traces.filterOptions", () => {
     it("should include all possible categorical score values from score configs", async () => {
       // Create a trace

--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/src/components/ui/button";
 import { MemoizedIOTableCell } from "@/src/components/ui/IOTableCell";
 import { useActiveCell } from "@/src/features/datasets/contexts/ActiveCellContext";
 import { useDatasetCompareFields } from "@/src/features/datasets/contexts/DatasetCompareFieldsContext";
-import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { cn } from "@/src/utils/tailwind";
 import { ClockIcon, ListTree } from "lucide-react";
@@ -15,7 +14,6 @@ import { useRouter } from "next/router";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useMergedAggregates } from "@/src/features/scores/lib/useMergedAggregates";
 import { useMergeScoreColumns } from "@/src/features/scores/lib/mergeScoreColumns";
-import { useTrpcError } from "@/src/hooks/useTrpcError";
 import { type ScoreAggregate } from "@langfuse/shared";
 import { computeScoreDiffs } from "@/src/features/datasets/lib/computeScoreDiffs";
 import { useMemo } from "react";
@@ -25,6 +23,17 @@ import { useResourceMetricsDiff } from "@/src/features/datasets/hooks/useResourc
 import { NotFoundCard } from "@/src/features/datasets/components/NotFoundCard";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { type RouterOutput } from "@/src/utils/types";
+
+// The dataset run comparison grid renders up to 50 rows x N selected runs at
+// once. Rather than each cell independently querying its trace/observation
+// (one HTTP request per cell), the page's full set of trace/observation ids
+// is batch-fetched once by DatasetCompareRunsTable via `traces.byIds` /
+// `observations.byIds`, and the resulting lookup maps are threaded down as
+// props so a cell only reads from the map.
+export type TraceByIdsItem = RouterOutput["traces"]["byIds"][number];
+export type ObservationByIdsItem =
+  RouterOutput["observations"]["byIds"][number];
 
 const DatasetAggregateCellContent = ({
   projectId,
@@ -33,6 +42,10 @@ const DatasetAggregateCellContent = ({
   serverScoreColumns,
   scoreDiffs,
   baselineRunValue,
+  tracesById,
+  observationsById,
+  isTracesLoading,
+  isObservationsLoading,
 }: {
   projectId: string;
   value: EnrichedDatasetRunItem;
@@ -40,11 +53,14 @@ const DatasetAggregateCellContent = ({
   serverScoreColumns: ScoreColumn[];
   scoreDiffs?: Record<string, BaselineDiff>;
   baselineRunValue?: EnrichedDatasetRunItem;
+  tracesById: Map<string, TraceByIdsItem>;
+  observationsById: Map<string, ObservationByIdsItem>;
+  isTracesLoading: boolean;
+  isObservationsLoading: boolean;
 }) => {
   const router = useRouter();
   const capture = usePostHogClientCapture();
   const { isBetaEnabled: isV4 } = useV4Beta();
-  const silentHttpCodes = [404];
   const { selectedFields } = useDatasetCompareFields();
   const { activeCell, setActiveCell } = useActiveCell();
 
@@ -56,49 +72,15 @@ const DatasetAggregateCellContent = ({
   // Merge server columns with cache-only columns
   const mergedScoreColumns = useMergeScoreColumns(serverScoreColumns);
 
-  // Subtract 1 day from the run item creation timestamp as a buffer in case the trace happened before the run
-  const fromTimestamp = new Date(
-    value.createdAt.getTime() - 24 * 60 * 60 * 1000,
-  );
-
-  // conditionally fetch the trace or observation depending on the presence of observationId
-  const trace = api.traces.byId.useQuery(
-    { traceId: value.trace.id, projectId, fromTimestamp },
-    {
-      enabled: value.observation === undefined,
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      retry: false,
-      staleTime: Infinity,
-      meta: { silentHttpCodes },
-    },
-  );
-  const observation = api.observations.byId.useQuery(
-    {
-      observationId: value.observation?.id as string, // disabled when observationId is undefined
-      projectId,
-      traceId: value.trace.id,
-    },
-    {
-      enabled: value.observation !== undefined,
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      retry: false,
-      staleTime: Infinity,
-      meta: { silentHttpCodes },
-    },
-  );
-
-  const data = value.observation === undefined ? trace.data : observation.data;
-  const isLoading =
-    value.observation === undefined ? trace.isLoading : observation.isLoading;
-
-  const { isSilentError } = useTrpcError(
-    value.observation === undefined ? trace.error : observation.error,
-    silentHttpCodes,
-  );
+  const isObservationCell = value.observation !== undefined;
+  const data =
+    value.observation === undefined
+      ? tracesById.get(value.trace.id)
+      : observationsById.get(value.observation.id);
+  const isLoading = isObservationCell ? isObservationsLoading : isTracesLoading;
+  // The batch fetch has completed but this cell's trace/observation was not
+  // returned (e.g. deleted, or outside the shared fromTimestamp bound).
+  const isSilentError = !isLoading && !data;
 
   const { latency, totalCost, latencyDiff, totalCostDiff } =
     useResourceMetricsDiff(value, baselineRunValue);
@@ -275,17 +257,25 @@ const DatasetAggregateCellContent = ({
   );
 };
 
+type CellDataLookups = {
+  tracesById: Map<string, TraceByIdsItem>;
+  observationsById: Map<string, ObservationByIdsItem>;
+  isTracesLoading: boolean;
+  isObservationsLoading: boolean;
+};
+
 const DatasetAggregateCellAgainstBaseline = ({
   value,
   projectId,
   serverScoreColumns,
   baselineRunValue,
+  ...cellDataLookups
 }: {
   projectId: string;
   value: EnrichedDatasetRunItem;
   serverScoreColumns: ScoreColumn[];
   baselineRunValue: EnrichedDatasetRunItem;
-}) => {
+} & CellDataLookups) => {
   // Merge cached score writes into aggregates for optimistic display
   const displayScores = useMergedAggregates(
     value.scores,
@@ -313,6 +303,7 @@ const DatasetAggregateCellAgainstBaseline = ({
       scores={displayScores}
       scoreDiffs={scoreDiffs}
       baselineRunValue={baselineRunValue}
+      {...cellDataLookups}
     />
   );
 };
@@ -321,11 +312,12 @@ const DatasetAggregateCell = ({
   value,
   projectId,
   serverScoreColumns,
+  ...cellDataLookups
 }: {
   projectId: string;
   value: EnrichedDatasetRunItem;
   serverScoreColumns: ScoreColumn[];
-}) => {
+} & CellDataLookups) => {
   // Merge cached score writes into aggregates for optimistic display
   const displayScores = useMergedAggregates(
     value.scores,
@@ -339,6 +331,7 @@ const DatasetAggregateCell = ({
       value={value}
       serverScoreColumns={serverScoreColumns}
       scores={displayScores}
+      {...cellDataLookups}
     />
   );
 };
@@ -349,7 +342,7 @@ type DatasetAggregateTableCellProps = {
   serverScoreColumns: ScoreColumn[];
   isBaselineRun: boolean;
   baselineRunValue?: EnrichedDatasetRunItem;
-};
+} & CellDataLookups;
 
 export const DatasetAggregateTableCell = ({
   projectId,
@@ -357,6 +350,7 @@ export const DatasetAggregateTableCell = ({
   serverScoreColumns,
   isBaselineRun,
   baselineRunValue,
+  ...cellDataLookups
 }: DatasetAggregateTableCellProps) => {
   return baselineRunValue && !isBaselineRun ? (
     <DatasetAggregateCellAgainstBaseline
@@ -364,12 +358,14 @@ export const DatasetAggregateTableCell = ({
       value={value}
       serverScoreColumns={serverScoreColumns}
       baselineRunValue={baselineRunValue}
+      {...cellDataLookups}
     />
   ) : (
     <DatasetAggregateCell
       projectId={projectId}
       value={value}
       serverScoreColumns={serverScoreColumns}
+      {...cellDataLookups}
     />
   );
 };

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -6,6 +6,10 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { getDatasetRunAggregateColumnProps } from "@/src/features/datasets/components/DatasetRunAggregateColumnHelpers";
+import {
+  type ObservationByIdsItem,
+  type TraceByIdsItem,
+} from "@/src/features/datasets/components/DatasetAggregateTableCell";
 import { useDatasetRunAggregateColumns } from "@/src/features/datasets/hooks/useDatasetRunAggregateColumns";
 import { useState, useEffect, useMemo } from "react";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
@@ -84,6 +88,88 @@ function DatasetCompareRunsTableInternal(props: {
     },
   );
 
+  const itemsData = datasetItemsWithRunData.data?.data;
+
+  // The grid is rows (dataset items) x columns (selected runs). Each cell
+  // needs the trace or observation for its (item, run) pair. Rather than let
+  // every cell query independently (one HTTP request per cell — up to
+  // 50 rows x N runs on a single page load), collect every id the currently
+  // rendered page needs and batch-fetch them in exactly one request per kind.
+  const { traceIds, observationIds, fromTimestamp } = useMemo(() => {
+    const traceIdSet = new Set<string>();
+    const observationIdSet = new Set<string>();
+    let minCreatedAt: Date | undefined;
+
+    (itemsData ?? []).forEach((item) => {
+      Object.values(item.runData ?? {}).forEach((value) => {
+        if (value.observation === undefined) {
+          traceIdSet.add(value.trace.id);
+        } else {
+          observationIdSet.add(value.observation.id);
+        }
+        if (!minCreatedAt || value.createdAt < minCreatedAt) {
+          minCreatedAt = value.createdAt;
+        }
+      });
+    });
+
+    return {
+      traceIds: Array.from(traceIdSet),
+      observationIds: Array.from(observationIdSet),
+      // Subtract 1 day from the earliest run item creation timestamp as a
+      // buffer in case a trace happened before the run (mirrors the per-cell
+      // buffer this batched fetch replaces).
+      fromTimestamp: minCreatedAt
+        ? new Date(minCreatedAt.getTime() - 24 * 60 * 60 * 1000)
+        : undefined,
+    };
+  }, [itemsData]);
+
+  const tracesByIdsQuery = api.traces.byIds.useQuery(
+    { projectId: props.projectId, traceIds, fromTimestamp },
+    {
+      enabled: traceIds.length > 0,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      retry: false,
+      staleTime: Infinity,
+    },
+  );
+
+  const observationsByIdsQuery = api.observations.byIds.useQuery(
+    { projectId: props.projectId, observationIds },
+    {
+      enabled: observationIds.length > 0,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      retry: false,
+      staleTime: Infinity,
+    },
+  );
+
+  const tracesById = useMemo(() => {
+    const map = new Map<string, TraceByIdsItem>();
+    tracesByIdsQuery.data?.forEach((trace) => map.set(trace.id, trace));
+    return map;
+  }, [tracesByIdsQuery.data]);
+
+  const observationsById = useMemo(() => {
+    const map = new Map<string, ObservationByIdsItem>();
+    observationsByIdsQuery.data?.forEach((observation) =>
+      map.set(observation.id, observation),
+    );
+    return map;
+  }, [observationsByIdsQuery.data]);
+
+  // Only "loading" while a batch this page actually needs is in flight; a
+  // page with no observation cells, for example, should not wait on the
+  // (disabled) observations query.
+  const isTracesLoading = traceIds.length > 0 && tracesByIdsQuery.isPending;
+  const isObservationsLoading =
+    observationIds.length > 0 && observationsByIdsQuery.isPending;
+
   const totalCountQuery = api.datasets.runItemCompareCount.useQuery({
     projectId: props.projectId,
     datasetId: props.datasetId,
@@ -133,6 +219,10 @@ function DatasetCompareRunsTableInternal(props: {
       datasetId: props.datasetId,
       updateRunFilters,
       getFiltersForRun,
+      tracesById,
+      observationsById,
+      isTracesLoading,
+      isObservationsLoading,
     });
 
   const columns: LangfuseColumnDef<DatasetCompareRunRowData>[] = [
@@ -211,7 +301,7 @@ function DatasetCompareRunsTableInternal(props: {
   ];
 
   const rows =
-    datasetItemsWithRunData.data?.data.map((item) => ({
+    itemsData?.map((item) => ({
       ...item,
       runs: item.runData,
     })) ?? [];

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -1,6 +1,10 @@
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { Skeleton } from "@/src/components/ui/skeleton";
-import { DatasetAggregateTableCell } from "@/src/features/datasets/components/DatasetAggregateTableCell";
+import {
+  DatasetAggregateTableCell,
+  type ObservationByIdsItem,
+  type TraceByIdsItem,
+} from "@/src/features/datasets/components/DatasetAggregateTableCell";
 import { type DatasetCompareRunRowData } from "@/src/features/datasets/components/DatasetCompareRunsTable";
 import { PopoverFilterBuilder } from "@/src/features/filters/components/filter-builder";
 import { type ColumnDefinition } from "@langfuse/shared";
@@ -14,19 +18,27 @@ import { Toggle } from "@/src/components/ui/toggle";
 import { useRouter } from "next/router";
 import { cn } from "@/src/utils/tailwind";
 
+type CellDataLookups = {
+  tracesById: Map<string, TraceByIdsItem>;
+  observationsById: Map<string, ObservationByIdsItem>;
+  isTracesLoading: boolean;
+  isObservationsLoading: boolean;
+};
+
 function DatasetAggregateCellWithBaselineDetection({
   value,
   runData,
   runId,
   projectId,
   serverScoreColumns,
+  ...cellDataLookups
 }: {
   value: EnrichedDatasetRunItem;
   runData: Record<string, EnrichedDatasetRunItem>;
   runId: string;
   projectId: string;
   serverScoreColumns?: ScoreColumn[];
-}) {
+} & CellDataLookups) {
   const router = useRouter();
   const baselineRunId = router.query.baseline as string | undefined;
 
@@ -41,6 +53,7 @@ function DatasetAggregateCellWithBaselineDetection({
       serverScoreColumns={serverScoreColumns ?? []}
       isBaselineRun={isBaselineRun}
       baselineRunValue={baselineRunValue}
+      {...cellDataLookups}
     />
   );
 }
@@ -175,6 +188,7 @@ export const constructDatasetRunAggregateColumns = ({
   updateRunFilters,
   getFiltersForRun,
   serverScoreColumns,
+  ...cellDataLookups
 }: {
   runAggregateColumnProps: RunAggregateColumnProps[];
   projectId: string;
@@ -182,7 +196,7 @@ export const constructDatasetRunAggregateColumns = ({
   updateRunFilters: (runId: string, filters: FilterState) => void;
   getFiltersForRun: (runId: string) => FilterState;
   serverScoreColumns?: ScoreColumn[];
-}): LangfuseColumnDef<DatasetCompareRunRowData>[] => {
+} & CellDataLookups): LangfuseColumnDef<DatasetCompareRunRowData>[] => {
   const isDataLoading = !isScoreColumnsAvailable(serverScoreColumns);
 
   return runAggregateColumnProps.map((col) => {
@@ -226,6 +240,7 @@ export const constructDatasetRunAggregateColumns = ({
             runId={id}
             projectId={projectId}
             serverScoreColumns={serverScoreColumns}
+            {...cellDataLookups}
           />
         );
       },

--- a/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
+++ b/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
@@ -1,5 +1,9 @@
 import { useMemo } from "react";
 import { constructDatasetRunAggregateColumns } from "@/src/features/datasets/components/DatasetRunAggregateColumnHelpers";
+import {
+  type ObservationByIdsItem,
+  type TraceByIdsItem,
+} from "@/src/features/datasets/components/DatasetAggregateTableCell";
 import { api } from "@/src/utils/api";
 import {
   datasetRunItemsTableColsWithOptions,
@@ -13,12 +17,20 @@ export function useDatasetRunAggregateColumns({
   datasetId,
   updateRunFilters,
   getFiltersForRun,
+  tracesById,
+  observationsById,
+  isTracesLoading,
+  isObservationsLoading,
 }: {
   projectId: string;
   runIds: string[];
   datasetId: string;
   updateRunFilters: (runId: string, filters: FilterState) => void;
   getFiltersForRun: (runId: string) => FilterState;
+  tracesById: Map<string, TraceByIdsItem>;
+  observationsById: Map<string, ObservationByIdsItem>;
+  isTracesLoading: boolean;
+  isObservationsLoading: boolean;
 }) {
   const datasetRunItemsFilterOptionsResponse =
     api.datasets.runItemFilterOptions.useQuery({
@@ -76,6 +88,10 @@ export function useDatasetRunAggregateColumns({
       serverScoreColumns: scoreKeysAndProps.data?.scoreColumns,
       updateRunFilters,
       getFiltersForRun,
+      tracesById,
+      observationsById,
+      isTracesLoading,
+      isObservationsLoading,
     });
   }, [
     runAggregateColumnProps,
@@ -84,6 +100,10 @@ export function useDatasetRunAggregateColumns({
     scoreKeysAndProps.data?.scoreColumns,
     updateRunFilters,
     getFiltersForRun,
+    tracesById,
+    observationsById,
+    isTracesLoading,
+    isObservationsLoading,
   ]);
 
   return {

--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -1,11 +1,18 @@
 import {
   createTRPCRouter,
   protectedGetTraceProcedure,
+  protectedProjectProcedure,
 } from "@/src/server/api/trpc";
 import { LangfuseNotFoundError, parseIO } from "@langfuse/shared";
-import { getObservationById } from "@langfuse/shared/src/server";
+import {
+  getObservationById,
+  getObservationsById,
+} from "@langfuse/shared/src/server";
 import { z } from "zod";
-import { toDomainWithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+import {
+  toDomainArrayWithStringifiedMetadata,
+  toDomainWithStringifiedMetadata,
+} from "@/src/utils/clientSideDomainTypes";
 
 export const observationsRouter = createTRPCRouter({
   byId: protectedGetTraceProcedure
@@ -43,5 +50,33 @@ export const observationsRouter = createTRPCRouter({
         output: parseIO(obs.output, input.verbosity) as string,
         internalModel: obs?.internalModelId,
       };
+    }),
+  // Batched counterpart to `byId`. Used by views (e.g. the dataset run
+  // comparison grid) that need many observations at once and would
+  // otherwise fire one `byId` request per cell. Project membership (checked
+  // by protectedProjectProcedure) is sufficient here because this endpoint
+  // is read-only and scoped to the caller's own project.
+  byIds: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        observationIds: z.array(z.string()),
+      }),
+    )
+    .query(async ({ input }) => {
+      if (input.observationIds.length === 0) return [];
+
+      const observations = await getObservationsById(
+        input.observationIds,
+        input.projectId,
+        true, // fetchWithInputOutput
+      );
+
+      return toDomainArrayWithStringifiedMetadata(observations).map((obs) => ({
+        ...obs,
+        input: obs.input as string,
+        output: obs.output as string,
+        internalModel: obs.internalModelId,
+      }));
     }),
 });

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -40,6 +40,7 @@ import {
   getTracesGroupedByTags,
   getObservationsForTrace,
   getTraceById,
+  getTracesByIds,
   logger,
   upsertTrace,
   convertTraceDomainToClickhouse,
@@ -382,6 +383,38 @@ export const traceRouter = createTRPCRouter({
           ? JSON.stringify(ctx.trace.metadata)
           : undefined,
       };
+    }),
+  // Batched counterpart to `byId`. Used by views (e.g. the dataset run
+  // comparison grid) that need many traces at once and would otherwise fire
+  // one `byId` request per cell. Project membership (checked by
+  // protectedProjectProcedure) is sufficient here because this endpoint is
+  // read-only and scoped to the caller's own project; unlike `byId`, it does
+  // not do the per-trace public/session visibility check used to expose a
+  // single trace outside its owning project.
+  byIds: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        traceIds: z.array(z.string()),
+        // lower bound across the requested traces, used to query CH more efficiently
+        fromTimestamp: z.date().nullish(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      if (input.traceIds.length === 0) return [];
+
+      const traces = await getTracesByIds(
+        input.traceIds,
+        ctx.session.projectId,
+        input.fromTimestamp ?? undefined,
+      );
+
+      return traces.map((trace) => ({
+        ...trace,
+        input: trace.input as string,
+        output: trace.output as string,
+        metadata: trace.metadata ? JSON.stringify(trace.metadata) : undefined,
+      }));
     }),
   byIdWithObservationsAndScores: protectedGetTraceProcedure
     .input(


### PR DESCRIPTION
## Summary
- The dataset run comparison grid fired one `traces.byId` / `observations.byId` request per cell, so a page of up to 50 items x N selected runs sent hundreds of concurrent requests the instant the grid rendered.
- Add batched `traces.byIds` / `observations.byIds` tRPC procedures scoped to the caller's project.
- `DatasetCompareRunsTable` now collects the trace/observation ids the current page needs and fetches each kind once, passing lookup maps down to `DatasetAggregateTableCell` / `DatasetAggregateCellContent` instead of each cell querying independently.

## Test plan
- [ ] Open a dataset with 2+ runs compared on a preview deployment (`pr-<N>.preview.langfuse.com`), seed data if needed, open the browser Network tab, and confirm the compare grid issues one `traces.byIds` / `observations.byIds` request per page load instead of one request per cell.
- [ ] Change the selected runs / page and confirm exactly one new batched request fires per change, not one per cell.
- [ ] Added server tests: `traces.byIds` (batches multiple ids, empty input, omits unresolved ids) in `web/src/__tests__/server/traces-trpc.servertest.ts`; `observations.byIds` in the new `web/src/__tests__/server/observations-router-trpc.servertest.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces per-cell trace and observation requests in the dataset run comparison grid with project-scoped batch procedures and lookup maps.

- Adds `traces.byIds` and `observations.byIds` procedures with server coverage.
- Collects IDs for the current page and issues one query per resource kind.
- Threads batch results and loading state through aggregate-column and cell components.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until batch request failures stop being presented as if every affected trace or observation was deleted.

A transient or server-side failure of either new batch query empties that resource lookup and causes all corresponding cells to render false Not Found states while disabling their actions.

**Files Needing Attention:** web/src/features/datasets/components/DatasetAggregateTableCell.tsx, web/src/features/datasets/components/DatasetCompareRunsTable.tsx
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Grid as DatasetCompareRunsTable
  participant TraceAPI as traces.byIds
  participant ObservationAPI as observations.byIds
  participant Cell as DatasetAggregateTableCell
  Grid->>Grid: Collect current-page IDs
  par Fetch traces
    Grid->>TraceAPI: traceIds + shared fromTimestamp
    TraceAPI-->>Grid: traces[]
  and Fetch observations
    Grid->>ObservationAPI: observationIds
    ObservationAPI-->>Grid: observations[]
  end
  Grid->>Grid: Build ID lookup maps
  Grid->>Cell: Maps and loading flags
  Cell->>Cell: Render output or missing state
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/components/DatasetAggregateTableCell.tsx:81-83
**Batch failures become not-found state**

When either batched lookup fails, its data map is empty and its pending flag becomes false, so every affected cell is classified as not found and loses its Annotate and peek actions even though the resources may still exist. Propagate the query error separately so only a successful response that omits an ID produces `NotFoundCard`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: batch trace/observation lookups in ..."](https://github.com/langfuse/langfuse/commit/22f87c132abbf0993d7a49536b0fc7635ef8b3fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55685778)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Web App (`web/`)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/web-app.md)
- Knowledge Base — [Datasets, Dataset Runs, and Experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-experiments.md)

<!-- /greptile_comment -->