### PR TITLE
fix(web): require audit log access for audit-log batch export downloads

### DIFF
--- a/web/src/__tests__/server/batchExport-trpc.servertest.ts
+++ b/web/src/__tests__/server/batchExport-trpc.servertest.ts
@@ -5,6 +5,7 @@ import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
 import {
   BatchExportFileFormat,
+  BatchExportStatus,
   BatchTableNames,
   type Plan,
 } from "@langfuse/shared";
@@ -163,6 +164,232 @@ describe("batchExport tRPC – audit_logs table authorization", () => {
       expect(job?.query).toMatchObject({ tableName: "audit_logs" });
     },
   );
+});
+
+const seedCompletedExport = (opts: {
+  projectId: string;
+  name: string;
+  tableName: BatchTableNames;
+}) =>
+  prisma.batchExport.create({
+    data: {
+      projectId: opts.projectId,
+      userId: "user-test",
+      status: BatchExportStatus.COMPLETED,
+      name: opts.name,
+      format: BatchExportFileFormat.CSV,
+      // Non-URL so downloadUrl cannot parse an object key and must fall back
+      // to the stored value instead of signing against the test bucket.
+      url: "not-a-valid-url",
+      finishedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      query: {
+        tableName: opts.tableName,
+        filter: null,
+        orderBy: null,
+      },
+    },
+  });
+
+describe("batchExport tRPC – audit_logs download and list authorization", () => {
+  afterAll(async () => {
+    await prisma.organization.deleteMany({
+      where: { id: { in: __orgIds } },
+    });
+  });
+
+  it("blocks a MEMBER from downloadUrl of an OWNER-created audit_logs export", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const exportJob = await seedCompletedExport({
+      projectId: project.id,
+      name: "owner audit export",
+      tableName: BatchTableNames.AuditLogs,
+    });
+
+    const memberCaller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "MEMBER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await expect(
+      memberCaller.batchExport.downloadUrl({
+        projectId: project.id,
+        batchExportId: exportJob.id,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("blocks an OWNER on cloud:hobby from downloadUrl of an audit_logs export", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const exportJob = await seedCompletedExport({
+      projectId: project.id,
+      name: "hobby audit export",
+      tableName: BatchTableNames.AuditLogs,
+    });
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:hobby",
+          projectRole: "OWNER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await expect(
+      caller.batchExport.downloadUrl({
+        projectId: project.id,
+        batchExportId: exportJob.id,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("allows an OWNER with audit-logs entitlement to downloadUrl an audit_logs export", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const exportJob = await seedCompletedExport({
+      projectId: project.id,
+      name: "entitled audit export",
+      tableName: BatchTableNames.AuditLogs,
+    });
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "OWNER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await expect(
+      caller.batchExport.downloadUrl({
+        projectId: project.id,
+        batchExportId: exportJob.id,
+      }),
+    ).resolves.toEqual({ url: "not-a-valid-url" });
+  });
+
+  it("still allows a MEMBER to downloadUrl a traces export", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const exportJob = await seedCompletedExport({
+      projectId: project.id,
+      name: "traces export",
+      tableName: BatchTableNames.Traces,
+    });
+
+    const memberCaller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "MEMBER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await expect(
+      memberCaller.batchExport.downloadUrl({
+        projectId: project.id,
+        batchExportId: exportJob.id,
+      }),
+    ).resolves.toEqual({ url: "not-a-valid-url" });
+  });
+
+  it("hides audit_logs exports from all for a MEMBER without auditLogs:read", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "audit export hidden",
+      tableName: BatchTableNames.AuditLogs,
+    });
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "traces export visible",
+      tableName: BatchTableNames.Traces,
+    });
+
+    const memberCaller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "MEMBER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    const result = await memberCaller.batchExport.all({
+      projectId: project.id,
+      page: 0,
+      limit: 50,
+    });
+
+    expect(result.exports.map((e) => e.name)).toEqual([
+      "traces export visible",
+    ]);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it("includes audit_logs exports in all for an OWNER with entitlement", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "audit export listed",
+      tableName: BatchTableNames.AuditLogs,
+    });
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "traces export listed",
+      tableName: BatchTableNames.Traces,
+    });
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "OWNER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    const result = await caller.batchExport.all({
+      projectId: project.id,
+      page: 0,
+      limit: 50,
+    });
+
+    expect(result.exports.map((e) => e.name).sort()).toEqual([
+      "audit export listed",
+      "traces export listed",
+    ]);
+    expect(result.totalCount).toBe(2);
+  });
 });
 
 describe("batchExport tRPC – useEventsTable snapshot", () => {

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -2,8 +2,14 @@ import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { env } from "@/src/env.mjs";
 import { parseBatchExportFileKeyFromUrl } from "@/src/features/batch-exports/server/batchExportFileKey";
 import { getBatchExportStorageServiceClient } from "@/src/features/batch-exports/server/getBatchExportStorageClient";
-import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
-import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import {
+  hasEntitlement,
+  throwIfNoEntitlement,
+} from "@/src/features/entitlements/server/hasEntitlement";
+import {
+  hasProjectAccess,
+  throwIfNoProjectAccess,
+} from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
@@ -22,6 +28,7 @@ import {
   QueueJobs,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
+import { type Session } from "next-auth";
 import { z } from "zod";
 import { assertLegacyTracingIoSearchCanCreateBatchJob } from "@/src/features/traces/server/legacyIoSearch";
 
@@ -32,6 +39,57 @@ const LEGACY_DOWNLOAD_WINDOW_MS = 24 * 60 * 60 * 1000;
 // The fresh URL only needs to cover the click-through: object stores check
 // signature expiry when the request starts, not while the download streams.
 const FRESH_DOWNLOAD_URL_TTL_SECONDS = 10 * 60;
+
+const isAuditLogBatchExportQuery = (query: unknown): boolean =>
+  typeof query === "object" &&
+  query !== null &&
+  "tableName" in query &&
+  query.tableName === BatchExportTableName.AuditLogs;
+
+const assertAuditLogBatchExportAccess = ({
+  session,
+  projectId,
+  query,
+}: {
+  session: Session;
+  projectId: string;
+  query: unknown;
+}) => {
+  if (!isAuditLogBatchExportQuery(query)) {
+    return;
+  }
+  throwIfNoEntitlement({
+    entitlement: "audit-logs",
+    sessionUser: session.user,
+    projectId,
+  });
+  throwIfNoProjectAccess({
+    session,
+    projectId,
+    scope: "auditLogs:read",
+  });
+};
+
+const canAccessAuditLogBatchExports = ({
+  session,
+  projectId,
+}: {
+  session: Session;
+  projectId: string;
+}) =>
+  Boolean(
+    session.user &&
+    hasEntitlement({
+      entitlement: "audit-logs",
+      sessionUser: session.user,
+      projectId,
+    }) &&
+    hasProjectAccess({
+      session,
+      projectId,
+      scope: "auditLogs:read",
+    }),
+  );
 
 const isDownloadWindowExpired = (batchExport: {
   finishedAt: Date | null;
@@ -67,18 +125,11 @@ export const batchExportRouter = createTRPCRouter({
           useEventsTable: ctx.session.user.v4BetaEnabled ?? false,
         };
 
-        if (query.tableName === BatchExportTableName.AuditLogs) {
-          throwIfNoEntitlement({
-            entitlement: "audit-logs",
-            sessionUser: ctx.session.user,
-            projectId,
-          });
-          throwIfNoProjectAccess({
-            session: ctx.session,
-            projectId,
-            scope: "auditLogs:read",
-          });
-        }
+        assertAuditLogBatchExportAccess({
+          session: ctx.session,
+          projectId,
+          query,
+        });
 
         assertLegacyTracingIoSearchCanCreateBatchJob({
           searchQuery: query.searchQuery,
@@ -171,6 +222,13 @@ export const batchExportRouter = createTRPCRouter({
       if (!batchExport) {
         throw new LangfuseNotFoundError("Batch export not found");
       }
+
+      assertAuditLogBatchExportAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        query: batchExport.query,
+      });
+
       if (
         batchExport.status !== BatchExportStatus.COMPLETED ||
         !batchExport.url
@@ -234,11 +292,26 @@ export const batchExportRouter = createTRPCRouter({
         scope: "batchExports:read",
       });
 
+      const where = {
+        projectId: input.projectId,
+        ...(canAccessAuditLogBatchExports({
+          session: ctx.session,
+          projectId: input.projectId,
+        })
+          ? {}
+          : {
+              NOT: {
+                query: {
+                  path: ["tableName"],
+                  equals: BatchExportTableName.AuditLogs,
+                },
+              },
+            }),
+      };
+
       const [exports, totalCount] = await Promise.all([
         ctx.prisma.batchExport.findMany({
-          where: {
-            projectId: input.projectId,
-          },
+          where,
           take: input.limit,
           skip: input.page * input.limit,
           orderBy: {
@@ -246,9 +319,7 @@ export const batchExportRouter = createTRPCRouter({
           },
         }),
         ctx.prisma.batchExport.count({
-          where: {
-            projectId: input.projectId,
-          },
+          where,
         }),
       ]);
 

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -48,10 +48,12 @@ const isAuditLogBatchExportQuery = (query: unknown): boolean =>
 
 const assertAuditLogBatchExportAccess = ({
   session,
+  sessionUser,
   projectId,
   query,
 }: {
   session: Session;
+  sessionUser: NonNullable<Session["user"]>;
   projectId: string;
   query: unknown;
 }) => {
@@ -60,7 +62,7 @@ const assertAuditLogBatchExportAccess = ({
   }
   throwIfNoEntitlement({
     entitlement: "audit-logs",
-    sessionUser: session.user,
+    sessionUser,
     projectId,
   });
   throwIfNoProjectAccess({
@@ -127,6 +129,7 @@ export const batchExportRouter = createTRPCRouter({
 
         assertAuditLogBatchExportAccess({
           session: ctx.session,
+          sessionUser: ctx.session.user,
           projectId,
           query,
         });
@@ -225,6 +228,7 @@ export const batchExportRouter = createTRPCRouter({
 
       assertAuditLogBatchExportAccess({
         session: ctx.session,
+        sessionUser: ctx.session.user,
         projectId: input.projectId,
         query: batchExport.query,
       });

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -11,6 +11,7 @@ import {
   throwIfNoProjectAccess,
 } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
+  type AuthedSession,
   createTRPCRouter,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
@@ -28,7 +29,6 @@ import {
   QueueJobs,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
-import { type Session } from "next-auth";
 import { z } from "zod";
 import { assertLegacyTracingIoSearchCanCreateBatchJob } from "@/src/features/traces/server/legacyIoSearch";
 
@@ -40,58 +40,34 @@ const LEGACY_DOWNLOAD_WINDOW_MS = 24 * 60 * 60 * 1000;
 // signature expiry when the request starts, not while the download streams.
 const FRESH_DOWNLOAD_URL_TTL_SECONDS = 10 * 60;
 
-const isAuditLogBatchExportQuery = (query: unknown): boolean =>
+const isAuditLogExport = (query: unknown): boolean =>
   typeof query === "object" &&
   query !== null &&
   "tableName" in query &&
   query.tableName === BatchExportTableName.AuditLogs;
 
-const assertAuditLogBatchExportAccess = ({
-  session,
-  sessionUser,
-  projectId,
-  query,
-}: {
-  session: Session;
-  sessionUser: NonNullable<Session["user"]>;
-  projectId: string;
-  query: unknown;
-}) => {
-  if (!isAuditLogBatchExportQuery(query)) {
-    return;
-  }
+const canReadAuditLogs = (session: AuthedSession, projectId: string) =>
+  hasEntitlement({
+    entitlement: "audit-logs",
+    sessionUser: session.user,
+    projectId,
+  }) && hasProjectAccess({ session, projectId, scope: "auditLogs:read" });
+
+// An audit-log export holds actor identifiers and admin actions, so reading
+// one needs the audit-log gates too, not just the batch-export ones.
+const assertAuditLogExportAccess = (
+  session: AuthedSession,
+  projectId: string,
+  query: unknown,
+) => {
+  if (!isAuditLogExport(query)) return;
   throwIfNoEntitlement({
     entitlement: "audit-logs",
-    sessionUser,
+    sessionUser: session.user,
     projectId,
   });
-  throwIfNoProjectAccess({
-    session,
-    projectId,
-    scope: "auditLogs:read",
-  });
+  throwIfNoProjectAccess({ session, projectId, scope: "auditLogs:read" });
 };
-
-const canAccessAuditLogBatchExports = ({
-  session,
-  projectId,
-}: {
-  session: Session;
-  projectId: string;
-}) =>
-  Boolean(
-    session.user &&
-    hasEntitlement({
-      entitlement: "audit-logs",
-      sessionUser: session.user,
-      projectId,
-    }) &&
-    hasProjectAccess({
-      session,
-      projectId,
-      scope: "auditLogs:read",
-    }),
-  );
 
 const isDownloadWindowExpired = (batchExport: {
   finishedAt: Date | null;
@@ -127,12 +103,7 @@ export const batchExportRouter = createTRPCRouter({
           useEventsTable: ctx.session.user.v4BetaEnabled ?? false,
         };
 
-        assertAuditLogBatchExportAccess({
-          session: ctx.session,
-          sessionUser: ctx.session.user,
-          projectId,
-          query,
-        });
+        assertAuditLogExportAccess(ctx.session, projectId, query);
 
         assertLegacyTracingIoSearchCanCreateBatchJob({
           searchQuery: query.searchQuery,
@@ -226,12 +197,11 @@ export const batchExportRouter = createTRPCRouter({
         throw new LangfuseNotFoundError("Batch export not found");
       }
 
-      assertAuditLogBatchExportAccess({
-        session: ctx.session,
-        sessionUser: ctx.session.user,
-        projectId: input.projectId,
-        query: batchExport.query,
-      });
+      assertAuditLogExportAccess(
+        ctx.session,
+        input.projectId,
+        batchExport.query,
+      );
 
       if (
         batchExport.status !== BatchExportStatus.COMPLETED ||
@@ -298,10 +268,7 @@ export const batchExportRouter = createTRPCRouter({
 
       const where = {
         projectId: input.projectId,
-        ...(canAccessAuditLogBatchExports({
-          session: ctx.session,
-          projectId: input.projectId,
-        })
+        ...(canReadAuditLogs(ctx.session, input.projectId)
           ? {}
           : {
               NOT: {

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -23,6 +23,7 @@ import {
   LangfuseNotFoundError,
   paginationZod,
 } from "@langfuse/shared";
+import { type Prisma } from "@langfuse/shared/src/db";
 import {
   BatchExportQueue,
   logger,
@@ -40,10 +41,13 @@ const LEGACY_DOWNLOAD_WINDOW_MS = 24 * 60 * 60 * 1000;
 // signature expiry when the request starts, not while the download streams.
 const FRESH_DOWNLOAD_URL_TTL_SECONDS = 10 * 60;
 
-const isAuditLogExport = (query: unknown): boolean =>
+// A persisted export's query is a Json column, so its table name is only
+// known at runtime. On create the query is still the validated input, where
+// `tableName` is typed and compared directly.
+const isAuditLogExport = (query: Prisma.JsonValue): boolean =>
   typeof query === "object" &&
   query !== null &&
-  "tableName" in query &&
+  !Array.isArray(query) &&
   query.tableName === BatchExportTableName.AuditLogs;
 
 const canReadAuditLogs = (session: AuthedSession, projectId: string) =>
@@ -55,12 +59,7 @@ const canReadAuditLogs = (session: AuthedSession, projectId: string) =>
 
 // An audit-log export holds actor identifiers and admin actions, so reading
 // one needs the audit-log gates too, not just the batch-export ones.
-const assertAuditLogExportAccess = (
-  session: AuthedSession,
-  projectId: string,
-  query: unknown,
-) => {
-  if (!isAuditLogExport(query)) return;
+const assertCanReadAuditLogs = (session: AuthedSession, projectId: string) => {
   throwIfNoEntitlement({
     entitlement: "audit-logs",
     sessionUser: session.user,
@@ -103,7 +102,9 @@ export const batchExportRouter = createTRPCRouter({
           useEventsTable: ctx.session.user.v4BetaEnabled ?? false,
         };
 
-        assertAuditLogExportAccess(ctx.session, projectId, query);
+        if (query.tableName === BatchExportTableName.AuditLogs) {
+          assertCanReadAuditLogs(ctx.session, projectId);
+        }
 
         assertLegacyTracingIoSearchCanCreateBatchJob({
           searchQuery: query.searchQuery,
@@ -197,11 +198,9 @@ export const batchExportRouter = createTRPCRouter({
         throw new LangfuseNotFoundError("Batch export not found");
       }
 
-      assertAuditLogExportAccess(
-        ctx.session,
-        input.projectId,
-        batchExport.query,
-      );
+      if (isAuditLogExport(batchExport.query)) {
+        assertCanReadAuditLogs(ctx.session, input.projectId);
+      }
 
       if (
         batchExport.status !== BatchExportStatus.COMPLETED ||


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16567.preview.langfuse.com](https://pr-16567.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

A project member with `batchExports:read` could list an owner-created audit-log export, copy its ID, and call `downloadUrl` to get a signed CSV of audit events. Create already required the `audit-logs` entitlement and `auditLogs:read`; download did not.

This change applies those same guards after loading the export, before issuing a download URL. Callers who cannot read audit logs also no longer see audit-log export rows (or their IDs/query metadata) in the export list.

Impacted packages: `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code.

## Checklist

- Follows existing batch-export tRPC authorization patterns
- Adds tRPC tests for denied MEMBER download, denied hobby-plan OWNER download, allowed entitled OWNER download, allowed MEMBER traces download, and list filtering
- `pnpm --filter web run test src/__tests__/server/batchExport-trpc.servertest.ts` → `Tests 13 passed (13)`
- `pnpm --filter web run typecheck` → passed
- `pnpm --filter web run lint` → passed
- Pre-commit repository lint → `Tasks: 7 successful, 7 total`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15589](https://linear.app/clickhouse/issue/LFE-15589/member-can-download-audit-log-batch-exports-without-auditlogsread)

<div><a href="https://cursor.com/agents/bc-45823cb2-7242-48aa-b9b9-d64b3d51fab4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45823cb2-7242-48aa-b9b9-d64b3d51fab4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR closes an audit-log export authorization gap by requiring the audit-log entitlement and project read scope before issuing download URLs, and by hiding audit-log exports from callers without that access.

- Centralizes audit-log batch-export authorization for creation and download.
- Applies equivalent non-throwing checks when filtering export listings and counts.
- Adds coverage for denied and permitted downloads and filtered listings.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security defects identified in the changed authorization paths.

The new download guard uses the same entitlement and project-scope checks as creation, while listing uses their behaviorally equivalent boolean forms and applies one shared filter to both rows and counts.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Batch export request] --> B{Operation}
  B -->|Create or download| C{Audit-log export?}
  B -->|List| D{Caller has audit-log entitlement and read scope?}
  C -->|No| E[Apply normal batch-export authorization]
  C -->|Yes| F[Require audit-log entitlement]
  F --> G[Require auditLogs:read]
  G --> H[Proceed]
  D -->|Yes| I[Return all project exports]
  D -->|No| J[Exclude audit-log exports and count]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): require auditLogs:read for aud..."](https://github.com/langfuse/langfuse/commit/0b0efde396b63673c8ec8c139dbbc0c115f8855c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56758323)</sub>

**Context used:**

- Knowledge Base — [Identity, access, and tenancy](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/identity-access-and-tenancy.md)
- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)

<!-- /greptile_comment -->