### PR TITLE
fix(worker): fail fast and auto-disable PostHog export on config faults (v3 backport of #16095)

### DIFF
--- a/packages/shared/prisma/migrations/20260813120000_add_posthog_integration_error_fields/migration.sql
+++ b/packages/shared/prisma/migrations/20260813120000_add_posthog_integration_error_fields/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "posthog_integrations" ADD COLUMN IF NOT EXISTS "last_error" TEXT;
+ALTER TABLE "posthog_integrations" ADD COLUMN IF NOT EXISTS "last_error_at" TIMESTAMP(3);

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1222,6 +1222,12 @@ model PosthogIntegration {
   createdAt              DateTime                         @default(now()) @map("created_at")
   exportSource           AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
 
+  // Last deterministic customer-config fault (bad hostname) that disabled the
+  // integration. Written by the worker, surfaced in the integration settings
+  // status section, and cleared on a successful run.
+  lastError   String?   @map("last_error")
+  lastErrorAt DateTime? @map("last_error_at")
+
   @@map("posthog_integrations")
 }
 

--- a/packages/shared/src/domain/automations.ts
+++ b/packages/shared/src/domain/automations.ts
@@ -29,6 +29,7 @@ export const TriggerEventSourceSchema = z.enum([
  */
 export const ProjectNotificationEventTypeSchema = z.enum([
   "blob-export-failed",
+  "posthog-export-failed",
   "evaluator-blocked",
 ]);
 export type ProjectNotificationEventType = z.infer<

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -20,6 +20,7 @@ export * from "./services/email/usageThresholdWarning/sendUsageThresholdWarningE
 export * from "./services/email/usageThresholdSuspension/sendUsageThresholdSuspensionEmail";
 export * from "./services/email/commentMention/sendCommentMentionEmail";
 export * from "./services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail";
+export * from "./services/email/posthogExportFailed/sendPostHogExportFailedEmail";
 export * from "./services/PromptService";
 export * from "./services/PromptService/types";
 export * from "./services/traces-ui-table-service";

--- a/packages/shared/src/server/notifications/buildProjectNotificationSlackMessage.ts
+++ b/packages/shared/src/server/notifications/buildProjectNotificationSlackMessage.ts
@@ -9,6 +9,7 @@ import {
 /** projectNotificationTitle maps an event type to a human-readable Slack title. */
 const projectNotificationTitle: Record<ProjectNotificationEventType, string> = {
   "blob-export-failed": "Blob storage export failed",
+  "posthog-export-failed": "PostHog export failed",
   "evaluator-blocked": "Evaluator blocked",
 };
 

--- a/packages/shared/src/server/notifications/dispatchProjectNotification.ts
+++ b/packages/shared/src/server/notifications/dispatchProjectNotification.ts
@@ -9,6 +9,7 @@ import { QueueJobs, QueueName } from "../queues";
 import { WebhookQueue } from "../redis/webhookQueue";
 import { getAutomations } from "../repositories/automation-repository";
 import { sendBlobStorageExportFailedEmail } from "../services/email/blobStorageExportFailed/sendBlobStorageExportFailedEmail";
+import { sendPostHogExportFailedEmail } from "../services/email/posthogExportFailed/sendPostHogExportFailedEmail";
 import { sendEvaluatorBlockedEmail } from "../services/email/evaluatorBlocked/sendEvaluatorBlockedEmail";
 import { getProjectAdminEmails } from "../services/getProjectAdminEmails";
 import { type ProjectNotificationEvent } from "./types";
@@ -171,6 +172,16 @@ async function sendEventAdminEmails({
         env: emailEnv,
         projectName: event.projectName,
         settingsUrl: `${emailEnv.NEXTAUTH_URL}/project/${event.projectId}/settings/integrations/blobstorage`,
+        receiverEmails,
+        disabled: event.disabled ?? false,
+      });
+      return;
+    }
+    case "posthog-export-failed": {
+      await sendPostHogExportFailedEmail({
+        env: emailEnv,
+        projectName: event.projectName,
+        settingsUrl: `${emailEnv.NEXTAUTH_URL}/project/${event.projectId}/settings/integrations/posthog`,
         receiverEmails,
         disabled: event.disabled ?? false,
       });

--- a/packages/shared/src/server/notifications/types.ts
+++ b/packages/shared/src/server/notifications/types.ts
@@ -52,6 +52,14 @@ export const ProjectNotificationEventSchema = z.discriminatedUnion(
     }),
     projectNotificationEventBaseSchema.extend({
       eventType: z.literal(
+        ProjectNotificationEventTypeSchema.enum["posthog-export-failed"],
+      ),
+      // true when the integration was auto-disabled after a deterministic
+      // customer-config fault (terminal event; selects the "disabled" variant).
+      disabled: z.boolean().optional(),
+    }),
+    projectNotificationEventBaseSchema.extend({
+      eventType: z.literal(
         ProjectNotificationEventTypeSchema.enum["evaluator-blocked"],
       ),
       blockReason: z.enum(EvaluatorBlockReason),

--- a/packages/shared/src/server/outbound-url/validation.ts
+++ b/packages/shared/src/server/outbound-url/validation.ts
@@ -14,6 +14,7 @@ export type OutboundUrlValidationErrorCode =
   | "https-required"
   | "invalid-encoding"
   | "invalid-syntax"
+  | "port-not-allowed"
   | "protocol-not-allowed"
   | "url-credentials-not-allowed";
 

--- a/packages/shared/src/server/services/email/posthogExportFailed/PostHogExportFailedEmailTemplate.tsx
+++ b/packages/shared/src/server/services/email/posthogExportFailed/PostHogExportFailedEmailTemplate.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+type PostHogExportFailedEmailTemplateProps = {
+  projectName: string;
+  settingsUrl: string;
+  // When true, the export was turned off after a configuration fault and the
+  // customer must fix their host and re-enable it — not a transient failure.
+  disabled?: boolean;
+};
+
+export const PostHogExportFailedEmailTemplate = ({
+  projectName,
+  settingsUrl,
+  disabled = false,
+}: PostHogExportFailedEmailTemplateProps) => {
+  const preview = disabled
+    ? `PostHog export disabled for project "${projectName}"`
+    : `PostHog export failed for project "${projectName}"`;
+  return (
+    <Html>
+      <Head />
+      <Preview>{preview}</Preview>
+      <Tailwind>
+        <Body className="bg-background my-auto mx-auto font-sans">
+          <Container className="mx-auto my-10 w-[465px] rounded border border-solid border-[#eaeaea] p-5">
+            <Section className="mt-8">
+              <Img
+                src="https://static.langfuse.com/langfuse_logo_transactional_email.png"
+                width="40"
+                height="40"
+                alt="Langfuse"
+                className="mx-auto my-0"
+              />
+            </Section>
+
+            <Section>
+              <Heading className="mx-0 my-[30px] p-0 text-center text-2xl font-normal text-black">
+                {disabled ? "PostHog Export Disabled" : "PostHog Export Failed"}
+              </Heading>
+              <Text className="text-gray-700 text-sm leading-6">
+                {disabled ? (
+                  <>
+                    The PostHog export for project &quot;{projectName}
+                    &quot; has been disabled after a configuration fault. This
+                    usually means the PostHog host is no longer reachable or
+                    valid. Once you have updated it, simply re-enable the export
+                    in the integration settings and it will pick up right where
+                    it left off.
+                  </>
+                ) : (
+                  <>
+                    The scheduled PostHog export for project &quot;
+                    {projectName}&quot; has failed after multiple attempts. It
+                    will be retried automatically at the next scheduled export.
+                    If the issue persists, review the integration settings to
+                    see the error details.
+                  </>
+                )}
+              </Text>
+            </Section>
+
+            <Section className="mt-8 text-center">
+              <Button
+                className="rounded bg-red-600 px-5 py-3 text-center text-xs font-semibold text-white no-underline"
+                href={settingsUrl}
+              >
+                Review Settings
+              </Button>
+            </Section>
+
+            <Hr className="border border-solid border-[#eaeaea] my-[26px] mx-0 w-full" />
+
+            <Section>
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                This notification was sent to project admins regarding a{" "}
+                {disabled ? "disabled" : "failed"} PostHog export for project
+                &quot;{projectName}&quot;.
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};

--- a/packages/shared/src/server/services/email/posthogExportFailed/sendPostHogExportFailedEmail.ts
+++ b/packages/shared/src/server/services/email/posthogExportFailed/sendPostHogExportFailedEmail.ts
@@ -1,0 +1,86 @@
+import { render } from "@react-email/render";
+import { createMailTransport } from "../transport";
+import { z } from "zod";
+import { sanitizeEmailSubject } from "../../../../utils/zod";
+import { logger } from "../../../logger";
+import { PostHogExportFailedEmailTemplate } from "./PostHogExportFailedEmailTemplate";
+
+export type SendPostHogExportFailedEmailParams = {
+  env: Partial<
+    Record<
+      | "EMAIL_FROM_ADDRESS"
+      | "SMTP_CONNECTION_URL"
+      | "NEXTAUTH_URL"
+      | "CLOUD_CRM_EMAIL",
+      string | undefined
+    >
+  >;
+  projectName: string;
+  settingsUrl: string;
+  receiverEmails: string[];
+  // When true, the export was disabled after a configuration fault (needs the
+  // customer to fix the host and re-enable) rather than a transient failure.
+  disabled?: boolean;
+};
+
+export const sendPostHogExportFailedEmail = async ({
+  env,
+  projectName,
+  settingsUrl,
+  receiverEmails,
+  disabled = false,
+}: SendPostHogExportFailedEmailParams) => {
+  if (!env.EMAIL_FROM_ADDRESS || !env.SMTP_CONNECTION_URL) {
+    logger.error(
+      "Missing environment variables for sending PostHog export failed email.",
+    );
+    return;
+  }
+
+  if (receiverEmails.length === 0) {
+    return;
+  }
+
+  try {
+    const mailer = createMailTransport(env.SMTP_CONNECTION_URL);
+    const safeProjectName = sanitizeEmailSubject(projectName);
+    const subject = disabled
+      ? `PostHog export disabled for "${safeProjectName}" – action required`
+      : `PostHog export failed for "${safeProjectName}"`;
+    const html = await render(
+      PostHogExportFailedEmailTemplate({
+        projectName: safeProjectName,
+        settingsUrl,
+        disabled,
+      }),
+    );
+
+    const mailOptions: Record<string, unknown> = {
+      to: receiverEmails,
+      from: {
+        address: env.EMAIL_FROM_ADDRESS,
+        name: "Langfuse",
+      },
+      replyTo: "support@langfuse.com",
+      subject,
+      html,
+    };
+
+    if (env.CLOUD_CRM_EMAIL) {
+      const emailSchema = z.email();
+      const validationResult = emailSchema.safeParse(env.CLOUD_CRM_EMAIL);
+
+      if (validationResult.success) {
+        mailOptions.bcc = validationResult.data;
+      } else {
+        logger.warn(
+          `Invalid CLOUD_CRM_EMAIL format: ${env.CLOUD_CRM_EMAIL}. Skipping BCC.`,
+        );
+      }
+    }
+
+    await mailer.sendMail(mailOptions);
+  } catch (error) {
+    logger.error("Failed to send PostHog export failed email", error);
+  }
+};

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -1,5 +1,6 @@
 import { env } from "../../env";
 import {
+  OutboundUrlValidationError,
   type OutboundUrlValidationWhitelist,
   parseOutboundUrl,
   resolveHost,
@@ -39,13 +40,24 @@ export async function validateWebhookURL(
 ): Promise<void> {
   const url = parseOutboundUrl(urlString);
 
+  // Coded, not bare Error: callers classify rejections off the `code` rather
+  // than the message. validateBlobStorageEndpoint already does this for the
+  // protocol check; these two were the only outbound-URL rejections in the repo
+  // that reached callers uncoded, which silently excluded them from
+  // customer-fault classification. Messages are unchanged.
   if (!["https:", "http:"].includes(url.protocol)) {
-    throw new Error("Only HTTP and HTTPS protocols are allowed");
+    throw new OutboundUrlValidationError(
+      "protocol-not-allowed",
+      "Only HTTP and HTTPS protocols are allowed",
+    );
   }
 
   const allowedPorts = options.allowedPorts ?? DEFAULT_WEBHOOK_ALLOWED_PORTS;
   if (url.port && allowedPorts !== "any" && !allowedPorts.includes(url.port)) {
-    throw new Error("Only ports 80 and 443 are allowed");
+    throw new OutboundUrlValidationError(
+      "port-not-allowed",
+      "Only ports 80 and 443 are allowed",
+    );
   }
 
   await validateOutboundUrlHost({

--- a/web/src/features/notifications/components/ProjectNotificationChannels.tsx
+++ b/web/src/features/notifications/components/ProjectNotificationChannels.tsx
@@ -36,6 +36,12 @@ const NOTIFIED_EVENTS: {
     description: "Sent when a scheduled blob storage export fails.",
   },
   {
+    value: "posthog-export-failed",
+    title: "PostHog export failed",
+    description:
+      "Sent when a PostHog export is disabled after a configuration error, such as an unreachable host.",
+  },
+  {
     value: "evaluator-blocked",
     title: "Evaluator deactivated",
     description:

--- a/web/src/features/posthog-integration/components/PostHogStatusSection.tsx
+++ b/web/src/features/posthog-integration/components/PostHogStatusSection.tsx
@@ -1,0 +1,54 @@
+import Header from "@/src/components/layouts/header";
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { type RouterOutputs } from "@/src/utils/api";
+
+type PostHogIntegrationConfig = NonNullable<
+  RouterOutputs["posthogIntegration"]["get"]["config"]
+>;
+
+/**
+ * PostHogStatusSection surfaces the persisted export fault next to the sync
+ * line. Neither is gated on `enabled`: a customer-config fault auto-disables
+ * the integration, so gating would hide the explanation at the one moment it
+ * is needed, and a manually disabled integration would render a bare header.
+ */
+export const PostHogStatusSection = ({
+  config,
+}: {
+  config: PostHogIntegrationConfig;
+}) => {
+  return (
+    <>
+      <Header title="Status" className="mt-8" />
+      {config.lastError && (
+        <Alert variant="destructive" className="mb-4">
+          {/* A fault normally arrives with the auto-disable, but the disable is
+              skipped when the host changed mid-run, leaving a fault on a still
+              enabled integration — so only promise "disabled" when it is. */}
+          <AlertTitle>
+            {config.enabled
+              ? "Last export failed"
+              : "Export disabled – action required"}
+          </AlertTitle>
+          <AlertDescription>
+            {config.lastError}
+            {config.lastErrorAt && (
+              <>
+                <br />
+                <span className="text-xs opacity-70">
+                  {new Date(config.lastErrorAt).toLocaleString()}
+                </span>
+              </>
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
+      <p className="text-primary text-sm">
+        Data synced until:{" "}
+        {config.lastSyncAt
+          ? new Date(config.lastSyncAt).toLocaleString()
+          : "Never (pending)"}
+      </p>
+    </>
+  );
+};

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -190,6 +190,8 @@ export const posthogIntegrationRouter = createTRPCRouter({
             // undefined → Prisma omits the column → preserves the persisted
             // value on partial updates (LFE-10296).
             exportSource: config.exportSource,
+            // lastError is deliberately left intact so the last fault stays
+            // visible until a successful run clears it.
           },
         });
 

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -55,6 +55,7 @@ import { useRouter } from "next/router";
 import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { type z } from "zod";
+import { PostHogStatusSection } from "@/src/features/posthog-integration/components/PostHogStatusSection";
 import { Info, ExternalLink } from "lucide-react";
 
 export default function PosthogIntegrationSettings() {
@@ -127,16 +128,8 @@ export default function PosthogIntegrationSettings() {
           </Card>
         </>
       )}
-      {state.data?.config?.enabled && (
-        <>
-          <Header title="Status" className="mt-8" />
-          <p className="text-primary text-sm">
-            Data synced until:{" "}
-            {state.data?.config?.lastSyncAt
-              ? new Date(state.data.config.lastSyncAt).toLocaleString()
-              : "Never (pending)"}
-          </p>
-        </>
+      {state.data?.config && (
+        <PostHogStatusSection config={state.data.config} />
       )}
     </ContainerPage>
   );

--- a/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
@@ -2,11 +2,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 /**
  * Unit tests for the PostHog integration project job's events_only legacy
- * guard (LFE-10148): a persisted legacy export source on an events_only
- * deployment reads the v3 traces/observations tables, which are no longer
- * written — the job must fail loudly before exporting empty data and
- * advancing lastSyncAt. Mocked in the same style as
- * mixpanelIntegrationProjectJob.test.ts.
+ * guard (LFE-10148) and customer-fault auto-disable path. Mocked in the same
+ * style as mixpanelIntegrationProjectJob.test.ts.
  */
 
 // vi.mock factories are hoisted above module scope, so all shared mutable
@@ -16,11 +13,71 @@ const h = vi.hoisted(() => {
     yield { langfuse_id: `${label}-1` };
   }
 
-  const posthogIntegrationUpdate = vi.fn();
+  // How many rows the atomic disable claim matches. 0 simulates a lost claim:
+  // either a concurrent run already flipped enabled, or the customer corrected
+  // the hostname mid-run so the run's `where` predicate no longer matches.
+  const disableClaim = { matchedRows: 1 };
+
+  // Observable completion of the terminal notification. `settled` flips only
+  // after a macrotask, so a caller that fires the dispatch without awaiting it
+  // returns while `settled` is still false — that gap is what distinguishes an
+  // awaited dispatch from a fire-and-forget one.
+  const notification = { settled: false, rejects: false };
+
+  // Stand-in for the Prisma namespace class. The record-not-found predicate is
+  // instanceof-based, so a duck-typed `{ code: "P2025" }` would not satisfy it
+  // — tests must throw a real instance of this class.
+  class PrismaClientKnownRequestError extends Error {
+    code: string;
+    constructor(message: string, { code }: { code: string }) {
+      super(message);
+      this.name = "PrismaClientKnownRequestError";
+      this.code = code;
+    }
+  }
+
+  // Lets a test fail the lastError/lastErrorAt persist write without disturbing
+  // the tests that need it to resolve.
+  const persist = { failWith: undefined as unknown };
+
+  const posthogIntegrationUpdate = vi.fn(async () => {
+    if (persist.failWith !== undefined) throw persist.failWith;
+  });
+  // The atomic disable (enabled true->false) uses updateMany. Only the disable
+  // write is claim-controlled; any other updateMany keeps matching.
+  const posthogIntegrationUpdateMany = vi.fn(
+    async (args?: { data?: Record<string, unknown> }) => ({
+      count: args?.data?.enabled === false ? disableClaim.matchedRows : 1,
+    }),
+  );
+  // Hostname preflight (throws OutboundUrlValidationError on a bad
+  // hostname) and the customer notification, both controllable per test.
+  const validateWebhookURL = vi.fn(async () => {});
+  const recordIncrement = vi.fn();
+  const dispatchProjectNotification = vi.fn(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    try {
+      if (notification.rejects) throw new Error("notification dispatch failed");
+    } finally {
+      notification.settled = true;
+    }
+  });
   const getTraces = vi.fn(() => fakeStream("traces"));
   const getGenerations = vi.fn(() => fakeStream("generations"));
   const getScores = vi.fn(() => fakeStream("scores"));
   const getEvents = vi.fn(() => fakeStream("events"));
+
+  // Minimal stand-in for the shared class. The classifier duck-types on
+  // `.name === "OutboundUrlValidationError"` + `.code` (it does not use
+  // instanceof), so this shape is sufficient for the mocked server barrel.
+  class OutboundUrlValidationError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "OutboundUrlValidationError";
+      this.code = code;
+    }
+  }
 
   const defaultIntegration = () => ({
     projectId: "project-1",
@@ -38,6 +95,15 @@ const h = vi.hoisted(() => {
 
   return {
     posthogIntegrationUpdate,
+    posthogIntegrationUpdateMany,
+    PrismaClientKnownRequestError,
+    persist,
+    disableClaim,
+    notification,
+    validateWebhookURL,
+    recordIncrement,
+    dispatchProjectNotification,
+    OutboundUrlValidationError,
     getTraces,
     getGenerations,
     getScores,
@@ -52,16 +118,25 @@ vi.mock("@langfuse/shared/src/db", () => ({
     posthogIntegration: {
       findFirst: vi.fn(async () => h.db.integration),
       update: h.posthogIntegrationUpdate,
+      updateMany: h.posthogIntegrationUpdateMany,
     },
+  },
+  // The record-not-found predicate lives in its own module but imports Prisma
+  // from this specifier, so this factory intercepts it too. Without this
+  // export the predicate throws a TypeError instead of returning a boolean.
+  Prisma: {
+    PrismaClientKnownRequestError: h.PrismaClientKnownRequestError,
   },
 }));
 
 vi.mock("@langfuse/shared/src/server", () => ({
   QueueName: { PostHogIntegrationProcessingQueue: "posthog" },
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-  recordIncrement: vi.fn(),
+  recordIncrement: h.recordIncrement,
   getCurrentSpan: vi.fn(() => undefined),
-  validateWebhookURL: vi.fn(async () => {}),
+  validateWebhookURL: h.validateWebhookURL,
+  dispatchProjectNotification: h.dispatchProjectNotification,
+  OutboundUrlValidationError: h.OutboundUrlValidationError,
   getTracesForAnalyticsIntegrations: h.getTraces,
   getGenerationsForAnalyticsIntegrations: h.getGenerations,
   getScoresForAnalyticsIntegrations: h.getScores,
@@ -90,7 +165,10 @@ vi.mock("posthog-node", () => ({
 // Resolves to worker/src/env (read by exportWriteModeGuard and the score
 // routing); the helpers mirror the real implementations.
 vi.mock("../env", () => ({
-  env: { LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy" },
+  env: {
+    LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
+    NEXTAUTH_URL: "http://localhost:3000",
+  },
   v4WritesToLegacyTables: (e: { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }) =>
     e.LANGFUSE_MIGRATION_V4_WRITE_MODE !== "events_only",
   v4WritesToEventsTable: (e: { LANGFUSE_MIGRATION_V4_WRITE_MODE: string }) =>
@@ -108,16 +186,29 @@ function makeJob() {
   } as unknown as Parameters<typeof handlePostHogIntegrationProjectJob>[0];
 }
 
+function resetSharedState() {
+  h.posthogIntegrationUpdate.mockClear();
+  h.persist.failWith = undefined;
+  // mockClear, not mockReset: the implementations above are claim/notification
+  // aware and must survive between tests; only the recorded calls reset.
+  h.posthogIntegrationUpdateMany.mockClear();
+  h.disableClaim.matchedRows = 1;
+  h.notification.settled = false;
+  h.notification.rejects = false;
+  h.recordIncrement.mockClear();
+  h.validateWebhookURL.mockReset();
+  h.validateWebhookURL.mockImplementation(async () => {});
+  h.dispatchProjectNotification.mockClear();
+  h.getTraces.mockClear();
+  h.getGenerations.mockClear();
+  h.getScores.mockClear();
+  h.getEvents.mockClear();
+  h.db.integration = h.defaultIntegration();
+  (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+}
+
 describe("handlePostHogIntegrationProjectJob events_only legacy guard (LFE-10148)", () => {
-  beforeEach(() => {
-    h.posthogIntegrationUpdate.mockClear();
-    h.getTraces.mockClear();
-    h.getGenerations.mockClear();
-    h.getScores.mockClear();
-    h.getEvents.mockClear();
-    h.db.integration = h.defaultIntegration();
-    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-  });
+  beforeEach(resetSharedState);
 
   it("throws before export and does not advance lastSyncAt on events_only + legacy source", async () => {
     (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
@@ -180,15 +271,7 @@ describe("handlePostHogIntegrationProjectJob events_only legacy guard (LFE-10148
 // LFE-11009: enriched sources on legacy write mode must fail loudly instead
 // of silently exporting empty data while lastSyncAt advances.
 describe("handlePostHogIntegrationProjectJob legacy-mode enriched guard (LFE-11009)", () => {
-  beforeEach(() => {
-    h.posthogIntegrationUpdate.mockClear();
-    h.getTraces.mockClear();
-    h.getGenerations.mockClear();
-    h.getScores.mockClear();
-    h.getEvents.mockClear();
-    h.db.integration = h.defaultIntegration();
-    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
-  });
+  beforeEach(resetSharedState);
 
   it.each(["EVENTS", "TRACES_OBSERVATIONS_EVENTS"])(
     "throws before export and does not advance lastSyncAt on legacy + %s source",
@@ -213,5 +296,237 @@ describe("handlePostHogIntegrationProjectJob legacy-mode enriched guard (LFE-110
 
     expect(h.getEvents).toHaveBeenCalledTimes(1);
     expect(h.posthogIntegrationUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// A bad/malicious PostHog hostname is a deterministic customer-config fault
+// — the job RESOLVES (not thrown, so the type:failed counter never increments
+// and the Failures monitor stays quiet), the integration is auto-disabled,
+// lastError/lastErrorAt are persisted, and the customer is notified once with
+// disabled=true. Transient/infra faults still throw, retry, and trip the
+// monitor unchanged.
+describe("handlePostHogIntegrationProjectJob customer-fault auto-disable", () => {
+  beforeEach(() => {
+    resetSharedState();
+    // A known-good source + write-mode combo so the pre-export write-mode
+    // guards pass and the handler reaches the hostname preflight.
+    h.db.integration = {
+      ...h.defaultIntegration(),
+      exportSource: "TRACES_OBSERVATIONS",
+    };
+    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "dual";
+  });
+
+  // Every `data` payload written across update + updateMany, so assertions
+  // don't over-constrain which Prisma method carries which column.
+  const writeData = (): Array<Record<string, unknown>> =>
+    [
+      ...h.posthogIntegrationUpdate.mock.calls,
+      ...h.posthogIntegrationUpdateMany.mock.calls,
+    ].map(
+      (call) =>
+        (call[0] as { data?: Record<string, unknown> } | undefined)?.data ?? {},
+    );
+
+  const disableNotifications = (): number =>
+    h.dispatchProjectNotification.mock.calls.filter((call) => {
+      const arg = call[0] as { event?: { disabled?: unknown } } | undefined;
+      return arg?.event?.disabled === true;
+    }).length;
+
+  // The atomic disable writes: updateMany calls carrying `enabled: false`.
+  const disableWrites = (): Array<{
+    where?: Record<string, unknown>;
+    data?: Record<string, unknown>;
+  }> =>
+    h.posthogIntegrationUpdateMany.mock.calls
+      .map((call) => call[0] as { where?: any; data?: any } | undefined)
+      .filter((arg): arg is { where?: any; data?: any } => Boolean(arg))
+      .filter((arg) => arg.data?.enabled === false);
+
+  // Counter emitted when an integration is auto-disabled. Matched on the
+  // metric-name fragment rather than the full string so the assertion tracks
+  // the behavior, not the namespace.
+  const disableMetrics = (): unknown[][] =>
+    h.recordIncrement.mock.calls.filter(
+      ([name]) =>
+        typeof name === "string" && name.includes("integration_disabled"),
+    );
+
+  const badHostnameFault = () =>
+    new h.OutboundUrlValidationError(
+      "blocked-hostname",
+      "Blocked hostname detected",
+    );
+
+  it("resolves and auto-disables on a blocked-hostname validation fault", async () => {
+    h.validateWebhookURL.mockRejectedValueOnce(
+      new h.OutboundUrlValidationError(
+        "blocked-hostname",
+        "Blocked hostname detected",
+      ),
+    );
+
+    // Must not throw — a throw would increment type:failed and fire the monitor.
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(writeData().some((data) => data.enabled === false)).toBe(true);
+    expect(
+      writeData().some(
+        (data) =>
+          typeof data.lastError === "string" &&
+          (data.lastError as string).length > 0,
+      ),
+    ).toBe(true);
+    expect(writeData().some((data) => data.lastErrorAt instanceof Date)).toBe(
+      true,
+    );
+    expect(disableNotifications()).toBe(1);
+  });
+
+  it("classifies through a wrapped cause chain and still disables", async () => {
+    h.validateWebhookURL.mockRejectedValueOnce(
+      new Error("posthog export failed", {
+        cause: new h.OutboundUrlValidationError(
+          "blocked-hostname",
+          "Blocked hostname detected",
+        ),
+      }),
+    );
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(writeData().some((data) => data.enabled === false)).toBe(true);
+    expect(disableNotifications()).toBe(1);
+  });
+
+  it.each([
+    ["protocol-not-allowed", "Only HTTP and HTTPS protocols are allowed"],
+    ["port-not-allowed", "Only ports 80 and 443 are allowed"],
+  ] as const)("resolves and auto-disables on %s", async (code, message) => {
+    h.validateWebhookURL.mockRejectedValueOnce(
+      new h.OutboundUrlValidationError(code, message),
+    );
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(writeData().some((data) => data.enabled === false)).toBe(true);
+    expect(disableNotifications()).toBe(1);
+  });
+
+  it.each([
+    [
+      "a dns-lookup-failed validation fault",
+      () =>
+        new h.OutboundUrlValidationError(
+          "dns-lookup-failed",
+          "DNS lookup failed for host.example",
+        ),
+    ],
+    [
+      "a generic ClickHouse-style error",
+      () => new Error("ClickHouse read failed"),
+    ],
+  ] as const)(
+    "rethrows on %s, leaves enabled unchanged, and does not notify",
+    async (_label, makeError) => {
+      h.validateWebhookURL.mockRejectedValueOnce(makeError());
+
+      await expect(
+        handlePostHogIntegrationProjectJob(makeJob()),
+      ).rejects.toThrow();
+
+      expect(writeData().some((data) => data.enabled === false)).toBe(false);
+      expect(h.dispatchProjectNotification).not.toHaveBeenCalled();
+    },
+  );
+
+  it("clears lastError/lastErrorAt on a successful run", async () => {
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(h.posthogIntegrationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ lastError: null, lastErrorAt: null }),
+      }),
+    );
+  });
+
+  it("scopes the atomic disable to the hostname this run validated", async () => {
+    h.validateWebhookURL.mockRejectedValueOnce(badHostnameFault());
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(disableWrites()).toHaveLength(1);
+    expect(disableWrites()[0].where).toEqual({
+      projectId: "project-1",
+      enabled: true,
+      posthogHostName: "https://us.posthog.com",
+    });
+  });
+
+  it("records the disable metric and notifies once when the claim is won", async () => {
+    h.validateWebhookURL.mockRejectedValueOnce(badHostnameFault());
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(disableMetrics()).toHaveLength(1);
+    expect(disableNotifications()).toBe(1);
+  });
+
+  it("stays silent when the disable claim matches no row", async () => {
+    h.disableClaim.matchedRows = 0;
+    h.validateWebhookURL.mockRejectedValueOnce(badHostnameFault());
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(disableWrites()).toHaveLength(1);
+    expect(h.dispatchProjectNotification).not.toHaveBeenCalled();
+    expect(disableMetrics()).toHaveLength(0);
+  });
+
+  it("completes the disable notification before the handler resolves", async () => {
+    h.validateWebhookURL.mockRejectedValueOnce(badHostnameFault());
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(h.notification.settled).toBe(true);
+  });
+
+  it("resolves and keeps the integration disabled when the notification rejects", async () => {
+    h.notification.rejects = true;
+    h.validateWebhookURL.mockRejectedValueOnce(badHostnameFault());
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(disableWrites()).toHaveLength(1);
+    expect(h.notification.settled).toBe(true);
+  });
+
+  it("drops the obsolete job when the integration is deleted mid-run", async () => {
+    h.validateWebhookURL.mockRejectedValueOnce(badHostnameFault());
+    h.persist.failWith = new h.PrismaClientKnownRequestError(
+      "An operation failed because it depends on one or more records that were required but not found.",
+      { code: "P2025" },
+    );
+
+    await handlePostHogIntegrationProjectJob(makeJob());
+
+    expect(h.posthogIntegrationUpdate).toHaveBeenCalledTimes(1);
+    expect(disableWrites()).toHaveLength(0);
+    expect(disableMetrics()).toHaveLength(0);
+    expect(h.dispatchProjectNotification).not.toHaveBeenCalled();
+  });
+
+  it("rethrows when persisting the error fails for any other reason", async () => {
+    h.validateWebhookURL.mockRejectedValueOnce(badHostnameFault());
+    h.persist.failWith = new Error("database unavailable");
+
+    await expect(
+      handlePostHogIntegrationProjectJob(makeJob()),
+    ).rejects.toThrow();
+
+    expect(disableWrites()).toHaveLength(0);
+    expect(disableMetrics()).toHaveLength(0);
+    expect(h.dispatchProjectNotification).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -88,6 +88,22 @@ describe("Webhook URL Validation", () => {
       ).rejects.toThrow("Only ports 80 and 443 are allowed");
     });
 
+    // Protocol and port rejections must carry an OutboundUrlValidationError
+    // code, not just a message: callers classify deterministic config faults
+    // off the code, so an uncoded rejection is silently unclassifiable and
+    // retries forever instead of disabling the integration.
+    it.each([
+      ["ftp://example.com", "protocol-not-allowed"],
+      ["file:///etc/passwd", "protocol-not-allowed"],
+      ["https://example.com:8080/hook", "port-not-allowed"],
+      ["http://example.com:3000/hook", "port-not-allowed"],
+    ])("should reject %s with a coded error", async (url, code) => {
+      await expect(validateWebhookURL(url)).rejects.toMatchObject({
+        name: "OutboundUrlValidationError",
+        code,
+      });
+    });
+
     it("should allow standard ports", async () => {
       await expect(
         validateWebhookURL("https://httpbin.org:443/post"),

--- a/worker/src/features/integrations/customerFaultClassification.test.ts
+++ b/worker/src/features/integrations/customerFaultClassification.test.ts
@@ -3,10 +3,16 @@ import { OutboundUrlValidationError } from "@langfuse/shared/src/server";
 import {
   classifyCustomerFault,
   isCustomerFaultError,
-} from "./isCustomerFaultError";
+} from "./customerFaultClassification";
 
-// Builds the wrapper the handler actually sees: StorageService.handleStorageError
-// rethrows SDK errors as `new Error("Failed to ...", { cause: sdkError })`.
+// Sole owner of the customer-fault case matrix. Every integration that
+// auto-disables on a deterministic customer-config fault classifies through
+// this module, so new provider codes or reason buckets belong here and nowhere
+// else — the blob storage re-export carries only a forwarding smoke test.
+
+// Builds the wrapper the handlers actually see: StorageService.handleStorageError
+// and the PostHog hostname preflight both rethrow as
+// `new Error(msg, { cause: originalError })`.
 const wrapped = (sdkError: unknown): Error =>
   new Error("Failed to upload file to S3", { cause: sdkError });
 
@@ -39,6 +45,20 @@ const gcsError = (
   Object.assign(err, { code, errors: [{ reason }] });
   return err;
 };
+
+// The deterministic outbound-URL allowlist and its reason buckets, in one place.
+// Both the boolean and the reason-bucket suites below are driven off this table
+// so a new code cannot be added to one and forgotten in the other.
+const OUTBOUND_URL_FAULTS = [
+  ["blocked-ip", "ssrf_blocked_endpoint"],
+  ["blocked-hostname", "ssrf_blocked_endpoint"],
+  ["invalid-syntax", "invalid_endpoint_url"],
+  ["invalid-encoding", "invalid_endpoint_url"],
+  ["https-required", "invalid_endpoint_url"],
+  ["protocol-not-allowed", "invalid_endpoint_url"],
+  ["port-not-allowed", "invalid_endpoint_url"],
+  ["url-credentials-not-allowed", "invalid_endpoint_url"],
+] as const;
 
 describe("isCustomerFaultError", () => {
   describe("customer_fault — S3 / S3-compatible", () => {
@@ -156,16 +176,7 @@ describe("isCustomerFaultError", () => {
   });
 
   describe("customer_fault — outbound-URL / SSRF validation rejection", () => {
-    it.each([
-      "blocked-ip",
-      "blocked-hostname",
-      "invalid-syntax",
-      "invalid-encoding",
-      "https-required",
-      "protocol-not-allowed",
-      "port-not-allowed",
-      "url-credentials-not-allowed",
-    ] as const)(
+    it.each(OUTBOUND_URL_FAULTS.map(([code]) => code))(
       "classifies a %s validation rejection as customer_fault",
       (code) => {
         const err = new OutboundUrlValidationError(code, "blocked");
@@ -223,16 +234,7 @@ describe("isCustomerFaultError", () => {
 });
 
 describe("classifyCustomerFault — disable reason buckets", () => {
-  it.each([
-    ["blocked-ip", "ssrf_blocked_endpoint"],
-    ["blocked-hostname", "ssrf_blocked_endpoint"],
-    ["invalid-syntax", "invalid_endpoint_url"],
-    ["invalid-encoding", "invalid_endpoint_url"],
-    ["https-required", "invalid_endpoint_url"],
-    ["protocol-not-allowed", "invalid_endpoint_url"],
-    ["port-not-allowed", "invalid_endpoint_url"],
-    ["url-credentials-not-allowed", "invalid_endpoint_url"],
-  ] as const)("maps outbound-url %s to %s", (code, reason) => {
+  it.each(OUTBOUND_URL_FAULTS)("maps outbound-url %s to %s", (code, reason) => {
     const err = new OutboundUrlValidationError(code, "blocked");
     expect(classifyCustomerFault(err)).toBe(reason);
     expect(classifyCustomerFault(wrapped(err))).toBe(reason);
@@ -290,5 +292,38 @@ describe("classifyCustomerFault — disable reason buckets", () => {
     const transient = new Error("network EAI_AGAIN");
     Object.assign(transient, { code: "EAI_AGAIN" });
     expect(classifyCustomerFault(wrapped(transient))).toBeUndefined();
+  });
+
+  // The reason bucket doubles as the disable decision (defined => disable), so
+  // every non-disabling input must yield undefined and not merely a falsy
+  // `isCustomerFaultError`. Covers the wrapped and bare-input paths that the
+  // boolean suite above asserts only through isCustomerFaultError.
+  describe("undefined for every non-disabling input", () => {
+    it("returns undefined for a wrapped dns-lookup-failed", () => {
+      const err = new OutboundUrlValidationError(
+        "dns-lookup-failed",
+        "DNS lookup failed for host.example",
+      );
+      expect(classifyCustomerFault(wrapped(err))).toBeUndefined();
+    });
+
+    it("returns undefined for a generic infra error, raw and wrapped", () => {
+      const err = new Error("ClickHouse read failed");
+      expect(classifyCustomerFault(err)).toBeUndefined();
+      expect(classifyCustomerFault(wrapped(err))).toBeUndefined();
+    });
+
+    it("returns undefined for a code-less error sharing a fault message", () => {
+      const err = new Error("Blocked hostname detected");
+      expect(classifyCustomerFault(err)).toBeUndefined();
+      expect(classifyCustomerFault(wrapped(err))).toBeUndefined();
+    });
+
+    it("returns undefined for null, undefined, and non-error inputs", () => {
+      expect(classifyCustomerFault(null)).toBeUndefined();
+      expect(classifyCustomerFault(undefined)).toBeUndefined();
+      expect(classifyCustomerFault("blocked-hostname")).toBeUndefined();
+      expect(classifyCustomerFault(403)).toBeUndefined();
+    });
   });
 });

--- a/worker/src/features/integrations/customerFaultClassification.ts
+++ b/worker/src/features/integrations/customerFaultClassification.ts
@@ -1,18 +1,13 @@
-// True when a caught blob-export error is a deterministic customer-config /
-// credential fault. The handler uses this (after BullMQ exhausts retries) to
-// disable the integration.
+// Classifies a caught integration-export error as a deterministic
+// customer-config / credential fault. Integration handlers use this to decide
+// whether to auto-disable an integration instead of retrying/alerting forever.
+// Each feature owns its own disable metric; only the classification is shared
+// here.
 //
 // Conservative allowlist of stable provider error codes, biased toward false:
 // a false positive disables a working integration, a false negative only keeps
-// retrying. Errors arrive wrapped via `new Error(..., { cause })`
-// (StorageService.handleStorageError), so we walk the cause chain.
-
-// Counter for integrations auto-disabled after a terminal customer fault, tagged
-// by `reason`. Lets a rollout regression (a classifier bug mass-disabling
-// working integrations) show up as a spike in the non-SSRF buckets against a
-// near-zero baseline, separately from expected SSRF/abuse disables.
-export const BLOB_INTEGRATION_DISABLED_METRIC =
-  "langfuse.blobstorage.integration_disabled.count";
+// retrying. Errors arrive wrapped via `new Error(..., { cause })` (e.g.
+// StorageService.handleStorageError), so we walk the cause chain.
 
 // Coarse cause bucket for a disable, for logs/metrics. `ssrf_blocked_endpoint`
 // is the SSRF-guard rejection (endpoint resolves to a blocked host/IP) — the

--- a/worker/src/features/integrations/prismaErrors.ts
+++ b/worker/src/features/integrations/prismaErrors.ts
@@ -1,0 +1,8 @@
+import { Prisma } from "@langfuse/shared/src/db";
+
+// An integration can be deleted while one of its runs is still in flight; a row
+// write racing that delete throws P2025. Integration handlers treat that as
+// "job is obsolete, complete it quietly" rather than as a failure to retry.
+export const isRecordNotFoundError = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError &&
+  error.code === "P2025";

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -10,6 +10,8 @@ import {
   getEventsForAnalyticsIntegrations,
   getCurrentSpan,
   validateWebhookURL,
+  recordIncrement,
+  dispatchProjectNotification,
 } from "@langfuse/shared/src/server";
 import {
   transformTraceForPostHog,
@@ -21,7 +23,16 @@ import { decrypt } from "@langfuse/shared/encryption";
 import { PostHog } from "posthog-node";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
 import { assertExportSourceWritable } from "../exportWriteModeGuard";
+import { classifyCustomerFault } from "../integrations/customerFaultClassification";
+import { isRecordNotFoundError } from "../integrations/prismaErrors";
 import { env, v4WritesToLegacyTables } from "../../env";
+
+// Counter for PostHog integrations auto-disabled after a deterministic
+// customer-config fault, tagged by `reason`. A classifier-regression
+// mass-disable shows up as a spike in the non-SSRF buckets vs a near-zero
+// baseline, separate from expected SSRF/abuse disables (mirrors blob's metric).
+export const POSTHOG_INTEGRATION_DISABLED_METRIC =
+  "langfuse.posthog.integration_disabled.count";
 
 type PostHogExecutionConfig = {
   projectId: string;
@@ -311,65 +322,70 @@ export const handlePostHogIntegrationProjectJob = async (
     return;
   }
 
-  // Validate PostHog hostname to prevent SSRF attacks before sending data
   try {
-    await validateWebhookURL(postHogIntegration.posthogHostName);
-  } catch (error) {
-    logger.error(
-      `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,
+    // Validate PostHog hostname to prevent SSRF attacks before sending data.
+    // Rewrap preserving { cause } so the single catch below can classify the
+    // OutboundUrlValidationError off the chain.
+    try {
+      await validateWebhookURL(postHogIntegration.posthogHostName);
+    } catch (error) {
+      logger.error(
+        `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw new Error(
+        `Invalid PostHog hostname for project ${projectId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+        { cause: error },
+      );
+    }
+
+    // Resume from lastSyncAt. On first run, fall back to the project's
+    // createdAt since no trace data can precede it.
+    const minTimestamp =
+      postHogIntegration.lastSyncAt || postHogIntegration.project.createdAt;
+    const uncappedMaxTimestamp = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
+
+    // Cap maxTimestamp at the next UTC day boundary after minTimestamp. Bounds
+    // per-run work so a stuck integration (or a backfill on an older project)
+    // does not re-scan an ever-growing window on each hourly retry, and aligns
+    // with the toDate(...) ClickHouse partition/ordering keys for better
+    // pruning. Healthy integrations are unaffected because uncappedMaxTimestamp
+    // wins whenever the sync is within one day of present.
+    const nextDayBoundary = new Date(
+      Date.UTC(
+        minTimestamp.getUTCFullYear(),
+        minTimestamp.getUTCMonth(),
+        minTimestamp.getUTCDate() + 1,
+      ),
     );
-    throw new Error(
-      `Invalid PostHog hostname for project ${projectId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+    const maxTimestamp = new Date(
+      Math.min(nextDayBoundary.getTime(), uncappedMaxTimestamp.getTime()),
     );
-  }
 
-  // Resume from lastSyncAt. On first run, fall back to the project's
-  // createdAt since no trace data can precede it.
-  const minTimestamp =
-    postHogIntegration.lastSyncAt || postHogIntegration.project.createdAt;
-  const uncappedMaxTimestamp = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
+    if (maxTimestamp <= minTimestamp) {
+      logger.info(
+        `[POSTHOG] Skipping PostHog integration for project ${projectId}: empty sync window (min: ${minTimestamp.toISOString()}, max: ${maxTimestamp.toISOString()})`,
+      );
+      return;
+    }
 
-  // Cap maxTimestamp at the next UTC day boundary after minTimestamp. Bounds
-  // per-run work so a stuck integration (or a backfill on an older project)
-  // does not re-scan an ever-growing window on each hourly retry, and aligns
-  // with the toDate(...) ClickHouse partition/ordering keys for better
-  // pruning. Healthy integrations are unaffected because uncappedMaxTimestamp
-  // wins whenever the sync is within one day of present.
-  const nextDayBoundary = new Date(
-    Date.UTC(
-      minTimestamp.getUTCFullYear(),
-      minTimestamp.getUTCMonth(),
-      minTimestamp.getUTCDate() + 1,
-    ),
-  );
-  const maxTimestamp = new Date(
-    Math.min(nextDayBoundary.getTime(), uncappedMaxTimestamp.getTime()),
-  );
-
-  if (maxTimestamp <= minTimestamp) {
     logger.info(
-      `[POSTHOG] Skipping PostHog integration for project ${projectId}: empty sync window (min: ${minTimestamp.toISOString()}, max: ${maxTimestamp.toISOString()})`,
+      `[POSTHOG] Syncing project ${projectId} from ${minTimestamp.toISOString()} to ${maxTimestamp.toISOString()}`,
     );
-    return;
-  }
 
-  logger.info(
-    `[POSTHOG] Syncing project ${projectId} from ${minTimestamp.toISOString()} to ${maxTimestamp.toISOString()}`,
-  );
+    // Fetch relevant data and send it to PostHog
+    const executionConfig: PostHogExecutionConfig = {
+      projectId,
+      projectName: postHogIntegration.project.name,
+      minTimestamp,
+      maxTimestamp,
+      decryptedPostHogApiKey: decrypt(
+        postHogIntegration.encryptedPosthogApiKey,
+      ),
+      postHogHost: postHogIntegration.posthogHostName,
+      useGraceHash: job.attemptsMade > 0,
+      volume: { bytes: 0 },
+    };
 
-  // Fetch relevant data and send it to PostHog
-  const executionConfig: PostHogExecutionConfig = {
-    projectId,
-    projectName: postHogIntegration.project.name,
-    minTimestamp,
-    maxTimestamp,
-    decryptedPostHogApiKey: decrypt(postHogIntegration.encryptedPosthogApiKey),
-    postHogHost: postHogIntegration.posthogHostName,
-    useGraceHash: job.attemptsMade > 0,
-    volume: { bytes: 0 },
-  };
-
-  try {
     // Fail loudly before exporting empty data and advancing lastSyncAt
     // (LFE-10148, LFE-11009); the catch below logs and BullMQ retries.
     assertExportSourceWritable(
@@ -404,12 +420,16 @@ export const handlePostHogIntegrationProjectJob = async (
     await Promise.all(processPromises);
 
     // Update the last run information for the postHogIntegration record.
+    // Clear any prior error state so a fixed + re-enabled integration reads as
+    // healthy.
     await prisma.posthogIntegration.update({
       where: {
         projectId,
       },
       data: {
         lastSyncAt: executionConfig.maxTimestamp,
+        lastError: null,
+        lastErrorAt: null,
       },
     });
     // Record gzipped on-wire export volume once the run has succeeded.
@@ -422,10 +442,127 @@ export const handlePostHogIntegrationProjectJob = async (
       `[POSTHOG] PostHog integration processing complete for project ${projectId}`,
     );
   } catch (error) {
-    logger.error(
-      `[POSTHOG] Error processing PostHog integration for project ${projectId}`,
-      error,
+    // A deterministic customer-config fault (a bad/malicious hostname rejected
+    // by validateWebhookURL) can't succeed until the customer fixes it.
+    // Classify it, disable the integration, persist the error, notify once,
+    // and RESOLVE (return) — a throw would increment the BullMQ `type:failed`
+    // metric on every attempt and keep the Failures monitor lit for a fault
+    // that will never clear on its own. Transient/infra faults stay on the
+    // retry+alert path unchanged.
+    const reason = classifyCustomerFault(error);
+    // Bounded like blob's extractStorageErrorMessage: today's classified
+    // messages are short static strings, but persisted error text should not
+    // grow unbounded if a future classified path carries a large SDK body.
+    const message = (
+      error instanceof Error ? error.message : String(error)
+    ).slice(0, 1000);
+
+    if (reason === undefined) {
+      logger.error(
+        `[POSTHOG] Error processing PostHog integration for project ${projectId}`,
+        error,
+      );
+      throw error;
+    }
+
+    try {
+      await prisma.posthogIntegration.update({
+        where: { projectId },
+        data: { lastError: message, lastErrorAt: new Date() },
+      });
+    } catch (persistError) {
+      if (isRecordNotFoundError(persistError)) {
+        // Integration deleted mid-run: nothing to persist, nobody to notify.
+        // Drop the obsolete job instead of retrying it.
+        logger.info(
+          `[POSTHOG] PostHog integration for project ${projectId} was deleted mid-run; dropping obsolete job after error: ${message}`,
+        );
+        return;
+      }
+      // Persisting failed for an infra reason (e.g. DB unavailable). Don't claim
+      // the customer fault as handled — rethrow so BullMQ retries and reclassifies.
+      logger.error(
+        `[POSTHOG] Failed to persist PostHog integration error for project ${projectId}`,
+        persistError,
+      );
+      throw persistError;
+    }
+
+    // Atomic disable: count === 1 means THIS worker flipped enabled true→false,
+    // so the terminal notification fires exactly once even if a concurrent run
+    // (distinct jobId, not queue-deduped) races the same fault. The host is
+    // part of the predicate so a run carrying stale config cannot disable a
+    // hostname the customer corrected mid-run — the fault we caught refers to a
+    // config that no longer exists, and the next scheduled run re-evaluates.
+    const { count } = await prisma.posthogIntegration.updateMany({
+      where: {
+        projectId,
+        enabled: true,
+        posthogHostName: postHogIntegration.posthogHostName,
+      },
+      data: { enabled: false },
+    });
+    if (count === 0) {
+      // Already disabled by a concurrent run, or the host changed under us.
+      logger.info(
+        `[POSTHOG] Skipped disabling PostHog integration for project ${projectId}: already disabled or host changed mid-run`,
+      );
+      return;
+    }
+
+    recordIncrement(POSTHOG_INTEGRATION_DISABLED_METRIC, 1, { reason });
+    logger.warn(
+      `[POSTHOG] Disabled PostHog integration for project ${projectId} after a customer fault (reason=${reason}): ${message}`,
+      { posthogDisableReason: reason, projectId },
     );
-    throw error;
+    // Awaited, not fire-and-forget: the job resolves immediately after this and
+    // the integration is now disabled, so the scheduler (which only enqueues
+    // enabled integrations) never revisits it. An interrupted dispatch would
+    // leave the customer silently disabled with no notification and no retry.
+    await notifyPostHogExportFailed(
+      projectId,
+      postHogIntegration.project.name,
+      postHogIntegration.posthogHostName,
+    );
+    return;
   }
 };
+
+// Terminal "export disabled" notification. Called at most once per broken
+// integration, guarded by the atomic enabled true→false claim, so it needs no
+// cooldown of its own (matching blob's disabled path, which also bypasses it).
+// Swallows every failure: notification trouble must not turn the deliberate
+// RESOLVE back into a job failure. projectName/host are passed in rather than
+// re-read — the caller already holds them.
+async function notifyPostHogExportFailed(
+  projectId: string,
+  projectName: string,
+  host: string,
+): Promise<void> {
+  try {
+    const settingsPath = `/project/${projectId}/settings/integrations/posthog`;
+    await dispatchProjectNotification({
+      projectId,
+      event: {
+        eventType: "posthog-export-failed",
+        severity: "ALERT",
+        projectId,
+        projectName,
+        // The integration is keyed by projectId (1:1); the host is the most
+        // useful human label for the failing export destination.
+        resourceId: projectId,
+        resourceName: host || "PostHog integration",
+        message: `PostHog export disabled for project "${projectName}" after a configuration fault.`,
+        url: env.NEXTAUTH_URL
+          ? `${env.NEXTAUTH_URL}${settingsPath}`
+          : undefined,
+        disabled: true,
+      },
+    });
+  } catch (error) {
+    logger.error(
+      `[POSTHOG] Failed to send failure notification for project ${projectId}`,
+      error,
+    );
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

v3 backport of #16095. A bad or malicious PostHog hostname is a deterministic customer-config fault: it cannot succeed until the customer fixes it. On v3 the handler treated it as an infra failure — logged at `error`, rethrew, got retried by the queue, and tripped the processing-failures monitor on every attempt of every scheduled run.

On a classified fault the handler now persists the error, atomically flips `enabled` true → false, records a disable metric tagged by reason, notifies the customer once, and resolves the job. Transient/infra faults still throw, retry, and alert as before. `dns-lookup-failed` stays excluded from the disable allowlist.

v3 also needed the groundwork this path depends on on `main` (#16135 / shared classifier helpers):

- `last_error` / `last_error_at` on `posthog_integrations`
- `posthog-export-failed` project notification event + admin email
- settings status surface for the persisted fault
- coded `protocol-not-allowed` / `port-not-allowed` webhook rejections so those faults are classifiable

Does **not** include declined connect-time SSRF pinning (#16091 / #16202).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `worker`
- `packages/shared`
- `web`

## Verification

- `pnpm --filter worker run test posthogIntegrationProjectJob.test.ts` → Tests 20 passed (20)
- `pnpm --filter worker run test webhook-validation.test.ts customerFaultClassification.test.ts isCustomerFaultError.test.ts` → Tests 158 passed (158)

## Mandatory Tasks

- [x] Self-reviewed

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15540](https://linear.app/clickhouse/issue/LFE-15540/backplate-security-fixes-to-v3)

<div><a href="https://cursor.com/agents/bc-de199a84-e8ad-4813-9370-52fc41268eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de199a84-e8ad-4813-9370-52fc41268eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport classifies deterministic PostHog destination faults, persists their status, atomically disables affected integrations, and sends project notifications while leaving transient failures retryable.

- Adds persisted PostHog error fields and displays them in integration settings.
- Adds PostHog failure notification types, Slack formatting, and admin email delivery.
- Adds coded webhook protocol and port errors plus shared customer-fault classification.
- Updates the PostHog worker to disable invalid integrations and clear errors after successful exports.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking classifier duplication that should be consolidated to prevent future behavioral drift.

The changed PostHog terminal-fault path is internally consistent, but the intended shared classification source currently coexists with a separate blob-storage copy that maintainers must keep synchronized.

**Files Needing Attention:** worker/src/features/integrations/customerFaultClassification.ts, worker/src/features/blobstorage/isCustomerFaultError.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Scheduled PostHog job] --> B[Validate configured host]
  B -->|Valid| C[Export project data]
  C -->|Success| D[Advance lastSyncAt and clear error]
  C -->|Transient or infrastructure fault| E[Throw for queue retry]
  B -->|Deterministic configuration fault| F[Persist bounded error]
  F --> G{Enabled and hostname unchanged?}
  G -->|No| H[Resolve without disabling]
  G -->|Yes| I[Atomically disable integration]
  I --> J[Record disable metric]
  J --> K[Dispatch project notification]
  K --> L[Resolve job]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/integrations/customerFaultClassification.ts:1-10
**Duplicated customer-fault classifier**

The new module is declared as the sole owner of customer-fault classification, but blob storage retains a separate full implementation instead of forwarding to it. Future provider-code or cause-chain changes therefore require synchronized edits and can make PostHog and blob exports handle identical faults differently.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): fail fast and auto-disable ..."](https://github.com/langfuse/langfuse/commit/8294e910590d7ad0767b4a874cfe4c65ed48f57a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56609023)</sub>

**Context used:**

- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->