### PR TITLE
fix(traces): hide empty usage info icon on observations

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -932,6 +932,13 @@ export default function ObservationsTable({
         const aggregatedUsage = calculateAggregatedUsage(
           row.original.usageDetails,
         );
+        if (
+          !aggregatedUsage.input &&
+          !aggregatedUsage.output &&
+          !aggregatedUsage.total
+        ) {
+          return null;
+        }
         return (
           <BreakdownTooltip
             details={row.original.usageDetails}

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -73,6 +73,7 @@ import { BatchExportTableButton } from "@/src/components/BatchExportTableButton"
 import {
   BreakdownTooltip,
   calculateAggregatedUsage,
+  hasNonZeroUsageDetails,
 } from "@/src/features/traces";
 import { InfoIcon } from "lucide-react";
 import { ProvidedModelNameCell } from "@/src/features/models/components/ProvidedModelNameCell";
@@ -935,7 +936,8 @@ export default function ObservationsTable({
         if (
           !aggregatedUsage.input &&
           !aggregatedUsage.output &&
-          !aggregatedUsage.total
+          !aggregatedUsage.total &&
+          !hasNonZeroUsageDetails(row.original.usageDetails)
         ) {
           return null;
         }

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.clienttest.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.clienttest.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+
+import { CostBadge, UsageBadge } from "./ObservationMetadataBadgesTooltip";
+
+describe("UsageBadge", () => {
+  it("hides the usage info icon for tool observations with no usage", () => {
+    const { container } = render(
+      <UsageBadge
+        type="TOOL"
+        inputUsage={0}
+        outputUsage={0}
+        totalUsage={0}
+        usageDetails={{ input: 0, output: 0, total: 0 }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("hides the usage info icon when aggregated usage details are all zero", () => {
+    const { container } = render(
+      <UsageBadge
+        type="GENERATION"
+        inputUsage={0}
+        outputUsage={0}
+        totalUsage={0}
+        usageDetails={{ input: 0, output: 0, total: 0 }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows usage for generation-like observations with tokens", () => {
+    render(
+      <UsageBadge
+        type="GENERATION"
+        inputUsage={12}
+        outputUsage={3}
+        totalUsage={15}
+        usageDetails={{ input: 12, output: 3, total: 15 }}
+      />,
+    );
+
+    expect(
+      screen.getByText("12 prompt → 3 completion (∑ 15)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows usage for tool observations that have ingested tokens", () => {
+    render(
+      <UsageBadge
+        type="TOOL"
+        inputUsage={4}
+        outputUsage={0}
+        totalUsage={4}
+        usageDetails={{ input: 4, total: 4 }}
+      />,
+    );
+
+    expect(
+      screen.getByText("4 prompt → 0 completion (∑ 4)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows usage when only custom usage details are present", () => {
+    render(
+      <UsageBadge
+        type="EMBEDDING"
+        inputUsage={0}
+        outputUsage={0}
+        totalUsage={0}
+        usageDetails={{ cache_read: 50 }}
+      />,
+    );
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("shows token counts without a usage info icon when the breakdown is empty", () => {
+    render(
+      <UsageBadge
+        type="AGENT"
+        inputUsage={12}
+        outputUsage={3}
+        totalUsage={15}
+        usageDetails={{ input: 0, output: 0, total: 0 }}
+      />,
+    );
+
+    expect(
+      screen.getByText("12 prompt → 3 completion (∑ 15)"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("CostBadge", () => {
+  it("hides when cost is zero", () => {
+    const { container } = render(
+      <CostBadge
+        totalCost={0}
+        costDetails={{ input: 0, output: 0, total: 0 }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -38,6 +38,12 @@ export function CostBadge({
   );
 }
 
+function hasNonZeroUsageDetails(
+  usageDetails: Record<string, number> | undefined,
+): usageDetails is Record<string, number> {
+  return Object.values(usageDetails ?? {}).some((value) => (value ?? 0) !== 0);
+}
+
 export function UsageBadge({
   type,
   inputUsage,
@@ -51,9 +57,7 @@ export function UsageBadge({
   totalUsage: number;
   usageDetails: Record<string, number> | undefined;
 }) {
-  // Only show for generation-like observations
-  if (!isGenerationLike(type) || !usageDetails) return null;
-
+  const hasBreakdown = hasNonZeroUsageDetails(usageDetails);
   const tokenText = formatTokenCounts(
     inputUsage,
     outputUsage,
@@ -62,15 +66,23 @@ export function UsageBadge({
   );
   const hasText = tokenText.length > 0;
 
+  if (!isGenerationLike(type) || (!hasText && !hasBreakdown)) return null;
+
+  const badge = (
+    <Badge
+      variant="tertiary"
+      className={`flex items-center gap-1 ${!hasText ? "h-6 pl-2" : ""}`}
+    >
+      {hasText ? <span>{tokenText}</span> : null}
+      {hasBreakdown ? <InfoIcon className="h-3 w-3" /> : null}
+    </Badge>
+  );
+
+  if (!hasBreakdown) return badge;
+
   return (
     <BreakdownTooltip details={usageDetails} isCost={false}>
-      <Badge
-        variant="tertiary"
-        className={`flex items-center gap-1 ${!hasText ? "h-6 pl-2" : ""}`}
-      >
-        {hasText && <span>{tokenText}</span>}
-        <InfoIcon className="h-3 w-3" />
-      </Badge>
+      {badge}
     </BreakdownTooltip>
   );
 }

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -10,6 +10,7 @@ import {
   type PriceSource,
 } from "@/src/features/traces/components/BreakdownTooltip";
 import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
+import { hasNonZeroUsageDetails } from "@/src/features/traces/fns/calculateAggregatedUsage";
 import { InfoIcon } from "lucide-react";
 
 export function CostBadge({
@@ -36,12 +37,6 @@ export function CostBadge({
       </Badge>
     </BreakdownTooltip>
   );
-}
-
-function hasNonZeroUsageDetails(
-  usageDetails: Record<string, number> | undefined,
-): usageDetails is Record<string, number> {
-  return Object.values(usageDetails ?? {}).some((value) => (value ?? 0) !== 0);
 }
 
 export function UsageBadge({

--- a/web/src/features/traces/fns/calculateAggregatedUsage.clienttest.ts
+++ b/web/src/features/traces/fns/calculateAggregatedUsage.clienttest.ts
@@ -1,0 +1,28 @@
+import {
+  calculateAggregatedUsage,
+  hasNonZeroUsageDetails,
+} from "./calculateAggregatedUsage";
+
+describe("hasNonZeroUsageDetails", () => {
+  it("is false for empty or zeroed usage", () => {
+    expect(hasNonZeroUsageDetails(undefined)).toBe(false);
+    expect(hasNonZeroUsageDetails({})).toBe(false);
+    expect(hasNonZeroUsageDetails({ input: 0, output: 0, total: 0 })).toBe(
+      false,
+    );
+  });
+
+  it("is true for custom-only usage keys", () => {
+    expect(hasNonZeroUsageDetails({ cache_read: 50 })).toBe(true);
+  });
+});
+
+describe("calculateAggregatedUsage", () => {
+  it("does not treat custom-only keys as input, output, or total", () => {
+    expect(calculateAggregatedUsage({ cache_read: 50 })).toEqual({
+      input: 0,
+      output: 0,
+      total: 0,
+    });
+  });
+});

--- a/web/src/features/traces/fns/calculateAggregatedUsage.ts
+++ b/web/src/features/traces/fns/calculateAggregatedUsage.ts
@@ -49,3 +49,9 @@ export const calculateAggregatedUsage = (
 
   return { input, output, total };
 };
+
+export function hasNonZeroUsageDetails(
+  details: Record<string, number | undefined> | undefined,
+): details is Record<string, number> {
+  return Object.values(details ?? {}).some((value) => (value ?? 0) !== 0);
+}

--- a/web/src/features/traces/index.ts
+++ b/web/src/features/traces/index.ts
@@ -17,7 +17,10 @@ export { traceDetailTitle } from "@/src/features/traces/fns/traceDetailTitle";
 export { useTraceDetailData } from "@/src/features/traces/hooks/useTraceDetailData";
 
 export { BreakdownTooltip } from "@/src/features/traces/components/BreakdownTooltip";
-export { calculateAggregatedUsage } from "@/src/features/traces/fns/calculateAggregatedUsage";
+export {
+  calculateAggregatedUsage,
+  hasNonZeroUsageDetails,
+} from "@/src/features/traces/fns/calculateAggregatedUsage";
 export { CopyIdsPopover } from "@/src/features/traces/components/CopyIdsPopover";
 
 export {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16545.preview.langfuse.com](https://pr-16545.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Tool observations and parent observations that only aggregate children were showing a usage info icon even when there was nothing to ingest or display. Clicking it opened a usage breakdown of `0 / 0 / 0`.

This hides the usage badge when there are no tokens, and only shows the info icon when the breakdown has non-zero details. The observations table tokens column now also skips empty usage, matching the traces table, while still showing custom-only usage keys.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client src/features/traces/components/ObservationMetadataBadgesTooltip.clienttest.tsx src/features/traces/fns/calculateAggregatedUsage.clienttest.ts` — `Tests  10 passed (10)`
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- First-commit CI: `all-ci-passed` succeeded (61 checks, 0 failed)
- Browser: seeded `support-agent --v4 --id-prefix deadbeef` on http://localhost:3000. Tool `crm.get-customer` and parent `support-copilot` have no usage `i`; generation `classify-intent` still shows `412 prompt → 31 completion (∑ 443)` with a breakdown.

## Test this

Preview: https://pr-16545.preview.langfuse.com (synthetic data only)

1. Open a trace with a tool observation.
2. Select the tool observation and confirm the header has no lone usage `i`.
3. Select a generation with tokens and confirm the usage badge and breakdown still appear.
4. Select a parent observation that only has child costs and confirm it does not open a `0 / 0 / 0` usage breakdown.

Data: demo project is enough. Optional: `pnpm run seed -- support-agent --v4 --id-prefix deadbeef`.
Sandbox: same path on http://localhost:3000 after the cloud stack is up.

[Tool observation header with no usage icon](https://cursor.com/agents/bc-30271edf-3aab-4a9f-9ae1-2993f60fcfb5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftool_observation_no_usage_icon.webp)
[Generation still shows usage badge](https://cursor.com/agents/bc-30271edf-3aab-4a9f-9ae1-2993f60fcfb5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgeneration_usage_badge_still_shown.webp)
[Parent agent header with no usage icon](https://cursor.com/agents/bc-30271edf-3aab-4a9f-9ae1-2993f60fcfb5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fparent_agent_no_usage_icon.webp)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have checked if my PR needs changes to the documentation
- I have added tests that prove my fix is effective
- I have checked if new and existing unit tests pass locally with my changes

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-6985](https://linear.app/clickhouse/issue/LFE-6985/ui-tool-type-observations-show-i-for-usage)

<div><a href="https://cursor.com/agents/bc-30271edf-3aab-4a9f-9ae1-2993f60fcfb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30271edf-3aab-4a9f-9ae1-2993f60fcfb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR suppresses empty observation usage badges, tooltips, and table cells while preserving token text and non-zero usage breakdowns.
- Adds value-based usage-breakdown detection to observation metadata badges.
- Omits the observations-table tokens cell when standard aggregated token usage is zero.
- Adds client tests for empty, token-bearing, and custom-only usage states.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The custom-only usage regression should be fixed before merging because valid observation usage becomes invisible in the table.

The new table guard classifies usage solely from input, output, and total aggregates even though the supported breakdown can contain meaningful custom-only metrics.

**Files Needing Attention:** web/src/components/table/use-cases/observations.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/use-cases/observations.tsx:935-939
**Custom usage is hidden**

When an observation contains a non-zero custom usage key but no input, output, or total usage, this aggregated-value check returns `null`, causing the table to hide the custom breakdown that `BreakdownTooltip` supports displaying.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): hide empty usage info icon ..."](https://github.com/langfuse/langfuse/commit/de694e5ec1da82804cfd0749414fd368bba4d352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56639938)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->