### PR TITLE
fix(api): ignore client-supplied comment author on project API keys

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -61,7 +61,7 @@ types:
         docs: The content of the comment. May include markdown. Currently limited to 5000 characters.
       authorUserId:
         type: optional<string>
-        docs: The id of the user who created the comment. Must be a member of the organization that owns the project, otherwise an error will be thrown.
+        docs: Deprecated and ignored. Project API keys are not bound to a user, so comments created via this endpoint are stored without an author. The field remains accepted for backwards compatibility. Use GET filters or the dashboard to read authors of comments created in the UI.
   CreateCommentResponse:
     properties:
       id:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -9189,9 +9189,10 @@ components:
           type: string
           nullable: true
           description: >-
-            The id of the user who created the comment. Must be a member of the
-            organization that owns the project, otherwise an error will be
-            thrown.
+            Deprecated and ignored. Project API keys are not bound to a user, so
+            comments created via this endpoint are stored without an author. The
+            field remains accepted for backwards compatibility. Use GET filters
+            or the dashboard to read authors of comments created in the UI.
       required:
         - projectId
         - objectType

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -41,6 +41,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (!orgMemberUserId) return;
   await prisma.organizationMembership.deleteMany({
     where: { userId: orgMemberUserId },
   });

--- a/web/src/__tests__/server/comments-api.servertest.ts
+++ b/web/src/__tests__/server/comments-api.servertest.ts
@@ -1,8 +1,5 @@
 import { randomUUID } from "crypto";
-import {
-  makeAPICall,
-  makeZodVerifiedAPICall,
-} from "@/src/__tests__/test-utils";
+import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
 import {
   GetCommentsV1Response,
   GetCommentV1Response,
@@ -19,11 +16,9 @@ import {
 
 const seedProjectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
-// POST /api/public/comments only accepts an authorUserId that belongs to a
-// member of the project's organization. CI provisions the seed project through
-// LANGFUSE_INIT_* instead of the Postgres seeder, so seeded ids such as
-// "user-1" do not exist there. Create a member of the project's organization
-// and use its id wherever a valid comment author is needed.
+// POST /api/public/comments ignores client-supplied authorUserId. Create an
+// organization member so tests can prove a write key cannot attribute comments
+// to that user.
 let orgMemberUserId: string;
 
 beforeAll(async () => {
@@ -94,7 +89,7 @@ describe("Create and get comments", () => {
       objectId: "1234",
       objectType: "TRACE",
       content: "hello",
-      authorUserId: orgMemberUserId,
+      authorUserId: null,
     });
   });
 
@@ -406,7 +401,6 @@ describe("Public API does NOT process mentions", () => {
         objectId: "no-mention-processing-trace",
         objectType: "TRACE",
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        authorUserId: orgMemberUserId,
       },
     );
 
@@ -426,11 +420,12 @@ describe("Public API does NOT process mentions", () => {
   });
 });
 
-describe("POST /api/public/comments authorUserId scoping", () => {
+describe("POST /api/public/comments authorUserId is not client-controlled", () => {
   const projectId = seedProjectId;
   const objectId = "author-scoping-trace";
   let otherOrgId: string;
   let otherOrgUserId: string;
+  let projectMemberUserId: string;
 
   beforeAll(async () => {
     await createTracesCh([
@@ -440,6 +435,35 @@ describe("POST /api/public/comments authorUserId scoping", () => {
         id: objectId,
       }),
     ]);
+
+    const project = await prisma.project.findUniqueOrThrow({
+      where: { id: projectId },
+      select: { orgId: true },
+    });
+
+    const projectMember = await prisma.user.create({
+      data: {
+        name: "Project Member Author",
+        email: `comment-project-member-${randomUUID()}@langfuse.com`,
+      },
+    });
+    projectMemberUserId = projectMember.id;
+
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        orgId: project.orgId,
+        userId: projectMemberUserId,
+        role: "MEMBER",
+      },
+    });
+    await prisma.projectMembership.create({
+      data: {
+        projectId,
+        userId: projectMemberUserId,
+        orgMembershipId: orgMembership.id,
+        role: "MEMBER",
+      },
+    });
 
     const otherOrg = await prisma.organization.create({
       data: { name: `Comment Author Scoping Org ${randomUUID()}` },
@@ -461,86 +485,57 @@ describe("POST /api/public/comments authorUserId scoping", () => {
 
   afterAll(async () => {
     await prisma.comment.deleteMany({ where: { projectId, objectId } });
+    await prisma.projectMembership.deleteMany({
+      where: { userId: projectMemberUserId },
+    });
     await prisma.organizationMembership.deleteMany({
-      where: { userId: otherOrgUserId },
+      where: { userId: { in: [otherOrgUserId, projectMemberUserId] } },
     });
     await prisma.organization.delete({ where: { id: otherOrgId } });
-    await prisma.user.delete({ where: { id: otherOrgUserId } });
-  });
-
-  it("should reject an authorUserId that is not a member of the project's organization", async () => {
-    const response = await makeAPICall<{ message: string; error: string }>(
-      "POST",
-      "/api/public/comments",
-      {
-        content: "spoofed comment",
-        objectId,
-        objectType: "TRACE",
-        projectId,
-        authorUserId: otherOrgUserId,
-      },
-    );
-
-    expect(response.status).toBe(400);
-    expect(response.body.error).toBe("InvalidRequestError");
-
-    const comments = await prisma.comment.findMany({
-      where: { projectId, authorUserId: otherOrgUserId },
+    await prisma.user.deleteMany({
+      where: { id: { in: [otherOrgUserId, projectMemberUserId] } },
     });
-    expect(comments).toHaveLength(0);
   });
 
-  it("should not disclose whether a rejected authorUserId exists", async () => {
-    const crossOrgResponse = await makeAPICall<{ message: string }>(
-      "POST",
-      "/api/public/comments",
-      {
-        content: "spoofed comment",
-        objectId,
-        objectType: "TRACE",
-        projectId,
-        authorUserId: otherOrgUserId,
-      },
-    );
-
-    const unknownUserResponse = await makeAPICall<{ message: string }>(
-      "POST",
-      "/api/public/comments",
-      {
-        content: "spoofed comment",
-        objectId,
-        objectType: "TRACE",
-        projectId,
-        authorUserId: `does-not-exist-${randomUUID()}`,
-      },
-    );
-
-    expect(crossOrgResponse.status).toBe(400);
-    expect(unknownUserResponse.status).toBe(400);
-    expect(crossOrgResponse.body.message).toBe(
-      unknownUserResponse.body.message,
-    );
-  });
-
-  it("should accept an authorUserId of an organization member without project-level ownership", async () => {
-    // orgMemberUserId has an organization membership but no project membership.
+  const expectUnattributedComment = async (authorUserId: string) => {
     const commentResponse = await makeZodVerifiedAPICall(
       PostCommentsV1Response,
       "POST",
       "/api/public/comments",
       {
-        content: "comment by org member",
+        content: `spoofed comment ${randomUUID()}`,
         objectId,
         objectType: "TRACE",
         projectId,
-        authorUserId: orgMemberUserId,
+        authorUserId,
       },
     );
 
     const comment = await prisma.comment.findUnique({
       where: { id: commentResponse.body.id },
     });
-    expect(comment?.authorUserId).toBe(orgMemberUserId);
+    expect(comment?.authorUserId).toBeNull();
+
+    const attributed = await prisma.comment.findMany({
+      where: { projectId, objectId, authorUserId },
+    });
+    expect(attributed).toHaveLength(0);
+  };
+
+  it("should ignore an authorUserId of an organization member", async () => {
+    await expectUnattributedComment(orgMemberUserId);
+  });
+
+  it("should ignore an authorUserId of a project member", async () => {
+    await expectUnattributedComment(projectMemberUserId);
+  });
+
+  it("should ignore an authorUserId from another organization", async () => {
+    await expectUnattributedComment(otherOrgUserId);
+  });
+
+  it("should ignore an unknown authorUserId without disclosing existence", async () => {
+    await expectUnattributedComment(`does-not-exist-${randomUUID()}`);
   });
 
   it("should still create comments without an authorUserId", async () => {

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -467,12 +467,34 @@ describe("MCP public API tools", () => {
         limit: 10,
       },
       context,
-    )) as { data: Array<{ id: string; content: string }> };
+    )) as {
+      data: Array<{ id: string; content: string; authorUserId: string | null }>;
+    };
     expect(listed.data).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: created.id, content: "MCP comment" }),
+        expect.objectContaining({
+          id: created.id,
+          content: "MCP comment",
+          authorUserId: null,
+        }),
       ]),
     );
+
+    const sessionUserId = uuidv4();
+    const attributed = (await handleCreateComment(
+      {
+        objectType: "PROMPT",
+        objectId: prompt.id,
+        content: "MCP session comment",
+      },
+      { ...context, userId: sessionUserId },
+    )) as { id: string };
+    await expect(
+      handleGetComment({ commentId: attributed.id }, context),
+    ).resolves.toMatchObject({
+      id: attributed.id,
+      authorUserId: sessionUserId,
+    });
 
     await expect(
       handleGetComment({ commentId: created.id }, context),

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -450,11 +450,13 @@ describe("MCP public API tools", () => {
       prompt: "Test prompt",
     });
 
+    const ignoredAuthorUserId = uuidv4();
     const created = (await handleCreateComment(
       {
         objectType: "PROMPT",
         objectId: prompt.id,
         content: "MCP comment",
+        authorUserId: ignoredAuthorUserId,
       },
       context,
     )) as { id: string };

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -8,13 +8,16 @@ import type {
   GetCommentsV1Query,
   PostCommentsV1Body,
 } from "@/src/features/public-api/types/comments";
-import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
+import { LangfuseNotFoundError } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 
 type CommentAuditScope = {
   projectId: string;
   orgId: string;
   apiKeyId: string;
+  // Server-authenticated user only (e.g. MCP session). Never taken from the
+  // request body — project API keys are not a user identity.
+  userId?: string | null;
 };
 
 type CreateCommentInput = {
@@ -71,40 +74,15 @@ export const getCommentRecordOrThrow = async ({
   return comment;
 };
 
-// The public API accepts a client-supplied authorUserId, so we must verify that
-// the author is a member of the authenticated project's organization. Otherwise
-// any project write key could attribute comments to arbitrary users.
-// The message is identical for unknown and out-of-scope users so that the
-// endpoint does not disclose whether a given user id exists.
-const throwIfAuthorNotInOrganization = async ({
-  authorUserId,
-  orgId,
-}: {
-  authorUserId: string;
-  orgId: string;
-}) => {
-  const membership = await prisma.organizationMembership.findFirst({
-    where: { orgId, userId: authorUserId },
-    select: { id: true },
-  });
-
-  if (!membership) {
-    throw new InvalidRequestError(
-      "authorUserId must belong to a member of the organization that owns the authenticated project.",
-    );
-  }
-};
-
 export const createCommentForApi = async ({
   input,
   auditScope,
 }: CreateCommentInput) => {
-  if (input.authorUserId != null) {
-    await throwIfAuthorNotInOrganization({
-      authorUserId: input.authorUserId,
-      orgId: auditScope.orgId,
-    });
-  }
+  // Ignore client-supplied authorUserId. A project API secret is not bound to a
+  // user, so persisting a caller-chosen id would let any write key impersonate
+  // another member in the dashboard. Attribute only when the caller itself is a
+  // server-authenticated user (MCP session).
+  const authorUserId = auditScope.userId ?? null;
 
   const result = await validateCommentReferenceObject({
     ctx: { prisma, auth: { scope: { projectId: auditScope.projectId } } },
@@ -124,7 +102,7 @@ export const createCommentForApi = async ({
       content: input.content,
       objectId: input.objectId,
       objectType: input.objectType,
-      authorUserId: input.authorUserId,
+      authorUserId,
       id: v4(),
       projectId: auditScope.projectId,
     },

--- a/web/src/features/mcp/features/comments/tools/createComment.ts
+++ b/web/src/features/mcp/features/comments/tools/createComment.ts
@@ -14,12 +14,12 @@ const CreateCommentToolBaseSchema = z
     content: z.string().trim().min(1).max(5000),
     objectId: z.string(),
     objectType: z.enum(CommentObjectType),
-    authorUserId: z.string().optional(),
   })
   .strict();
 
 const CreateCommentToolSchema = PostCommentsV1Body.omit({
   projectId: true,
+  authorUserId: true,
 });
 
 export const [createCommentTool, handleCreateComment] = defineTool({

--- a/web/src/features/mcp/features/comments/tools/createComment.ts
+++ b/web/src/features/mcp/features/comments/tools/createComment.ts
@@ -14,12 +14,12 @@ const CreateCommentToolBaseSchema = z
     content: z.string().trim().min(1).max(5000),
     objectId: z.string(),
     objectType: z.enum(CommentObjectType),
+    authorUserId: z.string().optional(),
   })
   .strict();
 
 const CreateCommentToolSchema = PostCommentsV1Body.omit({
   projectId: true,
-  authorUserId: true,
 });
 
 export const [createCommentTool, handleCreateComment] = defineTool({

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -27,7 +27,9 @@ const APIComment = z
  */
 
 // POST /comments
-// Note: Public API does not process mentions or inline comment positioning
+// Note: Public API does not process mentions or inline comment positioning.
+// authorUserId is accepted for backwards compatibility but ignored: project API
+// keys are not a user identity, so the stored author is always null.
 export const PostCommentsV1Body = z
   .object({
     projectId: z.string(),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16569.preview.langfuse.com](https://pr-16569.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Project API keys are not a user identity. `POST /api/public/comments` previously persisted a client-supplied `authorUserId` after only checking organization membership, so a write key could attribute comments to any other org member in the dashboard.

This change ignores `authorUserId` on the public create path and stores no author unless the caller is a server-authenticated user (MCP session `userId`). The deprecated request field stays accepted by REST and MCP for backwards compatibility. GET still returns authors of comments created in the UI. Audit logs continue to record the real `apiKeyId`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Impacted packages

- `web` (public comments service, MCP createComment, API tests)
- `fern` (create comment request docs)

## Verification

- Required CI: `all-ci-passed` succeeded
- `pnpm run lint`: `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test src/__tests__/server/comments-api.servertest.ts`: `Tests  17 passed (17)`
- `pnpm --filter web run test src/__tests__/server/mcp-public-api-tools.servertest.ts`: `Tests  14 passed (14)`
- Preview commit `0f6e2af47db81755d2efb17453aacb5135902363`: POSTed a synthetic trace comment with `authorUserId: "spoof-preview-1787683330"`, then GET returned HTTP 200 with `authorUserId: null` (`verified: true`)

[Preview API verification showing supplied author ignored](https://cursor.com/agents/bc-1e46068b-ae1a-475a-8928-121605d3fa8c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview-comment-author-regression.png)

Skipped `pnpm run scan:client-bundle` locally because this is a server-only comments API change; CI's production web image build and client checks passed.

## Mandatory Tasks

- [x] Self-reviewed the code.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15594](https://linear.app/clickhouse/issue/LFE-15594/security-p4-public-comments-api-lets-api-keys-spoof-authoruserid)

<div><a href="https://cursor.com/agents/bc-1e46068b-ae1a-475a-8928-121605d3fa8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e46068b-ae1a-475a-8928-121605d3fa8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents project API keys from assigning arbitrary comment authors by deriving attribution only from server-established identity.
- Ignores client-supplied `authorUserId` on the public comments service.
- Removes author selection from the MCP create-comment tool and adds attribution-focused server tests.
- Updates Fern and generated OpenAPI documentation to describe the deprecated field.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The author-spoofing fix is sound, but the MCP schema should continue accepting and ignoring the deprecated field before merging to avoid breaking existing tool callers.

The strict MCP input schema now rejects a field that previously formed part of the advertised tool contract, even though the change promises backward-compatible acceptance.

**Files Needing Attention:** web/src/features/mcp/features/comments/tools/createComment.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/mcp/features/comments/tools/createComment.ts:20-23
**MCP schema rejects deprecated field**

When an existing MCP client sends the previously advertised `authorUserId`, the strict schema now treats it as an unknown field and returns `InvalidParams`, causing a formerly valid create-comment call to fail instead of creating an unattributed comment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): ignore client-supplied comment..."](https://github.com/langfuse/langfuse/commit/5a94c0a6e79cca1ea7b8697e0091df41618b74bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56773903)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)
- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)
- Knowledge Base — [Identity, access, and tenancy](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/identity-access-and-tenancy.md)
</details>


<!-- /greptile_comment -->