### PR TITLE
feat(in-app-agent): propose evaluator drafts in the UI

### DIFF
--- a/packages/shared/src/in-app-agent/constants.ts
+++ b/packages/shared/src/in-app-agent/constants.ts
@@ -3,6 +3,23 @@ import { InAppAgentRunStatus } from "../features/inAppAgent/types";
 // Avoid renaming this as the FE is aware of this when rendering, renaming it would cause history issues
 export const IN_APP_AGENT_REDIRECT_TOOL_NAME = "langfuse_proposeRedirect";
 
+export const IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME =
+  "langfuse_proposeEvaluatorDraft";
+
+export const IN_APP_AGENT_UI_PROPOSAL_TOOL_NAMES = new Set<string>([
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
+]);
+
+export function isInAppAgentUiProposalToolName(
+  toolName: string | undefined,
+): boolean {
+  return (
+    typeof toolName === "string" &&
+    IN_APP_AGENT_UI_PROPOSAL_TOOL_NAMES.has(toolName)
+  );
+}
+
 export const IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE = "tool_call_rejected";
 
 export const IN_APP_AGENT_GENERIC_ERROR_MESSAGE =

--- a/packages/shared/src/in-app-agent/schema.ts
+++ b/packages/shared/src/in-app-agent/schema.ts
@@ -7,6 +7,8 @@
 import type { EventType } from "@ag-ui/core";
 import { z } from "zod";
 
+import { PersistedEvalOutputDefinitionSchema } from "../features/evals/outputDefinition";
+
 // @ag-ui/core@0.0.52 publishes Zod v3-shaped declarations, but this package
 // uses Zod v4, causing its exported z.infer-based types to resolve as unknown.
 // Duplicate the relevant schemas locally until
@@ -42,6 +44,49 @@ export const InAppAgentRedirectActionToolResultSchema = z.object({
   label: z.string().min(1).max(80),
   href: z.string().min(1),
 });
+
+export const InAppAgentEvaluatorDraftVariableMappingSchema = z.object({
+  templateVariable: z.string().min(1),
+  selectedColumnId: z.string().min(1),
+  jsonSelector: z.string().nullish(),
+});
+
+export const InAppAgentLlmEvaluatorDraftSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  description: z.string().trim().max(2_000).nullable(),
+  definition: z.object({
+    type: z.literal("LLM_AS_JUDGE"),
+    prompt: z.string().min(1).max(100_000),
+    provider: z.string().nullable(),
+    model: z.string().nullable(),
+    modelParams: z.record(z.string(), z.unknown()).nullable(),
+    vars: z.array(z.string()),
+    variableMapping: z
+      .array(InAppAgentEvaluatorDraftVariableMappingSchema)
+      .nullable(),
+    outputDefinition: PersistedEvalOutputDefinitionSchema,
+  }),
+});
+
+export type InAppAgentLlmEvaluatorDraft = z.infer<
+  typeof InAppAgentLlmEvaluatorDraftSchema
+>;
+
+export const InAppAgentUiDraftActionToolResultSchema = z.object({
+  type: z.literal("uiDraftAction"),
+  label: z.string().min(1).max(80),
+  href: z.string().min(1),
+  destination: z.literal("newEvaluator"),
+  draft: InAppAgentLlmEvaluatorDraftSchema,
+});
+
+export const InAppAgentUiProposalToolResultSchema = z.discriminatedUnion(
+  "type",
+  [
+    InAppAgentRedirectActionToolResultSchema,
+    InAppAgentUiDraftActionToolResultSchema,
+  ],
+);
 
 export const InAppAgentSandboxToolNameSchema = z.enum([
   "read",

--- a/packages/shared/src/in-app-agent/server/mcpPolicy.ts
+++ b/packages/shared/src/in-app-agent/server/mcpPolicy.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 import type { ProjectScope } from "../../features/rbac/projectAccessRights";
 import { hasProjectAccessByRole } from "../../features/rbac/projectAccessRights";
 import { Role } from "../../db";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
+import {
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+} from "../constants";
 import {
   buildInAppAgentToolApprovalEvent,
   type InAppAgentToolApprovalSource,
@@ -412,6 +415,7 @@ export async function createInAppAgentMcpRunOverride(params: {
 
 export const IN_APP_AGENT_AUTO_APPROVED_EXTERNAL_TOOL_NAMES = new Set([
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
 ]);
 
 export const IN_APP_AGENT_SANDBOX_TOOL_NAMES = new Set([

--- a/packages/shared/src/in-app-agent/server/persistence.test.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.test.ts
@@ -2,7 +2,10 @@ import { EventType } from "@ag-ui/core";
 import { describe, expect, it } from "vitest";
 
 import type { PrismaClient } from "../../db";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
+import {
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
+  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+} from "../constants";
 import { buildInAppAgentToolApprovalEvent } from "../approvalEvents";
 import {
   createSandboxToolCallFileAccumulator,
@@ -133,6 +136,33 @@ describe("partitionPendingRunEvents", () => {
     const end = {
       type: EventType.TOOL_CALL_END,
       toolCallId: "redirect-1",
+    };
+
+    expect(partitionPendingRunEvents([start, sidecar, args, end])).toEqual({
+      eventsToAppend: [],
+      retainedEvents: [start, sidecar, args, end],
+    });
+  });
+
+  it("retains an evaluator draft proposal until the result arrives", () => {
+    const sidecar = buildInAppAgentToolApprovalEvent({
+      toolCallId: "draft-1",
+      toolName: IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
+      source: "auto",
+    });
+    const start = {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "draft-1",
+      toolCallName: IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
+    };
+    const args = {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: "draft-1",
+      delta: "{}",
+    };
+    const end = {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: "draft-1",
     };
 
     expect(partitionPendingRunEvents([start, sidecar, args, end])).toEqual({

--- a/packages/shared/src/in-app-agent/server/persistence.ts
+++ b/packages/shared/src/in-app-agent/server/persistence.ts
@@ -12,7 +12,10 @@ import {
   LangfuseInternalTraceEnvironment,
   logger,
 } from "../../server";
-import { isSettledInAppAgentRunStatus } from "../constants";
+import {
+  isInAppAgentUiProposalToolName,
+  isSettledInAppAgentRunStatus,
+} from "../constants";
 import { recordRunTerminalOutcome } from "./runMetrics";
 import { Prisma } from "../../db";
 import type { InAppAgentConversation, PrismaClient } from "../../db";
@@ -27,7 +30,7 @@ import { truncate } from "../../utils/stringChecks";
 import { assertUnreachable } from "../../utils/typeChecks";
 import {
   AgUiMessageSchema,
-  InAppAgentRedirectActionToolResultSchema,
+  InAppAgentUiProposalToolResultSchema,
   type AgUiEvent,
   type AgUiMessage,
 } from "../schema";
@@ -36,7 +39,6 @@ import {
   dropUnpairedAssistantToolCalls,
 } from "../messages";
 import { compactPersistedEventDeltas } from "./eventCompaction";
-import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "../constants";
 import { safeJsonParse } from "../../utils/json";
 import {
   type CompletedInAppAgentMcpToolCall,
@@ -665,8 +667,7 @@ export function partitionPendingRunEvents(events: readonly AgUiEvent[]): {
     if (
       toolCallId &&
       pendingEvent.type === EventType.TOOL_CALL_START &&
-      getString(pendingEvent, "toolCallName") ===
-        IN_APP_AGENT_REDIRECT_TOOL_NAME
+      isInAppAgentUiProposalToolName(getString(pendingEvent, "toolCallName"))
     ) {
       openRedirectToolCallIds.add(toolCallId);
     }
@@ -1353,7 +1354,7 @@ function dropRedirectToolCallEvents(events: readonly AgUiEvent[]): AgUiEvent[] {
   for (const event of events) {
     if (
       event.type === EventType.TOOL_CALL_START &&
-      getString(event, "toolCallName") === IN_APP_AGENT_REDIRECT_TOOL_NAME
+      isInAppAgentUiProposalToolName(getString(event, "toolCallName"))
     ) {
       const toolCallId = getString(event, "toolCallId");
       if (toolCallId) {
@@ -1363,10 +1364,7 @@ function dropRedirectToolCallEvents(events: readonly AgUiEvent[]): AgUiEvent[] {
 
     if (event.type === EventType.TOOL_CALL_RESULT) {
       const toolCallId = getString(event, "toolCallId");
-      if (
-        toolCallId &&
-        isRedirectActionToolResult(getString(event, "content"))
-      ) {
+      if (toolCallId && isUiProposalToolResult(getString(event, "content"))) {
         redirectToolCallIds.add(toolCallId);
       }
     }
@@ -1394,7 +1392,7 @@ function dropRedirectToolCallEvents(events: readonly AgUiEvent[]): AgUiEvent[] {
 
     return (
       event.type === EventType.TOOL_CALL_RESULT &&
-      isRedirectActionToolResult(getString(event, "content"))
+      isUiProposalToolResult(getString(event, "content"))
     );
   });
 }
@@ -1403,7 +1401,7 @@ function dropRedirectActionToolResults(messages: readonly AgUiMessage[]) {
   let changed = false;
   const sanitizedMessages = messages.filter((message) => {
     const keep =
-      message.role !== "tool" || !isRedirectActionToolResult(message.content);
+      message.role !== "tool" || !isUiProposalToolResult(message.content);
 
     changed = changed || !keep;
     return keep;
@@ -1456,15 +1454,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function isRedirectActionToolResult(content: string | undefined) {
+function isUiProposalToolResult(content: string | undefined) {
   if (!content) {
     return false;
   }
 
   try {
-    return InAppAgentRedirectActionToolResultSchema.safeParse(
-      JSON.parse(content),
-    ).success;
+    return InAppAgentUiProposalToolResultSchema.safeParse(JSON.parse(content))
+      .success;
   } catch {
     return false;
   }

--- a/packages/shared/src/in-app-agent/server/systemPrompt.ts
+++ b/packages/shared/src/in-app-agent/server/systemPrompt.ts
@@ -63,6 +63,7 @@ The tool call should be the last thing in your response before ending your turn,
 Use the redirect proposal only for known in-app destinations from the tool schema. Never invent URLs or ask the user to paste links.
 When the user asks for a trace view with specific state, use the typed trace params for time ranges, search, filters, and ordering instead of describing URL query parameters.
 Use a short action label, for example "Open members" or "Open traces".
+When proposing a new LLM-as-a-judge evaluator, call {{evaluatorDraftToolName}} with the evaluator name, prompt, variable mappings, and score output so the product can open the evaluator creation form pre-filled. Do not also call createEvaluator unless the user explicitly asks you to create the evaluator immediately without reviewing the form. Use the label "Review evaluator in UI".
 </user_navigation>
 
 <world_knowledge>

--- a/packages/shared/src/utils/productUrl.ts
+++ b/packages/shared/src/utils/productUrl.ts
@@ -158,6 +158,14 @@ export const buildDatasetsPath = (params: {
 export const buildEvalsPath = (params: { projectId: string }) =>
   `${buildProjectPath(params)}/evals`;
 
+export const buildNewEvaluatorPath = (params: {
+  projectId: string;
+  agentDraft?: boolean;
+}) =>
+  appendProductPathQuery(`${buildProjectPath(params)}/evals/new`, {
+    agentDraft: params.agentDraft ? "1" : undefined,
+  });
+
 export const buildExperimentsPath = (params: { projectId: string }) =>
   `${buildProjectPath(params)}/experiments`;
 

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
+/* eslint-disable @repo/no-style-props */
 import Header from "@/src/components/layouts/header";
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button, type ButtonProps } from "@/src/components/ui/button";

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
 import Header from "@/src/components/layouts/header";
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button, type ButtonProps } from "@/src/components/ui/button";

--- a/web/src/features/evals/v2/fns/evaluators/agentEvaluatorDraft.clienttest.ts
+++ b/web/src/features/evals/v2/fns/evaluators/agentEvaluatorDraft.clienttest.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { agentEvaluatorDraftToSetupDraft } from "./agentEvaluatorDraft";
+
+describe("agentEvaluatorDraftToSetupDraft", () => {
+  it("keeps name, prompt, mappings, and score output for the setup form", () => {
+    const draft = agentEvaluatorDraftToSetupDraft({
+      name: "Helpfulness",
+      description: "Scores whether the answer helps the user.",
+      definition: {
+        type: "LLM_AS_JUDGE",
+        prompt: "Score {{output}} given {{input}}",
+        provider: null,
+        model: null,
+        modelParams: null,
+        vars: ["output", "input"],
+        variableMapping: [
+          {
+            templateVariable: "output",
+            selectedColumnId: "output",
+            jsonSelector: null,
+          },
+          {
+            templateVariable: "input",
+            selectedColumnId: "input",
+            jsonSelector: null,
+          },
+        ],
+        outputDefinition: {
+          version: 2,
+          dataType: "NUMERIC",
+          reasoning: { description: "Explain the score." },
+          score: {
+            description: "Helpfulness from 0 to 1.",
+            minValue: 0,
+            maxValue: 1,
+          },
+        },
+      },
+    });
+
+    expect(draft.name).toBe("Helpfulness");
+    expect(draft.definition.type).toBe("LLM_AS_JUDGE");
+    if (draft.definition.type !== "LLM_AS_JUDGE") {
+      throw new Error("expected LLM evaluator");
+    }
+    expect(draft.definition.prompt).toContain("{{output}}");
+    expect(draft.definition.variableMapping).toEqual([
+      {
+        templateVariable: "output",
+        selectedColumnId: "output",
+        jsonSelector: null,
+      },
+      {
+        templateVariable: "input",
+        selectedColumnId: "input",
+        jsonSelector: null,
+      },
+    ]);
+    expect(draft.definition.outputDefinition).toMatchObject({
+      dataType: "NUMERIC",
+      score: { minValue: 0, maxValue: 1 },
+    });
+  });
+});

--- a/web/src/features/evals/v2/fns/evaluators/agentEvaluatorDraft.ts
+++ b/web/src/features/evals/v2/fns/evaluators/agentEvaluatorDraft.ts
@@ -1,0 +1,14 @@
+import type { InAppAgentLlmEvaluatorDraft } from "@langfuse/shared/in-app-agent";
+
+import type { EvaluatorSetupDraft } from "@/src/features/evals/v2/types/templateGallery";
+import type { EvaluatorDefinition } from "@/src/features/evals/v2/server/evaluators/evaluatorTypes";
+
+export function agentEvaluatorDraftToSetupDraft(
+  draft: InAppAgentLlmEvaluatorDraft,
+): EvaluatorSetupDraft {
+  return {
+    name: draft.name,
+    description: draft.description,
+    definition: draft.definition as EvaluatorDefinition,
+  };
+}

--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
@@ -14,6 +14,7 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
       managedTemplateKey: "exact-match",
       isCustomTemplate: false,
       isFromScratch: false,
+      isFromAssistant: false,
     });
   });
 
@@ -27,6 +28,7 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
       evaluatorType: "LLM_AS_JUDGE",
       isCustomTemplate: true,
       isFromScratch: false,
+      isFromAssistant: false,
     });
   });
 
@@ -40,6 +42,21 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
       evaluatorType: "LLM_AS_JUDGE",
       isCustomTemplate: false,
       isFromScratch: true,
+      isFromAssistant: false,
+    });
+  });
+
+  it("reports evaluators opened from the in-app assistant", () => {
+    expect(
+      getEvaluatorCreationAnalyticsProperties({
+        evaluatorType: "LLM_AS_JUDGE",
+        creationSource: { type: "assistant" },
+      }),
+    ).toEqual({
+      evaluatorType: "LLM_AS_JUDGE",
+      isCustomTemplate: false,
+      isFromScratch: false,
+      isFromAssistant: true,
     });
   });
 });

--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
@@ -3,7 +3,8 @@ import type { EvalTemplateType } from "@langfuse/shared";
 export type EvaluatorCreationSource =
   | { type: "managed"; templateKey: string }
   | { type: "custom" }
-  | { type: "scratch" };
+  | { type: "scratch" }
+  | { type: "assistant" };
 
 export function getEvaluatorCreationAnalyticsProperties({
   evaluatorType,
@@ -18,6 +19,7 @@ export function getEvaluatorCreationAnalyticsProperties({
       managedTemplateKey: creationSource.templateKey,
       isCustomTemplate: false,
       isFromScratch: false,
+      isFromAssistant: false,
     };
   }
 
@@ -25,5 +27,6 @@ export function getEvaluatorCreationAnalyticsProperties({
     evaluatorType,
     isCustomTemplate: creationSource.type === "custom",
     isFromScratch: creationSource.type === "scratch",
+    isFromAssistant: creationSource.type === "assistant",
   };
 }

--- a/web/src/features/evals/v2/pages/NewEvaluatorPage.tsx
+++ b/web/src/features/evals/v2/pages/NewEvaluatorPage.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from "next/router";
-import { useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { EvalTemplateTypeEnum } from "@langfuse/shared";
 
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { useEvalTemplate } from "@/src/features/evals/v2/hooks/useEvalTemplate";
 import { agentEvaluatorDraftToSetupDraft } from "@/src/features/evals/v2/fns/evaluators/agentEvaluatorDraft";
-import { readAgentEvaluatorDraft } from "@/src/features/in-app-agent/lib/evaluatorDraftStorage";
+import { takeAgentEvaluatorDraft } from "@/src/features/in-app-agent/lib/evaluatorDraftStorage";
 import { EvaluatorSetupPage } from "./EvaluatorSetupPage";
 
 function requestedEvaluatorType(value: string | string[] | undefined) {
@@ -43,26 +43,7 @@ export default function NewEvaluatorPage() {
   }
 
   if (isAgentDraft) {
-    const storedDraft = readAgentEvaluatorDraft(projectId);
-    if (!storedDraft) {
-      return (
-        <div className="p-6">
-          This assistant draft is no longer available. Ask the assistant to
-          propose the evaluator again.
-        </div>
-      );
-    }
-
-    return (
-      <EvaluatorSetupPage
-        mode="create"
-        key="assistant-draft"
-        projectId={projectId}
-        initialDraft={agentEvaluatorDraftToSetupDraft(storedDraft)}
-        initialType={EvalTemplateTypeEnum.LLM_AS_JUDGE}
-        creationSource={{ type: "assistant" }}
-      />
-    );
+    return <AssistantEvaluatorDraftPage projectId={projectId} />;
   }
 
   if (template.isNotFound) {
@@ -84,6 +65,30 @@ export default function NewEvaluatorPage() {
       initialDraft={template.draft}
       initialType={initialType}
       creationSource={creationSource}
+    />
+  );
+}
+
+function AssistantEvaluatorDraftPage({ projectId }: { projectId: string }) {
+  const [draft] = useState(() => takeAgentEvaluatorDraft(projectId));
+
+  if (!draft) {
+    return (
+      <div className="p-6">
+        This assistant draft is no longer available. Ask the assistant to
+        propose the evaluator again.
+      </div>
+    );
+  }
+
+  return (
+    <EvaluatorSetupPage
+      mode="create"
+      key="assistant-draft"
+      projectId={projectId}
+      initialDraft={agentEvaluatorDraftToSetupDraft(draft)}
+      initialType={EvalTemplateTypeEnum.LLM_AS_JUDGE}
+      creationSource={{ type: "assistant" }}
     />
   );
 }

--- a/web/src/features/evals/v2/pages/NewEvaluatorPage.tsx
+++ b/web/src/features/evals/v2/pages/NewEvaluatorPage.tsx
@@ -1,8 +1,11 @@
 import { useRouter } from "next/router";
+import { useSyncExternalStore } from "react";
 import { EvalTemplateTypeEnum } from "@langfuse/shared";
 
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { useEvalTemplate } from "@/src/features/evals/v2/hooks/useEvalTemplate";
+import { agentEvaluatorDraftToSetupDraft } from "@/src/features/evals/v2/fns/evaluators/agentEvaluatorDraft";
+import { readAgentEvaluatorDraft } from "@/src/features/in-app-agent/lib/evaluatorDraftStorage";
 import { EvaluatorSetupPage } from "./EvaluatorSetupPage";
 
 function requestedEvaluatorType(value: string | string[] | undefined) {
@@ -11,9 +14,17 @@ function requestedEvaluatorType(value: string | string[] | undefined) {
     : EvalTemplateTypeEnum.LLM_AS_JUDGE;
 }
 
+const subscribeNever = () => () => undefined;
+
 export default function NewEvaluatorPage() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
+  const isAgentDraft = router.query.agentDraft === "1";
+  const isClient = useSyncExternalStore(
+    subscribeNever,
+    () => true,
+    () => false,
+  );
   const templateKey =
     typeof router.query.template === "string" ? router.query.template : null;
   const evaluatorId =
@@ -24,11 +35,34 @@ export default function NewEvaluatorPage() {
     projectId,
     templateKey,
     evaluatorId,
-    enabled: router.isReady,
+    enabled: router.isReady && !isAgentDraft,
   });
 
-  if (!router.isReady || template.isPending) {
+  if (!router.isReady || (isAgentDraft && !isClient) || template.isPending) {
     return <Skeleton className="m-6 h-96 w-[calc(100%-3rem)]" />;
+  }
+
+  if (isAgentDraft) {
+    const storedDraft = readAgentEvaluatorDraft(projectId);
+    if (!storedDraft) {
+      return (
+        <div className="p-6">
+          This assistant draft is no longer available. Ask the assistant to
+          propose the evaluator again.
+        </div>
+      );
+    }
+
+    return (
+      <EvaluatorSetupPage
+        mode="create"
+        key="assistant-draft"
+        projectId={projectId}
+        initialDraft={agentEvaluatorDraftToSetupDraft(storedDraft)}
+        initialType={EvalTemplateTypeEnum.LLM_AS_JUDGE}
+        creationSource={{ type: "assistant" }}
+      />
+    );
   }
 
   if (template.isNotFound) {

--- a/web/src/features/evals/v2/store/evaluatorSetupStore/evaluatorSetupStore.clienttest.ts
+++ b/web/src/features/evals/v2/store/evaluatorSetupStore/evaluatorSetupStore.clienttest.ts
@@ -114,6 +114,64 @@ describe("createEvaluatorSetupStore", () => {
     expect(store.getState().sampleFilter).toBe(initialSampleFilter);
   });
 
+  it("hydrates an LLM-as-judge draft into the setup form", () => {
+    const store = createEvaluatorSetupStore({
+      initialEvaluator: {
+        name: "Helpfulness",
+        description: "Scores whether the answer helps the user.",
+        definition: {
+          type: "LLM_AS_JUDGE",
+          prompt: "Score {{output}} given {{input}}",
+          provider: null,
+          model: null,
+          modelParams: null,
+          vars: ["output", "input"],
+          variableMapping: [
+            {
+              templateVariable: "output",
+              selectedColumnId: "output",
+              jsonSelector: null,
+            },
+            {
+              templateVariable: "input",
+              selectedColumnId: "input",
+              jsonSelector: null,
+            },
+          ],
+          outputDefinition: {
+            version: 2,
+            dataType: "NUMERIC",
+            reasoning: { description: "Explain the score." },
+            score: {
+              description: "Helpfulness from 0 to 1.",
+              minValue: 0,
+              maxValue: 1,
+            },
+          },
+        },
+      },
+      initialType: "LLM_AS_JUDGE",
+      mode: "create",
+    });
+
+    expect(store.getState()).toMatchObject({
+      type: "LLM_AS_JUDGE",
+      name: "Helpfulness",
+      description: "Scores whether the answer helps the user.",
+      prompt: "Score {{output}} given {{input}}",
+      scoreOutput: {
+        dataType: "NUMERIC",
+        scoreDescription: "Helpfulness from 0 to 1.",
+        minValue: "0",
+        maxValue: "1",
+      },
+      variableFields: {
+        output: { selectedColumnId: "output", jsonSelector: null },
+        input: { selectedColumnId: "input", jsonSelector: null },
+      },
+    });
+  });
+
   it("starts a blank code evaluator from the gallery", () => {
     const store = createEvaluatorSetupStore({
       initialEvaluator: null,

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
@@ -114,16 +114,45 @@ export const AssistantTextWithLongFeedbackComment = meta.story({
   },
 });
 
-export const AssistantTextWithRedirectAction = meta.story({
+export const AssistantTextWithEvaluatorDraftAction = meta.story({
   args: {
     role: "assistant",
     content: {
       type: "text",
-      text: "I found the members settings page for this project.",
+      text: "I drafted a helpfulness evaluator you can review in the form.",
       redirectAction: {
         type: "redirectAction",
-        label: "Open members",
-        href: "/project/project-1/settings/members",
+        label: "Review evaluator in UI",
+        href: "/project/project-1/evals/new?agentDraft=1",
+        evaluatorDraft: {
+          name: "Helpfulness",
+          description: null,
+          definition: {
+            type: "LLM_AS_JUDGE",
+            prompt: "Score {{output}}",
+            provider: null,
+            model: null,
+            modelParams: null,
+            vars: ["output"],
+            variableMapping: [
+              {
+                templateVariable: "output",
+                selectedColumnId: "output",
+                jsonSelector: null,
+              },
+            ],
+            outputDefinition: {
+              version: 2,
+              dataType: "NUMERIC",
+              reasoning: { description: "Explain the score." },
+              score: {
+                description: "Quality of the response.",
+                minValue: 0,
+                maxValue: 1,
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -28,6 +28,7 @@ import {
   type ButtonHTMLAttributes,
   type ReactNode,
 } from "react";
+import type { InAppAgentLlmEvaluatorDraft } from "@langfuse/shared/in-app-agent";
 import type {
   InAppAgentMessageFeedback,
   InAppAgentMessageFeedbackValue,
@@ -42,6 +43,8 @@ import {
 import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
 import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { writeAgentEvaluatorDraft } from "@/src/features/in-app-agent/lib/evaluatorDraftStorage";
 import {
   expandMarkdownSelection,
   getMarkdownSourceRangeFromRenderedOffsets,
@@ -60,6 +63,7 @@ type InAppAgentRedirectActionContent = {
   type: "redirectAction";
   label: string;
   href: string;
+  evaluatorDraft?: InAppAgentLlmEvaluatorDraft;
 };
 
 export type InAppAgentMessageContent =
@@ -747,6 +751,8 @@ function RedirectActionButton({
   isCompact: boolean;
 }) {
   const router = useRouter();
+  const projectId = useProjectIdFromURL();
+  const capture = usePostHogClientCapture();
 
   return (
     <Button
@@ -755,6 +761,13 @@ function RedirectActionButton({
       variant="outline"
       className={cn("shrink-0", isCompact ? "h-6 px-2 text-xs" : "h-7")}
       onClick={() => {
+        if (content.evaluatorDraft && projectId) {
+          writeAgentEvaluatorDraft(projectId, content.evaluatorDraft);
+          capture("in_app_agent:evaluator_draft_opened", {
+            evaluatorType: content.evaluatorDraft.definition.type,
+          });
+        }
+
         router.push(content.href).catch(() => undefined);
       }}
     >

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/src/components/ui/popover";
 import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
 import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
+import { asSingleQueryParam } from "@/src/hooks/useReadyRouteParams";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { writeAgentEvaluatorDraft } from "@/src/features/in-app-agent/lib/evaluatorDraftStorage";
@@ -751,7 +752,7 @@ function RedirectActionButton({
   isCompact: boolean;
 }) {
   const router = useRouter();
-  const projectId = useProjectIdFromURL();
+  const projectId = asSingleQueryParam(router.query?.projectId);
   const capture = usePostHogClientCapture();
 
   return (

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -18,7 +18,7 @@ import { useRouter } from "next/router";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { createInAppAgentConversationId } from "../ids";
 import {
-  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  isInAppAgentUiProposalToolName,
   AgUiMessageSchema,
   dropEmptyAssistantMessages,
   dropUnpairedAssistantToolCalls,
@@ -570,7 +570,7 @@ function InAppAiAgentProviderInner({
             : false) ||
           (message.toolCalls?.some(
             (toolCall) =>
-              toolCall.function.name !== IN_APP_AGENT_REDIRECT_TOOL_NAME &&
+              !isInAppAgentUiProposalToolName(toolCall.function.name) &&
               (loadingEventIds.has(toolCall.id) ||
                 unresolvedActiveRunToolCallIds.has(toolCall.id)),
           ) ??

--- a/web/src/features/in-app-agent/components/useSmoothStreamingMessages.ts
+++ b/web/src/features/in-app-agent/components/useSmoothStreamingMessages.ts
@@ -2,7 +2,7 @@ import { useEffect, useEffectEvent, useReducer } from "react";
 
 import type { InAppAgentPendingToolApproval } from "./InAppAiAgentProvider";
 import {
-  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  isInAppAgentUiProposalToolName,
   type AgUiMessage,
 } from "@langfuse/shared/in-app-agent";
 import { assertUnreachable } from "@/src/utils/types";
@@ -450,7 +450,7 @@ function getTargetTools(
     }
 
     for (const toolCall of message.toolCalls ?? []) {
-      if (toolCall.function.name === IN_APP_AGENT_REDIRECT_TOOL_NAME) {
+      if (isInAppAgentUiProposalToolName(toolCall.function.name)) {
         continue;
       }
 
@@ -656,7 +656,7 @@ function projectToolMessages(
     }
 
     for (const toolCall of message.toolCalls ?? []) {
-      if (toolCall.function.name !== IN_APP_AGENT_REDIRECT_TOOL_NAME) {
+      if (!isInAppAgentUiProposalToolName(toolCall.function.name)) {
         knownToolCallIds.add(toolCall.id);
       }
     }
@@ -679,11 +679,11 @@ function projectToolMessages(
 
     const toolCalls = message.toolCalls.filter(
       (toolCall) =>
-        toolCall.function.name === IN_APP_AGENT_REDIRECT_TOOL_NAME ||
+        isInAppAgentUiProposalToolName(toolCall.function.name) ||
         Boolean(toolDisplayById[toolCall.id]),
     );
     const hasPendingTool = message.toolCalls.some((toolCall) => {
-      if (toolCall.function.name === IN_APP_AGENT_REDIRECT_TOOL_NAME) {
+      if (isInAppAgentUiProposalToolName(toolCall.function.name)) {
         return false;
       }
 

--- a/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -1,4 +1,5 @@
 import {
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
   type AgUiMessage,
 } from "@langfuse/shared/in-app-agent";
@@ -34,6 +35,7 @@ const KNOWN_IN_APP_AGENT_PROGRESS_TOOLS = [
   ),
   ...IN_APP_AGENT_SANDBOX_TOOL_NAMES,
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
   "langfuseDocs_search",
   "langfuseDocs_fetch",
   "skill",
@@ -1182,5 +1184,88 @@ describe("getDrawerMessages", () => {
     if (toolGroup?.content.type === "toolGroup") {
       expect(toolGroup.content.tools[0]).not.toHaveProperty("approval");
     }
+  });
+
+  it("folds an evaluator UI draft into a review action instead of a tool card", () => {
+    const mappedMessages = getDrawerMessages({
+      error: null,
+      isRunning: false,
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "I drafted a helpfulness evaluator.",
+          toolCalls: [
+            {
+              id: "tool-call-1",
+              type: "function",
+              function: {
+                name: IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
+                arguments: JSON.stringify({ name: "Helpfulness" }),
+              },
+            },
+          ],
+        },
+        {
+          id: "tool-1",
+          role: "tool",
+          toolCallId: "tool-call-1",
+          content: JSON.stringify({
+            type: "uiDraftAction",
+            label: "Review evaluator in UI",
+            href: "/project/project-1/evals/new?agentDraft=1",
+            destination: "newEvaluator",
+            draft: {
+              name: "Helpfulness",
+              description: null,
+              definition: {
+                type: "LLM_AS_JUDGE",
+                prompt: "Score {{output}}",
+                provider: null,
+                model: null,
+                modelParams: null,
+                vars: ["output"],
+                variableMapping: [
+                  {
+                    templateVariable: "output",
+                    selectedColumnId: "output",
+                    jsonSelector: null,
+                  },
+                ],
+                outputDefinition: {
+                  version: 2,
+                  dataType: "NUMERIC",
+                  reasoning: { description: "Explain the score." },
+                  score: {
+                    description: "Quality of the response.",
+                    minValue: 0,
+                    maxValue: 1,
+                  },
+                },
+              },
+            },
+          }),
+        },
+      ] satisfies AgUiMessage[],
+    });
+
+    expect(mappedMessages).toMatchObject([
+      {
+        id: "assistant-1",
+        content: {
+          type: "text",
+          text: "I drafted a helpfulness evaluator.",
+          redirectAction: {
+            type: "redirectAction",
+            label: "Review evaluator in UI",
+            href: "/project/project-1/evals/new?agentDraft=1",
+            evaluatorDraft: {
+              name: "Helpfulness",
+            },
+          },
+        },
+      },
+    ]);
+    expect(mappedMessages).toHaveLength(1);
   });
 });

--- a/web/src/features/in-app-agent/components/utils/utils.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.ts
@@ -5,11 +5,11 @@ import type { InAppAgentMessageContent } from "../InAppAgentMessage";
 import { deduplicateBy } from "@/src/utils/arrays";
 import { safeJsonParse, stableJsonStringify } from "@langfuse/shared";
 import {
-  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  isInAppAgentUiProposalToolName,
   IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE,
   AgUiMessageSchema,
   type AgUiMessage,
-  InAppAgentRedirectActionToolResultSchema,
+  InAppAgentUiProposalToolResultSchema,
   InAppAgentRateLimitErrorResponseSchema,
 } from "@langfuse/shared/in-app-agent";
 import {
@@ -71,6 +71,7 @@ const IN_APP_AGENT_TOOL_PROGRESS_LABEL_OVERRIDES: Record<string, string> = {
   getPromptUnresolved: "Inspecting prompt",
   listDashboardWidgets: "Browsing widgets",
   proposeRedirect: "Opening page",
+  proposeEvaluatorDraft: "Preparing evaluator",
   queryMetrics: "Checking metrics",
   read: "Reading file",
   submitFeedback: "Submitting user feedback",
@@ -536,7 +537,7 @@ export function getDrawerMessages({
       message.role === "assistant"
         ? (message.toolCalls?.flatMap(
             (toolCall): InAppAgentToolCallContent[] => {
-              if (toolCall.function.name === IN_APP_AGENT_REDIRECT_TOOL_NAME) {
+              if (isInAppAgentUiProposalToolName(toolCall.function.name)) {
                 return [];
               }
 
@@ -782,9 +783,20 @@ function getRedirectActionFromToolResult(
   message: Extract<AgUiMessage, { role: "tool" }>,
 ): Extract<InAppAgentMessageContent, { type: "redirectAction" }> | null {
   try {
-    return InAppAgentRedirectActionToolResultSchema.parse(
+    const parsed = InAppAgentUiProposalToolResultSchema.parse(
       JSON.parse(message.content),
     );
+
+    if (parsed.type === "redirectAction") {
+      return parsed;
+    }
+
+    return {
+      type: "redirectAction",
+      label: parsed.label,
+      href: parsed.href,
+      evaluatorDraft: parsed.draft,
+    };
   } catch {
     return null;
   }

--- a/web/src/features/in-app-agent/lib/display.ts
+++ b/web/src/features/in-app-agent/lib/display.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import {
-  IN_APP_AGENT_REDIRECT_TOOL_NAME,
+  isInAppAgentUiProposalToolName,
   type AgUiMessage,
 } from "@langfuse/shared/in-app-agent";
 import type { InAppAgentUiMessage } from "../schema";
@@ -296,7 +296,7 @@ export function projectInAppAgentMessagesForDisplay(
 
     for (const toolCall of message.toolCalls ?? []) {
       if (
-        toolCall.function.name !== IN_APP_AGENT_REDIRECT_TOOL_NAME &&
+        !isInAppAgentUiProposalToolName(toolCall.function.name) &&
         !firstToolCallMessageIds.has(toolCall.id)
       ) {
         firstToolCallMessageIds.set(toolCall.id, message.id);
@@ -334,7 +334,7 @@ export function projectInAppAgentMessagesForDisplay(
       const placement = state.toolCallPlacements[toolCall.id];
       if (
         !placement ||
-        toolCall.function.name === IN_APP_AGENT_REDIRECT_TOOL_NAME ||
+        isInAppAgentUiProposalToolName(toolCall.function.name) ||
         firstToolCallMessageIds.get(toolCall.id) !== message.id
       ) {
         continue;
@@ -378,7 +378,7 @@ export function projectInAppAgentMessagesForDisplay(
     toolCall: InAppAgentToolCall,
     messageId: string,
   ) =>
-    toolCall.function.name !== IN_APP_AGENT_REDIRECT_TOOL_NAME &&
+    !isInAppAgentUiProposalToolName(toolCall.function.name) &&
     firstToolCallMessageIds.get(toolCall.id) !== messageId;
 
   return messages.flatMap<InAppAgentDisplayMessage>((message) => {
@@ -395,7 +395,7 @@ export function projectInAppAgentMessagesForDisplay(
                 return false;
               }
 
-              if (toolCall.function.name === IN_APP_AGENT_REDIRECT_TOOL_NAME) {
+              if (isInAppAgentUiProposalToolName(toolCall.function.name)) {
                 return true;
               }
 

--- a/web/src/features/in-app-agent/lib/evaluatorDraftStorage.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/evaluatorDraftStorage.clienttest.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearAgentEvaluatorDraft,
+  forgetPendingAgentEvaluatorDraft,
+  readAgentEvaluatorDraft,
+  writeAgentEvaluatorDraft,
+} from "./evaluatorDraftStorage";
+
+describe("evaluatorDraftStorage", () => {
+  afterEach(() => {
+    clearAgentEvaluatorDraft("project-1");
+    clearAgentEvaluatorDraft("project-2");
+    window.sessionStorage.clear();
+  });
+
+  it("round-trips a draft for the same project", () => {
+    writeAgentEvaluatorDraft("project-1", {
+      name: "Helpfulness",
+      description: null,
+      definition: {
+        type: "LLM_AS_JUDGE",
+        prompt: "Score {{output}}",
+        provider: null,
+        model: null,
+        modelParams: null,
+        vars: ["output"],
+        variableMapping: [
+          {
+            templateVariable: "output",
+            selectedColumnId: "output",
+          },
+        ],
+        outputDefinition: {
+          version: 2,
+          dataType: "NUMERIC",
+          reasoning: { description: "Explain the score." },
+          score: {
+            description: "Quality of the response.",
+            minValue: 0,
+            maxValue: 1,
+          },
+        },
+      },
+    });
+
+    expect(readAgentEvaluatorDraft("project-1")?.name).toBe("Helpfulness");
+    expect(readAgentEvaluatorDraft("project-2")).toBeNull();
+  });
+
+  it("reads a previously written draft from session storage after memory is cleared", () => {
+    writeAgentEvaluatorDraft("project-1", {
+      name: "Helpfulness",
+      description: null,
+      definition: {
+        type: "LLM_AS_JUDGE",
+        prompt: "Score {{output}}",
+        provider: null,
+        model: null,
+        modelParams: null,
+        vars: ["output"],
+        variableMapping: [
+          {
+            templateVariable: "output",
+            selectedColumnId: "output",
+          },
+        ],
+        outputDefinition: {
+          version: 2,
+          dataType: "NUMERIC",
+          reasoning: { description: "Explain the score." },
+          score: {
+            description: "Quality of the response.",
+            minValue: 0,
+            maxValue: 1,
+          },
+        },
+      },
+    });
+
+    forgetPendingAgentEvaluatorDraft("project-1");
+
+    expect(readAgentEvaluatorDraft("project-1")?.name).toBe("Helpfulness");
+  });
+});

--- a/web/src/features/in-app-agent/lib/evaluatorDraftStorage.clienttest.ts
+++ b/web/src/features/in-app-agent/lib/evaluatorDraftStorage.clienttest.ts
@@ -4,6 +4,7 @@ import {
   clearAgentEvaluatorDraft,
   forgetPendingAgentEvaluatorDraft,
   readAgentEvaluatorDraft,
+  takeAgentEvaluatorDraft,
   writeAgentEvaluatorDraft,
 } from "./evaluatorDraftStorage";
 
@@ -81,5 +82,40 @@ describe("evaluatorDraftStorage", () => {
     forgetPendingAgentEvaluatorDraft("project-1");
 
     expect(readAgentEvaluatorDraft("project-1")?.name).toBe("Helpfulness");
+  });
+
+  it("consumes a draft so a later read cannot reuse it", () => {
+    writeAgentEvaluatorDraft("project-1", {
+      name: "Helpfulness",
+      description: null,
+      definition: {
+        type: "LLM_AS_JUDGE",
+        prompt: "Score {{output}}",
+        provider: null,
+        model: null,
+        modelParams: null,
+        vars: ["output"],
+        variableMapping: [
+          {
+            templateVariable: "output",
+            selectedColumnId: "output",
+          },
+        ],
+        outputDefinition: {
+          version: 2,
+          dataType: "NUMERIC",
+          reasoning: { description: "Explain the score." },
+          score: {
+            description: "Quality of the response.",
+            minValue: 0,
+            maxValue: 1,
+          },
+        },
+      },
+    });
+
+    expect(takeAgentEvaluatorDraft("project-1")?.name).toBe("Helpfulness");
+    expect(readAgentEvaluatorDraft("project-1")).toBeNull();
+    expect(takeAgentEvaluatorDraft("project-1")).toBeNull();
   });
 });

--- a/web/src/features/in-app-agent/lib/evaluatorDraftStorage.ts
+++ b/web/src/features/in-app-agent/lib/evaluatorDraftStorage.ts
@@ -1,0 +1,79 @@
+import {
+  InAppAgentLlmEvaluatorDraftSchema,
+  type InAppAgentLlmEvaluatorDraft,
+} from "@langfuse/shared/in-app-agent";
+
+const STORAGE_KEY_PREFIX = "langfuse:in-app-agent-evaluator-draft";
+
+let pendingDraftByProjectId = new Map<string, InAppAgentLlmEvaluatorDraft>();
+
+function getStorageKey(projectId: string) {
+  return `${STORAGE_KEY_PREFIX}:${projectId}`;
+}
+
+export function writeAgentEvaluatorDraft(
+  projectId: string,
+  draft: InAppAgentLlmEvaluatorDraft,
+) {
+  pendingDraftByProjectId.set(projectId, draft);
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(
+      getStorageKey(projectId),
+      JSON.stringify(draft),
+    );
+  } catch {
+    // Session storage can throw in private mode; the in-memory copy still works
+    // for same-tab navigation from the assistant button.
+  }
+}
+
+export function clearAgentEvaluatorDraft(projectId: string) {
+  pendingDraftByProjectId.delete(projectId);
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(getStorageKey(projectId));
+  } catch {
+    // Ignore quota / private-mode failures; in-memory state is already cleared.
+  }
+}
+
+/** Drops the in-memory copy so a later read exercises sessionStorage. */
+export function forgetPendingAgentEvaluatorDraft(projectId: string) {
+  pendingDraftByProjectId.delete(projectId);
+}
+
+export function readAgentEvaluatorDraft(
+  projectId: string,
+): InAppAgentLlmEvaluatorDraft | null {
+  const pending = pendingDraftByProjectId.get(projectId);
+  if (pending) {
+    return pending;
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const stored = window.sessionStorage.getItem(getStorageKey(projectId));
+    if (!stored) {
+      return null;
+    }
+
+    const parsed = InAppAgentLlmEvaluatorDraftSchema.safeParse(
+      JSON.parse(stored),
+    );
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/features/in-app-agent/lib/evaluatorDraftStorage.ts
+++ b/web/src/features/in-app-agent/lib/evaluatorDraftStorage.ts
@@ -77,3 +77,14 @@ export function readAgentEvaluatorDraft(
     return null;
   }
 }
+
+/** Reads the pending draft once, then drops it so refresh/history cannot reuse it. */
+export function takeAgentEvaluatorDraft(
+  projectId: string,
+): InAppAgentLlmEvaluatorDraft | null {
+  const draft = readAgentEvaluatorDraft(projectId);
+  if (draft) {
+    clearAgentEvaluatorDraft(projectId);
+  }
+  return draft;
+}

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -344,6 +344,7 @@ export const events = {
     "new_chat_turn",
     "quick_action_started",
     "tool_approval_decided",
+    "evaluator_draft_opened",
   ],
   cmd_k_menu: ["opened", "search_entered", "navigated"],
   spend_alert: ["created", "updated", "deleted"],

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React from "react";
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button } from "@/src/components/ui/button";

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import React from "react";
 import { ActionButtonCountBadge } from "@/src/components/ui/action-button-count-badge";
 import { Button } from "@/src/components/ui/button";

--- a/worker/src/features/in-app-agent/runtime/agent.test.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgUiEvent } from "@langfuse/shared/in-app-agent";
 import {
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
   IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER,
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
   IN_APP_AGENT_TOOL_APPROVAL_EVENT_NAME,
@@ -1150,6 +1151,9 @@ describe("createAgUiStream", () => {
     expect(
       agentTools?.[IN_APP_AGENT_REDIRECT_TOOL_NAME]?.requireApproval,
     ).not.toBe(true);
+    expect(
+      agentTools?.[IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME]?.requireApproval,
+    ).not.toBe(true);
     const docsSearchTool = agentTools?.langfuseDocs_search;
     await expect(docsSearchTool?.execute?.({}, {})).resolves.toMatchObject({
       _meta: expect.objectContaining({
@@ -1185,6 +1189,29 @@ describe("createAgUiStream", () => {
       href: "/project/project-1/widgets/widget-1",
     });
 
+    const evaluatorDraftTool = getAgentTools(
+      vi.mocked(Agent).mock.calls[0]?.[0],
+    )?.[IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME];
+
+    await expect(
+      evaluatorDraftTool?.execute?.({
+        name: "Helpfulness",
+        prompt: "Score the response.\n\nInput: {{input}}\nOutput: {{output}}",
+      }),
+    ).resolves.toMatchObject({
+      type: "uiDraftAction",
+      label: "Review evaluator in UI",
+      href: "/project/project-1/evals/new?agentDraft=1",
+      destination: "newEvaluator",
+      draft: {
+        name: "Helpfulness",
+        definition: {
+          type: "LLM_AS_JUDGE",
+          vars: ["input", "output"],
+        },
+      },
+    });
+
     expect(promptMocks.getPrompt).toHaveBeenCalledWith(
       "in-app-agent-system-prompt",
       undefined,
@@ -1194,6 +1221,7 @@ describe("createAgUiStream", () => {
       expect.objectContaining({
         currentDate: "",
         redirectToolName: IN_APP_AGENT_REDIRECT_TOOL_NAME,
+        evaluatorDraftToolName: IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
         sandboxFilesystem: expect.stringContaining("<sandbox_filesystem>"),
         screenContext: "",
         userContext: expect.stringContaining("<user_context>"),

--- a/worker/src/features/in-app-agent/runtime/agent.test.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.test.ts
@@ -1212,6 +1212,36 @@ describe("createAgUiStream", () => {
       },
     });
 
+    await expect(
+      evaluatorDraftTool?.execute?.({
+        name: "Correctness",
+        prompt:
+          "Compare the answer to the expected output.\n\nOutput: {{output}}\nExpected: {{expected_output}}",
+      }),
+    ).resolves.toMatchObject({
+      type: "uiDraftAction",
+      destination: "newEvaluator",
+      draft: {
+        name: "Correctness",
+        definition: {
+          type: "LLM_AS_JUDGE",
+          vars: ["output", "expected_output"],
+          variableMapping: [
+            {
+              templateVariable: "output",
+              selectedColumnId: "output",
+              jsonSelector: null,
+            },
+            {
+              templateVariable: "expected_output",
+              selectedColumnId: "experimentItemExpectedOutput",
+              jsonSelector: null,
+            },
+          ],
+        },
+      },
+    });
+
     expect(promptMocks.getPrompt).toHaveBeenCalledWith(
       "in-app-agent-system-prompt",
       undefined,

--- a/worker/src/features/in-app-agent/runtime/agent.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.ts
@@ -30,6 +30,7 @@ import {
 import {
   createSandboxTools,
   createRedirectActionTool,
+  createEvaluatorDraftTool,
   getToolCallId,
   hasCallableExecute,
   withOptionalSilentMcpOutput,
@@ -52,6 +53,7 @@ import type { InAppAgentSandbox } from "./sandbox";
 import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "@langfuse/shared";
 import { logger } from "@langfuse/shared/src/server";
 import {
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
   IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER,
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
 } from "@langfuse/shared/in-app-agent";
@@ -319,6 +321,7 @@ export async function createAgUiStream(params: {
     variables: {
       currentDate: "",
       redirectToolName: IN_APP_AGENT_REDIRECT_TOOL_NAME,
+      evaluatorDraftToolName: IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
       sandboxFilesystem: formatSandboxContext(params.options.sandbox),
       screenContext: "",
       userContext: formatUserContext(params.input.context),
@@ -1187,6 +1190,9 @@ async function createMastraAdapter(params: {
             projectId: params.options.redirectAction.projectId,
             isV4Enabled: params.options.redirectAction.isV4Enabled,
           }),
+          [IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME]: createEvaluatorDraftTool({
+            projectId: params.options.redirectAction.projectId,
+          }),
           ...(params.options.sandbox
             ? createSandboxTools(params.options.sandbox)
             : {}),
@@ -1531,6 +1537,7 @@ async function getSystemPromptInstructions(params: {
   variables: {
     currentDate: string;
     redirectToolName: string;
+    evaluatorDraftToolName: string;
     sandboxFilesystem: string;
     screenContext: string;
     userContext: string;

--- a/worker/src/features/in-app-agent/runtime/tools.ts
+++ b/worker/src/features/in-app-agent/runtime/tools.ts
@@ -4,7 +4,14 @@ import {
 } from "@mastra/core/schema";
 import { createTool, Tool } from "@mastra/core/tools";
 import type { InAppAgentSandbox } from "./sandbox";
-import { assertUnreachable } from "@langfuse/shared";
+import {
+  assertUnreachable,
+  extractVariables,
+  ObservationLevelDomain,
+  PersistedEvalOutputDefinitionSchema,
+  TABLE_AGGREGATION_OPTIONS,
+  TracingSearchType,
+} from "@langfuse/shared";
 import { getToolFailureMessage } from "@langfuse/shared/in-app-agent/server/toolErrors";
 import {
   buildDashboardsPath,
@@ -14,6 +21,7 @@ import {
   buildExperimentsPath,
   buildModelsPath,
   buildMonitorsPath,
+  buildNewEvaluatorPath,
   buildPlaygroundPath,
   buildProjectMembersPath,
   buildProjectSettingsPath,
@@ -26,15 +34,13 @@ import {
 } from "@langfuse/shared/src/server";
 import z from "zod";
 import {
-  ObservationLevelDomain,
-  TABLE_AGGREGATION_OPTIONS,
-  TracingSearchType,
-} from "@langfuse/shared";
-import {
+  InAppAgentEvaluatorDraftVariableMappingSchema,
+  InAppAgentLlmEvaluatorDraftSchema,
   InAppAgentSandboxBashArgsSchema,
   InAppAgentSandboxEditArgsSchema,
   InAppAgentSandboxReadArgsSchema,
   InAppAgentSandboxWriteArgsSchema,
+  IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
   IN_APP_AGENT_SILENT_MCP_OUTPUT_TYPE,
 } from "@langfuse/shared/in-app-agent";
@@ -583,4 +589,90 @@ function getRedirectHref(
   }
 
   return assertUnreachable(input);
+}
+
+const DEFAULT_EVALUATOR_DRAFT_OUTPUT_DEFINITION = {
+  version: 2 as const,
+  dataType: "NUMERIC" as const,
+  reasoning: { description: "Explain the score." },
+  score: {
+    description: "Quality of the response.",
+    minValue: 0,
+    maxValue: 1,
+  },
+};
+
+const InAppAgentProposeEvaluatorDraftInputSchema = z.object({
+  label: z.string().min(1).max(80).default("Review evaluator in UI"),
+  name: z.string().trim().min(1).max(200),
+  description: z.string().trim().max(2_000).optional(),
+  prompt: z.string().min(1).max(100_000),
+  variableMapping: z
+    .array(InAppAgentEvaluatorDraftVariableMappingSchema)
+    .optional(),
+  outputDefinition: PersistedEvalOutputDefinitionSchema.optional(),
+});
+
+export function createEvaluatorDraftTool({ projectId }: { projectId: string }) {
+  return createTool({
+    id: IN_APP_AGENT_EVALUATOR_DRAFT_TOOL_NAME,
+    description:
+      "Propose a filled evaluator creation form in the Langfuse UI. Use this instead of createEvaluator when the user should review an LLM-as-a-judge evaluator before saving. This does not create the evaluator.",
+    inputSchema: InAppAgentProposeEvaluatorDraftInputSchema,
+    execute: async (input) => {
+      return getEvaluatorDraftToolResult({ input, projectId });
+    },
+  });
+}
+
+export function getEvaluatorDraftToolResult({
+  input,
+  projectId,
+}: {
+  input: unknown;
+  projectId: string;
+}) {
+  const parsedInput = InAppAgentProposeEvaluatorDraftInputSchema.parse(input);
+  const vars = extractVariables(parsedInput.prompt);
+  const variableMapping =
+    parsedInput.variableMapping ??
+    vars.map((templateVariable) => ({
+      templateVariable,
+      selectedColumnId: inferEvaluatorDraftColumn(templateVariable),
+      jsonSelector: null,
+    }));
+  const draft = InAppAgentLlmEvaluatorDraftSchema.parse({
+    name: parsedInput.name,
+    description: parsedInput.description?.trim()
+      ? parsedInput.description.trim()
+      : null,
+    definition: {
+      type: "LLM_AS_JUDGE",
+      prompt: parsedInput.prompt,
+      provider: null,
+      model: null,
+      modelParams: null,
+      vars,
+      variableMapping,
+      outputDefinition:
+        parsedInput.outputDefinition ??
+        DEFAULT_EVALUATOR_DRAFT_OUTPUT_DEFINITION,
+    },
+  });
+
+  return {
+    type: "uiDraftAction" as const,
+    label: parsedInput.label,
+    href: buildNewEvaluatorPath({ projectId, agentDraft: true }),
+    destination: "newEvaluator" as const,
+    draft,
+  };
+}
+
+function inferEvaluatorDraftColumn(variable: string) {
+  return ["output", "response", "answer", "completion"].includes(
+    variable.toLowerCase(),
+  )
+    ? "output"
+    : "input";
 }

--- a/worker/src/features/in-app-agent/runtime/tools.ts
+++ b/worker/src/features/in-app-agent/runtime/tools.ts
@@ -670,9 +670,22 @@ export function getEvaluatorDraftToolResult({
 }
 
 function inferEvaluatorDraftColumn(variable: string) {
-  return ["output", "response", "answer", "completion"].includes(
-    variable.toLowerCase(),
-  )
-    ? "output"
-    : "input";
+  const normalized = variable.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+  if (["output", "response", "answer", "completion"].includes(normalized)) {
+    return "output";
+  }
+
+  if (
+    [
+      "expectedoutput",
+      "expected",
+      "groundtruth",
+      "experimentitemexpectedoutput",
+    ].includes(normalized)
+  ) {
+    return "experimentItemExpectedOutput";
+  }
+
+  return "input";
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16552.preview.langfuse.com](https://pr-16552.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Prototype for sharing a recording of the intended assistant → evaluator setup flow.

When the assistant proposes an LLM-as-judge evaluator, chat shows **Review evaluator in UI**. Clicking it opens `/evals/new` with name, prompt, mappings, and score output filled. Saving the form creates the evaluator. MCP `createEvaluator` still works if the user approves that tool instead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Impacted packages

- `@langfuse/shared` — draft schema, auto-approved local tool, prompt copy, persistence
- `worker` — `langfuse_proposeEvaluatorDraft` tool
- `web` — drawer action, sessionStorage draft, `/evals/new?agentDraft=1` hydration

## How it works

1. The assistant calls auto-approved `langfuse_proposeEvaluatorDraft` instead of `createEvaluator` unless the user asks to create immediately.
2. The drawer folds that result into a **Review evaluator in UI** button (same pattern as page redirects).
3. Click writes the draft to memory + `sessionStorage`, then navigates to `/project/:id/evals/new?agentDraft=1`.
4. The create form seeds once from that draft via `initialDraft`. User edits and hits Create evaluator.

## Tracking

`in_app_agent:evaluator_draft_opened` with `{ evaluatorType }` only (no prompt text). Save still uses evaluator creation analytics, now with `isFromAssistant`.

## Verification

- `pnpm turbo run lint --filter=@langfuse/shared --filter=worker --filter=web` — Tasks: 7 successful, 7 total (pre-commit also ran full `turbo run lint`)
- `pnpm turbo run typecheck --filter=@langfuse/shared --filter=worker --filter=web` — Tasks: 6 successful, 6 total
- `pnpm --filter @langfuse/shared run test persistence.test` — Tests 4 passed (4)
- `pnpm --filter worker run test src/features/in-app-agent/runtime/agent.test.ts` — Tests 27 passed (27)
- `pnpm --filter web run test-client` (targeted client files) — Tests 370 passed (370), including the new draft/storage/drawer/store cases

Skipped Fern regeneration (no public API contract change). Skipped `pnpm run scan:client-bundle` (no production web build in this change).

Local browser signoff on `http://localhost:3000` (demo user): hydrating `/evals/new?agentDraft=1` filled name, prompt, mappings, and score output; **Create evaluator** persisted `Assistant Helpfulness` as `LLM_AS_JUDGE`. Live assistant chat was not exercised here — this Cloud stack has no Langfuse AI model configured, so the model cannot emit the chat button. Worker tests still cover the auto-approved draft tool; MCP `createEvaluator` is unchanged.

[New evaluator form filled from an assistant draft](https://cursor.com/agents/bc-14651498-2cdf-4a66-b2fc-695a3b6e90ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_evaluator_form_filled_from_assistant_draft.webp)
[Evaluators list after creating the draft](https://cursor.com/agents/bc-14651498-2cdf-4a66-b2fc-695a3b6e90ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevaluators_list_after_create.webp)
[review_evaluator_in_ui_form_filled_and_created.mp4](https://cursor.com/agents/bc-14651498-2cdf-4a66-b2fc-695a3b6e90ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freview_evaluator_in_ui_form_filled_and_created.mp4)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Test this

Preview (once deployed): https://pr-16552.preview.langfuse.com

Sandbox: `http://localhost:3000` after the Cursor Cloud stack is up. Login `demo@langfuse.com` / `password`.

1. Open the in-app assistant in a project (needs a configured Langfuse AI model).
2. Ask it to propose an LLM-as-judge evaluator (for example helpfulness).
3. Click **Review evaluator in UI**.
4. Confirm `/evals/new` is filled with name, prompt, mappings, and score output.
5. Hit **Create evaluator** and confirm the evaluator exists.
6. In a new chat, ask it to **create** the evaluator immediately and confirm MCP `createEvaluator` still shows an approval card.

Data: demo project is enough.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14651498-2cdf-4a66-b2fc-695a3b6e90ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14651498-2cdf-4a66-b2fc-695a3b6e90ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an auto-approved in-app-agent tool that proposes an LLM-as-judge evaluator and opens the evaluator creation UI with the draft prefilled.
- Adds shared evaluator-draft schemas, proposal-tool classification, persistence handling, and prompt guidance.
- Adds worker-side draft construction with inferred prompt-variable mappings and default numeric output.
- Adds browser storage, drawer navigation, form hydration, and assistant-attribution analytics.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The retained assistant draft should be consumed or cleared before merging so browser history and refresh cannot reopen an already-used evaluator draft.

The new draft URL always rehydrates the same session-scoped value, but no production path clears that value after the form opens, saves, or closes, allowing stale evaluator content to be presented and created again.

**Files Needing Attention:** web/src/features/evals/v2/pages/NewEvaluatorPage.tsx, web/src/features/in-app-agent/lib/evaluatorDraftStorage.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant A as In-app agent
    participant W as Worker tool
    participant D as Assistant drawer
    participant S as sessionStorage
    participant E as Evaluator form
    U->>A: Request evaluator proposal
    A->>W: proposeEvaluatorDraft
    W-->>D: UI action and validated draft
    U->>D: Review evaluator in UI
    D->>S: Store project-scoped draft
    D->>E: "Navigate with agentDraft=1"
    E->>S: Read draft
    E-->>U: Prefilled creation form
    U->>E: Edit and save evaluator
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/pages/NewEvaluatorPage.tsx:46
**Stale evaluator draft is reused**

When a user saves or leaves an assistant draft and later refreshes or returns through browser history to `/evals/new?agentDraft=1`, this page reads the retained project-scoped draft again because no hydration, save, or close path clears it, causing the previous evaluator to be repopulated and potentially created twice.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(in-app-agent): propose evaluator dr..."](https://github.com/langfuse/langfuse/commit/cea4ba3ae87d638bc7f7659e53db9cb9ad9ed444) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56680818)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [In-app agent execution](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent-execution.md)
- Knowledge Base — [Product web application](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/product-web-application.md)
- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
</details>


<!-- /greptile_comment -->