### PR TITLE
fix(evals): serialize eval job dedup to prevent duplicate executions

### DIFF
--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -1292,6 +1292,68 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       expect(jobs[0].endTime).to.be.null;
     }, 10_000);
 
+    test("does not create duplicate job executions when createEvalJobs races concurrently", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await prisma.llmApiKeys.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          secretKey: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          customModels: [],
+          displaySecretKey: "123456",
+        },
+      });
+
+      await createMigratedEvalConfig({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const payload = {
+        projectId,
+        traceId: traceId,
+      };
+
+      // Simulate independent producers (trace-upsert, dataset-run-item-upsert,
+      // CreateEvalQueue) delivering near-simultaneously for the same trace.
+      await Promise.all(
+        Array.from({ length: 8 }, () =>
+          createEvalJobs({
+            sourceEventType: "trace-upsert",
+            event: payload,
+            jobTimestamp,
+          }),
+        ),
+      );
+
+      const jobs = await prisma.jobExecution.findMany({
+        where: { projectId },
+      });
+
+      expect(jobs.length).toBe(1);
+    }, 10_000);
+
     test("does not create job for inactive config", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
       const traceId = randomUUID();

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -1354,6 +1354,98 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       expect(jobs.length).toBe(1);
     }, 10_000);
 
+    test("creates separate job executions for distinct dataset item versions", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+      const datasetId = randomUUID();
+      const datasetItemId = randomUUID();
+      const validFromV1 = new Date("2024-01-01T00:00:00.000Z");
+      const validFromV2 = new Date("2024-06-01T00:00:00.000Z");
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await prisma.dataset.create({
+        data: {
+          id: datasetId,
+          projectId,
+          name: "test-dataset",
+        },
+      });
+
+      // Create version 1 (superseded) with validTo set
+      await prisma.datasetItem.create({
+        data: {
+          id: datasetItemId,
+          projectId,
+          datasetId,
+          validFrom: validFromV1,
+          validTo: validFromV2,
+        },
+      });
+
+      // Create version 2 (current) with validTo = null
+      await prisma.datasetItem.create({
+        data: {
+          id: datasetItemId,
+          projectId,
+          datasetId,
+          validFrom: validFromV2,
+          validTo: null,
+        },
+      });
+
+      await createMigratedEvalConfig({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.DATASET,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: {
+          projectId,
+          traceId,
+          datasetItemId,
+          datasetItemValidFrom: validFromV1,
+        },
+        jobTimestamp,
+      });
+
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: {
+          projectId,
+          traceId,
+          datasetItemId,
+          datasetItemValidFrom: validFromV2,
+        },
+        jobTimestamp,
+      });
+
+      const jobs = await prisma.jobExecution.findMany({
+        where: { projectId },
+      });
+
+      expect(jobs.length).toBe(2);
+      expect(
+        jobs.map((j) => j.jobInputDatasetItemValidFrom?.toISOString()).sort(),
+      ).toEqual([validFromV1.toISOString(), validFromV2.toISOString()].sort());
+    }, 10_000);
+
     test("does not create job for inactive config", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
       const traceId = randomUUID();

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -755,27 +755,67 @@ export const createEvalJobs = async ({
         `Creating eval job execution for config ${config.id} and trace ${event.traceId}`,
       );
 
-      await prisma.jobExecution.create({
-        data: {
-          id: jobExecutionId,
-          projectId: event.projectId,
-          jobConfigurationId: config.id,
-          jobInputTraceId: event.traceId,
-          jobInputTraceTimestamp: traceTimestamp,
-          jobTemplateId: config.evalTemplateId,
-          status: "PENDING",
-          startTime: new Date(),
-          ...(datasetItem
-            ? {
-                jobInputDatasetItemId: datasetItem.id,
-                ...("validFrom" in datasetItem && {
-                  jobInputDatasetItemValidFrom: datasetItem.validFrom,
-                }),
-                jobInputObservationId: observationId || null,
-              }
-            : {}),
-        },
+      // The batched existence check above is a point-in-time read shared by every
+      // producer that can reach this line for the same dedup key (trace-upsert,
+      // dataset-run-item-upsert, and CreateEvalQueue workers). Serialize the final
+      // recheck-and-insert on that key so a concurrent race can't create two rows.
+      const dedupeLockKey = [
+        event.projectId,
+        config.id,
+        event.traceId,
+        datasetItem?.id ?? "",
+        observationId ?? "",
+      ].join(":");
+
+      const wasInserted = await prisma.$transaction(async (tx) => {
+        await tx.$executeRaw(
+          Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${dedupeLockKey}, 0))`,
+        );
+
+        const existingRow = await tx.jobExecution.findFirst({
+          where: {
+            projectId: event.projectId,
+            jobConfigurationId: config.id,
+            jobInputTraceId: event.traceId,
+            jobInputDatasetItemId: datasetItem?.id ?? null,
+            jobInputObservationId: observationId ?? null,
+          },
+          select: { id: true },
+        });
+        if (existingRow) {
+          return false;
+        }
+
+        await tx.jobExecution.create({
+          data: {
+            id: jobExecutionId,
+            projectId: event.projectId,
+            jobConfigurationId: config.id,
+            jobInputTraceId: event.traceId,
+            jobInputTraceTimestamp: traceTimestamp,
+            jobTemplateId: config.evalTemplateId,
+            status: "PENDING",
+            startTime: new Date(),
+            ...(datasetItem
+              ? {
+                  jobInputDatasetItemId: datasetItem.id,
+                  ...("validFrom" in datasetItem && {
+                    jobInputDatasetItemValidFrom: datasetItem.validFrom,
+                  }),
+                  jobInputObservationId: observationId || null,
+                }
+              : {}),
+          },
+        });
+        return true;
       });
+
+      if (!wasInserted) {
+        logger.debug(
+          `Eval job for config ${config.id} and trace ${event.traceId} was created by a concurrent worker`,
+        );
+        continue;
+      }
 
       // add the job to the next queue so that eval can be executed
       const shardingKey = `${event.projectId}-${jobExecutionId}`;

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -462,6 +462,7 @@ export const createEvalJobs = async ({
             jobConfigurationId: true,
             jobInputDatasetItemId: true,
             jobInputObservationId: true,
+            jobInputDatasetItemValidFrom: true,
           },
           where: {
             projectId: event.projectId,
@@ -475,17 +476,22 @@ export const createEvalJobs = async ({
     `Batched query for ${configIds.length} configs, found ${allExistingJobs.length} existing jobs`,
   );
 
-  // Helper function to find matching job for a config
+  // Helper function to find matching job for a config. Compares by
+  // validFrom too, so distinct versions of the same dataset item are not
+  // treated as duplicates of one another.
   const findMatchingJob = (
     configId: string,
     datasetItemId: string | null,
     observationId: string | null,
+    datasetItemValidFrom: Date | null,
   ) => {
     return allExistingJobs.find(
       (job) =>
         job.jobConfigurationId === configId &&
         job.jobInputDatasetItemId === datasetItemId &&
-        job.jobInputObservationId === observationId,
+        job.jobInputObservationId === observationId &&
+        (job.jobInputDatasetItemValidFrom?.getTime() ?? null) ===
+          (datasetItemValidFrom?.getTime() ?? null),
     );
   };
 
@@ -716,12 +722,18 @@ export const createEvalJobs = async ({
       }
     }
 
+    const datasetItemValidFrom =
+      datasetItem && "validFrom" in datasetItem
+        ? datasetItem.validFrom
+        : undefined;
+
     // Find the existing job for the given configuration from the batched results.
     // We either use it for deduplication or we cancel it in case it became "deselected".
     const matchingJob = findMatchingJob(
       config.id,
       datasetItem?.id ?? null,
       observationId ?? null,
+      datasetItemValidFrom ?? null,
     );
     const existingJob = matchingJob ? [matchingJob] : [];
 
@@ -765,6 +777,7 @@ export const createEvalJobs = async ({
         event.traceId,
         datasetItem?.id ?? "",
         observationId ?? "",
+        datasetItemValidFrom?.toISOString() ?? "",
       ].join(":");
 
       const wasInserted = await prisma.$transaction(async (tx) => {
@@ -779,6 +792,7 @@ export const createEvalJobs = async ({
             jobInputTraceId: event.traceId,
             jobInputDatasetItemId: datasetItem?.id ?? null,
             jobInputObservationId: observationId ?? null,
+            jobInputDatasetItemValidFrom: datasetItemValidFrom ?? null,
           },
           select: { id: true },
         });


### PR DESCRIPTION
## What does this PR do?

Fixes #16493.

`createEvalJobs` in `worker/src/features/evaluation/evalService.ts` deduplicated eval executions with a non-atomic find-then-create: it read a batch of existing `job_executions` rows, then later created a new row if none matched. Three independent producers can call this for the same trace (trace-upsert shard workers, dataset-run-item-upsert workers, and `CreateEvalQueue` workers). Under concurrency, two callers can both pass the existence check before either has inserted, so both create a `job_executions` row and both run the LLM-as-judge evaluation — producing duplicate score rows and doubling LLM spend.

The fix wraps the final existence recheck and the insert in a single Postgres transaction, serialized by an advisory lock (`pg_advisory_xact_lock`) keyed on the exact dedup identity (`projectId:jobConfigurationId:traceId:datasetItemId:observationId`). Only one concurrent caller can hold the lock at a time, so the recheck it performs is guaranteed accurate, and only one of them creates the row.

This PR addresses the duplicate-execution race described in the issue. The separate "stranded PENDING forever" failure mode (a crash between `jobExecution.create` and the BullMQ enqueue) needs a reconciler for stale `PENDING` rows and is a larger, separate change — left out of this fix to keep it minimal and reviewable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Testing

Added a test that fires 8 concurrent `createEvalJobs` calls at the same trace/config and asserts only one `job_executions` row is created. Verified it fails reliably without the fix and passes reliably with it:

Without the fix (`git checkout HEAD~1 -- worker/src/features/evaluation/evalService.ts`), 5/5 runs failed:
```
❯ src/__tests__/evalService.test.ts (107 tests | 1 failed) 8123ms
 Test Files  1 failed (1)
      Tests  1 failed | 106 passed (107)
 1. does not create duplicate job executions when createEvalJobs races concurrently [failed]
```

With the fix, 5/5 runs passed:
```
✓ src/__tests__/evalService.test.ts (107 tests) 7872ms
 Test Files  1 passed (1)
      Tests  107 passed (107)
```

Full targeted suite (`pnpm --filter worker run test evalService.test.ts`): `Tests  107 passed (107)`.

`pnpm --filter worker run typecheck`: passes with no errors.

`pnpm --filter worker run lint`: no new warnings from this change (one pre-existing, unrelated warning in `commentMentionHandler.ts` is present on `main` too and untouched by this PR).

## Disclosure

This PR was prepared by an autonomous coding agent (Claude Code) against the reported issue, then verified by running the repo's real lint/typecheck/test commands locally as shown above.

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR serializes evaluation-job deduplication with a PostgreSQL transaction and advisory lock, then rechecks for an existing execution before insertion.
- Adds an advisory lock keyed by project, configuration, trace, dataset item, and observation.
- Skips queueing when a concurrent worker already created the execution.
- Adds a concurrency test covering repeated creation for the same trace and configuration.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The dataset-version identity omission should be fixed before merging because the new serialization can suppress a requested evaluation for a distinct dataset item version.

The post-lock lookup treats executions for different versions of one dataset item as identical, even though callers select versions and the execution row persists the selected validFrom.

**Files Needing Attention:** worker/src/features/evaluation/evalService.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant P1 as Producer 1
  participant P2 as Producer 2
  participant DB as PostgreSQL
  participant Q as Eval queue
  P1->>DB: Acquire dedup advisory lock
  P2->>DB: Wait for same lock
  P1->>DB: Recheck and insert execution
  P1->>Q: Enqueue evaluation
  P1-->>DB: Commit and release lock
  P2->>DB: Acquire lock and recheck
  DB-->>P2: Existing execution
  P2->>P2: Skip enqueue
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/evaluation/evalService.ts:780-781
**Dataset versions collapse during dedup**

When two dataset-run-item requests target different versions of the same dataset item with the same trace, observation, and evaluation configuration, the lock and authoritative recheck omit `validFrom`, so the second version is treated as an existing execution and produces no evaluation score.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): serialize eval job dedup to ..."](https://github.com/langfuse/langfuse/commit/4fbdada018606eaec760d9d061fe6fac574b7f77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56350738)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->