### PR TITLE
fix(scores): support evaluator metadata filters

### DIFF
--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -13,6 +13,7 @@ import {
   eventsTableTraceNameSqlForAlias,
 } from "../../eventsTable";
 import { LISTABLE_SCORE_TYPES } from "../../domain/scores";
+import { EvalExecutionMetadataKey } from "../evals/evalExecutionMetadata";
 
 // The data model defines all available dimensions, measures, and the timeDimension for a given view.
 // Make sure to update web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts if you make changes
@@ -849,6 +850,15 @@ const createScoreSpecificDimensions = (
     alias: "name",
     type: "string",
     description: "Name of the score (e.g., accuracy, toxicity).",
+  },
+  evaluatorId: {
+    sql: `coalesce(nullIf(${tableAlias}.metadata['${EvalExecutionMetadataKey.EVALUATOR_ID}'], ''), ${tableAlias}.metadata['${EvalExecutionMetadataKey.JOB_CONFIGURATION_ID}'])`,
+    alias: "evaluatorId",
+    type: "string",
+    description:
+      "Identifier of the evaluator, falling back to its legacy evaluation rule identifier.",
+    highCardinality: true,
+    uiHidden: true,
   },
   source: {
     sql: `${tableAlias}.source`,

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -170,6 +170,27 @@ describe("queryBuilder filter type validation", () => {
     expect(query).toContain(": Boolean}");
   });
 
+  it.each(["v1", "v2"] as const)(
+    "lowers evaluator score filters in the %s scores view",
+    async (version) => {
+      const { query } = await buildQueryWithFilter(
+        {
+          column: "evaluatorId",
+          operator: "any of",
+          value: ["evaluator-1", "rule-1"],
+          type: "stringOptions",
+        },
+        { view: "scores-numeric" },
+        version,
+      );
+
+      expect(query).toContain(
+        "coalesce(nullIf(scores_numeric.metadata['evaluator_id'], ''), scores_numeric.metadata['job_configuration_id'])",
+      );
+      expect(query).toContain("IN ({stringOptionsFilter");
+    },
+  );
+
   it("lowers the semantic-root observation filter only in the v2 events view", async () => {
     const { query } = await buildQueryWithFilter(
       {

--- a/packages/shared/src/tableDefinitions/scoresTable.ts
+++ b/packages/shared/src/tableDefinitions/scoresTable.ts
@@ -70,6 +70,12 @@ export const scoresTableCols: ColumnDefinition[] = [
     internal: "",
     options: [],
   },
+  {
+    name: "Metadata",
+    id: "metadata",
+    type: "stringObject",
+    internal: 's."metadata"',
+  },
   { name: "Value", id: "value", type: "number", internal: 's."value"' },
   {
     name: "Boolean Value",

--- a/web/src/features/filters/config/scores-config.clienttest.ts
+++ b/web/src/features/filters/config/scores-config.clienttest.ts
@@ -3,6 +3,19 @@
 import { getScoreFilterConfig, observationScopeFilter } from "./scores-config";
 
 describe("getScoreFilterConfig", () => {
+  it("offers score metadata in the filter sidebar", () => {
+    const config = getScoreFilterConfig();
+
+    expect(config.columnDefinitions).toContainEqual(
+      expect.objectContaining({ id: "metadata", type: "stringObject" }),
+    );
+    expect(config.facets).toContainEqual({
+      type: "stringKeyValue",
+      column: "metadata",
+      label: "Metadata",
+    });
+  });
+
   it("omits sidebar facets for hidden score columns", () => {
     const config = getScoreFilterConfig([
       "traceId",

--- a/web/src/features/filters/config/scores-config.ts
+++ b/web/src/features/filters/config/scores-config.ts
@@ -54,6 +54,11 @@ export const scoreFilterConfig: FilterConfig = {
       label: "Data Type",
     },
     {
+      type: "stringKeyValue" as const,
+      column: "metadata",
+      label: "Metadata",
+    },
+    {
       type: "numeric" as const,
       column: "value",
       label: "Numeric Value",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16439.preview.langfuse.com](https://pr-16439.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Register the evaluator/rule metadata fallback in the shared dashboard score data model so code-evaluator score links work in both score table and chart queries.
- Add the generic Metadata key/value filter to the scores sidebar.
- Cover v1/v2 dashboard lowering and sidebar exposure across `@langfuse/shared` and `web`; validated with focused shared, client, and server tests plus typechecking, formatting, and lint.

## Linear

- None

## Major Decisions

- Keep `evaluatorId` hidden as a dashboard grouping dimension while allowing it as an internal filter. It resolves current `evaluator_id` metadata first and falls back to legacy `job_configuration_id`.

## Review Focus

- Confirm the metadata fallback is appropriate for all score data types and both query-model versions.
- Check that exposing the generic score Metadata facet is consistent with the traces and observations sidebars.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Registers a shared evaluator metadata fallback so evaluator-linked score filters work across dashboard query models, and exposes score metadata filtering in the sidebar.
- Adds a hidden `evaluatorId` score dimension that prefers `evaluator_id` and falls back to legacy `job_configuration_id`.
- Adds the generic Metadata column and key/value filter facet for scores.
- Adds focused coverage for v1/v2 evaluator filter lowering and client-side metadata facet exposure.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the evaluator fallback and metadata facet consistently wired across the relevant score query paths.

The added evaluator dimension is available across all score data types and both query-model versions, while the metadata facet resolves through valid legacy, events-based, and Postgres filter mappings.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scores): support evaluator metadata ..."](https://github.com/langfuse/langfuse/commit/def928914f5b08814fe18ba3bd54b96b61de2567) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55824065)</sub>

<!-- /greptile_comment -->