### PR TITLE
fix: reject filters on pair-expanded dimensions

### DIFF
--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { InvalidRequestError } from "../../../errors";
 import type { FilterCondition } from "../../../types";
 import { getViewDeclaration } from "../dataModel";
 import type { QueryType, ViewVersion } from "../types";
@@ -131,18 +132,21 @@ describe("queryBuilder filter type validation", () => {
   );
 
   it("rejects filters on pair-expanded dimensions", async () => {
-    await expect(
-      buildQueryWithFilter(
-        {
-          column: "usageType",
-          operator: "contains",
-          value: "cache",
-          type: "string",
-        },
-        undefined,
-        "v2",
-      ),
-    ).rejects.toThrow("Field 'usageType' cannot be used as a filter.");
+    const result = buildQueryWithFilter(
+      {
+        column: "usageType",
+        operator: "contains",
+        value: "cache",
+        type: "string",
+      },
+      undefined,
+      "v2",
+    );
+
+    await expect(result).rejects.toThrow(InvalidRequestError);
+    await expect(result).rejects.toThrow(
+      "Field 'usageType' cannot be used as a filter.",
+    );
   });
 
   it.each([

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -130,6 +130,21 @@ describe("queryBuilder filter type validation", () => {
     },
   );
 
+  it("rejects filters on pair-expanded dimensions", async () => {
+    await expect(
+      buildQueryWithFilter(
+        {
+          column: "usageType",
+          operator: "contains",
+          value: "cache",
+          type: "string",
+        },
+        undefined,
+        "v2",
+      ),
+    ).rejects.toThrow("Field 'usageType' cannot be used as a filter.");
+  });
+
   it.each([
     {
       name: "arrayOptions on string array dimension",

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -337,6 +337,12 @@ export class QueryBuilder {
       const dimension = this.resolveDimension(filter.column, view);
 
       if (dimension) {
+        if (dimension.pairExpand) {
+          throw new InvalidRequestError(
+            `Field '${filter.column}' cannot be used as a filter.`,
+          );
+        }
+
         const compatibleFilterTypes = getCompatibleFilterTypesForQueryDimension(
           dimension.type,
         );

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -36,6 +36,7 @@ vi.mock(
 
 import { nanoid } from "nanoid";
 import { createHash, randomUUID } from "crypto";
+import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -2097,6 +2098,34 @@ describe("MCP Read Tools", () => {
           context,
         ),
       ).rejects.toThrow(/Use returned metric aliases.*getMetricsSchema/i);
+    });
+
+    it("should return an invalid request for filters on pair-expanded dimensions", async () => {
+      const context = mockServerContext();
+
+      await expect(
+        handleQueryMetrics(
+          {
+            view: "observations",
+            metrics: [{ measure: "count", aggregation: "count" }],
+            filters: [
+              {
+                type: "string",
+                column: "usageType",
+                operator: "contains",
+                value: "cache",
+              },
+            ],
+            ...metricsWindow,
+          } as unknown as Parameters<typeof handleQueryMetrics>[0],
+          context,
+        ),
+      ).rejects.toMatchObject({
+        code: ErrorCode.InvalidRequest,
+        message: expect.stringContaining(
+          "Field 'usageType' cannot be used as a filter.",
+        ),
+      });
     });
 
     it("should apply default row_limit of 100 when omitted", async () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16481.preview.langfuse.com](https://pr-16481.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Reject query filters targeting pair-expanded dimensions before SQL generation.
- Surface the rejection to MCP clients as an InvalidRequest error with the invalid field.
- Add query-builder and queryMetrics regression coverage for usageType filters.

## Impacted packages

- packages/shared
- web

## Verification

- `pnpm --filter @langfuse/shared run test src/features/query/server/queryBuilder.filterValidation.test.ts` — 25 passed
- focused queryMetrics MCP regression — 1 passed
- MCP error contract suites — 40 passed
- `pnpm run lint` — 7/7 tasks successful
- `pnpm run typecheck` — 8/8 tasks successful
- `pnpm --filter worker run typecheck` — passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents query filters from targeting pair-expanded dimensions, avoiding unsupported filtering semantics for dimensions that preserve aligned map key/value expansion.
- Adds an early validation error for filters on pair-expanded dimensions.
- Adds regression coverage confirming that a `usageType` filter is rejected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The validation change consistently enforces the stated restriction before query construction, and the regression test exercises the intended `usageType` rejection path.
</details>

<sub>Reviews (1): Last reviewed commit: ["Reject filters on pair-expanded dimensio..."](https://github.com/langfuse/langfuse/commit/f817be73f30d5412671c6e05e32a2b5956454aab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56266763)</sub>

**Context used:**

- Knowledge Base — [Analytics and query data](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/analytics-query-data.md)

<!-- /greptile_comment -->
