### PR TITLE
fix(evals): link code evaluators to their scores

### DIFF
--- a/packages/shared/src/server/tableMappings/mapScoresTable.ts
+++ b/packages/shared/src/server/tableMappings/mapScoresTable.ts
@@ -60,6 +60,13 @@ export const scoresTableUiColumnDefinitions: UiColumnMappings = [
     queryPrefix: "s",
   },
   {
+    uiTableName: "Evaluator ID",
+    uiTableId: "evaluatorId",
+    clickhouseTableName: "scores",
+    clickhouseSelect:
+      "coalesce(nullIf(s.metadata['evaluator_id'], ''), s.metadata['job_configuration_id'])",
+  },
+  {
     uiTableName: "Value",
     uiTableId: "value",
     clickhouseTableName: "scores",

--- a/packages/shared/src/tableDefinitions/scoresTable.ts
+++ b/packages/shared/src/tableDefinitions/scoresTable.ts
@@ -62,6 +62,14 @@ export const scoresTableCols: ColumnDefinition[] = [
     internal: 's."name"',
     options: [],
   },
+  {
+    name: "Evaluator ID",
+    id: "evaluatorId",
+    type: "stringOptions",
+    // ClickHouse-only virtual column; see mapScoresTable.ts.
+    internal: "",
+    options: [],
+  },
   { name: "Value", id: "value", type: "number", internal: 's."value"' },
   {
     name: "Boolean Value",

--- a/web/src/__tests__/server/scores-trpc.servertest.ts
+++ b/web/src/__tests__/server/scores-trpc.servertest.ts
@@ -195,6 +195,76 @@ describe("scores trpc", () => {
       );
     });
 
+    it("filters evaluator scores by recorded evaluator and legacy rule metadata", async () => {
+      const [evaluator, otherEvaluator] = await Promise.all(
+        ["Evaluator", "Other evaluator"].map((name) =>
+          prisma.evaluator.create({
+            data: { projectId, name, type: "CODE" },
+          }),
+        ),
+      );
+      const rule = await prisma.evaluationRule.create({
+        data: {
+          projectId,
+          name: "Legacy rule",
+          targetObject: "EVENT",
+          filter: [],
+          sampling: 1,
+          delay: 0,
+          assignments: {
+            create: { projectId, evaluatorId: evaluator.id },
+          },
+        },
+      });
+      const directScore = createTraceScore({
+        project_id: projectId,
+        name: "direct-score",
+        metadata: { evaluator_id: evaluator.id },
+      });
+      const legacyScore = createTraceScore({
+        project_id: projectId,
+        name: "legacy-score-with-a-different-name",
+        metadata: { job_configuration_id: rule.id },
+      });
+      const otherScore = createTraceScore({
+        project_id: projectId,
+        name: "other-score",
+        metadata: { evaluator_id: otherEvaluator.id },
+      });
+      await createScoresCh([directScore, legacyScore, otherScore]);
+
+      const payload = {
+        projectId,
+        filter: [
+          {
+            column: "evaluatorId",
+            type: "stringOptions" as const,
+            operator: "any of" as const,
+            value: [evaluator.id, rule.id],
+          },
+        ],
+        orderBy: { column: "timestamp", order: "DESC" as const },
+        page: 0,
+        limit: 50,
+      };
+
+      const [scores, eventScores, count, eventCount] = await Promise.all([
+        caller.scores.all(payload),
+        caller.scores.allFromEvents(payload),
+        caller.scores.countAll({ ...payload, orderBy: null }),
+        caller.scores.countAllFromEvents({ ...payload, orderBy: null }),
+      ]);
+
+      expect(new Set(scores.scores.map(({ id }) => id))).toEqual(
+        new Set([directScore.id, legacyScore.id]),
+      );
+      expect(new Set(eventScores.scores.map(({ id }) => id))).toEqual(
+        new Set([directScore.id, legacyScore.id]),
+      );
+      expect(count.totalCount).toBe(2);
+      expect(eventCount.totalCount).toBe(2);
+    });
+
     it("does not match empty boolean representations when filtering boolean values", async () => {
       const trueBooleanScore = createTraceScore({
         project_id: projectId,

--- a/web/src/features/evals/v2/fns/evaluators/evaluatorScoresUrl.clienttest.ts
+++ b/web/src/features/evals/v2/fns/evaluators/evaluatorScoresUrl.clienttest.ts
@@ -11,9 +11,15 @@ import {
 } from "./evaluatorScoresUrl";
 
 describe("evaluatorScoresUrl", () => {
-  it("shows evaluator scores across all environments", () => {
+  it("filters code evaluator scores by evaluator and assigned rule IDs", () => {
     const url = new URL(
-      evaluatorScoresUrl("project-1", "evaluator-name"),
+      evaluatorScoresUrl(
+        "project-1",
+        "evaluator-id",
+        "Code evaluator",
+        EvalTemplateTypeEnum.CODE,
+        ["rule-1", "rule-2"],
+      ),
       "https://langfuse.local",
     );
 
@@ -21,10 +27,38 @@ describe("evaluatorScoresUrl", () => {
     expect(url.searchParams.get("showAllEnvironments")).toBe("true");
     expect(decodeFiltersGeneric(url.searchParams.get("filter") ?? "")).toEqual([
       {
+        column: "evaluatorId",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["evaluator-id", "rule-1", "rule-2"],
+      },
+      {
+        column: "source",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["EVAL"],
+      },
+    ]);
+  });
+
+  it("filters judge scores by evaluator name", () => {
+    const url = new URL(
+      evaluatorScoresUrl(
+        "project-1",
+        "evaluator-id",
+        "Correctness",
+        EvalTemplateTypeEnum.LLM_AS_JUDGE,
+        ["rule-1"],
+      ),
+      "https://langfuse.local",
+    );
+
+    expect(decodeFiltersGeneric(url.searchParams.get("filter") ?? "")).toEqual([
+      {
         column: "name",
         type: "stringOptions",
         operator: "any of",
-        value: ["evaluator-name"],
+        value: ["Correctness"],
       },
       {
         column: "source",

--- a/web/src/features/evals/v2/fns/evaluators/evaluatorScoresUrl.ts
+++ b/web/src/features/evals/v2/fns/evaluators/evaluatorScoresUrl.ts
@@ -6,14 +6,30 @@ import {
   encodeFiltersGeneric,
 } from "@langfuse/shared";
 
-export function evaluatorScoresUrl(projectId: string, name: string) {
+export function evaluatorScoresUrl(
+  projectId: string,
+  evaluatorId: string,
+  evaluatorName: string,
+  evaluatorType: EvalTemplateType,
+  assignedRuleIds: string[],
+) {
+  const evaluatorFilter: FilterState[number] =
+    evaluatorType === EvalTemplateTypeEnum.CODE
+      ? {
+          column: "evaluatorId",
+          type: "stringOptions",
+          operator: "any of",
+          value: [...new Set([evaluatorId, ...assignedRuleIds])],
+        }
+      : {
+          column: "name",
+          type: "stringOptions",
+          operator: "any of",
+          value: [evaluatorName],
+        };
+
   const filter: FilterState = [
-    {
-      column: "name",
-      type: "stringOptions",
-      operator: "any of",
-      value: [name],
-    },
+    evaluatorFilter,
     {
       column: "source",
       type: "stringOptions",

--- a/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
@@ -443,7 +443,15 @@ export default function EvaluatorsPage() {
             <EvaluatorActionsCell
               canViewExecutions={hasExecutionReadAccess}
               onViewScores={() =>
-                router.push(evaluatorScoresUrl(projectId, row.original.name))
+                router.push(
+                  evaluatorScoresUrl(
+                    projectId,
+                    row.original.id,
+                    row.original.name,
+                    row.original.type,
+                    row.original.assignedRuleIds,
+                  ),
+                )
               }
               onViewExecutions={() =>
                 router.push(

--- a/web/src/features/evals/v2/server/evaluators/evaluatorRepository.ts
+++ b/web/src/features/evals/v2/server/evaluators/evaluatorRepository.ts
@@ -180,7 +180,7 @@ export async function listEvaluators(params: {
         assignments: {
           where: { projectId: params.projectId },
           select: {
-            evaluationRule: { select: { status: true } },
+            evaluationRule: { select: { id: true, status: true } },
           },
         },
       },
@@ -190,6 +190,9 @@ export async function listEvaluators(params: {
   return {
     evaluators: evaluators.map(({ assignments, ...evaluator }) => ({
       ...evaluator,
+      assignedRuleIds: assignments.map(
+        ({ evaluationRule }) => evaluationRule.id,
+      ),
       hasActiveRules: assignments.some(
         ({ evaluationRule }) => evaluationRule.status === "ACTIVE",
       ),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16438.preview.langfuse.com](https://pr-16438.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Link code evaluators to scores using evaluator metadata and assigned rule IDs, so custom score names remain discoverable.
- Keep LLM judge score links name-based to preserve their existing behavior.
- Add the shared score filter mapping used by both score query paths and cover current and legacy metadata. Changes affect `web` and `@langfuse/shared`; validated with targeted client/server tests, web typechecking, formatting, and repository lint.

## Linear

- None

## Major Decisions

- Resolve current `evaluator_id` and legacy `job_configuration_id` metadata through one virtual score filter because separate table filters are combined with AND.

## Review Focus

- Confirm the legacy rule-ID fallback covers migrated code-evaluator scores without changing name-based judge links.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR links code evaluators to their score rows through evaluator and legacy rule metadata while retaining name-based links for LLM judges.
- Adds a virtual evaluator-ID score filter backed by current and legacy metadata.
- Passes evaluator identity and assigned rule IDs into score-page navigation.
- Extends evaluator list results and score-query tests for the new filtering behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until score navigation preserves legacy scores associated with rules that have since been detached or reassigned.

Code-evaluator navigation derives its legacy lookup IDs only from current assignments, so historical scores whose metadata references a former rule are silently excluded.

**Files Needing Attention:** web/src/features/evals/v2/server/evaluators/evaluatorRepository.ts; web/src/features/evals/v2/fns/evaluators/evaluatorScoresUrl.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  E[Evaluator row] -->|evaluator ID + current assigned rule IDs| U[Scores URL filter]
  U --> Q[Score query]
  Q --> M{Score metadata}
  M -->|evaluator_id present| C[Match current score]
  M -->|legacy job_configuration_id| L[Match legacy rule ID]
  D[Detached historical rule] -. ID absent from current assignments .-> U
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/server/evaluators/evaluatorRepository.ts:193-195
**Historical rule links are dropped**

When an evaluator's rule assignment is detached or replaced, `assignedRuleIds` contains only its current rules, so the generated score filter excludes legacy scores whose `job_configuration_id` references a former rule.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): link code evaluators to thei..."](https://github.com/langfuse/langfuse/commit/e8adbd60dd35e6b7707bcacae3046335505bc0b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55820970)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)
- Knowledge Base — [Shared Package](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/shared-package.md)

<!-- /greptile_comment -->