### PR TITLE
test: stabilize evaluator and SSRF integration coverage

### DIFF
--- a/web/src/__tests__/server/unstable-evaluator-v2-api.servertest.ts
+++ b/web/src/__tests__/server/unstable-evaluator-v2-api.servertest.ts
@@ -228,11 +228,11 @@ describe("unstable evaluator API on stable evaluator storage", () => {
     await Promise.all([
       prisma.evaluator.update({
         where: { id: older.id },
-        data: { createdAt: new Date("2026-01-01T00:00:00.000Z") },
+        data: { updatedAt: new Date("2026-01-01T00:00:00.000Z") },
       }),
       prisma.evaluator.update({
         where: { id: newer.id },
-        data: { createdAt: new Date("2026-01-02T00:00:00.000Z") },
+        data: { updatedAt: new Date("2026-01-02T00:00:00.000Z") },
       }),
     ]);
 

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -135,9 +135,9 @@ vi.mock("../env", () => ({
     LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
     LANGFUSE_POSTHOG_FLUSH_DELAY_MS: 0,
     LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: 0,
-    // Must stay non-zero, else the Mixpanel abort timer fires at ~0ms and masks
-    // the SSRF block with a spurious timeout error.
-    LANGFUSE_MIXPANEL_TIMEOUT_MS: 30_000,
+    // Keep this non-zero so connect-time validation wins the race with the
+    // abort while still bounding the test when the protected request stalls.
+    LANGFUSE_MIXPANEL_TIMEOUT_MS: 1_000,
   },
   v4WritesToLegacyTables: (e: { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }) =>
     e.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only",
@@ -362,7 +362,7 @@ describe("Mixpanel sender — SSRF connect-time pinning", () => {
     expect(causeChainIncludes(thrown, "Blocked IP address detected")).toBe(
       true,
     );
-  }, 40_000);
+  }, 5_000);
 });
 
 describe("outbound validation classification", () => {

--- a/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
@@ -145,6 +145,25 @@ vi.mock("../env", () => ({
     e.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "legacy",
 }));
 
+vi.mock("posthog-node", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("posthog-node")>();
+  return {
+    ...actual,
+    PostHog: class extends actual.PostHog {
+      constructor(
+        apiKey: string,
+        options: ConstructorParameters<typeof actual.PostHog>[1],
+      ) {
+        super(apiKey, {
+          ...options,
+          requestTimeout: 1_000,
+          fetchRetryCount: 0,
+        });
+      }
+    },
+  };
+});
+
 // Imported after mocks are registered.
 import {
   handlePostHogIntegrationProjectJob,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16468.preview.langfuse.com](https://pr-16468.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

- Disables PostHog SDK retries in the SSRF pinning test and bounds mocked analytics request timeouts, avoiding real retry backoff while preserving connect-time validation coverage.
- Makes evaluator pagination deterministic by setting the `updatedAt` field used by the repository sort.
- Impacts `worker` and `web` tests only; production behavior is unchanged.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm run lint` (commit hook): `Tasks: 7 successful, 7 total`
- `pnpm --filter worker run test analyticsIntegrationSsrfPinning.test.ts`: `Tests 13 passed (13)`; 5 consecutive runs passed, with test execution reduced from 36.12s to 58–68ms.
- `pnpm --filter web run test src/__tests__/server/unstable-evaluator-v2-api.servertest.ts`: `Tests 9 passed (9)`; 10 consecutive runs passed.

## What to doubt in review

- Confirm that disabling PostHog retries in this test does not remove a retry-specific contract; the assertions cover terminal SSRF classification, not SDK retry behavior.
- Confirm that `updatedAt` remains the intended evaluator list sort key; the pagination fixture now pins that exact repository contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11780985-2a64-44e6-acd0-522da31c9836?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11780985-2a64-44e6-acd0-522da31c9836&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes evaluator and SSRF integration coverage by aligning pagination fixtures with the repository sort field and shortening the Mixpanel test timeout.

- Sets deterministic evaluator `updatedAt` values for pagination assertions.
- Reduces the mocked Mixpanel request timeout and overall SSRF test bound.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, although the shortened Mixpanel timeout can still make the SSRF integration test flaky on a heavily loaded CI worker.

The evaluator fixture now matches the repository ordering contract, while the SSRF test still relies on an unmocked DNS callback completing before a one-second abort timer.

**Files Needing Attention:** worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/__tests__/analyticsIntegrationSsrfPinning.test.ts:140
**One-second DNS validation race**

If a loaded CI worker delays the real `dns.lookup("localhost")` callback past one second, the abort timer rejects with the plain Mixpanel timeout error before connect-time validation reports the blocked address, so the SSRF assertions fail and the test remains flaky.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: stabilize evaluator and SSRF integ..."](https://github.com/langfuse/langfuse/commit/cfb9b0fb1ffe5cfac3ba6d8a386b4fec21944012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56194566)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->