### PR TITLE
fix(playground): decode streamed completions with stream:true

### DIFF
--- a/web/src/features/playground/page/context/chatCompletionStream.clienttest.ts
+++ b/web/src/features/playground/page/context/chatCompletionStream.clienttest.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the playground completion stream's UTF-8 decoding.
+ *
+ * /api/chatCompletion streams the provider's raw text through a
+ * TextEncoderStream, so chunk boundaries fall on arbitrary byte offsets and
+ * routinely split a multi-byte character in two.
+ */
+import { getChatCompletionStream } from "@/src/features/playground/page/context";
+
+const originalFetch = global.fetch;
+
+/** Streams `text` as UTF-8, emitting `chunkSize` bytes at a time. */
+function mockStreamingFetch(text: string, chunkSize: number) {
+  const bytes = new TextEncoder().encode(text);
+
+  global.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (let i = 0; i < bytes.length; i += chunkSize) {
+            controller.enqueue(bytes.slice(i, i + chunkSize));
+          }
+          controller.close();
+        },
+      }),
+    })) as unknown as typeof global.fetch;
+}
+
+async function collectCompletion(): Promise<string> {
+  let output = "";
+  for await (const token of getChatCompletionStream(
+    "project-id",
+    [],
+    {} as never,
+  )) {
+    output += token;
+  }
+  return output;
+}
+
+describe("getChatCompletionStream", () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should not corrupt multi-byte characters split across chunks", async () => {
+    const text = "Hola 🌍, 你好 — café";
+    // 1 byte per chunk splits every multi-byte character.
+    mockStreamingFetch(text, 1);
+
+    expect(await collectCompletion()).toBe(text);
+  });
+
+  it("should decode correctly for chunk sizes that straddle character boundaries", async () => {
+    const text = "🌍你好café🌍你好café";
+
+    for (const chunkSize of [2, 3, 5, 7]) {
+      mockStreamingFetch(text, chunkSize);
+      expect(await collectCompletion()).toBe(text);
+    }
+  });
+
+  it("should pass through pure ASCII unchanged", async () => {
+    const text = "The quick brown fox jumps over the lazy dog";
+    mockStreamingFetch(text, 4);
+
+    expect(await collectCompletion()).toBe(text);
+  });
+});

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -845,7 +845,7 @@ async function getChatCompletionWithStructuredOutput(
   }
 }
 
-async function* getChatCompletionStream(
+export async function* getChatCompletionStream(
   projectId: string | undefined,
   messages: ChatMessageWithId[],
   modelParams: UIModelParams,
@@ -895,10 +895,17 @@ async function* getChatCompletionStream(
       const { done, value } = await reader.read();
       if (done) break;
 
-      const token = decoder.decode(value);
+      // `stream: true` keeps a trailing incomplete UTF-8 sequence buffered
+      // until the next chunk. Without it a multi-byte character split across
+      // two network chunks decodes to replacement characters.
+      const token = decoder.decode(value, { stream: true });
 
       yield token;
     }
+
+    // Flush any bytes the decoder held back from the final chunk.
+    const tail = decoder.decode();
+    if (tail) yield tail;
   } catch (error) {
     throw error;
   } finally {


### PR DESCRIPTION
**Problem.** The playground reads `/api/chatCompletion` with a `TextDecoder` but calls `decode(value)` without the `stream` option, so every network chunk is decoded as if it were a complete stream. A multi-byte character split across two chunks decodes to replacement characters, corrupting the rendered output, the output JSON and the playground cache.

The handler streams the provider's text through a `TextEncoderStream` (`chatCompletionHandler.ts`), so there is no framing — chunk boundaries fall on arbitrary byte offsets. Any non-ASCII completion (emoji, CJK, accented Latin, typographic dashes) can hit this.

**Fix.** Decode with `{ stream: true }` and flush the decoder once the stream ends. This matches the two other streaming readers in the codebase, `useSSEDashboardQuery` and `backgroundAgentClient`, which already pass `{ stream: true }` — the playground is the only outlier. Same bug class as #14471 / #14504, different call site.

**Test.** New `chatCompletionStream.clienttest.ts` feeds a completion through a mocked `fetch` at 1-, 2-, 3-, 5- and 7-byte chunk sizes. Fails on `main`:

```
expected 'Hola ����, ������ ��� caf��' to be 'Hola 🌍, 你好 — café'
```

and passes with the fix. ASCII passthrough covered as a control. Full `client` suite: 3585 tests passing, no regressions; `tsc --noEmit`, `prettier` and `eslint --max-warnings 0` clean.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes streamed playground completions by preserving incomplete UTF-8 byte sequences between network chunks and flushing the decoder when the response ends.
- Exports the completion-stream generator for direct testing.
- Uses stateful `TextDecoder` decoding to prevent split multibyte characters from becoming replacement characters.
- Adds coverage for ASCII and multibyte text across several byte-chunk sizes.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the decoder lifecycle matching the playground stream’s UTF-8 byte contract.

The changed reader buffers incomplete UTF-8 sequences across chunks, flushes them before generator completion, and its caller safely concatenates all yielded text; no blocking or independently actionable issue remains.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Provider completion text] --> B[TextEncoderStream]
  B --> C[Arbitrary network byte chunks]
  C --> D[TextDecoder with stream enabled]
  D --> E[Flush decoder at end]
  E --> F[Correct playground output]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playground): decode streamed complet..."](https://github.com/langfuse/langfuse/commit/960723ff5c1052d654595757c2bdc851cde0f18d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56179735)</sub>

<!-- /greptile_comment -->