### PR TITLE
fix(pricing): price reasoning tokens at the output rate as a fallback

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -155,6 +155,17 @@ function withSerializedEventByteLength(
   };
 }
 
+// Usage detail keys that represent reasoning/thinking tokens across
+// different provider integrations and OTel gen_ai semconv variants. Providers
+// bill these at the standard output token rate, so we fall back to the
+// model's "output" price when no price is defined for the exact key.
+const REASONING_TOKEN_USAGE_TYPE_ALIASES = new Set([
+  "reasoning_tokens",
+  "thoughts_tokens",
+  "output_reasoning_tokens",
+  "output_reasoning",
+]);
+
 const immutableEntityKeys: {
   [TableName.Traces]: (keyof TraceRecordInsertType)[];
   [TableName.Scores]: (keyof ScoreRecordInsertType)[];
@@ -1658,7 +1669,15 @@ export class IngestionService {
     const finalCostEntries: [string, number][] = [];
 
     for (const [key, units] of Object.entries(usageUnits)) {
-      const price = modelPrices?.find((price) => price.usageType === key);
+      const price =
+        modelPrices?.find((price) => price.usageType === key) ??
+        // Providers report reasoning tokens under a range of usage keys
+        // (OTel gen_ai semconv, provider-specific SDKs, etc.). If the model's
+        // price list has no entry for the exact key, price reasoning tokens
+        // like standard output tokens rather than leaving them uncosted.
+        (REASONING_TOKEN_USAGE_TYPE_ALIASES.has(key)
+          ? modelPrices?.find((price) => price.usageType === "output")
+          : undefined);
 
       if (units != null && price) {
         finalCostEntries.push([key, price.price.mul(units).toNumber()]);

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -190,6 +190,37 @@ describe("Token Cost Calculation", () => {
     expect(costs.total_cost).toBe(9.0);
   });
 
+  it("should price reasoning token usage keys at the output rate when the model has no dedicated reasoning price", async () => {
+    const prices = await prisma.price.findMany({
+      where: {
+        modelId,
+      },
+    });
+
+    const usageUnits = {
+      input: 100,
+      output: 200,
+      reasoning_tokens: 50,
+    };
+
+    const userProvidedCosts = {
+      input: null,
+      output: null,
+      total: null,
+    };
+
+    const costs = (IngestionService as any).calculateUsageCosts(
+      prices as any,
+      userProvidedCosts,
+      usageUnits,
+    );
+
+    expect(costs.cost_details.input).toBe(1.0); // 100 tokens * 0.01
+    expect(costs.cost_details.output).toBe(4.0); // 200 tokens * 0.02
+    expect(costs.cost_details.reasoning_tokens).toBe(1.0); // 50 tokens * output price 0.02
+    expect(costs.total_cost).toBe(6.0);
+  });
+
   it("should correctly calculate token costs with user provided costs", async () => {
     const prices = await prisma.price.findMany({
       where: {


### PR DESCRIPTION
## What & why

Fixes #16508.

Providers report reasoning/thinking tokens under a variety of usage keys —
OTel `gen_ai.usage.reasoning_tokens`, provider-specific `thoughts_tokens`,
etc. Langfuse's cost calculator (`IngestionService.calculateUsageCosts`)
only prices a usage-detail bucket when a model's price list has an exact
`usageType` match for that key. If a model's price list doesn't happen to
define a price entry for the exact reasoning-token key a given
instrumentation library sent, those tokens are tracked (e.g. under "Other
usage") but priced at $0, even though the provider bills them at the
standard output-token rate.

This adds a small, explicit fallback: for a known set of reasoning-token
usage-detail keys (`reasoning_tokens`, `thoughts_tokens`,
`output_reasoning_tokens`, `output_reasoning`), if the model has no price
for the exact key, use the model's `output` price instead. This only
changes behavior for usage keys that were previously uncosted — any model
that already defines an explicit price for one of these keys is unaffected.

## Test plan

Added a unit test to the existing `calculateUsageCosts` suite
(`worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts`)
using a model whose price list only defines `input`/`output`/`total`
(no reasoning-specific price), asserting a `reasoning_tokens` usage bucket
is priced at the output rate.

Confirmed the new test fails without the fix (reverting only
`worker/src/services/IngestionService/index.ts` via
`git checkout HEAD~1 -- worker/src/services/IngestionService/index.ts`):

```
AssertionError: expected undefined to be 1 // Object.is equality
 ❯ src/services/IngestionService/tests/calculateTokenCost.unit.test.ts:220:49
    218|     expect(costs.cost_details.input).toBe(1.0);
    219|     expect(costs.cost_details.output).toBe(4.0);
    220|     expect(costs.cost_details.reasoning_tokens).toBe(1.0);
       |                                                 ^
 Test Files  1 failed (1)
      Tests  1 failed | 30 passed (31)
```

With the fix restored, the full file passes:

```
$ pnpm --filter worker run test calculateTokenCost.unit.test.ts
 ✓ src/services/IngestionService/tests/calculateTokenCost.unit.test.ts (31 tests) 507ms
 Test Files  1 passed (1)
      Tests  31 passed (31)
```

Also ran, both clean:
```
$ pnpm --filter worker run lint
Tasks: 7 successful, 7 total

$ pnpm --filter worker run typecheck
(exit 0)
```

## AI disclosure

This PR was drafted by an autonomous coding agent (Claude) from the issue
description, with the diff, tests, and verification output above produced
and checked by the agent before pushing.

## What I'd want a reviewer to doubt

- The fallback key list (`reasoning_tokens`, `thoughts_tokens`,
  `output_reasoning_tokens`, `output_reasoning`) is scoped to what the
  issue names plus the two normalized keys the OTel ingestion processor
  already emits for reasoning tokens. It's possible there's a broader or
  narrower canonical list intended (e.g. whether `output_reasoning_tokens`
  should be pulled in at all, since most current model price entries
  already price it explicitly and this only matters for models that don't).
- I deliberately did *not* touch `OtelIngestionProcessor.ts`'s
  reasoning/output-token subtraction logic (which currently only recognizes
  `reasoning.output_tokens` and `completion_details.reasoning` as inclusive
  of output token counts). Extending that subtraction to also treat a bare
  `reasoning_tokens` key as inclusive of output felt like a separate,
  riskier judgment call about whether that key is emitted inclusively or
  additively across different instrumentation libraries — happy to be
  told that's actually needed too.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents known reasoning-token usage buckets from remaining uncosted when a model lacks a matching price entry.
- Adds a fallback from four reasoning/thinking usage aliases to the model’s output-token price.
- Preserves exact usage-type prices when configured.
- Adds unit coverage for pricing `reasoning_tokens` through the fallback.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

Known producers normalize reasoning usage into additive buckets before cost calculation, exact reasoning prices retain precedence, and the fallback matches the repository’s established pricing semantics.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): price reasoning tokens at ..."](https://github.com/langfuse/langfuse/commit/56538bcd83c3d308850191c5043ee6edfe688a16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56378613)</sub>

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->