### PR TITLE
fix(web): mask PostHog session replay content (v3 backport of #16302)

### DIFF
--- a/web/src/__tests__/posthog-session-replay-mask.clienttest.ts
+++ b/web/src/__tests__/posthog-session-replay-mask.clienttest.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import type { PostHogConfig } from "posthog-js";
+
+const { initMock } = vi.hoisted(() => ({
+  initMock: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: initMock,
+  },
+}));
+
+vi.mock("posthog-js/react", () => ({
+  PostHogProvider: vi.fn(),
+}));
+
+describe("PostHog session replay privacy", () => {
+  it("masks all rendered text and input values", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.i.posthog.com");
+
+    await import("@/src/pages/_app");
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const config = initMock.mock.calls[0]![1] as Partial<PostHogConfig>;
+    expect(config.session_recording).toMatchObject({
+      maskAllInputs: true,
+      maskTextSelector: "*",
+    });
+  });
+});

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -100,6 +100,8 @@ if (
       if (process.env.NODE_ENV === "development") posthog.debug();
     },
     session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: "*",
       maskCapturedNetworkRequestFn(request) {
         request.requestBody = request.requestBody ? "REDACTED" : undefined;
         request.responseBody = request.responseBody ? "REDACTED" : undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v3 backport of #16302. Cherry-picked clean from `77a41e6d9`.

PostHog session recordings now mask all rendered text and inputs (`maskAllInputs` + `maskTextSelector: "*"`). Existing network body redaction is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client posthog-session-replay-mask.clienttest.ts`
  - `Tests 1 passed (1)`

## Mandatory Tasks

- [x] Self-reviewed the cherry-pick against v3 `_app.tsx`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport configures the global PostHog client to mask all rendered text and input values in session replays while retaining network-body redaction.

- Adds `maskAllInputs` and a catch-all text masking selector to session recording.
- Adds a client test asserting that the privacy configuration is passed to PostHog initialization.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking test-structure issue around the callback-local import.

The production configuration uses supported PostHog options at the correct nesting; the only accepted concern is the repository-rule violation in the new test.

**Files Needing Attention:** web/src/__tests__/posthog-session-replay-mask.clienttest.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/posthog-session-replay-mask.clienttest.ts:24
**Callback-local application import**

The test dynamically imports `_app` inside its callback, contrary to the repository requirement that imports remain at module scope. This introduces a nonstandard, module-cache-dependent setup; move the required environment configuration into an appropriate setup boundary so `_app` can be imported at module scope.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(posthog): mask session replay conten..."](https://github.com/langfuse/langfuse/commit/5e88bc887338418b68ac3b161cdd5360ee3c97a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56608757)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)
- Knowledge Base — [Product web application](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/product-web-application.md)

<!-- /greptile_comment -->