### PR TITLE
fix(traces): snap json viewer jump-to without animation

### DIFF
--- a/web/src/features/traces/components/AdvancedJsonViewer/SimpleMultiSectionViewer.clienttest.tsx
+++ b/web/src/features/traces/components/AdvancedJsonViewer/SimpleMultiSectionViewer.clienttest.tsx
@@ -1,0 +1,94 @@
+/**
+ * Jump-to in the non-virtualized JSON viewer must snap to the section, not
+ * animate. Smooth scrolling makes Input/Output/Metadata hops feel slow.
+ *
+ * Row/header internals are stubbed so this file does not pull the media
+ * viewer (and `@langfuse/shared`) just to assert scroll behavior.
+ */
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+
+vi.mock("./components/JsonRowFixed", () => ({
+  JsonRowFixed: () => <div />,
+}));
+vi.mock("./components/JsonRowScrollable", () => ({
+  JsonRowScrollable: () => <div />,
+}));
+vi.mock("./components/MultiSectionJsonViewerHeader", () => ({
+  MultiSectionJsonViewerHeader: ({ title }: { title: string }) => (
+    <div>{title}</div>
+  ),
+}));
+
+import {
+  SimpleMultiSectionViewer,
+  type SimpleMultiSectionViewerHandle,
+} from "./SimpleMultiSectionViewer";
+import { buildMultiSectionTree } from "./utils/multiSectionTree";
+import type { JSONTheme, JsonSection } from "./types";
+
+const theme: JSONTheme = {
+  background: "#fff",
+  foreground: "#000",
+  keyColor: "#000",
+  stringColor: "#000",
+  numberColor: "#000",
+  booleanColor: "#000",
+  nullColor: "#000",
+  punctuationColor: "#000",
+  lineNumberColor: "#000",
+  expandButtonColor: "#000",
+  copyButtonColor: "#000",
+  hoverBackground: "#eee",
+  selectedBackground: "#eee",
+  searchMatchBackground: "#ff0",
+  searchCurrentBackground: "#ff0",
+  fontSize: "12px",
+  lineHeight: 20,
+  indentSize: 12,
+};
+
+describe("SimpleMultiSectionViewer jump-to", () => {
+  it("scrolls to a section instantly", () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    const tree = buildMultiSectionTree(
+      [
+        { key: "input", data: { hello: "world" } },
+        { key: "output", data: { result: 1 } },
+      ],
+      { initialExpansion: true },
+    );
+    const sections: JsonSection[] = [
+      { key: "input", data: { hello: "world" }, title: "Input" },
+      { key: "output", data: { result: 1 }, title: "Output" },
+    ];
+
+    const viewerRef = createRef<SimpleMultiSectionViewerHandle>();
+    const scrollContainerRef = createRef<HTMLDivElement>();
+
+    render(
+      <div ref={scrollContainerRef}>
+        <SimpleMultiSectionViewer
+          ref={viewerRef}
+          tree={tree}
+          sections={sections}
+          expansionVersion={0}
+          theme={theme}
+          scrollContainerRef={scrollContainerRef}
+        />
+      </div>,
+    );
+
+    viewerRef.current?.scrollToSection("output");
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        behavior: "instant",
+        block: "start",
+      }),
+    );
+  });
+});

--- a/web/src/features/traces/components/AdvancedJsonViewer/SimpleMultiSectionViewer.clienttest.tsx
+++ b/web/src/features/traces/components/AdvancedJsonViewer/SimpleMultiSectionViewer.clienttest.tsx
@@ -5,7 +5,7 @@
  * Row/header internals are stubbed so this file does not pull the media
  * viewer (and `@langfuse/shared`) just to assert scroll behavior.
  */
-import { createRef } from "react";
+import { createRef, type RefObject } from "react";
 import { render } from "@testing-library/react";
 
 vi.mock("./components/JsonRowFixed", () => ({
@@ -76,7 +76,7 @@ describe("SimpleMultiSectionViewer jump-to", () => {
           sections={sections}
           expansionVersion={0}
           theme={theme}
-          scrollContainerRef={scrollContainerRef}
+          scrollContainerRef={scrollContainerRef as RefObject<HTMLDivElement>}
         />
       </div>,
     );

--- a/web/src/features/traces/components/AdvancedJsonViewer/SimpleMultiSectionViewer.tsx
+++ b/web/src/features/traces/components/AdvancedJsonViewer/SimpleMultiSectionViewer.tsx
@@ -175,7 +175,7 @@ const SimpleMultiSectionViewerInner = forwardRef<
         );
         if (sectionElement) {
           sectionElement.scrollIntoView({
-            behavior: "smooth",
+            behavior: "instant",
             block: "start",
           });
         }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16542.preview.langfuse.com](https://pr-16542.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Clicking **Jump to** (Input, Output, Metadata, …) in the advanced JSON viewer now snaps immediately to that section instead of animating a smooth scroll.

The virtualized viewer already jumped without animation (`behavior: "auto"`). This aligns the non-virtualized path.

Search-match scrolling is unchanged (still smooth).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web exec eslint` on the two changed files (`--max-warnings 0`)
- `pnpm --filter web run test-client src/features/traces/components/AdvancedJsonViewer/SimpleMultiSectionViewer.clienttest.tsx` — `Tests  1 passed (1)`
- `pnpm --filter web run typecheck` — pass (the first preview build failed because this client test's `createRef` type did not match the viewer's `RefObject<HTMLDivElement>`)
- Pre-commit `turbo run lint`: `Tasks: 7 successful, 7 total`

Browser signoff against a live trace is still needed on the preview — local Docker was not available in this environment.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- My code follows the style guidelines of this project (`pnpm run format`)
- I have checked if my changes generate no new warnings
- I have added tests that prove my fix is effective
- I have checked if new and existing unit tests pass locally with my changes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15002](https://linear.app/clickhouse/issue/LFE-15002/advanced-json-viewer-dont-animate-jump-to)

<div><a href="https://cursor.com/agents/bc-40a4f13d-5743-4e5f-a6f2-5b209bb232a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40a4f13d-5743-4e5f-a6f2-5b209bb232a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes jump-to-section navigation in the non-virtualized advanced JSON viewer from smooth scrolling to an immediate snap, aligning its user-visible behavior with the virtualized viewer.
- Uses `behavior: "instant"` for explicit section jumps while preserving smooth search-match scrolling.
- Adds a focused client test asserting the immediate-scroll option.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed behavior.

The production change is narrowly scoped to the scroll behavior option for section jumps, preserves the separate smooth search path, and is covered by a focused test.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): snap json viewer jump-to wi..."](https://github.com/langfuse/langfuse/commit/6ad50f67503b63e8099f6cfee879b3de64ceb2c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56636623)</sub>

<!-- /greptile_comment -->