### PR TITLE
fix(otel): drop Gemini's text_prompt_tokens usage detail to avoid double-counting

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2956,6 +2956,10 @@ export class OtelIngestionProcessor {
             "reasoning.output_tokens",
             "completion_details.reasoning",
             "completion_details.audio",
+            // Gemini's prompt modality breakdown (via PydanticAI's OTel
+            // export) always sums back to prompt_tokens/input_tokens, so
+            // keeping it as its own bucket double-counts it against input.
+            "details.text_prompt_tokens",
           ].includes(key)
         ) {
           return acc;

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -7941,6 +7941,100 @@ describe("OTel Resource Span Mapping", () => {
       expect(usageDetails["reasoning.output_tokens"]).toBeUndefined();
     });
 
+    it("should not double count gen_ai.usage.details.text_prompt_tokens against input_tokens (PydanticAI/Gemini)", async () => {
+      // PydanticAI's Gemini export sets gen_ai.usage.input_tokens to the full
+      // prompt token count, but also emits Gemini's prompt modality
+      // breakdown as gen_ai.usage.details.text_prompt_tokens. For a text-only
+      // prompt this equals input_tokens exactly, so keeping it as its own
+      // usage bucket doubles the input total wherever all buckets are summed
+      // (e.g. the ingestion pipeline's total fallback).
+      const traceId = "abcdef1234567890abcdef1234567897";
+
+      const geminiDetailsSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "pydantic-ai",
+              version: "1.0.0",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("1234567890abcde6", "hex"),
+                name: "pydantic-ai-gemini-usage-details",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: { intValue: { low: 100, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "gen_ai.usage.output_tokens",
+                    value: { intValue: { low: 50, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "gen_ai.usage.details.text_prompt_tokens",
+                    value: { intValue: { low: 100, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "gen_ai.usage.details.thoughts_tokens",
+                    value: { intValue: { low: 20, high: 0, unsigned: false } },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        geminiDetailsSpan,
+        new Set(),
+      );
+      const observationEvent = events.find(
+        (e) => e.type === "generation-create" || e.type === "span-create",
+      );
+
+      expect(observationEvent).toBeDefined();
+      const usageDetails = observationEvent?.body.usageDetails as Record<
+        string,
+        number
+      >;
+      expect(usageDetails.input).toBe(100);
+      expect(usageDetails.output).toBe(50);
+      // The redundant modality breakdown must not be passed through as its
+      // own bucket, since it duplicates the already-counted input tokens.
+      expect(usageDetails["text_prompt_tokens"]).toBeUndefined();
+      // thoughts_tokens is genuinely additional (not included in
+      // output_tokens), so it stays as its own bucket.
+      expect(usageDetails["thoughts_tokens"]).toBe(20);
+      // No double count: the sum of all input* buckets must equal the
+      // reported input token count, not 2x.
+      const inputSum = Object.entries(usageDetails)
+        .filter(([key]) => key.startsWith("input"))
+        .reduce((acc, [, value]) => acc + value, 0);
+      expect(inputSum).toBe(100);
+    });
+
     it("should clamp output at 0 when reasoning details exceed the emitted output count", async () => {
       // Reasoning > output must floor output at 0 (negatives are dropped downstream); breaks the output-sum invariant by design.
       const traceId = "abcdef1234567890abcdef1234567896";


### PR DESCRIPTION
## TL;DR

Fixes #16489 — Gemini traces via PydanticAI showed a doubled "Total Usage" because a redundant usage-detail field was being counted twice.

## What does this PR do?

PydanticAI's OTel export for Gemini models sends `gen_ai.usage.input_tokens`
for the full prompt token count, but also sends Gemini's prompt modality
breakdown as `gen_ai.usage.details.text_prompt_tokens`. For a text-only
prompt this is the same number as `input_tokens`.

`OtelIngestionProcessor.extractGenericGenAiUsageDetails` already strips out
other known redundant breakdowns (cache read/write, reasoning, audio) before
storing `usageDetails`, precisely so that summing every value in the map
gives the correct total token count. `details.text_prompt_tokens` was
missing from that list, so it survived as its own bucket. Whenever no
explicit `gen_ai.usage.total_tokens` attribute is present, downstream code
(`IngestionService.getUsageUnits` in the worker) falls back to
`Object.values(usageDetails).reduce(sum)` for the total — which then counted
the prompt tokens twice.

This adds `details.text_prompt_tokens` to the existing exclusion list, the
same way the sibling reasoning/audio/cache breakdowns are already handled.
`details.thoughts_tokens` (Gemini's separate thinking-token count) is left
untouched — per Gemini's own API semantics, `total_token_count = prompt +
candidates + thoughts`, so thoughts tokens are genuinely additional and
must stay in the total.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

Added `should not double count gen_ai.usage.details.text_prompt_tokens
against input_tokens (PydanticAI/Gemini)` to
`web/src/__tests__/server/api/otel/otelMapping.servertest.ts`, next to the
existing Google ADK reasoning-token test that guards the same invariant.

Confirmed it fails without the fix (reverted the source change, rebuilt
`@langfuse/shared`, reran):

```
AssertionError: expected 100 to be undefined
 ❯ src/__tests__/server/api/otel/otelMapping.servertest.ts:8026:50
   expect(usageDetails["text_prompt_tokens"]).toBeUndefined();
```

With the fix applied, the full otel mapping suite passes:

```
✓ |server| src/__tests__/server/api/otel/otelMapping.servertest.ts (247 tests | 1 skipped) 204ms
 Test Files  1 passed (1)
      Tests  246 passed | 1 skipped (247)
```

Also ran, all clean:
- `pnpm --filter @langfuse/shared run typecheck` — passes, no output
- `pnpm run lint` (via the pre-commit hook, full turbo run) — `Tasks: 7 successful, 7 total`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

---

This PR was authored with AI assistance (Claude Code), with the diagnosis,
fix, and test verified manually as described above.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents Gemini usage totals from double-counting PydanticAI’s redundant text prompt token detail.

- Excludes `details.text_prompt_tokens` from normalized OpenTelemetry usage details.
- Adds a regression test confirming input and thought-token buckets remain correctly represented.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the targeted redundant usage bucket removed and regression coverage in place.

The changed normalization preserves the canonical input and output counts, removes only the duplicate Gemini text prompt detail, and retains additive thought tokens.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): drop Gemini&#39;s text\_prompt\_tok..."](https://github.com/langfuse/langfuse/commit/a6c662b72e23f4129c4d7788ce80de5363956ba5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56322329)</sub>

<!-- /greptile_comment -->