### PR TITLE
fix(auth): stop leaking internal error details from signup endpoints

### DIFF
--- a/web/src/__tests__/server/unit/signup-error-leak.servertest.ts
+++ b/web/src/__tests__/server/unit/signup-error-leak.servertest.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const { createUserEmailPasswordMock, loggerWarnMock } = vi.hoisted(() => ({
+  createUserEmailPasswordMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    NEXT_PUBLIC_SIGN_UP_DISABLED: undefined,
+    AUTH_DISABLE_SIGNUP: undefined,
+    AUTH_DISABLE_USERNAME_PASSWORD: undefined,
+    AUTH_DOMAINS_WITH_SSO_ENFORCEMENT: undefined,
+    LANGFUSE_NEW_USER_SIGNUP_WEBHOOK: undefined,
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+    EMAIL_VERIFY_MODE: undefined,
+  },
+}));
+
+vi.mock("@/src/features/auth-credentials/lib/credentialsServerUtils", () => ({
+  createUserEmailPassword: createUserEmailPasswordMock,
+}));
+
+vi.mock("@/src/features/auth/lib/signupAttribution", () => ({
+  getAdClickIdsFromRequest: () => ({}),
+}));
+
+vi.mock("@/src/ee/features/multi-tenant-sso/utils", () => ({
+  getSsoAuthProviderIdForDomain: vi.fn(async () => null),
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: { warn: loggerWarnMock },
+}));
+
+import { signupApiHandler } from "@/src/features/auth-credentials/server/signupApiHandler";
+
+function buildReqRes(body: unknown) {
+  const req = {
+    method: "POST",
+    body,
+  } as unknown as NextApiRequest;
+
+  const res = {
+    statusCode: 200,
+    payload: null as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.payload = payload;
+      return this;
+    },
+  } as unknown as NextApiResponse & {
+    statusCode: number;
+    payload: any;
+  };
+
+  return { req, res };
+}
+
+const validBody = {
+  email: "user@example.com",
+  password: "Str0ng&SecurePass!",
+  name: "Test User",
+};
+
+describe("signupApiHandler error responses do not leak internals (#16504)", () => {
+  beforeEach(() => {
+    createUserEmailPasswordMock.mockReset();
+    loggerWarnMock.mockReset();
+  });
+
+  it("passes through known validation messages", async () => {
+    createUserEmailPasswordMock.mockRejectedValue(
+      new Error("Password needs to be at least 8 characters long."),
+    );
+    const { req, res } = buildReqRes(validBody);
+
+    await signupApiHandler(req, res);
+
+    expect(res.statusCode).toBe(422);
+    expect(res.payload).toEqual({
+      message: "Password needs to be at least 8 characters long.",
+    });
+  });
+
+  it("passes through duplicate-account messages", async () => {
+    createUserEmailPasswordMock.mockRejectedValue(
+      new Error("User with email already exists. Please sign in."),
+    );
+    const { req, res } = buildReqRes(validBody);
+
+    await signupApiHandler(req, res);
+
+    expect(res.statusCode).toBe(422);
+    expect(res.payload).toEqual({
+      message: "User with email already exists. Please sign in.",
+    });
+  });
+
+  it("replaces raw Prisma errors with a generic message", async () => {
+    // Simulate what Prisma throws on a DB-level failure: table/column names
+    // and query details inside the message.
+    createUserEmailPasswordMock.mockRejectedValue(
+      new Error(
+        'Invalid `prisma.user.create()` invocation:\n\nUnique constraint failed on the constraint: `users_email_key`\n{"clientVersion":"5.22.0"}',
+      ),
+    );
+    const { req, res } = buildReqRes(validBody);
+
+    await signupApiHandler(req, res);
+
+    expect(res.statusCode).toBe(422);
+    const payload = res.payload as { message: string };
+    expect(payload.message).not.toContain("prisma");
+    expect(payload.message).not.toContain("users_email_key");
+    expect(payload.message).toBe(
+      "Signup failed. Please check your input and try again.",
+    );
+  });
+
+  it("still logs the full error server-side", async () => {
+    const internalDetail =
+      'Invalid `prisma.user.create()` invocation:\n\nerror: column "x" does not exist';
+    createUserEmailPasswordMock.mockRejectedValue(new Error(internalDetail));
+    const { req, res } = buildReqRes(validBody);
+
+    await signupApiHandler(req, res);
+
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    const logged = String(loggerWarnMock.mock.calls[0][0]);
+    expect(logged).toContain(internalDetail);
+  });
+});

--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -101,11 +101,24 @@ export async function signupApiHandler(
       { adClickIds: getAdClickIdsFromRequest(req) },
     );
   } catch (error) {
-    const message =
+    const logMessage =
       "Signup: Error creating user: " +
       (error instanceof Error ? error.message : JSON.stringify(error));
-    logger.warn(message, body.email.toLowerCase(), body.name);
-    res.status(422).json({ message: message });
+    logger.warn(logMessage, body.email.toLowerCase(), body.name);
+
+    // Only forward messages we authored ourselves (validation, duplicate
+    // account). Everything else can carry Prisma/Postgres internals, so it
+    // gets a generic response while the details stay in the server logs.
+    const knownMessages = [
+      "Password needs to be at least 8 characters long.",
+      "User with email already exists. Please sign in.",
+      "You have already signed up via an identity provider. Please sign in.",
+    ];
+    const safeMessage =
+      error instanceof Error && knownMessages.includes(error.message)
+        ? error.message
+        : "Signup failed. Please check your input and try again.";
+    res.status(422).json({ message: safeMessage });
 
     return;
   }

--- a/web/src/pages/api/auth/signup-verify.ts
+++ b/web/src/pages/api/auth/signup-verify.ts
@@ -115,11 +115,15 @@ export default async function handler(
       res.status(200).json({ status: "ok" });
       return;
     }
-    const message =
+    const logMessage =
       "Signup verify: Error creating user: " +
       (error instanceof Error ? error.message : JSON.stringify(error));
-    logger.warn(message, normalizedEmail, name);
-    res.status(500).json({ message });
+    logger.warn(logMessage, normalizedEmail, name);
+    // Raw Prisma/Postgres error details stay in the logs; the response
+    // carries a generic message only.
+    res.status(500).json({
+      message: "Signup verification failed. Please try again later.",
+    });
     return;
   }
 


### PR DESCRIPTION
Fixes #16504

The credentials signup endpoint caught every error from createUserEmailPassword and returned error.message directly in the HTTP response. The validation layer only throws a few known messages, but anything else that goes wrong (a Postgres outage, a schema drift, a connection failure) also lands in that catch, and those messages carry Prisma internals: constraint names, query fragments, client versions. All of it went to unauthenticated callers.

The fix keeps the known, authored messages (password policy, duplicate account) so user experience does not change, and replaces everything else with a generic response. The full error still goes to the server log, so debugging is not lost. signup-verify.ts had the same catch shape and got the same treatment.

How tested: new unit tests in web/src/__tests__/server/unit/signup-error-leak.servertest.ts cover both known-message passthrough and the Prisma-style failure. Without the fix 3 of 4 tests fail (raw messages reach the response body); with it 4 of 4 pass. Run with `pnpm --filter web run test src/__tests__/server/unit/signup-error-leak.servertest.ts`.

One note for review: the knownMessages allowlist duplicates strings that live in credentialsServerUtils.ts. I kept the duplication rather than exporting a constant because it keeps this PR scoped to the leak; happy to refactor into shared constants if maintainers prefer that.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents unauthenticated signup endpoints from returning raw database and infrastructure exception details while retaining full server-side logging.

- Preserves three authored credential-signup messages through an explicit allowlist.
- Replaces unexpected credential-signup and verification failures with fixed user-facing messages.
- Adds unit coverage for credential-signup message passthrough, sanitization, and logging.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking omission of regression coverage for signup-verify.

The sanitization logic preserves every current authored credential error and prevents unexpected exception details from reaching callers; only the second changed endpoint remains untested.

**Files Needing Attention:** web/src/__tests__/server/unit/signup-error-leak.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/unit/signup-error-leak.servertest.ts:70
**Signup verification remains untested**

The regression suite invokes only `signupApiHandler`, leaving the separately changed `signup-verify` sanitization path uncovered. A future regression that returns raw database or infrastructure errors from that endpoint will pass this suite.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): stop leaking internal error d..."](https://github.com/langfuse/langfuse/commit/fff6b01ec881dc41bd2be31e032b74cc02f538c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56387349)</sub>

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)

<!-- /greptile_comment -->