### PR TITLE
fix(events): preserve explicit trace names in synthetic traces

### DIFF
--- a/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
@@ -70,6 +70,24 @@ const createEvent = (overrides: Partial<EventInput> = {}) =>
   }) satisfies EventInput;
 
 describe("adaptEventsToTraceFormat", () => {
+  it("uses the explicit trace name for the synthetic trace", () => {
+    const result = adaptEventsToTraceFormat({
+      events: [createEvent()],
+      traceId: "trace-1",
+    });
+
+    expect(result.trace.name).toBe("Trace name");
+  });
+
+  it("falls back to the root observation name when the trace name is missing", () => {
+    const result = adaptEventsToTraceFormat({
+      events: [createEvent({ traceName: null })],
+      traceId: "trace-1",
+    });
+
+    expect(result.trace.name).toBe("Root span");
+  });
+
   it("does not double-stringify root I/O already stringified for tRPC", () => {
     const input = JSON.stringify({
       prototype: "input",

--- a/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
@@ -88,6 +88,24 @@ describe("adaptEventsToTraceFormat", () => {
     expect(result.trace.name).toBe("Root span");
   });
 
+  it("uses an explicit trace name from a later child observation", () => {
+    const result = adaptEventsToTraceFormat({
+      events: [
+        createEvent({ traceName: null }),
+        createEvent({
+          id: "obs-2",
+          name: "Child span",
+          parentObservationId: "obs-1",
+          startTime: new Date(baseDate.getTime() + 1_000),
+          traceName: "Trace name from child",
+        }),
+      ],
+      traceId: "trace-1",
+    });
+
+    expect(result.trace.name).toBe("Trace name from child");
+  });
+
   it("does not double-stringify root I/O already stringified for tRPC", () => {
     const input = JSON.stringify({
       prototype: "input",

--- a/web/src/features/events/lib/eventsToTraceAdapter.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.ts
@@ -87,7 +87,7 @@ export function adaptEventsToTraceFormat(params: {
   const trace: SyntheticTrace = {
     id: traceId,
     projectId: earliest.projectId,
-    name: primaryObservation.name ?? null,
+    name: primaryObservation.traceName || primaryObservation.name || null,
     timestamp: earliest.startTime,
     input: rootIO?.input ?? null,
     output: rootIO?.output ?? null,

--- a/web/src/features/events/lib/eventsToTraceAdapter.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.ts
@@ -57,6 +57,27 @@ export function adaptEventsToTraceFormat(params: {
   const root = events.find((e) => !e.parentObservationId);
   const primaryObservation = root ?? earliest;
 
+  const latestExplicitTraceNameEvent =
+    events.reduce<EventsTraceObservation | null>((latest, event) => {
+      const isRootNameFallback =
+        !event.parentObservationId && event.traceName === event.name;
+      if (!event.traceName || isRootNameFallback) return latest;
+      if (!latest) return event;
+
+      if (event.updatedAt.getTime() > latest.updatedAt.getTime()) return event;
+      if (event.updatedAt.getTime() < latest.updatedAt.getTime()) return latest;
+
+      return event.createdAt.getTime() > latest.createdAt.getTime()
+        ? event
+        : latest;
+    }, null);
+
+  const traceName =
+    latestExplicitTraceNameEvent?.traceName ||
+    primaryObservation.traceName ||
+    primaryObservation.name ||
+    null;
+
   const latestTaggedEvent = events.reduce<EventsTraceObservation | null>(
     (latest, event) => {
       if (event.traceTags.length === 0) return latest;
@@ -87,7 +108,7 @@ export function adaptEventsToTraceFormat(params: {
   const trace: SyntheticTrace = {
     id: traceId,
     projectId: earliest.projectId,
-    name: primaryObservation.traceName || primaryObservation.name || null,
+    name: traceName,
     timestamp: earliest.startTime,
     input: rootIO?.input ?? null,
     output: rootIO?.output ?? null,


### PR DESCRIPTION
## What changed

- Use traceName when building synthetic traces from events.
- Fall back to the root observation name when there is no explicit trace name.
- Add regression tests for both paths.

## Why

The events table already resolves the trace name from trace_name first, then the root observation name. The adapter was using only the observation name, so a trace with an explicit trace name could show the root span name in trace detail.

## Tests

- Focused client test for eventsToTraceAdapter: 3 passed
- Web TypeScript check
- Full web ESLint
- Prettier check
- Commit hook: 7 lint tasks successful,

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates synthetic traces created from events to prefer an explicit trace name and adds regression coverage for explicit-name and fallback behavior.
- Uses traceName before the root observation name when constructing a synthetic trace.
- Adds client tests for an explicit trace name and a missing trace name.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This should be fixed before merging because traces with an explicit name on a non-primary event can still display the root observation name in detail.

The events surface resolves trace names across all event rows, while the changed adapter reads traceName only from the root-or-earliest row, leaving the reported table/detail inconsistency reachable.

**Files Needing Attention:** web/src/features/events/lib/eventsToTraceAdapter.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/events/lib/eventsToTraceAdapter.ts:90
**Single-row trace name resolution**

When a later or non-root event carries the explicit trace name but the selected root-or-earliest observation has a null `traceName`, this reads only the selected observation and falls back to its name, causing the events table and trace detail to display different trace names.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): preserve explicit trace nam..."](https://github.com/langfuse/langfuse/commit/d8dbcb11e198656bed0fde573d0283b20f5e27a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56236114)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->