### PR TITLE
feat(datasets): add PATCH endpoint for partial dataset updates

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -2,6 +2,7 @@
 imports:
   commons: ./commons.yml
   pagination: ./utils/pagination.yml
+  unstableErrors: ./unstable/errors.yml
 service:
   auth: true
   base-path: /api/public
@@ -33,6 +34,38 @@ service:
       path: /v2/datasets
       request: CreateDatasetRequest
       response: commons.Dataset
+    update:
+      method: PATCH
+      docs: |
+        Partially update a dataset. Omitted fields are left unchanged; pass
+        `null` for `description`, `metadata`, `inputSchema`, or
+        `expectedOutputSchema` to clear them.
+
+        Renaming a dataset (`name`) changes the URL used to address it, since
+        this API is keyed by name.
+
+        Setting `inputSchema` or `expectedOutputSchema` to a non-null value
+        validates all existing dataset items against it; the request fails
+        with `schema_validation_failed` if any item does not conform.
+
+        This endpoint returns the structured error contract documented on
+        `unstableErrors.PublicApiError` (`message`, `code`, optional
+        `details`) instead of the `message`/`error` shape used by other
+        dataset endpoints.
+      path: /v2/datasets/{datasetName}
+      path-parameters:
+        datasetName: string
+      request: UpdateDatasetRequest
+      response: commons.Dataset
+      errors:
+        - unstableErrors.BadRequestError
+        - unstableErrors.UnauthorizedError
+        - unstableErrors.AccessDeniedError
+        - unstableErrors.NotFoundError
+        - unstableErrors.MethodNotAllowedError
+        - unstableErrors.ConflictError
+        - unstableErrors.TooManyRequestsError
+        - unstableErrors.InternalServerError
     getRun:
       availability:
         status: deprecated
@@ -91,6 +124,23 @@ types:
       expectedOutputSchema:
         type: optional<unknown>
         docs: JSON Schema for validating dataset item expected outputs. When set, all new and existing dataset items will be validated against this schema.
+  UpdateDatasetRequest:
+    properties:
+      name:
+        type: optional<string>
+        docs: New name for the dataset. Renaming changes the URL used to address this dataset, since this API is keyed by name.
+      description:
+        type: optional<nullable<string>>
+        docs: Pass `null` to clear the existing description.
+      metadata:
+        type: optional<nullable<unknown>>
+        docs: Replaces the existing metadata. Pass `null` to clear it.
+      inputSchema:
+        type: optional<nullable<unknown>>
+        docs: JSON Schema for validating dataset item inputs. A non-null value is validated against all existing dataset items. Pass `null` to remove the schema.
+      expectedOutputSchema:
+        type: optional<nullable<unknown>>
+        docs: JSON Schema for validating dataset item expected outputs. A non-null value is validated against all existing dataset items. Pass `null` to remove the schema.
   PaginatedDatasetRuns:
     properties:
       data: list<commons.DatasetRun>

--- a/fern/apis/server/definition/unstable/errors.yml
+++ b/fern/apis/server/definition/unstable/errors.yml
@@ -2,7 +2,10 @@
 types:
   PublicApiErrorCode:
     docs: |
-      Machine-readable error code returned by the unstable evaluators API.
+      Machine-readable error code. Originates from the unstable evaluators API
+      and is also used by select endpoints on the stable API (currently
+      `PATCH /api/public/v2/datasets/{datasetName}`) that document this
+      contract explicitly.
 
       SDKs, CLIs, and agents should branch on `code` rather than parsing the human-readable `message`.
       The HTTP status still indicates the broad error class, while `code` gives the specific failure reason.
@@ -20,6 +23,7 @@ types:
       - resource_not_found
       - name_conflict
       - evaluator_preflight_failed
+      - schema_validation_failed
       - conflict
       - unprocessable_content
       - rate_limited
@@ -43,6 +47,38 @@ types:
         type: list<unknown>
         docs: Path to the invalid field, for example `["mapping", 0, "jsonPath"]`.
 
+  PublicApiSchemaValidationFieldError:
+    docs: |
+      One JSON Schema validation failure for a single dataset item field.
+    properties:
+      path:
+        type: string
+        docs: JSON pointer to the invalid location within the field's value, for example `/country`.
+      message:
+        type: string
+        docs: Human-readable explanation of the validation failure.
+      keyword:
+        type: optional<string>
+        docs: The JSON Schema keyword that failed, for example `enum` or `additionalProperties`.
+
+  PublicApiSchemaValidationField:
+    docs: Which of a dataset item's fields failed schema validation.
+    enum:
+      - input
+      - expectedOutput
+
+  PublicApiSchemaValidationError:
+    docs: |
+      One dataset item that fails a newly assigned `inputSchema` or `expectedOutputSchema`.
+    properties:
+      datasetItemId:
+        type: string
+        docs: Id of the failing dataset item.
+      field: PublicApiSchemaValidationField
+      errors:
+        type: list<PublicApiSchemaValidationFieldError>
+        docs: Validation failures for this field. Only the first Ajv error per field is reported.
+
   PublicApiErrorDetails:
     docs: |
       Optional structured context attached to an unstable-evals error.
@@ -54,6 +90,7 @@ types:
       - JSONPath validation failures populate `field`, `variable`, and `value`
       - evaluator preflight failures populate `evaluatorName`, `provider`, and `model`
       - rate limiting populates `retryAfterSeconds`, `limit`, `remaining`, and `resetAt`
+      - schema validation failures populate `validationErrors`
     properties:
       issues:
         type: optional<list<PublicApiValidationIssue>>
@@ -100,6 +137,9 @@ types:
       resetAt:
         type: optional<string>
         docs: ISO-8601 timestamp when the current rate-limit window resets.
+      validationErrors:
+        type: optional<list<PublicApiSchemaValidationError>>
+        docs: Dataset items that fail a newly assigned schema. Capped at 10 entries.
 
   PublicApiError:
     docs: |
@@ -188,6 +228,18 @@ types:
             limit: 1000
             remaining: 0
             resetAt: "2026-03-30T10:00:00.000Z"
+      - name: SchemaValidationFailed
+        value:
+          message: Schema validation failed for 1 item(s)
+          code: schema_validation_failed
+          details:
+            validationErrors:
+              - datasetItemId: item-abc
+                field: input
+                errors:
+                  - path: /country
+                    message: must be equal to one of the allowed values
+                    keyword: enum
 
 errors:
   BadRequestError:
@@ -200,11 +252,16 @@ errors:
       - invalid JSONPath selector
       - missing or duplicate variable mappings
 
+      Typical dataset PATCH examples:
+      - the new `name` fails validation
+      - an updated `inputSchema` or `expectedOutputSchema` rejects existing dataset items
+
       Recovery guidance:
       - read `details.issues` for malformed bodies or queries
       - read `details.column`, `details.invalidValues`, and `details.allowedValues` for filter problems
       - for `details.column=datasetId`, call `GET /api/public/v2/datasets` and retry with dataset `id` values from that response
       - read `details.variable` or `details.variables` for mapping problems
+      - read `details.validationErrors` for dataset items that fail a newly assigned schema; fix or remove those items, or relax the schema, then retry
     status-code: 400
     type: PublicApiError
   UnauthorizedError:
@@ -226,7 +283,7 @@ errors:
     status-code: 403
     type: PublicApiError
   NotFoundError:
-    docs: The requested evaluator or evaluation rule does not exist within the authorized project.
+    docs: The requested resource does not exist within the authorized project.
     status-code: 404
     type: PublicApiError
   MethodNotAllowedError:
@@ -237,14 +294,14 @@ errors:
     docs: |
       The request conflicts with existing state.
 
-      Typical unstable-eval examples:
+      Typical examples:
       - evaluator version changed during concurrent creation
-      - an evaluation rule name already exists in the project, so the caller should PATCH the existing resource instead
+      - an evaluation rule or dataset name already exists in the project, so the caller should PATCH the existing resource instead
       - enabling another evaluation rule would exceed the project limit of 500 active evaluation rules
       - the underlying state changed between read and write operations, so the client should retry
 
       Recovery guidance:
-      - for `name_conflict`, PATCH the existing evaluation rule instead of creating another one
+      - for `name_conflict`, PATCH the existing resource instead of creating or renaming into a duplicate
       - for the active-limit conflict, disable another active evaluation rule before enabling a new one
     status-code: 409
     type: PublicApiError

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1407,6 +1407,89 @@ paths:
             application/json:
               schema: {}
       security: *ref_0
+    patch:
+      description: |-
+        Partially update a dataset. Omitted fields are left unchanged; pass
+        `null` for `description`, `metadata`, `inputSchema`, or
+        `expectedOutputSchema` to clear them.
+
+        Renaming a dataset (`name`) changes the URL used to address it, since
+        this API is keyed by name.
+
+        Setting `inputSchema` or `expectedOutputSchema` to a non-null value
+        validates all existing dataset items against it; the request fails
+        with `schema_validation_failed` if any item does not conform.
+
+        This endpoint returns the structured error contract documented on
+        `unstableErrors.PublicApiError` (`message`, `code`, optional
+        `details`) instead of the `message`/`error` shape used by other
+        dataset endpoints.
+      operationId: datasets_update
+      tags:
+        - Datasets
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dataset'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unstablePublicApiError'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unstablePublicApiError'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unstablePublicApiError'
+      security: *ref_0
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDatasetRequest'
   /api/public/datasets/{datasetName}/runs/{runName}:
     get:
       description: >-
@@ -11238,6 +11321,35 @@ components:
             schema.
       required:
         - name
+    UpdateDatasetRequest:
+      title: UpdateDatasetRequest
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+          description: >-
+            New name for the dataset. Renaming changes the URL used to address
+            this dataset, since this API is keyed by name.
+        description:
+          type: string
+          nullable: true
+          description: Pass `null` to clear the existing description.
+        metadata:
+          nullable: true
+          description: Replaces the existing metadata. Pass `null` to clear it.
+        inputSchema:
+          nullable: true
+          description: >-
+            JSON Schema for validating dataset item inputs. A non-null value is
+            validated against all existing dataset items. Pass `null` to remove
+            the schema.
+        expectedOutputSchema:
+          nullable: true
+          description: >-
+            JSON Schema for validating dataset item expected outputs. A non-null
+            value is validated against all existing dataset items. Pass `null`
+            to remove the schema.
     PaginatedDatasetRuns:
       title: PaginatedDatasetRuns
       type: object
@@ -15916,13 +16028,20 @@ components:
         - resource_not_found
         - name_conflict
         - evaluator_preflight_failed
+        - schema_validation_failed
         - conflict
         - unprocessable_content
         - rate_limited
         - method_not_allowed
         - internal_error
       description: >-
-        Machine-readable error code returned by the unstable evaluators API.
+        Machine-readable error code. Originates from the unstable evaluators API
+
+        and is also used by select endpoints on the stable API (currently
+
+        `PATCH /api/public/v2/datasets/{datasetName}`) that document this
+
+        contract explicitly.
 
 
         SDKs, CLIs, and agents should branch on `code` rather than parsing the
@@ -15959,6 +16078,58 @@ components:
         - code
         - message
         - path
+    unstablePublicApiSchemaValidationFieldError:
+      title: unstablePublicApiSchemaValidationFieldError
+      type: object
+      description: One JSON Schema validation failure for a single dataset item field.
+      properties:
+        path:
+          type: string
+          description: >-
+            JSON pointer to the invalid location within the field's value, for
+            example `/country`.
+        message:
+          type: string
+          description: Human-readable explanation of the validation failure.
+        keyword:
+          type: string
+          nullable: true
+          description: >-
+            The JSON Schema keyword that failed, for example `enum` or
+            `additionalProperties`.
+      required:
+        - path
+        - message
+    unstablePublicApiSchemaValidationField:
+      title: unstablePublicApiSchemaValidationField
+      type: string
+      enum:
+        - input
+        - expectedOutput
+      description: Which of a dataset item's fields failed schema validation.
+    unstablePublicApiSchemaValidationError:
+      title: unstablePublicApiSchemaValidationError
+      type: object
+      description: >-
+        One dataset item that fails a newly assigned `inputSchema` or
+        `expectedOutputSchema`.
+      properties:
+        datasetItemId:
+          type: string
+          description: Id of the failing dataset item.
+        field:
+          $ref: '#/components/schemas/unstablePublicApiSchemaValidationField'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/unstablePublicApiSchemaValidationFieldError'
+          description: >-
+            Validation failures for this field. Only the first Ajv error per
+            field is reported.
+      required:
+        - datasetItemId
+        - field
+        - errors
     unstablePublicApiErrorDetails:
       title: unstablePublicApiErrorDetails
       type: object
@@ -15982,6 +16153,8 @@ components:
 
         - rate limiting populates `retryAfterSeconds`, `limit`, `remaining`, and
         `resetAt`
+
+        - schema validation failures populate `validationErrors`
       properties:
         issues:
           type: array
@@ -16057,6 +16230,14 @@ components:
           type: string
           nullable: true
           description: ISO-8601 timestamp when the current rate-limit window resets.
+        validationErrors:
+          type: array
+          items:
+            $ref: '#/components/schemas/unstablePublicApiSchemaValidationError'
+          nullable: true
+          description: >-
+            Dataset items that fail a newly assigned schema. Capped at 10
+            entries.
     unstablePublicApiError:
       title: unstablePublicApiError
       type: object

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -22,6 +22,7 @@ import {
   GetDatasetV2Response,
   GetDatasetsV1Response,
   GetDatasetsV2Response,
+  PatchDatasetV2Response,
   PostDatasetItemsV1Response,
   PostDatasetRunItemsV1Response,
   PostDatasetsV1Response,
@@ -1869,6 +1870,233 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
 
     expect(deleteRes.status).toBe(200);
   }, 90000);
+
+  describe("PATCH /api/public/v2/datasets/{datasetName}", () => {
+    it("should rename a dataset and make it addressable under the new name", async () => {
+      const oldName = `patch-rename-old-${v4()}`;
+      const newName = `patch-rename-new-${v4()}`;
+
+      await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        { name: oldName },
+        auth,
+      );
+
+      const patchRes = await makeZodVerifiedAPICall(
+        PatchDatasetV2Response,
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(oldName)}`,
+        { name: newName },
+        auth,
+      );
+      expect(patchRes.body.name).toBe(newName);
+
+      const oldNameRes = await makeAPICall(
+        "GET",
+        `/api/public/v2/datasets/${encodeURIComponent(oldName)}`,
+        undefined,
+        auth,
+      );
+      expect(oldNameRes.status).toBe(404);
+
+      const newNameRes = await makeZodVerifiedAPICall(
+        GetDatasetV2Response,
+        "GET",
+        `/api/public/v2/datasets/${encodeURIComponent(newName)}`,
+        undefined,
+        auth,
+      );
+      expect(newNameRes.body.name).toBe(newName);
+    });
+
+    it("should rename datasets across folder paths", async () => {
+      const flatName = `patch-flat-${v4()}`;
+      const nestedName = `folder/patch-nested-${v4()}`;
+      const otherNestedName = `folder/patch-other-nested-${v4()}`;
+
+      await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        { name: flatName },
+        auth,
+      );
+
+      // flat name -> nested folder path
+      const toNested = await makeZodVerifiedAPICall(
+        PatchDatasetV2Response,
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(flatName)}`,
+        { name: nestedName },
+        auth,
+      );
+      expect(toNested.body.name).toBe(nestedName);
+
+      // nested folder path -> another nested folder path
+      const toOtherNested = await makeZodVerifiedAPICall(
+        PatchDatasetV2Response,
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(nestedName)}`,
+        { name: otherNestedName },
+        auth,
+      );
+      expect(toOtherNested.body.name).toBe(otherNestedName);
+
+      const finalRes = await makeZodVerifiedAPICall(
+        GetDatasetV2Response,
+        "GET",
+        `/api/public/v2/datasets/${encodeURIComponent(otherNestedName)}`,
+        undefined,
+        auth,
+      );
+      expect(finalRes.body.name).toBe(otherNestedName);
+    });
+
+    it("should leave omitted fields unchanged and only update what is provided", async () => {
+      const datasetName = `patch-partial-${v4()}`;
+
+      const created = await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        {
+          name: datasetName,
+          description: "original description",
+          metadata: { original: true },
+        },
+        auth,
+      );
+      expect(created.body.description).toBe("original description");
+
+      const patchRes = await makeZodVerifiedAPICall(
+        PatchDatasetV2Response,
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(datasetName)}`,
+        { metadata: { updated: true } },
+        auth,
+      );
+
+      expect(patchRes.body.description).toBe("original description");
+      expect(patchRes.body.metadata).toEqual({ updated: true });
+      expect(patchRes.body.name).toBe(datasetName);
+    });
+
+    it("should clear description and metadata when explicitly set to null", async () => {
+      const datasetName = `patch-clear-${v4()}`;
+
+      await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        {
+          name: datasetName,
+          description: "to be cleared",
+          metadata: { toBeCleared: true },
+        },
+        auth,
+      );
+
+      const patchRes = await makeZodVerifiedAPICall(
+        PatchDatasetV2Response,
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(datasetName)}`,
+        { description: null, metadata: null },
+        auth,
+      );
+
+      expect(patchRes.body.description).toBeNull();
+      expect(patchRes.body.metadata).toBeNull();
+    });
+
+    it("should return a structured 404 for an unknown dataset", async () => {
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(`does-not-exist-${v4()}`)}`,
+        { description: "irrelevant" },
+        auth,
+      );
+
+      expect(res.status).toBe(404);
+      expect((res.body as any).code).toBe("resource_not_found");
+    });
+
+    it("should return a structured 409 when renaming onto an existing dataset name", async () => {
+      const nameA = `patch-conflict-a-${v4()}`;
+      const nameB = `patch-conflict-b-${v4()}`;
+
+      await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        { name: nameA },
+        auth,
+      );
+      await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        { name: nameB },
+        auth,
+      );
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(nameA)}`,
+        { name: nameB },
+        auth,
+      );
+
+      expect(res.status).toBe(409);
+      expect((res.body as any).code).toBe("name_conflict");
+    });
+
+    it("should return a structured 400 for an invalid new name", async () => {
+      const datasetName = `patch-invalid-name-${v4()}`;
+
+      await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        { name: datasetName },
+        auth,
+      );
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(datasetName)}`,
+        { name: "/leading-slash-not-allowed" },
+        auth,
+      );
+
+      expect(res.status).toBe(400);
+      expect((res.body as any).code).toBe("invalid_request");
+    });
+
+    it("should return a structured 400 for a malformed request body", async () => {
+      const datasetName = `patch-malformed-body-${v4()}`;
+
+      await makeZodVerifiedAPICall(
+        PostDatasetsV2Response,
+        "POST",
+        "/api/public/v2/datasets",
+        { name: datasetName },
+        auth,
+      );
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(datasetName)}`,
+        { name: 123 },
+        auth,
+      );
+
+      expect(res.status).toBe(400);
+      expect((res.body as any).code).toBe("invalid_body");
+      expect((res.body as any).details?.issues).toBeDefined();
+    });
+  });
 
   it("should support dataset versioning via version query parameter", async () => {
     const datasetName = `versioned-dataset-${v4()}`;

--- a/web/src/__tests__/server/datasets-schema-validation.servertest.ts
+++ b/web/src/__tests__/server/datasets-schema-validation.servertest.ts
@@ -7,6 +7,7 @@ import {
 import {
   PostDatasetsV2Response,
   PostDatasetItemsV1Response,
+  PatchDatasetV2Response,
 } from "@/src/features/public-api/types/datasets";
 import {
   createOrgProjectAndApiKey,
@@ -598,6 +599,105 @@ describe("Public API - Dataset Schema Enforcement", () => {
 
       expect(res.status).toBe(400);
       expect((res.body as any).message).toContain("validation failed");
+    });
+  });
+
+  describe("PATCH /api/public/v2/datasets/{datasetName} - Schema Validation", () => {
+    it("should block setting a schema that existing items fail with a structured error", async () => {
+      const patchFailDatasetName = uniqueDatasetName("patch-fail");
+      await makeAPICall(
+        "POST",
+        "/api/public/v2/datasets",
+        { name: patchFailDatasetName },
+        auth,
+      );
+
+      const item = await makeAPICall(
+        "POST",
+        "/api/public/dataset-items",
+        {
+          datasetName: patchFailDatasetName,
+          input: { text: 123 }, // Invalid for simpleText schema
+        },
+        auth,
+      );
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(patchFailDatasetName)}`,
+        { inputSchema: TEST_SCHEMAS.simpleText },
+        auth,
+      );
+
+      expect(res.status).toBe(400);
+      const body = res.body as any;
+      expect(body.code).toBe("schema_validation_failed");
+      expect(body.message).toContain("validation failed");
+      expect(body.details.validationErrors).toEqual([
+        expect.objectContaining({
+          datasetItemId: (item.body as any).id,
+          field: "input",
+          errors: [
+            expect.objectContaining({
+              path: expect.any(String),
+              message: expect.any(String),
+            }),
+          ],
+        }),
+      ]);
+    });
+
+    it("should persist a schema that all existing items satisfy", async () => {
+      const patchPassDatasetName = uniqueDatasetName("patch-pass");
+      await makeAPICall(
+        "POST",
+        "/api/public/v2/datasets",
+        { name: patchPassDatasetName },
+        auth,
+      );
+
+      await makeAPICall(
+        "POST",
+        "/api/public/dataset-items",
+        {
+          datasetName: patchPassDatasetName,
+          input: { text: "valid" },
+        },
+        auth,
+      );
+
+      const res = await makeZodVerifiedAPICall(
+        PatchDatasetV2Response,
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(patchPassDatasetName)}`,
+        { inputSchema: TEST_SCHEMAS.simpleText },
+        auth,
+      );
+
+      expect(res.body.inputSchema).toEqual(TEST_SCHEMAS.simpleText);
+    });
+
+    it("should clear an existing schema when set to null", async () => {
+      const patchClearDatasetName = uniqueDatasetName("patch-clear-schema");
+      await makeAPICall(
+        "POST",
+        "/api/public/v2/datasets",
+        {
+          name: patchClearDatasetName,
+          inputSchema: TEST_SCHEMAS.simpleText,
+        },
+        auth,
+      );
+
+      const res = await makeZodVerifiedAPICall(
+        PatchDatasetV2Response,
+        "PATCH",
+        `/api/public/v2/datasets/${encodeURIComponent(patchClearDatasetName)}`,
+        { inputSchema: null },
+        auth,
+      );
+
+      expect(res.body.inputSchema).toBeNull();
     });
   });
 

--- a/web/src/__tests__/server/unit/with-middlewares-structured-errors.servertest.ts
+++ b/web/src/__tests__/server/unit/with-middlewares-structured-errors.servertest.ts
@@ -1,0 +1,150 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { LangfuseNotFoundError } from "@langfuse/shared";
+
+const {
+  mockLoggerWarn,
+  mockLoggerError,
+  mockLoggerInfo,
+  mockTraceException,
+  MockClickHouseResourceError,
+} = vi.hoisted(() => ({
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockTraceException: vi.fn(),
+  MockClickHouseResourceError: class MockClickHouseResourceError extends (
+    Error
+  ) {},
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  redis: null,
+  logger: {
+    debug: vi.fn(),
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+  },
+  traceException: mockTraceException,
+  contextWithLangfuseProps: vi.fn(() => ({})),
+  ClickHouseResourceError: MockClickHouseResourceError,
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn(async () => undefined),
+    }),
+  },
+}));
+
+vi.mock("@/src/utils/exceptions", () => ({
+  isPrismaException: vi.fn(() => false),
+}));
+
+vi.mock("@/src/features/public-api/server/cors", () => ({
+  cors: vi.fn(),
+  runMiddleware: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/src/features/public-api/server/clickHouseRequestTags", () => ({
+  clickHouseRouteForRequest: vi.fn(() => "test-route"),
+}));
+
+vi.mock("@opentelemetry/api", () => ({
+  context: {
+    with: vi.fn(async (_ctx: unknown, fn: () => unknown) => await fn()),
+  },
+}));
+
+// This test exercises the REAL withMiddlewares and the REAL
+// unstable-public-api-error-contract module, so it verifies the actual
+// wire-format decision, not a mocked stand-in.
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { createUnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
+
+describe("withMiddlewares - structured error rendering", () => {
+  const createReqRes = () =>
+    createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      headers: {},
+    });
+
+  it("renders a plain BaseError with the legacy {message, error} shape on a file with no error contract", async () => {
+    const { req, res } = createReqRes();
+
+    const handler = withMiddlewares({
+      GET: async () => {
+        throw new LangfuseNotFoundError("Dataset not found");
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      message: "Dataset not found",
+      error: "LangfuseNotFoundError",
+    });
+  });
+
+  it("renders an UnstablePublicApiError with the structured {message, code} shape even on a file with no error contract", async () => {
+    const { req, res } = createReqRes();
+
+    const handler = withMiddlewares({
+      GET: async () => {
+        throw createUnstablePublicApiError({
+          httpCode: 404,
+          code: "resource_not_found",
+          message: "Dataset not found",
+        });
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      message: "Dataset not found",
+      code: "resource_not_found",
+    });
+  });
+
+  it("renders an UnstablePublicApiError with details when provided", async () => {
+    const { req, res } = createReqRes();
+
+    const handler = withMiddlewares({
+      GET: async () => {
+        throw createUnstablePublicApiError({
+          httpCode: 400,
+          code: "schema_validation_failed",
+          message: "Schema validation failed for 1 item(s)",
+          details: {
+            validationErrors: [
+              {
+                datasetItemId: "item-1",
+                field: "input",
+                errors: [{ path: "/country", message: "must be enum" }],
+              },
+            ],
+          },
+        });
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      message: "Schema validation failed for 1 item(s)",
+      code: "schema_validation_failed",
+      details: {
+        validationErrors: [
+          {
+            datasetItemId: "item-1",
+            field: "input",
+            errors: [{ path: "/country", message: "must be enum" }],
+          },
+        ],
+      },
+    });
+  });
+});

--- a/web/src/features/datasets/server/actions/createDataset.ts
+++ b/web/src/features/datasets/server/actions/createDataset.ts
@@ -5,12 +5,62 @@ import {
   Prisma,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { validateAllDatasetItems } from "@langfuse/shared/src/server";
+import {
+  validateAllDatasetItems,
+  type ValidationResult,
+} from "@langfuse/shared/src/server";
 
 type DatasetJson =
   | Prisma.InputJsonObject
   | Prisma.JsonValue
   | typeof Prisma.DbNull;
+
+/**
+ * Runs validateAllDatasetItems only when a schema is actually changing, using
+ * the final (post-update) schema values. Shared by the POST upsert path and
+ * the public API PATCH update path so both apply the identical check; each
+ * caller decides how to surface a failing ValidationResult.
+ */
+export const validateDatasetSchemaUpdate = async ({
+  projectId,
+  datasetId,
+  currentInputSchema,
+  currentExpectedOutputSchema,
+  nextInputSchema,
+  nextExpectedOutputSchema,
+}: {
+  projectId: string;
+  datasetId: string;
+  currentInputSchema: Record<string, unknown> | null;
+  currentExpectedOutputSchema: Record<string, unknown> | null;
+  nextInputSchema?: Record<string, unknown> | null;
+  nextExpectedOutputSchema?: Record<string, unknown> | null;
+}): Promise<ValidationResult | null> => {
+  const isSettingInputSchema = nextInputSchema !== undefined;
+  const isSettingExpectedOutputSchema = nextExpectedOutputSchema !== undefined;
+
+  if (!isSettingInputSchema && !isSettingExpectedOutputSchema) {
+    return null;
+  }
+
+  const finalInputSchema = isSettingInputSchema
+    ? nextInputSchema
+    : currentInputSchema;
+  const finalExpectedOutputSchema = isSettingExpectedOutputSchema
+    ? nextExpectedOutputSchema
+    : currentExpectedOutputSchema;
+
+  if (finalInputSchema === null && finalExpectedOutputSchema === null) {
+    return null;
+  }
+
+  return validateAllDatasetItems({
+    datasetId,
+    projectId,
+    inputSchema: finalInputSchema,
+    expectedOutputSchema: finalExpectedOutputSchema,
+  });
+};
 
 type UpsertDatasetInput = {
   id?: string;
@@ -92,37 +142,28 @@ export const upsertDataset = async ({
 
   // If updating and schemas are being set, validate all existing items
   if (existingDataset) {
-    const isSettingInputSchema = input.inputSchema !== undefined;
-    const isSettingExpectedOutputSchema =
-      input.expectedOutputSchema !== undefined;
+    const validationResult = await validateDatasetSchemaUpdate({
+      projectId,
+      datasetId: existingDataset.id,
+      currentInputSchema: existingDataset.inputSchema as Record<
+        string,
+        unknown
+      > | null,
+      currentExpectedOutputSchema: existingDataset.expectedOutputSchema as Record<
+        string,
+        unknown
+      > | null,
+      nextInputSchema: input.inputSchema as Record<string, unknown> | null,
+      nextExpectedOutputSchema: input.expectedOutputSchema as Record<
+        string,
+        unknown
+      > | null,
+    });
 
-    if (isSettingInputSchema || isSettingExpectedOutputSchema) {
-      // Determine final schemas after update
-      const finalInputSchema = isSettingInputSchema
-        ? input.inputSchema
-        : existingDataset.inputSchema;
-      const finalExpectedOutputSchema = isSettingExpectedOutputSchema
-        ? input.expectedOutputSchema
-        : existingDataset.expectedOutputSchema;
-
-      // Validate if any schema is being set (not null)
-      if (finalInputSchema !== null || finalExpectedOutputSchema !== null) {
-        const validationResult = await validateAllDatasetItems({
-          datasetId: existingDataset.id,
-          projectId,
-          inputSchema: finalInputSchema as Record<string, unknown> | null,
-          expectedOutputSchema: finalExpectedOutputSchema as Record<
-            string,
-            unknown
-          > | null,
-        });
-
-        if (!validationResult.isValid) {
-          throw new InvalidRequestError(
-            `Schema validation failed for ${validationResult.errors.length === 10 ? "more than 10" : validationResult.errors.length} item(s). Details: ${JSON.stringify(validationResult.errors)}`,
-          );
-        }
-      }
+    if (validationResult && !validationResult.isValid) {
+      throw new InvalidRequestError(
+        `Schema validation failed for ${validationResult.errors.length === 10 ? "more than 10" : validationResult.errors.length} item(s). Details: ${JSON.stringify(validationResult.errors)}`,
+      );
     }
   }
 

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -18,6 +18,7 @@ import {
   type GetDatasetRunsV1Query,
   type GetDatasetsV2Query,
   type GetDatasetV2Query,
+  type PatchDatasetV2Body,
   type PostDatasetRunItemsV1Body,
   type PostDatasetsV1Body,
   type PostDatasetsV2Body,
@@ -29,6 +30,7 @@ import {
 } from "@/src/features/public-api/types/datasets";
 import {
   ApiError,
+  DatasetNameSchema,
   type JSONValue,
   LangfuseConflictError,
   LangfuseNotFoundError,
@@ -41,7 +43,11 @@ import {
   datasetItemMediaReferenceKey,
   resolveDatasetItemMediaReferences,
 } from "@/src/features/media/server/datasetItemMediaReferences";
-import { upsertDataset } from "./actions/createDataset";
+import {
+  upsertDataset,
+  validateDatasetSchemaUpdate,
+} from "./actions/createDataset";
+import { createUnstablePublicApiError } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import {
   addToDeleteDatasetQueue,
   createDatasetItemFilterState,
@@ -289,6 +295,144 @@ export const createDatasetForApi = async ({
       orgId: auditScope.orgId,
       apiKeyId: auditScope.apiKeyId,
       before: existingDataset ?? undefined,
+      after: dataset,
+    });
+  }
+
+  return transformDbDatasetToAPIDataset(dataset);
+};
+
+export const updateDatasetForApi = async ({
+  datasetName,
+  body,
+  projectId,
+  auditScope,
+}: {
+  datasetName: string;
+  body: z.infer<typeof PatchDatasetV2Body>;
+  projectId: string;
+  auditScope?: DatasetAuditScope;
+}) => {
+  const existingDataset = await prisma.dataset.findFirst({
+    where: { name: datasetName, projectId },
+  });
+
+  if (!existingDataset) {
+    throw createUnstablePublicApiError({
+      httpCode: 404,
+      code: "resource_not_found",
+      message: "Dataset not found",
+    });
+  }
+
+  const isRenaming =
+    body.name !== undefined && body.name !== existingDataset.name;
+
+  if (isRenaming) {
+    const validation = DatasetNameSchema.safeParse(body.name);
+    if (!validation.success) {
+      throw createUnstablePublicApiError({
+        httpCode: 400,
+        code: "invalid_request",
+        message: "Dataset name not valid. " + validation.error.message,
+      });
+    }
+
+    const conflictingDataset = await prisma.dataset.findUnique({
+      where: { projectId_name: { projectId, name: body.name as string } },
+      select: { id: true },
+    });
+
+    if (conflictingDataset) {
+      throw createUnstablePublicApiError({
+        httpCode: 409,
+        code: "name_conflict",
+        message: "Dataset name already in use",
+      });
+    }
+  }
+
+  const validationResult = await validateDatasetSchemaUpdate({
+    projectId,
+    datasetId: existingDataset.id,
+    currentInputSchema: existingDataset.inputSchema as Record<
+      string,
+      unknown
+    > | null,
+    currentExpectedOutputSchema: existingDataset.expectedOutputSchema as Record<
+      string,
+      unknown
+    > | null,
+    nextInputSchema: body.inputSchema as
+      | Record<string, unknown>
+      | null
+      | undefined,
+    nextExpectedOutputSchema: body.expectedOutputSchema as
+      | Record<string, unknown>
+      | null
+      | undefined,
+  });
+
+  if (validationResult && !validationResult.isValid) {
+    throw createUnstablePublicApiError({
+      httpCode: 400,
+      code: "schema_validation_failed",
+      message: `Schema validation failed for ${validationResult.errors.length === 10 ? "more than 10" : validationResult.errors.length} item(s)`,
+      details: { validationErrors: validationResult.errors },
+    });
+  }
+
+  let dataset;
+  try {
+    dataset = await prisma.dataset.update({
+      where: { id_projectId: { id: existingDataset.id, projectId } },
+      data: {
+        name: body.name,
+        description: body.description,
+        metadata:
+          body.metadata === undefined
+            ? undefined
+            : body.metadata === null
+              ? Prisma.DbNull
+              : body.metadata,
+        inputSchema:
+          body.inputSchema === undefined
+            ? undefined
+            : body.inputSchema === null
+              ? Prisma.DbNull
+              : body.inputSchema,
+        expectedOutputSchema:
+          body.expectedOutputSchema === undefined
+            ? undefined
+            : body.expectedOutputSchema === null
+              ? Prisma.DbNull
+              : body.expectedOutputSchema,
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw createUnstablePublicApiError({
+        httpCode: 409,
+        code: "name_conflict",
+        message: "Dataset name already in use",
+      });
+    }
+
+    throw error;
+  }
+
+  if (auditScope) {
+    await auditLog({
+      action: "update",
+      resourceType: "dataset",
+      resourceId: dataset.id,
+      projectId,
+      orgId: auditScope.orgId,
+      apiKeyId: auditScope.apiKeyId,
+      before: existingDataset,
       after: dataset,
     });
   }

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -20,6 +20,7 @@ import {
   sendUnstablePublicApiErrorResponse,
   toUnstablePublicApiError,
   unstablePublicEvalsErrorContract,
+  UnstablePublicApiError,
   type PublicApiErrorContract,
 } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import { clickHouseRouteForRequest } from "@/src/features/public-api/server/clickHouseRequestTags";
@@ -137,6 +138,19 @@ export function withMiddlewares(
             message: errorMessage,
             error: "Request timed out",
           });
+        }
+
+        // Errors that already carry the structured {message, code, details}
+        // contract render that way even on routes whose file-level default is
+        // the legacy {message, error} shape - this lets a single route adopt
+        // the structured contract without changing sibling routes in the same
+        // file.
+        if (error instanceof UnstablePublicApiError) {
+          logBaseError(error);
+          if (error.httpCode >= 500 && error.httpCode < 600) {
+            traceException(error);
+          }
+          return sendUnstablePublicApiErrorResponse(res, error);
         }
 
         if (options?.errorContract === unstablePublicEvalsErrorContract) {

--- a/web/src/features/public-api/shared/unstable-public-api-error-schema.ts
+++ b/web/src/features/public-api/shared/unstable-public-api-error-schema.ts
@@ -15,6 +15,7 @@ export const unstablePublicApiErrorCodes = [
   "name_conflict",
   "evaluator_in_use",
   "evaluator_preflight_failed",
+  "schema_validation_failed",
   "conflict",
   "unprocessable_content",
   "rate_limited",
@@ -31,6 +32,22 @@ const UnstablePublicApiValidationIssue = z
     path: z.array(z.union([z.string(), z.number()])),
   })
   .loose();
+
+const UnstablePublicApiSchemaValidationFieldError = z
+  .object({
+    path: z.string(),
+    message: z.string(),
+    keyword: z.string().optional(),
+  })
+  .strict();
+
+const UnstablePublicApiSchemaValidationError = z
+  .object({
+    datasetItemId: z.string(),
+    field: z.enum(["input", "expectedOutput"]),
+    errors: z.array(UnstablePublicApiSchemaValidationFieldError),
+  })
+  .strict();
 
 export const UnstablePublicApiErrorDetails = z
   .object({
@@ -49,6 +66,7 @@ export const UnstablePublicApiErrorDetails = z
     limit: z.number().int().positive().optional(),
     remaining: z.number().int().nonnegative().optional(),
     resetAt: z.string().optional(),
+    validationErrors: z.array(UnstablePublicApiSchemaValidationError).optional(),
   })
   .strict();
 

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -178,6 +178,19 @@ export const GetDatasetV2Query = z.object({
 });
 export const GetDatasetV2Response = APIDataset.strict();
 
+// PATCH /v2/datasets/{datasetName}
+export const PatchDatasetV2Query = z.object({
+  datasetName: queryStringZod,
+});
+export const PatchDatasetV2Body = z.object({
+  name: z.string().optional(),
+  description: z.string().nullish(),
+  metadata: jsonSchema.nullish(),
+  inputSchema: DatasetJSONSchema.nullish(),
+  expectedOutputSchema: DatasetJSONSchema.nullish(),
+});
+export const PatchDatasetV2Response = APIDataset.strict();
+
 // GET /datasets/{name}/runs
 export const GetDatasetRunsV1Query = z.object({
   name: queryStringZod, // dataset name from URL, name as it is v1

--- a/web/src/pages/api/public/v2/datasets/[datasetName]/index.ts
+++ b/web/src/pages/api/public/v2/datasets/[datasetName]/index.ts
@@ -2,10 +2,15 @@ import { prisma } from "@langfuse/shared/src/db";
 import {
   GetDatasetV2Query,
   GetDatasetV2Response,
+  PatchDatasetV2Body,
+  PatchDatasetV2Query,
+  PatchDatasetV2Response,
   transformDbDatasetToAPIDataset,
 } from "@/src/features/public-api/types/datasets";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import { unstablePublicEvalsErrorContract } from "@/src/features/public-api/server/unstable-public-api-error-contract";
+import { updateDatasetForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { LangfuseNotFoundError } from "@langfuse/shared";
 
 export default withMiddlewares({
@@ -28,6 +33,22 @@ export default withMiddlewares({
         throw new LangfuseNotFoundError("Dataset not found");
       }
       return transformDbDatasetToAPIDataset(dataset);
+    },
+  }),
+  PATCH: createAuthedProjectAPIRoute({
+    name: "Update Dataset",
+    querySchema: PatchDatasetV2Query,
+    bodySchema: PatchDatasetV2Body,
+    responseSchema: PatchDatasetV2Response,
+    rateLimitResource: "datasets",
+    errorContract: unstablePublicEvalsErrorContract,
+    fn: async ({ query, body, auth }) => {
+      return updateDatasetForApi({
+        datasetName: query.datasetName,
+        body,
+        projectId: auth.scope.projectId,
+        auditScope: auth.scope,
+      });
     },
   }),
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16524.preview.langfuse.com](https://pr-16524.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a public PATCH endpoint for partial dataset updates, including renaming, nullable field clearing, schema validation, structured errors, API contracts, and server tests.
- Adds project-scoped dataset updates with audit logging and conflict handling.
- Validates existing items before assigning input or expected-output schemas.
- Extends Fern/OpenAPI and shared structured-error schemas for the endpoint.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The schema-update race should be fixed before merging because a successful PATCH can leave the dataset inconsistent with its newly persisted schema.

Validation of existing items and persistence of the new schema are not serialized with dataset-item writes, allowing a concurrent item to be accepted under the old schema and remain after the new schema is committed.

**Files Needing Attention:** web/src/features/datasets/server/publicDatasetService.ts; packages/shared/src/server/repositories/dataset-items.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant P as PATCH schema update
  participant DB as Database
  participant I as Concurrent item write
  P->>DB: Read dataset and old schema
  P->>DB: Validate current items against new schema
  I->>DB: Read old schema
  I->>I: Validate new item against old schema
  I->>DB: Persist item
  P->>DB: Persist new schema
  Note over DB: Dataset may now contain an item invalid under the new schema
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/server/publicDatasetService.ts:355
**Schema update races item writes**

If a dataset item is written concurrently with this PATCH, validation can finish before that item is persisted while the item is independently validated against the old schema. The PATCH then commits the new schema, leaving a dataset item that violates it despite returning success.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(datasets): add PATCH endpoint for p..."](https://github.com/langfuse/langfuse/commit/bfcb67db9f263e3cde62427ced3106c3e4e5332d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56591289)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->