### PR TITLE
fix(web): stop printing misleading CLICKHOUSE_PASSWORD hint on every clickhouse migration failure

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -118,7 +118,6 @@ fi
 if [ $status -ne 0 ]; then
     echo "Applying clickhouse migrations failed. Common causes:"
     echo "  1. The database is unavailable or unreachable."
-    echo "  2. CLICKHOUSE_PASSWORD contains special characters that are not URL-encoded."
     check_clickhouse_password "$CLICKHOUSE_PASSWORD"
     echo "Exiting..."
     exit $status

--- a/web/entrypoint.test.sh
+++ b/web/entrypoint.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression test for the "Common cause 2" ClickHouse migration failure
+# message: it must not be printed unconditionally, only when
+# CLICKHOUSE_PASSWORD actually contains characters that need URL-encoding.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT
+
+app_root="$tmpdir/app"
+mkdir -p "$app_root/web" "$app_root/packages/shared/clickhouse/scripts" "$tmpdir/bin"
+
+cp "$repo_root/web/entrypoint.sh" "$app_root/web/entrypoint.sh"
+chmod +x "$app_root/web/entrypoint.sh"
+
+# Stub prisma so the postgres migration step always succeeds, leaving only
+# the ClickHouse migration to fail.
+cat <<'EOF' > "$tmpdir/bin/prisma"
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$tmpdir/bin/prisma"
+
+# Simulate a ClickHouse migration failure unrelated to the password, e.g. a
+# dirty schema_migrations state.
+cat <<'EOF' > "$app_root/packages/shared/clickhouse/scripts/up.sh"
+#!/bin/sh
+echo "error: Dirty database version 1. Fix and force version."
+exit 1
+EOF
+chmod +x "$app_root/packages/shared/clickhouse/scripts/up.sh"
+
+run_entrypoint() {
+  (
+    cd "$app_root"
+    PATH="$tmpdir/bin:$PATH" \
+      DATABASE_URL="postgresql://user:pass@localhost:5432/db" \
+      CLICKHOUSE_URL="http://localhost:8123" \
+      CLICKHOUSE_PASSWORD="plainpassword" \
+      sh web/entrypoint.sh true
+  )
+}
+
+output="$(run_entrypoint || true)"
+
+if ! printf '%s\n' "$output" | grep -Fq "Applying clickhouse migrations failed. Common causes:"; then
+  echo "expected the clickhouse failure banner to still print"
+  printf '%s\n' "$output"
+  exit 1
+fi
+
+if printf '%s\n' "$output" | grep -Fq "CLICKHOUSE_PASSWORD contains special characters that are not URL-encoded."; then
+  echo "the unconditional CLICKHOUSE_PASSWORD hint must not print for a plain alphanumeric password"
+  printf '%s\n' "$output"
+  exit 1
+fi
+
+echo "entrypoint.sh clickhouse failure message test passed"


### PR DESCRIPTION
Fixes #16440

## TL;DR

`web/entrypoint.sh` printed "CLICKHOUSE_PASSWORD contains special characters
that are not URL-encoded" as an unconditional "common cause" on **every**
ClickHouse migration failure, even when the password was plain alphanumeric
and the real cause was something else (e.g. a dirty `schema_migrations`
state after an interrupted `docker compose up`). This sent self-hosters down
the wrong troubleshooting path.

## What changed

Removed the unconditional line at `web/entrypoint.sh:121`. The existing
conditional `check_clickhouse_password()` hint is untouched — it still
prints its detailed HINT only when `CLICKHOUSE_PASSWORD` actually contains
`& = # ? % + @` or a space.

```diff
     echo "Applying clickhouse migrations failed. Common causes:"
     echo "  1. The database is unavailable or unreachable."
-    echo "  2. CLICKHOUSE_PASSWORD contains special characters that are not URL-encoded."
     check_clickhouse_password "$CLICKHOUSE_PASSWORD"
```

## Test plan

Added `web/entrypoint.test.sh` (same standalone-bash-test convention as
`scripts/codex/setup.test.sh`): it stubs `prisma` to succeed, simulates a
ClickHouse migration failure unrelated to credentials (`Dirty database
version 1. Fix and force version.`) with a plain alphanumeric
`CLICKHOUSE_PASSWORD`, then asserts the failure banner still prints but the
misleading "Common cause 2" line does not.

Confirmed the test fails against the pre-fix script (`git checkout HEAD~1 --
web/entrypoint.sh`), then passes after the fix:

```
$ bash web/entrypoint.test.sh   # before fix
the unconditional CLICKHOUSE_PASSWORD hint must not print for a plain alphanumeric password
...
EXIT: 1

$ bash web/entrypoint.test.sh   # after fix
entrypoint.sh clickhouse failure message test passed
EXIT: 0
```

Also ran `shellcheck web/entrypoint.sh web/entrypoint.test.sh` — no new
warnings (one pre-existing, unrelated `SC2164` on line 111 outside this
diff).

**Skipped:** `pnpm run lint` / `pnpm run typecheck` — this sandbox has no
`node_modules` installed and the change touches only a shell script and a
plain-bash test file with no JS/TS surface for those tools to check.

## What a reviewer should doubt

- Whether removing the "common cause" line entirely is the right call vs.
  gating it the same way `check_unencoded_credentials` gates the Postgres
  message (i.e., keep a static list item but make it conditional). I chose
  straight removal since the conditional `check_clickhouse_password` HINT
  already covers the same information when it's actually relevant, and
  that's what the issue's suggested fix asked for.
- I did not implement the issue's "optional" suggestion (detecting
  `Dirty database version N` and printing a targeted remediation message) —
  that's a bigger behavioral addition, not the minimal fix for the
  misleading-line bug this issue reports.

---
This PR was authored by an autonomous AI agent (Claude, via Anthropic's
Claude Agent SDK) as part of Langfuse's open-source contribution tooling.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the unconditional ClickHouse password warning from migration failures while preserving the conditional password check.
- Adds a standalone shell regression test that simulates an unrelated ClickHouse migration failure.
- Verifies that the general failure banner remains while the misleading password message is absent for a plain password.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The production change only removes an unconditional message, and password-specific guidance remains available through the existing conditional checker.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop printing misleading CLICK..."](https://github.com/langfuse/langfuse/commit/930e7ac9174f8145ac7cb9d33c5b191c3e325d40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55825548)</sub>

<!-- /greptile_comment -->