### PR TITLE
fix(rbac): gate updateProjectRole on rbac-project-roles entitlement (v3 backport of #16171)

### DIFF
--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -395,9 +395,121 @@ describe("membersRouter.updateOrgMembership - audit log state capture", () => {
   });
 });
 
+describe("membersRouter.updateProjectRole - rbac-project-roles entitlement", () => {
+  it.each([
+    "cloud:hobby",
+    "cloud:core",
+    "cloud:pro",
+    "oss",
+    "self-hosted:pro",
+  ] as const)(
+    "rejects assigning a project role on %s (no rbac-project-roles)",
+    async (plan) => {
+      const { org, project, caller } = await prepare(plan);
+
+      const targetUser = await createTestUser();
+      const orgMembership = await prisma.organizationMembership.create({
+        data: {
+          userId: targetUser.id,
+          orgId: org.id,
+          role: Role.MEMBER,
+        },
+      });
+
+      await expect(
+        caller.members.updateProjectRole({
+          orgId: org.id,
+          orgMembershipId: orgMembership.id,
+          userId: targetUser.id,
+          projectId: project.id,
+          projectRole: Role.VIEWER,
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      const row = await prisma.projectMembership.findUnique({
+        where: {
+          projectId_userId: {
+            projectId: project.id,
+            userId: targetUser.id,
+          },
+        },
+      });
+      expect(row).toBeNull();
+    },
+  );
+
+  it.each([
+    "cloud:team",
+    "cloud:enterprise",
+    "self-hosted:enterprise",
+  ] as const)("allows assigning a project role on %s", async (plan) => {
+    const { org, project, caller } = await prepare(plan);
+
+    const targetUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+
+    await expect(
+      caller.members.updateProjectRole({
+        orgId: org.id,
+        orgMembershipId: orgMembership.id,
+        userId: targetUser.id,
+        projectId: project.id,
+        projectRole: Role.VIEWER,
+      }),
+    ).resolves.toMatchObject({ userId: targetUser.id, role: Role.VIEWER });
+  });
+
+  it("allows clearing an existing project role on cloud:hobby without entitlement", async () => {
+    const { org, project, caller } = await prepare("cloud:hobby");
+
+    const targetUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+    await prisma.projectMembership.create({
+      data: {
+        userId: targetUser.id,
+        projectId: project.id,
+        role: Role.VIEWER,
+        orgMembershipId: orgMembership.id,
+      },
+    });
+
+    await expect(
+      caller.members.updateProjectRole({
+        orgId: org.id,
+        orgMembershipId: orgMembership.id,
+        userId: targetUser.id,
+        projectId: project.id,
+        projectRole: Role.NONE,
+      }),
+    ).resolves.toMatchObject({ userId: targetUser.id });
+
+    const row = await prisma.projectMembership.findUnique({
+      where: {
+        projectId_userId: {
+          projectId: project.id,
+          userId: targetUser.id,
+        },
+      },
+    });
+    expect(row).toBeNull();
+  });
+});
+
 describe("membersRouter.updateProjectRole - audit log state capture", () => {
   it("records action=create with after when assigning a new project role", async () => {
-    const { org, project, caller } = await prepare("cloud:core");
+    const { org, project, caller } = await prepare("cloud:team");
 
     const targetUser = await createTestUser();
     const orgMembership = await prisma.organizationMembership.create({
@@ -437,7 +549,7 @@ describe("membersRouter.updateProjectRole - audit log state capture", () => {
   });
 
   it("records action=update with before and after when changing an existing project role", async () => {
-    const { org, project, caller } = await prepare("cloud:core");
+    const { org, project, caller } = await prepare("cloud:team");
 
     const targetUser = await createTestUser();
     const orgMembership = await prisma.organizationMembership.create({
@@ -485,7 +597,7 @@ describe("membersRouter.updateProjectRole - audit log state capture", () => {
   });
 
   it("uses consistent resourceId across create, update, and delete", async () => {
-    const { org, project, caller } = await prepare("cloud:core");
+    const { org, project, caller } = await prepare("cloud:team");
 
     const targetUser = await createTestUser();
     const orgMembership = await prisma.organizationMembership.create({
@@ -539,7 +651,7 @@ describe("membersRouter.updateProjectRole - audit log state capture", () => {
 
 describe("membersRouter.updateProjectRole - orgMembership/userId consistency", () => {
   it("rejects a mismatched orgMembershipId / userId pair with BAD_REQUEST and writes nothing", async () => {
-    const { org, project, caller } = await prepare("cloud:core");
+    const { org, project, caller } = await prepare("cloud:team");
 
     // The org member who actually owns the targeted org membership.
     const targetUser = await createTestUser();
@@ -584,7 +696,7 @@ describe("membersRouter.updateProjectRole - orgMembership/userId consistency", (
   });
 
   it("allows a matching orgMembershipId / userId pair", async () => {
-    const { org, project, caller } = await prepare("cloud:core");
+    const { org, project, caller } = await prepare("cloud:team");
 
     const targetUser = await createTestUser();
     const orgMembership = await prisma.organizationMembership.create({
@@ -617,8 +729,8 @@ describe("membersRouter.updateProjectRole - orgMembership/userId consistency", (
 
 describe("membersRouter.updateProjectRole - project organization consistency", () => {
   it("rejects a project from another organization without writing membership or audit log", async () => {
-    const { org, ownerUser, caller } = await prepare("cloud:core");
-    const { project: otherOrgProject } = await createTestOrg("cloud:core");
+    const { org, ownerUser, caller } = await prepare("cloud:team");
+    const { project: otherOrgProject } = await createTestOrg("cloud:team");
 
     const orgMembership = await prisma.organizationMembership.findUniqueOrThrow(
       {

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -652,6 +652,25 @@ export const membersRouter = createTRPCRouter({
         });
       }
 
+      // Project-level role assignments require the rbac-project-roles entitlement
+      // (Team/Enterprise cloud, Enterprise self-hosted). Mirror the create path.
+      // Clearing a role (null / NONE) stays allowed so orgs can clean up after a
+      // plan downgrade without needing the paid entitlement.
+      if (input.projectRole !== null && input.projectRole !== Role.NONE) {
+        const entitled = hasEntitlement({
+          entitlement: "rbac-project-roles",
+          sessionUser: ctx.session.user,
+          orgId: input.orgId,
+        });
+        if (!entitled) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message:
+              "Organization does not have the required entitlement to set project roles",
+          });
+        }
+      }
+
       const project = await ctx.prisma.project.findFirst({
         where: {
           id: input.projectId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backport of #16171 to the `v3` maintenance line.

`updateProjectRole` now checks the `rbac-project-roles` entitlement before assigning a non-null/non-NONE project role, matching the existing `create` path. Clearing a project role (`null` / `NONE`) remains allowed so orgs can clean up after a plan downgrade without the paid entitlement.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web` (`membersRouter.updateProjectRole`, members tRPC server tests)

## Verification

- Cherry-pick applied cleanly onto `origin/v3`
- `pnpm --filter web run test members-trpc.servertest.ts` → **Tests 23 passed (23)**

## Mandatory Tasks

- [x] Self-reviewed the cherry-pick against v3 members RBAC

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR backports entitlement enforcement to project-role updates while preserving role removal after a plan downgrade.
- Rejects non-clearing project-role assignments when `rbac-project-roles` is unavailable.
- Keeps `null` and `NONE` cleanup operations available without the entitlement.
- Adds plan coverage and adjusts existing tests to use an entitled plan.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new guard consistently rejects paid project-role assignments on ineligible plans, permits supported cleanup representations, and resolves entitled Cloud and self-hosted plans through the established session path.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): gate updateProjectRole on rba..."](https://github.com/langfuse/langfuse/commit/8abf6b2a3b5b9dd5153fbace0171703fa45eb64f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56609030)</sub>

<!-- /greptile_comment -->