### PR TITLE
refactor(web): Create more feature dirs in storybook

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -26,10 +26,20 @@ const DESIGN_COMPONENT_STORIES = [
 // Directories that get their own sidebar section instead of the flat
 // Playground default. This is not a `stories` entry with a `titlePrefix`
 // because story titles are injected into each meta — see StoryTitleGroup.
+// Only stories inside a configured directory can appear under its feature;
+// explicit story titles are rejected by the title plugin.
 const STORY_TITLE_GROUPS: StoryTitleGroup[] = [
   {
     directory: "src/features/evals/v2/components",
     titlePrefix: "Features/Evaluations",
+  },
+  {
+    directory: "src/features/in-app-agent/components",
+    titlePrefix: "Features/In-App Agent",
+  },
+  {
+    directory: "src/features/traces/components",
+    titlePrefix: "Features/Traces",
   },
 ];
 const DESIGN_REFERENCE_STORIES = [


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16521.preview.langfuse.com](https://pr-16521.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands Storybook’s feature-specific sidebar organization.
- Groups in-app agent component stories under `Features/In-App Agent`.
- Groups trace component stories under `Features/Traces`.
- Documents that grouped stories cannot declare explicit titles.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The newly grouped directories match the title plugin’s path rules, their existing stories remain included, and none declares an explicit meta title that would trigger validation failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Create more feature dirs ..."](https://github.com/langfuse/langfuse/commit/c66cdb41469eec9676170520ff1cf671ad6e35d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56586196)</sub>

<!-- /greptile_comment -->