### PR TITLE
fix(automations): require fresh tokens for dispatch URL changes (v3 backport of #16479)

### DIFF
--- a/web/src/__tests__/server/automations-trpc.servertest.ts
+++ b/web/src/__tests__/server/automations-trpc.servertest.ts
@@ -2657,7 +2657,7 @@ describe("automations trpc", () => {
   });
 
   describe("automations.updateAutomation with GITHUB_DISPATCH", () => {
-    it("should update GitHub dispatch automation URL without requiring token", async () => {
+    it("should reject a GitHub dispatch URL update without a new token", async () => {
       const { project, caller } = await prepare();
 
       // Create initial automation
@@ -2696,42 +2696,34 @@ describe("automations trpc", () => {
         },
       });
 
-      // Update URL and event type without providing new token
-      const response = await caller.automations.updateAutomation({
-        projectId: project.id,
-        automationId: automation.id,
-        name: "Updated GitHub Dispatch",
-        eventSource: "prompt",
-        eventAction: ["created", "updated"],
-        filter: [],
-        status: JobConfigState.ACTIVE,
-        actionType: "GITHUB_DISPATCH",
-        actionConfig: {
-          type: "GITHUB_DISPATCH",
-          url: "https://api.github.com/repos/owner/new-repo/dispatches",
-          eventType: "new-event",
-          githubToken: "", // Empty token means keep existing
-        },
-      });
-
-      expect(response.action.id).toBe(action.id);
-      expect(response.action.type).toBe("GITHUB_DISPATCH");
-
-      const config = response.action.config as any;
-      expect(config.url).toBe(
-        "https://api.github.com/repos/owner/new-repo/dispatches",
+      await expect(
+        caller.automations.updateAutomation({
+          projectId: project.id,
+          automationId: automation.id,
+          name: "Updated GitHub Dispatch",
+          eventSource: "prompt",
+          eventAction: ["created", "updated"],
+          filter: [],
+          status: JobConfigState.ACTIVE,
+          actionType: "GITHUB_DISPATCH",
+          actionConfig: {
+            type: "GITHUB_DISPATCH",
+            url: "https://api.github.com/repos/owner/new-repo/dispatches",
+            eventType: "new-event",
+          },
+        }),
+      ).rejects.toThrow(
+        "GitHub Personal Access Token is required when changing the dispatch URL",
       );
-      expect(config.eventType).toBe("new-event");
-      expect(config.displayGitHubToken).toBe("ghp_...ken"); // Preserved
 
-      // Verify secrets not exposed in response
-      expect(config).not.toHaveProperty("githubToken");
-
-      // Verify the automation name was updated
-      const updatedAutomation = await prisma.automation.findFirst({
-        where: { id: automation.id },
+      const unchangedAction = await prisma.action.findUniqueOrThrow({
+        where: { id: action.id },
       });
-      expect(updatedAutomation?.name).toBe("Updated GitHub Dispatch");
+      const unchangedConfig = unchangedAction.config as any;
+      expect(unchangedConfig.url).toBe(
+        "https://api.github.com/repos/owner/repo/dispatches",
+      );
+      expect(decrypt(unchangedConfig.githubToken)).toBe("ghp_old_token");
     });
 
     it("should update GitHub dispatch automation with new token", async () => {
@@ -2773,7 +2765,7 @@ describe("automations trpc", () => {
         },
       });
 
-      // Update with new token
+      // Update the URL and rotate the token together.
       const response = await caller.automations.updateAutomation({
         projectId: project.id,
         automationId: automation.id,
@@ -2785,7 +2777,7 @@ describe("automations trpc", () => {
         actionType: "GITHUB_DISPATCH",
         actionConfig: {
           type: "GITHUB_DISPATCH",
-          url: "https://api.github.com/repos/owner/repo/dispatches",
+          url: "https://api.github.com/repos/owner/new-repo/dispatches",
           githubToken: "ghp_new_token_456",
         },
       });
@@ -2807,9 +2799,12 @@ describe("automations trpc", () => {
       const dbConfig = updatedAction?.config as any;
       expect(dbConfig.githubToken).not.toBe("ghp_new_token_456"); // Encrypted
       expect(decrypt(dbConfig.githubToken)).toBe("ghp_new_token_456"); // Can decrypt
+      expect(dbConfig.url).toBe(
+        "https://api.github.com/repos/owner/new-repo/dispatches",
+      );
     });
 
-    it("should preserve encrypted token when updating without providing new token", async () => {
+    it("should preserve encrypted token when updating an unchanged URL", async () => {
       const { project, caller } = await prepare();
 
       const originalToken = "ghp_original_token_xyz";
@@ -2834,7 +2829,7 @@ describe("automations trpc", () => {
           type: "GITHUB_DISPATCH",
           config: {
             type: "GITHUB_DISPATCH",
-            url: "https://api.github.com/repos/owner/repo/dispatches",
+            url: "https://github.com/api/v3/repos/owner/repo/dispatches",
             eventType: "original-event-type",
             githubToken: encryptedToken,
             displayGitHubToken: "ghp_...xyz",
@@ -2851,7 +2846,9 @@ describe("automations trpc", () => {
         },
       });
 
-      // Update URL without providing token
+      // Update the event type using an equivalent URL representation without
+      // providing a token. Hostnames are case-insensitive and :443 is the
+      // default port for HTTPS, so this remains the same destination.
       await caller.automations.updateAutomation({
         projectId: project.id,
         automationId: automation.id,
@@ -2863,7 +2860,7 @@ describe("automations trpc", () => {
         actionType: "GITHUB_DISPATCH",
         actionConfig: {
           type: "GITHUB_DISPATCH",
-          url: "https://api.github.com/repos/new-owner/new-repo/dispatches",
+          url: "https://GITHUB.COM:443/api/v3/repos/owner/repo/dispatches",
           eventType: "new-event-type",
           // githubToken intentionally omitted
         },
@@ -2884,7 +2881,7 @@ describe("automations trpc", () => {
 
       // Verify URL and eventType were updated
       expect(dbConfig.url).toBe(
-        "https://api.github.com/repos/new-owner/new-repo/dispatches",
+        "https://GITHUB.COM:443/api/v3/repos/owner/repo/dispatches",
       );
       expect(dbConfig.eventType).toBe("new-event-type");
     });

--- a/web/src/features/automations/components/actions/GitHubDispatchActionForm.tsx
+++ b/web/src/features/automations/components/actions/GitHubDispatchActionForm.tsx
@@ -11,6 +11,7 @@ import { type UseFormReturn } from "react-hook-form";
 import { type ActionDomain } from "@langfuse/shared";
 import { ExternalLink } from "lucide-react";
 import Link from "next/link";
+import { areGitHubDispatchUrlsEquivalent } from "../../githubDispatchUrl";
 
 interface GitHubDispatchActionFormProps {
   form: UseFormReturn<any>;
@@ -23,6 +24,11 @@ export const GitHubDispatchActionForm: React.FC<
   GitHubDispatchActionFormProps
 > = ({ form, disabled }) => {
   const displayGitHubToken = form.watch("githubDispatch.displayGitHubToken");
+  const currentUrl = form.watch("githubDispatch.url");
+  const originalUrl = form.watch("githubDispatch.originalUrl");
+  const isUrlChanged =
+    originalUrl !== undefined &&
+    !areGitHubDispatchUrlsEquivalent(currentUrl, originalUrl);
 
   return (
     <div className="space-y-4">
@@ -93,7 +99,7 @@ export const GitHubDispatchActionForm: React.FC<
           <FormItem>
             <FormLabel className="flex items-center">
               GitHub Personal Access Token
-              {!displayGitHubToken && (
+              {(!displayGitHubToken || isUrlChanged) && (
                 <span className="text-destructive ml-1">*</span>
               )}
             </FormLabel>
@@ -108,9 +114,11 @@ export const GitHubDispatchActionForm: React.FC<
             <FormDescription>
               GitHub PAT with <code className="text-xs">repo</code> scope for
               repository dispatch.
-              {displayGitHubToken
-                ? " Leave empty to keep existing token."
-                : ""}{" "}
+              {isUrlChanged
+                ? " Enter a new token when changing the dispatch URL."
+                : displayGitHubToken
+                  ? " Leave empty to keep existing token."
+                  : ""}{" "}
               <Link
                 href="https://github.com/settings/tokens/new?scopes=repo&description=Langfuse%20Automation"
                 target="_blank"

--- a/web/src/features/automations/components/actions/GitHubDispatchActionHandler.clienttest.ts
+++ b/web/src/features/automations/components/actions/GitHubDispatchActionHandler.clienttest.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { GitHubDispatchActionHandler } from "./GitHubDispatchActionHandler";
+
+const handler = new GitHubDispatchActionHandler();
+
+const formData = (overrides: Record<string, string> = {}) => ({
+  githubDispatch: {
+    url: overrides.url ?? "https://api.github.com/repos/owner/repo/dispatches",
+    originalUrl: overrides.originalUrl,
+    eventType: "repository-updated",
+    githubToken: overrides.githubToken ?? "",
+    displayGitHubToken: overrides.displayGitHubToken ?? "ghp_...ken",
+  },
+});
+
+describe("GitHubDispatchActionHandler URL and token validation", () => {
+  it("requires a new token when the dispatch URL changes", () => {
+    const result = handler.validateFormData(
+      formData({
+        originalUrl: "https://api.github.com/repos/owner/repo/dispatches",
+        url: "https://api.github.com/repos/owner/other-repo/dispatches",
+      }),
+    );
+
+    expect(result).toEqual({
+      isValid: false,
+      errors: ["GitHub token is required when changing the dispatch URL"],
+    });
+  });
+
+  it("allows an update without a token for an equivalent URL", () => {
+    const result = handler.validateFormData(
+      formData({
+        originalUrl: "https://github.com/api/v3/repos/owner/repo/dispatches",
+        url: "https://GITHUB.COM:443/api/v3/repos/owner/repo/dispatches",
+      }),
+    );
+
+    expect(result).toEqual({ isValid: true });
+  });
+});

--- a/web/src/features/automations/components/actions/GitHubDispatchActionHandler.tsx
+++ b/web/src/features/automations/components/actions/GitHubDispatchActionHandler.tsx
@@ -8,6 +8,7 @@ import {
   type ActionDomain,
 } from "@langfuse/shared";
 import { z } from "zod";
+import { areGitHubDispatchUrlsEquivalent } from "../../githubDispatchUrl";
 
 // Define the form schema for GitHub dispatch actions
 export const GitHubDispatchActionFormSchema = z.object({
@@ -16,6 +17,7 @@ export const GitHubDispatchActionFormSchema = z.object({
     eventType: z.string().min(1, "Event type is required").max(100),
     githubToken: z.string(),
     displayGitHubToken: z.string().optional(), // Display value for existing token
+    originalUrl: z.string().optional(),
   }),
 });
 
@@ -50,6 +52,12 @@ export class GitHubDispatchActionHandler implements BaseActionHandler<GitHubDisp
           "displayGitHubToken" in automation.action.config
             ? automation.action.config.displayGitHubToken
             : undefined,
+        originalUrl:
+          automation?.action?.type === "GITHUB_DISPATCH" &&
+          automation?.action?.config &&
+          "url" in automation.action.config
+            ? automation.action.config.url
+            : undefined,
       },
     };
   }
@@ -70,9 +78,18 @@ export class GitHubDispatchActionHandler implements BaseActionHandler<GitHubDisp
       errors.push("Event type must be 100 characters or less");
     }
 
-    // Token is required only if there's no existing token (displayGitHubToken)
-    if (
-      !formData.githubDispatch?.githubToken &&
+    const existingUrl = formData.githubDispatch?.originalUrl;
+    const isUrlChanged =
+      existingUrl !== undefined &&
+      !areGitHubDispatchUrlsEquivalent(
+        formData.githubDispatch.url,
+        existingUrl,
+      );
+
+    if (isUrlChanged && !formData.githubDispatch?.githubToken.trim()) {
+      errors.push("GitHub token is required when changing the dispatch URL");
+    } else if (
+      !formData.githubDispatch?.githubToken.trim() &&
       !formData.githubDispatch?.displayGitHubToken
     ) {
       errors.push("GitHub token is required");

--- a/web/src/features/automations/components/automationForm.tsx
+++ b/web/src/features/automations/components/automationForm.tsx
@@ -68,6 +68,7 @@ const githubDispatchSchema = z.object({
   eventType: z.string().min(1, "Event type is required").max(100),
   githubToken: z.string(),
   displayGitHubToken: z.string().optional(),
+  originalUrl: z.string().optional(),
 });
 
 /** promptEventActionDefaults is the default eventAction set for a fresh prompt-source automation. */
@@ -505,6 +506,7 @@ export const AutomationForm = ({
           githubToken: githubDefaults.githubDispatch.githubToken || "",
           displayGitHubToken:
             githubDefaults.githubDispatch.displayGitHubToken || undefined,
+          originalUrl: githubDefaults.githubDispatch.originalUrl,
         },
       };
     }

--- a/web/src/features/automations/githubDispatchUrl.ts
+++ b/web/src/features/automations/githubDispatchUrl.ts
@@ -1,0 +1,10 @@
+export function areGitHubDispatchUrlsEquivalent(
+  firstUrl: string,
+  secondUrl: string,
+): boolean {
+  try {
+    return new URL(firstUrl).href === new URL(secondUrl).href;
+  } catch {
+    return firstUrl === secondUrl;
+  }
+}

--- a/web/src/features/automations/server/githubDispatchHelpers.ts
+++ b/web/src/features/automations/server/githubDispatchHelpers.ts
@@ -11,6 +11,7 @@ import {
   validateWebhookURL,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
+import { areGitHubDispatchUrlsEquivalent } from "../githubDispatchUrl";
 
 interface GitHubDispatchConfigOptions {
   actionConfig: ActionCreate;
@@ -82,6 +83,23 @@ export async function processGitHubDispatchActionConfig({
     });
   }
 
+  const isUrlChanged =
+    existingActionConfig !== undefined &&
+    !areGitHubDispatchUrlsEquivalent(urlToUse, existingActionConfig.url);
+  const newGithubToken =
+    typeof gitHubDispatchConfig.githubToken === "string" &&
+    gitHubDispatchConfig.githubToken.trim() !== ""
+      ? gitHubDispatchConfig.githubToken
+      : undefined;
+
+  if (isUrlChanged && !newGithubToken) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message:
+        "GitHub Personal Access Token is required when changing the dispatch URL",
+    });
+  }
+
   // Determine event type to use
   let eventTypeToUse: string;
   if (
@@ -102,11 +120,8 @@ export async function processGitHubDispatchActionConfig({
   let displayToken: string;
   let returnToken: string | undefined;
 
-  if (
-    gitHubDispatchConfig.githubToken &&
-    gitHubDispatchConfig.githubToken.trim() !== ""
-  ) {
-    tokenToUse = gitHubDispatchConfig.githubToken;
+  if (newGithubToken) {
+    tokenToUse = newGithubToken;
     displayToken = maskGitHubToken(tokenToUse);
     returnToken = tokenToUse;
   } else if (existingActionConfig?.githubToken) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

v3 backport of #16479. Cherry-picked clean from `bbc391cf5`.

GitHub repository-dispatch automations could reuse a stored personal access token when the destination URL changed, which would send an existing credential to a new endpoint. The server now requires a fresh non-empty token for actual destination changes, while still preserving the stored token when the endpoint is unchanged (including equivalent URL forms). The edit form mirrors that rule.

### Not ported from the same security-fix batch

- **#16307** (bind remote-experiment secret headers to the URL) — v3 has no `remoteExperimentRequestHeaders` / signing-secret columns, so that leak path does not exist on this line.
- **#16202 / #16091** (analytics export connect-time SSRF pinning) — previously declined for v3 as not a straightforward backport.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test 'src/__tests__/server/automations-trpc.servertest.ts'`
  - `Tests 44 passed (44)`
- `pnpm --filter web run test-client 'src/features/automations/components/actions/GitHubDispatchActionHandler.clienttest.ts'`
  - `Tests 2 passed (2)`
- Targeted ESLint `--max-warnings 0` on the touched web files: passed
- Revert-check: restoring `githubDispatchHelpers.ts` to `origin/v3` with the new tests kept, `should reject a GitHub dispatch URL update without a new token` fails (`promise resolved instead of rejecting`) — the leak reproduces on unpatched v3

## Mandatory Tasks

- [x] Self-reviewed the cherry-pick against the v3 helpers and tests

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents a stored GitHub personal access token from being reused when an automation’s dispatch destination changes.
- Adds shared URL-equivalence handling to client and server validation.
- Requires a non-empty replacement token for actual destination changes while preserving the stored token for equivalent URLs.
- Extends server and client tests for changed and equivalent destination behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with client and server enforcement aligned around the stored-credential boundary.

The update path compares the submitted destination against the persisted GitHub action, rejects destination changes without a fresh token, and preserves the encrypted credential only when the destination is equivalent; no concrete blocking or non-blocking defect remains.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[User edits GitHub dispatch automation] --> B[Compare submitted URL with stored URL]
  B -->|Equivalent destination| C[Preserve encrypted stored token]
  B -->|Different destination| D{Fresh non-empty token supplied?}
  D -->|No| E[Reject update]
  D -->|Yes| F[Encrypt and store replacement token]
  C --> G[Persist updated automation]
  F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(automations): require fresh tokens f..."](https://github.com/langfuse/langfuse/commit/5a31a4f02ae767a20d780c1280721e21de2d2742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56599900)</sub>

<!-- /greptile_comment -->