### PR TITLE
chore(deps): bump @ferrucc-io/emoji-picker to 0.1.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,8 +520,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
       '@ferrucc-io/emoji-picker':
-        specifier: ^0.0.47
-        version: 0.0.47(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)
+        specifier: ^0.1.2
+        version: 0.1.2(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.0(react@19.2.4))
@@ -656,7 +656,7 @@ importers:
         version: 8.20.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-virtual':
         specifier: ^3.13.12
-        version: 3.13.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 3.14.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@trpc/client':
         specifier: ^11.13.4
         version: 11.13.4(@trpc/server@11.13.4(typescript@7.0.2))(typescript@7.0.2)
@@ -851,7 +851,7 @@ importers:
         version: 2.2.2
       tailwind-merge:
         specifier: ^3.5.0
-        version: 3.5.0
+        version: 3.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.2)
@@ -2146,12 +2146,12 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@ferrucc-io/emoji-picker@0.0.47':
-    resolution: {integrity: sha512-w7lRzT3bvf7NdNl+cfJT3+KFCrdWXy8H0LPtDamFxHoOb6SBbWvRnMBX0Ot24NIvNtfFkXXeo5z9/SMo2e9DzQ==}
+  '@ferrucc-io/emoji-picker@0.1.2':
+    resolution: {integrity: sha512-P15x8qOOz3n12lkCWrnKbniy2otHTg0JLyK2LNsQzrj2UJwltSDcitqj10+FRf4dMEFuGKHPjiwqP/8Xz2e+YA==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^18.2.0 || ^19.0.0
-      react-dom: ^18.2.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
       tailwindcss: '>=3.0.0'
 
   '@floating-ui/core@1.7.3':
@@ -5093,8 +5093,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.13.12':
-    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5103,8 +5103,8 @@ packages:
     resolution: {integrity: sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==}
     engines: {node: '>=12'}
 
-  '@tanstack/virtual-core@3.13.12':
-    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@testing-library/dom@10.0.0':
     resolution: {integrity: sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==}
@@ -8201,8 +8201,8 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
-  jotai@2.15.0:
-    resolution: {integrity: sha512-nbp/6jN2Ftxgw0VwoVnOg0m5qYM1rVcfvij+MZx99Z5IK13eGve9FJoCwGv+17JvVthTjhSmNtT5e1coJnr6aw==}
+  jotai@2.20.2:
+    resolution: {integrity: sha512-aHB4CNb9qRcyf0mwSB6EO5bCGAjx8cTwFgOFCE2leOnTzqACbnSWG8XoWB3LxCT1Qoj03I1OWAHszDmN4uHb/w==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@babel/core': '>=7.0.0'
@@ -10327,11 +10327,8 @@ packages:
     peerDependencies:
       tailwindcss: ^3.3.0 || ^4.0.0 || ^4.0.0-beta
 
-  tailwind-merge@2.6.0:
-    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
-
-  tailwind-merge@3.5.0:
-    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -12419,15 +12416,15 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@ferrucc-io/emoji-picker@0.0.47(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)':
+  '@ferrucc-io/emoji-picker@0.1.2(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)':
     dependencies:
-      '@tanstack/react-virtual': 3.13.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual': 3.14.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      jotai: 2.15.0(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4)
+      jotai: 2.20.2(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4)
       node-emoji: 2.2.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      tailwind-merge: 2.6.0
+      tailwind-merge: 3.6.0
       tailwindcss: 4.2.2
       unicode-emoji-json: 0.8.0
     transitivePeerDependencies:
@@ -15313,15 +15310,15 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@tanstack/react-virtual@3.13.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-virtual@3.14.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@tanstack/virtual-core': 3.13.12
+      '@tanstack/virtual-core': 3.17.8
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
   '@tanstack/table-core@8.20.5': {}
 
-  '@tanstack/virtual-core@3.13.12': {}
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@testing-library/dom@10.0.0':
     dependencies:
@@ -18893,7 +18890,7 @@ snapshots:
 
   jose@6.2.3: {}
 
-  jotai@2.15.0(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4):
+  jotai@2.20.2(@babel/core@7.29.6(supports-color@8.1.1))(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4):
     optionalDependencies:
       '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/template': 7.28.6
@@ -21373,7 +21370,7 @@ snapshots:
       remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       remend: 1.3.0
-      tailwind-merge: 3.5.0
+      tailwind-merge: 3.6.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.1
@@ -21541,9 +21538,7 @@ snapshots:
       local-pkg: 1.2.1
       tailwindcss: 4.2.2
 
-  tailwind-merge@2.6.0: {}
-
-  tailwind-merge@3.5.0: {}
+  tailwind-merge@3.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.2.2):
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -52,7 +52,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@ferrucc-io/emoji-picker": "^0.0.47",
+    "@ferrucc-io/emoji-picker": "^0.1.2",
     "@hookform/resolvers": "^5.2.2",
     "@langfuse/shared": "workspace:*",
     "@lezer/highlight": "^1.2.3",


### PR DESCRIPTION
Fixes #16472

## What

Bumps `@ferrucc-io/emoji-picker` in `web` from `^0.0.47` to `^0.1.2` (one-line manifest change + regenerated `pnpm-lock.yaml`).

## Why

`@ferrucc-io/emoji-picker` ≤ 0.0.x ran a synchronous canvas-based emoji-support probe at import time, which blocked the main thread for multiple seconds on Windows + Chrome/Edge (see #16472 for the full investigation). The fix landed upstream in ferrucc-io/emoji-picker#114 and shipped as 0.1.2. `^0.0.47` does not pick up 0.1.x under semver, so a manifest bump is required.

## Compatibility

- Public API is backwards compatible. `ReactionPicker.tsx` only uses `EmojiPicker` with `onEmojiSelect` / `emojiSize` / `emojisPerRow` and the compound children; none of these changed between 0.0.47 and 0.1.2. No source changes were needed.
- Followed `.agents/skills/pnpm-upgrade-package`: release-age helper reports 0.1.2 (published 2026-08-17) is installable under `minimumReleaseAge: 7200` without any `minimumReleaseAgeExclude` entry.
- `pnpm dedupe` was run once. Besides the emoji-picker bump itself (and its transitive deps `jotai`, `@tanstack/virtual-core`), dedupe collapsed `web`'s existing `@tanstack/react-virtual` (3.13.12 → 3.14.10) and `tailwind-merge` (3.5.0 → 3.6.0) onto the versions 0.1.2 brought in, so each is installed once. Both stay inside the ranges already declared in `web/package.json`.
- `pnpm why -r @ferrucc-io/emoji-picker` → only `0.1.2` (via `web`).

## Verification

- `pnpm --filter web typecheck` — passed
- `pnpm --filter web lint` — passed (`--max-warnings 0`)
- `pnpm --filter web build` — `✓ Compiled successfully`, 83/83 static pages generated


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR upgrades `@ferrucc-io/emoji-picker` from 0.0.47 to 0.1.2 to avoid the synchronous import-time emoji-support probe.
- Updates the web package manifest and regenerated lockfile.
- Deduplicates compatible `@tanstack/react-virtual`, `@tanstack/virtual-core`, `jotai`, and `tailwind-merge` versions.
- Preserves the existing React, React DOM, Tailwind, and emoji-picker usage contracts.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete correctness, security, installation, or compatibility issue identified.

The manifest and lockfile are consistent, the upgraded package retains the API used by the web application, and the incidental deduplicated versions remain within existing declared ranges.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump @ferrucc-io/emoji-pick..."](https://github.com/langfuse/langfuse/commit/6d5cd72f0427564c4f9ef1f25f1df03ebac760bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56537248)</sub>

<!-- /greptile_comment -->