### PR TITLE
feat(widgets): add traceSessionId dimension and update sessionId description

### DIFF
--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -725,7 +725,17 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
     sql: "scores.session_id",
     alias: "sessionId",
     type: "string",
-    description: "Identifier of the session.",
+    description:
+      "Session the score is directly attached to (session-level scores only).",
+    highCardinality: true,
+  },
+  traceSessionId: {
+    sql: "nullIf(events_traces.session_id, '')",
+    alias: "traceSessionId",
+    type: "string",
+    relationTable: "events_traces",
+    description:
+      "Session of the parent trace (for trace- and observation-level scores).",
     highCardinality: true,
   },
   // Run-level scores (dataset_run_id on scores table). Used by experiment

--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -5287,6 +5287,71 @@ describe("query builder measure-aggregation validation", () => {
     });
   });
 
+  describe("v2 scores sessionId vs traceSessionId dimensions", () => {
+    it("should resolve traceSessionId via the events_traces join and keep sessionId on the scores table", async () => {
+      const projectId = randomUUID();
+
+      // sessionId: trace/observation scores never populate scores.session_id
+      // (only session-level scores do), so it must not pull in the events_traces
+      // join and must filter the scores table directly.
+      const sessionIdBuilder = new QueryBuilder(undefined, "v2");
+      const { query: sessionIdQuery } = await sessionIdBuilder.build(
+        {
+          view: "scores-numeric",
+          dimensions: [],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [
+            {
+              column: "sessionId",
+              operator: "=",
+              value: "session-1",
+              type: "string",
+            },
+          ],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            Date.now() - 7 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          toTimestamp: new Date(Date.now()).toISOString(),
+          orderBy: null,
+        },
+        projectId,
+      );
+      expect(sessionIdQuery).toContain("scores.session_id");
+      expect(sessionIdQuery).not.toContain("JOIN events_core");
+
+      // traceSessionId: resolves the parent trace's session via the
+      // events_traces join, matching v3's sessionId semantics.
+      const traceSessionIdBuilder = new QueryBuilder(undefined, "v2");
+      const { query: traceSessionIdQuery } = await traceSessionIdBuilder.build(
+        {
+          view: "scores-numeric",
+          dimensions: [],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [
+            {
+              column: "traceSessionId",
+              operator: "=",
+              value: "session-1",
+              type: "string",
+            },
+          ],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            Date.now() - 7 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          toTimestamp: new Date(Date.now()).toISOString(),
+          orderBy: null,
+        },
+        projectId,
+      );
+      expect(traceSessionIdQuery).toContain(
+        "INNER JOIN events_core AS events_traces",
+      );
+      expect(traceSessionIdQuery).toContain("events_traces.session_id =");
+    });
+  });
+
   describe("rootEventCondition threshold gating", () => {
     const rootEventSubqueryPrefix =
       "IN (SELECT events_traces.trace_id FROM events_core events_traces";

--- a/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
@@ -202,6 +202,10 @@ const viewFilterDefinitions: Record<
       sourceSpec("Session", { uiTableId: "session" }),
       sourceSpec("Session", { uiTableId: "sessionId" }),
     ),
+    defineField(
+      "traceSessionId",
+      sourceSpec("Trace Session", { uiTableId: "traceSession" }),
+    ),
     defineField("metadata", sourceSpec("Metadata", { uiTableId: "metadata" })),
     defineField(
       "traceName",
@@ -249,6 +253,10 @@ const viewFilterDefinitions: Record<
       sourceSpec("Session", { uiTableId: "session" }),
       sourceSpec("Session", { uiTableId: "sessionId" }),
     ),
+    defineField(
+      "traceSessionId",
+      sourceSpec("Trace Session", { uiTableId: "traceSession" }),
+    ),
     defineField("metadata", sourceSpec("Metadata", { uiTableId: "metadata" })),
     defineField(
       "traceName",
@@ -295,6 +303,10 @@ const viewFilterDefinitions: Record<
       "sessionId",
       sourceSpec("Session", { uiTableId: "session" }),
       sourceSpec("Session", { uiTableId: "sessionId" }),
+    ),
+    defineField(
+      "traceSessionId",
+      sourceSpec("Trace Session", { uiTableId: "traceSession" }),
     ),
     defineField("metadata", sourceSpec("Metadata", { uiTableId: "metadata" })),
     defineField(

--- a/web/src/features/dashboard/lib/viewFilterToTableFilter.ts
+++ b/web/src/features/dashboard/lib/viewFilterToTableFilter.ts
@@ -112,6 +112,7 @@ const VIEW_DIMENSION_TO_TABLE_COL_V3: Record<ViewName, TableColumnMap> = {
 
 const V4_SCORE_VIEW_DIMENSION_TO_TABLE_COL: TableColumnMap = {
   ...V3_SCORE_VIEW_DIMENSION_TO_TABLE_COL,
+  traceSessionId: "sessionId",
   traceRelease: null,
 };
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16463.preview.langfuse.com](https://pr-16463.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR distinguishes scores directly attached to sessions from scores whose parent trace belongs to a session, then exposes the new `traceSessionId` field in score dashboard filters.

- Adds the `traceSessionId` v2 score dimension backed by `events_traces`.
- Adds score-view UI mappings and View-as-table conversion.
- Adds query-builder coverage for `sessionId` and `traceSessionId` join behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until traceSessionId preserves scores whose native V4 trace root has an external parent.

The new dimension activates a parentless-only INNER JOIN, so a supported native V4 event shape causes valid score rows to disappear from filtered and grouped dashboard results.

**Files Needing Attention:** packages/shared/src/features/query/dataModel.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Score query filters or groups by traceSessionId] --> B[Activate events_traces relation]
    B --> C[INNER JOIN requiring parent_span_id = empty]
    C --> D{Matching parentless event exists?}
    D -->|Yes| E[Resolve trace session]
    D -->|No: native V4 app root has external parent| F[Score row omitted]
    F --> G[Dashboard aggregate undercounts scores]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/features/query/dataModel.ts:733-737
**Parentless join drops V4 scores**

When a native V4 trace has an app root with an external parent, `traceSessionId` activates an inner join that only accepts `parent_span_id = ''`. The join finds no trace row and silently excludes the associated trace- or observation-level scores from dashboard filters and aggregates.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(query): add traceSessionId dimensio..."](https://github.com/langfuse/langfuse/commit/d195d23b906c7858a1e5ab41a7c9a9b3d7a90457) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56185103)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Analytics and query data](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/analytics-query-data.md)
- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)
</details>


<!-- /greptile_comment -->