### PR TITLE
fix(traces): render empty I/O as JSON null in every view

### DIFF
--- a/web/src/components/ui/PrettyJsonView.empty.clienttest.tsx
+++ b/web/src/components/ui/PrettyJsonView.empty.clienttest.tsx
@@ -1,0 +1,70 @@
+/**
+ * Empty I/O must render as JSON `null` in both pretty and JSON views.
+ * `undefined` is a JS artifact (optional props, `value ?? undefined` at call
+ * sites); JSON has no undefined, so the two views must not disagree.
+ */
+import { render, screen } from "@testing-library/react";
+import type * as CodeJsonViewerModule from "@/src/components/ui/CodeJsonViewer";
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+const jsonView = vi.hoisted(() => ({
+  json: undefined as unknown,
+}));
+vi.mock("@/src/components/ui/CodeJsonViewer", async (importOriginal) => {
+  const actual = await importOriginal<typeof CodeJsonViewerModule>();
+  return {
+    ...actual,
+    JSONView: (props: { json?: unknown; title?: string }) => {
+      jsonView.json = props.json;
+      return <div data-testid="json-view">{props.title}</div>;
+    },
+  };
+});
+
+import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+
+describe("PrettyJsonView empty JSON null vs undefined", () => {
+  beforeEach(() => {
+    jsonView.json = undefined;
+  });
+
+  it("shows null in pretty view for a missing/undefined value", () => {
+    render(
+      <PrettyJsonView json={undefined} title="Output" currentView="pretty" />,
+    );
+
+    expect(screen.getByText("null")).toBeInTheDocument();
+    expect(screen.queryByText("undefined")).not.toBeInTheDocument();
+  });
+
+  it("shows null in pretty view for JSON null", () => {
+    render(<PrettyJsonView json={null} title="Input" currentView="pretty" />);
+
+    expect(screen.getByText("null")).toBeInTheDocument();
+    expect(screen.queryByText("undefined")).not.toBeInTheDocument();
+  });
+
+  it("hands JSON null to JSONView when parsedJson is null and json is undefined", () => {
+    render(
+      <PrettyJsonView
+        json={undefined}
+        parsedJson={null}
+        title="Output"
+        currentView="json"
+      />,
+    );
+
+    expect(jsonView.json).toBeNull();
+  });
+
+  it("hands JSON null to JSONView when both json and parsedJson are undefined", () => {
+    render(
+      <PrettyJsonView json={undefined} title="Output" currentView="json" />,
+    );
+
+    expect(jsonView.json).toBeNull();
+  });
+});

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -118,8 +118,9 @@ function filterTableRows(
 }
 
 function getEmptyValueDisplay(value: unknown): string | null {
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
+  // JSON has no `undefined` — treat a missing value like JSON null so pretty
+  // and JSON views agree on empty input/output.
+  if (value === null || value === undefined) return "null";
   if (value === "") return "empty string";
   if (
     typeof value === "object" &&
@@ -861,9 +862,17 @@ export function PrettyJsonView(props: {
   // while hidden via display:none). Pass a deep clone so the two views stay
   // independent.
   const jsonViewInput = useMemo(() => {
-    if (parsedJson === null || parsedJson === undefined) return props.json;
-    if (typeof parsedJson !== "object") return parsedJson;
-    return structuredClone(parsedJson);
+    if (parsedJson !== null && typeof parsedJson === "object") {
+      return structuredClone(parsedJson);
+    }
+    // JSON has no `undefined`. Empty I/O (missing field or JS undefined from
+    // `value ?? undefined` call sites) must render as null so JSON view
+    // matches pretty view. Do not fall back to `props.json` when parsedJson is
+    // already JSON null — that raw prop is often `undefined`.
+    if (parsedJson === undefined) {
+      return props.json === undefined ? null : props.json;
+    }
+    return parsedJson;
   }, [parsedJson, props.json]);
 
   const actualCurrentView = props.currentView ?? "pretty";

--- a/web/src/features/traces/components/IOPreview/IOPreviewJSON.clienttest.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewJSON.clienttest.tsx
@@ -21,6 +21,7 @@ vi.mock(
       sections: {
         key: string;
         hideData?: boolean;
+        data?: unknown;
         renderFooter?: (ctx: unknown) => React.ReactNode;
       }[];
     }) => (
@@ -30,6 +31,9 @@ vi.mock(
             key={s.key}
             data-testid={`section-${s.key}`}
             data-hide-data={String(!!s.hideData)}
+            data-json={
+              s.data === undefined ? "undefined" : JSON.stringify(s.data)
+            }
           >
             {!s.hideData && <span data-testid={`data-${s.key}`}>data</span>}
             {s.renderFooter ? s.renderFooter({}) : null}
@@ -358,5 +362,53 @@ describe("IOPreviewJSON node-count gating", () => {
 
     expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
     expect(screen.getByTestId("data-input")).toBeInTheDocument();
+  });
+});
+
+describe("IOPreviewJSON empty JSON null vs undefined", () => {
+  it("keeps parsed JSON null instead of falling through to an undefined raw field", () => {
+    render(
+      <IOPreviewJSON
+        input={undefined}
+        output={undefined}
+        parsedInput={null}
+        parsedOutput={null}
+        hideIfNull={false}
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    expect(screen.getByTestId("section-input")).toHaveAttribute(
+      "data-json",
+      "null",
+    );
+    expect(screen.getByTestId("section-output")).toHaveAttribute(
+      "data-json",
+      "null",
+    );
+  });
+
+  it("renders empty input and empty output as the same JSON null", () => {
+    render(
+      <IOPreviewJSON
+        input={undefined}
+        output={undefined}
+        hideIfNull={false}
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    expect(screen.getByTestId("section-input")).toHaveAttribute(
+      "data-json",
+      "null",
+    );
+    expect(screen.getByTestId("section-output")).toHaveAttribute(
+      "data-json",
+      "null",
+    );
   });
 });

--- a/web/src/features/traces/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewJSON.tsx
@@ -24,7 +24,7 @@ import { CommentableJsonView } from "@/src/features/comments/components/Commenta
 import { InlineCommentBubble } from "@/src/features/comments/components/InlineCommentBubble";
 import { type CommentedPathsByField } from "@/src/features/traces/components/AdvancedJsonViewer/utils/commentRanges";
 import { type ExpansionState } from "@/src/features/traces/components/AdvancedJsonViewer/types";
-import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
+import { type Prisma, type ScoreDomain } from "@langfuse/shared";
 import {
   decodeUnicodeInJson,
   DECODE_UNICODE_MAX_NODES,
@@ -36,6 +36,7 @@ import {
   JSON_VIEW_RENDER_ROW_LIMIT,
   probeJsonField,
 } from "./fns/jsonViewSizeGate";
+import { resolveParsedJsonField } from "./fns/resolveParsedJsonField";
 
 // A field needing windowing is gated to the lazy byte-engine viewer, so the
 // gate row limit IS the virtualization threshold (single source of truth). The
@@ -152,15 +153,17 @@ function IOPreviewJSONInner({
   // (e.g. session events rows in v4 mode). Parse once here, BEFORE the decode
   // and tree-build, so the node-count gate below can act on the parsed shape.
   const inputParsed = useMemo(
-    () => (isParsing ? undefined : (parsedInput ?? deepParseJson(input))),
+    () => (isParsing ? undefined : resolveParsedJsonField(parsedInput, input)),
     [parsedInput, input, isParsing],
   );
   const outputParsed = useMemo(
-    () => (isParsing ? undefined : (parsedOutput ?? deepParseJson(output))),
+    () =>
+      isParsing ? undefined : resolveParsedJsonField(parsedOutput, output),
     [parsedOutput, output, isParsing],
   );
   const metadataParsed = useMemo(
-    () => (isParsing ? undefined : (parsedMetadata ?? deepParseJson(metadata))),
+    () =>
+      isParsing ? undefined : resolveParsedJsonField(parsedMetadata, metadata),
     [parsedMetadata, metadata, isParsing],
   );
 
@@ -248,13 +251,11 @@ function IOPreviewJSONInner({
   // Treat it as present so hideIfNull callers still show the fallback instead
   // of silently dropping the field.
   const showInput =
-    !hideInput &&
-    (inputTooLarge || !(hideIfNull && effectiveInput === undefined));
+    !hideInput && (inputTooLarge || !(hideIfNull && effectiveInput == null));
   const showOutput =
-    !hideOutput &&
-    (outputTooLarge || !(hideIfNull && effectiveOutput === undefined));
+    !hideOutput && (outputTooLarge || !(hideIfNull && effectiveOutput == null));
   const showMetadata =
-    metadataTooLarge || !(hideIfNull && effectiveMetadata === undefined);
+    metadataTooLarge || !(hideIfNull && effectiveMetadata == null);
 
   const downloadName = observationId ?? traceId;
 

--- a/web/src/features/traces/components/IOPreview/IOPreviewJSONSimple.clienttest.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewJSONSimple.clienttest.tsx
@@ -8,10 +8,23 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 // PrettyJsonView is the unvirtualized render path we must NOT reach for
 // over-limit fields — mock it so its presence is observable by test id.
+// Capture json/parsedJson so empty-field tests can assert null vs undefined.
+const prettyJsonView = vi.hoisted(() => ({
+  calls: [] as { title?: string; json?: unknown; parsedJson?: unknown }[],
+}));
 vi.mock("@/src/components/ui/PrettyJsonView", () => ({
-  PrettyJsonView: (props: { title?: string }) => (
-    <div data-testid="pretty-json-view">{props.title}</div>
-  ),
+  PrettyJsonView: (props: {
+    title?: string;
+    json?: unknown;
+    parsedJson?: unknown;
+  }) => {
+    prettyJsonView.calls.push({
+      title: props.title,
+      json: props.json,
+      parsedJson: props.parsedJson,
+    });
+    return <div data-testid="pretty-json-view">{props.title}</div>;
+  },
 }));
 
 vi.mock("./components/CorrectedOutputField", () => ({
@@ -34,6 +47,10 @@ import { JSON_VIEW_RENDER_CHAR_LIMIT } from "./fns/jsonViewSizeGate";
 const FALLBACK_TEXT = /too large to render in JSON view/i;
 
 describe("IOPreviewJSONSimple size gating", () => {
+  beforeEach(() => {
+    prettyJsonView.calls = [];
+  });
+
   it("renders the fallback and NOT PrettyJsonView for an over-limit field", () => {
     const huge = "x".repeat(JSON_VIEW_RENDER_CHAR_LIMIT + 1);
     render(
@@ -141,5 +158,53 @@ describe("IOPreviewJSONSimple size gating", () => {
     expect(viewers).toHaveLength(1);
     expect(viewers[0]).toHaveTextContent("Input");
     expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+  });
+});
+
+describe("IOPreviewJSONSimple empty JSON null vs undefined", () => {
+  beforeEach(() => {
+    prettyJsonView.calls = [];
+  });
+
+  it("keeps parsed JSON null instead of falling through to an undefined raw field", () => {
+    // Call sites pass `output ?? undefined`, so a stored JSON null becomes JS
+    // undefined on the raw prop while the worker still parsed it as null.
+    // `parsedOutput ?? deepParseJson(output)` would discard that null.
+    render(
+      <IOPreviewJSONSimple
+        input={undefined}
+        output={undefined}
+        parsedInput={null}
+        parsedOutput={null}
+        hideIfNull={false}
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    const inputCall = prettyJsonView.calls.find((c) => c.title === "Input");
+    const outputCall = prettyJsonView.calls.find((c) => c.title === "Output");
+    expect(inputCall?.parsedJson).toBeNull();
+    expect(outputCall?.parsedJson).toBeNull();
+  });
+
+  it("renders empty input and empty output as the same JSON null", () => {
+    render(
+      <IOPreviewJSONSimple
+        input={undefined}
+        output={undefined}
+        hideIfNull={false}
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    const inputCall = prettyJsonView.calls.find((c) => c.title === "Input");
+    const outputCall = prettyJsonView.calls.find((c) => c.title === "Output");
+    expect(inputCall?.parsedJson).toBeNull();
+    expect(outputCall?.parsedJson).toBeNull();
+    expect(inputCall?.parsedJson).toEqual(outputCall?.parsedJson);
   });
 });

--- a/web/src/features/traces/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
+import { type Prisma, type ScoreDomain } from "@langfuse/shared";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { type MediaReturnType } from "@/src/features/media/validation";
 import { CorrectedOutputField } from "./components/CorrectedOutputField";
@@ -8,6 +8,7 @@ import {
   JSON_VIEW_RENDER_CHAR_LIMIT,
   probeJsonField,
 } from "./fns/jsonViewSizeGate";
+import { resolveParsedJsonField } from "./fns/resolveParsedJsonField";
 
 export interface IOPreviewJSONSimpleProps {
   input?: Prisma.JsonValue;
@@ -101,19 +102,19 @@ export function IOPreviewJSONSimple({
   const effectiveInput = useMemo(() => {
     if (isParsing) return undefined; // Wait for Web Worker to finish
     if (inputTooLarge) return undefined;
-    return parsedInput ?? deepParseJson(input);
+    return resolveParsedJsonField(parsedInput, input);
   }, [parsedInput, input, isParsing, inputTooLarge]);
 
   const effectiveOutput = useMemo(() => {
     if (isParsing) return undefined;
     if (outputTooLarge) return undefined;
-    return parsedOutput ?? deepParseJson(output);
+    return resolveParsedJsonField(parsedOutput, output);
   }, [parsedOutput, output, isParsing, outputTooLarge]);
 
   const effectiveMetadata = useMemo(() => {
     if (isParsing) return undefined;
     if (metadataTooLarge) return undefined;
-    return parsedMetadata ?? deepParseJson(metadata);
+    return resolveParsedJsonField(parsedMetadata, metadata);
   }, [parsedMetadata, metadata, isParsing, metadataTooLarge]);
 
   // An over-limit field parses to `undefined` above, but it is not empty — it

--- a/web/src/features/traces/components/IOPreview/IOPreviewPretty.clienttest.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewPretty.clienttest.tsx
@@ -1,0 +1,90 @@
+/**
+ * Formatted (pretty) view must render empty input and empty output the same
+ * way: JSON `null`, not JS `undefined`. Input used to be coalesced with
+ * `?? null` while output was passed through.
+ */
+import { render } from "@testing-library/react";
+
+const prettyJsonView = vi.hoisted(() => ({
+  calls: [] as { title?: string; json?: unknown }[],
+}));
+vi.mock("@/src/components/ui/PrettyJsonView", () => ({
+  PrettyJsonView: (props: { title?: string; json?: unknown }) => {
+    prettyJsonView.calls.push({ title: props.title, json: props.json });
+    return <div data-testid="pretty-json-view">{props.title}</div>;
+  },
+}));
+
+vi.mock("./components/CorrectedOutputField", () => ({
+  CorrectedOutputField: () => <div data-testid="corrected-output" />,
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  deepParseJson: (value: unknown) => value,
+}));
+
+vi.mock("../../hooks/useChatMLParser", () => ({
+  useChatMLParser: () => ({
+    canDisplayAsChat: false,
+    allMessages: [],
+    additionalInput: undefined,
+    allTools: [],
+    toolCallCounts: new Map(),
+    toolCallsByName: new Map(),
+    messageToToolCallNumbers: new Map(),
+    toolNameToDefinitionNumber: new Map(),
+    inputMessageCount: 0,
+  }),
+}));
+
+import { IOPreviewPretty } from "./IOPreviewPretty";
+
+describe("IOPreviewPretty empty JSON null vs undefined", () => {
+  beforeEach(() => {
+    prettyJsonView.calls = [];
+  });
+
+  it("passes JSON null for both empty input and empty output", () => {
+    render(
+      <IOPreviewPretty
+        input={undefined}
+        output={undefined}
+        parsedInput={undefined}
+        parsedOutput={undefined}
+        hideIfNull={false}
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    const inputCall = prettyJsonView.calls.find((c) => c.title === "Input");
+    const outputCall = prettyJsonView.calls.find((c) => c.title === "Output");
+    expect(inputCall?.json).toBeNull();
+    expect(outputCall?.json).toBeNull();
+  });
+
+  it("keeps parsed JSON null for both fields", () => {
+    render(
+      <IOPreviewPretty
+        input={undefined}
+        output={undefined}
+        parsedInput={null}
+        parsedOutput={null}
+        hideIfNull={false}
+        showCorrections={false}
+        projectId="p"
+        traceId="t"
+      />,
+    );
+
+    const inputCall = prettyJsonView.calls.find((c) => c.title === "Input");
+    const outputCall = prettyJsonView.calls.find((c) => c.title === "Output");
+    expect(inputCall?.json).toBeNull();
+    expect(outputCall?.json).toBeNull();
+  });
+});

--- a/web/src/features/traces/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewPretty.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
+import { type Prisma, type ScoreDomain } from "@langfuse/shared";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { type MetadataFilterActions } from "@/src/components/table/ValueCell";
 import { useMarkdownRenderCharacterLimit } from "@/src/hooks/useMarkdownRenderCharacterLimit";
@@ -16,6 +16,7 @@ import {
 } from "./IOPreview";
 import { CorrectedOutputField } from "./components/CorrectedOutputField";
 import { isOnlyJsonMessage } from "../../fns/chatMessageUtils";
+import { resolveParsedJsonField } from "./fns/resolveParsedJsonField";
 
 interface JsonInputOutputViewProps {
   parsedInput: unknown;
@@ -70,7 +71,7 @@ function JsonInputOutputView({
       {showOutput && (
         <PrettyJsonView
           title="Output"
-          json={parsedOutput}
+          json={parsedOutput ?? null}
           isLoading={isLoading}
           isParsing={isParsing}
           media={media?.filter((m) => m.field === "output") ?? []}
@@ -159,16 +160,22 @@ export function IOPreviewPretty({
   // IMPORTANT: Don't parse while isParsing=true to avoid double-parsing with different object references
   const parsedInput = isParsing
     ? undefined // Wait for Web Worker to finish
-    : (preParsedInput ??
-      deepParseJson(input, { maxSize: 300_000, maxDepth: 2 }));
+    : resolveParsedJsonField(preParsedInput, input, {
+        maxSize: 300_000,
+        maxDepth: 2,
+      });
   const parsedOutput = isParsing
     ? undefined
-    : (preParsedOutput ??
-      deepParseJson(output, { maxSize: 300_000, maxDepth: 2 }));
+    : resolveParsedJsonField(preParsedOutput, output, {
+        maxSize: 300_000,
+        maxDepth: 2,
+      });
   const parsedMetadata = isParsing
     ? undefined
-    : (preParsedMetadata ??
-      deepParseJson(metadata, { maxSize: 100_000, maxDepth: 2 }));
+    : resolveParsedJsonField(preParsedMetadata, metadata, {
+        maxSize: 100_000,
+        maxDepth: 2,
+      });
 
   // Enable the metadata rows' actions menu (copy + add-to-filter). Observation
   // metadata filters the observations table; trace metadata the traces table.
@@ -265,7 +272,7 @@ export function IOPreviewPretty({
   };
 
   // Determine if metadata should be shown
-  const shouldShowMetadata = showMetadata && parsedMetadata !== undefined;
+  const shouldShowMetadata = showMetadata && parsedMetadata != null;
   const showData = contentMode !== "conversation";
   const shouldRenderMessages =
     canDisplayAsChat && !allMessages.every(isOnlyJsonMessage);

--- a/web/src/features/traces/components/IOPreview/fns/resolveParsedJsonField.ts
+++ b/web/src/features/traces/components/IOPreview/fns/resolveParsedJsonField.ts
@@ -1,0 +1,21 @@
+import { deepParseJson, type DeepParseJsonOptions } from "@langfuse/shared";
+
+/**
+ * Resolve a pre-parsed JSON field without treating JSON `null` as missing.
+ *
+ * `??` coalesces both `null` and `undefined`. Call sites often pass
+ * `value ?? undefined`, so a stored JSON null becomes JS undefined on the
+ * raw prop while the worker still parsed it as `null`. Falling through then
+ * renders `undefined` in JSON view and `null` in pretty view.
+ *
+ * JSON has no `undefined`. Normalize it to `null` so empty input and empty
+ * output look the same in every I/O view.
+ */
+export function resolveParsedJsonField(
+  parsed: unknown,
+  raw: unknown,
+  options?: DeepParseJsonOptions,
+): unknown {
+  const value = parsed !== undefined ? parsed : deepParseJson(raw, options);
+  return value === undefined ? null : value;
+}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16560.preview.langfuse.com](https://pr-16560.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Empty observation/trace input and output could show as `undefined` in JSON view and `null` in formatted (pretty) view — and input vs output could disagree even when both fields were empty.

JSON has no `undefined`. That mismatch came from `??` treating a stored JSON `null` as missing and falling through to a raw prop that call sites coerce with `value ?? undefined`. Pretty view also coalesced only input.

This keeps a real parsed `null` and normalizes missing values to `null`, so formatted, JSON, and JSON beta all show `null` for empty I/O.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run lint` — ESLint passed (`--max-warnings 0`)
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-client` on:
  - `src/features/traces/components/IOPreview/IOPreviewJSON.clienttest.tsx`
  - `src/features/traces/components/IOPreview/IOPreviewJSONSimple.clienttest.tsx`
  - `src/features/traces/components/IOPreview/IOPreviewPretty.clienttest.tsx`
  - `src/components/ui/PrettyJsonView.empty.clienttest.tsx`
  - `src/components/ui/PrettyJsonView.gate.clienttest.tsx`
  - Result: `Tests  29 passed (29)`
- Skipped browser signoff: Docker was not available in this environment, so the local full-stack app was not running.
- Skipped `pnpm run typecheck` / worker tests: web UI-only change with no shared/worker contract edits.

## Mandatory Tasks

- [x] Self-reviewed the code.

## Checklist

- Tests cover parsed-null-vs-undefined-raw and empty input/output parity in pretty, JSON, and JSON beta.
- Did not add a changelog entry; this is a small display-consistency fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-8206](https://linear.app/clickhouse/issue/LFE-8206/json-rendering-output-null-vs-undefined)

<div><a href="https://cursor.com/agents/bc-02dbbd3b-07b6-4396-9423-5b5067b6b4a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02dbbd3b-07b6-4396-9423-5b5067b6b4a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consistently represents empty trace and observation input/output as JSON `null` across formatted, JSON, and JSON beta views.

- Adds a shared resolver that preserves parsed JSON null and normalizes missing values.
- Aligns empty-field visibility and rendering across the I/O preview implementations.
- Adds focused client tests for null-versus-undefined behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

Present invalid and size-limited JSON values remain intact, while only genuinely missing values are normalized to null consistently across the affected trace preview paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): render empty I/O as JSON nu..."](https://github.com/langfuse/langfuse/commit/cf2f2ad15d63f43be145c81d9add541044b588de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56717911)</sub>

<!-- /greptile_comment -->