### PR TITLE
fix(ingestion): preserve explicit usage total 0 and fix numeric falsiness in token calculations

### DIFF
--- a/worker/src/__tests__/legacyIngestionUsage.test.ts
+++ b/worker/src/__tests__/legacyIngestionUsage.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from "vitest";
+import { IngestionService } from "../services/IngestionService";
+import { eventTypes } from "@langfuse/shared/src/server";
+
+describe("IngestionService mapObservationEventsToRecords usage calculations", () => {
+  // Create an IngestionService instance with mocked dependencies
+  const ingestionService = new IngestionService(
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+
+  it("preserves explicit usage.total: 0 without overwriting via input + output", () => {
+    const events: any[] = [
+      {
+        id: "evt-1",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-1",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "cached-gen",
+          usage: {
+            input: 100,
+            output: 50,
+            total: 0,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-1",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      input: 100,
+      output: 50,
+      total: 0,
+    });
+  });
+
+  it("calculates total correctly when input is 0 and output is 50", () => {
+    const events: any[] = [
+      {
+        id: "evt-2",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-2",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "zero-input-gen",
+          usage: {
+            input: 0,
+            output: 50,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-2",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      input: 0,
+      output: 50,
+      total: 50,
+    });
+  });
+
+  it("calculates total correctly when input is 50 and output is 0", () => {
+    const events: any[] = [
+      {
+        id: "evt-3",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-3",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "zero-output-gen",
+          usage: {
+            input: 50,
+            output: 0,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-3",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      input: 50,
+      output: 0,
+      total: 50,
+    });
+  });
+
+  it("calculates total correctly when both input and output are 0", () => {
+    const events: any[] = [
+      {
+        id: "evt-4",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-4",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "all-zero-gen",
+          usage: {
+            input: 0,
+            output: 0,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-4",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      input: 0,
+      output: 0,
+      total: 0,
+    });
+  });
+
+  it("preserves explicit non-zero total count", () => {
+    const events: any[] = [
+      {
+        id: "evt-5",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-5",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "explicit-total-gen",
+          usage: {
+            input: 100,
+            output: 50,
+            total: 200,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-5",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      input: 100,
+      output: 50,
+      total: 200,
+    });
+  });
+
+  it("does not compute fallback total when usageDetails is present", () => {
+    const events: any[] = [
+      {
+        id: "evt-6",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-6",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "usage-details-gen",
+          usageDetails: {
+            input: 100,
+            custom_tokens: 30,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-6",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      input: 100,
+      custom_tokens: 30,
+    });
+  });
+
+  it("calculates total correctly when only input is provided", () => {
+    const events: any[] = [
+      {
+        id: "evt-7",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-7",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "input-only-gen",
+          usage: {
+            input: 100,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-7",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      input: 100,
+      total: 100,
+    });
+  });
+
+  it("calculates total correctly when only output is provided", () => {
+    const events: any[] = [
+      {
+        id: "evt-8",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-8",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "output-only-gen",
+          usage: {
+            output: 50,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-8",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({
+      output: 50,
+      total: 50,
+    });
+  });
+
+  it("leaves provided_usage_details empty when usage is empty object", () => {
+    const events: any[] = [
+      {
+        id: "evt-9",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-9",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "empty-usage-gen",
+          usage: {},
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-9",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_usage_details).toEqual({});
+  });
+
+  it("preserves zero costs in provided_cost_details", () => {
+    const events: any[] = [
+      {
+        id: "evt-10",
+        type: eventTypes.OBSERVATION_CREATE,
+        timestamp: new Date().toISOString(),
+        body: {
+          id: "obs-10",
+          traceId: "trace-1",
+          type: "GENERATION",
+          name: "zero-cost-gen",
+          usage: {
+            input: 100,
+            output: 50,
+            total: 0,
+            inputCost: 0,
+            outputCost: 0,
+            totalCost: 0,
+          },
+        },
+      },
+    ];
+
+    const records = (ingestionService as any).mapObservationEventsToRecords({
+      projectId: "proj-1",
+      entityId: "obs-10",
+      observationEventList: events,
+      prompt: null,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].provided_cost_details).toEqual({
+      input: 0,
+      output: 0,
+      total: 0,
+    });
+  });
+});

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1498,7 +1498,7 @@ export class IngestionService {
         );
 
         const newTotalCount =
-          newInputCount || newOutputCount
+          newInputCount != null || newOutputCount != null
             ? (newInputCount ?? 0) + (newOutputCount ?? 0)
             : undefined;
 
@@ -1922,13 +1922,12 @@ export class IngestionService {
         "usage" in obs.body ? obs.body.usage?.output : undefined;
 
       const newTotalCount =
-        ("usage" in obs.body ? obs.body.usage?.total : undefined) ||
+        ("usage" in obs.body ? obs.body.usage?.total : undefined) ??
         (Object.keys(
           "usageDetails" in obs.body ? (obs.body.usageDetails ?? {}) : {},
-        ).length === 0
-          ? newInputCount && newOutputCount
-            ? newInputCount + newOutputCount
-            : (newInputCount ?? newOutputCount)
+        ).length === 0 &&
+        (newInputCount != null || newOutputCount != null)
+          ? (newInputCount ?? 0) + (newOutputCount ?? 0)
           : undefined);
 
       let provided_usage_details: Record<string, number> = {};


### PR DESCRIPTION
Fixes #16503

## Problem
In the legacy observation ingestion path (`worker/src/services/IngestionService/index.ts`), `newTotalCount` was calculated using the `||` operator:
```typescript
const newTotalCount =
  ("usage" in obs.body ? obs.body.usage?.total : undefined) ||
  (Object.keys("usageDetails" in obs.body ? (obs.body.usageDetails ?? {}) : {}).length === 0
    ? newInputCount && newOutputCount
      ? newInputCount + newOutputCount
      : (newInputCount ?? newOutputCount)
    : undefined);
```

This caused two issues:
1. **Explicit `total: 0` overwritten:** When an observation explicitly specified `usage.total: 0` (e.g., cached responses or 0-token generations), `0 || (...)` treated `0` as falsy and overwrote it with `input + output`.
2. **Numeric falsiness in fallback branch:** When `input` was `0` and `output` was `50` (or vice versa), `0 && 50` evaluated to `0` (falsy) in `newInputCount && newOutputCount`, taking the `(newInputCount ?? newOutputCount)` branch and producing `0` instead of `0 + 50 = 50`.
3. **Tokenization usage count logic:** Line 1501 used `newInputCount || newOutputCount` to decide whether to sum counts, treating `0 || 0` as falsy and returning `undefined` instead of `0`.

## Changes
- Replaced `||` with nullish coalescing `??` for `obs.body.usage?.total`.
- Fixed fallback branch condition to `newInputCount != null || newOutputCount != null` and summed `(newInputCount ?? 0) + (newOutputCount ?? 0)`.
- Updated tokenization total count check to use `!= null`.
- Added unit tests in `worker/src/__tests__/legacyIngestionUsage.test.ts` covering explicit `total: 0`, single-sided 0 token counts, all-zero token counts, and cost detail preservation.

## Verification
- Unit tests: `vitest run src/__tests__/legacyIngestionUsage.test.ts` (10/10 passed)
- Typecheck: `tsc --noEmit --skipLibCheck` (clean)
- Code formatting & lint: `prettier` and `turbo run lint` (all 7 tasks passing)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects zero-value handling in legacy observation usage calculations.
- Preserves an explicitly supplied `usage.total` of zero.
- Derives totals correctly when either token count is zero or absent.
- Adds focused unit coverage for zero-token and zero-cost payloads.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The changed nullish checks preserve explicit zero totals and correctly derive totals from zero-valued token counts without changing the behavior for absent usage or nonempty usageDetails.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): preserve explicit total ..."](https://github.com/langfuse/langfuse/commit/e587be60418ba1e969ef30e6a8015c2f5c7618fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56550251)</sub>

<!-- /greptile_comment -->