### PR TITLE
fix(pricing): price GPT-5.4 reasoning tokens

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -5314,7 +5314,7 @@
     "modelName": "gpt-5.4-mini",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-mini)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-24T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5333,6 +5333,9 @@
           "input_cached_tokens": 0.075e-6,
           "input_cache_read": 0.075e-6,
           "output": 4.5e-6,
+          "output_reasoning_tokens": 4.5e-6,
+          "output_reasoning": 4.5e-6,
+          "reasoning_tokens": 4.5e-6,
           "cache_read_input_tokens": 0.075e-6
         }
       },
@@ -5354,6 +5357,9 @@
           "input_cached_tokens": 0.15e-6,
           "input_cache_read": 0.15e-6,
           "output": 9e-6,
+          "output_reasoning_tokens": 9e-6,
+          "output_reasoning": 9e-6,
+          "reasoning_tokens": 9e-6,
           "cache_read_input_tokens": 0.15e-6
         }
       },
@@ -5375,6 +5381,9 @@
           "input_cached_tokens": 0.0375e-6,
           "input_cache_read": 0.0375e-6,
           "output": 2.25e-6,
+          "output_reasoning_tokens": 2.25e-6,
+          "output_reasoning": 2.25e-6,
+          "reasoning_tokens": 2.25e-6,
           "cache_read_input_tokens": 0.0375e-6
         }
       }
@@ -5385,7 +5394,7 @@
     "modelName": "gpt-5.4-mini-2026-03-17",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-mini-2026-03-17)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-24T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5404,6 +5413,9 @@
           "input_cached_tokens": 0.075e-6,
           "input_cache_read": 0.075e-6,
           "output": 4.5e-6,
+          "output_reasoning_tokens": 4.5e-6,
+          "output_reasoning": 4.5e-6,
+          "reasoning_tokens": 4.5e-6,
           "cache_read_input_tokens": 0.075e-6
         }
       },
@@ -5425,6 +5437,9 @@
           "input_cached_tokens": 0.15e-6,
           "input_cache_read": 0.15e-6,
           "output": 9e-6,
+          "output_reasoning_tokens": 9e-6,
+          "output_reasoning": 9e-6,
+          "reasoning_tokens": 9e-6,
           "cache_read_input_tokens": 0.15e-6
         }
       },
@@ -5446,6 +5461,9 @@
           "input_cached_tokens": 0.0375e-6,
           "input_cache_read": 0.0375e-6,
           "output": 2.25e-6,
+          "output_reasoning_tokens": 2.25e-6,
+          "output_reasoning": 2.25e-6,
+          "reasoning_tokens": 2.25e-6,
           "cache_read_input_tokens": 0.0375e-6
         }
       }
@@ -5456,7 +5474,7 @@
     "modelName": "gpt-5.4-nano",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-nano)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-24T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5475,6 +5493,9 @@
           "input_cached_tokens": 0.02e-6,
           "input_cache_read": 0.02e-6,
           "output": 1.25e-6,
+          "output_reasoning_tokens": 1.25e-6,
+          "output_reasoning": 1.25e-6,
+          "reasoning_tokens": 1.25e-6,
           "cache_read_input_tokens": 0.02e-6
         }
       },
@@ -5496,6 +5517,9 @@
           "input_cached_tokens": 0.01e-6,
           "input_cache_read": 0.01e-6,
           "output": 0.625e-6,
+          "output_reasoning_tokens": 0.625e-6,
+          "output_reasoning": 0.625e-6,
+          "reasoning_tokens": 0.625e-6,
           "cache_read_input_tokens": 0.01e-6
         }
       }
@@ -5506,7 +5530,7 @@
     "modelName": "gpt-5.4-nano-2026-03-17",
     "matchPattern": "(?i)^(openai\\/)?(gpt-5.4-nano-2026-03-17)$",
     "createdAt": "2026-03-18T00:00:00.000Z",
-    "updatedAt": "2026-08-20T00:00:00.000Z",
+    "updatedAt": "2026-08-24T00:00:00.000Z",
     "tokenizerConfig": {
       "tokensPerName": 1,
       "tokenizerModel": "gpt-4",
@@ -5525,6 +5549,9 @@
           "input_cached_tokens": 0.02e-6,
           "input_cache_read": 0.02e-6,
           "output": 1.25e-6,
+          "output_reasoning_tokens": 1.25e-6,
+          "output_reasoning": 1.25e-6,
+          "reasoning_tokens": 1.25e-6,
           "cache_read_input_tokens": 0.02e-6
         }
       },
@@ -5546,6 +5573,9 @@
           "input_cached_tokens": 0.01e-6,
           "input_cache_read": 0.01e-6,
           "output": 0.625e-6,
+          "output_reasoning_tokens": 0.625e-6,
+          "output_reasoning": 0.625e-6,
+          "reasoning_tokens": 0.625e-6,
           "cache_read_input_tokens": 0.01e-6
         }
       }

--- a/worker/src/scripts/upsertDefaultModelPrices.test.ts
+++ b/worker/src/scripts/upsertDefaultModelPrices.test.ts
@@ -10,6 +10,7 @@ import {
   type DefaultModelPrice,
   upsertModelWithTiers,
 } from "./upsertDefaultModelPrices";
+import defaultModelPrices from "../constants/default-model-prices.json";
 
 describe("upsertModelWithTiers", () => {
   beforeEach(() => {
@@ -106,5 +107,40 @@ describe("upsertModelWithTiers", () => {
       "tier.upsert:1",
       "tier.upsert:2",
     ]);
+  });
+});
+
+describe("default GPT-5.4 mini and nano prices", () => {
+  it("prices all reasoning aliases at each tier's output rate", () => {
+    const expectedStandardOutputPrices = {
+      "gpt-5.4-mini": 4.5e-6,
+      "gpt-5.4-mini-2026-03-17": 4.5e-6,
+      "gpt-5.4-nano": 1.25e-6,
+      "gpt-5.4-nano-2026-03-17": 1.25e-6,
+    };
+
+    for (const [modelName, expectedStandardOutputPrice] of Object.entries(
+      expectedStandardOutputPrices,
+    )) {
+      const model = defaultModelPrices.find(
+        (defaultModel) => defaultModel.modelName === modelName,
+      );
+
+      expect(model, modelName).toBeDefined();
+      if (!model) continue;
+
+      for (const tier of model.pricingTiers) {
+        expect(tier.prices, `${modelName}/${tier.name}`).toMatchObject({
+          output_reasoning_tokens: tier.prices.output,
+          output_reasoning: tier.prices.output,
+          reasoning_tokens: tier.prices.output,
+        });
+      }
+
+      const standardTier = model.pricingTiers.find((tier) => tier.isDefault);
+      expect(standardTier?.prices.output, modelName).toBe(
+        expectedStandardOutputPrice,
+      );
+    }
   });
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16480.preview.langfuse.com](https://pr-16480.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Add reasoning-token pricing aliases to the managed GPT-5.4 mini and nano model entries, including dated variants.
- Keep each alias aligned with its tier's existing output rate across Standard, Fast mode, and Flex tiers.
- Add regression coverage for all four model entries and every managed pricing tier.

## Validation

- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
- `CI=true pnpm --filter worker run test src/scripts/upsertDefaultModelPrices.test.ts`
- `CI=true pnpm --filter worker run lint`
- `CI=true pnpm exec prettier --check worker/src/constants/default-model-prices.json worker/src/scripts/upsertDefaultModelPrices.test.ts`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds reasoning-token pricing aliases for GPT-5.4 mini and nano, including their dated variants, with each alias matching the applicable tier’s output rate.

- Advances the four model records’ update timestamps so existing installations reconcile the new prices.
- Covers Standard, Fast mode, and Flex tiers where available.
- Adds regression assertions for every affected model and pricing tier.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The new aliases follow the repository’s existing GPT pricing convention, use each tier’s established output rate, and the timestamp and upsert behavior ensure the added price rows are reconciled.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): price GPT-5.4 reasoning to..."](https://github.com/langfuse/langfuse/commit/21d1e3fa2bda73db97d64e7cb63da6cf724fbda7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56255913)</sub>

<!-- /greptile_comment -->