### PR TITLE
fix(evals): persist LLM-as-judge ERROR only on final attempt so BullMQ retries execute

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -335,23 +335,33 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
         }
       }
 
-      await prisma.jobExecution.update({
-        where: {
-          id: job.data.payload.jobExecutionId,
-          projectId: job.data.payload.projectId,
-        },
-        data: {
-          status: JobExecutionStatus.ERROR,
-          endTime: new Date(),
-          error:
-            llmError || isUnrecoverableError(e)
-              ? (llmError?.message ?? (e as Error).message)
-              : "An internal error occurred",
-          executionTraceId,
-        },
-      });
+      const isTerminalError = Boolean(llmError) || isUnrecoverableError(e);
+      const totalAttempts = job.opts.attempts ?? 1;
+      const isFinalAttempt = job.attemptsMade + 1 >= totalAttempts;
 
-      if (llmError || isUnrecoverableError(e)) return;
+      // Only persist the terminal ERROR state when there will be no more
+      // retries; otherwise observationEvalProcessor would short-circuit the
+      // retry attempts because it skips jobs already in ERROR status.
+      if (isTerminalError || isFinalAttempt) {
+        await prisma.jobExecution.update({
+          where: {
+            id: job.data.payload.jobExecutionId,
+            projectId: job.data.payload.projectId,
+          },
+          data: {
+            status: JobExecutionStatus.ERROR,
+            endTime: new Date(),
+            // Show user-facing error messages (LLM and config errors)
+            error:
+              llmError || isUnrecoverableError(e)
+                ? (llmError?.message ?? (e as Error).message)
+                : "An internal error occurred",
+            executionTraceId,
+          },
+        });
+      }
+
+      if (isTerminalError) return;
 
       traceException(e);
       logger.error(


### PR DESCRIPTION
## What does this PR do?

Fixes #16491

Ports the retry guard from `worker/src/queues/codeEvalQueue.ts` (L52–68) into `llmAsJudgeExecutionQueueProcessorBuilder` in `worker/src/queues/evalQueue.ts`.

**The bug**: the LLM-as-judge catch handler persisted a **terminal** `JobExecutionStatus.ERROR` to Postgres on *every* failure, then rethrew so BullMQ could retry (`llmAsJudgeExecutionQueue` is configured with `attempts: 10`). But the shared processor skips executions already in ERROR status:

```ts
// worker/src/features/evaluation/observationEval/observationEvalProcessor.ts, L108–117
if (job.status === "CANCELLED" || job.status === "ERROR") {
  logger.debug(`Job execution ${event.jobExecutionId} was cancelled or has an error.`);
  return;
}
```

So after one transient failure (S3 blip, ClickHouse hiccup, network timeout), attempts 2–10 short-circuited and acked without doing work — the evaluation was permanently lost while the remaining retry budget burned as no-ops. The code-eval queue fixed this exact pattern with an explicit comment explaining why ("otherwise observationEvalProcessor would short-circuit the retry attempts"); the LLM-as-judge builder never received the same treatment.

**The change**: mirror the code-eval guard — compute `isTerminalError` and `isFinalAttempt` and only write the terminal ERROR row when there will be no more retries:

```ts
const isTerminalError = Boolean(llmError) || isUnrecoverableError(e);
const totalAttempts = job.opts.attempts ?? 1;
const isFinalAttempt = job.attemptsMade + 1 >= totalAttempts;

if (isTerminalError || isFinalAttempt) { /* persist ERROR */ }
if (isTerminalError) return;
traceException(e); logger.error(...); throw e;   // BullMQ retries with row untouched
```

Behavior for LLM errors / unrecoverable errors is unchanged (terminal → ERROR + early return). The dataset-item eval executor (`evalJobExecutorQueueProcessorBuilder`) is intentionally untouched — its consumer `evaluate()` only short-circuits on CANCELLED (evalService.ts L1374), so premature ERROR persistence there is cosmetic, not fatal.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have read the contributing guide
- My code follows the style guidelines of this project (`pnpm run format`)
- I have commented my code, particularly in hard-to-understand areas
- No documentation changes needed
- Lint/format clean
- Existing behavior pinned by existing worker/web suites; CI will exercise the eval processors


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents retryable LLM-as-judge failures from prematurely marking executions as terminal errors.
- Persists `ERROR` immediately for LLM and unrecoverable errors.
- Defers `ERROR` persistence for other failures until the final BullMQ attempt.
- Preserves rethrowing of retryable failures so remaining attempts can execute.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because retryable failures remain eligible for processing while terminal and exhausted failures are still recorded.

The changed guard uses the queue job’s inherited attempt count and current attempt number to defer terminal persistence only when BullMQ has retries remaining, avoiding the existing ERROR-status short circuit.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[LLM-as-judge execution fails] --> B{Terminal error?}
  B -->|Yes| C[Persist ERROR]
  C --> D[Stop processing]
  B -->|No| E{Final BullMQ attempt?}
  E -->|Yes| F[Persist ERROR]
  F --> G[Throw failure]
  E -->|No| H[Leave execution non-terminal]
  H --> G
  G --> I{Attempts remain?}
  I -->|Yes| J[BullMQ retries execution]
  I -->|No| K[Job remains failed]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): persist LLM-as-judge ERROR o..."](https://github.com/langfuse/langfuse/commit/264ad7d806d94c4c26fa0d5206f6f1734ec0fc3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56363976)</sub>

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->