### PR TITLE
fix(observability): remove user emails from Datadog traces (v3 backport of #15908)

### DIFF
--- a/packages/shared/src/server/instrumentation/index.test.ts
+++ b/packages/shared/src/server/instrumentation/index.test.ts
@@ -1,9 +1,14 @@
-import { context } from "@opentelemetry/api";
+import {
+  context,
+  propagation,
+  ROOT_CONTEXT,
+  type Span,
+} from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { normalizeClickHouseQueryTags } from "../clickhouse/queryTags";
 import { contextWithLangfuseProps } from "../headerPropagation";
-import { instrumentAsync, instrumentSync } from ".";
+import { addUserToSpan, instrumentAsync, instrumentSync } from ".";
 
 describe("instrumentation baggage propagation", () => {
   // Baggage only propagates through context.with once a manager is registered.
@@ -55,5 +60,28 @@ describe("instrumentation baggage propagation", () => {
       route: "langfuse.queue.monitor",
       projectId: "project-1",
     });
+  });
+
+  it("does not add user emails to span attributes or baggage", () => {
+    const span = {
+      setAttribute: vi.fn(),
+    } as unknown as Span;
+    const attributes = {
+      userId: "user-1",
+      email: "user@example.com",
+    } as Parameters<typeof addUserToSpan>[0];
+
+    const userContext = context.with(ROOT_CONTEXT, () =>
+      addUserToSpan(attributes, span),
+    );
+
+    expect(span.setAttribute).toHaveBeenCalledWith("user.id", "user-1");
+    expect(span.setAttribute).not.toHaveBeenCalledWith(
+      "user.email",
+      "user@example.com",
+    );
+    expect(propagation.getBaggage(userContext!)?.getEntry("user.email")).toBe(
+      undefined,
+    );
   });
 });

--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -210,7 +210,6 @@ export const addUserToSpan = (
   attributes: {
     userId?: string;
     projectId?: string;
-    email?: string;
     orgId?: string;
     plan?: string;
     apiKeyId?: string;
@@ -234,12 +233,6 @@ export const addUserToSpan = (
       value: attributes.userId,
     });
     activeSpan.setAttribute("user.id", attributes.userId);
-  }
-  if (attributes.email) {
-    baggage = baggage.setEntry("user.email", {
-      value: attributes.email,
-    });
-    activeSpan.setAttribute("user.email", attributes.email);
   }
   if (attributes.projectId) {
     baggage = baggage.setEntry("langfuse.project.id", {

--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -204,7 +204,6 @@ describe("in-app agent public API route auth", () => {
 
     expect(instrumentationMocks.addUserToSpan).toHaveBeenCalledWith({
       userId: "user-1",
-      email: "test@example.com",
     });
   });
 
@@ -880,7 +879,6 @@ describe("in-app agent public API route auth", () => {
       );
       expect(instrumentationMocks.addUserToSpan).toHaveBeenLastCalledWith({
         userId: sessionUser.id,
-        email: sessionUser.email,
         projectId: project.id,
         orgId: org.id,
         plan: "cloud:team",

--- a/web/src/__tests__/server/unit/auth-sign-in-span.servertest.ts
+++ b/web/src/__tests__/server/unit/auth-sign-in-span.servertest.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuthSpan, mockInstrumentAsync } = vi.hoisted(() => {
+  const mockAuthSpan = {
+    setAttributes: vi.fn(),
+  };
+
+  return {
+    mockAuthSpan,
+    mockInstrumentAsync: vi.fn(
+      async (
+        _options: unknown,
+        callback: (span: typeof mockAuthSpan) => unknown,
+      ) => callback(mockAuthSpan),
+    ),
+  };
+});
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  instrumentAsync: mockInstrumentAsync,
+}));
+
+vi.mock("@/src/ee/features/multi-tenant-sso/utils", () => ({
+  findMultiTenantSsoConfig: vi.fn(),
+  getSsoAuthProviderIdForDomain: vi.fn(),
+  loadSsoProviders: vi.fn().mockResolvedValue([]),
+}));
+
+import { getAuthOptions } from "@/src/server/auth";
+
+describe("next-auth sign-in span attributes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not attach the user email to the sign-in span", async () => {
+    const authOptions = await getAuthOptions();
+    const signIn = authOptions.callbacks?.signIn;
+    if (!signIn) throw new Error("Expected a sign-in callback");
+
+    await signIn({
+      user: { id: "user-1", email: "user@example.com" },
+      account: null,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(mockAuthSpan.setAttributes).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        "auth.email": "user@example.com",
+      }),
+    );
+  });
+});

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -109,7 +109,6 @@ export default async function handler(request: Request) {
 
     addUserToSpan({
       userId,
-      email: user.email ?? undefined,
     });
 
     if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
@@ -257,7 +256,6 @@ export default async function handler(request: Request) {
 
     addUserToSpan({
       userId,
-      email: user.email ?? undefined,
       projectId: rateLimitScope.projectId ?? undefined,
       orgId: rateLimitScope.orgId,
       plan: rateLimitScope.plan,

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -65,7 +65,6 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
 
   addUserToSpan({
     userId: session?.user?.id,
-    email: session?.user?.email ?? undefined,
   });
 
   return createInnerTRPCContext({ session, headers });

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -815,7 +815,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             },
           });
 
-          span.setAttribute("langfuse.user.email", dbUser?.email ?? "");
           span.setAttribute("langfuse.user.id", dbUser?.id ?? "");
           // V4 preview availability is governed by the write mode:
           // - events_only: the legacy traces/observations tables are no longer
@@ -961,7 +960,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
         });
       },
       async signIn({ user, account, profile }) {
-        return instrumentAsync({ name: "next-auth-sign-in" }, async (span) => {
+        return instrumentAsync({ name: "next-auth-sign-in" }, async () => {
           // Block sign in without valid user.email
           const email = user.email?.toLowerCase();
           if (!email) {
@@ -973,9 +972,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             throw new Error("Invalid email found in user object");
           }
 
-          span.setAttributes({
-            "auth.email": email,
-          });
           // EE: Check custom SSO enforcement, enforce the specific SSO provider on email domain
           // This also blocks setting a password for an email that is enforced to use SSO via password reset flow
           const userDomain = email.split("@")[1].toLowerCase();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v3 backport of #15908. Core instrumentation/auth paths only; in-app-agent files from main were skipped because they do not exist on v3. The v3 `ee/` in-app-agent handler was adapted so `addUserToSpan` no longer accepts `email`.

Datadog spans and baggage no longer carry user email.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `packages/shared`
- `web`

## Verification

- `pnpm --filter @langfuse/shared run test index.test.ts` → **Tests 3 passed (3)**
- `pnpm --filter web run test auth-sign-in-span.servertest.ts` → **Tests 1 passed (1)**
- Full lint/typecheck and heavy in-app-agent integration skipped (needs fuller stack)

## Mandatory Tasks

- [x] Self-reviewed the adapted cherry-pick against v3 Datadog span user fields

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport removes authenticated-user email addresses from Datadog/OpenTelemetry span attributes and baggage while retaining non-email user identifiers.
- Removes email handling from the shared `addUserToSpan` contract.
- Updates tRPC and in-app-agent callers to stop supplying email.
- Removes email attributes from session and sign-in spans.
- Adds regression coverage for baggage, span attributes, and sign-in instrumentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the reviewed Datadog span and baggage paths consistently excluding authenticated-user emails.

The shared instrumentation contract and all production callers were updated together, the removed email attributes do not participate in authentication or authorization decisions, and no changed path leaves the authenticated user's email in Datadog spans or baggage.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Authenticated request] --> B[Auth, tRPC, or in-app-agent path]
  B --> C[addUserToSpan]
  C --> D[user.id and scoped identifiers]
  D --> E[OpenTelemetry span and baggage]
  E --> F[Datadog export]
  B -. user email omitted .-> C
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observability): remove user emails f..."](https://github.com/langfuse/langfuse/commit/9a9d06a383c31a0dd92eadb8fffe302dc7d0cdb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56609026)</sub>

<!-- /greptile_comment -->