### PR TITLE
fix(evals): serialize eval job execution creation to prevent duplicate scores

### DIFF
--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -751,6 +751,54 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       expect(jobs[0].startTime).not.toBeNull();
     }, 10_000);
 
+    test("does not create duplicate 'trace' eval jobs when producers race on the same trace", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await createMigratedEvalConfig({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const payload = {
+        projectId,
+        traceId: traceId,
+      };
+
+      // Simulate many producers (e.g. trace-upsert and dataset-run-item-upsert
+      // shard workers) delivering near-simultaneously for the same trace + config.
+      await Promise.all(
+        Array.from({ length: 20 }, () =>
+          createEvalJobs({
+            sourceEventType: "trace-upsert",
+            event: payload,
+            jobTimestamp,
+          }),
+        ),
+      );
+
+      await expect(
+        prisma.jobExecution.count({ where: { projectId } }),
+      ).resolves.toBe(1);
+    }, 10_000);
+
     test("creates new 'dataset' eval job", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
       const traceId = randomUUID();

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -799,6 +799,69 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       ).resolves.toBe(1);
     }, 10_000);
 
+    test("does not create duplicate 'trace' eval jobs when a dataset-run-item event carrying an observationId is delivered twice", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+      const observationId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await upsertObservation({
+        id: observationId,
+        trace_id: traceId,
+        project_id: projectId,
+        type: "GENERATION",
+        start_time: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await createMigratedEvalConfig({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      // A dataset-run-item-upsert event carries an observationId even when it is
+      // evaluated against a TRACE-target rule, where no datasetItem is ever
+      // looked up. Delivering the same event twice must not create two rows.
+      const payload = {
+        projectId,
+        traceId,
+        datasetItemId: randomUUID(),
+        observationId,
+      };
+
+      await createEvalJobs({
+        sourceEventType: "dataset-run-item-upsert",
+        event: payload,
+        jobTimestamp,
+      });
+      await createEvalJobs({
+        sourceEventType: "dataset-run-item-upsert",
+        event: payload,
+        jobTimestamp,
+      });
+
+      await expect(
+        prisma.jobExecution.count({ where: { projectId } }),
+      ).resolves.toBe(1);
+    }, 10_000);
+
     test("creates new 'dataset' eval job", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
       const traceId = randomUUID();

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -266,6 +266,46 @@ function toTraceEvalConfig(rule: TraceRule): TraceEvalConfig | null {
   };
 }
 
+// Serializes concurrent check-then-create attempts for the same dedup key so that two
+// producers racing on the same trace/config cannot both pass the existence check and
+// insert duplicate job_executions rows (there is no DB unique constraint on this key).
+async function createJobExecutionIfAbsent(params: {
+  projectId: string;
+  jobConfigurationId: string;
+  jobInputTraceId: string;
+  jobInputDatasetItemId: string | null;
+  jobInputObservationId: string | null;
+  data: Prisma.JobExecutionUncheckedCreateInput;
+}): Promise<JobExecution | null> {
+  const lockKey = [
+    params.projectId,
+    params.jobConfigurationId,
+    params.jobInputTraceId,
+    params.jobInputDatasetItemId ?? "",
+    params.jobInputObservationId ?? "",
+  ].join(":");
+
+  return prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
+
+    const existing = await tx.jobExecution.findFirst({
+      where: {
+        projectId: params.projectId,
+        jobConfigurationId: params.jobConfigurationId,
+        jobInputTraceId: params.jobInputTraceId,
+        jobInputDatasetItemId: params.jobInputDatasetItemId,
+        jobInputObservationId: params.jobInputObservationId,
+      },
+      select: { id: true },
+    });
+    if (existing) {
+      return null;
+    }
+
+    return tx.jobExecution.create({ data: params.data });
+  });
+}
+
 export const createEvalJobs = async ({
   event,
   sourceEventType,
@@ -755,7 +795,12 @@ export const createEvalJobs = async ({
         `Creating eval job execution for config ${config.id} and trace ${event.traceId}`,
       );
 
-      await prisma.jobExecution.create({
+      const createdJob = await createJobExecutionIfAbsent({
+        projectId: event.projectId,
+        jobConfigurationId: config.id,
+        jobInputTraceId: event.traceId,
+        jobInputDatasetItemId: datasetItem?.id ?? null,
+        jobInputObservationId: observationId ?? null,
         data: {
           id: jobExecutionId,
           projectId: event.projectId,
@@ -776,6 +821,14 @@ export const createEvalJobs = async ({
             : {}),
         },
       });
+
+      if (!createdJob) {
+        // Lost the race to a concurrent producer that inserted the same dedup key first.
+        logger.debug(
+          `Eval job for config ${config.id} and trace ${event.traceId} was created concurrently, skipping`,
+        );
+        continue;
+      }
 
       // add the job to the next queue so that eval can be executed
       const shardingKey = `${event.projectId}-${jobExecutionId}`;

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -800,7 +800,7 @@ export const createEvalJobs = async ({
         jobConfigurationId: config.id,
         jobInputTraceId: event.traceId,
         jobInputDatasetItemId: datasetItem?.id ?? null,
-        jobInputObservationId: observationId ?? null,
+        jobInputObservationId: datasetItem ? (observationId ?? null) : null,
         data: {
           id: jobExecutionId,
           projectId: event.projectId,


### PR DESCRIPTION
## What does this PR do?

Fixes #16492.

`createEvalJobs` in `worker/src/features/evaluation/evalService.ts` deduplicated eval job executions with a non-atomic find-then-create: it batch-queries existing `job_executions` rows, then later creates a new row if none matched. There is no DB unique constraint on the dedup key `(projectId, jobConfigurationId, jobInputTraceId, jobInputDatasetItemId, jobInputObservationId)`, so two producers racing on the same trace (e.g. a trace-upsert shard worker and a dataset-run-item-upsert worker both firing for the same trace) could both pass the existence check before either insert committed, resulting in two `job_executions` rows for the same trace + eval config. Each row runs its own LLM-as-judge evaluation and produces its own score row (score ids are derived from the random `jobExecutionId`), so this caused duplicate visible scores and doubled LLM spend.

The fix wraps the check-then-create in a Postgres transaction serialized by an advisory lock (`pg_advisory_xact_lock(hashtext(...))`) keyed on the dedup tuple, so a losing concurrent writer waits for the winner's transaction to commit and then observes its row via `findFirst`, skipping the insert instead of racing it. This avoids a schema migration.

This PR addresses the duplicate-creation race (failure mode 1 in the issue). The separate stranded-PENDING failure mode described in the issue (a crash between `jobExecution.create` and `EvalExecutionQueue.add`) is a distinct problem — it needs either a reconciler for stale PENDING rows or reordering the create/enqueue steps — and is left out here to keep this fix small and reviewable.

## Test plan

Added `does not create duplicate 'trace' eval jobs when producers race on the same trace` to `worker/src/__tests__/evalService.test.ts`: it creates one trace and one active trace-level eval config, then fires 20 concurrent `createEvalJobs` calls for that trace and asserts exactly one `job_executions` row exists afterward.

Confirmed the test fails without the fix and passes with it:

```
$ git checkout HEAD~1 -- worker/src/features/evaluation/evalService.ts
$ pnpm run test src/__tests__/evalService.test.ts -t "does not create duplicate"
 FAIL  src/__tests__/evalService.test.ts > eval service tests > create eval jobs > does not create duplicate 'trace' eval jobs when producers race on the same trace
AssertionError: expected 19 to be 1 // Object.is equality
...
 Test Files  1 failed (1)

$ git checkout HEAD -- worker/src/features/evaluation/evalService.ts
$ pnpm run test src/__tests__/evalService.test.ts -t "does not create duplicate"
 Test Files  1 passed (1)
      Tests  1 passed | 106 skipped (107)
```

Full suite with the fix applied:

```
$ pnpm run test src/__tests__/evalService.test.ts
 Test Files  1 passed (1)
      Tests  107 passed (107)
```

Typecheck and lint:

```
$ pnpm --filter worker run typecheck
$ dotenv -e ../.env -- tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo
(no errors)

$ pnpm --filter worker run lint
$ eslint . --cache --cache-location dist/.eslintcache --max-warnings 0 --concurrency 2
(no errors, no warnings)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the diff.

## Checklist

- [x] I've read the contributing guide.
- [x] My code follows the style guidelines of this project (`pnpm run format`).
- [x] I haven't checked if my PR needs changes to the documentation (none needed — internal worker behavior only).
- [x] I checked my changes generate no new lint warnings.
- [x] I added a test that proves my fix is effective (fails without the fix, passes with it).
- [x] New and existing unit tests pass locally with my changes.

---

This PR was authored with AI assistance (Claude); all changes were reviewed and tested by a human before opening.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR serializes evaluation-job existence checks and creation with a transaction-scoped PostgreSQL advisory lock to prevent concurrent producers from creating duplicate executions.
- Adds an atomic create-if-absent helper for trace and dataset evaluation jobs.
- Skips queueing when another producer created the same execution first.
- Adds a 20-producer concurrency regression test for trace evaluation jobs.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the transactional lookup and insert use the same deduplication tuple for observation-bearing dataset events processed against TRACE rules.

The advisory lock closes the tested trace-upsert race, but a current dataset-run-item producer supplies an observation ID that the changed lookup uses while the corresponding TRACE job insert stores NULL, allowing duplicate executions and scores.

**Files Needing Attention:** worker/src/features/evaluation/evalService.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P1 as Producer 1
    participant P2 as Producer 2
    participant DB as PostgreSQL
    participant Q as Evaluation queue
    P1->>DB: Begin transaction and acquire tuple lock
    P2->>DB: Wait for same tuple lock
    P1->>DB: Find no execution and insert
    P1->>DB: Commit and release lock
    P1->>Q: Enqueue created execution
    DB-->>P2: Acquire lock
    P2->>DB: Find existing execution
    P2->>DB: Commit without insert
    Note over P2,DB: Observation-bearing TRACE events currently look up a tuple different from the inserted tuple
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/evaluation/evalService.ts:802-803
**Deduplication uses mismatched tuple**

When an observation-bearing dataset-run-item event is processed against a TRACE rule, the transactional lookup includes `observationId`, but the inserted trace job stores it as `NULL` because `datasetItem` is absent. Subsequent deliveries miss the existing execution and create duplicate evaluation jobs, scores, and LLM calls.

```suggestion
        jobInputDatasetItemId: datasetItem?.id ?? null,
        jobInputObservationId: datasetItem ? observationId ?? null : null,
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): serialize eval job execution..."](https://github.com/langfuse/langfuse/commit/751750d24c970094ea69a6ced4884f479e693f00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56347217)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->