### PR TITLE
fix(web): replace misleading migration password errors with actionable dirty state hints (fixes #16440)

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -99,7 +99,7 @@ status=$?
 if [ $status -ne 0 ]; then
     echo "Applying database migrations failed. Common causes:"
     echo "  1. The database is unavailable or unreachable."
-    echo "  2. DATABASE_URL / DIRECT_URL credentials contain special characters that are not URL-encoded."
+    echo "  2. The migration state is dirty and needs to be forcefully resolved."
     check_unencoded_credentials "$DIRECT_URL"
     echo "Exiting..."
     exit $status
@@ -118,7 +118,7 @@ fi
 if [ $status -ne 0 ]; then
     echo "Applying clickhouse migrations failed. Common causes:"
     echo "  1. The database is unavailable or unreachable."
-    echo "  2. CLICKHOUSE_PASSWORD contains special characters that are not URL-encoded."
+    echo "  2. The migration state is dirty and needs to be forcefully resolved."
     check_clickhouse_password "$CLICKHOUSE_PASSWORD"
     echo "Exiting..."
     exit $status


### PR DESCRIPTION
## Description
This PR addresses issue #16440 where `web/entrypoint.sh` would unconditionally print misleading warnings about `CLICKHOUSE_PASSWORD` and `DATABASE_URL` containing unencoded special characters whenever a database migration failed for any reason.

## Changes Made
- Removed the unconditional password warning lines from both the Postgres and ClickHouse failure blocks. The helper functions (`check_unencoded_credentials` and `check_clickhouse_password`) already conditionally print the warning if the password actually fails the checks.
- Added a new generic "common cause" hinting at dirty migration states (`The migration state is dirty and needs to be forcefully resolved.`). This is a highly frequent and actionable cause for migration crashes and provides much better guidance than the false-positive password error.

Fixes #16440.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces unconditional credential warnings after Postgres and ClickHouse migration failures with a generic dirty-migration-state hint, while retaining the conditional credential checks.
- Updates Postgres migration failure guidance.
- Updates ClickHouse migration failure guidance.
- Preserves the original migration exit statuses and conditional credential diagnostics.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it changes only failure guidance and preserves the existing conditional credential diagnostics and exit behavior.

Both migration systems can represent failed or dirty migration state, and the updated messages do not change startup control flow or suppress applicable credential warnings.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): replace misleading migration p..."](https://github.com/langfuse/langfuse/commit/22a7916df073fda9f663d933dc94ea201864d630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55878331)</sub>

<!-- /greptile_comment -->