### PR TITLE
fix(evals): only persist terminal ERROR on final LLM-as-judge retry attempt

### DIFF
--- a/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
@@ -139,7 +139,13 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     }>,
   ) => Promise<unknown>;
 
-  const createMockJob = (overrides: Record<string, unknown> = {}): Job<any> => {
+  const createMockJob = (
+    overrides: {
+      data?: Record<string, unknown>;
+      attemptsMade?: number;
+      opts?: { attempts?: number };
+    } = {},
+  ): Job<any> => {
     return {
       data: {
         id: "queue-job-123",
@@ -151,8 +157,10 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
           observationS3Path,
         },
         retryBaggage: { attempt: 0 },
-        ...overrides,
+        ...overrides.data,
       },
+      attemptsMade: overrides.attemptsMade ?? 0,
+      opts: overrides.opts ?? { attempts: 10 },
     } as Job<any>;
   };
 
@@ -399,11 +407,27 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
   });
 
   describe("unexpected errors (retryable by BullMQ)", () => {
-    it("should set ERROR status with generic message for unexpected errors", async () => {
+    it("should rethrow retryable errors without writing ERROR while retries remain", async () => {
       const unexpectedError = new Error("Database connection failed");
       (processObservationEval as Mock).mockRejectedValue(unexpectedError);
 
-      const job = createMockJob();
+      const job = createMockJob({ attemptsMade: 0, opts: { attempts: 10 } });
+
+      // Should rethrow for BullMQ retry
+      await expect(llmAsJudgeExecutionQueueProcessor(job)).rejects.toThrow(
+        "Database connection failed",
+      );
+
+      // Persisting ERROR here would make observationEvalProcessor
+      // short-circuit every subsequent BullMQ retry attempt as a no-op.
+      expect(prisma.jobExecution.update).not.toHaveBeenCalled();
+    });
+
+    it("should set ERROR status with generic message on the final retry attempt", async () => {
+      const unexpectedError = new Error("Database connection failed");
+      (processObservationEval as Mock).mockRejectedValue(unexpectedError);
+
+      const job = createMockJob({ attemptsMade: 9, opts: { attempts: 10 } });
 
       // Should rethrow for BullMQ retry
       await expect(llmAsJudgeExecutionQueueProcessor(job)).rejects.toThrow(
@@ -473,7 +497,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
       (processObservationEval as Mock).mockResolvedValue(undefined);
 
       const job = createMockJob({
-        retryBaggage: { attempt: 3 },
+        data: { retryBaggage: { attempt: 3 } },
       });
       await llmAsJudgeExecutionQueueProcessor(job as Job<any>);
 

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -335,23 +335,32 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
         }
       }
 
-      await prisma.jobExecution.update({
-        where: {
-          id: job.data.payload.jobExecutionId,
-          projectId: job.data.payload.projectId,
-        },
-        data: {
-          status: JobExecutionStatus.ERROR,
-          endTime: new Date(),
-          error:
-            llmError || isUnrecoverableError(e)
-              ? (llmError?.message ?? (e as Error).message)
-              : "An internal error occurred",
-          executionTraceId,
-        },
-      });
+      const isTerminalError = Boolean(llmError) || isUnrecoverableError(e);
+      const totalAttempts = job.opts.attempts ?? 1;
+      const isFinalAttempt = job.attemptsMade + 1 >= totalAttempts;
 
-      if (llmError || isUnrecoverableError(e)) return;
+      // Only persist the terminal ERROR state when there will be no more
+      // retries; otherwise observationEvalProcessor would short-circuit the
+      // retry attempts because it skips jobs already in ERROR status.
+      if (isTerminalError || isFinalAttempt) {
+        await prisma.jobExecution.update({
+          where: {
+            id: job.data.payload.jobExecutionId,
+            projectId: job.data.payload.projectId,
+          },
+          data: {
+            status: JobExecutionStatus.ERROR,
+            endTime: new Date(),
+            error:
+              llmError || isUnrecoverableError(e)
+                ? (llmError?.message ?? (e as Error).message)
+                : "An internal error occurred",
+            executionTraceId,
+          },
+        });
+      }
+
+      if (isTerminalError) return;
 
       traceException(e);
       logger.error(


### PR DESCRIPTION
## TL;DR

Fixes #16491: a transient (retryable) error in the LLM-as-judge eval queue was permanently killing the eval, because the queue wrote a terminal `ERROR` status to Postgres *before* rethrowing the error for a BullMQ retry — and `observationEvalProcessor` skips any job execution that's already `ERROR`. Every retry attempt after the first therefore became a silent no-op.

## What changed

`worker/src/queues/evalQueue.ts` (`llmAsJudgeExecutionQueueProcessorBuilder`): only persist `JobExecutionStatus.ERROR` when the error is terminal (an LLM error or `UnrecoverableError`) or this is the job's final BullMQ attempt. Otherwise leave the row untouched before rethrowing, so `observationEvalProcessor` doesn't short-circuit the next retry.

This mirrors the guard `worker/src/queues/codeEvalQueue.ts` already uses (and documents) for the sibling CODE-eval queue — the two queues had diverged, and only the LLM-as-judge one had the bug.

## Test plan

Added/updated coverage in `worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts`:
- new test: a retryable, non-LLM error on a non-final attempt rethrows **without** writing `ERROR` (this is the regression test — it fails against the old code).
- new test: the same error type on the final attempt still writes `ERROR` with the masked message.
- existing LLM-error / `UnrecoverableError` / retry-scheduling tests updated to pass `attemptsMade`/`opts.attempts` through the mock job and still pass unchanged.

Verified the regression test actually catches the bug:
```
git checkout HEAD~1 -- worker/src/queues/evalQueue.ts
pnpm --filter worker run test llmAsJudgeExecutionQueueProcessor.test.ts
# → 1 failed | 18 passed — "should rethrow retryable errors without writing ERROR while retries remain" fails,
#   asserting prisma.jobExecution.update was called when it shouldn't have been
git checkout HEAD -- worker/src/queues/evalQueue.ts
```

With the fix applied:
```
$ pnpm --filter worker run test llmAsJudgeExecutionQueueProcessor.test.ts
✓ src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts (19 tests) 536ms
Test Files  1 passed (1)
     Tests  19 passed (19)
```

```
$ pnpm --filter worker run test codeEvalExecutionQueueProcessor.test.ts
✓ src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts (7 tests) 16ms
Test Files  1 passed (1)
     Tests  7 passed (7)
```

```
$ pnpm --filter worker run lint
$ eslint . --cache --cache-location dist/.eslintcache --max-warnings 0 --concurrency 2
(clean, no output)
```

```
$ pnpm --filter worker run typecheck
$ dotenv -e ../.env -- tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo
(clean, no output)
```

Did not run the full `worker` test suite — most other suites require live Postgres/Redis/ClickHouse, which aren't available in this environment; the targeted suites above cover every code path touched by this change.

## Disclosure

This PR was written with AI assistance (Claude Code), reviewed and verified by me before pushing.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes LLM-as-judge retries by deferring durable `ERROR` status until an error is intrinsically terminal or the BullMQ attempt budget is exhausted.
- Uses BullMQ attempt metadata to identify the final attempt.
- Leaves retryable executions nonterminal so subsequent attempts are not short-circuited.
- Adds regression coverage for non-final and final unexpected-error paths.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the retry-state change aligned to the queue’s configured BullMQ attempts and covered by focused regression tests.

Retryable unexpected failures remain nonterminal before the last configured attempt, while terminal errors and exhausted jobs still receive a durable ERROR state.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[LLM-as-judge attempt fails] --> B{Terminal error?}
  B -->|Yes| C[Persist ERROR]
  B -->|No| D{Final BullMQ attempt?}
  D -->|Yes| C
  D -->|No| E[Leave execution nonterminal]
  E --> F[Throw for BullMQ retry]
  C --> G{Retryable unexpected error?}
  G -->|Yes| H[Throw and let BullMQ mark job failed]
  G -->|No| I[Return]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): only persist terminal ERROR ..."](https://github.com/langfuse/langfuse/commit/a909096eb697ad5ccbd0c118e6b332d83fa28609) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56345120)</sub>

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->