### PR TITLE
fix(rbac): let project members view the API keys page (v3 backport of #16312)

### DIFF
--- a/web/src/__tests__/server/project-api-key-trpc.servertest.ts
+++ b/web/src/__tests__/server/project-api-key-trpc.servertest.ts
@@ -25,8 +25,10 @@ describe("project API keys trpc", () => {
     });
   });
 
-  async function createProjectCaller() {
-    const { projectId, orgId } = await createOrgProjectAndApiKey();
+  async function createProjectCaller(
+    projectRole: "ADMIN" | "MEMBER" = "ADMIN",
+  ) {
+    const { projectId, orgId, publicKey } = await createOrgProjectAndApiKey();
 
     const session: Session = {
       expires: "1",
@@ -47,7 +49,7 @@ describe("project API keys trpc", () => {
             projects: [
               {
                 id: projectId,
-                role: "ADMIN",
+                role: projectRole,
                 retentionDays: 30,
                 deletedAt: null,
                 hasTraces: false,
@@ -74,7 +76,7 @@ describe("project API keys trpc", () => {
     const ctx = createInnerTRPCContext({ session, headers: {} });
     const caller = appRouter.createCaller({ ...ctx, prisma });
 
-    return { caller, projectId };
+    return { caller, projectId, publicKey };
   }
 
   describe("projectApiKeys.byProjectId", () => {
@@ -95,6 +97,17 @@ describe("project API keys trpc", () => {
       expect(apiKeys.map((key) => key.note)).not.toContain(
         "In-app agent key hidden from project UI",
       );
+    });
+
+    // The settings page gates the list view on apiKeys:read, which MEMBERs
+    // hold without apiKeys:CUD. Pin that this read path stays open to them.
+    it("lists keys for MEMBER callers, who only hold apiKeys:read", async () => {
+      const { caller, projectId, publicKey } =
+        await createProjectCaller("MEMBER");
+
+      const apiKeys = await caller.projectApiKeys.byProjectId({ projectId });
+
+      expect(apiKeys.map((key) => key.publicKey)).toContain(publicKey);
     });
   });
 

--- a/web/src/features/public-api/components/ApiKeyList.clienttest.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.clienttest.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { type Role } from "@langfuse/shared/src/db";
+
+const { projectApiKeys, mockSession } = vi.hoisted(() => ({
+  projectApiKeys: [
+    {
+      id: "key-1",
+      createdAt: new Date("2026-01-02T03:04:05.000Z"),
+      expiresAt: null,
+      lastUsedAt: null,
+      note: "Production key",
+      publicKey: "pk-lf-1234",
+      displaySecretKey: "sk-lf-...5678",
+      createdByUser: null,
+      createdByApiKey: null,
+    },
+  ],
+  mockSession: { data: null as unknown },
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockSession,
+}));
+
+vi.mock("@/src/utils/api", () => {
+  const noopMutation = () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  });
+  return {
+    api: {
+      projectApiKeys: {
+        byProjectId: {
+          useQuery: (
+            _input: unknown,
+            options?: { enabled?: boolean },
+          ): { data?: typeof projectApiKeys } =>
+            options?.enabled ? { data: projectApiKeys } : {},
+        },
+        create: { useMutation: noopMutation },
+        updateNote: { useMutation: noopMutation },
+        delete: { useMutation: noopMutation },
+      },
+      organizationApiKeys: {
+        byOrganizationId: { useQuery: () => ({}) },
+        create: { useMutation: noopMutation },
+        updateNote: { useMutation: noopMutation },
+        delete: { useMutation: noopMutation },
+      },
+      useUtils: () => ({
+        projectApiKeys: { invalidate: vi.fn() },
+        organizationApiKeys: { invalidate: vi.fn() },
+      }),
+    },
+    reportNonTrpcError: vi.fn(),
+  };
+});
+
+vi.mock("@/src/features/public-api/hooks/useLangfuseEnvCode", () => ({
+  useLangfuseEnvCode: () => 'LANGFUSE_PUBLIC_KEY="pk-lf-..."',
+  useLangfuseBaseUrl: () => "http://localhost:3000",
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+import { ApiKeyList } from "./ApiKeyList";
+
+const PROJECT_ID = "project-1";
+
+function renderAsProjectRole(role: Role) {
+  mockSession.data = {
+    user: {
+      admin: false,
+      organizations: [{ id: "org-1", projects: [{ id: PROJECT_ID, role }] }],
+    },
+  };
+
+  return render(<ApiKeyList entityId={PROJECT_ID} scope="project" />);
+}
+
+describe("ApiKeyList project access gating", () => {
+  it("lists keys read-only for a MEMBER, who holds apiKeys:read but not apiKeys:CUD", () => {
+    renderAsProjectRole("MEMBER");
+
+    expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
+    expect(screen.getByTitle("pk-lf-1234")).toBeInTheDocument();
+    expect(screen.getByText("sk-lf-...5678")).toBeInTheDocument();
+    // Write controls stay behind apiKeys:CUD: no create button, and the note
+    // renders as plain text instead of the click-to-edit affordance.
+    expect(
+      screen.queryByRole("button", { name: /create new api keys/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Production key")).toBeInTheDocument();
+    expect(screen.queryByText("Click to add note")).not.toBeInTheDocument();
+  });
+
+  it("shows write controls for an ADMIN, who holds apiKeys:CUD", () => {
+    renderAsProjectRole("ADMIN");
+
+    expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
+    expect(screen.getByTitle("pk-lf-1234")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /create new api keys/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("denies access to a VIEWER, who holds neither api key scope", () => {
+    renderAsProjectRole("VIEWER");
+
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+    expect(screen.queryByTitle("pk-lf-1234")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -45,9 +45,12 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
     );
   }
 
-  const hasProjectAccess = useHasProjectAccess({
+  // Viewing the list only needs apiKeys:read, which project MEMBERs hold.
+  // Create, delete, and note editing stay behind apiKeys:CUD and are gated
+  // individually by CreateApiKeyButton, DeleteApiKeyButton, and ApiKeyNote.
+  const hasProjectReadAccess = useHasProjectAccess({
     projectId: props.entityId,
-    scope: "apiKeys:CUD",
+    scope: "apiKeys:read",
   });
   const hasOrganizationAccess = useHasOrganizationAccess({
     organizationId: props.entityId,
@@ -55,11 +58,11 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
   });
 
   const hasAccess =
-    props.scope === "project" ? hasProjectAccess : hasOrganizationAccess;
+    props.scope === "project" ? hasProjectReadAccess : hasOrganizationAccess;
 
   const projectApiKeysQuery = api.projectApiKeys.byProjectId.useQuery(
     { projectId: entityId },
-    { enabled: hasProjectAccess && props.scope === "project" },
+    { enabled: hasProjectReadAccess && props.scope === "project" },
   );
   const organizationApiKeysQuery =
     api.organizationApiKeys.byOrganizationId.useQuery(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

v3 backport of #16312. Cherry-picked `e70e14e96` onto `v3` with a small conflict adaptation in the project API keys tRPC test helper.

The project API keys settings page gated its whole render — and the list query's `enabled` flag — on `apiKeys:CUD`, so a project MEMBER saw "Access Denied" even though the RBAC definition grants MEMBER `apiKeys:read` and `projectApiKeys.byProjectId` only requires that scope.

Gate the project list view on `apiKeys:read` instead. Create, delete, and note editing already gate themselves on `apiKeys:CUD` individually, so members get a read-only view and write controls stay hidden. Organization keys are unchanged: there is only one org scope, `organization:CRUD_apiKeys`.

### Conflict adaptation

On v3, `createProjectCaller` hard-coded project role `ADMIN`. The cherry-pick needed the main-line helper shape: accept `projectRole`, return `publicKey`, and use `role: projectRole` so the new MEMBER list test exercises `apiKeys:read` without `apiKeys:CUD`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client 'ApiKeyList.clienttest.tsx'` → Tests 3 passed (3)
- `pnpm --filter web run test 'project-api-key-trpc.servertest.ts'` → Tests 5 passed (5)
- Targeted ESLint `--max-warnings 0` on the touched web files: passed

## Mandatory Tasks

- [x] Self-reviewed the cherry-pick against the v3 ApiKeyList and RBAC scopes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes the project API-key list gate from apiKeys:CUD to apiKeys:read so project members can view keys without receiving mutation controls.
- Adds client coverage for MEMBER, ADMIN, and VIEWER rendering behavior.
- Adds server coverage confirming MEMBER callers can list project API keys.
- Adapts the server-test helper to accept a project role and return the generated public key.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking import-placement issue in the new client test.

The read gate matches the server procedure and project role rights, while all credential mutations remain independently protected; the only accepted concern is test-module import organization.

**Files Needing Attention:** web/src/features/public-api/components/ApiKeyList.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/public-api/components/ApiKeyList.clienttest.tsx:69
**Keep imports at module top**

The `ApiKeyList` import appears after module-level mock declarations, violating the repository's import organization rule and making dependencies less consistent and discoverable.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): let project members view the ..."](https://github.com/langfuse/langfuse/commit/12828d48272118ac52bed918f0ddd1437f63f8e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56609025)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->