### PR TITLE
feat(otel): log encoded request body sizes

### DIFF
--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -28,6 +28,8 @@ export const config = {
   },
 };
 
+const OTEL_REQUEST_BODY_WARNING_BYTES = 16 * 1024 * 1024;
+
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "OTel Traces",
@@ -48,9 +50,11 @@ export default withMiddlewares({
       const maxBodyBytes = env.LANGFUSE_OTEL_INGESTION_MAX_BODY_BYTES;
 
       let body: Buffer;
+      let encodedBodyBytes: number;
       let bodyFailureMessage = "Failed to read request body";
       try {
         body = await readOtelRequestBody(req, maxBodyBytes);
+        encodedBodyBytes = body.byteLength;
 
         if (req.headers["content-encoding"]?.includes("gzip")) {
           bodyFailureMessage = "Failed to decompress request body";
@@ -238,9 +242,17 @@ export default withMiddlewares({
         };
       }
 
-      // Warn on oversized OTEL request bodies (16MB threshold)
-      const bodyBytes = body.byteLength;
-      if (bodyBytes > 16 * 1024 * 1024) {
+      // Warn on oversized OTEL request bodies (16MB threshold). Keep one
+      // warning per accepted request, even when both encoded and decoded sizes
+      // cross the threshold.
+      // Keep the encoded size available after optional decompression so the
+      // warning can identify requests that would cross an encoded-only
+      // threshold as well as requests that are large after decompression.
+      const decodedBodyBytes = body.byteLength;
+      if (
+        encodedBodyBytes > OTEL_REQUEST_BODY_WARNING_BYTES ||
+        decodedBodyBytes > OTEL_REQUEST_BODY_WARNING_BYTES
+      ) {
         let spanCount = 0;
         for (const rs of resourceSpans) {
           for (const ss of rs?.scopeSpans ?? []) {
@@ -249,7 +261,10 @@ export default withMiddlewares({
         }
         logger.warn("OTEL request body exceeds 16MB", {
           projectId: auth.scope.projectId,
-          bodyBytes,
+          // Keep bodyBytes as the decoded-size field for existing queries.
+          bodyBytes: decodedBodyBytes,
+          decodedBodyBytes,
+          encodedBodyBytes,
           spanCount,
         });
       }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16517.preview.langfuse.com](https://pr-16517.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

TL;DR: Log both encoded and decoded OTEL request body sizes when either exceeds 16 MiB, while preserving the existing decoded-size bodyBytes field.

Impacted package:
- web: web/src/pages/api/public/otel/v1/traces/index.ts

Verification:
- pnpm --filter web run test src/__tests__/server/unit/otel-request-body.servertest.ts — Test Files 1 passed (1); Tests 7 passed (7)
- pnpm exec prettier --check web/src/pages/api/public/otel/v1/traces/index.ts — All matched files use Prettier code style!
- pnpm run lint — Tasks: 7 successful, 7 total
- pnpm --filter web run typecheck — completed successfully (tsc exited 0)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends oversized OTEL request logging while preserving the existing decoded-size field.
- Captures the encoded request size before optional gzip decompression.
- Emits one warning when either encoded or decoded size exceeds 16 MiB.
- Adds explicit encoded and decoded size fields while retaining `bodyBytes` for existing queries.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or contract issues identified.

The route reads an unmodified raw request buffer, records its size before optional gzip decompression, preserves the legacy decoded `bodyBytes` meaning, and emits at most one warning without altering request acceptance or queueing.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(otel): log encoded request body siz..."](https://github.com/langfuse/langfuse/commit/f17a85f51c4821b9bfeff22413f9d8a1154e14c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56577089)</sub>

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->