### PR TITLE
fix(chatml): render reasoning block when completion is empty string

### DIFF
--- a/packages/shared/src/utils/IORepresentation/chatML/types.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/types.ts
@@ -269,6 +269,11 @@ export const BaseChatMlMessageSchema = z
     // Thinking/reasoning content from models
     thinking: z.array(ThinkingContentPartSchema).optional(),
     redacted_thinking: z.array(RedactedThinkingContentPartSchema).optional(),
+    // Legacy OpenAI Chat Completions `{"completion": "", "reasoning": "..."}`
+    // shape (no Responses API reasoning item wrapper). The OpenAI adapter
+    // normalizes this into a top-level `reasoning` field on the message
+    // rather than nesting it under `json`.
+    reasoning: z.string().nullish(),
   })
   .loose();
 
@@ -337,6 +342,7 @@ export const ChatMlMessageSchema = BaseChatMlMessageSchema.refine(
       tool_call_id,
       thinking,
       redacted_thinking,
+      reasoning,
       ...other
     }) => ({
       role,
@@ -349,6 +355,7 @@ export const ChatMlMessageSchema = BaseChatMlMessageSchema.refine(
       tool_call_id,
       thinking,
       redacted_thinking,
+      reasoning,
       ...(Object.keys(other).length === 0 ? {} : { json: other }),
     }),
   );

--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -228,6 +228,21 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
     };
   }
 
+  // Handle legacy Chat Completions shape {completion, reasoning}.
+  // Reasoning models (e.g., via OpenRouter) may emit a reasoning trace
+  // alongside an empty completion; surface `reasoning` as a top-level
+  // field so the renderer shows the reasoning block rather than nesting
+  // it under `json` (#15343).
+  if (typeof working.completion === "string") {
+    return {
+      role: working.role ?? "assistant",
+      content: working.completion,
+      ...(typeof working.reasoning === "string" && working.reasoning.length > 0
+        ? { reasoning: working.reasoning }
+        : {}),
+    };
+  }
+
   // Convert direct function call message to tool_calls array format
   // Format: { type: "function_call", name: "...", arguments: {...}, call_id: "..." }
   // Convert to: { role: "assistant", tool_calls: [{ id, name, arguments, type }] }
@@ -494,6 +509,18 @@ function preprocessData(data: unknown): unknown {
 
   // Single message
   if (typeof data === "object" && "role" in data) {
+    return normalizeMessage(data);
+  }
+
+  // Legacy {completion, reasoning} output (OpenRouter broadcast and
+  // similar). Promote the reasoning value to a top-level message field so
+  // the chatml renderer can show the reasoning block rather than nesting
+  // it under `json` (#15343).
+  if (
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    typeof (data as Record<string, unknown>).completion === "string"
+  ) {
     return normalizeMessage(data);
   }
 

--- a/worker/src/__tests__/chatml/adapters/openai.test.ts
+++ b/worker/src/__tests__/chatml/adapters/openai.test.ts
@@ -710,4 +710,46 @@ describe("OpenAI Adapter", () => {
       );
     });
   });
+
+  describe("legacy {completion, reasoning} output (#15343)", () => {
+    it("should surface reasoning as a top-level field when completion is empty", () => {
+      // Regression test for #15343: reasoning models via OpenRouter may emit
+      // a reasoning trace alongside an empty completion. The reasoning value
+      // must be a top-level field on the normalized message so the renderer
+      // can show the reasoning block rather than nesting it under `json`.
+      const output = {
+        completion: "",
+        reasoning: "thought process",
+      };
+
+      const result = normalizeOutput(output, { framework: "openai" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("");
+      expect(result.data?.[0].reasoning).toBe("thought process");
+      // The reasoning value should not be wrapped in `json` — it must reach
+      // the renderer as a first-class field.
+      expect(result.data?.[0].json).toBeUndefined();
+    });
+
+    it("should preserve non-empty completion alongside reasoning", () => {
+      const output = {
+        completion: "the answer",
+        reasoning: "thought process",
+      };
+
+      const result = normalizeOutput(output, { framework: "openai" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("the answer");
+      expect(result.data?.[0].reasoning).toBe("thought process");
+    });
+
+    it("should not set reasoning when only completion is present", () => {
+      const output = { completion: "the answer" };
+
+      const result = normalizeOutput(output, { framework: "openai" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("the answer");
+      expect(result.data?.[0].reasoning).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Fixes #16464.

## Problem

Legacy OpenAI Chat Completions outputs of shape `{completion: "", reasoning: "..."}` (an increasingly common shape for reasoning models that produce reasoning but emit no assistant text) lost the `reasoning` value during normalization.

The OpenAI adapter's `normalizeMessage` and `preprocessData` both fell through this shape unchanged. The schema parser then routed the `reasoning` value into the `json` overflow bag because `BaseChatMlMessageSchema` did not declare a `reasoning` field. The chatml observation panel's pretty view reads only first-class fields, so the reasoning block was hidden in the JSON tree rather than rendered.

## Prior attempts

Two previous PRs closed without merging attempted this fix:
- #15370 `fix/reasoning-block-empty-completion` (closed 2026-08-22)
- #16158 `agent/fix-empty-completion-reasoning` (closed 2026-08-16)

Both had the correct diagnosis. They were scoped to the renderer / JSON overflow path; this PR addresses the same problem at the data model so the field is first-class on the message rather than hidden in `json`.

## Fix

- **`packages/shared/src/utils/IORepresentation/chatML/types.ts`** — add `reasoning: z.string().nullish()` to `BaseChatMlMessageSchema`; update the second `.transform` in `ChatMlMessageSchema` to pass `reasoning` through alongside `thinking` and `redacted_thinking`.
- **`packages/shared/src/utils/chatml/adapters/openai.ts`** — handle the legacy `{completion, reasoning}` shape in both `normalizeMessage` (produces `{role, content, reasoning}` when both are strings) and `preprocessData` (routes the legacy shape into `normalizeMessage`).
- **`worker/src/__tests__/chatml/adapters/openai.test.ts`** — three regression tests: reasoning surfaced when completion is empty, non-empty completion preserved alongside reasoning, and completion-only output continues to render without reasoning.

## Testing

- `pnpm --filter worker exec vitest run src/__tests__/chatml/adapters/openai.test.ts` → 30/30 pass
- `pnpm --filter worker exec vitest run src/__tests__/chatml/` → 135/135 pass
- prettier --check on all 3 changed files: clean
- eslint on changed files: no errors

## Compatibility

- `reasoning: z.string().nullish()` accepts `string | null | undefined`, matching the existing `content: z.union([...]).nullish()` pattern in the same schema.
- `normalizeMessage` only sets `reasoning` when `reasoning` is a non-empty string — pre-existing outputs without the field continue to render as before.
- No new public API; this only widens the chatml internal data model.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes reasoning from legacy `{completion, reasoning}` OpenAI-compatible outputs into the typed ChatML message model.
- Adds a nullable first-class `reasoning` field to the shared ChatML schema.
- Normalizes legacy completion outputs into assistant messages carrying content and reasoning.
- Adds worker regression coverage for empty, non-empty, and completion-only variants.
- The emitted field is not connected to the renderer’s existing thinking representation, so reasoning-only messages still do not render as intended.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until the normalized reasoning value is connected to the renderer’s recognized reasoning representation.

The new field survives normalization, but current rendering and filtering only recognize thinking arrays, causing the target reasoning-only output to appear as generic JSON or disappear in conversation mode.

**Files Needing Attention:** packages/shared/src/utils/chatml/adapters/openai.ts, packages/shared/src/utils/IORepresentation/chatML/types.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Legacy completion and reasoning output] --> B[OpenAI normalizeMessage]
  B --> C[Top-level reasoning string]
  C --> D[Shared ChatML schema]
  D --> E{Display mode}
  E -->|All| F[Generic JSON table]
  E -->|Conversation| G[Message filtered out]
  C -. Expected .-> H[Dedicated reasoning block]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/utils/chatml/adapters/openai.ts:240-242
**Reasoning bypasses rendering path**

When a legacy output has an empty `completion` and a non-empty `reasoning`, this branch emits a top-level reasoning string while the renderer and conversation filter recognize only `thinking` and `redacted_thinking` arrays, causing the reasoning to appear as generic JSON in the all-content view and disappear entirely in conversation mode.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chatml): render reasoning block when..."](https://github.com/langfuse/langfuse/commit/7c8550762e1ae88b1e1f7067035bff11cee3c47d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56195854)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->