### PR TITLE
fix(evals): clarify evaluator saved dialog heading

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialog/EvaluatorSavedDialog.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialog/EvaluatorSavedDialog.tsx
@@ -85,7 +85,9 @@ export function EvaluatorSavedDialog({
         <DialogBody className="gap-0 p-0">
           <div className="grid h-[22rem] grid-cols-[minmax(0,1fr)_15rem] overflow-hidden">
             <div className="min-w-0 overflow-y-auto px-6 py-5 [scrollbar-gutter:stable]">
-              <h3 className="mb-2 text-sm font-bold">How should it run</h3>
+              <h3 className="mb-2 text-sm font-bold">
+                Set up rule to run on incoming observations
+              </h3>
               <RadioGroup
                 value={mode}
                 onValueChange={(value) =>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16557.preview.langfuse.com](https://pr-16557.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Renames the heading in the "Evaluator saved" dialog from "How should it run" to "Set up rule to run on incoming observations", so the section says what the choice actually does.

Text-only change, no logic touched.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the saved-evaluator dialog heading with more explicit rule-setup copy.
- Changes the heading to “Set up rule to run on incoming observations.”
- The new wording does not cover the dialog’s experiment-scoped and deferred batch/experiment options.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking copy issue where the new heading does not describe experiment and batch execution options.

The change affects only static copy, but the heading frames the entire section as incoming-observation setup even though users can attach an experiment rule or defer setup for batch and prompt-experiment execution.

**Files Needing Attention:** web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialog/EvaluatorSavedDialog.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialog/EvaluatorSavedDialog.tsx:88-90
**Heading excludes other execution scopes**

The observation-specific heading does not cover the section's experiment-rule and deferred batch/experiment options, making the available execution scopes less clear.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): clarify evaluator saved dial..."](https://github.com/langfuse/langfuse/commit/13cb37c8e80234fd49cdbc9e921f66686e5f5f87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56700969)</sub>

<!-- /greptile_comment -->