### PR TITLE
fix(experiments): keep evaluator search modal mounted

### DIFF
--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -50,6 +50,7 @@ import { EvaluatorsStep } from "./steps/EvaluatorsStep";
 import { ExperimentDetailsStep } from "./steps/ExperimentDetailsStep";
 import { ReviewStep } from "./steps/ReviewStep";
 import type { ExperimentEvaluatorAssignmentsHandle } from "@/src/features/experiments/components/ExperimentEvaluatorAssignments/types/experimentEvaluatorAssignmentsHandle";
+import { canNavigateToExperimentStep } from "@/src/features/experiments/fns/canNavigateToExperimentStep";
 
 // Import step prop types
 import {
@@ -422,7 +423,16 @@ export const MultiStepExperimentForm = ({
     }
   };
 
+  const canNavigateToStep = (stepId: string) =>
+    canNavigateToExperimentStep({
+      targetStepId: stepId,
+      useV2Evaluators,
+      isLoadingAssignments: v2EvaluatorSelection.isLoadingAssignments,
+    });
+
   const handleStepChange = (stepId: string) => {
+    if (!canNavigateToStep(stepId)) return;
+
     if (stepId === "review") {
       setHasAttemptedReview(true);
     }
@@ -593,27 +603,35 @@ export const MultiStepExperimentForm = ({
           <DialogBody>
             <Breadcrumb className="mb-6 w-full">
               <BreadcrumbList className="flex w-full justify-between sm:justify-start">
-                {steps.map((step, index) => (
-                  <React.Fragment key={step.id}>
-                    <BreadcrumbItem>
-                      {step.id === activeStep ? (
-                        <BreadcrumbPage className="flex items-center">
-                          {renderStepStatusIcon(step.id, step.label)}
-                          {step.label}
-                        </BreadcrumbPage>
-                      ) : (
-                        <BreadcrumbLink
-                          onClick={() => handleStepChange(step.id)}
-                          className="flex cursor-pointer items-center"
-                        >
-                          {renderStepStatusIcon(step.id, step.label)}
-                          {step.label}
-                        </BreadcrumbLink>
-                      )}
-                    </BreadcrumbItem>
-                    {index < steps.length - 1 && <BreadcrumbSeparator />}
-                  </React.Fragment>
-                ))}
+                {steps.map((step, index) => {
+                  const isNavigationDisabled = !canNavigateToStep(step.id);
+                  return (
+                    <React.Fragment key={step.id}>
+                      <BreadcrumbItem>
+                        {step.id === activeStep ? (
+                          <BreadcrumbPage className="flex items-center">
+                            {renderStepStatusIcon(step.id, step.label)}
+                            {step.label}
+                          </BreadcrumbPage>
+                        ) : (
+                          <BreadcrumbLink
+                            aria-disabled={isNavigationDisabled}
+                            onClick={() => handleStepChange(step.id)}
+                            className={`flex items-center ${
+                              isNavigationDisabled
+                                ? "pointer-events-none opacity-50"
+                                : "cursor-pointer"
+                            }`}
+                          >
+                            {renderStepStatusIcon(step.id, step.label)}
+                            {step.label}
+                          </BreadcrumbLink>
+                        )}
+                      </BreadcrumbItem>
+                      {index < steps.length - 1 && <BreadcrumbSeparator />}
+                    </React.Fragment>
+                  );
+                })}
               </BreadcrumbList>
             </Breadcrumb>
 

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -534,6 +534,7 @@ export const MultiStepExperimentForm = ({
         search: v2EvaluatorSelection.search,
         onSearchChange: v2EvaluatorSelection.onSearchChange,
         onSaveAssignments: v2EvaluatorSelection.onSaveAssignments,
+        isLoadingAssignments: v2EvaluatorSelection.isLoadingAssignments,
         isUpdating: v2EvaluatorSelection.isUpdating,
       }
     : {
@@ -697,7 +698,8 @@ export const MultiStepExperimentForm = ({
                     loading={
                       activeStep === "evaluators" &&
                       useV2Evaluators &&
-                      v2EvaluatorSelection.isUpdating
+                      (v2EvaluatorSelection.isLoadingAssignments ||
+                        v2EvaluatorSelection.isUpdating)
                     }
                   >
                     Next

--- a/web/src/features/experiments/components/steps/EvaluatorsStep.tsx
+++ b/web/src/features/experiments/components/steps/EvaluatorsStep.tsx
@@ -11,6 +11,7 @@ import { EvaluatorForm } from "@/src/features/evals/components/evaluator-form";
 import { type EvaluatorsStepProps } from "@/src/features/experiments/types/stepProps";
 import { StepHeader } from "@/src/features/experiments/components/shared/StepHeader";
 import { ExperimentEvaluatorAssignments } from "@/src/features/experiments/components/ExperimentEvaluatorAssignments/ExperimentEvaluatorAssignments";
+import { Skeleton } from "@/src/components/ui/skeleton";
 
 export const EvaluatorsStep: React.FC<EvaluatorsStepProps> = ({
   projectId,
@@ -38,19 +39,23 @@ export const EvaluatorsStep: React.FC<EvaluatorsStepProps> = ({
         ) : null}
         {hasEvalReadAccess && datasetId ? (
           evaluatorState.version === "v2" ? (
-            <ExperimentEvaluatorAssignments
-              ref={evaluatorAssignmentsRef}
-              showSaveButton={false}
-              projectId={projectId}
-              datasetId={datasetId}
-              datasetVersion={datasetVersion}
-              evaluatorOptions={evaluatorState.evaluatorOptions}
-              initialAssignments={evaluatorState.selectedAssignments}
-              search={evaluatorState.search}
-              onSearchChange={evaluatorState.onSearchChange}
-              onSaveAssignments={evaluatorState.onSaveAssignments}
-              disabled={!hasEvalWriteAccess || evaluatorState.isUpdating}
-            />
+            evaluatorState.isLoadingAssignments ? (
+              <Skeleton className="h-20 w-full" />
+            ) : (
+              <ExperimentEvaluatorAssignments
+                ref={evaluatorAssignmentsRef}
+                showSaveButton={false}
+                projectId={projectId}
+                datasetId={datasetId}
+                datasetVersion={datasetVersion}
+                evaluatorOptions={evaluatorState.evaluatorOptions}
+                initialAssignments={evaluatorState.selectedAssignments}
+                search={evaluatorState.search}
+                onSearchChange={evaluatorState.onSearchChange}
+                onSaveAssignments={evaluatorState.onSaveAssignments}
+                disabled={!hasEvalWriteAccess || evaluatorState.isUpdating}
+              />
+            )
           ) : (
             <TemplateSelector
               projectId={projectId}

--- a/web/src/features/experiments/fns/canNavigateToExperimentStep.clienttest.ts
+++ b/web/src/features/experiments/fns/canNavigateToExperimentStep.clienttest.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { canNavigateToExperimentStep } from "./canNavigateToExperimentStep";
+
+describe("canNavigateToExperimentStep", () => {
+  it("blocks the review step while evaluator assignments are loading", () => {
+    expect(
+      canNavigateToExperimentStep({
+        targetStepId: "review",
+        useV2Evaluators: true,
+        isLoadingAssignments: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows other navigation while evaluator assignments are loading", () => {
+    expect(
+      canNavigateToExperimentStep({
+        targetStepId: "details",
+        useV2Evaluators: true,
+        isLoadingAssignments: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/web/src/features/experiments/fns/canNavigateToExperimentStep.ts
+++ b/web/src/features/experiments/fns/canNavigateToExperimentStep.ts
@@ -1,0 +1,15 @@
+export function canNavigateToExperimentStep({
+  targetStepId,
+  useV2Evaluators,
+  isLoadingAssignments,
+}: {
+  targetStepId: string;
+  useV2Evaluators: boolean;
+  isLoadingAssignments: boolean;
+}) {
+  return !(
+    targetStepId === "review" &&
+    useV2Evaluators &&
+    isLoadingAssignments
+  );
+}

--- a/web/src/features/experiments/hooks/useExperimentV2EvaluatorSelection.clienttest.ts
+++ b/web/src/features/experiments/hooks/useExperimentV2EvaluatorSelection.clienttest.ts
@@ -1,7 +1,36 @@
+import { act, renderHook } from "@testing-library/react";
 import { EvalTargetObject } from "@langfuse/shared";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getDatasetExperimentRules } from "./useExperimentV2EvaluatorSelection";
+import {
+  getDatasetExperimentRules,
+  useExperimentV2EvaluatorSelection,
+} from "./useExperimentV2EvaluatorSelection";
+
+const apiMocks = vi.hoisted(() => ({
+  evaluatorOptionsQuery: vi.fn(),
+  rulesQuery: vi.fn(),
+  createRuleMutation: vi.fn(),
+  createRuleMutateAsync: vi.fn(),
+  updateRuleMutation: vi.fn(),
+  invalidateRules: vi.fn(),
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      evalsV2: { rules: { list: { invalidate: apiMocks.invalidateRules } } },
+    }),
+    evalsV2: {
+      options: { useQuery: apiMocks.evaluatorOptionsQuery },
+      rules: {
+        list: { useQuery: apiMocks.rulesQuery },
+        create: { useMutation: apiMocks.createRuleMutation },
+        update: { useMutation: apiMocks.updateRuleMutation },
+      },
+    },
+  },
+}));
 
 const experimentRootFilter = {
   column: "isExperimentItemRootSpan",
@@ -9,6 +38,107 @@ const experimentRootFilter = {
   operator: "=",
   value: true,
 } as const;
+
+describe("useExperimentV2EvaluatorSelection", () => {
+  beforeEach(() => {
+    apiMocks.evaluatorOptionsQuery.mockReturnValue({
+      data: [],
+      isPending: false,
+    });
+    apiMocks.rulesQuery.mockReturnValue({
+      data: { rules: [] },
+      isPending: false,
+    });
+    apiMocks.createRuleMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: apiMocks.createRuleMutateAsync,
+    });
+    apiMocks.updateRuleMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("does not load evaluation rules before a dataset is selected", () => {
+    renderHook(() =>
+      useExperimentV2EvaluatorSelection({
+        projectId: "project-1",
+        datasetId: null,
+        enabled: true,
+        canWrite: true,
+      }),
+    );
+
+    expect(apiMocks.rulesQuery).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("does not save assignments while existing rules are loading", async () => {
+    apiMocks.rulesQuery.mockReturnValue({
+      data: undefined,
+      isPending: true,
+    });
+
+    const { result } = renderHook(() =>
+      useExperimentV2EvaluatorSelection({
+        projectId: "project-1",
+        datasetId: "dataset-1",
+        enabled: true,
+        canWrite: true,
+      }),
+    );
+
+    await act(() =>
+      result.current.onSaveAssignments([
+        { evaluatorId: "evaluator-1", variableMapping: [] } as never,
+      ]),
+    );
+
+    expect(result.current.isLoadingAssignments).toBe(true);
+    expect(apiMocks.createRuleMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("stays ready while an evaluator search is loading", () => {
+    vi.useFakeTimers();
+    const previousOptions: never[] = [];
+    apiMocks.evaluatorOptionsQuery.mockImplementation((input, queryOptions) => {
+      const data = input.search
+        ? queryOptions.placeholderData?.(previousOptions)
+        : previousOptions;
+      return {
+        data,
+        isPending: input.search ? data === undefined : false,
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useExperimentV2EvaluatorSelection({
+        projectId: "project-1",
+        datasetId: "dataset-1",
+        enabled: true,
+        canWrite: true,
+      }),
+    );
+
+    act(() => {
+      result.current.onSearchChange("quality");
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(apiMocks.evaluatorOptionsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: "quality" }),
+      expect.any(Object),
+    );
+    expect(result.current.isPending).toBe(false);
+  });
+});
 
 describe("getDatasetExperimentRules", () => {
   it("only returns the rule scoped to the selected dataset", () => {

--- a/web/src/features/experiments/hooks/useExperimentV2EvaluatorSelection.ts
+++ b/web/src/features/experiments/hooks/useExperimentV2EvaluatorSelection.ts
@@ -68,7 +68,10 @@ export function useExperimentV2EvaluatorSelection({
       limit: 100,
       search: searchQuery.trim() || undefined,
     },
-    { enabled },
+    {
+      enabled,
+      placeholderData: (previousData) => previousData,
+    },
   );
   const rules = api.evalsV2.rules.list.useQuery(
     {
@@ -145,7 +148,7 @@ export function useExperimentV2EvaluatorSelection({
   const isUpdating = createRule.isPending || updateRule.isPending;
 
   const onSaveAssignments = async (assignments: RuleDraft["assignments"]) => {
-    if (!datasetId || !canWrite || isUpdating) return;
+    if (!datasetId || !canWrite || isUpdating || rules.isPending) return;
 
     const evaluatorMappings = assignments.map((assignment) => ({
       evaluatorId: assignment.evaluatorId,
@@ -199,9 +202,8 @@ export function useExperimentV2EvaluatorSelection({
     options,
     selectedEvaluatorNames,
     selectedAssignments,
-    isPending:
-      enabled &&
-      (evaluatorOptions.isPending || (Boolean(datasetId) && rules.isPending)),
+    isPending: enabled && evaluatorOptions.isPending,
+    isLoadingAssignments: enabled && Boolean(datasetId) && rules.isPending,
     isUpdating,
     search,
     onSearchChange: (value: string) => {

--- a/web/src/features/experiments/types/stepProps.ts
+++ b/web/src/features/experiments/types/stepProps.ts
@@ -108,6 +108,7 @@ type V2EvaluatorState = {
   search: string;
   onSearchChange: (value: string) => void;
   onSaveAssignments: (assignments: RuleDraft["assignments"]) => Promise<void>;
+  isLoadingAssignments: boolean;
   isUpdating: boolean;
 };
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16482.preview.langfuse.com](https://pr-16482.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- Keep the experiment form mounted while evaluator search results refresh.
- Load dataset evaluation rules only after selecting a dataset and show loading inside the evaluator step.
- Prevent assignment saves while existing rules are still loading, avoiding duplicate rules.
- Add regressions for lazy rule loading, search refreshes, and the save guard.

## Test plan

- `pnpm --filter web run test-client useExperimentV2EvaluatorSelection`
- `pnpm run lint`
- `git diff --check`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR keeps the evaluator-selection UI mounted while search results refresh, lazily loads dataset evaluation rules, and blocks assignment saves during that load.
- Preserves previous evaluator options during debounced searches.
- Separates evaluator-option loading from dataset-assignment loading.
- Adds loading UI and regression tests for lazy loading, search refreshes, and save guarding.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The breadcrumb bypass should be fixed before merging because users can reach review and run an experiment before evaluator assignments are loaded and saved.

Assignment loading protects the Next action but not direct breadcrumb navigation, which bypasses the only handler that saves evaluator assignments.

**Files Needing Attention:** web/src/features/experiments/components/MultiStepExperimentForm.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Select dataset] --> B[Load existing evaluator rules]
  B --> C{Rules loaded?}
  C -->|No| D[Show evaluator skeleton]
  D --> E[Next disabled]
  D --> F[Breadcrumb remains clickable]
  F --> G[Review step]
  G --> H[Run experiment without evaluator save]
  C -->|Yes| I[Edit evaluator assignments]
  I --> J[Next saves assignments]
  J --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/experiments/components/MultiStepExperimentForm.tsx:605-607
**Breadcrumb bypasses assignment loading**

When existing evaluator rules are loading, the breadcrumbs remain clickable and `handleStepChange` bypasses the assignment save performed by `handleNextStep`, allowing the user to reach review and run the experiment without the intended evaluator configuration.

```suggestion
                        <BreadcrumbLink
                          onClick={() => {
                            if (
                              useV2Evaluators &&
                              v2EvaluatorSelection.isLoadingAssignments
                            )
                              return;
                            handleStepChange(step.id);
                          }}
                          className="flex cursor-pointer items-center"
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): keep evaluator search ..."](https://github.com/langfuse/langfuse/commit/64c3ea2b0dba37446e7741a4fe42e70130f868c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56268060)</sub>

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)

<!-- /greptile_comment -->