### PR TITLE
fix(ingestion): preserve explicit usage.total of 0 in legacy events

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1922,7 +1922,7 @@ export class IngestionService {
         "usage" in obs.body ? obs.body.usage?.output : undefined;
 
       const newTotalCount =
-        ("usage" in obs.body ? obs.body.usage?.total : undefined) ||
+        ("usage" in obs.body ? obs.body.usage?.total : undefined) ??
         (Object.keys(
           "usageDetails" in obs.body ? (obs.body.usageDetails ?? {}) : {},
         ).length === 0

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -365,6 +365,64 @@ describe("IngestionService unit tests", () => {
     }
   });
 
+  it("preserves an explicit usage.total of 0 instead of overwriting it with input + output", async () => {
+    const addToQueue = vi.fn();
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      { addToQueue } as any,
+      {} as any,
+    );
+    const timestamp = "2026-07-22T00:00:00.000Z";
+    const observationEventList: ObservationEvent[] = [
+      {
+        id: "event-id",
+        timestamp,
+        type: "generation-create",
+        body: {
+          id: "observation-id",
+          traceId: "trace-id",
+          startTime: timestamp,
+          usage: {
+            input: 100,
+            output: 50,
+            total: 0,
+          },
+          environment: "default",
+        },
+      },
+    ];
+
+    vi.spyOn(ingestionService as any, "getClickhouseRecord").mockResolvedValue(
+      null,
+    );
+    vi.spyOn(ingestionService as any, "getPrompt").mockResolvedValue(null);
+    vi.spyOn(ingestionService as any, "getGenerationUsage").mockResolvedValue(
+      {},
+    );
+
+    await (ingestionService as any).processObservationEventList({
+      projectId: "project-id",
+      entityId: "observation-id",
+      createdAtTimestamp: new Date(timestamp),
+      observationEventList,
+      writeToStagingTables: false,
+      attribution: {
+        ingestionApiKey: "api-key",
+        ingestionSdkName: "sdk",
+        ingestionSdkVersion: "1.0.0",
+      },
+    });
+
+    const queuedRecord = addToQueue.mock.calls.find(
+      ([table]) => table === TableName.Observations,
+    )?.[1];
+    expect(queuedRecord).toMatchObject({
+      provided_usage_details: { input: 100, output: 50, total: 0 },
+      usage_details: { input: 100, output: 50, total: 0 },
+    });
+  });
+
   it("correctly sorts events in ascending order by timestamp", async () => {
     const firstTrace = { timestamp: 1, type: "observation-create" };
     const secondTrace = { timestamp: 1, type: "observation-update" };

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -406,7 +406,7 @@ describe("IngestionService unit tests", () => {
       entityId: "observation-id",
       createdAtTimestamp: new Date(timestamp),
       observationEventList,
-      writeToStagingTables: false,
+      writeToStagingTables: true,
       attribution: {
         ingestionApiKey: "api-key",
         ingestionSdkName: "sdk",
@@ -414,13 +414,18 @@ describe("IngestionService unit tests", () => {
       },
     });
 
-    const queuedRecord = addToQueue.mock.calls.find(
-      ([table]) => table === TableName.Observations,
-    )?.[1];
-    expect(queuedRecord).toMatchObject({
-      provided_usage_details: { input: 100, output: 50, total: 0 },
-      usage_details: { input: 100, output: 50, total: 0 },
-    });
+    for (const table of [
+      TableName.Observations,
+      TableName.ObservationsBatchStaging,
+    ]) {
+      const queuedRecord = addToQueue.mock.calls.find(
+        ([queuedTable]) => queuedTable === table,
+      )?.[1];
+      expect(queuedRecord).toMatchObject({
+        provided_usage_details: { input: 100, output: 50, total: 0 },
+        usage_details: { input: 100, output: 50, total: 0 },
+      });
+    }
   });
 
   it("correctly sorts events in ascending order by timestamp", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #16503

In the legacy ingestion path, `newTotalCount` was computed with
`("usage" in obs.body ? obs.body.usage?.total : undefined) || (...)`.
Since `||` treats `0` as falsy, an explicitly provided `usage.total: 0`
was silently overwritten with a computed `input + output` sum. This
corrupted `provided_usage_details.total` and `usage_details.total` for
any event that legitimately reports zero total tokens (e.g. cached
responses), which cascades into "Total Usage" dashboard metrics and
cost calculations.

The fix replaces `||` with `??` on that line
(`worker/src/services/IngestionService/index.ts`), so only
`null`/`undefined` fall through to the computed fallback, while an
explicit `0` is preserved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Test plan

Added a unit test in
`worker/src/services/IngestionService/tests/IngestionService.unit.test.ts`:
"preserves an explicit usage.total of 0 instead of overwriting it with
input + output". It sends a `generation-create` legacy event with
`usage: { input: 100, output: 50, total: 0 }` and asserts the queued
observation record's `provided_usage_details.total` and
`usage_details.total` are `0`.

Confirmed the test fails against the pre-fix code
(`git checkout HEAD~1 -- worker/src/services/IngestionService/index.ts`,
then reran):

```
FAIL  ... IngestionService unit tests > preserves an explicit usage.total of 0 ...
- Expected
+ Received
  {
    "provided_usage_details": { "input": 100, "output": 50, "total": 0 },
-   "total": 0,
+   "total": 150,
  }
 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

After restoring the fix, `pnpm --filter worker run test IngestionService.unit.test.ts`:

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Also ran, both clean:

```
pnpm --filter worker run lint      # no errors
pnpm --filter worker run typecheck # no errors
```

`worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts`
was not run to completion in this environment because it requires a
live Postgres/Redis connection that isn't available here (unrelated to
this change).

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format` / lint clean)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests for the touched file pass locally with my changes

---

This fix was drafted with AI assistance (Claude Code) and reviewed by a human before submission.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes legacy observation ingestion so an explicitly supplied `usage.total` of zero is preserved instead of replaced by the input/output sum.

- Replaces the truthy fallback with a nullish fallback when calculating total usage.
- Adds a unit test covering persistence of zero in both provided and normalized usage details.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The fallback change matches the validated usage contract, preserves the intended explicit zero, and is covered by a focused regression test.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): preserve explicit usage...."](https://github.com/langfuse/langfuse/commit/028f869f6a75f8d6965e27241b385ae1510c3be9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56367594)</sub>

<!-- /greptile_comment -->