### PR TITLE
fix(sentry): redact PII in all session replays (v3 backport of #16373)

### DIFF
--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -122,11 +122,24 @@ properly (below).
    that only reads the exception value silently never fires on them (the reason
    the original invalid-href filter never worked).
 
-7. **PII — never put user content in a message, `extra`, or tag.** No prompt
-   text, trace content, tokens, share-link secrets, user/session ids. Respect
-   the replay masking already configured for HIPAA/regions in
-   `instrumentation-client.ts`. A message that interpolates user data both leaks
-   and shatters grouping (Rule 5).
+7. **PII / HIPAA — never put user content in a message, `extra`, breadcrumb,
+   or tag.** No prompt text, trace content, tokens, share-link secrets,
+   user/session ids. This is not hygiene — it is the compliance boundary: ALL
+   cloud regions, **including HIPAA**, report to the **same US Sentry org**,
+   and error events are **never masked**, so this discipline is the only thing
+   keeping user content out of them. Session Replay is the masked channel:
+   [`instrumentation-client.ts`](../../../web/instrumentation-client.ts) sets
+   `maskAllText`, `maskAllInputs`, and `blockAllMedia` so every replay is fully
+   masked in every deployment. **Never remove or weaken that mask** — the
+   `replayIntegration` options must be covered by a CI regression test
+   asserting every region against the real module (the mask-guard
+   `instrumentation-client-replay-mask.clienttest.ts`; landing with #15802).
+   Reject any diff that touches Replay masking without that guard passing, and run
+   every diff touching `instrumentation-client.ts` or replay config through
+   the reviewer checklist in the
+   [reference](references/sentry-capture-contract.md#pii-and-the-hipaa-compliance-boundary).
+   A message that interpolates user data both leaks and shatters grouping
+   (Rule 5).
 
 8. **VERIFY in the environment that actually fires the error.** Router/console
    validations run only in the **real client runtime, not jsdom** — a green unit
@@ -162,6 +175,8 @@ properly (below).
   that reads the wrong event field (Rule 6).
 - Interpolating ids/user data into the message → PII + grouping explosion
   (Rules 5, 7).
+- Removing/weakening the unconditional replay mask, or "fixing" the mask-guard
+  test instead of the diff that tripped it (Rule 7).
 - Trusting a green jsdom test as proof the noise is gone (Rule 8).
 - An ad-hoc inline `beforeSend` check instead of a named, tested predicate in
   `sentryFilters.ts`.

--- a/.agents/skills/sentry-instrumentation/SKILL.md
+++ b/.agents/skills/sentry-instrumentation/SKILL.md
@@ -184,8 +184,10 @@ properly (below).
 ## References
 
 - [references/sentry-capture-contract.md](references/sentry-capture-contract.md)
-  — the capture contract in depth: the shared-helper APIs, the beforeSend /
+  — the capture contract in depth: the shared-helper APIs, the PII/HIPAA
+  compliance boundary (replay mask + reviewer checklist), the beforeSend /
   denylist authoring protocol (field-reading, negative fixtures), fingerprinting
   and `area` tagging, the known noise families, and the shipped-PR case studies
   (#15145 / #15173 / #15174 / #15175 / #15238 / #15243 / #15245). Read when
-  authoring a suppression rule, hardening a capture path, or triaging a family.
+  authoring a suppression rule, hardening a capture path, touching replay/region
+  config, or triaging a family.

--- a/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
+++ b/.agents/skills/sentry-instrumentation/references/sentry-capture-contract.md
@@ -7,6 +7,7 @@ the detail behind its rules.
 ## Contents
 
 - [Where Sentry is wired](#where-sentry-is-wired)
+- [PII and the HIPAA compliance boundary](#pii-and-the-hipaa-compliance-boundary)
 - [The shared capture helpers](#the-shared-capture-helpers)
 - [beforeSend / denylist authoring protocol](#beforesend--denylist-authoring-protocol)
 - [Fingerprinting, tagging, messages](#fingerprinting-tagging-messages)
@@ -17,7 +18,7 @@ the detail behind its rules.
 
 - **The only `Sentry.init`** is [`web/instrumentation-client.ts`](../../../../web/instrumentation-client.ts)
   — client-side only. It configures `beforeSend`, `captureConsoleIntegration({ levels: ["error"] })`,
-  `httpClientIntegration()`, `replayIntegration(...)` (masking gated on region/HIPAA),
+  `httpClientIntegration()`, `replayIntegration(...)` (unconditional masking),
   and `denyUrls` (browser-extension origins).
 - **The worker and web server have no Sentry SDK** — backend signal lives in the
   server-side observability/APM stack, not Sentry. Do not assume a backend error
@@ -34,6 +35,43 @@ the detail behind its rules.
   PR #15243 drops expected `data.code`s (`NOT_FOUND` / `FORBIDDEN` /
   `UNAUTHORIZED`) there with a breadcrumb and tags the rest
   (`trpc.code` / `trpc.path`).
+
+## PII and the HIPAA compliance boundary
+
+ALL cloud regions — **including HIPAA** — report to the **same US Sentry org**.
+Two mechanisms keep user content (prompts, traces, PII/PHI) out of it, and they
+cover **different channels**. Do not conflate them.
+
+1. **Session Replay → the unconditional mask.**
+   [`instrumentation-client.ts`](../../../../web/instrumentation-client.ts)
+   configures `replayIntegration({ maskAllText, maskAllInputs, blockAllMedia })`
+   so replays are **fully masked in every deployment**. The mask must never be
+   removed or weakened, and it must be covered by a CI regression test that
+   executes the real module per region and fails on any change to the options
+   (the mask-guard `instrumentation-client-replay-mask.clienttest.ts`; landing
+   with #15802). A diff that trips that guard is a compliance change, not a
+   broken test; a diff that touches Replay masking without the guard passing
+   must be rejected.
+2. **Error events → the capture discipline (SKILL rule 7).** The mask covers
+   Session Replay ONLY. Error-event payloads — message, breadcrumbs, `extra`,
+   tags — are **not masked in any region**. The rule "no user content in
+   messages/extra/tags" IS the compliance boundary for error events; there is
+   no downstream scrub to catch a leak. `sendDefaultPii` stays unset (false),
+   so the SDK attaches no cookies, headers, request/response bodies, or user
+   IP.
+
+**Reviewer checklist — any diff touching `instrumentation-client.ts` or the
+replay integration:**
+
+- `maskAllText`, `maskAllInputs`, and `blockAllMedia` remain `true` in every
+  deployment, and the mask-guard clienttest (landing with #15802) asserts
+  against the real module — not a copy of the config or an uncalled predicate.
+- No new replay option weakens masking (e.g.
+  `maskAllInputs: false`, unmask/unblock selectors).
+- `sendDefaultPii` remains unset/false; no integration starts attaching
+  bodies, headers, or cookies.
+- Changes to the mask-guard test itself (skipped cases, loosened assertions,
+  region list edits) are reviewed as compliance changes.
 
 ## The shared capture helpers
 

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -5,11 +5,6 @@ import {
   isReactDevtoolsInternalEvent,
 } from "@/src/utils/sentryFilters";
 
-const isEuOrUsRegionNonHipaa =
-  process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
-    ? ["EU", "US"].includes(process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
-    : false;
-
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
@@ -51,8 +46,9 @@ Sentry.init({
   // Replay may only be enabled for the client-side
   integrations: [
     Sentry.replayIntegration({
-      maskAllText: !isEuOrUsRegionNonHipaa,
-      blockAllMedia: !isEuOrUsRegionNonHipaa,
+      maskAllText: true,
+      maskAllInputs: true,
+      blockAllMedia: true,
     }),
     Sentry.browserTracingIntegration(),
     Sentry.httpClientIntegration(),

--- a/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
+++ b/web/src/__tests__/instrumentation-client-replay-mask.clienttest.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+
+/**
+ * Session Replay masking guard.
+ *
+ * All cloud regions (including HIPAA) report to the same US Sentry org.
+ * The compliance safeguard for Session Replay is the unconditional
+ * `maskAllText` / `maskAllInputs` / `blockAllMedia` configuration in
+ * `web/instrumentation-client.ts`: replays are masked in every deployment.
+ * Removing or weakening that configuration would ship unmasked replay of
+ * user content (prompts, traces, PII/PHI) to Sentry.
+ *
+ * Scope note: the mask covers Session Replay ONLY. Error-event payloads
+ * (message, breadcrumbs, extra, tags) are never masked — for those, the
+ * capture-contract rule "no user content in messages/extra/tags" (skill
+ * rule 7) is the compliance boundary.
+ *
+ * These tests import the REAL `web/instrumentation-client.ts` module (the
+ * file Next.js executes in the browser) with `@sentry/nextjs` mocked, and
+ * assert on the arguments Sentry actually receives. They intentionally do
+ * NOT test a copy of the config or an exported predicate: if the replay
+ * options move, stop flowing into `Sentry.init`, or change values, these
+ * tests fail. If this file fails after an instrumentation change, the
+ * change weakens the compliance mask — fix the change, not the test.
+ */
+
+type ReplayOptions = {
+  maskAllText: boolean;
+  maskAllInputs: boolean;
+  blockAllMedia: boolean;
+};
+
+const { initMock, replayIntegrationMock, replaySentinel } = vi.hoisted(() => {
+  const replaySentinel = { name: "Replay-sentinel" };
+  return {
+    initMock: vi.fn<(options: { integrations: unknown[] }) => void>(),
+    replayIntegrationMock: vi.fn((_options: ReplayOptions) => replaySentinel),
+    replaySentinel,
+  };
+});
+
+vi.mock("@sentry/nextjs", () => ({
+  init: initMock,
+  replayIntegration: replayIntegrationMock,
+  browserTracingIntegration: vi.fn(() => ({ name: "BrowserTracing" })),
+  httpClientIntegration: vi.fn(() => ({ name: "HttpClient" })),
+  captureConsoleIntegration: vi.fn(() => ({ name: "CaptureConsole" })),
+  browserProfilingIntegration: vi.fn(() => ({ name: "BrowserProfiling" })),
+  captureRouterTransitionStart: vi.fn(),
+}));
+
+/**
+ * Executes the real instrumentation-client module under the given cloud
+ * region and returns the options `Sentry.replayIntegration` was called with.
+ * Also asserts the resulting integration instance is actually wired into
+ * `Sentry.init` — a replay integration that is configured but never passed
+ * to init would silently disable replay instead of masking it.
+ */
+async function loadReplayOptions(
+  region: string | undefined,
+): Promise<ReplayOptions> {
+  vi.resetModules();
+  initMock.mockClear();
+  replayIntegrationMock.mockClear();
+  vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", region);
+
+  await import("@/instrumentation-client");
+
+  expect(initMock).toHaveBeenCalledTimes(1);
+  expect(replayIntegrationMock).toHaveBeenCalledTimes(1);
+  expect(initMock.mock.calls[0]![0].integrations).toContain(replaySentinel);
+
+  return replayIntegrationMock.mock.calls[0]![0]!;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("Session Replay masking is unconditional (compliance guard)", () => {
+  // Every region must be fully masked. `toStrictEqual` on the whole
+  // options object is deliberate: any new replay option must be reviewed
+  // here for its compliance impact before it can ship.
+  const regions: [string | undefined, string][] = [
+    ["EU", "the EU cloud region"],
+    ["US", "the US cloud region"],
+    ["HIPAA", "the HIPAA cloud region"],
+    ["JP", "a non-EU/US cloud region"],
+    ["STAGING", "the staging environment"],
+    ["DEV", "the dev environment"],
+    [undefined, "self-hosted (region unset)"],
+    ["", "an empty region value"],
+    ["us", "a lowercase region value"],
+  ];
+
+  it.each(regions)(
+    "region %j (%s) gets text, input, and media masking",
+    async (region) => {
+      await expect(loadReplayOptions(region)).resolves.toStrictEqual({
+        maskAllText: true,
+        maskAllInputs: true,
+        blockAllMedia: true,
+      });
+    },
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

v3 backport of #16373 (adapted; mainline `06f7a377b`).

Sentry session replays now always mask text, inputs, and media instead of only applying that mask in EU/US non-HIPAA regions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client instrumentation-client-replay-mask.clienttest.ts`
  - `Tests 9 passed (9)`
- Full lint/typecheck skipped (config-only backport; targeted clienttest covers the regression)

## Mandatory Tasks

- [x] Self-reviewed the adapted cherry-pick against v3 Sentry client instrumentation

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport makes Sentry Session Replay masking unconditional across every deployment and adds a regression test against the real client instrumentation module.

- Removes region- and HIPAA-dependent replay masking.
- Enables text, input, and media masking for every replay.
- Adds coverage for cloud regions, self-hosted deployments, and unusual region values.
- Documents the replay and error-event PII boundaries in the Sentry instrumentation guidance.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with unconditional replay masking correctly wired and protected by targeted regression coverage.

The changed Sentry configuration strengthens replay privacy in every deployment, and the installed SDK plus existing Vitest configuration support the new options and test harness.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(sentry): note PII/HIPAA replay-mask..."](https://github.com/langfuse/langfuse/commit/e1008688ca04c4d94d730a32794163c07b5a6f58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56606207)</sub>

<!-- /greptile_comment -->