### PR TITLE
fix(auth): harden NextAuth callback handling (v3 backport of #15760, #15989, #16461)

### DIFF
--- a/web/src/__tests__/server/unit/getServerAuthSession-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/getServerAuthSession-invalid-callback-url.servertest.ts
@@ -1,0 +1,114 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { NextRequest } from "next/server";
+import type * as NextAuth from "next-auth";
+import { createMocks } from "node-mocks-http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getCookieName } from "@/src/server/utils/cookies";
+
+const { mockGetServerSession } = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mockGetServerSession,
+}));
+
+vi.mock("@/src/ee/features/multi-tenant-sso/utils", () => ({
+  findMultiTenantSsoConfig: vi.fn(),
+  getSsoAuthProviderIdForDomain: vi.fn(),
+  loadSsoProviders: vi.fn().mockResolvedValue([]),
+}));
+
+import {
+  getAuthOptions,
+  getServerAuthSession,
+  getServerAuthSessionForRequest,
+} from "@/src/server/auth";
+
+const callbackUrlCookieName = getCookieName("next-auth.callback-url");
+const originalNextAuthSecret = process.env.NEXTAUTH_SECRET;
+
+const assertSanitizedRequest = (request: {
+  cookies?: Partial<Record<string, string>>;
+}) => {
+  expect(request.cookies?.[callbackUrlCookieName]).toBeUndefined();
+  expect(request.cookies?.["next-auth.session-token"]).toBe("valid-token");
+};
+
+describe("getServerAuthSession invalid callback URL handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockImplementation(async (request) => {
+      assertSanitizedRequest(request);
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    if (originalNextAuthSecret === undefined) {
+      delete process.env.NEXTAUTH_SECRET;
+    } else {
+      process.env.NEXTAUTH_SECRET = originalNextAuthSecret;
+    }
+  });
+
+  it("removes an invalid callback-url cookie before calling next-auth", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+    });
+    req.cookies = {
+      [callbackUrlCookieName]: "nslookup -q=cname scanner.example",
+      "next-auth.session-token": "valid-token",
+    };
+
+    await expect(getServerAuthSession({ req, res })).resolves.toBeNull();
+
+    expect(mockGetServerSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes an invalid callback-url cookie from an App Router request", async () => {
+    const { getServerSession: realGetServerSession } =
+      await vi.importActual<typeof NextAuth>("next-auth");
+    process.env.NEXTAUTH_SECRET = "test-secret";
+    mockGetServerSession.mockImplementation((request, response, options) => {
+      assertSanitizedRequest(request);
+      return realGetServerSession(request, response, options);
+    });
+
+    const request = new NextRequest("http://localhost/api/chatCompletion", {
+      headers: {
+        cookie: `${callbackUrlCookieName}=nslookup -q=cname scanner.example; next-auth.session-token=valid-token`,
+      },
+    });
+
+    await expect(getServerAuthSessionForRequest(request)).resolves.toBeNull();
+
+    expect(mockGetServerSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("sanitizes an invalid callback-url cookie from a raw cookie header", async () => {
+    const request = new Request("http://localhost/api/chatCompletion", {
+      headers: {
+        cookie: `${callbackUrlCookieName}=nslookup -q=cname scanner.example; next-auth.session-token=valid-token`,
+      },
+    });
+
+    await expect(getServerAuthSessionForRequest(request)).resolves.toBeNull();
+
+    expect(mockGetServerSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the base URL for a malformed redirect callback URL", async () => {
+    const authOptions = await getAuthOptions();
+    const redirect = authOptions.callbacks?.redirect;
+    if (!redirect) throw new Error("Expected a redirect callback");
+
+    expect(
+      redirect({
+        url: "/project/test\r\nscanner-payload",
+        baseUrl: "http://localhost:3000",
+      }),
+    ).toBe("http://localhost:3000");
+  });
+});

--- a/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
+++ b/web/src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts
@@ -104,6 +104,49 @@ function createRequest({
   return { req, res };
 }
 
+const callbackUrlCookieName = "next-auth.callback-url";
+const htmlActions = ["signin", "signout", "error", "verify-request"] as const;
+const expectedHtmlActionStatus = {
+  signin: 302,
+  signout: 200,
+  error: 302,
+  "verify-request": 200,
+} as const;
+const duplicateCallbackUrl = ["/home", "https://evil.com"];
+
+const getHeaderText = (res: NextApiResponse, name: string) => {
+  const value = res.getHeader(name);
+  return Array.isArray(value) ? value.join("\n") : String(value ?? "");
+};
+
+const callAuthWithoutInvalidCallbackUrlError = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => {
+  const consoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => undefined);
+
+  try {
+    await auth(req, res);
+    expect(
+      consoleError.mock.calls.some((args) =>
+        args.some((argument) =>
+          String(argument).includes("INVALID_CALLBACK_URL_ERROR"),
+        ),
+      ),
+    ).toBe(false);
+  } finally {
+    consoleError.mockRestore();
+  }
+};
+
+const expectSafeCallbackUrlResponse = (res: NextApiResponse) => {
+  expect(res.statusCode).toBeLessThan(500);
+  expect(getHeaderText(res, "Location")).not.toContain("evil.com");
+  expect(getHeaderText(res, "Set-Cookie")).not.toContain("evil.com");
+};
+
 describe("NextAuth error route malformed input handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -148,6 +191,32 @@ describe("NextAuth error route malformed input handling", () => {
     expect(res.getHeader("Location")).toBe(
       "/auth/error?error=configuration%0D%0Ascanner-payload",
     );
+  });
+
+  for (const action of htmlActions) {
+    it(`sanitizes duplicated callbackUrl query parameters for GET ${action} (/home first)`, async () => {
+      const { req, res } = createRequest({
+        nextauth: [action],
+        query: { callbackUrl: duplicateCallbackUrl },
+      });
+
+      await callAuthWithoutInvalidCallbackUrlError(req, res);
+
+      expect(res.statusCode).toBe(expectedHtmlActionStatus[action]);
+      expectSafeCallbackUrlResponse(res);
+    });
+  }
+
+  it("sanitizes an invalid callback-url cookie for GET signin", async () => {
+    const { req, res } = createRequest({
+      nextauth: ["signin"],
+      cookies: { [callbackUrlCookieName]: "https://evil.com%0d%0a" },
+    });
+
+    await callAuthWithoutInvalidCallbackUrlError(req, res);
+
+    expect(res.statusCode).toBe(expectedHtmlActionStatus.signin);
+    expectSafeCallbackUrlResponse(res);
   });
 
   it("uses a generic error for an ambiguous array-valued error", async () => {

--- a/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
@@ -192,3 +192,54 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
     expect(mockNextAuth).not.toHaveBeenCalled();
   });
 });
+
+describe("[...nextauth] credentials callback method guard", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a GET to the credentials callback with 405 and an Allow: POST header", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res.getHeader("Allow")).toBe("POST");
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("rejects a PUT to the credentials callback with 405", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "PUT",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("passes a POST to the credentials callback through to next-auth", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("still returns 200 for a HEAD to the credentials callback", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "HEAD",
+      query: { nextauth: ["callback", "credentials"] },
+    });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
+++ b/web/src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts
@@ -1,10 +1,38 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 
-const { mockNextAuth, mockGetAuthOptions } = vi.hoisted(() => ({
-  mockNextAuth: vi.fn(async (_req: unknown, res: any) => res.status(200).end()),
-  mockGetAuthOptions: vi.fn(async () => ({})),
-}));
+type NextAuthRequestSnapshot = Pick<NextApiRequest, "query" | "cookies">;
+
+const {
+  mockNextAuth,
+  mockGetAuthOptions,
+  mockLoggerWarn,
+  mockNextAuthRequestSnapshot,
+} = vi.hoisted(() => {
+  const mockNextAuthRequestSnapshot =
+    vi.fn<(snapshot: NextAuthRequestSnapshot) => void>();
+  const mockNextAuth = vi.fn(
+    async (req: NextApiRequest, res: NextApiResponse) => {
+      mockNextAuthRequestSnapshot({
+        query: Object.fromEntries(
+          Object.entries(req.query).map(([key, value]) => [
+            key,
+            Array.isArray(value) ? [...value] : value,
+          ]),
+        ),
+        cookies: { ...req.cookies },
+      });
+      res.status(200).end();
+    },
+  );
+
+  return {
+    mockNextAuth,
+    mockGetAuthOptions: vi.fn(async () => ({})),
+    mockLoggerWarn: vi.fn(),
+    mockNextAuthRequestSnapshot,
+  };
+});
 
 vi.mock("next-auth", () => ({ default: mockNextAuth }));
 
@@ -17,7 +45,7 @@ vi.mock("@langfuse/shared/src/server", () => ({
   logger: {
     debug: vi.fn(),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: mockLoggerWarn,
     error: vi.fn(),
   },
   ClickHouseClientManager: {
@@ -39,6 +67,13 @@ vi.mock("@/src/env.mjs", () => ({
 
 import handler from "@/src/pages/api/auth/[...nextauth]";
 
+const callbackUrlCookieName = "next-auth.callback-url";
+
+const getNextAuthRequest = (): NextAuthRequestSnapshot => {
+  expect(mockNextAuthRequestSnapshot).toHaveBeenCalledTimes(1);
+  return mockNextAuthRequestSnapshot.mock.calls[0]![0];
+};
+
 const callHandler = async (options: Parameters<typeof createMocks>[0] = {}) => {
   const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
     method: "GET",
@@ -46,7 +81,7 @@ const callHandler = async (options: Parameters<typeof createMocks>[0] = {}) => {
     ...options,
   });
   await handler(req, res);
-  return { req, res };
+  return { res };
 };
 
 describe("[...nextauth] invalid callbackUrl handling", () => {
@@ -122,6 +157,9 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
+    expect(getNextAuthRequest().query.callbackUrl).toBe(
+      "https://cloud.langfuse.com/project/abc",
+    );
   });
 
   it("passes through a relative callbackUrl", async () => {
@@ -134,6 +172,7 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
+    expect(getNextAuthRequest().query.callbackUrl).toBe("/project/abc");
   });
 
   it("passes through a valid callback-url cookie", async () => {
@@ -143,6 +182,9 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
+    expect(getNextAuthRequest().cookies[callbackUrlCookieName]).toBe(
+      "https://cloud.langfuse.com",
+    );
   });
 
   it("passes through when no callbackUrl is present", async () => {
@@ -150,6 +192,8 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
+    expect(getNextAuthRequest().query.callbackUrl).toBeUndefined();
+    expect(getNextAuthRequest().cookies[callbackUrlCookieName]).toBeUndefined();
   });
 
   it("passes through an empty callbackUrl query param (next-auth treats it as absent)", async () => {
@@ -159,6 +203,7 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
+    expect(getNextAuthRequest().query.callbackUrl).toBe("");
   });
 
   it("passes through an empty callback-url cookie (next-auth treats it as absent)", async () => {
@@ -168,15 +213,58 @@ describe("[...nextauth] invalid callbackUrl handling", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
+    expect(getNextAuthRequest().cookies[callbackUrlCookieName]).toBe("");
   });
 
-  it("passes an invalid callbackUrl through on GET signin (next-auth redirects to its error page instead of 500ing)", async () => {
+  it("removes an invalid callbackUrl before passing GET signin to next-auth", async () => {
     const { res } = await callHandler({
       query: { nextauth: ["signin"], callbackUrl: "www.example.com/foo" },
     });
 
     expect(res._getStatusCode()).toBe(200);
     expect(mockNextAuth).toHaveBeenCalledTimes(1);
+    expect(getNextAuthRequest().query.callbackUrl).toBeUndefined();
+  });
+
+  it("removes invalid callbackUrl query and cookie independently before GET signin", async () => {
+    const { res } = await callHandler({
+      query: {
+        nextauth: ["signin"],
+        callbackUrl: ["https://evil.com", "/home"],
+      },
+      cookies: { [callbackUrlCookieName]: "https://evil.com%0d%0a" },
+    });
+
+    expect(res._getStatusCode()).toBe(200);
+    const nextAuthRequest = getNextAuthRequest();
+    expect(nextAuthRequest.query.callbackUrl).toBeUndefined();
+    expect(nextAuthRequest.cookies[callbackUrlCookieName]).toBeUndefined();
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(2);
+
+    const warningMetadata = mockLoggerWarn.mock.calls.map(
+      ([message, metadata]) => {
+        expect(message).toBe("[NEXT_AUTH] Invalid callback URL");
+        expect(Object.keys(metadata).sort()).toEqual(
+          ["action", "path", "inputSource", "valueType"].sort(),
+        );
+        expect(JSON.stringify(metadata)).not.toContain("evil.com");
+        return metadata;
+      },
+    );
+    expect(warningMetadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "signin",
+          inputSource: "query",
+          valueType: "array",
+        }),
+        expect.objectContaining({
+          action: "signin",
+          inputSource: "cookie",
+          valueType: "string",
+        }),
+      ]),
+    );
   });
 
   it("rejects an invalid callbackUrl on POST signin with 400 (no HTML error-page carve-out for POST)", async () => {

--- a/web/src/features/playground/server/authorizeRequest.ts
+++ b/web/src/features/playground/server/authorizeRequest.ts
@@ -1,6 +1,4 @@
-import { getServerSession } from "next-auth";
-
-import { getAuthOptions } from "@/src/server/auth";
+import { getServerAuthSessionForRequest } from "@/src/server/auth";
 import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
 import { ForbiddenError, UnauthorizedError } from "@langfuse/shared";
 import { hasProjectAccess } from "../../rbac/utils/checkProjectAccess";
@@ -11,9 +9,9 @@ export type AuthorizeRequestResult = {
 
 export const authorizeRequestOrThrow = async (
   projectId: string,
+  request: Request,
 ): Promise<AuthorizeRequestResult> => {
-  const authOptions = await getAuthOptions();
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSessionForRequest(request);
   if (!session?.user) throw new UnauthorizedError("Unauthenticated");
 
   if (!isProjectMemberOrAdmin(session.user, projectId))

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -28,7 +28,7 @@ import * as opentelemetry from "@opentelemetry/api";
 export default async function chatCompletionHandler(req: NextRequest) {
   try {
     const body = validateChatCompletionBody(await req.json());
-    const { userId } = await authorizeRequestOrThrow(body.projectId);
+    const { userId } = await authorizeRequestOrThrow(body.projectId, req);
 
     const blockedUsers = env.LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION;
     if (blockedUsers.has(userId)) {

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -10,6 +10,10 @@ const maxAuthErrorLength = 1_000;
 const authErrorFallback = "Configuration";
 
 type AuthErrorSource = "query" | "path";
+type CallbackUrlInputSource = "query" | "cookie";
+
+const getCallbackUrlValueType = (value: unknown) =>
+  Array.isArray(value) ? "array" : typeof value;
 
 // Single parse of the [...nextauth] catch-all: [action, provider], e.g.
 // /api/auth/callback/credentials -> ["callback", "credentials"].
@@ -81,31 +85,55 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
 
   // next-auth rejects malformed callbackUrl values (query param or cookie)
   // with a hardcoded 500, so vulnerability scanners probing auth routes page
-  // our server-error monitors. Malformed client input is a 4xx; reject it
-  // before next-auth sees it. Two carve-outs keep parity with next-auth:
-  // falsy values are treated as absent (assertConfig checks truthiness), and
-  // GET requests to next-auth's HTML page actions are exempt — those never
-  // 500; next-auth redirects them to the configured error page.
+  // our server-error monitors. Falsy values are treated as absent because
+  // next-auth's assertConfig checks truthiness. For GET requests to next-auth's
+  // HTML page actions, remove malformed inputs and let next-auth render its
+  // normal flow; other actions retain the 400 boundary.
   const rendersHtmlErrorPage =
     req.method === "GET" &&
     ["signin", "signout", "error", "verify-request"].includes(
       nextAuthAction ?? "",
     );
+  const callbackUrlCookieName = getCookieName("next-auth.callback-url");
   const callbackUrlParam = req.query.callbackUrl;
-  const callbackUrlCookie =
-    req.cookies[getCookieName("next-auth.callback-url")];
-  const invalidCallbackUrl =
-    !rendersHtmlErrorPage &&
-    ((Boolean(callbackUrlParam) && !isValidCallbackUrl(callbackUrlParam)) ||
-      (Boolean(callbackUrlCookie) && !isValidCallbackUrl(callbackUrlCookie)));
-  if (invalidCallbackUrl) {
-    logger.warn("[NEXT_AUTH] Rejected invalid callback URL", {
-      callbackUrlParamType: Array.isArray(callbackUrlParam)
-        ? "array"
-        : typeof callbackUrlParam,
-      callbackUrlCookiePresent: Boolean(callbackUrlCookie),
+  const callbackUrlCookie = req.cookies[callbackUrlCookieName];
+  const invalidCallbackUrlParam =
+    Boolean(callbackUrlParam) && !isValidCallbackUrl(callbackUrlParam);
+  const invalidCallbackUrlCookie =
+    Boolean(callbackUrlCookie) && !isValidCallbackUrl(callbackUrlCookie);
+
+  const logInvalidCallbackUrl = (
+    inputSource: CallbackUrlInputSource,
+    value: unknown,
+  ) => {
+    logger.warn("[NEXT_AUTH] Invalid callback URL", {
+      action: nextAuthAction,
       path: req.url?.split("?")[0]?.slice(0, 200),
+      inputSource,
+      valueType: getCallbackUrlValueType(value),
     });
+  };
+
+  if (invalidCallbackUrlParam) {
+    logInvalidCallbackUrl("query", callbackUrlParam);
+  }
+  if (invalidCallbackUrlCookie) {
+    logInvalidCallbackUrl("cookie", callbackUrlCookie);
+  }
+
+  if (rendersHtmlErrorPage) {
+    if (invalidCallbackUrlParam) {
+      const { callbackUrl: _invalidCallbackUrl, ...sanitizedQuery } = req.query;
+      req.query = sanitizedQuery;
+    }
+    if (invalidCallbackUrlCookie) {
+      const {
+        [callbackUrlCookieName]: _invalidCallbackUrl,
+        ...sanitizedCookies
+      } = req.cookies;
+      req.cookies = sanitizedCookies;
+    }
+  } else if (invalidCallbackUrlParam || invalidCallbackUrlCookie) {
     return res.status(400).json({ message: "Invalid callback URL" });
   }
 

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -1,7 +1,6 @@
-import { validateHeaderValue } from "node:http";
-
 import { getAuthOptions } from "@/src/server/auth";
 import { getCookieName } from "@/src/server/utils/cookies";
+import { isValidCallbackUrl } from "@/src/server/utils/nextAuthCallbackUrl";
 import { env } from "@/src/env.mjs";
 import { logger } from "@langfuse/shared/src/server";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -52,23 +51,6 @@ const encodeAuthError = (error: unknown, source: AuthErrorSource) => {
   }
 };
 
-// Mirrors next-auth's assertConfig check (core/lib/assert.ts). Must never be
-// stricter than next-auth: relative URLs always pass (next-auth resolves them
-// against the deployment origin), absolute URLs must parse with an http(s)
-// scheme.
-const isValidCallbackUrl = (url: unknown): boolean => {
-  if (typeof url !== "string") return false;
-  try {
-    validateHeaderValue("Location", url);
-    return /^https?:/.test(
-      new URL(url, url.startsWith("/") ? "http://localhost" : undefined)
-        .protocol,
-    );
-  } catch {
-    return false;
-  }
-};
-
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // Workaround for corporate email link checkers (e.g., Outlook SafeLink)
   // https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
@@ -100,9 +82,11 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
       (Boolean(callbackUrlCookie) && !isValidCallbackUrl(callbackUrlCookie)));
   if (invalidCallbackUrl) {
     logger.warn("[NEXT_AUTH] Rejected invalid callback URL", {
-      callbackUrlParam: String(callbackUrlParam).slice(0, 200),
-      callbackUrlCookie: String(callbackUrlCookie).slice(0, 200),
-      path: req.url?.slice(0, 200),
+      callbackUrlParamType: Array.isArray(callbackUrlParam)
+        ? "array"
+        : typeof callbackUrlParam,
+      callbackUrlCookiePresent: Boolean(callbackUrlCookie),
+      path: req.url?.split("?")[0]?.slice(0, 200),
     });
     return res.status(400).json({ message: "Invalid callback URL" });
   }

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -11,9 +11,15 @@ const authErrorFallback = "Configuration";
 
 type AuthErrorSource = "query" | "path";
 
-const getAuthAction = (req: NextApiRequest) => {
+// Single parse of the [...nextauth] catch-all: [action, provider], e.g.
+// /api/auth/callback/credentials -> ["callback", "credentials"].
+const getNextAuthSegments = (
+  req: NextApiRequest,
+): [string | undefined, string | undefined] => {
   const nextauth = req.query.nextauth;
-  return Array.isArray(nextauth) ? nextauth[0] : nextauth;
+  return Array.isArray(nextauth)
+    ? [nextauth[0], nextauth[1]]
+    : [nextauth, undefined];
 };
 
 const logAuthErrorFallback = (
@@ -52,10 +58,25 @@ const encodeAuthError = (error: unknown, source: AuthErrorSource) => {
 };
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
+  const [nextAuthAction, nextAuthProvider] = getNextAuthSegments(req);
+
   // Workaround for corporate email link checkers (e.g., Outlook SafeLink)
   // https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
   if (req.method === "HEAD") {
     return res.status(200).end();
+  }
+
+  // next-auth answers non-POST requests to the credentials callback with a
+  // bare, unlogged 500, so scanners probing this URL page our error-rate
+  // monitors. Reject them with a 405 before next-auth sees them.
+  const isCredentialsCallback =
+    nextAuthAction === "callback" && nextAuthProvider === "credentials";
+  if (isCredentialsCallback && req.method !== "POST") {
+    logger.warn(
+      `[NEXT_AUTH] Rejected ${req.method} to credentials callback with 405`,
+    );
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ message: "Method Not Allowed" });
   }
 
   // next-auth rejects malformed callbackUrl values (query param or cookie)
@@ -65,9 +86,6 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // falsy values are treated as absent (assertConfig checks truthiness), and
   // GET requests to next-auth's HTML page actions are exempt — those never
   // 500; next-auth redirects them to the configured error page.
-  const nextAuthAction = Array.isArray(req.query.nextauth)
-    ? req.query.nextauth[0]
-    : req.query.nextauth;
   const rendersHtmlErrorPage =
     req.method === "GET" &&
     ["signin", "signout", "error", "verify-request"].includes(
@@ -95,10 +113,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // This happens before NextAuth processes the callback, allowing us to preserve
   // the IdP's error_description which NextAuth would otherwise strip
   // Only intercept if this is an OAuth callback request (path starts with 'callback')
-  const isCallbackRequest =
-    Array.isArray(req.query.nextauth) &&
-    req.query.nextauth.length > 0 &&
-    req.query.nextauth[0] === "callback";
+  const isCallbackRequest = nextAuthAction === "callback";
 
   if (
     isCallbackRequest &&
@@ -133,10 +148,8 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   // NextAuth interpolates unknown error values directly into a Location
   // header. Encode user-controlled text before it reaches that code path so
   // control characters cannot make Node throw ERR_INVALID_CHAR.
-  if (getAuthAction(req) === "error") {
-    const nextauth = req.query.nextauth;
-    const error =
-      req.query.error ?? (Array.isArray(nextauth) ? nextauth[1] : undefined);
+  if (nextAuthAction === "error") {
+    const error = req.query.error ?? nextAuthProvider;
     if (error !== undefined) {
       const source = req.query.error !== undefined ? "query" : "path";
       req.query.error = encodeAuthError(error, source);

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -39,6 +39,10 @@ import { type Provider } from "next-auth/providers/index";
 import { getCookieName, getCookieOptions } from "./utils/cookies";
 import { nextAuthLogger } from "./utils/nextAuthLogger";
 import {
+  getRequestCookies,
+  isValidCallbackUrl,
+} from "./utils/nextAuthCallbackUrl";
+import {
   findMultiTenantSsoConfig,
   getSsoAuthProviderIdForDomain,
   loadSsoProviders,
@@ -758,6 +762,8 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
       // keeps the default same-origin semantics while turning malformed input
       // into a safe redirect to baseUrl instead of a 500.
       redirect({ url, baseUrl }) {
+        if (!isValidCallbackUrl(url)) return baseUrl;
+
         try {
           // Relative callback URLs are always safe to resolve against baseUrl.
           if (url.startsWith("/")) return `${baseUrl}${url}`;
@@ -1157,5 +1163,66 @@ export const getServerAuthSession = async (ctx: {
   ctx.res.setHeader("Pragma", "no-cache");
   ctx.res.setHeader("Expires", "0");
 
+  sanitizeServerSessionCallbackUrl(
+    ctx.req,
+    ctx.req.url?.split("?")[0]?.slice(0, 200),
+  );
+
   return getServerSession(ctx.req, ctx.res, authOptions);
+};
+
+/**
+ * App Router equivalent of getServerAuthSession. Passing the request and
+ * response explicitly lets us sanitize the parsed cookies before next-auth's
+ * config assertion runs.
+ */
+export const getServerAuthSessionForRequest = async (request: Request) => {
+  const authOptions = await getAuthOptions();
+  const cookies = getRequestCookies(request);
+  const req = {
+    headers: Object.fromEntries(request.headers.entries()),
+    cookies,
+  } as GetServerSidePropsContext["req"];
+
+  sanitizeServerSessionCallbackUrl(
+    req,
+    new URL(request.url).pathname.slice(0, 200),
+  );
+
+  const res = {
+    getHeader: () => undefined,
+    setCookie: () => undefined,
+    setHeader: () => undefined,
+  } as unknown as GetServerSidePropsContext["res"];
+
+  const session = await getServerSession(req, res, authOptions);
+
+  // Match getServerSession's App Router behavior. The explicit request/response
+  // form above selects its Pages Router branch, which otherwise keeps expires.
+  if (!session) return session;
+
+  const { expires: _expires, ...sessionWithoutExpires } = session;
+
+  return sessionWithoutExpires as Session;
+};
+
+const sanitizeServerSessionCallbackUrl = (
+  req: { cookies?: Partial<Record<string, string>> },
+  path: string | undefined,
+) => {
+  const callbackUrlCookieName = getCookieName("next-auth.callback-url");
+  const callbackUrlCookie = req.cookies?.[callbackUrlCookieName];
+
+  if (!callbackUrlCookie || isValidCallbackUrl(callbackUrlCookie)) return;
+
+  const { [callbackUrlCookieName]: _invalidCallbackUrl, ...sanitizedCookies } =
+    req.cookies ?? {};
+  req.cookies = sanitizedCookies;
+
+  logger.warn(
+    "[NEXT_AUTH] Ignored invalid callback URL for server-side session",
+    {
+      path,
+    },
+  );
 };

--- a/web/src/server/utils/nextAuthCallbackUrl.ts
+++ b/web/src/server/utils/nextAuthCallbackUrl.ts
@@ -1,0 +1,57 @@
+import { validateHeaderValue } from "node:http";
+
+type RequestWithCookieStore = Request & {
+  cookies?: {
+    getAll: () => Array<{ name: string; value: string }>;
+  };
+};
+
+// Matches next-auth's URL/scheme check and also rejects values Node cannot
+// safely place in a Location header. Relative URLs must start with `/`;
+// absolute URLs must parse with an http(s) scheme.
+export const isValidCallbackUrl = (url: unknown): boolean => {
+  if (typeof url !== "string") return false;
+  try {
+    validateHeaderValue("Location", url);
+    return /^https?:/.test(
+      new URL(url, url.startsWith("/") ? "http://localhost" : undefined)
+        .protocol,
+    );
+  } catch {
+    return false;
+  }
+};
+
+const parseCookieHeader = (cookieHeader: string | null) => {
+  const cookies: Record<string, string> = {};
+
+  for (const part of cookieHeader?.split(";") ?? []) {
+    const separatorIndex = part.indexOf("=");
+    if (separatorIndex === -1) continue;
+
+    const name = part.slice(0, separatorIndex).trim();
+    if (!name) continue;
+
+    const value = part.slice(separatorIndex + 1).trim();
+    try {
+      cookies[name] = decodeURIComponent(value);
+    } catch {
+      cookies[name] = value;
+    }
+  }
+
+  return cookies;
+};
+
+export const getRequestCookies = (request: Request) => {
+  const requestWithCookieStore = request as RequestWithCookieStore;
+  if (requestWithCookieStore.cookies) {
+    return Object.fromEntries(
+      requestWithCookieStore.cookies
+        .getAll()
+        .map(({ name, value }) => [name, value]),
+    );
+  }
+
+  return parseCookieHeader(request.headers.get("cookie"));
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v3 backport of #15760, #15989, and #16461.

Hardens NextAuth callback handling so invalid callback URLs and non-POST credentials callbacks no longer 500. In-app-agent hunks from #15760 were skipped (absent on v3). Playground `getServerAuthSessionForRequest` wiring was kept.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `nextauth-invalid-callback-url.servertest.ts` → **Tests 18 passed (18)**
- `getServerAuthSession-invalid-callback-url.servertest.ts` → **Tests 4 passed (4)**
- `next-auth-route-malformed-input.servertest.ts` → **Tests 11 passed (11)**
- Full stack smoke skipped (Docker daemon unavailable in the worktree)

## Mandatory Tasks

- [x] Self-reviewed the three cherry-picks against v3 NextAuth routes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport hardens NextAuth request handling against malformed callback URLs and unsupported credentials-callback methods while preserving normal authentication flows.

- Centralizes callback URL validation and removes invalid callback cookies before server-side session resolution.
- Adds request-aware App Router session resolution for playground authorization.
- Returns safe client errors instead of NextAuth-generated server errors for malformed auth requests.
- Adds focused server tests for route sanitization, redirect fallback, credentials methods, and session lookup.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The authentication boundary consistently rejects or removes malformed callback inputs before NextAuth processes them, preserves valid callback and credentials POST flows, and keeps playground membership and permission enforcement intact.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Incoming auth or playground request] --> B{Request type}
  B -->|NextAuth route| C{Credentials callback}
  C -->|Non-POST| D[Return 405]
  C -->|POST or other action| E{Callback URL valid}
  E -->|Invalid HTML GET| F[Remove malformed query or cookie]
  E -->|Invalid other action| G[Return 400]
  E -->|Valid| H[Invoke NextAuth]
  F --> H
  B -->|Playground request| I[Extract request cookies]
  I --> J[Remove invalid callback URL cookie]
  J --> K[Resolve server session]
  K --> L[Check project membership and playground scope]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): sidestep 500 on NextAuth HTML..."](https://github.com/langfuse/langfuse/commit/e5217655ffeac4aa61a84224c1e8e8f43d15d0eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56609035)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)
- Knowledge Base — [Prompts, playground, and models](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/prompts-playground-and-models.md)
- Knowledge Base — [Product web application](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/product-web-application.md)
</details>


<!-- /greptile_comment -->