### PR TITLE
fix(web): gate blob storage tRPC on scheduled-blob-exports entitlement

### DIFF
--- a/web/src/__tests__/blob-storage-settings-page.clienttest.tsx
+++ b/web/src/__tests__/blob-storage-settings-page.clienttest.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mocks = vi.hoisted(() => ({
+  hasAccess: true,
+  hasEntitlement: false,
+  useQuery: vi.fn(),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { projectId: "proj-1" } }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+vi.mock("@/src/components/layouts/container-page", () => ({
+  default: ({
+    children,
+    headerProps,
+  }: {
+    children: ReactNode;
+    headerProps: { title: string };
+  }) => (
+    <div>
+      <h1>{headerProps.title}</h1>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/src/components/layouts/header", () => ({
+  default: ({ title }: { title: string }) => <h2>{title}</h2>,
+}));
+
+vi.mock("@/src/components/ui/StatusBadge/StatusBadge", () => ({
+  StatusBadge: () => null,
+}));
+
+vi.mock("@/src/components/ui/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => (
+    <button>{children}</button>
+  ),
+}));
+
+vi.mock("@/src/components/ui/card", () => ({
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock(
+  "@/src/features/analytics-integrations/components/IntegrationSettingsSkeleton",
+  () => ({
+    IntegrationSettingsSkeleton: () => <div>Loading configuration</div>,
+  }),
+);
+
+vi.mock(
+  "@/src/features/blobstorage-integration/components/BlobStorageIntegrationContainer",
+  () => ({
+    BlobStorageIntegrationContainer: () => <div>Blob storage form</div>,
+  }),
+);
+
+vi.mock(
+  "@/src/features/blobstorage-integration/components/BlobStorageStatusSection",
+  () => ({
+    BlobStorageStatusSection: () => <div>Blob storage status</div>,
+  }),
+);
+
+vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => mocks.hasAccess,
+}));
+
+vi.mock("@/src/features/entitlements/hooks", () => ({
+  useHasEntitlement: () => mocks.hasEntitlement,
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    blobStorageIntegration: {
+      get: {
+        useQuery: mocks.useQuery,
+      },
+    },
+  },
+}));
+
+import BlobStorageIntegrationSettings from "@/src/pages/project/[projectId]/settings/integrations/blobstorage";
+
+describe("BlobStorageIntegrationSettings entitlement gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasAccess = true;
+    mocks.hasEntitlement = false;
+    mocks.useQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+  });
+
+  it("does not fetch config and shows a plan message without scheduled-blob-exports", () => {
+    render(<BlobStorageIntegrationSettings />);
+
+    expect(
+      screen.getByText("This feature is not available in your current plan."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Loading configuration")).not.toBeInTheDocument();
+    expect(screen.queryByText("Blob storage form")).not.toBeInTheDocument();
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      { projectId: "proj-1" },
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("shows the role message when entitled but without integrations access", () => {
+    mocks.hasEntitlement = true;
+    mocks.hasAccess = false;
+
+    render(<BlobStorageIntegrationSettings />);
+
+    expect(
+      screen.getByText(
+        /Your current role does not grant you access to these settings/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Loading configuration")).not.toBeInTheDocument();
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      { projectId: "proj-1" },
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("fetches config when entitled and allowed", () => {
+    mocks.hasEntitlement = true;
+    mocks.hasAccess = true;
+    mocks.useQuery.mockReturnValue({
+      data: { config: { enabled: false }, writeMode: "upsert" },
+      isLoading: false,
+    });
+
+    render(<BlobStorageIntegrationSettings />);
+
+    expect(screen.getByText("Blob storage form")).toBeInTheDocument();
+    expect(screen.queryByText("Loading configuration")).not.toBeInTheDocument();
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      { projectId: "proj-1" },
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+});

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -15,6 +15,7 @@ import {
   OBSERVATION_FIELD_GROUPS_FULL,
   LEGACY_EXPORT_PROJECT_CUTOFF,
   LEGACY_BLOB_EXPORTER_CUTOFF,
+  type Plan,
 } from "@langfuse/shared";
 import { env } from "@/src/env.mjs";
 import { env as sharedEnv } from "@langfuse/shared/src/env";
@@ -49,7 +50,13 @@ vi.mock("@langfuse/shared/src/server", async () => {
 
 const __orgIds: string[] = [];
 
-const prepare = async () => {
+const prepare = async ({
+  admin = true,
+  plan = "cloud:hobby",
+}: {
+  admin?: boolean;
+  plan?: Plan;
+} = {}) => {
   const { project, org } = await createOrgProjectAndApiKey();
 
   const session: Session = {
@@ -63,7 +70,7 @@ const prepare = async () => {
           id: org.id,
           name: org.name,
           role: "OWNER",
-          plan: "cloud:hobby",
+          plan,
           cloudConfig: undefined,
           metadata: {},
           aiFeaturesEnabled: false,
@@ -90,11 +97,11 @@ const prepare = async () => {
         observationEvals: false,
         experimentsV4Enabled: false,
       },
-      admin: true,
+      admin,
     },
     environment: {
       enableExperimentalFeatures: false,
-      selfHostedInstancePlan: "cloud:hobby",
+      selfHostedInstancePlan: plan,
     },
   };
 
@@ -189,6 +196,60 @@ describe("Blob Storage Integration tRPC Router", () => {
       where: {
         id: { in: __orgIds },
       },
+    });
+  });
+
+  describe("scheduled-blob-exports entitlement", () => {
+    it("blocks a non-admin OWNER on cloud:hobby from all blobStorageIntegration procedures", async () => {
+      const { caller, project } = await prepare({
+        admin: false,
+        plan: "cloud:hobby",
+      });
+      await createIntegration({ projectId: project.id });
+
+      await expect(
+        caller.blobStorageIntegration.get({ projectId: project.id }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        message: expect.stringContaining("scheduled-blob-exports"),
+      });
+
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      await expect(
+        caller.blobStorageIntegration.runNow({ projectId: project.id }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      await expect(
+        caller.blobStorageIntegration.validate({ projectId: project.id }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      await expect(
+        caller.blobStorageIntegration.delete({ projectId: project.id }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      const stillThere = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: project.id },
+      });
+      expect(stillThere).not.toBeNull();
+    });
+
+    it("allows a non-admin OWNER on cloud:team to read the integration", async () => {
+      const { caller, project } = await prepare({
+        admin: false,
+        plan: "cloud:team",
+      });
+      await createIntegration({ projectId: project.id });
+
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.config?.projectId).toBe(project.id);
     });
   });
 

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   createTRPCRouter,
@@ -14,6 +15,7 @@ import {
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { resolveExportSource } from "@/src/features/analytics-integrations/server/exportSource";
 import { TRPCError } from "@trpc/server";
+import { type Session } from "next-auth";
 import { env } from "@/src/env.mjs";
 import {
   logger,
@@ -62,14 +64,35 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   return error.message;
 };
 
+const assertBlobStorageIntegrationAccess = ({
+  session,
+  projectId,
+}: {
+  session: Session;
+  projectId: string;
+}) => {
+  throwIfNoProjectAccess({
+    session,
+    projectId,
+    scope: "integrations:CRUD",
+  });
+  if (!session.user) {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+  throwIfNoEntitlement({
+    entitlement: "scheduled-blob-exports",
+    projectId,
+    sessionUser: session.user,
+  });
+};
+
 export const blobStorageIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
     .query(async ({ input, ctx }) => {
-      throwIfNoProjectAccess({
+      assertBlobStorageIntegrationAccess({
         session: ctx.session,
         projectId: input.projectId,
-        scope: "integrations:CRUD",
       });
       try {
         const config = await ctx.prisma.blobStorageIntegration.findFirst({
@@ -111,10 +134,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
     )
     .mutation(async ({ input, ctx }) => {
       try {
-        throwIfNoProjectAccess({
+        assertBlobStorageIntegrationAccess({
           session: ctx.session,
           projectId: input.projectId,
-          scope: "integrations:CRUD",
         });
 
         const existingIntegration =
@@ -186,10 +208,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       try {
-        throwIfNoProjectAccess({
+        assertBlobStorageIntegrationAccess({
           session: ctx.session,
           projectId: input.projectId,
-          scope: "integrations:CRUD",
         });
         await auditLog({
           session: ctx.session,
@@ -204,6 +225,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           },
         });
       } catch (e) {
+        if (e instanceof TRPCError) {
+          throw e;
+        }
         logger.error(`Failed to delete blob storage integration`, e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
@@ -216,10 +240,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       try {
-        throwIfNoProjectAccess({
+        assertBlobStorageIntegrationAccess({
           session: ctx.session,
           projectId: input.projectId,
-          scope: "integrations:CRUD",
         });
 
         // Check if integration exists and is enabled
@@ -324,10 +347,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       try {
-        throwIfNoProjectAccess({
+        assertBlobStorageIntegrationAccess({
           session: ctx.session,
           projectId: input.projectId,
-          scope: "integrations:CRUD",
         });
 
         // Get persisted configuration

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -71,14 +71,14 @@ const assertBlobStorageIntegrationAccess = ({
   session: Session;
   projectId: string;
 }) => {
+  if (!session.user) {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
   throwIfNoProjectAccess({
     session,
     projectId,
     scope: "integrations:CRUD",
   });
-  if (!session.user) {
-    throw new TRPCError({ code: "UNAUTHORIZED" });
-  }
   throwIfNoEntitlement({
     entitlement: "scheduled-blob-exports",
     projectId,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/src/components/ui/card";
 import { IntegrationSettingsSkeleton } from "@/src/features/analytics-integrations/components/IntegrationSettingsSkeleton";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api, type RouterOutputs } from "@/src/utils/api";
 import { deriveSyncStatus } from "@/src/features/blobstorage-integration/deriveSyncStatus";
@@ -40,10 +41,12 @@ export default function BlobStorageIntegrationSettings() {
     projectId,
     scope: "integrations:CRUD",
   });
+  const hasEntitlement = useHasEntitlement("scheduled-blob-exports");
+  const canLoadConfig = hasAccess && hasEntitlement;
   const state = api.blobStorageIntegration.get.useQuery(
     { projectId },
     {
-      enabled: hasAccess,
+      enabled: canLoadConfig,
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
@@ -58,7 +61,7 @@ export default function BlobStorageIntegrationSettings() {
   );
 
   const syncStatus =
-    state.isLoading || !hasAccess || !state.data?.config
+    state.isLoading || !canLoadConfig || !state.data?.config
       ? undefined
       : syncStatusFromConfig(state.data.config);
 
@@ -94,17 +97,20 @@ export default function BlobStorageIntegrationSettings() {
         small test file, and the &quot;Run Now&quot; button to trigger an
         immediate export.
       </p>
-      {!hasAccess && (
+      {!hasEntitlement ? (
+        <p className="text-sm">
+          This feature is not available in your current plan.
+        </p>
+      ) : !hasAccess ? (
         <p className="text-sm">
           Your current role does not grant you access to these settings, please
           reach out to your project admin or owner.
         </p>
-      )}
-      {state.data?.config && (
-        <BlobStorageStatusSection config={state.data.config} />
-      )}
-      {hasAccess && (
+      ) : (
         <>
+          {state.data?.config && (
+            <BlobStorageStatusSection config={state.data.config} />
+          )}
           <Header title="Configuration" className="mt-8" />
           <Card className="p-3">
             {!state.data ? (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16568.preview.langfuse.com](https://pr-16568.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The blob storage integration tRPC router only checked `integrations:CRUD`. Hobby (and other non-Team) org owners could still configure, persist, enable, and trigger scheduled blob export through tRPC even though the REST API and settings UI already require the `scheduled-blob-exports` entitlement.

This adds that entitlement check on `get`, `update`, `delete`, `runNow`, and `validate`. `delete` now rethrows `TRPCError` so a forbidden call stays `FORBIDDEN` instead of becoming `INTERNAL_SERVER_ERROR`.

The settings deep-link page now also checks `scheduled-blob-exports` before calling `get`, so hobby owners see a plan message instead of an infinite skeleton.

Instance admins still bypass entitlements (existing session `admin` behavior). Existing tRPC tests use `admin: true` and stay on that path.

The worker scheduler still selects any `enabled: true` integration. This PR only closes the tRPC write/read path, matching REST/UI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Targeted web tests: `pnpm --filter web run test src/__tests__/server/blob-storage-integration-trpc.servertest.ts` — `Tests 48 passed (48)`
- Client tests: `pnpm --filter web run test-client src/__tests__/blob-storage-settings-page.clienttest.tsx` — `Tests 3 passed (3)`
- Lint: pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- Skipped worker tests: worker schedule/processing unchanged
- Skipped REST API tests: REST already enforced this entitlement
- Skipped typecheck and full `pnpm run lint` outside the pre-commit turbo lint run

## Test plan

1. As a hobby org owner (not instance admin), call `blobStorageIntegration.update` / `get` / `runNow` — expect `FORBIDDEN` and no persisted config.
2. Deep-link `/project/<id>/settings/integrations/blobstorage` on a Cloud hobby org — expect the plan message, not a loading skeleton.
3. As a Team/Enterprise owner, the same calls still succeed and the settings form still loads.

[Blob storage settings form on demo project](https://cursor.com/agents/bc-a9c50a29-4c56-454d-b09c-cf45efc1372d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblob-storage-settings-form.webp)
[blob-storage-settings-form-loads.mp4](https://cursor.com/agents/bc-a9c50a29-4c56-454d-b09c-cf45efc1372d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblob-storage-settings-form-loads.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9c50a29-4c56-454d-b09c-cf45efc1372d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9c50a29-4c56-454d-b09c-cf45efc1372d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consistently gates all blob-storage integration tRPC procedures on the `scheduled-blob-exports` entitlement while preserving instance-admin access and correct forbidden error responses.

- Centralizes project RBAC and entitlement enforcement in a shared access assertion.
- Applies the assertion to get, update, delete, run-now, and validation procedures.
- Preserves `TRPCError` from delete instead of converting authorization failures into internal errors.
- Adds tests for Hobby-plan denial and Team-plan access.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the entitlement gate is consistently enforced without breaking administrator or self-hosted access.

The shared guard retains project RBAC, applies the intended plan entitlement, preserves forbidden errors across every procedure, and continues to honor administrator and self-hosted access semantics.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): gate blob storage tRPC on sche..."](https://github.com/langfuse/langfuse/commit/94b9881cba00df545ef9bd89558eb078089b3953) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56773813)</sub>

<!-- /greptile_comment -->