### PR TITLE
fix(evals): make trace eval job dedup atomic

### DIFF
--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -799,62 +799,7 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       const jobs = await prisma.jobExecution.findMany({ where: { projectId } });
 
-      // One row, so one score - the primary key rejected the second insert.
       expect(jobs.length).toBe(1);
-    }, 10_000);
-
-    test("still enqueues the eval when a concurrent producer won the insert", async () => {
-      const { projectId } = await createOrgProjectAndApiKey();
-      const traceId = randomUUID();
-
-      await upsertTrace({
-        id: traceId,
-        project_id: projectId,
-        timestamp: convertDateToClickhouseDateTime(new Date()),
-        created_at: convertDateToClickhouseDateTime(new Date()),
-        updated_at: convertDateToClickhouseDateTime(new Date()),
-      });
-
-      await createMigratedEvalConfig({
-        data: {
-          id: randomUUID(),
-          projectId,
-          filter: JSON.parse("[]"),
-          jobType: "EVAL",
-          delay: 0,
-          sampling: new Decimal("1"),
-          targetObject: EvalTargetObject.TRACE,
-          scoreName: "score",
-          variableMapping: JSON.parse("[]"),
-        },
-      });
-
-      // Simulate losing the insert race: the row is already there, so the
-      // ON CONFLICT DO NOTHING insert reports zero rows written. Racing on the
-      // real interleaving would make this assertion flaky.
-      const createManySpy = vi
-        .spyOn(prisma.jobExecution, "createMany")
-        .mockResolvedValue({ count: 0 });
-
-      const add = vi.fn().mockResolvedValue(undefined);
-      const getInstanceSpy = vi
-        .spyOn(EvalExecutionQueue, "getInstance")
-        .mockReturnValue({ add } as never);
-
-      try {
-        await createEvalJobs({
-          sourceEventType: "trace-upsert",
-          event: { projectId, traceId },
-          jobTimestamp,
-        });
-      } finally {
-        createManySpy.mockRestore();
-        getInstanceSpy.mockRestore();
-      }
-
-      // The loser must not stay silent. A duplicate execution is idempotent,
-      // whereas skipping the enqueue risks an execution nobody ever runs.
-      expect(add).toHaveBeenCalledTimes(1);
     }, 10_000);
 
     test("does not leave a PENDING eval job behind when enqueueing fails", async () => {

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -43,7 +43,10 @@ vi.mock("@langfuse/shared/src/server", async () => {
 });
 
 // Import the mocked function
-import { generateLLMText } from "@langfuse/shared/src/server";
+import {
+  EvalExecutionQueue,
+  generateLLMText,
+} from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../errors/UnrecoverableError";
 
 let OPENAI_API_KEY = process.env.OPENAI_API_KEY;
@@ -749,6 +752,116 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       expect(jobs[0].jobInputTraceId).toBe(traceId);
       expect(jobs[0].status.toString()).toBe("PENDING");
       expect(jobs[0].startTime).not.toBeNull();
+    }, 10_000);
+
+    test("creates a single eval job when two producers race for the same trace", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await createMigratedEvalConfig({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const payload = { projectId, traceId };
+
+      // Two shard workers observing the same trace concurrently. Both pass the
+      // dedup existence check before either inserts.
+      await Promise.all([
+        createEvalJobs({
+          sourceEventType: "trace-upsert",
+          event: payload,
+          jobTimestamp,
+        }),
+        createEvalJobs({
+          sourceEventType: "trace-upsert",
+          event: payload,
+          jobTimestamp,
+        }),
+      ]);
+
+      const jobs = await prisma.jobExecution.findMany({ where: { projectId } });
+
+      expect(jobs.length).toBe(1);
+    }, 10_000);
+
+    test("does not leave a PENDING eval job behind when enqueueing fails", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await createMigratedEvalConfig({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const getInstanceSpy = vi
+        .spyOn(EvalExecutionQueue, "getInstance")
+        .mockReturnValue({
+          add: vi.fn().mockRejectedValue(new Error("redis is down")),
+        } as never);
+
+      try {
+        await expect(
+          createEvalJobs({
+            sourceEventType: "trace-upsert",
+            event: { projectId, traceId },
+            jobTimestamp,
+          }),
+        ).rejects.toThrow("redis is down");
+      } finally {
+        getInstanceSpy.mockRestore();
+      }
+
+      // The row must be gone, otherwise the BullMQ redelivery hits the dedup
+      // check and the execution stays PENDING forever.
+      await expect(
+        prisma.jobExecution.count({ where: { projectId } }),
+      ).resolves.toBe(0);
+
+      // The retry recreates and enqueues it.
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: { projectId, traceId },
+        jobTimestamp,
+      });
+
+      await expect(
+        prisma.jobExecution.count({ where: { projectId } }),
+      ).resolves.toBe(1);
     }, 10_000);
 
     test("creates new 'dataset' eval job", async () => {

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -799,7 +799,62 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       const jobs = await prisma.jobExecution.findMany({ where: { projectId } });
 
+      // One row, so one score - the primary key rejected the second insert.
       expect(jobs.length).toBe(1);
+    }, 10_000);
+
+    test("still enqueues the eval when a concurrent producer won the insert", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await createMigratedEvalConfig({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      // Simulate losing the insert race: the row is already there, so the
+      // ON CONFLICT DO NOTHING insert reports zero rows written. Racing on the
+      // real interleaving would make this assertion flaky.
+      const createManySpy = vi
+        .spyOn(prisma.jobExecution, "createMany")
+        .mockResolvedValue({ count: 0 });
+
+      const add = vi.fn().mockResolvedValue(undefined);
+      const getInstanceSpy = vi
+        .spyOn(EvalExecutionQueue, "getInstance")
+        .mockReturnValue({ add } as never);
+
+      try {
+        await createEvalJobs({
+          sourceEventType: "trace-upsert",
+          event: { projectId, traceId },
+          jobTimestamp,
+        });
+      } finally {
+        createManySpy.mockRestore();
+        getInstanceSpy.mockRestore();
+      }
+
+      // The loser must not stay silent. A duplicate execution is idempotent,
+      // whereas skipping the enqueue risks an execution nobody ever runs.
+      expect(add).toHaveBeenCalledTimes(1);
     }, 10_000);
 
     test("does not leave a PENDING eval job behind when enqueueing fails", async () => {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -276,10 +276,6 @@ function toTraceEvalConfig(rule: TraceRule): TraceEvalConfig | null {
  * spend and — because score ids are derived from the job execution id — shows
  * up as duplicate scores. Deriving the id from the dedup key lets the primary
  * key reject the loser instead.
- *
- * Rows written before this change still carry random ids; they keep
- * deduplicating through the existence check, which matches on the key columns
- * rather than on the id.
  */
 function createDeterministicJobExecutionId(params: {
   projectId: string;

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -797,9 +797,8 @@ export const createEvalJobs = async ({
       );
 
       // `createMany` with `skipDuplicates` turns the insert into an
-      // INSERT ... ON CONFLICT DO NOTHING on the primary key. The racing loser
-      // gets `count: 0` and must not enqueue, so one execution stays one
-      // execution (and one score, since score ids derive from this id).
+      // INSERT ... ON CONFLICT DO NOTHING on the primary key, so a racing
+      // producer cannot add a second row for the same dedup key.
       const { count: insertedCount } = await prisma.jobExecution.createMany({
         data: [
           {
@@ -825,11 +824,17 @@ export const createEvalJobs = async ({
         skipDuplicates: true,
       });
 
-      if (insertedCount === 0) {
+      // Losing the insert race is not a reason to stay silent: both producers
+      // enqueue, exactly as the observation-eval scheduler does. A duplicate
+      // run is idempotent (same row, and score ids derive from the job
+      // execution id, so the second run overwrites rather than duplicates),
+      // while skipping the enqueue risks the opposite failure - an execution
+      // nobody picks up.
+      const isInsertOwner = insertedCount === 1;
+      if (!isInsertOwner) {
         logger.debug(
-          `Concurrent producer already created eval job ${jobExecutionId} for config ${config.id} and trace ${event.traceId}`,
+          `Concurrent producer already created eval job ${jobExecutionId} for config ${config.id} and trace ${event.traceId}, enqueueing anyway`,
         );
-        continue;
       }
 
       try {
@@ -865,17 +870,24 @@ export const createEvalJobs = async ({
         // The row exists but nothing will ever pick it up. Without this
         // compensating delete the BullMQ redelivery would hit the dedup check
         // above and skip re-enqueueing, stranding the execution at PENDING.
-        logger.warn(
-          `Failed to enqueue eval execution ${jobExecutionId}, removing the orphaned job execution so the retry can recreate it`,
-          e,
-        );
-        await prisma.jobExecution.deleteMany({
-          where: {
-            id: jobExecutionId,
-            projectId: event.projectId,
-            status: JobExecutionStatus.PENDING,
-          },
-        });
+        //
+        // Only the producer that inserted the row may delete it. A producer
+        // that lost the race would otherwise delete a row the winner has
+        // already queued work for, and that queued job would find nothing to
+        // execute.
+        if (isInsertOwner) {
+          logger.warn(
+            `Failed to enqueue eval execution ${jobExecutionId}, removing the orphaned job execution so the retry can recreate it`,
+            e,
+          );
+          await prisma.jobExecution.deleteMany({
+            where: {
+              id: jobExecutionId,
+              projectId: event.projectId,
+              status: JobExecutionStatus.PENDING,
+            },
+          });
+        }
         throw e;
       }
     } else {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -797,8 +797,9 @@ export const createEvalJobs = async ({
       );
 
       // `createMany` with `skipDuplicates` turns the insert into an
-      // INSERT ... ON CONFLICT DO NOTHING on the primary key, so a racing
-      // producer cannot add a second row for the same dedup key.
+      // INSERT ... ON CONFLICT DO NOTHING on the primary key. The racing loser
+      // gets `count: 0` and must not enqueue, so one execution stays one
+      // execution (and one score, since score ids derive from this id).
       const { count: insertedCount } = await prisma.jobExecution.createMany({
         data: [
           {
@@ -824,17 +825,11 @@ export const createEvalJobs = async ({
         skipDuplicates: true,
       });
 
-      // Losing the insert race is not a reason to stay silent: both producers
-      // enqueue, exactly as the observation-eval scheduler does. A duplicate
-      // run is idempotent (same row, and score ids derive from the job
-      // execution id, so the second run overwrites rather than duplicates),
-      // while skipping the enqueue risks the opposite failure - an execution
-      // nobody picks up.
-      const isInsertOwner = insertedCount === 1;
-      if (!isInsertOwner) {
+      if (insertedCount === 0) {
         logger.debug(
-          `Concurrent producer already created eval job ${jobExecutionId} for config ${config.id} and trace ${event.traceId}, enqueueing anyway`,
+          `Concurrent producer already created eval job ${jobExecutionId} for config ${config.id} and trace ${event.traceId}`,
         );
+        continue;
       }
 
       try {
@@ -870,24 +865,17 @@ export const createEvalJobs = async ({
         // The row exists but nothing will ever pick it up. Without this
         // compensating delete the BullMQ redelivery would hit the dedup check
         // above and skip re-enqueueing, stranding the execution at PENDING.
-        //
-        // Only the producer that inserted the row may delete it. A producer
-        // that lost the race would otherwise delete a row the winner has
-        // already queued work for, and that queued job would find nothing to
-        // execute.
-        if (isInsertOwner) {
-          logger.warn(
-            `Failed to enqueue eval execution ${jobExecutionId}, removing the orphaned job execution so the retry can recreate it`,
-            e,
-          );
-          await prisma.jobExecution.deleteMany({
-            where: {
-              id: jobExecutionId,
-              projectId: event.projectId,
-              status: JobExecutionStatus.PENDING,
-            },
-          });
-        }
+        logger.warn(
+          `Failed to enqueue eval execution ${jobExecutionId}, removing the orphaned job execution so the retry can recreate it`,
+          e,
+        );
+        await prisma.jobExecution.deleteMany({
+          where: {
+            id: jobExecutionId,
+            projectId: event.projectId,
+            status: JobExecutionStatus.PENDING,
+          },
+        });
         throw e;
       }
     } else {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -266,6 +266,40 @@ function toTraceEvalConfig(rule: TraceRule): TraceEvalConfig | null {
   };
 }
 
+/**
+ * Stable id for a trace/dataset eval execution, derived from the same key the
+ * dedup lookup uses.
+ *
+ * Two producers (trace-upsert shards, dataset-run-item-upsert, CreateEvalQueue)
+ * can observe the same trace concurrently and both pass the read-then-write
+ * existence check. A random id lets both inserts succeed, which doubles LLM
+ * spend and — because score ids are derived from the job execution id — shows
+ * up as duplicate scores. Deriving the id from the dedup key lets the primary
+ * key reject the loser instead.
+ *
+ * Rows written before this change still carry random ids; they keep
+ * deduplicating through the existence check, which matches on the key columns
+ * rather than on the id.
+ */
+function createDeterministicJobExecutionId(params: {
+  projectId: string;
+  configId: string;
+  traceId: string;
+  datasetItemId: string | null;
+  observationId: string | null;
+}): string {
+  return createW3CTraceId(
+    JSON.stringify([
+      "trace-eval",
+      params.projectId,
+      params.configId,
+      params.traceId,
+      params.datasetItemId,
+      params.observationId,
+    ]),
+  );
+}
+
 export const createEvalJobs = async ({
   event,
   sourceEventType,
@@ -728,7 +762,18 @@ export const createEvalJobs = async ({
     // If we matched a trace for a trace event, we create a job or
     // if we have both trace and datasetItem.
     if (traceExists && (!isDatasetConfig || Boolean(datasetItem))) {
-      const jobExecutionId = randomUUID();
+      // Derive the id from the dedup key instead of randomising it, so two
+      // producers racing on the same (config, trace, dataset item, observation)
+      // compute the same primary key. The insert below then relies on the
+      // primary key to reject the loser atomically, which the read-then-write
+      // existence check above cannot do on its own.
+      const jobExecutionId = createDeterministicJobExecutionId({
+        projectId: event.projectId,
+        configId: config.id,
+        traceId: event.traceId,
+        datasetItemId: datasetItem?.id ?? null,
+        observationId: observationId ?? null,
+      });
 
       // deduplication: if a job exists already for a trace event, we do not create a new one.
       if (existingJob.length > 0) {
@@ -755,56 +800,88 @@ export const createEvalJobs = async ({
         `Creating eval job execution for config ${config.id} and trace ${event.traceId}`,
       );
 
-      await prisma.jobExecution.create({
-        data: {
-          id: jobExecutionId,
-          projectId: event.projectId,
-          jobConfigurationId: config.id,
-          jobInputTraceId: event.traceId,
-          jobInputTraceTimestamp: traceTimestamp,
-          jobTemplateId: config.evalTemplateId,
-          status: "PENDING",
-          startTime: new Date(),
-          ...(datasetItem
-            ? {
-                jobInputDatasetItemId: datasetItem.id,
-                ...("validFrom" in datasetItem && {
-                  jobInputDatasetItemValidFrom: datasetItem.validFrom,
-                }),
-                jobInputObservationId: observationId || null,
-              }
-            : {}),
-        },
-      });
-
-      // add the job to the next queue so that eval can be executed
-      const shardingKey = `${event.projectId}-${jobExecutionId}`;
-      await EvalExecutionQueue.getInstance({ shardingKey })?.add(
-        QueueName.EvaluationExecution,
-        {
-          name: QueueJobs.EvaluationExecution,
-          id: randomUUID(),
-          timestamp: new Date(),
-          payload: {
+      // `createMany` with `skipDuplicates` turns the insert into an
+      // INSERT ... ON CONFLICT DO NOTHING on the primary key. The racing loser
+      // gets `count: 0` and must not enqueue, so one execution stays one
+      // execution (and one score, since score ids derive from this id).
+      const { count: insertedCount } = await prisma.jobExecution.createMany({
+        data: [
+          {
+            id: jobExecutionId,
             projectId: event.projectId,
-            jobExecutionId: jobExecutionId,
-            delay: config.delay,
-            ...(config.evaluatorId
+            jobConfigurationId: config.id,
+            jobInputTraceId: event.traceId,
+            jobInputTraceTimestamp: traceTimestamp,
+            jobTemplateId: config.evalTemplateId,
+            status: "PENDING",
+            startTime: new Date(),
+            ...(datasetItem
               ? {
-                  evaluatorId: config.evaluatorId,
-                  evaluationRuleId: config.evaluationRuleId,
+                  jobInputDatasetItemId: datasetItem.id,
+                  ...("validFrom" in datasetItem && {
+                    jobInputDatasetItemValidFrom: datasetItem.validFrom,
+                  }),
+                  jobInputObservationId: observationId || null,
                 }
               : {}),
           },
-          retryBaggage: {
-            originalJobTimestamp: new Date(),
-            attempt: 0,
+        ],
+        skipDuplicates: true,
+      });
+
+      if (insertedCount === 0) {
+        logger.debug(
+          `Concurrent producer already created eval job ${jobExecutionId} for config ${config.id} and trace ${event.traceId}`,
+        );
+        continue;
+      }
+
+      try {
+        // add the job to the next queue so that eval can be executed
+        const shardingKey = `${event.projectId}-${jobExecutionId}`;
+        await EvalExecutionQueue.getInstance({ shardingKey })?.add(
+          QueueName.EvaluationExecution,
+          {
+            name: QueueJobs.EvaluationExecution,
+            id: randomUUID(),
+            timestamp: new Date(),
+            payload: {
+              projectId: event.projectId,
+              jobExecutionId: jobExecutionId,
+              delay: config.delay,
+              ...(config.evaluatorId
+                ? {
+                    evaluatorId: config.evaluatorId,
+                    evaluationRuleId: config.evaluationRuleId,
+                  }
+                : {}),
+            },
+            retryBaggage: {
+              originalJobTimestamp: new Date(),
+              attempt: 0,
+            },
           },
-        },
-        {
-          delay: config.delay, // milliseconds
-        },
-      );
+          {
+            delay: config.delay, // milliseconds
+          },
+        );
+      } catch (e) {
+        // The row exists but nothing will ever pick it up. Without this
+        // compensating delete the BullMQ redelivery would hit the dedup check
+        // above and skip re-enqueueing, stranding the execution at PENDING.
+        logger.warn(
+          `Failed to enqueue eval execution ${jobExecutionId}, removing the orphaned job execution so the retry can recreate it`,
+          e,
+        );
+        await prisma.jobExecution.deleteMany({
+          where: {
+            id: jobExecutionId,
+            projectId: event.projectId,
+            status: JobExecutionStatus.PENDING,
+          },
+        });
+        throw e;
+      }
     } else {
       // if we do not have a match, and execution exists, we mark the job as cancelled
       // we do this, because a second trace event might 'deselect' a trace


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16562.preview.langfuse.com](https://pr-16562.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Problem

`createEvalJobs` deduplicates trace/dataset eval executions with a read-then-write check: it queries `job_executions` for an existing row, and inserts one if it finds none. Three producers run this concurrently for the same trace — trace-upsert shard workers, dataset-run-item-upsert workers, and `CreateEvalQueue` workers — so two of them can both pass the check before either inserts. There is no unique constraint to stop the second insert; `job_executions` only has a plain index on `(project_id, job_configuration_id, job_input_trace_id)`.

Both rows then run the LLM-as-judge evaluation. Because score ids are derived from the *random* `jobExecutionId` (`createDeterministicEvalScoreId`), the two runs write to two different score ids, so users see duplicated scores and pay for the evaluation twice.

Second, smaller failure mode: the row is created *before* the execution job is enqueued. If enqueueing fails, the BullMQ redelivery finds the existing row, hits the dedup `continue`, and never enqueues — the execution stays `PENDING` forever with nothing to pick it up.

## Fix

1. **Derive the job execution id from the dedup key** instead of randomising it, so racing producers compute the same primary key.
2. **Insert with `createMany({ skipDuplicates: true })`** — an `INSERT ... ON CONFLICT DO NOTHING` on the primary key. The loser gets `count: 0` and skips enqueueing. No migration needed: the existing primary key does the work.
3. **Delete the row if enqueueing throws**, so the retry recreates and enqueues it rather than stranding it at `PENDING`.

Rows written before this change still carry random ids. They keep deduplicating correctly, because the existence check matches on the key columns, not on the id.

This mirrors what the observation-eval scheduler already does (`scheduleObservationEvals.ts`: deterministic `createW3CTraceId` id + `upsert`), which is why that path is not affected by this bug.

## Tests

Two new cases in `worker/src/__tests__/evalService.test.ts`, both verified to fail against the previous behaviour:

- `creates a single eval job when two producers race for the same trace` — previously produced 2 rows, now 1.
- `does not leave a PENDING eval job behind when enqueueing fails` — previously left an orphaned `PENDING` row that the retry skipped; now the row is gone and the retry recreates it.

## Not covered

A `SIGKILL` landing exactly between the insert and the enqueue still strands the row — the compensating delete cannot run if the process is gone. Closing that needs a reconciler for stale `PENDING` executions, which I left out of this PR.

## Verification

- `pnpm --filter worker run test evalService observationEval` — `Tests 292 passed (292)`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm run typecheck` — `Tasks: 8 successful, 8 total`

Closes #16492
