### PR TITLE
fix(web): keep short JSON lists collapsed by default

### DIFF
--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -4,6 +4,8 @@ import { type Row } from "@tanstack/react-table";
 import { urlRegex } from "@langfuse/shared";
 import {
   SMALL_ARRAY_THRESHOLD,
+  SMALL_OBJECT_THRESHOLD,
+  objectFitsInSingleRowPreview,
   type JsonTableRow,
 } from "@/src/components/table/utils/jsonExpansionUtils";
 import { classifyMediaValue } from "@/src/components/ui/media/mediaUtils";
@@ -36,7 +38,6 @@ export type MetadataFilterActions = {
 const MAX_STRING_LENGTH_FOR_LINK_DETECTION = 1500;
 export const MAX_CELL_DISPLAY_CHARS = 2000;
 const ARRAY_PREVIEW_ITEMS = 3;
-const OBJECT_PREVIEW_KEYS = 2;
 const MONO_TEXT_CLASSES = "font-mono text-xs wrap-break-word";
 const PREVIEW_TEXT_CLASSES = "italic text-gray-500 dark:text-gray-400";
 
@@ -100,7 +101,7 @@ function renderArrayValue(arr: unknown[]): JSX.Element {
           const obj = item as Record<string, unknown>;
           const keys = Object.keys(obj);
           if (keys.length === 0) return "{}";
-          if (keys.length <= OBJECT_PREVIEW_KEYS) {
+          if (keys.length <= SMALL_OBJECT_THRESHOLD) {
             const keyPreview = keys.map((k) => `"${k}": ...`).join(", ");
             return `{${keyPreview}}`;
           }
@@ -129,10 +130,29 @@ function renderArrayValue(arr: unknown[]): JSX.Element {
   );
 }
 
+function formatPreviewPrimitive(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === null) return "null";
+  return String(value);
+}
+
+function formatShortObjectPreview(obj: Record<string, unknown>): string | null {
+  if (!objectFitsInSingleRowPreview(obj)) return null;
+  const fields = Object.entries(obj).map(
+    ([key, field]) =>
+      `${JSON.stringify(key)}: ${formatPreviewPrimitive(field)}`,
+  );
+  return `{${fields.join(", ")}}`;
+}
+
 function renderObjectValue(obj: Record<string, unknown>): JSX.Element {
   const keys = Object.keys(obj);
   if (keys.length === 0) {
     return <span className={PREVIEW_TEXT_CLASSES}>empty object</span>;
+  }
+  const shortPreview = formatShortObjectPreview(obj);
+  if (shortPreview) {
+    return <span className={PREVIEW_TEXT_CLASSES}>{shortPreview}</span>;
   }
   return <span className={PREVIEW_TEXT_CLASSES}>{keys.length} items</span>;
 }
@@ -448,6 +468,14 @@ export const ValueCell = memo(
           };
         }
         case "object": {
+          const hasVisibleChildRows =
+            row.getIsExpanded() && row.subRows.length > 0;
+          if (hasVisibleChildRows) {
+            return {
+              content: null,
+              needsTruncation: false,
+            };
+          }
           const objectValue = value as Record<string, unknown>;
           // Objects always show previews, never truncate
           return {

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -95,7 +95,7 @@ function renderArrayValue(arr: unknown[]): JSX.Element {
     const displayItems = arr
       .map((item) => {
         const itemType = getValueType(item);
-        if (itemType === "string") return `"${String(item)}"`;
+        if (itemType === "string") return JSON.stringify(item);
         if (itemType === "object" && item !== null) {
           const obj = item as Record<string, unknown>;
           const keys = Object.keys(obj);
@@ -117,7 +117,7 @@ function renderArrayValue(arr: unknown[]): JSX.Element {
     .slice(0, ARRAY_PREVIEW_ITEMS)
     .map((item) => {
       const itemType = getValueType(item);
-      if (itemType === "string") return `"${String(item)}"`;
+      if (itemType === "string") return JSON.stringify(item);
       if (itemType === "object" || itemType === "array") return "...";
       return String(item);
     })
@@ -428,9 +428,13 @@ export const ValueCell = memo(
             needsTruncation: false,
           };
         case "array": {
-          // Expanded lists already show each item as a child row; repeating
-          // the same text in the parent preview is just noise.
-          if (row.getIsExpanded()) {
+          // Hide the parent preview only when expanded children are actually
+          // rendered. showNullValues={false} can filter every child out while
+          // leaving the expand chevron (hasChildren is computed on the raw
+          // array), and blanking the cell then loses the only remaining value.
+          const hasVisibleChildRows =
+            row.getIsExpanded() && row.subRows.length > 0;
+          if (hasVisibleChildRows) {
             return {
               content: null,
               needsTruncation: false,

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -2,7 +2,10 @@ import { memo, type JSX, useState } from "react";
 import { useRouter } from "next/router";
 import { type Row } from "@tanstack/react-table";
 import { urlRegex } from "@langfuse/shared";
-import { type JsonTableRow } from "@/src/components/table/utils/jsonExpansionUtils";
+import {
+  SMALL_ARRAY_THRESHOLD,
+  type JsonTableRow,
+} from "@/src/components/table/utils/jsonExpansionUtils";
 import { classifyMediaValue } from "@/src/components/ui/media/mediaUtils";
 import { MediaReferenceTag } from "@/src/components/ui/media/MediaReferenceTag";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
@@ -32,7 +35,6 @@ export type MetadataFilterActions = {
 
 const MAX_STRING_LENGTH_FOR_LINK_DETECTION = 1500;
 export const MAX_CELL_DISPLAY_CHARS = 2000;
-const SMALL_ARRAY_THRESHOLD = 5;
 const ARRAY_PREVIEW_ITEMS = 3;
 const OBJECT_PREVIEW_KEYS = 2;
 const MONO_TEXT_CLASSES = "font-mono text-xs wrap-break-word";
@@ -426,6 +428,14 @@ export const ValueCell = memo(
             needsTruncation: false,
           };
         case "array": {
+          // Expanded lists already show each item as a child row; repeating
+          // the same text in the parent preview is just noise.
+          if (row.getIsExpanded()) {
+            return {
+              content: null,
+              needsTruncation: false,
+            };
+          }
           const arrayValue = value as unknown[];
           // Arrays always show previews, never truncate
           return {

--- a/web/src/components/table/utils/jsonExpansionUtils.clienttest.ts
+++ b/web/src/components/table/utils/jsonExpansionUtils.clienttest.ts
@@ -1,7 +1,9 @@
 import {
   arrayFitsInSingleRowPreview,
   getSmartExpansionState,
+  objectFitsInSingleRowPreview,
   SMALL_ARRAY_THRESHOLD,
+  SMALL_OBJECT_THRESHOLD,
   transformJsonToTableData,
 } from "@/src/components/table/utils/jsonExpansionUtils";
 
@@ -49,11 +51,46 @@ describe("arrayFitsInSingleRowPreview", () => {
   });
 });
 
+describe("objectFitsInSingleRowPreview", () => {
+  it("is true for a short object of primitives", () => {
+    expect(objectFitsInSingleRowPreview({ name: "Ada" })).toBe(true);
+    expect(objectFitsInSingleRowPreview({ ok: true, n: 1 })).toBe(true);
+  });
+
+  it("is true at the preview size limit", () => {
+    const value = Object.fromEntries(
+      Array.from({ length: SMALL_OBJECT_THRESHOLD }, (_, i) => [`k${i}`, i]),
+    );
+    expect(objectFitsInSingleRowPreview(value)).toBe(true);
+  });
+
+  it("is false when the preview would omit fields or nest further", () => {
+    expect(objectFitsInSingleRowPreview({ a: 1, b: 2, c: 3 })).toBe(false);
+    expect(objectFitsInSingleRowPreview({ name: { first: "Ada" } })).toBe(
+      false,
+    );
+  });
+
+  it("is false for empty objects, arrays, and primitives", () => {
+    expect(objectFitsInSingleRowPreview({})).toBe(false);
+    expect(objectFitsInSingleRowPreview(["Ada"])).toBe(false);
+    expect(objectFitsInSingleRowPreview("Ada")).toBe(false);
+  });
+});
+
 describe("getSmartExpansionState", () => {
   it("does not expand a short primitive list whose preview already shows every item", () => {
     const rows = tableRows({
       brand: "Acme",
       channels: ["email", "paid_social"],
+    });
+
+    expect(getSmartExpansionState(rows, DEFAULT_MAX_ROWS)).toEqual({});
+  });
+
+  it("does not expand a short object whose preview already shows every field", () => {
+    const rows = tableRows({
+      user: { name: "Ada" },
     });
 
     expect(getSmartExpansionState(rows, DEFAULT_MAX_ROWS)).toEqual({});

--- a/web/src/components/table/utils/jsonExpansionUtils.clienttest.ts
+++ b/web/src/components/table/utils/jsonExpansionUtils.clienttest.ts
@@ -1,0 +1,94 @@
+import {
+  arrayFitsInSingleRowPreview,
+  getSmartExpansionState,
+  SMALL_ARRAY_THRESHOLD,
+  transformJsonToTableData,
+} from "@/src/components/table/utils/jsonExpansionUtils";
+
+const DEFAULT_MAX_ROWS = 20;
+
+/** Same lazy top-level shape PrettyJsonView uses for smart expansion. */
+const tableRows = (json: unknown) =>
+  transformJsonToTableData(json, "", 0, "", true);
+
+describe("arrayFitsInSingleRowPreview", () => {
+  it("is true for a short list of primitives", () => {
+    expect(arrayFitsInSingleRowPreview(["email", "paid_social"])).toBe(true);
+    expect(arrayFitsInSingleRowPreview([1, 2, 3])).toBe(true);
+    expect(arrayFitsInSingleRowPreview([true, null])).toBe(true);
+  });
+
+  it("is true at the preview size limit", () => {
+    expect(
+      arrayFitsInSingleRowPreview(
+        Array.from({ length: SMALL_ARRAY_THRESHOLD }, (_, i) => `item-${i}`),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when the preview would truncate", () => {
+    expect(
+      arrayFitsInSingleRowPreview(
+        Array.from(
+          { length: SMALL_ARRAY_THRESHOLD + 1 },
+          (_, i) => `item-${i}`,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for lists of objects or nested arrays", () => {
+    expect(arrayFitsInSingleRowPreview([{ name: "Ada" }])).toBe(false);
+    expect(arrayFitsInSingleRowPreview([[1, 2]])).toBe(false);
+  });
+
+  it("is false for empty arrays and non-arrays", () => {
+    expect(arrayFitsInSingleRowPreview([])).toBe(false);
+    expect(arrayFitsInSingleRowPreview({ a: 1 })).toBe(false);
+    expect(arrayFitsInSingleRowPreview("email")).toBe(false);
+  });
+});
+
+describe("getSmartExpansionState", () => {
+  it("does not expand a short primitive list whose preview already shows every item", () => {
+    const rows = tableRows({
+      brand: "Acme",
+      channels: ["email", "paid_social"],
+    });
+
+    expect(getSmartExpansionState(rows, DEFAULT_MAX_ROWS)).toEqual({});
+  });
+
+  it("still expands a list of objects whose preview is incomplete", () => {
+    const rows = tableRows({
+      users: [{ name: "Ada" }, { name: "Bob" }],
+    });
+
+    expect(getSmartExpansionState(rows, DEFAULT_MAX_ROWS)).toEqual({
+      users: true,
+    });
+  });
+
+  it("still expands a primitive list that does not fit in the single-row preview", () => {
+    const rows = tableRows({
+      tags: ["a", "b", "c", "d", "e", "f"],
+    });
+
+    expect(getSmartExpansionState(rows, DEFAULT_MAX_ROWS)).toEqual({
+      tags: true,
+    });
+  });
+
+  it("expands a nested object but leaves its short primitive list collapsed", () => {
+    const rows = tableRows({
+      config: {
+        theme: "dark",
+        channels: ["email", "paid_social"],
+      },
+    });
+
+    expect(getSmartExpansionState(rows, DEFAULT_MAX_ROWS)).toEqual({
+      config: true,
+    });
+  });
+});

--- a/web/src/components/table/utils/jsonExpansionUtils.ts
+++ b/web/src/components/table/utils/jsonExpansionUtils.ts
@@ -2,6 +2,11 @@
  * Utility functions for JSON expansion state management across traces
  */
 
+/** Arrays at or below this size show every item in the parent-row preview. */
+export const SMALL_ARRAY_THRESHOLD = 5;
+
+const DEEPEST_DEFAULT_EXPANSION_LEVEL = 10;
+
 // Convert row ID (e.g., "metadata-settings-theme") to key path (e.g., "metadata.settings.theme")
 export function convertRowIdToKeyPath(rowId: string): string {
   return rowId.replace(/-/g, ".");
@@ -62,6 +67,122 @@ function hasChildren(value: unknown, valueType: JsonTableRow["type"]): boolean {
       Object.keys(value as Record<string, unknown>).length > 0) ||
     (valueType === "array" && Array.isArray(value) && value.length > 0)
   );
+}
+
+function isPrimitiveJsonValue(value: unknown): boolean {
+  const type = getValueType(value);
+  return type !== "object" && type !== "array";
+}
+
+/**
+ * True when the table's single-row array preview already shows every item
+ * completely (a short list of primitives). Those lists should stay collapsed
+ * by default so the preview is not duplicated as child rows.
+ */
+export function arrayFitsInSingleRowPreview(value: unknown): boolean {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  if (value.length > SMALL_ARRAY_THRESHOLD) return false;
+  return value.every(isPrimitiveJsonValue);
+}
+
+function findOptimalExpansionLevel(
+  data: JsonTableRow[],
+  maxRows: number,
+): number {
+  if (data.length > maxRows) {
+    return 0;
+  }
+
+  function findOptimalRecursively(
+    rows: JsonTableRow[],
+    currentLevel: number,
+    cumulativeCount: number,
+    visitedData = new WeakSet(),
+  ): number {
+    const rowsAtThisLevel = rows.length;
+    const newCumulativeCount = cumulativeCount + rowsAtThisLevel;
+
+    if (newCumulativeCount > maxRows) {
+      return currentLevel - 1;
+    }
+
+    if (currentLevel >= DEEPEST_DEFAULT_EXPANSION_LEVEL) {
+      return currentLevel;
+    }
+
+    let childRows: JsonTableRow[] = [];
+
+    for (const row of rows) {
+      // Short primitive lists stay collapsed; don't spend the row budget on
+      // children the user will not see by default.
+      if (arrayFitsInSingleRowPreview(row.value)) continue;
+
+      if (row.hasChildren && row.rawChildData) {
+        if (typeof row.rawChildData !== "object" || row.rawChildData === null) {
+          continue;
+        }
+
+        if (visitedData.has(row.rawChildData)) {
+          continue;
+        }
+
+        visitedData.add(row.rawChildData);
+
+        const children = getRowChildren(row);
+        // Use concat instead of spread to avoid stack overflow with large arrays
+        childRows = childRows.concat(children);
+      }
+    }
+
+    if (childRows.length === 0) {
+      return currentLevel;
+    }
+
+    return findOptimalRecursively(
+      childRows,
+      currentLevel + 1,
+      newCumulativeCount,
+      visitedData,
+    );
+  }
+
+  return Math.max(0, findOptimalRecursively(data, 0, 0));
+}
+
+/**
+ * Default expand/collapse map for the pretty JSON table.
+ * Short primitive lists stay collapsed because their parent-row preview
+ * already shows the full contents.
+ */
+export function getSmartExpansionState(
+  data: JsonTableRow[],
+  maxRows: number,
+): Record<string, boolean> {
+  const optimalLevel = findOptimalExpansionLevel(data, maxRows);
+  if (optimalLevel <= 0) return {};
+
+  const smartExpanded: Record<string, boolean> = {};
+
+  const expandRowsToLevel = (rows: JsonTableRow[], currentLevel: number) => {
+    for (const row of rows) {
+      if (
+        !row.hasChildren ||
+        currentLevel >= optimalLevel ||
+        arrayFitsInSingleRowPreview(row.value)
+      ) {
+        continue;
+      }
+
+      smartExpanded[convertRowIdToKeyPath(row.id)] = true;
+      const children = getRowChildren(row);
+      if (children.length > 0) {
+        expandRowsToLevel(children, currentLevel + 1);
+      }
+    }
+  };
+
+  expandRowsToLevel(data, 0);
+  return smartExpanded;
 }
 
 export function transformJsonToTableData(

--- a/web/src/components/table/utils/jsonExpansionUtils.ts
+++ b/web/src/components/table/utils/jsonExpansionUtils.ts
@@ -5,6 +5,9 @@
 /** Arrays at or below this size show every item in the parent-row preview. */
 export const SMALL_ARRAY_THRESHOLD = 5;
 
+/** Objects at or below this many primitive fields show those fields inline. */
+export const SMALL_OBJECT_THRESHOLD = 2;
+
 const DEEPEST_DEFAULT_EXPANSION_LEVEL = 10;
 
 // Convert row ID (e.g., "metadata-settings-theme") to key path (e.g., "metadata.settings.theme")
@@ -85,6 +88,28 @@ export function arrayFitsInSingleRowPreview(value: unknown): boolean {
   return value.every(isPrimitiveJsonValue);
 }
 
+/**
+ * True when the table's single-row object preview already shows every field
+ * completely (a short object of primitives). Those objects should stay
+ * collapsed by default so the preview is not duplicated as child rows.
+ */
+export function objectFitsInSingleRowPreview(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0 || entries.length > SMALL_OBJECT_THRESHOLD) {
+    return false;
+  }
+  return entries.every(([, field]) => isPrimitiveJsonValue(field));
+}
+
+function valueFitsInSingleRowPreview(value: unknown): boolean {
+  return (
+    arrayFitsInSingleRowPreview(value) || objectFitsInSingleRowPreview(value)
+  );
+}
+
 function findOptimalExpansionLevel(
   data: JsonTableRow[],
   maxRows: number,
@@ -115,7 +140,7 @@ function findOptimalExpansionLevel(
     for (const row of rows) {
       // Short primitive lists stay collapsed; don't spend the row budget on
       // children the user will not see by default.
-      if (arrayFitsInSingleRowPreview(row.value)) continue;
+      if (valueFitsInSingleRowPreview(row.value)) continue;
 
       if (row.hasChildren && row.rawChildData) {
         if (typeof row.rawChildData !== "object" || row.rawChildData === null) {
@@ -151,8 +176,8 @@ function findOptimalExpansionLevel(
 
 /**
  * Default expand/collapse map for the pretty JSON table.
- * Short primitive lists stay collapsed because their parent-row preview
- * already shows the full contents.
+ * Short primitive lists and short primitive objects stay collapsed because
+ * their parent-row preview already shows the full contents.
  */
 export function getSmartExpansionState(
   data: JsonTableRow[],
@@ -168,7 +193,7 @@ export function getSmartExpansionState(
       if (
         !row.hasChildren ||
         currentLevel >= optimalLevel ||
-        arrayFitsInSingleRowPreview(row.value)
+        valueFitsInSingleRowPreview(row.value)
       ) {
         continue;
       }

--- a/web/src/components/ui/PrettyJsonView.expansion.clienttest.tsx
+++ b/web/src/components/ui/PrettyJsonView.expansion.clienttest.tsx
@@ -107,7 +107,7 @@ describe("PrettyJsonView short-list expansion", () => {
     expect(within(prettyTable()).getByText('["a\\"b"]')).toBeInTheDocument();
   });
 
-  it("still expands a short list of objects whose preview is incomplete", () => {
+  it("still expands a short list of objects and previews the collapsed object fields", () => {
     renderPrettyJson(
       <PrettyJsonView
         json={{
@@ -119,9 +119,36 @@ describe("PrettyJsonView short-list expansion", () => {
 
     const table = prettyTable();
     // The list itself expands so each object is a child row. Nested object
-    // keys stay collapsed (one-level smart expansion) and show "N items".
+    // keys stay collapsed; the object preview shows the short fields.
     expect(within(table).getByText("0")).toBeInTheDocument();
-    expect(within(table).getByText("1 items")).toBeInTheDocument();
+    expect(within(table).getByText('{"name": "Ada"}')).toBeInTheDocument();
+    expect(within(table).queryByText("1 items")).not.toBeInTheDocument();
     expect(within(table).queryByText("name")).not.toBeInTheDocument();
+  });
+
+  it("hides a short object preview after the user expands it", () => {
+    renderPrettyJson(
+      <PrettyJsonView
+        json={{
+          users: [{ name: "Ada" }],
+        }}
+        title="Input"
+      />,
+    );
+
+    const table = prettyTable();
+    const objectRow = within(table).getByText("0").closest("tr");
+    expect(objectRow).not.toBeNull();
+    const expandButton = within(objectRow as HTMLElement).getAllByRole(
+      "button",
+    )[0];
+    fireEvent.click(expandButton!);
+
+    const expandedTable = prettyTable();
+    expect(
+      within(expandedTable).queryByText('{"name": "Ada"}'),
+    ).not.toBeInTheDocument();
+    expect(within(expandedTable).getByText("name")).toBeInTheDocument();
+    expect(within(expandedTable).getByText('"Ada"')).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/PrettyJsonView.expansion.clienttest.tsx
+++ b/web/src/components/ui/PrettyJsonView.expansion.clienttest.tsx
@@ -68,6 +68,45 @@ describe("PrettyJsonView short-list expansion", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the parent preview when every expanded child is hidden", () => {
+    renderPrettyJson(
+      <PrettyJsonView
+        json={{
+          flags: [null, 0, ""],
+        }}
+        title="Input"
+        showNullValues={false}
+      />,
+    );
+
+    const table = prettyTable();
+    const flagsRow = within(table).getByText("flags").closest("tr");
+    expect(flagsRow).not.toBeNull();
+    const expandButton = within(flagsRow as HTMLElement).getAllByRole(
+      "button",
+    )[0];
+    fireEvent.click(expandButton!);
+
+    const expandedTable = prettyTable();
+    expect(
+      within(expandedTable).getByText('[null, 0, ""]'),
+    ).toBeInTheDocument();
+    expect(within(expandedTable).queryByText("null")).not.toBeInTheDocument();
+  });
+
+  it("escapes quotes in the collapsed list preview", () => {
+    renderPrettyJson(
+      <PrettyJsonView
+        json={{
+          quoted: ['a"b'],
+        }}
+        title="Input"
+      />,
+    );
+
+    expect(within(prettyTable()).getByText('["a\\"b"]')).toBeInTheDocument();
+  });
+
   it("still expands a short list of objects whose preview is incomplete", () => {
     renderPrettyJson(
       <PrettyJsonView

--- a/web/src/components/ui/PrettyJsonView.expansion.clienttest.tsx
+++ b/web/src/components/ui/PrettyJsonView.expansion.clienttest.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { type ReactNode } from "react";
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
+import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+
+function renderPrettyJson(ui: ReactNode) {
+  return render(<MarkdownContextProvider>{ui}</MarkdownContextProvider>);
+}
+
+function prettyTable() {
+  return screen.getByRole("table");
+}
+
+describe("PrettyJsonView short-list expansion", () => {
+  it("keeps a short primitive list collapsed so the preview is not duplicated", () => {
+    renderPrettyJson(
+      <PrettyJsonView
+        json={{
+          brand: "Acme",
+          channels: ["email", "paid_social"],
+        }}
+        title="Input"
+      />,
+    );
+
+    const table = prettyTable();
+    expect(within(table).getByText("channels")).toBeInTheDocument();
+    expect(
+      within(table).getByText('["email", "paid_social"]'),
+    ).toBeInTheDocument();
+    // Child index rows would repeat the same strings next to path 0 / 1.
+    expect(within(table).queryByText("0")).not.toBeInTheDocument();
+    expect(within(table).queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("hides the parent-row list preview after the user expands it", () => {
+    renderPrettyJson(
+      <PrettyJsonView
+        json={{
+          channels: ["email", "paid_social"],
+        }}
+        title="Input"
+      />,
+    );
+
+    const table = prettyTable();
+    const channelsRow = within(table).getByText("channels").closest("tr");
+    expect(channelsRow).not.toBeNull();
+    const expandButton = within(channelsRow as HTMLElement).getAllByRole(
+      "button",
+    )[0];
+    fireEvent.click(expandButton!);
+
+    const expandedTable = prettyTable();
+    expect(
+      within(expandedTable).queryByText('["email", "paid_social"]'),
+    ).not.toBeInTheDocument();
+    expect(within(expandedTable).getByText("0")).toBeInTheDocument();
+    expect(within(expandedTable).getByText("1")).toBeInTheDocument();
+    expect(within(expandedTable).getByText('"email"')).toBeInTheDocument();
+    expect(
+      within(expandedTable).getByText('"paid_social"'),
+    ).toBeInTheDocument();
+  });
+
+  it("still expands a short list of objects whose preview is incomplete", () => {
+    renderPrettyJson(
+      <PrettyJsonView
+        json={{
+          users: [{ name: "Ada" }],
+        }}
+        title="Input"
+      />,
+    );
+
+    const table = prettyTable();
+    // The list itself expands so each object is a child row. Nested object
+    // keys stay collapsed (one-level smart expansion) and show "N items".
+    expect(within(table).getByText("0")).toBeInTheDocument();
+    expect(within(table).getByText("1 items")).toBeInTheDocument();
+    expect(within(table).queryByText("name")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -51,7 +51,7 @@ import {
 import { useMarkdownRenderCharacterLimit } from "@/src/hooks/useMarkdownRenderCharacterLimit";
 import {
   convertRowIdToKeyPath,
-  getRowChildren,
+  getSmartExpansionState,
   type JsonTableRow,
   transformJsonToTableData,
 } from "@/src/components/table/utils/jsonExpansionUtils";
@@ -77,7 +77,6 @@ const DEFAULT_MAX_ROWS = 20;
 // Used for root-level objects where user has no parent to expand from. Therefore,
 // set higher to ensure objects like metadata with many keys are still displayed
 const DEFAULT_MAX_ROWS_IF_ROOT = 100;
-const DEEPEST_DEFAULT_EXPANSION_LEVEL = 10;
 
 const MAX_CELL_DISPLAY_CHARS = 2000;
 
@@ -267,70 +266,6 @@ function generateAllChildrenRecursively(
       generateAllChildrenRecursively(child, onRowGenerated);
     });
   }
-}
-
-function findOptimalExpansionLevel(
-  data: JsonTableRow[],
-  maxRows: number,
-): number {
-  if (data.length > maxRows) {
-    return 0;
-  }
-
-  function findOptimalRecursively(
-    rows: JsonTableRow[],
-    currentLevel: number,
-    cumulativeCount: number,
-    visitedData = new WeakSet(),
-  ): number {
-    const rowsAtThisLevel = rows.length;
-    const newCumulativeCount = cumulativeCount + rowsAtThisLevel;
-
-    // If expanding to this level exceeds maxRows, return previous level
-    if (newCumulativeCount > maxRows) {
-      return currentLevel - 1;
-    }
-
-    if (currentLevel >= DEEPEST_DEFAULT_EXPANSION_LEVEL) {
-      return currentLevel;
-    }
-
-    // Get all children for next level
-    let childRows: JsonTableRow[] = [];
-
-    for (const row of rows) {
-      if (row.hasChildren && row.rawChildData) {
-        if (typeof row.rawChildData !== "object" || row.rawChildData === null) {
-          continue; // Skip non-objects
-        }
-
-        // Skip if we've already processed this exact data to prevent cycles
-        if (visitedData.has(row.rawChildData)) {
-          continue;
-        }
-
-        // Mark data as visited
-        visitedData.add(row.rawChildData);
-
-        const children = getRowChildren(row);
-        // Use concat instead of spread to avoid stack overflow with large arrays
-        childRows = childRows.concat(children);
-      }
-    }
-
-    if (childRows.length === 0) {
-      return currentLevel;
-    }
-
-    return findOptimalRecursively(
-      childRows,
-      currentLevel + 1,
-      newCumulativeCount,
-      visitedData,
-    );
-  }
-
-  return Math.max(0, findOptimalRecursively(data, 0, 0));
 }
 
 function handleRowExpansion(
@@ -1037,37 +972,9 @@ export function PrettyJsonView(props: {
       return enhancedState;
     }
 
-    // No external state -> use smart expansion
-    const optimalLevel = findOptimalExpansionLevel(
-      baseTableData,
-      DEFAULT_MAX_ROWS,
-    );
-
-    if (optimalLevel > 0) {
-      const smartExpanded: ExpandedState = {};
-
-      const expandRowsToLevel = (
-        rows: JsonTableRow[],
-        currentLevel: number,
-      ) => {
-        rows.forEach((row) => {
-          if (row.hasChildren && currentLevel < optimalLevel) {
-            const keyPath = convertRowIdToKeyPath(row.id);
-            smartExpanded[keyPath] = true;
-
-            const children = getRowChildren(row);
-            if (children.length > 0) {
-              expandRowsToLevel(children, currentLevel + 1);
-            }
-          }
-        });
-      };
-      expandRowsToLevel(baseTableData, 0);
-
-      return smartExpanded;
-    }
-
-    return {};
+    // No external state -> use smart expansion. Short primitive lists stay
+    // collapsed because the parent-row preview already shows their contents.
+    return getSmartExpansionState(baseTableData, DEFAULT_MAX_ROWS);
   }, [baseTableData, props.externalExpansionState]);
 
   // actual expansion state used by the table (combines initial + user changes)


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16574.preview.langfuse.com](https://pr-16574.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The pretty JSON table default-expanded every short list, even when the parent-row preview already showed the full contents (`["email", "paid_social"]`). That duplicated the same text as child rows `0` / `1` and made compact payloads look messy.

This change:

- Leaves short primitive lists (≤5 items, no nested objects/arrays) collapsed on first render
- Hides the parent-row list/object preview once a row is expanded **and** at least one child row is actually rendered
- Keeps the parent preview if expansion would otherwise leave a blank cell (trace log view hides `null` / `""` / `0` children)
- Escapes quotes in the collapsed array preview (`["a\"b"]` instead of `["a"b"]`)
- Shows short object fields in the collapsed preview (`{"name": "Ada"}` instead of `1 items`)
- Still expands lists of objects and longer primitive lists whose preview is truncated

Impacted package: `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code

## Checklist

- Followed project style (`pnpm run format` via pre-commit)
- Added tests for default-expansion, filtered-child expansion, quote escaping, and short object previews
- Targeted client tests pass: `Tests 20 passed (20)`
- Pre-commit lint: `Tasks: 7 successful, 7 total`

## Test this

Preview: https://pr-16574.preview.langfuse.com

1. Open a trace whose input/output has a short string list (for example `channels: ["email", "paid_social"]`).
2. Confirm the list stays collapsed and only the single-row preview is visible.
3. Expand the row and confirm the preview disappears while child rows `0`, `1`, … appear.
4. Confirm a list of objects still expands by default, and each collapsed object row shows its short fields (for example `{"name": "Ada"}`) instead of `1 items`.
5. In a log view (`showNullValues=false`), expand a list of only `null` / `0` / `""` and confirm the parent preview stays visible.

Data: search the demo project traces for `short-list-preview`.

Sandbox: same path on `http://localhost:3000` after the cloud stack is up.

## Verification

```text
pnpm --filter web run test-client PrettyJsonView.expansion jsonExpansionUtils
# Tests 20 passed (20)

# pre-commit
# Tasks: 7 successful, 7 total
```

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15597](https://linear.app/clickhouse/issue/LFE-15597/in-json-renderer-if-lists-are-short-fit-in-single-row-preview-we)

<div><a href="https://cursor.com/agents/bc-6943d6d7-0683-4750-b825-ea96f8c5efa4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6943d6d7-0683-4750-b825-ea96f8c5efa4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes smart JSON-table expansion so short primitive arrays remain collapsed while longer or nested arrays still expand, and suppresses an array’s parent preview after expansion.

- Centralizes the short-array threshold and extracts reusable smart-expansion helpers.
- Adds unit and component coverage for default array expansion and parent-preview behavior.
- Newly relies on inline previews as the sole default representation of short arrays, exposing malformed previews for strings requiring escaping.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until short arrays containing strings that require escaping are rendered unambiguously in their collapsed default state.

The new default-collapse behavior makes the existing unescaped inline array preview the only initially visible representation, producing malformed JSON-like output for valid strings containing quotes.

**Files Needing Attention:** web/src/components/table/utils/jsonExpansionUtils.ts, web/src/components/table/ValueCell.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/utils/jsonExpansionUtils.ts:86
**Collapsed preview mangles quoted strings**

When a short array contains a string with embedded quotes, `arrayFitsInSingleRowPreview` keeps it collapsed while `renderArrayValue` wraps the unescaped content in quotes, causing valid input such as `["a\"b"]` to appear as malformed `["a"b"]` until manually expanded.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep short JSON lists collapse..."](https://github.com/langfuse/langfuse/commit/b384d17078ee6c38ef54a7c4d320244b54de735a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56852528)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->