### PR TITLE
fix(shared): preserve user text when splitting pydantic-ai tool responses

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/pydantic-ai.test.ts
+++ b/packages/shared/src/utils/chatml/adapters/pydantic-ai.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { pydanticAIAdapter } from "./pydantic-ai";
+
+describe("pydanticAIAdapter preprocess", () => {
+  const ctx = { metadata: undefined };
+
+  it("preserves user text that shares a request with tool responses", () => {
+    const data = [
+      {
+        role: "user",
+        parts: [
+          { type: "tool_call_response", id: "t1", result: "42" },
+          { type: "text", content: "now summarize the result" },
+        ],
+      },
+    ];
+
+    const result = pydanticAIAdapter.preprocess(data, "input", ctx);
+
+    expect(result).toEqual([
+      { role: "tool", tool_call_id: "t1", content: "42" },
+      { role: "user", content: "now summarize the result" },
+    ]);
+  });
+
+  it("keeps splitting pure tool-response user messages into tool messages only", () => {
+    const data = [
+      {
+        role: "user",
+        parts: [
+          { type: "tool_call_response", id: "t1", result: "a" },
+          { type: "tool_call_response", id: "t2", result: "b" },
+        ],
+      },
+    ];
+
+    const result = pydanticAIAdapter.preprocess(data, "input", ctx);
+
+    expect(result).toEqual([
+      { role: "tool", tool_call_id: "t1", content: "a" },
+      { role: "tool", tool_call_id: "t2", content: "b" },
+    ]);
+  });
+
+  it("keeps assistant tool calls with their text content", () => {
+    const data = [
+      {
+        role: "assistant",
+        parts: [
+          { type: "text", content: "calling the tool" },
+          { type: "tool_call", id: "t1", name: "lookup", arguments: '{"q":1}' },
+        ],
+      },
+    ];
+
+    const result = pydanticAIAdapter.preprocess(data, "input", ctx);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: "calling the tool",
+        tool_calls: [
+          { id: "t1", name: "lookup", arguments: '{"q":1}', type: "function" },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps plain user text messages unchanged", () => {
+    const data = [
+      { role: "user", parts: [{ type: "text", content: "hello" }] },
+    ];
+
+    const result = pydanticAIAdapter.preprocess(data, "input", ctx);
+
+    expect(result).toEqual([{ role: "user", content: "hello" }]);
+  });
+});

--- a/packages/shared/src/utils/chatml/adapters/pydantic-ai.ts
+++ b/packages/shared/src/utils/chatml/adapters/pydantic-ai.ts
@@ -213,12 +213,20 @@ function normalizeMessage(
 
   // User message with tool responses - split into separate tool messages
   if (message.role === "user" && toolResponses.length > 0) {
-    return toolResponses.map((tr) =>
+    const toolMessages = toolResponses.map((tr) =>
       removeNullFields({
         role: "tool",
         ...tr,
       }),
     );
+
+    // A user request can mix tool responses with authored text; keep the
+    // text instead of dropping it when the message is split.
+    if (text) {
+      toolMessages.push(removeNullFields({ role: "user", content: text }));
+    }
+
+    return toolMessages;
   }
 
   // Regular text message (may include thinking for assistant messages)


### PR DESCRIPTION
## Root cause

`normalizeMessage()` in `packages/shared/src/utils/chatml/adapters/pydantic-ai.ts` splits a **user** message containing `tool_call_response` parts into separate `role: "tool"` messages — and returned *only* those, discarding any text the same request carried (pydantic-ai allows `ModelRequest(parts=[ToolReturnPart(...), UserPromptPart("...")])`). The normalized output feeds trace rendering and playground replay, so affected traces show a tool result with no user follow-up, and replaying them sends an incomplete conversation.

Repro and impact in #16447.

## Fix

Keep the authored text: after mapping the tool responses, emit any accumulated `text` as a trailing `{ role: "user", content }` message (+9/-1). Pure tool-response messages are unaffected (no trailing message is added when there is no text).

## Test

- [x] New colocated suite `packages/shared/src/utils/chatml/adapters/pydantic-ai.test.ts` (first coverage for this module)
- [x] Regression: mixed `[tool_call_response, text]` request → `[tool, user]` — **fails on main** (text missing)
- [x] Contracts kept: pure tool responses split unchanged; assistant `tool_calls` + text unchanged; plain text unchanged
- [x] `pnpm exec vitest run src/utils/chatml/adapters/pydantic-ai.test.ts` → 4 passed
- [x] Pre-commit hooks green: prettier check + turbo lint pass on the changed files

## Diff scope

2 files: adapter split branch (+9/-1), new test file (+78).

Fixes #16447


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes Pydantic AI message normalization so authored user text is retained when a request also contains tool responses.
- Splits tool responses into tool-role messages and appends retained text as a user-role message.
- Adds regression coverage for mixed requests, pure tool responses, assistant tool calls, and plain user text.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The changed branch retains previously discarded user text while preserving pure tool-response and ordinary message behavior, and the new tests cover the relevant normalization paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): preserve user text when spl..."](https://github.com/langfuse/langfuse/commit/3ca4f8862c9620e28f618507597b88989538c18b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55977004)</sub>

<!-- /greptile_comment -->