### PR TITLE
fix(worker): preserve explicit usage.total of 0 in legacy ingestion

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1922,7 +1922,7 @@ export class IngestionService {
         "usage" in obs.body ? obs.body.usage?.output : undefined;
 
       const newTotalCount =
-        ("usage" in obs.body ? obs.body.usage?.total : undefined) ||
+        ("usage" in obs.body ? obs.body.usage?.total : undefined) ??
         (Object.keys(
           "usageDetails" in obs.body ? (obs.body.usageDetails ?? {}) : {},
         ).length === 0

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -365,6 +365,67 @@ describe("IngestionService unit tests", () => {
     }
   });
 
+  it("preserves an explicit usage.total of 0 on legacy ingestion events", async () => {
+    const addToQueue = vi.fn();
+    const ingestionService = new IngestionService(
+      {} as any,
+      {} as any,
+      { addToQueue } as any,
+      {} as any,
+    );
+    const timestamp = "2026-08-25T00:00:00.000Z";
+    const observationEventList: ObservationEvent[] = [
+      {
+        id: "event-id",
+        timestamp,
+        type: "generation-create",
+        body: {
+          id: "observation-id",
+          traceId: "trace-id",
+          startTime: timestamp,
+          usage: {
+            input: 100,
+            output: 50,
+            total: 0,
+          },
+          environment: "default",
+        },
+      },
+    ];
+
+    vi.spyOn(ingestionService as any, "getClickhouseRecord").mockResolvedValue(
+      null,
+    );
+    vi.spyOn(ingestionService as any, "getPrompt").mockResolvedValue(null);
+    vi.spyOn(ingestionService as any, "getGenerationUsage").mockResolvedValue(
+      {},
+    );
+
+    await (ingestionService as any).processObservationEventList({
+      projectId: "project-id",
+      entityId: "observation-id",
+      createdAtTimestamp: new Date(timestamp),
+      observationEventList,
+      writeToStagingTables: true,
+      attribution: {
+        ingestionApiKey: "api-key",
+        ingestionSdkName: "sdk",
+        ingestionSdkVersion: "1.0.0",
+      },
+    });
+
+    for (const table of [
+      TableName.Observations,
+      TableName.ObservationsBatchStaging,
+    ]) {
+      const record = addToQueue.mock.calls.find(
+        ([queuedTable]) => queuedTable === table,
+      )?.[1];
+      expect(record?.provided_usage_details?.total).toBe(0);
+      expect(record?.usage_details?.total).toBe(0);
+    }
+  });
+
   it("correctly sorts events in ascending order by timestamp", async () => {
     const firstTrace = { timestamp: 1, type: "observation-create" };
     const secondTrace = { timestamp: 1, type: "observation-update" };


### PR DESCRIPTION
## What does this PR do?

Fixes #16503

In `worker/src/services/IngestionService/index.ts` (`mapObservationEventsToRecords`, ~line 1924 on current main), the legacy ingestion path computed the observation total with an `||` chain:

```typescript
const newTotalCount =
  ("usage" in obs.body ? obs.body.usage?.total : undefined) ||
  (Object.keys(...).length === 0 ? ... : undefined);
```

JavaScript's `||` short-circuits on any falsy value, so an explicitly provided `usage.total: 0` (legitimate for cached responses or callers intentionally reporting zero tokens) was treated as *missing* and silently overwritten by the computed `input + output` total. This corrupts `provided_usage_details.total`, `usage_details.total`, and anything derived from them (usage metrics, cost calculations, exports).

This PR replaces that one `||` with `??` (nullish coalescing) so only `null`/`undefined` fall through to the computed fallback. Explicit zero values are now preserved.

> **Note for reviewers:** while preparing this fix we noticed two other open community PRs addressing the same line — #16507 (identical minimal change + test) and #16513 (broader numeric-falsiness cleanup). Ours is the same minimal fix with a regression test that also covers the dual-write path (`observations` + `observations_batch_staging`). Happy to withdraw if the maintainers prefer one of the others.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Reproduction

Standalone script running the exact before/after expressions against the same inputs:

```
case                                  before(||)    after(??)
explicit total: 0  (the bug)          150           0
no total provided                     150           150
total: null                           150           150
explicit non-zero total: 200          200           200
```

Only the explicit-zero case changes; all existing fallback semantics are untouched. The new unit test encodes this:

- **Without the fix** it fails: `AssertionError: expected 150 to be +0`
- **With the fix** it passes

## How did you test it?

- Added a unit test to `worker/src/services/IngestionService/tests/IngestionService.unit.test.ts` following the file's existing conventions (`vi.spyOn` mocks of `getClickhouseRecord` / `getPrompt` / `getGenerationUsage`, asserting both queued records).
- The worker package was installable in our environment, so contrary to a typical fork-PR limitation this test **was run locally**: targeted run passes (1 passed | 12 skipped), and the full file passes (13/13). We also confirmed the test fails on unfixed `upstream/main` code (regression lock).
- Not covered locally: the wider CI matrix (lint, typecheck across packages, E2E/integration suites against live ClickHouse/Postgres). Full-suite coverage happens in CI.
- No DCO sign-off added (none required); CLA will be signed via the CLA assistant bot.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- My changes generate no new warnings
- I have added tests that prove my fix is effective
- I have checked that existing unit tests pass locally with my changes
