### PR TITLE
fix(automations): surface prompt-version webhook enqueue failures instead of swallowing them

### DIFF
--- a/worker/src/__tests__/promptVersionProcessor.test.ts
+++ b/worker/src/__tests__/promptVersionProcessor.test.ts
@@ -445,4 +445,84 @@ describe("promptVersionChangeWorker", () => {
     expect(executions).toHaveLength(1);
     expect(webhookQueueAddMock).toHaveBeenCalledTimes(1);
   });
+
+  it("does not skip a legitimate execution for a different event action on the same prompt id", async () => {
+    const promptId = v4();
+    const actionId = v4();
+    await prisma.action.create({
+      data: {
+        id: actionId,
+        projectId,
+        type: ActionType.WEBHOOK,
+        config: {
+          type: "WEBHOOK",
+          url: "https://webhook.example.com/test",
+          headers: {},
+          method: "POST",
+        },
+      },
+    });
+
+    const triggerId = v4();
+    await prisma.trigger.create({
+      data: {
+        id: triggerId,
+        projectId,
+        eventSource: TriggerEventSource.Prompt,
+        eventActions: [],
+        status: JobConfigState.ACTIVE,
+        filter: [],
+      },
+    });
+
+    const automationId = v4();
+    await prisma.automation.create({
+      data: {
+        id: automationId,
+        name: `automation-${v4()}`,
+        projectId,
+        triggerId,
+        actionId,
+      },
+    });
+
+    const baseEvent = {
+      entityType: "prompt-version" as const,
+      projectId,
+      promptId,
+      prompt: {
+        id: promptId,
+        projectId,
+        name: "test-prompt",
+        version: 1,
+        prompt: { messages: [{ role: "user", content: "Hello" }] },
+        config: null,
+        tags: [],
+        labels: [],
+        type: PromptType.Chat,
+        isActive: true,
+        createdBy: "test-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        commitMessage: null,
+      },
+      user: {
+        id: "test-user",
+        name: "Test User",
+        email: "test@example.com",
+      },
+    };
+
+    // Same prompt id, two distinct lifecycle events for that same trigger.
+    // The second event must not be treated as a duplicate of the first.
+    await promptVersionProcessor({ ...baseEvent, action: "created" });
+    await promptVersionProcessor({ ...baseEvent, action: "deleted" });
+
+    const executions = await prisma.automationExecution.findMany({
+      where: { projectId, automationId },
+    });
+
+    expect(executions).toHaveLength(2);
+    expect(webhookQueueAddMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/worker/src/__tests__/promptVersionProcessor.test.ts
+++ b/worker/src/__tests__/promptVersionProcessor.test.ts
@@ -14,6 +14,7 @@ import { ActionType, prisma } from "@langfuse/shared/src/db";
 import { promptVersionProcessor } from "../features/entityChange/promptVersionProcessor";
 
 const webhookQueueAddMock = vi.fn();
+const webhookQueueGetInstanceMock = vi.fn();
 
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   const actual =
@@ -21,7 +22,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   return {
     ...actual,
     WebhookQueue: {
-      getInstance: () => ({ add: webhookQueueAddMock }),
+      getInstance: () => webhookQueueGetInstanceMock(),
     },
   };
 });
@@ -34,6 +35,8 @@ describe("promptVersionChangeWorker", () => {
     projectId = result.projectId;
     webhookQueueAddMock.mockReset();
     webhookQueueAddMock.mockResolvedValue(undefined);
+    webhookQueueGetInstanceMock.mockReset();
+    webhookQueueGetInstanceMock.mockReturnValue({ add: webhookQueueAddMock });
   });
 
   it.each([
@@ -275,5 +278,171 @@ describe("promptVersionChangeWorker", () => {
     // The execution record must not be left stuck PENDING forever.
     expect(executions[0].status).toBe(ActionExecutionStatus.ERROR);
     expect(executions[0].error).toContain("redis connection lost");
+  });
+
+  it("marks the execution as ERROR and rethrows when the webhook queue is unavailable", async () => {
+    webhookQueueGetInstanceMock.mockReturnValue(null);
+
+    const promptId = v4();
+    const actionId = v4();
+    await prisma.action.create({
+      data: {
+        id: actionId,
+        projectId,
+        type: ActionType.WEBHOOK,
+        config: {
+          type: "WEBHOOK",
+          url: "https://webhook.example.com/test",
+          headers: {},
+          method: "POST",
+        },
+      },
+    });
+
+    const triggerId = v4();
+    await prisma.trigger.create({
+      data: {
+        id: triggerId,
+        projectId,
+        eventSource: TriggerEventSource.Prompt,
+        eventActions: ["created"],
+        status: JobConfigState.ACTIVE,
+        filter: [],
+      },
+    });
+
+    const automationId = v4();
+    await prisma.automation.create({
+      data: {
+        id: automationId,
+        name: `automation-${v4()}`,
+        projectId,
+        triggerId,
+        actionId,
+      },
+    });
+
+    const event: EntityChangeEventType = {
+      entityType: "prompt-version",
+      projectId,
+      promptId,
+      action: "created",
+      prompt: {
+        id: promptId,
+        projectId,
+        name: "test-prompt",
+        version: 1,
+        prompt: { messages: [{ role: "user", content: "Hello" }] },
+        config: null,
+        tags: [],
+        labels: [],
+        type: PromptType.Chat,
+        isActive: true,
+        createdBy: "test-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        commitMessage: null,
+      },
+      user: {
+        id: "test-user",
+        name: "Test User",
+        email: "test@example.com",
+      },
+    };
+
+    // A null queue instance (e.g. Redis unavailable) must not be silently
+    // skipped by optional chaining; it must fail loudly so BullMQ retries.
+    await expect(promptVersionProcessor(event)).rejects.toThrow();
+
+    const executions = await prisma.automationExecution.findMany({
+      where: { projectId, automationId },
+    });
+
+    expect(executions).toHaveLength(1);
+    expect(executions[0].status).toBe(ActionExecutionStatus.ERROR);
+    expect(executions[0].error).toContain("Webhook queue is unavailable");
+  });
+
+  it("does not create a duplicate execution or re-enqueue a trigger that already succeeded", async () => {
+    const promptId = v4();
+    const actionId = v4();
+    await prisma.action.create({
+      data: {
+        id: actionId,
+        projectId,
+        type: ActionType.WEBHOOK,
+        config: {
+          type: "WEBHOOK",
+          url: "https://webhook.example.com/test",
+          headers: {},
+          method: "POST",
+        },
+      },
+    });
+
+    const triggerId = v4();
+    await prisma.trigger.create({
+      data: {
+        id: triggerId,
+        projectId,
+        eventSource: TriggerEventSource.Prompt,
+        eventActions: ["created"],
+        status: JobConfigState.ACTIVE,
+        filter: [],
+      },
+    });
+
+    const automationId = v4();
+    await prisma.automation.create({
+      data: {
+        id: automationId,
+        name: `automation-${v4()}`,
+        projectId,
+        triggerId,
+        actionId,
+      },
+    });
+
+    const event: EntityChangeEventType = {
+      entityType: "prompt-version",
+      projectId,
+      promptId,
+      action: "created",
+      prompt: {
+        id: promptId,
+        projectId,
+        name: "test-prompt",
+        version: 1,
+        prompt: { messages: [{ role: "user", content: "Hello" }] },
+        config: null,
+        tags: [],
+        labels: [],
+        type: PromptType.Chat,
+        isActive: true,
+        createdBy: "test-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        commitMessage: null,
+      },
+      user: {
+        id: "test-user",
+        name: "Test User",
+        email: "test@example.com",
+      },
+    };
+
+    await promptVersionProcessor(event);
+    expect(webhookQueueAddMock).toHaveBeenCalledTimes(1);
+
+    // Simulate BullMQ replaying the same entity-change job, e.g. because a
+    // different trigger failed and the aggregate error triggered a retry.
+    await promptVersionProcessor(event);
+
+    const executions = await prisma.automationExecution.findMany({
+      where: { projectId, automationId },
+    });
+
+    expect(executions).toHaveLength(1);
+    expect(webhookQueueAddMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/worker/src/__tests__/promptVersionProcessor.test.ts
+++ b/worker/src/__tests__/promptVersionProcessor.test.ts
@@ -525,4 +525,108 @@ describe("promptVersionChangeWorker", () => {
     expect(executions).toHaveLength(2);
     expect(webhookQueueAddMock).toHaveBeenCalledTimes(2);
   });
+
+  it("retries instead of skipping forever when a PENDING execution is stale (worker crashed before enqueueing)", async () => {
+    const promptId = v4();
+    const actionId = v4();
+    await prisma.action.create({
+      data: {
+        id: actionId,
+        projectId,
+        type: ActionType.WEBHOOK,
+        config: {
+          type: "WEBHOOK",
+          url: "https://webhook.example.com/test",
+          headers: {},
+          method: "POST",
+        },
+      },
+    });
+
+    const triggerId = v4();
+    await prisma.trigger.create({
+      data: {
+        id: triggerId,
+        projectId,
+        eventSource: TriggerEventSource.Prompt,
+        eventActions: ["created"],
+        status: JobConfigState.ACTIVE,
+        filter: [],
+      },
+    });
+
+    const automationId = v4();
+    await prisma.automation.create({
+      data: {
+        id: automationId,
+        name: `automation-${v4()}`,
+        projectId,
+        triggerId,
+        actionId,
+      },
+    });
+
+    // Simulate a worker that created the execution row and then died before
+    // it could enqueue the webhook job or mark the row ERROR, leaving it
+    // stuck PENDING well outside the entity-change job's retry window.
+    await prisma.automationExecution.create({
+      data: {
+        id: v4(),
+        projectId,
+        automationId,
+        triggerId,
+        actionId,
+        status: ActionExecutionStatus.PENDING,
+        sourceId: promptId,
+        createdAt: new Date(Date.now() - 10 * 60 * 1000),
+        input: {
+          promptName: "test-prompt",
+          promptVersion: 1,
+          promptId,
+          automationId,
+          type: "prompt-version",
+          action: "created",
+        },
+      },
+    });
+
+    const event: EntityChangeEventType = {
+      entityType: "prompt-version",
+      projectId,
+      promptId,
+      action: "created",
+      prompt: {
+        id: promptId,
+        projectId,
+        name: "test-prompt",
+        version: 1,
+        prompt: { messages: [{ role: "user", content: "Hello" }] },
+        config: null,
+        tags: [],
+        labels: [],
+        type: PromptType.Chat,
+        isActive: true,
+        createdBy: "test-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        commitMessage: null,
+      },
+      user: {
+        id: "test-user",
+        name: "Test User",
+        email: "test@example.com",
+      },
+    };
+
+    await promptVersionProcessor(event);
+
+    const executions = await prisma.automationExecution.findMany({
+      where: { projectId, automationId },
+    });
+
+    // The stale PENDING row must not have blocked a fresh attempt: a second
+    // execution is created and its webhook is actually enqueued.
+    expect(executions).toHaveLength(2);
+    expect(webhookQueueAddMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/worker/src/__tests__/promptVersionProcessor.test.ts
+++ b/worker/src/__tests__/promptVersionProcessor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { v4 } from "uuid";
 import {
   ActionExecutionStatus,
@@ -13,12 +13,27 @@ import {
 import { ActionType, prisma } from "@langfuse/shared/src/db";
 import { promptVersionProcessor } from "../features/entityChange/promptVersionProcessor";
 
+const webhookQueueAddMock = vi.fn();
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    WebhookQueue: {
+      getInstance: () => ({ add: webhookQueueAddMock }),
+    },
+  };
+});
+
 describe("promptVersionChangeWorker", () => {
   let projectId: string;
 
   beforeEach(async () => {
     const result = await createOrgProjectAndApiKey();
     projectId = result.projectId;
+    webhookQueueAddMock.mockReset();
+    webhookQueueAddMock.mockResolvedValue(undefined);
   });
 
   it.each([
@@ -177,4 +192,88 @@ describe("promptVersionChangeWorker", () => {
       }
     },
   );
+
+  it("marks the execution as ERROR and rethrows when enqueueing the webhook job fails", async () => {
+    webhookQueueAddMock.mockRejectedValue(new Error("redis connection lost"));
+
+    const promptId = v4();
+    const actionId = v4();
+    await prisma.action.create({
+      data: {
+        id: actionId,
+        projectId,
+        type: ActionType.WEBHOOK,
+        config: {
+          type: "WEBHOOK",
+          url: "https://webhook.example.com/test",
+          headers: {},
+          method: "POST",
+        },
+      },
+    });
+
+    const triggerId = v4();
+    await prisma.trigger.create({
+      data: {
+        id: triggerId,
+        projectId,
+        eventSource: TriggerEventSource.Prompt,
+        eventActions: ["created"],
+        status: JobConfigState.ACTIVE,
+        filter: [],
+      },
+    });
+
+    const automationId = v4();
+    await prisma.automation.create({
+      data: {
+        id: automationId,
+        name: `automation-${v4()}`,
+        projectId,
+        triggerId,
+        actionId,
+      },
+    });
+
+    const event: EntityChangeEventType = {
+      entityType: "prompt-version",
+      projectId,
+      promptId,
+      action: "created",
+      prompt: {
+        id: promptId,
+        projectId,
+        name: "test-prompt",
+        version: 1,
+        prompt: { messages: [{ role: "user", content: "Hello" }] },
+        config: null,
+        tags: [],
+        labels: [],
+        type: PromptType.Chat,
+        isActive: true,
+        createdBy: "test-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        commitMessage: null,
+      },
+      user: {
+        id: "test-user",
+        name: "Test User",
+        email: "test@example.com",
+      },
+    };
+
+    // The job must reject so BullMQ's retry budget applies instead of the
+    // failure being swallowed and the job reported as successfully processed.
+    await expect(promptVersionProcessor(event)).rejects.toThrow();
+
+    const executions = await prisma.automationExecution.findMany({
+      where: { projectId, automationId },
+    });
+
+    expect(executions).toHaveLength(1);
+    // The execution record must not be left stuck PENDING forever.
+    expect(executions[0].status).toBe(ActionExecutionStatus.ERROR);
+    expect(executions[0].error).toContain("redis connection lost");
+  });
 });

--- a/worker/src/features/entityChange/promptVersionProcessor.ts
+++ b/worker/src/features/entityChange/promptVersionProcessor.ts
@@ -135,6 +135,13 @@ export const promptVersionProcessor = async (
  * Enqueue an automation action for a prompt version change.
  * Handles both webhook and Slack actions by enqueueing to the same webhook queue.
  */
+// Worst-case retry window for the entity-change job (5 attempts, exponential
+// backoff from 5s) is well under 2 minutes. A PENDING execution older than
+// this was left behind by a worker that died between creating the row and
+// enqueueing/erroring it, not a delivery still in flight, so it must not
+// permanently block a fresh attempt.
+const STALE_PENDING_EXECUTION_MS = 5 * 60 * 1000;
+
 async function enqueueAutomationAction({
   promptData,
   action,
@@ -163,19 +170,31 @@ async function enqueueAutomationAction({
   }
 
   // Guard against duplicate deliveries when BullMQ retries this job after a
-  // partial failure: skip triggers that already have a non-errored execution
-  // for this exact source and event action instead of creating a second one
-  // and re-enqueuing. Filtering on `action` too matters because the same
-  // trigger can legitimately fire for multiple event actions (e.g. "created"
-  // then "deleted") against the same prompt id.
+  // partial failure: skip triggers that already have a completed (or still
+  // in-flight) execution for this exact source and event action instead of
+  // creating a second one and re-enqueuing. Filtering on `action` too matters
+  // because the same trigger can legitimately fire for multiple event actions
+  // (e.g. "created" then "deleted") against the same prompt id. A PENDING
+  // execution only blocks a retry while it's recent; a stale one is treated
+  // as abandoned so it doesn't lose the delivery forever.
   const existingExecution = await prisma.automationExecution.findFirst({
     where: {
       projectId,
       triggerId,
       actionId,
       sourceId: promptData.id,
-      status: { not: ActionExecutionStatus.ERROR },
       input: { path: ["action"], equals: action },
+      OR: [
+        {
+          status: {
+            notIn: [ActionExecutionStatus.ERROR, ActionExecutionStatus.PENDING],
+          },
+        },
+        {
+          status: ActionExecutionStatus.PENDING,
+          createdAt: { gt: new Date(Date.now() - STALE_PENDING_EXECUTION_MS) },
+        },
+      ],
     },
   });
 

--- a/worker/src/features/entityChange/promptVersionProcessor.ts
+++ b/worker/src/features/entityChange/promptVersionProcessor.ts
@@ -162,6 +162,26 @@ async function enqueueAutomationAction({
     );
   }
 
+  // Guard against duplicate deliveries when BullMQ retries this job after a
+  // partial failure: skip triggers that already have a non-errored execution
+  // for this exact source instead of creating a second one and re-enqueuing.
+  const existingExecution = await prisma.automationExecution.findFirst({
+    where: {
+      projectId,
+      triggerId,
+      actionId,
+      sourceId: promptData.id,
+      status: { not: ActionExecutionStatus.ERROR },
+    },
+  });
+
+  if (existingExecution) {
+    logger.debug(
+      `Automation execution ${existingExecution.id} already exists for trigger ${triggerId}, action ${actionId}, and source ${promptData.id}; skipping duplicate enqueue`,
+    );
+    return;
+  }
+
   const executionId = v4();
 
   // Create execution record
@@ -190,7 +210,12 @@ async function enqueueAutomationAction({
 
   // Queue to webhook processor (handles both webhook and Slack actions)
   try {
-    await WebhookQueue.getInstance()?.add(QueueName.WebhookQueue, {
+    const webhookQueue = WebhookQueue.getInstance();
+    if (!webhookQueue) {
+      throw new Error("Webhook queue is unavailable");
+    }
+
+    await webhookQueue.add(QueueName.WebhookQueue, {
       timestamp: new Date(),
       id: v4(),
       payload: {

--- a/worker/src/features/entityChange/promptVersionProcessor.ts
+++ b/worker/src/features/entityChange/promptVersionProcessor.ts
@@ -47,7 +47,11 @@ export const promptVersionProcessor = async (
       action: event.action,
     });
 
-    // Process each trigger
+    // Process each trigger. Collect failures instead of swallowing them so
+    // that infra failures (e.g. a dropped webhook enqueue) still surface as
+    // a job failure and get retried by BullMQ, while a bad trigger doesn't
+    // block the remaining ones from being processed.
+    const triggerErrors: unknown[] = [];
     for (const trigger of triggers) {
       try {
         const eventMatches = matchesTriggerFilter(
@@ -109,7 +113,15 @@ export const promptVersionProcessor = async (
           `Error processing trigger ${trigger.id} for prompt ${event.promptId} for project ${event.projectId}: ${error}`,
         );
         // Continue processing other triggers instead of failing the entire operation
+        triggerErrors.push(error);
       }
+    }
+
+    if (triggerErrors.length > 0) {
+      throw new AggregateError(
+        triggerErrors,
+        `Failed to process ${triggerErrors.length} of ${triggers.length} trigger(s) for prompt ${event.promptId} for project ${event.projectId}`,
+      );
     }
   } catch (error) {
     logger.error(
@@ -177,24 +189,39 @@ async function enqueueAutomationAction({
   );
 
   // Queue to webhook processor (handles both webhook and Slack actions)
-  await WebhookQueue.getInstance()?.add(QueueName.WebhookQueue, {
-    timestamp: new Date(),
-    id: v4(),
-    payload: {
-      projectId,
-      automationId: automations[0].id,
-      executionId,
+  try {
+    await WebhookQueue.getInstance()?.add(QueueName.WebhookQueue, {
+      timestamp: new Date(),
+      id: v4(),
       payload: {
-        action: action as TriggerEventAction,
-        type: "prompt-version",
-        prompt: {
-          ...promptData,
-          prompt: jsonSchemaNullable.parse(promptData.prompt),
-          config: jsonSchemaNullable.parse(promptData.config),
+        projectId,
+        automationId: automations[0].id,
+        executionId,
+        payload: {
+          action: action as TriggerEventAction,
+          type: "prompt-version",
+          prompt: {
+            ...promptData,
+            prompt: jsonSchemaNullable.parse(promptData.prompt),
+            config: jsonSchemaNullable.parse(promptData.config),
+          },
+          ...(user ? { user } : {}),
         },
-        ...(user ? { user } : {}),
       },
-    },
-    name: QueueJobs.WebhookJob,
-  });
+      name: QueueJobs.WebhookJob,
+    });
+  } catch (error) {
+    // The execution row was already created as PENDING above. If enqueueing
+    // fails, mark it as ERROR so it doesn't stay stuck PENDING forever, and
+    // rethrow so the caller's retry mechanism applies.
+    await prisma.automationExecution.update({
+      where: { id: executionId, projectId },
+      data: {
+        status: ActionExecutionStatus.ERROR,
+        finishedAt: new Date(),
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+    });
+    throw error;
+  }
 }

--- a/worker/src/features/entityChange/promptVersionProcessor.ts
+++ b/worker/src/features/entityChange/promptVersionProcessor.ts
@@ -164,7 +164,10 @@ async function enqueueAutomationAction({
 
   // Guard against duplicate deliveries when BullMQ retries this job after a
   // partial failure: skip triggers that already have a non-errored execution
-  // for this exact source instead of creating a second one and re-enqueuing.
+  // for this exact source and event action instead of creating a second one
+  // and re-enqueuing. Filtering on `action` too matters because the same
+  // trigger can legitimately fire for multiple event actions (e.g. "created"
+  // then "deleted") against the same prompt id.
   const existingExecution = await prisma.automationExecution.findFirst({
     where: {
       projectId,
@@ -172,6 +175,7 @@ async function enqueueAutomationAction({
       actionId,
       sourceId: promptData.id,
       status: { not: ActionExecutionStatus.ERROR },
+      input: { path: ["action"], equals: action },
     },
   });
 
@@ -200,6 +204,7 @@ async function enqueueAutomationAction({
         promptId: promptData.id,
         automationId: automations[0].id,
         type: "prompt-version",
+        action,
       },
     },
   });


### PR DESCRIPTION
## What does this PR do?

Prompt-version automations (webhook / Slack actions) could permanently lose a
webhook delivery. `enqueueAutomationAction` in
`worker/src/features/entityChange/promptVersionProcessor.ts` creates an
`automationExecution` row as `PENDING` and then enqueues the webhook job. If
the enqueue call threw (e.g. a Redis blip), the error propagated into the
per-trigger `catch` block in `promptVersionProcessor`, which only logged it
and continued — so the entityChange job completed "successfully", BullMQ
never retried, and the execution row was left stuck `PENDING` forever with no
webhook ever delivered.

This PR:
- Wraps the webhook enqueue call in a `try`/`catch`. On failure it marks the
  already-created execution row `ERROR` (with the error message and
  `finishedAt`) instead of leaving it stuck `PENDING`, then rethrows.
- Changes the per-trigger loop in `promptVersionProcessor` to collect errors
  instead of only logging them, and throws an aggregate error after
  processing all triggers. This preserves the existing "one bad trigger
  doesn't block the others" behavior while letting real failures propagate
  so BullMQ's retry budget applies (the outer `catch` already rethrows to
  trigger retries).

Fixes #16494

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format`)
- I have added tests that prove my fix is effective
- I have checked that new and existing unit tests pass locally with my changes

## Test plan

Added a new test to the existing suite,
`worker/src/__tests__/promptVersionProcessor.test.ts`, that mocks
`WebhookQueue.getInstance().add` to reject, then asserts:
1. `promptVersionProcessor` rejects (so BullMQ retries).
2. The `automationExecution` row ends up `ERROR`, not stuck `PENDING`.

Confirmed the new test fails against the pre-fix code (`git checkout HEAD~1 --
worker/src/features/entityChange/promptVersionProcessor.ts`, keeping the new
test):

```
 × marks the execution as ERROR and rethrows when enqueueing the webhook job fails 54ms (retry x3)
AssertionError: promise resolved "undefined" instead of rejecting
```

With the fix restored, the full suite passes:

```
$ pnpm --filter worker run test src/__tests__/promptVersionProcessor.test.ts
 ✓ src/__tests__/promptVersionProcessor.test.ts (10 tests) 287ms
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Also ran, both clean:

```
$ pnpm --filter worker run lint
$ pnpm --filter worker run typecheck
```

## AI disclosure

This change (diagnosis, fix, and test) was drafted by an AI coding agent and
reviewed before opening this PR.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR marks prompt-version automation executions as failed when webhook enqueueing throws and propagates per-trigger failures so BullMQ can retry the entity-change job.

- Adds aggregate failure propagation after all matching triggers are processed.
- Updates failed enqueue executions from `PENDING` to `ERROR` before rethrowing.
- Adds a regression test for a rejected webhook queue add.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until unavailable queues are surfaced and retries are made idempotent for triggers that already enqueued successfully.

A null queue still silently loses deliveries and leaves PENDING executions, while aggregate retries can create duplicate executions and external deliveries after partial success.

**Files Needing Attention:** worker/src/features/entityChange/promptVersionProcessor.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  E[Prompt-version entity-change job] --> T[Process matching triggers]
  T --> S[Successful trigger enqueues delivery]
  T --> F[Another trigger fails]
  F --> A[Throw AggregateError]
  A --> R[BullMQ retries whole entity-change job]
  R --> T
  S --> D[Duplicate execution and delivery on retry]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/entityChange/promptVersionProcessor.ts:193
**Unavailable queue bypasses failure handling**

When `WebhookQueue.getInstance()` returns `null` because Redis is unavailable or unconfigured, optional chaining skips `add` without throwing, so the execution remains `PENDING`, the delivery is lost, and the entity-change job completes without retrying.

```suggestion
    const webhookQueue = WebhookQueue.getInstance();
    if (!webhookQueue) throw new Error("Webhook queue is unavailable");
    await webhookQueue.add(QueueName.WebhookQueue, {
```

### Issue 2
worker/src/features/entityChange/promptVersionProcessor.ts:120-124
**Partial success creates duplicate deliveries**

When one matching trigger enqueues successfully and another trigger fails, the aggregate error retries the entire entity-change job without an idempotency guard. Each retry creates fresh execution and webhook job IDs for the already-successful trigger, causing duplicate execution records and duplicate webhook or Slack deliveries.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): surface prompt-version..."](https://github.com/langfuse/langfuse/commit/79b3231de8f08c91455c7ab151b19d5a773f1e15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56353746)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)
- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)

<!-- /greptile_comment -->