### PR TITLE
fix(evals): keep corrupted-filter evaluation rules patchable and deletable

### DIFF
--- a/web/src/__tests__/server/unstable-evals-api.servertest.ts
+++ b/web/src/__tests__/server/unstable-evals-api.servertest.ts
@@ -783,6 +783,62 @@ describe("/api/public/unstable evaluators API", () => {
     expect(deleted.status).toBe(200);
   });
 
+  it("does not overwrite a corrupted stored filter when a PATCH renames the rule", async () => {
+    const evaluator = await makeZodVerifiedAPICall(
+      PostUnstableEvaluatorResponse,
+      "POST",
+      "/api/public/unstable/evaluators",
+      {
+        name: "Corrupted filter rename evaluator",
+        prompt: "Judge {{input}}",
+        outputDefinition: numericOutputDefinition,
+        mapping: [{ variable: "input", source: "input" }],
+      },
+      auth,
+    );
+
+    const corruptedFilter = [{ type: "legacy_unsupported", column: "input" }];
+    const nativeRule = await prisma.evaluationRule.create({
+      data: {
+        projectId,
+        name: "corrupted_filter_rename_rule",
+        targetObject: "event",
+        status: "ACTIVE",
+        sampling: 1,
+        delay: 0,
+        timeScope: ["NEW"],
+        filter: corruptedFilter,
+        assignments: {
+          create: {
+            projectId,
+            evaluatorId: evaluator.body.id,
+          },
+        },
+      },
+    });
+
+    const patched = await makeAPICall(
+      "PATCH",
+      `/api/public/unstable/evaluation-rules/${nativeRule.id}`,
+      { name: "renamed_corrupted_filter_rule" },
+      auth,
+    );
+    // The rule's own filter still can't be re-validated, so this patch is
+    // rejected rather than applied — but critically, it must fail loudly
+    // instead of silently persisting the degraded (empty) public read
+    // representation over the real stored filter.
+    expect(patched.status).toBe(400);
+
+    await expect(
+      prisma.evaluationRule.findUniqueOrThrow({
+        where: { id: nativeRule.id },
+      }),
+    ).resolves.toMatchObject({
+      name: "corrupted_filter_rename_rule",
+      filter: corruptedFilter,
+    });
+  });
+
   it("rejects create bodies that combine evaluators with the deprecated mapping alias", async () => {
     const evaluator = await makeZodVerifiedAPICall(
       PostUnstableEvaluatorResponse,

--- a/web/src/__tests__/server/unstable-evals-api.servertest.ts
+++ b/web/src/__tests__/server/unstable-evals-api.servertest.ts
@@ -719,6 +719,70 @@ describe("/api/public/unstable evaluators API", () => {
     expect(deleted.status).toBe(200);
   });
 
+  it("still allows disabling and deleting an observation rule with a corrupted stored filter", async () => {
+    const evaluator = await makeZodVerifiedAPICall(
+      PostUnstableEvaluatorResponse,
+      "POST",
+      "/api/public/unstable/evaluators",
+      {
+        name: "Corrupted filter rule evaluator",
+        prompt: "Judge {{input}}",
+        outputDefinition: numericOutputDefinition,
+        mapping: [{ variable: "input", source: "input" }],
+      },
+      auth,
+    );
+
+    // Mirrors a migrated rule whose stored filter no longer parses under the
+    // current public schema (e.g. an unrecognized filter `type`).
+    const corruptedFilter = [{ type: "legacy_unsupported", column: "input" }];
+    const nativeRule = await prisma.evaluationRule.create({
+      data: {
+        projectId,
+        name: "corrupted_filter_rule",
+        targetObject: "event",
+        status: "ACTIVE",
+        sampling: 1,
+        delay: 0,
+        timeScope: ["NEW"],
+        filter: corruptedFilter,
+        assignments: {
+          create: {
+            projectId,
+            evaluatorId: evaluator.body.id,
+          },
+        },
+      },
+    });
+
+    const patched = await makeAPICall(
+      "PATCH",
+      `/api/public/unstable/evaluation-rules/${nativeRule.id}`,
+      { enabled: false },
+      auth,
+    );
+    expect(patched.status).toBe(200);
+    expect(
+      PatchUnstableEvaluationRuleResponse.parse(patched.body),
+    ).toMatchObject({ id: nativeRule.id, enabled: false });
+
+    // The corrupted filter is left untouched rather than being silently
+    // replaced by the degraded (empty) public read representation.
+    await expect(
+      prisma.evaluationRule.findUniqueOrThrow({
+        where: { id: nativeRule.id },
+      }),
+    ).resolves.toMatchObject({ filter: corruptedFilter });
+
+    const deleted = await makeAPICall(
+      "DELETE",
+      `/api/public/unstable/evaluation-rules/${nativeRule.id}`,
+      undefined,
+      auth,
+    );
+    expect(deleted.status).toBe(200);
+  });
+
   it("rejects create bodies that combine evaluators with the deprecated mapping alias", async () => {
     const evaluator = await makeZodVerifiedAPICall(
       PostUnstableEvaluatorResponse,

--- a/web/src/features/evals/server/unstable-public-api/adapters.ts
+++ b/web/src/features/evals/server/unstable-public-api/adapters.ts
@@ -434,6 +434,23 @@ function toApiFilters(
   return parsedPublicFilters.data;
 }
 
+// A migrated rule can carry a stored filter that no longer parses under the
+// current public schema. Degrading to an empty filter here (rather than
+// throwing) keeps the rule readable, patchable, and deletable through the
+// public API instead of making it permanently unmanageable; the corruption
+// is still logged in toApiFilters above.
+function toApiFiltersOrDegraded(
+  filters: unknown,
+  target: PublicEvaluationRuleTargetType,
+): PublicEvaluationRuleFilterType[] {
+  try {
+    return toApiFilters(filters, target);
+  } catch (error) {
+    if (!(error instanceof InternalServerError)) throw error;
+    return [];
+  }
+}
+
 export function toApiEvaluator(params: {
   template: StoredPublicEvaluatorTemplate;
   evaluationRuleCount: number;
@@ -610,7 +627,7 @@ export function toApiV2EvaluationRule(
     pausedMessage: block.pausedMessage,
     sampling: Number(rule.sampling),
     target,
-    filter: toApiFilters(rule.filter, target),
+    filter: toApiFiltersOrDegraded(rule.filter, target),
     mapping: toApiReadMappings(effectiveFirstMapping),
     createdAt: rule.createdAt,
     updatedAt: rule.updatedAt,

--- a/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
@@ -598,6 +598,25 @@ export async function updatePublicEvaluationRule(params: {
     params.input.evaluator !== undefined ||
     ("mapping" in params.input && params.input.mapping !== undefined);
 
+  const targetUnchanged = !(
+    "target" in params.input && params.input.target !== undefined
+  );
+  const filterUnchanged = !(
+    "filter" in params.input && params.input.filter !== undefined
+  );
+
+  if (targetUnchanged && filterUnchanged) {
+    // A stored filter that fails to parse under the current public schema
+    // degrades to `[]` in existingPublic (see toApiV2EvaluationRule).
+    // Round-tripping that through toStoredFilter would silently erase the
+    // real stored filter on any patch that never touches target or filter —
+    // not just an enabled/sampling-only one. Keep the stored bytes as-is
+    // instead. (Only safe when target/filter are unchanged: switching target
+    // away from "experiment" relies on the public round-trip to strip the
+    // internal experiment-root marker filter.)
+    ruleFields.filter = existing.filter as typeof ruleFields.filter;
+  }
+
   // A patch that only flips enabled/sampling never needs to touch the stored
   // filter or assignments. Routing it through ruleService.setEnabled instead
   // of ruleService.update means it can disable (and, via findPublic...OrThrow
@@ -605,22 +624,10 @@ export async function updatePublicEvaluationRule(params: {
   // current schema, since setEnabled never re-validates that filter.
   const isEnabledOrSamplingOnlyPatch =
     !("name" in params.input && params.input.name !== undefined) &&
-    !("target" in params.input && params.input.target !== undefined) &&
-    !("filter" in params.input && params.input.filter !== undefined) &&
+    targetUnchanged &&
+    filterUnchanged &&
     !patchesFirstAssignment &&
     !params.input.evaluators;
-
-  if (isEnabledOrSamplingOnlyPatch) {
-    // A stored filter that fails to parse under the current public schema
-    // degrades to `[]` in existingPublic (see toApiV2EvaluationRule).
-    // Round-tripping that through toStoredFilter would silently erase the
-    // real stored filter on a patch that never touches target or filter.
-    // Keep the stored bytes as-is instead. (Only safe when target/filter
-    // are unchanged: switching target away from "experiment" relies on the
-    // public round-trip to strip the internal experiment-root marker
-    // filter.)
-    ruleFields.filter = existing.filter as typeof ruleFields.filter;
-  }
 
   if (
     "mapping" in params.input &&

--- a/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
@@ -598,6 +598,30 @@ export async function updatePublicEvaluationRule(params: {
     params.input.evaluator !== undefined ||
     ("mapping" in params.input && params.input.mapping !== undefined);
 
+  // A patch that only flips enabled/sampling never needs to touch the stored
+  // filter or assignments. Routing it through ruleService.setEnabled instead
+  // of ruleService.update means it can disable (and, via findPublic...OrThrow
+  // below, delete) a rule whose stored filter no longer parses under the
+  // current schema, since setEnabled never re-validates that filter.
+  const isEnabledOrSamplingOnlyPatch =
+    !("name" in params.input && params.input.name !== undefined) &&
+    !("target" in params.input && params.input.target !== undefined) &&
+    !("filter" in params.input && params.input.filter !== undefined) &&
+    !patchesFirstAssignment &&
+    !params.input.evaluators;
+
+  if (isEnabledOrSamplingOnlyPatch) {
+    // A stored filter that fails to parse under the current public schema
+    // degrades to `[]` in existingPublic (see toApiV2EvaluationRule).
+    // Round-tripping that through toStoredFilter would silently erase the
+    // real stored filter on a patch that never touches target or filter.
+    // Keep the stored bytes as-is instead. (Only safe when target/filter
+    // are unchanged: switching target away from "experiment" relies on the
+    // public round-trip to strip the internal experiment-root marker
+    // filter.)
+    ruleFields.filter = existing.filter as typeof ruleFields.filter;
+  }
+
   if (
     "mapping" in params.input &&
     params.input.mapping !== undefined &&
@@ -702,6 +726,7 @@ export async function updatePublicEvaluationRule(params: {
     replacementAssignments,
     patchedFirstAssignment,
     effectiveAssignmentCount: effectiveAssignments.length,
+    isEnabledOrSamplingOnlyPatch,
   });
   const evaluationRule = toApiWritableV2EvaluationRule(updated);
   if (params.auditScope) {
@@ -742,7 +767,27 @@ async function updateRuleWithRuleService(params: {
   replacementAssignments: PreparedAssignment[] | null;
   patchedFirstAssignment: PreparedAssignment | null;
   effectiveAssignmentCount: number;
+  isEnabledOrSamplingOnlyPatch: boolean;
 }) {
+  const enabled =
+    params.effectiveAssignmentCount > 0 &&
+    params.fields.status === JobConfigState.ACTIVE;
+
+  if (params.isEnabledOrSamplingOnlyPatch) {
+    await runRuleServiceMutation(() =>
+      ruleService.setEnabled({
+        projectId: params.projectId,
+        ruleId: params.evaluationRuleId,
+        enabled,
+        sampling: params.fields.sampling,
+      }),
+    );
+    return findPublicV2EvaluationRuleOrThrow({
+      projectId: params.projectId,
+      evaluationRuleId: params.evaluationRuleId,
+    });
+  }
+
   const firstAssignment = params.existing.assignments[0];
   const evaluatorMappings = params.replacementAssignments
     ? params.replacementAssignments.map((assignment) => ({
@@ -776,9 +821,7 @@ async function updateRuleWithRuleService(params: {
       ruleId: params.evaluationRuleId,
       targetObject: params.fields.targetObject as EvalTargetObject,
       name: params.fields.scoreName,
-      enabled:
-        params.effectiveAssignmentCount > 0 &&
-        params.fields.status === JobConfigState.ACTIVE,
+      enabled,
       sampling: params.fields.sampling,
       filter: params.fields.filter as FilterState,
       ...(evaluatorMappings === undefined ? {} : { evaluatorMappings }),


### PR DESCRIPTION
## What does this PR do?

Fixes #16445.

A migrated evaluation rule whose stored filter no longer parses under the
current public schema made **every** public API call on that rule fail with
HTTP 500 `"Evaluation rule filter is corrupted"` — `GET`, `PATCH`, `DELETE`,
and `list`. There was no way to disable or delete a live, misbehaving rule
through the public API.

Root cause: `toApiV2EvaluationRule` (used by every read path, and by
`updatePublicEvaluationRule`/`deletePublicEvaluationRule` to build the
pre-mutation "existing" representation) threw as soon as it tried to
re-serialize the stored filter into the public shape — before any mutation
could even be attempted.

### Fix

- `toApiV2EvaluationRule` now degrades an unparseable stored filter to `[]`
  in the public read shape instead of throwing (the parse failure is still
  logged via the existing `logger.error` call in `toApiFilters`). This alone
  unblocks `GET`, `list`, and lets the pre-mutation read succeed for `PATCH`
  and `DELETE`.
- A `PATCH` that only flips `enabled`/`sampling` (no `name`/`target`/`filter`/
  evaluator changes) is now routed through `RuleService.setEnabled` instead
  of `RuleService.update`. `setEnabled` never re-validates or rewrites the
  stored filter, so it can disable a rule even when that filter is corrupted
  — `update` unconditionally re-validates whatever filter it's given
  (inherited or not), which would still reject a corrupted rule. This also
  fixes a related edge case: without this, an enabled/sampling-only PATCH on
  a corrupted rule would have silently overwritten the real stored filter
  with the degraded `[]` value.
- `DELETE` needed no separate change: it was already filter-independent once
  the pre-mutation read stopped throwing.

This is a read/write-path fix only; it does not touch how the rule engine
itself evaluates the stored filter at runtime.

### Test plan

Added `web/src/__tests__/server/unstable-evals-api.servertest.ts` >
`"still allows disabling and deleting an observation rule with a corrupted
stored filter"`. It inserts a rule directly via Prisma with a filter shape
that fails the current public schema (mirroring a migrated/legacy rule),
then verifies:
- `PATCH { enabled: false }` returns 200 (was 500 before the fix).
- The stored filter is left byte-for-byte untouched afterward (no silent
  data loss).
- `DELETE` then succeeds (200).

Confirmed the test fails against the pre-fix code (`git checkout HEAD~1` on
the two source files, i.e. reverting just the fix while keeping the test):

```
AssertionError: expected 500 to be 200
```

Full verification, run locally against Postgres/ClickHouse via
`docker compose -f docker-compose.dev.yml`:

- `pnpm --filter web run test src/__tests__/server/unstable-evals-api.servertest.ts`
  → `Tests  16 passed (16)`
- `pnpm --filter web run test src/__tests__/server/unit/unstable-evals-service.servertest.ts src/__tests__/server/unit/unstable-evals-contract.servertest.ts`
  → `Tests  42 passed (42)`
- `pnpm --filter web run lint` → clean
- `pnpm --filter web run typecheck` → clean

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have checked if my PR needs changes to the documentation (no — internal
  behavior fix, no contract change)
- I have added tests that prove my fix is effective or that my feature works
- I have checked if new and existing unit tests pass locally with my changes

## What to doubt in review

- The `isEnabledOrSamplingOnlyPatch` check in `updatePublicEvaluationRule`
  only bypasses `RuleService.update` when the request touches none of
  `name`/`target`/`filter`/`evaluator(s)`. A PATCH that changes anything else
  (e.g. just renaming) on a corrupted-filter rule still 400s inside
  `RuleService.update`'s own filter re-validation — that's unchanged by this
  PR and out of scope per the issue's "at minimum, disable/delete" ask, but
  worth confirming that's an acceptable residual limitation.
- The degraded filter (`[]`) is only ever used for the public API's *read*
  representation and for the (skippable) preflight check when re-enabling; it
  is never written back to storage — writes either omit the filter (routed
  through `setEnabled`) or come from a fresh, valid `input.filter`. Worth a
  second look that no other code path derives a write value from the
  degraded read shape.
- This PR does not add a "corruption" flag to the public response (one of
  the three options the issue proposed). Consumers reading a corrupted rule
  will see `filter: []` with no signal that it differs from a genuinely
  empty filter, beyond the server-side log line already emitted by
  `toApiFilters`.

## AI disclosure

This PR was authored by an autonomous coding agent (Claude) operating on
this repository, with the changes reviewed against the repo's own tests,
lint, and typecheck before being pushed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes evaluation rules with corrupted stored filters readable and routes enabled/sampling-only updates through the filter-independent status mutation path.
- Degrades corrupted filters to an empty public representation.
- Preserves stored filter bytes for enabled/sampling-only PATCH requests.
- Adds an integration test covering disable and delete recovery.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR needs a fix before merging because some filter-omitting PATCH requests can silently erase a corrupted rule's stored filter.

The new degraded read value is correctly isolated for enabled/sampling-only updates, but name and assignment updates still derive writable fields from that value and persist an empty filter.

**Files Needing Attention:** web/src/features/evals/server/unstable-public-api/adapters.ts, web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load rule with corrupted stored filter] --> B[toApiV2EvaluationRule]
  B --> C[Public filter becomes empty array]
  C --> D{PATCH fields}
  D -->|enabled or sampling only| E[Preserve stored filter and call setEnabled]
  D -->|name or assignment fields| F[Use empty public filter in ruleFields]
  F --> G[RuleService.update]
  G --> H[Stored filter overwritten with empty array]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/server/unstable-public-api/adapters.ts:630
**Degraded filter leaks into writes**

When a corrupted-filter rule receives a PATCH that omits `filter` but changes its name or assignments, this degraded `[]` value becomes the default writable filter and `RuleService.update` persists it, silently erasing the stored filter and potentially activating the rule without filtering.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): keep corrupted-filter evalua..."](https://github.com/langfuse/langfuse/commit/64b25fcb48d375cc426617935bda156217c2c2f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55971896)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Evaluation Pipeline (LLM-as-Judge)](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/evaluation-pipeline.md)

<!-- /greptile_comment -->