### PR TITLE
fix(chatml): parse single-message inputs

### DIFF
--- a/packages/shared/src/utils/chatml/core.ts
+++ b/packages/shared/src/utils/chatml/core.ts
@@ -22,7 +22,7 @@ function isSingleChatMlMessage(
     typeof input === "object" &&
     !Array.isArray(input) &&
     typeof (input as Record<string, unknown>).role === "string" &&
-    "content" in input
+    ("content" in input || "tool_calls" in input)
   );
 }
 

--- a/packages/shared/src/utils/chatml/core.ts
+++ b/packages/shared/src/utils/chatml/core.ts
@@ -41,6 +41,12 @@ export function mapToChatMl(
     return ChatMlArraySchema.safeParse(inputObject.data.messages);
   }
 
+  // Single message object, e.g. { role: "user", content: "..." }
+  const singleMessage = ChatMlMessageSchema.safeParse(input);
+  if (singleMessage.success) {
+    return ChatMlArraySchema.safeParse([singleMessage.data]);
+  }
+
   return result;
 }
 

--- a/packages/shared/src/utils/chatml/core.ts
+++ b/packages/shared/src/utils/chatml/core.ts
@@ -14,6 +14,18 @@ import { selectAdapter, type NormalizerContext } from "./adapters";
 
 type ChatMlMessage = z.infer<typeof ChatMlMessageSchema>;
 
+function isSingleChatMlMessage(
+  input: unknown,
+): input is Record<string, unknown> {
+  return (
+    input !== null &&
+    typeof input === "object" &&
+    !Array.isArray(input) &&
+    typeof (input as Record<string, unknown>).role === "string" &&
+    "content" in input
+  );
+}
+
 export function mapToChatMl(
   input: unknown,
 ): ReturnType<typeof ChatMlArraySchema.safeParse> {
@@ -42,17 +54,8 @@ export function mapToChatMl(
   }
 
   // Single message object, e.g. { role: "user", content: "..." }
-  if (
-    input &&
-    typeof input === "object" &&
-    !Array.isArray(input) &&
-    typeof (input as Record<string, unknown>).role === "string" &&
-    "content" in input
-  ) {
-    const singleMessage = ChatMlMessageSchema.safeParse(input);
-    if (singleMessage.success) {
-      return ChatMlArraySchema.safeParse([singleMessage.data]);
-    }
+  if (isSingleChatMlMessage(input)) {
+    return ChatMlArraySchema.safeParse([input]);
   }
 
   return result;
@@ -98,6 +101,8 @@ export function cleanLegacyOutput(output: unknown, fallback?: unknown) {
 export function extractAdditionalInput(
   input: unknown,
 ): Record<string, unknown> | undefined {
+  if (isSingleChatMlMessage(input)) return undefined;
+
   const adapter = selectAdapter({ metadata: input, data: input });
   const consumedInputKeys = new Set(
     ["messages"].concat(adapter.getConsumedInputKeys?.(input) ?? []),

--- a/packages/shared/src/utils/chatml/core.ts
+++ b/packages/shared/src/utils/chatml/core.ts
@@ -42,9 +42,17 @@ export function mapToChatMl(
   }
 
   // Single message object, e.g. { role: "user", content: "..." }
-  const singleMessage = ChatMlMessageSchema.safeParse(input);
-  if (singleMessage.success) {
-    return ChatMlArraySchema.safeParse([singleMessage.data]);
+  if (
+    input &&
+    typeof input === "object" &&
+    !Array.isArray(input) &&
+    typeof (input as Record<string, unknown>).role === "string" &&
+    "content" in input
+  ) {
+    const singleMessage = ChatMlMessageSchema.safeParse(input);
+    if (singleMessage.success) {
+      return ChatMlArraySchema.safeParse([singleMessage.data]);
+    }
   }
 
   return result;

--- a/worker/src/__tests__/chatml/framework-traces/claude-agent-2025-12-22.chatml.json
+++ b/worker/src/__tests__/chatml/framework-traces/claude-agent-2025-12-22.chatml.json
@@ -51,11 +51,13 @@
   },
   "e9aac170e5d48125": {
     "input": {
-      "success": false,
-      "error": {
-        "name": "ZodError",
-        "message": "[\n  {\n    \"expected\": \"array\",\n    \"code\": \"invalid_type\",\n    \"path\": [],\n    \"message\": \"Invalid input: expected array, received object\"\n  }\n]"
-      }
+      "success": true,
+      "data": [
+        {
+          "content": "What's the weather like in Berlin and New York?",
+          "role": "user"
+        }
+      ]
     },
     "output": {
       "success": true,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16565.preview.langfuse.com](https://pr-16565.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Accept valid single ChatML message objects in the shared input mapper.
- Preserve existing array and `{ messages: [...] }` handling.

## Validation

- `git diff --check` passed.
- Focused shared lint was attempted but could not start because dependencies were unavailable and registry access returned `ENOTFOUND`.
- No regression test added, per request.

## Reviewer focus

Please doubt whether wrapping a single validated message here has any unintended effect on provider-specific adapter formats.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends the shared ChatML mapper to accept a bare, valid message object while preserving array and messages-wrapper handling.
- Validates bare objects with ChatMlMessageSchema.
- Wraps successful single-message parses into a ChatML array.
- The current implementation reparses transformed messages and can double-nest passthrough metadata.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The metadata-shape regression should be fixed before merging because valid single messages can normalize differently from equivalent one-element arrays.

The new branch applies non-idempotent ChatML transforms twice, moving passthrough metadata from json to json.json and breaking consumers that expect the normal flattened representation.

**Files Needing Attention:** packages/shared/src/utils/chatml/core.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/utils/chatml/core.ts:47
**Double-parsed message metadata**

When a valid single message contains `additional_kwargs` or another passthrough field, reparsing `singleMessage.data` applies the non-idempotent message transforms twice and returns the metadata under `json.json` instead of `json`, causing trace previews to display an extra nested object and consumers of `message.json.<field>` to miss the metadata.

```suggestion
    return ChatMlArraySchema.safeParse([input]);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chatml): parse single-message inputs"](https://github.com/langfuse/langfuse/commit/55efc3d2c3bc18638eca658bdfbe312048c865ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56748314)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->