### PR TITLE
fix(evals): preserve LLM judge BullMQ retries

### DIFF
--- a/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
@@ -139,7 +139,13 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     }>,
   ) => Promise<unknown>;
 
-  const createMockJob = (overrides: Record<string, unknown> = {}): Job<any> => {
+  const createMockJob = (
+    overrides: {
+      data?: Record<string, unknown>;
+      attemptsMade?: number;
+      opts?: { attempts?: number };
+    } = {},
+  ): Job<any> => {
     return {
       data: {
         id: "queue-job-123",
@@ -151,8 +157,10 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
           observationS3Path,
         },
         retryBaggage: { attempt: 0 },
-        ...overrides,
+        ...overrides.data,
       },
+      attemptsMade: overrides.attemptsMade ?? 0,
+      opts: overrides.opts ?? { attempts: 10 },
     } as Job<any>;
   };
 
@@ -399,7 +407,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
   });
 
   describe("unexpected errors (retryable by BullMQ)", () => {
-    it("should set ERROR status with generic message for unexpected errors", async () => {
+    it("should rethrow unexpected errors without persisting ERROR while BullMQ retries remain", async () => {
       const unexpectedError = new Error("Database connection failed");
       (processObservationEval as Mock).mockRejectedValue(unexpectedError);
 
@@ -410,17 +418,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
         "Database connection failed",
       );
 
-      expect(prisma.jobExecution.update).toHaveBeenCalledWith({
-        where: {
-          id: jobExecutionId,
-          projectId,
-        },
-        data: expect.objectContaining({
-          status: JobExecutionStatus.ERROR,
-          error: "An internal error occurred",
-          executionTraceId: "test-trace-id",
-        }),
-      });
+      expect(prisma.jobExecution.update).not.toHaveBeenCalled();
     });
 
     it("should call traceException for unexpected errors", async () => {
@@ -448,6 +446,30 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
         "Network timeout",
       );
     });
+
+    it("should persist ERROR on the final BullMQ attempt", async () => {
+      const unexpectedError = new Error("Database connection failed");
+      (processObservationEval as Mock).mockRejectedValue(unexpectedError);
+
+      await expect(
+        llmAsJudgeExecutionQueueProcessor(
+          createMockJob({ attemptsMade: 9, opts: { attempts: 10 } }),
+        ),
+      ).rejects.toThrow(unexpectedError);
+
+      expect(prisma.jobExecution.update).toHaveBeenCalledWith({
+        where: {
+          id: jobExecutionId,
+          projectId,
+        },
+        data: {
+          status: JobExecutionStatus.ERROR,
+          endTime: expect.any(Date),
+          error: "An internal error occurred",
+          executionTraceId: "test-trace-id",
+        },
+      });
+    });
   });
 
   describe("execution trace ID", () => {
@@ -473,7 +495,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
       (processObservationEval as Mock).mockResolvedValue(undefined);
 
       const job = createMockJob({
-        retryBaggage: { attempt: 3 },
+        data: { retryBaggage: { attempt: 3 } },
       });
       await llmAsJudgeExecutionQueueProcessor(job as Job<any>);
 

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -335,23 +335,31 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
         }
       }
 
-      await prisma.jobExecution.update({
-        where: {
-          id: job.data.payload.jobExecutionId,
-          projectId: job.data.payload.projectId,
-        },
-        data: {
-          status: JobExecutionStatus.ERROR,
-          endTime: new Date(),
-          error:
-            llmError || isUnrecoverableError(e)
+      const isTerminalError = Boolean(llmError) || isUnrecoverableError(e);
+      const totalAttempts = job.opts.attempts ?? 1;
+      const isFinalAttempt = job.attemptsMade + 1 >= totalAttempts;
+
+      // Only persist the terminal ERROR state when there will be no more
+      // retries; otherwise observationEvalProcessor would short-circuit the
+      // retry attempts because it skips jobs already in ERROR status.
+      if (isTerminalError || isFinalAttempt) {
+        await prisma.jobExecution.update({
+          where: {
+            id: job.data.payload.jobExecutionId,
+            projectId: job.data.payload.projectId,
+          },
+          data: {
+            status: JobExecutionStatus.ERROR,
+            endTime: new Date(),
+            error: isTerminalError
               ? (llmError?.message ?? (e as Error).message)
               : "An internal error occurred",
-          executionTraceId,
-        },
-      });
+            executionTraceId,
+          },
+        });
+      }
 
-      if (llmError || isUnrecoverableError(e)) return;
+      if (isTerminalError) return;
 
       traceException(e);
       logger.error(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16510.preview.langfuse.com](https://pr-16510.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Prevents transient LLM-as-judge execution failures from persisting a terminal `ERROR` state before BullMQ exhausts its retries. Terminal evaluator failures still complete immediately, and unexpected failures persist `ERROR` on the final attempt.

Adds regression coverage for both the retryable first-attempt path and the final-attempt boundary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter worker run test llmAsJudgeExecutionQueueProcessor.test.ts` — 19 passed
- `pnpm run lint` — 7 successful, 7 total
- `pnpm --filter worker run typecheck` — passed
- Prettier check — all matched files use Prettier code style
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-252d4408-8d0e-43ae-a817-67c2d7a73508?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-252d4408-8d0e-43ae-a817-67c2d7a73508&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves BullMQ retries for unexpected LLM-as-judge failures by delaying the durable `ERROR` state until the final configured attempt.
- Distinguishes terminal evaluator errors from unexpected retryable failures.
- Persists unexpected failures only when BullMQ reaches its final attempt.
- Adds regression tests for intermediate and final retry boundaries.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because unexpected failures retain their BullMQ retry opportunity while terminal and exhausted failures still receive a durable error state.

The final-attempt calculation matches the queue’s ten-attempt configuration and BullMQ’s zero-based attempts counter, while classified terminal errors continue to complete immediately.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Execute LLM judge job] --> B{Execution succeeds?}
  B -->|Yes| C[Complete job]
  B -->|No| D{Terminal evaluator error?}
  D -->|Yes| E[Persist ERROR]
  D -->|No| F{Final BullMQ attempt?}
  F -->|Yes| G[Persist ERROR and rethrow]
  F -->|No| H[Rethrow without persisting ERROR]
  H --> I[BullMQ retries job]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): preserve LLM judge BullMQ re..."](https://github.com/langfuse/langfuse/commit/6417ab1dd9dd36a816bbe9effc9efe92a673e3bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56385947)</sub>

**Context used:**

- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)
- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)

<!-- /greptile_comment -->