### PR TITLE
fix(evals): render boolean test results as text

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/TestResultPanelView/TestResultPanelView.stories.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/TestResultPanelView/TestResultPanelView.stories.tsx
@@ -86,6 +86,40 @@ export const CodeSuccess = meta.story({
   },
 });
 
+export const BooleanCodeSuccess = meta.story({
+  name: "Boolean Code Success",
+  args: {
+    title: "Code Output",
+    result: {
+      status: "code-success",
+      scores: [
+        {
+          name: "Factuality",
+          value: "true",
+          comment: "The response is factually correct.",
+        },
+        {
+          name: "Contains PII",
+          value: "false",
+          comment: null,
+        },
+      ],
+    },
+    durationMs: 280,
+    estimatedCostUsd: null,
+    rawOutput: {
+      scores: [
+        { name: "Factuality", value: 1, dataType: "BOOLEAN" },
+        { name: "Contains PII", value: 0, dataType: "BOOLEAN" },
+      ],
+    },
+    rawOpen: false,
+    traceActions: traceActions("trace-execution"),
+    rerunAction: rerunAction(false, null),
+    onRawOpenChange: actions.onRawOpenChange,
+  },
+});
+
 export const Error = meta.story({
   args: {
     title: "LLM Output",

--- a/web/src/features/evals/v2/fns/evaluatorTesting/toTestResultPanelState.clienttest.ts
+++ b/web/src/features/evals/v2/fns/evaluatorTesting/toTestResultPanelState.clienttest.ts
@@ -33,6 +33,28 @@ describe("toTestResultPanelState", () => {
     });
   });
 
+  it("renders numeric boolean code scores as true and false", () => {
+    expect(
+      toTestResultPanelState({
+        type: "CODE",
+        isPending: false,
+        result: {
+          success: true,
+          scores: [
+            { name: "Passed", value: 1, dataType: "BOOLEAN" },
+            { name: "Failed", value: 0, dataType: "BOOLEAN" },
+          ],
+        },
+      }),
+    ).toEqual({
+      status: "code-success",
+      scores: [
+        { name: "Passed", value: "true", comment: null },
+        { name: "Failed", value: "false", comment: null },
+      ],
+    });
+  });
+
   it.each([
     { matches: ["very funny"], expectedScore: "very funny" },
     {

--- a/web/src/features/evals/v2/fns/evaluatorTesting/toTestResultPanelState.ts
+++ b/web/src/features/evals/v2/fns/evaluatorTesting/toTestResultPanelState.ts
@@ -33,9 +33,13 @@ export function toTestResultPanelState(params: {
       status: "code-success",
       scores: scores.map((score, index) => {
         const item = score as Record<string, unknown>;
+        const value =
+          item.dataType === "BOOLEAN" && typeof item.value === "number"
+            ? item.value === 1
+            : item.value;
         return {
           name: String(item.name ?? `Score ${index + 1}`),
-          value: String(item.value ?? ""),
+          value: String(value ?? ""),
           comment: item.comment == null ? null : String(item.comment),
         };
       }),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16514.preview.langfuse.com](https://pr-16514.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Displays code evaluator boolean test results as `true` and `false` instead of their numeric wire values (`1` and `0`). Adds regression coverage for both boolean outcomes and a Storybook state for visual review.

[eval_boolean_results_true_false.mp4](https://cursor.com/agents/bc-1463a12e-5d4c-470d-aeac-4f142d7c6193/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval_boolean_results_true_false.mp4)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

Impacted package: `web`

- `pnpm --filter web run test-client src/features/evals/v2/fns/evaluatorTesting/toTestResultPanelState.clienttest.ts` — `Tests 5 passed (5)`
- `pnpm --filter web run test-storybook src/features/evals/v2/components/Evaluators/Testing/components/TestResultPanelView/TestResultPanelView.stories.tsx` — `Tests 7 passed (7)`
- Pre-commit formatting — passed
- Pre-commit lint — `Tasks: 7 successful, 7 total`
- GitHub CI — 40 successful, 0 failed, 0 pending
- Preview smoke test — https://pr-16514.preview.langfuse.com loads and auto-signs into the synthetic demo project; no existing evaluator is seeded for an end-to-end test run

## What to doubt in review

- The display conversion intentionally applies only to numeric values tagged with `dataType: "BOOLEAN"`; numeric score values without that type remain unchanged.
- The server and raw output intentionally retain `1`/`0`; only the user-facing result panel converts them to `true`/`false`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1463a12e-5d4c-470d-aeac-4f142d7c6193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1463a12e-5d4c-470d-aeac-4f142d7c6193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Converts normalized boolean code-evaluator test scores from numeric wire values into user-facing `true` and `false` text.
- Adds client regression coverage for both boolean outcomes.
- Adds a Storybook state showing boolean score results.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The display transformation matches the evaluator result contract, and the added tests cover both normalized boolean outcomes.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): render boolean test results ..."](https://github.com/langfuse/langfuse/commit/f9c0a2508bcf92b47f41a171a74abd49c2bf3f4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56567938)</sub>

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)

<!-- /greptile_comment -->