### PR TITLE
fix(evals): activate disabled rules on evaluator attach

### DIFF
--- a/web/src/__tests__/server/evaluation-rule-v2-service.servertest.ts
+++ b/web/src/__tests__/server/evaluation-rule-v2-service.servertest.ts
@@ -717,6 +717,26 @@ describe("RuleService", () => {
       });
     });
 
+    it("enables a disabled rule when attaching with activation", async () => {
+      const evaluator = await createEvaluator();
+      const service = createService();
+      const rule = await service.create(
+        { ...createInput(), enabled: false },
+        null,
+      );
+      const attachment = {
+        projectId,
+        ruleId: rule.id,
+        assignment: { evaluatorId: evaluator.id, variableMapping: null },
+        enableRule: true,
+      };
+
+      await expect(service.attach(attachment)).resolves.toMatchObject({
+        enabled: true,
+        assignments: [expect.objectContaining({ evaluatorId: evaluator.id })],
+      });
+    });
+
     it("updates experiment filters and assignments", async () => {
       const [first, second] = await Promise.all([
         createEvaluator(),

--- a/web/src/__tests__/server/evaluation-rule-v2-trpc.servertest.ts
+++ b/web/src/__tests__/server/evaluation-rule-v2-trpc.servertest.ts
@@ -252,12 +252,15 @@ describe("evaluation rule v2 tRPC", () => {
     ).resolves.toBe(0);
   });
 
-  it("supports attaching and detaching an evaluator", async () => {
+  it("supports attaching with activation and detaching an evaluator", async () => {
     const [first, second] = await Promise.all([
       createEvaluator("First transport evaluator"),
       createEvaluator("Second transport evaluator"),
     ]);
-    const rule = await caller.evalsV2.rules.create(ruleInput(first.id));
+    const rule = await caller.evalsV2.rules.create({
+      ...ruleInput(first.id),
+      enabled: false,
+    });
     const attached = await caller.evalsV2.rules.attach({
       projectId,
       ruleId: rule.id,
@@ -265,8 +268,10 @@ describe("evaluation rule v2 tRPC", () => {
       variableMapping: [
         { templateVariable: "output", selectedColumnId: "input" },
       ],
+      enableRule: true,
     });
 
+    expect(attached.enabled).toBe(true);
     expect(attached.assignments).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ evaluatorId: second.id }),

--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
@@ -404,7 +404,7 @@ export function EvaluatorSavedDialogContainer({
             />
             {selectedRule.assignments.length > 0 ? (
               <p className="text-muted-foreground text-sm">
-                Already assigned to this rule:{" "}
+                Already attached to:{" "}
                 {selectedRule.assignments
                   .map(({ evaluator }) => evaluator.name)
                   .join(", ")}

--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
@@ -69,22 +69,37 @@ export function EvaluatorSavedDialogContainer({
     evaluator.hasCompletedTestCall ?? false,
   );
   const missingCostTestRequest = useRef<Promise<void> | null>(null);
-  const rules = api.evalsV2.rules.list.useQuery(
+  const activeRules = api.evalsV2.rules.list.useQuery(
     {
       projectId,
       page: 1,
       limit: 100,
+      enabled: true,
+      targetObjects: [EvalTargetObject.EVENT, EvalTargetObject.EXPERIMENT],
+    },
+    { enabled: dialogPhase === "saved" },
+  );
+  const inactiveRules = api.evalsV2.rules.list.useQuery(
+    {
+      projectId,
+      page: 1,
+      limit: 100,
+      enabled: false,
       targetObjects: [EvalTargetObject.EVENT, EvalTargetObject.EXPERIMENT],
     },
     { enabled: dialogPhase === "saved" },
   );
   const availableRules = useMemo(
     () =>
-      [...(rules.data?.rules ?? [])].sort(
+      [
+        ...(activeRules.data?.rules ?? []),
+        ...(inactiveRules.data?.rules ?? []),
+      ].sort(
         (left, right) => right.assignments.length - left.assignments.length,
       ),
-    [rules.data?.rules],
+    [activeRules.data?.rules, inactiveRules.data?.rules],
   );
+  const rulesPending = activeRules.isPending || inactiveRules.isPending;
   const {
     supportedFilters: supportedRuleFilters,
     unsupportedReasons: unsupportedRuleFilterReasons,
@@ -285,7 +300,7 @@ export function EvaluatorSavedDialogContainer({
     if (
       mode !== "different-scope" ||
       selectedRuleId !== undefined ||
-      rules.isPending
+      rulesPending
     ) {
       return;
     }
@@ -296,13 +311,7 @@ export function EvaluatorSavedDialogContainer({
     } else {
       setSelectedRuleId(null);
     }
-  }, [
-    availableRules,
-    mode,
-    rules.isPending,
-    selectExistingRule,
-    selectedRuleId,
-  ]);
+  }, [availableRules, mode, rulesPending, selectExistingRule, selectedRuleId]);
 
   const handleModeChange = (nextMode: EvaluatorSavedMode) => {
     estimateRequestId.current += 1;
@@ -314,7 +323,7 @@ export function EvaluatorSavedDialogContainer({
       return;
     }
     setSelectedRuleId(
-      nextMode === "different-scope" && !rules.isPending ? null : undefined,
+      nextMode === "different-scope" && !rulesPending ? null : undefined,
     );
     setIsEstimating(false);
     if (nextMode === "test-filters") {
@@ -349,7 +358,7 @@ export function EvaluatorSavedDialogContainer({
       onOpenChange={setRulePickerOpen}
       disabledRules={[]}
       availableRules={availableRules}
-      loading={rules.isPending}
+      loading={rulesPending}
       onSelectAvailableRule={selectExistingRule}
       onCreateRule={selectNewRule}
     >
@@ -395,7 +404,7 @@ export function EvaluatorSavedDialogContainer({
             />
             {selectedRule.assignments.length > 0 ? (
               <p className="text-muted-foreground text-sm">
-                Already running on this rule:{" "}
+                Already assigned to this rule:{" "}
                 {selectedRule.assignments
                   .map(({ evaluator }) => evaluator.name)
                   .join(", ")}

--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
@@ -74,7 +74,6 @@ export function EvaluatorSavedDialogContainer({
       projectId,
       page: 1,
       limit: 100,
-      enabled: true,
       targetObjects: [EvalTargetObject.EVENT, EvalTargetObject.EXPERIMENT],
     },
     { enabled: dialogPhase === "saved" },
@@ -126,6 +125,7 @@ export function EvaluatorSavedDialogContainer({
       ruleId: rule.id,
       evaluatorId: evaluator.id,
       variableMapping: null,
+      enableRule: !rule.enabled,
     });
     capture("evaluation_rules:attach_evaluator", {
       evaluatorCount: 1,

--- a/web/src/features/evals/v2/server/rules/ruleRouter.ts
+++ b/web/src/features/evals/v2/server/rules/ruleRouter.ts
@@ -238,6 +238,7 @@ export const ruleRouter = createTRPCRouter({
           evaluatorId: input.evaluatorId,
           variableMapping: input.variableMapping,
         },
+        enableRule: input.enableRule,
       });
     }),
 

--- a/web/src/features/evals/v2/server/rules/ruleService.ts
+++ b/web/src/features/evals/v2/server/rules/ruleService.ts
@@ -513,6 +513,7 @@ export class RuleService {
     projectId: string;
     ruleId: string;
     assignment: RuleAssignmentInput;
+    enableRule?: boolean;
   }) {
     await this.prisma.$transaction(async (prisma) => {
       const rule = await this.requireRule(
@@ -528,9 +529,24 @@ export class RuleService {
       });
       await repository.attachEvaluator({
         prisma,
-        ...params,
+        projectId: params.projectId,
+        ruleId: params.ruleId,
         assignment: assignment!,
       });
+      if (params.enableRule) {
+        this.assertLegacyRuleCanBeEnabled(rule.targetObject, true);
+        await assertActiveRuleLimitNotExceeded({
+          prisma,
+          projectId: params.projectId,
+          additionalActiveRules: rule.status === JobConfigState.ACTIVE ? 0 : 1,
+        });
+        await repository.setRuleStatus({
+          prisma,
+          projectId: params.projectId,
+          ruleIds: [params.ruleId],
+          enabled: true,
+        });
+      }
     });
     await invalidateProjectEvalConfigCaches(params.projectId);
     const rule = await this.get(params.projectId, params.ruleId);

--- a/web/src/features/evals/v2/server/rules/ruleTypes.ts
+++ b/web/src/features/evals/v2/server/rules/ruleTypes.ts
@@ -87,6 +87,7 @@ export const SetRuleEnabledSchema = RuleIdSchema.extend({
 export const RuleAssignmentSchema = RuleIdSchema.extend({
   evaluatorId: z.string(),
   variableMapping: observationVariableMappingList.nullable(),
+  enableRule: z.boolean().optional(),
 });
 
 export const RuleAssignmentIdSchema = RuleIdSchema.extend({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16465.preview.langfuse.com](https://pr-16465.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Includes inactive evaluation rules in the post-save evaluator attachment modal while preserving the existing active-rule result window through separate active and inactive queries. Selecting an inactive rule now attaches the evaluator and activates the rule atomically, including active-rule limit validation.

Impacted package: `web`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter web run test src/__tests__/server/evaluation-rule-v2-service.servertest.ts src/__tests__/server/evaluation-rule-v2-trpc.servertest.ts` — 59 passed
- `pnpm --filter web run typecheck`
- `pnpm run lint` (pre-commit hook) — 7/7 tasks successful
- CI — 38 successful, 0 failed, 0 pending before the wording-only follow-up
- Preview verified at `https://pr-16465.preview.langfuse.com`: an inactive rule appeared in the post-save picker and became enabled automatically after attachment.

[inactive_rule_attach_auto_enable.mp4](https://cursor.com/agents/bc-d4350d46-8a8d-4e7f-9732-0592e68a3f34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finactive_rule_attach_auto_enable.mp4)

[Latest PR preview shows the rule enabled with the evaluator attached](https://cursor.com/agents/bc-d4350d46-8a8d-4e7f-9732-0592e68a3f34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flatest_preview_auto_enabled_rule.webp)

## Analytics

No new event: the existing `evaluation_rules:attach_evaluator` event already captures the user attachment intent without raw values.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4350d46-8a8d-4e7f-9732-0592e68a3f34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4350d46-8a8d-4e7f-9732-0592e68a3f34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR allows inactive evaluation rules to appear in the post-save evaluator attachment flow and atomically activates a selected rule while attaching the evaluator.

- Extends the attachment schema, router, and service with optional rule activation.
- Validates the active-rule limit within the attachment transaction.
- Adds service and tRPC coverage for attach-and-activate behavior.
- Expands the dialog's rule query to include inactive rules, but retains a fixed 100-rule page.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The rule-list reachability regression should be fixed before merging because inactive rules can displace active rules from the dialog's unpageable first 100 results.

The attachment and activation transaction is coherent, but broadening a fixed-size query without server-side search or pagination makes valid rules unreachable in larger projects.

**Files Needing Attention:** web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant D as Evaluator saved dialog
    participant API as Rules tRPC API
    participant DB as PostgreSQL
    U->>D: Select inactive rule and attach
    D->>API: attach(enableRule: true)
    API->>DB: Begin transaction
    API->>DB: Attach evaluator
    API->>DB: Validate active-rule limit
    API->>DB: Activate rule
    DB-->>API: Commit
    API-->>D: Activated rule with assignment
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialogContainer/EvaluatorSavedDialogContainer.tsx:72-78
**Fixed page hides eligible rules**

When a project has more than 100 eligible rules, removing the enabled filter mixes recently updated inactive rules into this fixed first page. Because the picker only filters these returned rows, inactive rules can displace previously available active rules and any rule outside the page cannot be selected for attachment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): activate disabled rules on e..."](https://github.com/langfuse/langfuse/commit/4d688f5937176f41af8f9a3b7513f084df62b588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56189803)</sub>

<!-- /greptile_comment -->