### PR TITLE
feat(annotation-queues): deduplicate items on addition to queue

### DIFF
--- a/packages/shared/src/server/annotationQueues/index.ts
+++ b/packages/shared/src/server/annotationQueues/index.ts
@@ -1,0 +1,1 @@
+export * from "./insertAnnotationQueueItems";

--- a/packages/shared/src/server/annotationQueues/insertAnnotationQueueItems.ts
+++ b/packages/shared/src/server/annotationQueues/insertAnnotationQueueItems.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from "crypto";
+
+import {
+  AnnotationQueueStatus,
+  type AnnotationQueueObjectType,
+  Prisma,
+  prisma,
+} from "../../db";
+
+export type InsertAnnotationQueueItemsParams = {
+  projectId: string;
+  queueId: string;
+  objectType: AnnotationQueueObjectType;
+  objectIds: string[];
+  status?: AnnotationQueueStatus;
+};
+
+export type InsertAnnotationQueueItemsResult = {
+  createdItems: Array<{ id: string; objectId: string }>;
+  skippedObjectIds: string[];
+};
+
+/**
+ * Inserts annotation queue items, skipping objects already present under the
+ * same [projectId, queueId, objectId, objectType] tuple (regardless of item
+ * status). The subquery is covered by the existing (object_id, object_type, project_id, queue_id)
+ * index. Two concurrent calls for the same object can still both insert
+ * (there is no constraint for Postgres to arbitrate on) - acceptable for
+ * this human-triggered action; this is the single place to harden further
+ * (e.g. an advisory lock) if that ever matters.
+ */
+export async function insertAnnotationQueueItems({
+  projectId,
+  queueId,
+  objectType,
+  objectIds,
+  status = AnnotationQueueStatus.PENDING,
+}: InsertAnnotationQueueItemsParams): Promise<InsertAnnotationQueueItemsResult> {
+  const uniqueObjectIds = Array.from(new Set(objectIds));
+  if (uniqueObjectIds.length === 0) {
+    return { createdItems: [], skippedObjectIds: [] };
+  }
+
+  const completedAt =
+    status === AnnotationQueueStatus.COMPLETED ? new Date() : null;
+
+  const candidateRows = Prisma.join(
+    uniqueObjectIds.map(
+      (objectId) =>
+        Prisma.sql`(${randomUUID()}::text, ${projectId}::text, ${queueId}::text, ${objectId}::text, ${objectType}::"AnnotationQueueObjectType", ${status}::"AnnotationQueueStatus", ${completedAt}::timestamp(3))`,
+    ),
+  );
+
+  const createdRows = await prisma.$queryRaw<
+    Array<{ id: string; object_id: string }>
+  >(Prisma.sql`
+    INSERT INTO "annotation_queue_items" (
+      "id", "project_id", "queue_id", "object_id", "object_type", "status", "completed_at"
+    )
+    SELECT candidate.id, candidate.project_id, candidate.queue_id, candidate.object_id, candidate.object_type, candidate.status, candidate.completed_at
+    FROM (VALUES ${candidateRows}) AS candidate(id, project_id, queue_id, object_id, object_type, status, completed_at)
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "annotation_queue_items" existing
+      WHERE existing."project_id" = candidate.project_id
+        AND existing."queue_id" = candidate.queue_id
+        AND existing."object_id" = candidate.object_id
+        AND existing."object_type" = candidate.object_type
+    )
+    RETURNING "id", "object_id"
+  `);
+
+  const createdObjectIds = new Set(createdRows.map((row) => row.object_id));
+
+  return {
+    createdItems: createdRows.map((row) => ({
+      id: row.id,
+      objectId: row.object_id,
+    })),
+    skippedObjectIds: uniqueObjectIds.filter(
+      (objectId) => !createdObjectIds.has(objectId),
+    ),
+  };
+}

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -6,6 +6,7 @@ import {
 
 export * from "./services/StorageService";
 export * from "./media";
+export * from "./annotationQueues";
 export * from "./services/safeBlobKeySegment";
 export * from "./ingestion/eventBucketPath";
 export * from "./cache";

--- a/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
@@ -123,4 +123,55 @@ describe("annotationQueueItems trpc", () => {
       ).rejects.toThrow("User does not have access to this resource or action");
     });
   });
+
+  describe("createMany", () => {
+    it("dedupes objects already queued, including duplicates within one call", async () => {
+      const setup = await createOrgProjectAndApiKey();
+      orgIds.push(setup.org.id);
+      const { caller } = createCallerForProjectRole(setup, "ADMIN");
+
+      const queue = await prisma.annotationQueue.create({
+        data: {
+          name: "Test Queue",
+          description: "Test Queue Description",
+          scoreConfigIds: [],
+          projectId: setup.project.id,
+        },
+      });
+
+      const alreadyQueuedObjectId = uuidv4();
+      await prisma.annotationQueueItem.create({
+        data: {
+          queueId: queue.id,
+          objectId: alreadyQueuedObjectId,
+          objectType: AnnotationQueueObjectType.TRACE,
+          projectId: setup.project.id,
+        },
+      });
+
+      const newObjectId = uuidv4();
+
+      const result = await caller.annotationQueueItems.createMany({
+        projectId: setup.project.id,
+        queueId: queue.id,
+        // newObjectId listed twice to also exercise in-batch dedup
+        objectIds: [alreadyQueuedObjectId, newObjectId, newObjectId],
+        objectType: AnnotationQueueObjectType.TRACE,
+      });
+
+      expect(result.createdCount).toBe(1);
+
+      const items = await prisma.annotationQueueItem.findMany({
+        where: {
+          queueId: queue.id,
+          objectType: AnnotationQueueObjectType.TRACE,
+          objectId: { in: [alreadyQueuedObjectId, newObjectId] },
+        },
+      });
+      expect(items).toHaveLength(2);
+      expect(
+        items.filter((item) => item.objectId === newObjectId),
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/web/src/__tests__/server/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queues-api.servertest.ts
@@ -652,6 +652,42 @@ describe("Annotation Queues API Endpoints", () => {
       expect(observationItem?.status).toBe(AnnotationQueueStatus.PENDING);
     });
 
+    it("should return the existing item instead of creating a duplicate", async () => {
+      const objectId = uuidv4();
+      const body = {
+        objectId,
+        objectType: AnnotationQueueObjectType.TRACE,
+      };
+
+      const firstResponse = await makeZodVerifiedAPICall(
+        CreateAnnotationQueueItemResponse,
+        "POST",
+        `/api/public/annotation-queues/${queueId}/items`,
+        body,
+        auth,
+      );
+      const secondResponse = await makeZodVerifiedAPICall(
+        CreateAnnotationQueueItemResponse,
+        "POST",
+        `/api/public/annotation-queues/${queueId}/items`,
+        body,
+        auth,
+      );
+
+      expect(firstResponse.status).toBe(200);
+      expect(secondResponse.status).toBe(200);
+      expect(secondResponse.body.id).toBe(firstResponse.body.id);
+
+      const items = await prisma.annotationQueueItem.findMany({
+        where: {
+          queueId,
+          objectId,
+          objectType: AnnotationQueueObjectType.TRACE,
+        },
+      });
+      expect(items).toHaveLength(1);
+    });
+
     it("should return 404 for non-existent queue", async () => {
       const nonExistentId = uuidv4();
       const response = await makeAPICall(

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -23,6 +23,7 @@ import {
   getObservationByIdFromEventsTable,
   getObservationsTraceIdsFromEventsTable,
   getTraceIdsForObservations,
+  insertAnnotationQueueItems,
   logger,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
@@ -318,26 +319,13 @@ export const queueItemRouter = createTRPCRouter({
           targetId: input.queueId,
         });
       } else {
-        const { count } = await ctx.prisma.annotationQueueItem.createMany({
-          data: input.objectIds.map((objectId) => ({
-            projectId: input.projectId,
-            queueId: input.queueId,
-            objectId,
-            objectType: input.objectType,
-          })),
-          skipDuplicates: true,
+        const { createdItems } = await insertAnnotationQueueItems({
+          projectId: input.projectId,
+          queueId: input.queueId,
+          objectType: input.objectType,
+          objectIds: input.objectIds,
         });
-        createdCount = count;
-
-        const createdItems = await ctx.prisma.annotationQueueItem.findMany({
-          where: {
-            projectId: input.projectId,
-            queueId: input.queueId,
-            objectId: { in: input.objectIds },
-            objectType: input.objectType,
-          },
-          orderBy: { createdAt: "desc" },
-        });
+        createdCount = createdItems.length;
 
         for (const item of createdItems) {
           await auditLog(
@@ -346,7 +334,14 @@ export const queueItemRouter = createTRPCRouter({
               resourceType: "annotationQueueItem",
               resourceId: item.id,
               action: "create",
-              after: item,
+              after: {
+                id: item.id,
+                projectId: input.projectId,
+                queueId: input.queueId,
+                objectId: item.objectId,
+                objectType: input.objectType,
+                status: AnnotationQueueStatus.PENDING,
+              },
             },
             ctx.prisma,
           );

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/src/features/public-api/types/annotation-queues";
 import {
   AnnotationQueueStatus,
+  InternalServerError,
   InvalidRequestError,
   LangfuseConflictError,
   LangfuseNotFoundError,
@@ -22,7 +23,10 @@ import {
   Prisma,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { getUserProjectRoles } from "@langfuse/shared/src/server";
+import {
+  getUserProjectRoles,
+  insertAnnotationQueueItems,
+} from "@langfuse/shared/src/server";
 import type { z } from "zod";
 
 type GetAnnotationQueuesInput = z.infer<typeof GetAnnotationQueuesQuery>;
@@ -404,19 +408,38 @@ export const createAnnotationQueueItemForApi = async ({
   // Create the queue item with status defaulting to PENDING if not provided
   const status = input.status || AnnotationQueueStatus.PENDING;
 
-  // Set completedAt if status is COMPLETED
-  const completedAt =
-    status === AnnotationQueueStatus.COMPLETED ? new Date() : null;
+  const { createdItems } = await insertAnnotationQueueItems({
+    projectId,
+    queueId,
+    objectType: input.objectType,
+    objectIds: [input.objectId],
+    status,
+  });
 
-  const item = await prisma.annotationQueueItem.create({
-    data: {
-      queueId,
-      objectId: input.objectId,
-      objectType: input.objectType,
-      status,
-      completedAt,
-      projectId,
-    },
+  // Idempotent: the object is already queued here, so return the existing
+  // item unchanged rather than erroring or creating a duplicate.
+  if (createdItems.length === 0) {
+    const existingItem = await prisma.annotationQueueItem.findFirst({
+      where: {
+        projectId,
+        queueId,
+        objectId: input.objectId,
+        objectType: input.objectType,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    if (!existingItem) {
+      throw new InternalServerError(
+        "Annotation queue item insert reported a duplicate but no existing item was found",
+      );
+    }
+
+    return toAnnotationQueueItemApi(existingItem);
+  }
+
+  const item = await prisma.annotationQueueItem.findUniqueOrThrow({
+    where: { id: createdItems[0].id },
   });
 
   if (auditScope) {

--- a/worker/src/features/batchAction/processAddToQueue.ts
+++ b/worker/src/features/batchAction/processAddToQueue.ts
@@ -1,5 +1,9 @@
-import { logger, traceException } from "@langfuse/shared/src/server";
-import { AnnotationQueueObjectType, prisma } from "@langfuse/shared/src/db";
+import {
+  insertAnnotationQueueItems,
+  logger,
+  traceException,
+} from "@langfuse/shared/src/server";
+import { AnnotationQueueObjectType } from "@langfuse/shared/src/db";
 
 const addToQueue = async ({
   projectId,
@@ -12,34 +16,12 @@ const addToQueue = async ({
   objectType: AnnotationQueueObjectType;
   targetId: string;
 }) => {
-  // cannot use prisma `createMany` operation as we do not have unique constraint enforced on schema level
-  // conflict must be handled on query level by reading existing items and filtering out traces that already exist
-
-  // First get existing items
-  const existingItems = await prisma.annotationQueueItem.findMany({
-    where: {
-      projectId,
-      queueId: targetId,
-      objectId: { in: objectIds },
-      objectType,
-    },
-    select: { objectId: true },
+  await insertAnnotationQueueItems({
+    projectId,
+    queueId: targetId,
+    objectType,
+    objectIds,
   });
-
-  // Filter out objects that already exist
-  const existingObjectIds = new Set(existingItems.map((item) => item.objectId));
-  const newObjectIds = objectIds.filter((id) => !existingObjectIds.has(id));
-
-  if (newObjectIds.length > 0) {
-    await prisma.annotationQueueItem.createMany({
-      data: newObjectIds.map((objectId) => ({
-        projectId,
-        queueId: targetId,
-        objectId,
-        objectType,
-      })),
-    });
-  }
 };
 
 export const processAddTracesToQueue = async (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16473.preview.langfuse.com](https://pr-16473.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes annotation-queue item insertion and deduplicates repeated object IDs across tRPC, public API, and worker batch actions.
- Adds a shared parameterized bulk-insert helper using `INSERT … WHERE NOT EXISTS`.
- Returns existing items for repeated public API creation requests.
- Updates tRPC and worker paths to use the shared helper and adds deduplication tests.
- The helper still permits duplicate rows when additions overlap concurrently.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until queue-item deduplication is made atomic for concurrent API and retryable worker executions.

The shared helper checks for an existing row and inserts without a uniqueness or serialization guard, so overlapping calls can still persist duplicate queue items and inflate queue results.

**Files Needing Attention:** packages/shared/src/server/annotationQueues/insertAnnotationQueueItems.ts; worker/src/features/batchAction/processAddToQueue.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Public API / tRPC / batch worker] --> B[insertAnnotationQueueItems]
  B --> C{Matching row exists?}
  C -->|Yes| D[Skip candidate]
  C -->|No| E[Insert queue item]
  E --> F[(annotation_queue_items)]
  D --> G[Return existing or created count]
  F --> G
  H[Concurrent invocation] --> C
  H --> E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/annotationQueues/insertAnnotationQueueItems.ts:59-68
**Deduplication remains non-atomic**

If API requests or batch jobs overlap for the same queue-item tuple, each statement can pass `NOT EXISTS` before either insert commits because the tuple has no unique constraint, causing duplicate rows that appear separately in queue lists and inflate item counts.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(annotation-queues): deduplicate ite..."](https://github.com/langfuse/langfuse/commit/106126cd2fe695f5770bcfee32021dd7cacfc9b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56223795)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->