### PR TITLE
fix(auth): return 400 for invalid Slack OAuth callback params (v3 backport of #15489)

### DIFF
--- a/web/src/__tests__/server/unit/slack-oauth-callback-status.servertest.ts
+++ b/web/src/__tests__/server/unit/slack-oauth-callback-status.servertest.ts
@@ -1,0 +1,110 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+
+const { mockInstallerHandleCallback, mockLogger } = vi.hoisted(() => ({
+  mockInstallerHandleCallback: vi.fn(),
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  SlackService: {
+    getInstance: () => ({
+      getInstaller: () => ({ handleCallback: mockInstallerHandleCallback }),
+    }),
+  },
+  SLACK_BOT_SCOPES: ["channels:read"],
+  parseSlackInstallationMetadata: vi.fn(),
+  logger: mockLogger,
+  // Consumed by the shared vitest teardown (src/__tests__/teardown.ts).
+  redis: null,
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn(async () => undefined),
+    }),
+  },
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    NEXTAUTH_URL: "http://localhost:3000",
+    NEXT_PUBLIC_BASE_PATH: undefined,
+  },
+}));
+
+vi.mock("@/src/server/auth", () => ({ getServerAuthSession: vi.fn() }));
+vi.mock("@/src/features/audit-logs/auditLog", () => ({ auditLog: vi.fn() }));
+vi.mock("@langfuse/shared/src/db", () => ({ prisma: {} }));
+
+import { handleCallback } from "@/src/features/slack/server/oauth-handlers";
+
+// Error codes produced by @slack/oauth's InstallProvider (dist/errors.d.ts).
+const codedError = (code: string, message: string) =>
+  Object.assign(new Error(message), { code });
+
+const runCallbackWithFailure = async (error: Error) => {
+  mockInstallerHandleCallback.mockImplementation(async (req, res, options) =>
+    options.failure(error, undefined, req, res),
+  );
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: "GET",
+    url: "/api/public/slack/oauth?foo=bar",
+  });
+  await handleCallback(req, res);
+  return res;
+};
+
+describe("slack oauth callback failure status mapping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    [
+      "slack_oauth_missing_code",
+      "Redirect url is missing the required code query parameter",
+    ],
+    [
+      "slack_oauth_missing_state",
+      "Redirect url is missing the state query parameter",
+    ],
+    [
+      "slack_oauth_invalid_state",
+      "The state parameter is not for this browser session",
+    ],
+    [
+      "slack_oauth_installer_authorization_error",
+      "User cancelled the OAuth installation flow!",
+    ],
+  ])(
+    "returns 400 and logs a warning for client-input error %s",
+    async (code, message) => {
+      const res = await runCallbackWithFailure(codedError(code, message));
+
+      expect(res.statusCode).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        message: "Invalid OAuth callback parameters",
+      });
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    // Token exchange failures surface as @slack/web-api platform errors.
+    ["slack_webapi_platform_error", "Failed to exchange code"],
+    ["slack_oauth_unknown_error", "Something unexpected happened"],
+  ])("returns 500 and logs an error for %s", async (code, message) => {
+    const res = await runCallbackWithFailure(codedError(code, message));
+
+    expect(res.statusCode).toBe(500);
+    expect(res._getJSONData()).toEqual({
+      message: "Internal server error",
+    });
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/features/slack/server/oauth-handlers.ts
+++ b/web/src/features/slack/server/oauth-handlers.ts
@@ -11,6 +11,21 @@ import { prisma } from "@langfuse/shared/src/db";
 import { getSafeRedirectPath } from "@/src/utils/redirect";
 import { getProductBaseUrl } from "@/src/utils/base-url";
 
+// ErrorCode values from @slack/oauth for callbacks that fail because of the
+// client's request — no/invalid `code`/`state` (scanners, expired installs)
+// or the user cancelling on Slack's consent screen — rather than because
+// anything failed on our side. Within InstallProvider.handleCallback the
+// authorization-error code is thrown only for `error=access_denied`
+// (user cancel); token-exchange failures carry @slack/web-api codes instead.
+// Kept as literals since web does not depend on @slack/oauth directly;
+// unknown codes fall through to 500.
+const SLACK_OAUTH_CLIENT_INPUT_ERROR_CODES = new Set<string>([
+  "slack_oauth_missing_state",
+  "slack_oauth_invalid_state",
+  "slack_oauth_missing_code",
+  "slack_oauth_installer_authorization_error",
+]);
+
 /**
  * SlackOAuthHandlers
  *
@@ -119,7 +134,20 @@ export async function handleCallback(
         },
 
         failure: async (error) => {
-          logger.error("OAuth callback failed", { error: error.message });
+          if (SLACK_OAUTH_CLIENT_INPUT_ERROR_CODES.has(error.code)) {
+            logger.warn("OAuth callback rejected", {
+              error: error.message,
+              code: error.code,
+            });
+            res
+              .status(400)
+              .json({ message: "Invalid OAuth callback parameters" });
+            return;
+          }
+          logger.error("OAuth callback failed", {
+            error: error.message,
+            code: error.code,
+          });
           res.status(500).json({ message: "Internal server error" });
         },
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v3 backport of #15489.

The Slack OAuth callback (`GET /api/public/slack/oauth`) returned a blanket 500 for every failure from `@slack/oauth`'s `InstallProvider`, including requests with a missing or invalid `code`/`state`. Vulnerability scanners hitting the endpoint therefore surfaced as server errors and polluted error-rate monitors.

This maps client-input error codes (`slack_oauth_missing_code`, `slack_oauth_missing_state`, `slack_oauth_invalid_state`, `slack_oauth_installer_authorization_error`) to a **400** with a warn-level log. All other failure codes keep the **500** + error-level log.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test slack-oauth-callback-status` — `Tests 6 passed (6)`

## Mandatory Tasks

- [x] Self-reviewed the cherry-pick against v3 Slack OAuth handlers

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport distinguishes malformed or cancelled Slack OAuth callbacks from internal failures, returning a generic 400 response and warning log for known client-input error codes while preserving 500 handling for unexpected failures.
- Adds explicit Slack OAuth callback error-code classification.
- Adds unit coverage for four client-input failures and two server-side or unknown failures.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking import-organization issue in the new test.

The callback mapping preserves unexpected failures as server errors and correctly separates the enumerated client-input cases; the only accepted concern is the test module's misplaced import.

**Files Needing Attention:** web/src/__tests__/server/unit/slack-oauth-callback-status.servertest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/unit/slack-oauth-callback-status.servertest.ts:43
**Import appears below mock setup**

The `handleCallback` import appears after executable mock declarations instead of with the imports at the top of the module, violating the repository's import-organization rule and making dependencies less consistent to locate.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(auth): cover Slack OAuth callback 4..."](https://github.com/langfuse/langfuse/commit/d9cf45ab524cd71d701b200e4809b11b5574e9ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56606487)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->