### PR TITLE
fix(evals): hide code evaluator variable mappings

### DIFF
--- a/web/src/features/evals/v2/components/Rules/EvaluatorMappingRow/EvaluatorMappingRow.stories.tsx
+++ b/web/src/features/evals/v2/components/Rules/EvaluatorMappingRow/EvaluatorMappingRow.stories.tsx
@@ -30,6 +30,21 @@ const store = createRuleSetupStore({
     },
   ],
 });
+const codeEvaluatorId = "exact-match";
+const codeEvaluatorStore = createRuleSetupStore({
+  name: "Experiment evaluators",
+  filter: [],
+  sampling: 1,
+  assignments: [
+    {
+      evaluatorId: codeEvaluatorId,
+      evaluatorName: "Exact Match",
+      evaluatorType: "CODE",
+      defaultVariableMapping,
+      variableMapping: null,
+    },
+  ],
+});
 
 const meta = preview.meta({ component: EvaluatorMappingRow });
 
@@ -41,6 +56,21 @@ export const FullyMapped = meta.story({
     defaultVariableMapping,
     store,
     sampleObject: null,
+    costEstimate: null,
+  },
+});
+
+export const CodeEvaluator = meta.story({
+  args: {
+    evaluatorId: codeEvaluatorId,
+    evaluatorName: "Exact Match",
+    evaluatorType: "CODE",
+    defaultVariableMapping,
+    store: codeEvaluatorStore,
+    sampleObject: {
+      input: "What is the capital of Germany?",
+      output: "Berlin",
+    },
     costEstimate: null,
   },
 });

--- a/web/src/features/evals/v2/components/Rules/EvaluatorMappingRow/EvaluatorMappingRow.tsx
+++ b/web/src/features/evals/v2/components/Rules/EvaluatorMappingRow/EvaluatorMappingRow.tsx
@@ -156,11 +156,15 @@ export const EvaluatorMappingRow = memo(function EvaluatorMappingRow({
           </Button>
         </div>
         <CollapsibleContent className="border-t p-3">
-          {mapping.length === 0 ? (
+          {isCodeEvaluator ? (
             <p className="text-muted-foreground text-sm">
-              {isCodeEvaluator
-                ? "Observation data is available directly in code evaluators, so no variable mapping is required."
-                : "No variable mapping is required because this evaluator does not define prompt variables."}
+              Observation data is available directly in code evaluators, so no
+              variable mapping is required.
+            </p>
+          ) : mapping.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              No variable mapping is required because this evaluator does not
+              define prompt variables.
             </p>
           ) : (
             <VariableMapping


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16527.preview.langfuse.com](https://pr-16527.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- keep code evaluators in the same collapsible row style as other evaluators
- replace editable variable mappings with a short explanation that code evaluators receive observation data directly
- add a Storybook state for the prompt experiment assignment row

## Testing

- `pnpm --filter web run test-storybook src/features/evals/v2/components/Rules/EvaluatorMappingRow/EvaluatorMappingRow.stories.tsx`
- `pnpm run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR keeps code evaluators in the shared collapsible assignment-row layout while replacing their mapping controls with an explanation that observation data is supplied directly. It also adds a Storybook state covering the code-evaluator row.

- Hides variable-mapping controls and mapping status for code evaluators.
- Preserves shared row actions and collapsible behavior.
- Adds Storybook coverage for the code-evaluator presentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

Code evaluator assignments are already constrained to system-managed mappings, and the updated component consistently removes both editable controls and mapping-derived status without affecting save progression.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): hide code evaluator variable..."](https://github.com/langfuse/langfuse/commit/3c031de65e1eaaeb871316c6b90e3c2481a9bb61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56605174)</sub>

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)

<!-- /greptile_comment -->