### PR TITLE
feat(csv): enhance CSV parsing with error handling for large and malformed files in preview mode

### DIFF
--- a/web/src/features/datasets/lib/csv/helpers.clienttest.ts
+++ b/web/src/features/datasets/lib/csv/helpers.clienttest.ts
@@ -43,4 +43,25 @@ describe("CSV dataset parsing", () => {
     expect(parseValue("true")).toBe(true);
     expect(parseValue("FALSE")).toBe(false);
   });
+
+  it("explains the preview truncation when a >2MB file has a quoted cell cut at the preview boundary", async () => {
+    const hugeCell = "A".repeat(3 * 1024 * 1024);
+    const file = new File([`input\n"${hugeCell}"\n`], "large.csv", {
+      type: "text/csv",
+    });
+
+    await expect(
+      parseCsvClient(file, { isPreview: true, collectSamples: true }),
+    ).rejects.toThrow(/single dataset items are too large/);
+  });
+
+  it("keeps the raw parser error for genuinely malformed small files", async () => {
+    const file = new File(['input\n"unclosed\n'], "malformed.csv", {
+      type: "text/csv",
+    });
+
+    await expect(
+      parseCsvClient(file, { isPreview: true, collectSamples: true }),
+    ).rejects.toThrow(/Quote Not Closed/);
+  });
 });

--- a/web/src/features/datasets/lib/csv/helpers.ts
+++ b/web/src/features/datasets/lib/csv/helpers.ts
@@ -108,6 +108,20 @@ export async function parseCsvClient(
   options: ParseOptions,
 ): Promise<CsvPreviewResult> {
   return new Promise((resolve, reject) => {
+    const isTruncatedPreview =
+      Boolean(options.isPreview) && file.size > PREVIEW_FILE_SIZE_BYTES;
+    const rejectWithTruncationHint = (error: Error) => {
+      if (isTruncatedPreview && error.message.includes("Quote Not Closed")) {
+        reject(
+          new Error(
+            "The file's single dataset items are too large. CSV imports are intended for text and structured JSON dataset items. Use the UI item editor or API/SDKs for multi-modal or very large dataset items: https://langfuse.com/docs/evaluation/experiments/datasets#multi-modal-dataset-items",
+          ),
+        );
+        return;
+      }
+      reject(error);
+    };
+
     const fileToRead = options.isPreview
       ? file.slice(0, PREVIEW_FILE_SIZE_BYTES)
       : file;
@@ -115,7 +129,12 @@ export async function parseCsvClient(
     const reader = new FileReader();
 
     reader.onload = async () => {
-      const parser = await createParser(options, resolve, reject, file.name);
+      const parser = await createParser(
+        options,
+        resolve,
+        rejectWithTruncationHint,
+        file.name,
+      );
       parser.write(reader.result as string);
       parser.end();
     };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16476.preview.langfuse.com](https://pr-16476.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a clearer CSV preview error for quoted fields truncated by the 2 MB preview boundary and adds coverage for truncated and malformed inputs.
- Detects unclosed quotes while previewing files larger than the preview limit.
- Replaces the parser error with guidance for oversized dataset items.
- Preserves the raw parser error for malformed small files.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until large malformed CSV files retain their actual parsing error instead of being reported as oversized dataset items.

The new heuristic replaces every unclosed-quote error from a previewed file over 2 MB, including genuine syntax errors, and preview failure blocks the import workflow before full parsing can correct the diagnosis.

**Files Needing Attention:** web/src/features/datasets/lib/csv/helpers.ts, web/src/features/datasets/lib/csv/helpers.clienttest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/lib/csv/helpers.ts:114
**Large malformed files are misclassified**

When a CSV over 2 MB contains a genuinely unclosed quote within the previewed portion, this condition replaces the parser error with the oversized-item hint based only on the original file size. The UI then gives incorrect remediation and leaves the preview unset, blocking the user from proceeding to the full import.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(csv): enhance CSV parsing with erro..."](https://github.com/langfuse/langfuse/commit/b8e7f0f350c9fcd9151250161a75fd9dda612aca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56245056)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->