### PR TITLE
chore(eslint): Extend `@repo/no-abstracted-overlay-trigger`

### DIFF
--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -169,4 +169,15 @@ export default [
       "react/no-unused-prop-types": "warn",
     },
   },
+  {
+    name: "langfuse/next/tests-and-stories",
+    files: [
+      "**/*.test.{ts,tsx}",
+      "**/*.story.{ts,tsx}",
+      "**/*.stories.{ts,tsx}",
+    ],
+    rules: {
+      "@repo/no-abstracted-overlay-trigger": "off",
+    },
+  },
 ];

--- a/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.test.ts
+++ b/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.test.ts
@@ -195,6 +195,30 @@ ruleTester.run("no-abstracted-overlay-trigger", rule, {
   invalid: [
     {
       code: `
+        import {
+          Drawer,
+          DrawerContent,
+          DrawerTrigger,
+        } from "@/src/components/ui/drawer";
+
+        export function AnnotateDrawer() {
+          return (
+            <Drawer>
+              <DrawerTrigger />
+              <DrawerContent />
+            </Drawer>
+          );
+        }
+      `,
+      errors: [
+        {
+          messageId: "abstractedTrigger",
+          data: { overlay: "Drawer" },
+        },
+      ],
+    },
+    {
+      code: `
             import {
               Dialog,
           DialogContent,

--- a/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.ts
+++ b/packages/eslint-plugin/src/rules/no-abstracted-overlay-trigger.ts
@@ -23,6 +23,12 @@ const OVERLAY_FAMILIES = [
     contents: ["DropdownMenuContent", "DropdownMenuSubContent"],
   },
   {
+    module: "@/src/components/ui/drawer",
+    root: "Drawer",
+    trigger: "DrawerTrigger",
+    contents: ["DrawerContent"],
+  },
+  {
     module: "@/src/components/ui/popover",
     root: "Popover",
     trigger: "PopoverTrigger",

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import Header from "@/src/components/layouts/header";
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button, type ButtonProps } from "@/src/components/ui/button";

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React from "react";
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button } from "@/src/components/ui/button";


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16548.preview.langfuse.com](https://pr-16548.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the overlay-trigger ESLint rule to Drawer components and adjusts lint configuration for tests, stories, and existing abstractions.
- Adds Drawer, DrawerTrigger, and DrawerContent to the recognized overlay families.
- Adds a Drawer rule test.
- Disables the rule for tests and stories and suppresses it in two existing Drawer abstractions.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["Extend overlay trigger linting"](https://github.com/langfuse/langfuse/commit/70e430887e3ea269c8863c0419779cad4fd2c90f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56659786)</sub>

<!-- /greptile_comment -->