### PR TITLE
fix(auth): rate-limit credentials login and signup

### DIFF
--- a/web/src/__tests__/server/unit/auth-handler-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/auth-handler-rate-limit.servertest.ts
@@ -67,6 +67,16 @@ vi.mock("@/src/ee/features/multi-tenant-sso/utils", () => ({
   getSsoAuthProviderIdForDomain: vi.fn(async () => null),
 }));
 
+vi.mock("@/src/features/auth/lib/signupSchema", () => ({
+  signupSchema: {
+    safeParse: (body: unknown) => ({ success: true, data: body }),
+  },
+}));
+
+vi.mock("@/src/features/auth/lib/signupAttribution", () => ({
+  getAdClickIdsFromRequest: () => undefined,
+}));
+
 import nextAuthHandler from "@/src/pages/api/auth/[...nextauth]";
 import { signupApiHandler } from "@/src/features/auth-credentials/server/signupApiHandler";
 

--- a/web/src/__tests__/server/unit/auth-handler-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/auth-handler-rate-limit.servertest.ts
@@ -1,0 +1,176 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+
+const {
+  mockApplyAuthRateLimit,
+  mockNextAuth,
+  mockGetAuthOptions,
+  mockCreateUserEmailPassword,
+} = vi.hoisted(() => ({
+  mockApplyAuthRateLimit: vi.fn(async () => false),
+  mockNextAuth: vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+    res.status(200).end();
+  }),
+  mockGetAuthOptions: vi.fn(async () => ({})),
+  mockCreateUserEmailPassword: vi.fn(async () => "user-id"),
+}));
+
+vi.mock("@/src/features/auth-credentials/server/authRateLimit", () => ({
+  applyAuthRateLimit: mockApplyAuthRateLimit,
+}));
+
+vi.mock("next-auth", () => ({ default: mockNextAuth }));
+
+vi.mock("@/src/server/auth", () => ({
+  getAuthOptions: mockGetAuthOptions,
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  redis: null,
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn(async () => undefined),
+    }),
+  },
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    NEXTAUTH_URL: "http://localhost:3000",
+    NEXT_PUBLIC_BASE_PATH: undefined,
+    NEXTAUTH_COOKIE_DOMAIN: undefined,
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+    NEXTAUTH_COOKIE_NAME_SUFFIX: undefined,
+    NEXT_PUBLIC_SIGN_UP_DISABLED: undefined,
+    AUTH_DISABLE_SIGNUP: undefined,
+    AUTH_DISABLE_USERNAME_PASSWORD: undefined,
+    AUTH_DOMAINS_WITH_SSO_ENFORCEMENT: undefined,
+    LANGFUSE_NEW_USER_SIGNUP_WEBHOOK: undefined,
+  },
+}));
+
+vi.mock("@/src/features/auth-credentials/lib/credentialsServerUtils", () => ({
+  createUserEmailPassword: mockCreateUserEmailPassword,
+}));
+
+vi.mock("@/src/features/auth-credentials/lib/credentialsUtils", () => ({
+  isEmailVerificationRequired: () => false,
+}));
+
+vi.mock("@/src/ee/features/multi-tenant-sso/utils", () => ({
+  getSsoAuthProviderIdForDomain: vi.fn(async () => null),
+}));
+
+import nextAuthHandler from "@/src/pages/api/auth/[...nextauth]";
+import { signupApiHandler } from "@/src/features/auth-credentials/server/signupApiHandler";
+
+describe("auth handlers apply rate limiting", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockApplyAuthRateLimit.mockResolvedValue(false);
+  });
+
+  it("rate-limits credentials login before NextAuth and skips NextAuth when limited", async () => {
+    mockApplyAuthRateLimit.mockImplementation(async (_req, res) => {
+      res
+        .status(429)
+        .json({ message: "Too many requests. Please retry in 3 seconds." });
+      return true;
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { nextauth: ["callback", "credentials"] },
+      body: { email: "user@example.com", password: "secret" },
+    });
+    await nextAuthHandler(req, res);
+
+    expect(mockApplyAuthRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "auth-login",
+    );
+    expect(res._getStatusCode()).toBe(429);
+    expect(mockNextAuth).not.toHaveBeenCalled();
+  });
+
+  it("passes credentials login through to NextAuth when not limited", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { nextauth: ["callback", "credentials"] },
+      body: { email: "user@example.com", password: "secret" },
+    });
+    await nextAuthHandler(req, res);
+
+    expect(mockApplyAuthRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "auth-login",
+    );
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not rate-limit non-credentials NextAuth routes", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { nextauth: ["session"] },
+    });
+    await nextAuthHandler(req, res);
+
+    expect(mockApplyAuthRateLimit).not.toHaveBeenCalled();
+    expect(mockNextAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("rate-limits signup before creating a user", async () => {
+    mockApplyAuthRateLimit.mockImplementation(async (_req, res) => {
+      res
+        .status(429)
+        .json({ message: "Too many requests. Please retry in 3 seconds." });
+      return true;
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        password: "Password1!",
+      },
+    });
+    await signupApiHandler(req, res);
+
+    expect(mockApplyAuthRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "auth-signup",
+    );
+    expect(res._getStatusCode()).toBe(429);
+    expect(mockCreateUserEmailPassword).not.toHaveBeenCalled();
+  });
+
+  it("creates a user when signup is not rate limited", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        password: "Password1!",
+      },
+    });
+    await signupApiHandler(req, res);
+
+    expect(mockApplyAuthRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "auth-signup",
+    );
+    expect(mockCreateUserEmailPassword).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+});

--- a/web/src/__tests__/server/unit/auth-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/auth-rate-limit.servertest.ts
@@ -125,6 +125,25 @@ describe("AuthRateLimitService", () => {
     ]);
   });
 
+  it("rate-limits signup by IP only so a spoofed email cannot lock out a victim", async () => {
+    const client = redis();
+    const hit = await AuthRateLimitService.getInstance(client).consume({
+      resource: "auth-signup",
+      ip: "203.0.113.10",
+      email: "victim@example.com",
+    });
+
+    expect(hit).toBeUndefined();
+    expect(mocks.options).toMatchObject([
+      {
+        keyPrefix: `${AUTH_RATE_LIMIT_REDIS_KEY_PREFIX}:auth-signup:ip`,
+        points: 10,
+        duration: 60 * 60,
+      },
+    ]);
+    expect(mocks.consume.mock.calls).toEqual([["203.0.113.10"]]);
+  });
+
   it("uses tighter signup buckets and fails open when Redis is unavailable", async () => {
     await AuthRateLimitService.getInstance(redis()).consume({
       resource: "auth-signup",

--- a/web/src/__tests__/server/unit/auth-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/auth-rate-limit.servertest.ts
@@ -3,12 +3,17 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 import { RateLimiterRes } from "rate-limiter-flexible";
 
-import { env } from "@/src/env.mjs";
-
-const mocks = vi.hoisted(() => ({
-  consume: vi.fn(),
-  options: [] as Array<Record<string, unknown>>,
+const { env, mocks } = vi.hoisted(() => ({
+  env: {
+    LANGFUSE_RATE_LIMITS_ENABLED: "true",
+  },
+  mocks: {
+    consume: vi.fn(),
+    options: [] as Array<Record<string, unknown>>,
+  },
 }));
+
+vi.mock("@/src/env.mjs", () => ({ env }));
 
 vi.mock("rate-limiter-flexible", () => {
   class MockRateLimiterRes {

--- a/web/src/__tests__/server/unit/auth-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/auth-rate-limit.servertest.ts
@@ -1,0 +1,233 @@
+import { createHash } from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { RateLimiterRes } from "rate-limiter-flexible";
+
+import { env } from "@/src/env.mjs";
+
+const mocks = vi.hoisted(() => ({
+  consume: vi.fn(),
+  options: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("rate-limiter-flexible", () => {
+  class MockRateLimiterRes {
+    remainingPoints = 0;
+    constructor(public msBeforeNext = 1000) {}
+  }
+
+  class MockRateLimiterRedis {
+    consume = mocks.consume;
+
+    constructor(options: Record<string, unknown>) {
+      mocks.options.push(options);
+    }
+  }
+
+  return {
+    RateLimiterRedis: MockRateLimiterRedis,
+    RateLimiterRes: MockRateLimiterRes,
+  };
+});
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  ClickHouseClientManager: {
+    getInstance: () => ({ closeAllConnections: vi.fn() }),
+  },
+  createNewRedisInstance: vi.fn(),
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  recordIncrement: vi.fn(),
+  redis: null,
+  redisQueueRetryOptions: {},
+}));
+
+import {
+  AUTH_RATE_LIMIT_REDIS_KEY_PREFIX,
+  AuthRateLimitService,
+  applyAuthRateLimit,
+  getEmailFromRequestBody,
+  getRequestIp,
+} from "@/src/features/auth-credentials/server/authRateLimit";
+
+describe("auth rate limiting helpers", () => {
+  it("reads the first x-forwarded-for hop, then x-real-ip", () => {
+    const { req: forwarded } = createMocks<NextApiRequest>({
+      headers: { "x-forwarded-for": "203.0.113.10, 10.0.0.1" },
+    });
+    expect(getRequestIp(forwarded)).toBe("203.0.113.10");
+
+    const { req: realIp } = createMocks<NextApiRequest>({
+      headers: { "x-real-ip": "198.51.100.7" },
+    });
+    expect(getRequestIp(realIp)).toBe("198.51.100.7");
+  });
+
+  it("normalizes emails from JSON bodies and ignores invalid values", () => {
+    expect(getEmailFromRequestBody({ email: "  User@Example.COM " })).toBe(
+      "user@example.com",
+    );
+    expect(getEmailFromRequestBody({ email: "not-an-email" })).toBeUndefined();
+    expect(getEmailFromRequestBody(undefined)).toBeUndefined();
+  });
+});
+
+describe("AuthRateLimitService", () => {
+  const originalRateLimitsEnabled = env.LANGFUSE_RATE_LIMITS_ENABLED;
+
+  const redis = () =>
+    ({
+      status: "ready",
+      disconnect: vi.fn(),
+    }) as any;
+
+  beforeEach(() => {
+    (env as any).LANGFUSE_RATE_LIMITS_ENABLED = "true";
+    AuthRateLimitService.shutdown();
+    mocks.consume.mockReset();
+    mocks.consume.mockResolvedValue({});
+    mocks.options.length = 0;
+  });
+
+  afterEach(() => {
+    (env as any).LANGFUSE_RATE_LIMITS_ENABLED = originalRateLimitsEnabled;
+    AuthRateLimitService.shutdown();
+  });
+
+  it("uses per-IP then hashed-email Redis buckets for login", async () => {
+    const client = redis();
+    const hit = await AuthRateLimitService.getInstance(client).consume({
+      resource: "auth-login",
+      ip: "203.0.113.10",
+      email: "user@example.com",
+    });
+
+    expect(hit).toBeUndefined();
+    expect(mocks.options).toMatchObject([
+      {
+        keyPrefix: `${AUTH_RATE_LIMIT_REDIS_KEY_PREFIX}:auth-login:ip`,
+        points: 30,
+        duration: 15 * 60,
+      },
+      {
+        keyPrefix: `${AUTH_RATE_LIMIT_REDIS_KEY_PREFIX}:auth-login:email`,
+        points: 10,
+        duration: 15 * 60,
+      },
+    ]);
+    expect(mocks.consume.mock.calls).toEqual([
+      ["203.0.113.10"],
+      [createHash("sha256").update("user@example.com").digest("hex")],
+    ]);
+  });
+
+  it("uses tighter signup buckets and fails open when Redis is unavailable", async () => {
+    await AuthRateLimitService.getInstance(redis()).consume({
+      resource: "auth-signup",
+      ip: "203.0.113.10",
+    });
+    expect(mocks.options).toMatchObject([
+      {
+        keyPrefix: `${AUTH_RATE_LIMIT_REDIS_KEY_PREFIX}:auth-signup:ip`,
+        points: 10,
+        duration: 60 * 60,
+      },
+    ]);
+
+    AuthRateLimitService.shutdown();
+    mocks.options.length = 0;
+    (env as any).LANGFUSE_RATE_LIMITS_ENABLED = "false";
+    await expect(
+      AuthRateLimitService.getInstance(null).consume({
+        resource: "auth-login",
+        ip: "203.0.113.10",
+      }),
+    ).resolves.toBeUndefined();
+    expect(mocks.options).toHaveLength(0);
+    (env as any).LANGFUSE_RATE_LIMITS_ENABLED = "true";
+
+    AuthRateLimitService.shutdown();
+    await expect(
+      AuthRateLimitService.getInstance(null).consume({
+        resource: "auth-login",
+        ip: "203.0.113.10",
+      }),
+    ).resolves.toBeUndefined();
+
+    AuthRateLimitService.shutdown();
+    mocks.consume.mockRejectedValueOnce(new Error("redis down"));
+    await expect(
+      AuthRateLimitService.getInstance(redis()).consume({
+        resource: "auth-login",
+        ip: "203.0.113.10",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns a rate-limit hit when the IP bucket is exhausted", async () => {
+    mocks.consume.mockRejectedValueOnce(new (RateLimiterRes as any)(4500));
+    const hit = await AuthRateLimitService.getInstance(redis()).consume({
+      resource: "auth-login",
+      ip: "203.0.113.10",
+      email: "user@example.com",
+    });
+
+    expect(hit).toMatchObject({
+      resource: "auth-login",
+      keyKind: "ip",
+      points: 30,
+      remainingPoints: 0,
+      msBeforeNext: 4500,
+    });
+    expect(mocks.consume).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("applyAuthRateLimit", () => {
+  const originalRateLimitsEnabled = env.LANGFUSE_RATE_LIMITS_ENABLED;
+
+  beforeEach(() => {
+    (env as any).LANGFUSE_RATE_LIMITS_ENABLED = "true";
+    AuthRateLimitService.shutdown();
+    mocks.consume.mockReset();
+    mocks.consume.mockResolvedValue({});
+    mocks.options.length = 0;
+  });
+
+  afterEach(() => {
+    (env as any).LANGFUSE_RATE_LIMITS_ENABLED = originalRateLimitsEnabled;
+    AuthRateLimitService.shutdown();
+  });
+
+  it("sends 429 with Retry-After when limited and otherwise allows the request", async () => {
+    const redis = {
+      status: "ready",
+      disconnect: vi.fn(),
+    } as any;
+    AuthRateLimitService.getInstance(redis);
+
+    const allowed = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      headers: { "x-forwarded-for": "203.0.113.10" },
+      body: { email: "user@example.com" },
+    });
+    await expect(
+      applyAuthRateLimit(allowed.req, allowed.res, "auth-login"),
+    ).resolves.toBe(false);
+    expect(allowed.res._getStatusCode()).toBe(200);
+
+    mocks.consume.mockRejectedValueOnce(new (RateLimiterRes as any)(2300));
+    const limited = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      headers: { "x-forwarded-for": "203.0.113.10" },
+      body: { email: "user@example.com" },
+    });
+    await expect(
+      applyAuthRateLimit(limited.req, limited.res, "auth-login"),
+    ).resolves.toBe(true);
+    expect(limited.res._getStatusCode()).toBe(429);
+    expect(limited.res.getHeader("Retry-After")).toBe(3);
+    expect(limited.res._getJSONData()).toEqual({
+      message: "Too many requests. Please retry in 3 seconds.",
+    });
+  });
+});

--- a/web/src/features/auth-credentials/server/authRateLimit.ts
+++ b/web/src/features/auth-credentials/server/authRateLimit.ts
@@ -1,0 +1,307 @@
+import { createHash } from "crypto";
+import { RateLimiterRedis, RateLimiterRes } from "rate-limiter-flexible";
+import { type Cluster, type Redis } from "ioredis";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { env } from "@/src/env.mjs";
+import { env as sharedEnv } from "@langfuse/shared/src/env";
+import {
+  createNewRedisInstance,
+  logger,
+  recordIncrement,
+  redisQueueRetryOptions,
+} from "@langfuse/shared/src/server";
+
+export const AUTH_RATE_LIMIT_REDIS_KEY_PREFIX = "rate-limit:auth";
+
+export type AuthRateLimitResource = "auth-login" | "auth-signup";
+
+const REDIS_RETRY_COOLDOWN_MS = 5_000;
+
+const AUTH_RATE_LIMITS: Record<
+  AuthRateLimitResource,
+  {
+    ip: { points: number; durationInSec: number };
+    email: { points: number; durationInSec: number };
+  }
+> = {
+  // Login is high-volume in shared NAT offices; keep IP generous and email tighter.
+  "auth-login": {
+    ip: { points: 30, durationInSec: 15 * 60 },
+    email: { points: 10, durationInSec: 15 * 60 },
+  },
+  // Signup is rare; tighter to stop dummy-account floods and email enumeration.
+  "auth-signup": {
+    ip: { points: 10, durationInSec: 60 * 60 },
+    email: { points: 5, durationInSec: 60 * 60 },
+  },
+};
+
+const redisStatus = (redis: Redis | Cluster) =>
+  "status" in redis ? redis.status : undefined;
+
+const getRetryAfterSeconds = (msBeforeNext: number | undefined) =>
+  Math.max(1, Math.ceil((msBeforeNext ?? 1000) / 1000));
+
+export const getRequestIp = (req: NextApiRequest): string => {
+  const forwarded = req.headers["x-forwarded-for"];
+  const forwardedValue = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+  const forwardedIp = forwardedValue?.split(",")[0]?.trim();
+  if (forwardedIp) {
+    return forwardedIp;
+  }
+
+  const realIpHeader = req.headers["x-real-ip"];
+  const realIp = Array.isArray(realIpHeader) ? realIpHeader[0] : realIpHeader;
+  if (realIp?.trim()) {
+    return realIp.trim();
+  }
+
+  const cfIpHeader = req.headers["cf-connecting-ip"];
+  const cfIp = Array.isArray(cfIpHeader) ? cfIpHeader[0] : cfIpHeader;
+  if (cfIp?.trim()) {
+    return cfIp.trim();
+  }
+
+  return req.socket?.remoteAddress ?? "unknown";
+};
+
+export const getEmailFromRequestBody = (body: unknown): string | undefined => {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return undefined;
+  }
+
+  const email = (body as Record<string, unknown>).email;
+  if (typeof email !== "string") {
+    return undefined;
+  }
+
+  const normalized = email.trim().toLowerCase();
+  return normalized.includes("@") ? normalized : undefined;
+};
+
+const hashEmail = (email: string) =>
+  createHash("sha256").update(email).digest("hex");
+
+type AuthRateLimitHit = {
+  resource: AuthRateLimitResource;
+  keyKind: "ip" | "email";
+  points: number;
+  remainingPoints: number;
+  msBeforeNext: number;
+};
+
+export class AuthRateLimitService {
+  private static instance: AuthRateLimitService | null = null;
+  private static redis: Redis | Cluster | null = null;
+
+  private redisUnavailableUntilMs = 0;
+  private redisConnectPromise: Promise<void> | null = null;
+
+  public static getInstance(redis?: Redis | Cluster | null) {
+    if (!AuthRateLimitService.instance || redis !== undefined) {
+      AuthRateLimitService.redis =
+        redis !== undefined
+          ? redis
+          : createNewRedisInstance({
+              keyPrefix: sharedEnv.REDIS_KEY_PREFIX ?? undefined,
+              enableAutoPipelining: false,
+              enableOfflineQueue: false,
+              lazyConnect: true,
+              ...redisQueueRetryOptions,
+            });
+      AuthRateLimitService.instance = new AuthRateLimitService();
+    }
+
+    return AuthRateLimitService.instance;
+  }
+
+  public static shutdown() {
+    const redis = AuthRateLimitService.redis;
+    if (redis && redisStatus(redis) !== "end") {
+      redis.disconnect();
+    }
+    AuthRateLimitService.redis = null;
+    AuthRateLimitService.instance = null;
+  }
+
+  public async consume(params: {
+    resource: AuthRateLimitResource;
+    ip: string;
+    email?: string;
+  }): Promise<AuthRateLimitHit | undefined> {
+    if (env.LANGFUSE_RATE_LIMITS_ENABLED === "false") {
+      return undefined;
+    }
+
+    const redis = AuthRateLimitService.redis;
+    if (!redis) {
+      this.allowBecauseRateLimitUnavailable(
+        params.resource,
+        "Redis is not configured for auth rate limiting",
+      );
+      return undefined;
+    }
+
+    if (Date.now() < this.redisUnavailableUntilMs) {
+      this.allowBecauseRateLimitUnavailable(
+        params.resource,
+        "Redis is temporarily unavailable",
+      );
+      return undefined;
+    }
+
+    try {
+      await this.ensureRedisReady(redis);
+    } catch (error) {
+      this.markRedisUnavailable(params.resource, error);
+      return undefined;
+    }
+
+    const limits = AUTH_RATE_LIMITS[params.resource];
+    const ipHit = await this.consumeLimiter({
+      redis,
+      resource: params.resource,
+      keyKind: "ip",
+      key: params.ip,
+      points: limits.ip.points,
+      durationInSec: limits.ip.durationInSec,
+    });
+    if (ipHit) {
+      return ipHit;
+    }
+
+    if (!params.email) {
+      return undefined;
+    }
+
+    return await this.consumeLimiter({
+      redis,
+      resource: params.resource,
+      keyKind: "email",
+      key: hashEmail(params.email),
+      points: limits.email.points,
+      durationInSec: limits.email.durationInSec,
+    });
+  }
+
+  private async ensureRedisReady(redis: Redis | Cluster) {
+    if (redisStatus(redis) === "ready") {
+      return;
+    }
+
+    this.redisConnectPromise ??= redis.connect().finally(() => {
+      this.redisConnectPromise = null;
+    });
+
+    await this.redisConnectPromise;
+  }
+
+  private async consumeLimiter(params: {
+    redis: Redis | Cluster;
+    resource: AuthRateLimitResource;
+    keyKind: "ip" | "email";
+    key: string;
+    points: number;
+    durationInSec: number;
+  }): Promise<AuthRateLimitHit | undefined> {
+    const limiter = new RateLimiterRedis({
+      storeClient: params.redis,
+      keyPrefix: `${AUTH_RATE_LIMIT_REDIS_KEY_PREFIX}:${params.resource}:${params.keyKind}`,
+      points: params.points,
+      duration: params.durationInSec,
+      rejectIfRedisNotReady: true,
+    });
+
+    try {
+      await limiter.consume(params.key);
+      return undefined;
+    } catch (error) {
+      if (error instanceof RateLimiterRes) {
+        recordIncrement("langfuse.rate_limit.exceeded", 1, {
+          resource: params.resource,
+          keyKind: params.keyKind,
+        });
+        return {
+          resource: params.resource,
+          keyKind: params.keyKind,
+          points: params.points,
+          remainingPoints: error.remainingPoints,
+          msBeforeNext: error.msBeforeNext,
+        };
+      }
+
+      this.markRedisUnavailable(params.resource, error);
+      return undefined;
+    }
+  }
+
+  private markRedisUnavailable(
+    resource: AuthRateLimitResource,
+    error: unknown,
+  ) {
+    this.redisUnavailableUntilMs = Date.now() + REDIS_RETRY_COOLDOWN_MS;
+    logger.warn("Auth rate limiter unavailable", {
+      resource,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    this.allowBecauseRateLimitUnavailable(
+      resource,
+      "Redis is temporarily unavailable",
+    );
+  }
+
+  private allowBecauseRateLimitUnavailable(
+    resource: AuthRateLimitResource,
+    reason: string,
+  ) {
+    logger.warn("Auth request allowed because rate limiting failed", {
+      resource,
+      reason,
+    });
+  }
+}
+
+const sendAuthRateLimitResponse = (
+  res: NextApiResponse,
+  hit: AuthRateLimitHit,
+) => {
+  const retryAfterSeconds = getRetryAfterSeconds(hit.msBeforeNext);
+  res.setHeader("Retry-After", retryAfterSeconds);
+  res.setHeader("X-RateLimit-Limit", hit.points);
+  res.setHeader("X-RateLimit-Remaining", Math.max(0, hit.remainingPoints));
+  res.status(429).json({
+    message: `Too many requests. Please retry in ${retryAfterSeconds} seconds.`,
+  });
+};
+
+/**
+ * Returns true when the request was rejected with 429.
+ * Fails open if Redis is unavailable so login/signup keep working.
+ */
+export async function applyAuthRateLimit(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  resource: AuthRateLimitResource,
+): Promise<boolean> {
+  try {
+    const hit = await AuthRateLimitService.getInstance().consume({
+      resource,
+      ip: getRequestIp(req),
+      email: getEmailFromRequestBody(req.body),
+    });
+
+    if (!hit) {
+      return false;
+    }
+
+    sendAuthRateLimitResponse(res, hit);
+    return true;
+  } catch (error) {
+    logger.warn("Auth rate limiting failed open", {
+      resource,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    return false;
+  }
+}

--- a/web/src/features/auth-credentials/server/authRateLimit.ts
+++ b/web/src/features/auth-credentials/server/authRateLimit.ts
@@ -4,7 +4,6 @@ import { type Cluster, type Redis } from "ioredis";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { env } from "@/src/env.mjs";
-import { env as sharedEnv } from "@langfuse/shared/src/env";
 import {
   createNewRedisInstance,
   logger,
@@ -104,7 +103,7 @@ export class AuthRateLimitService {
         redis !== undefined
           ? redis
           : createNewRedisInstance({
-              keyPrefix: sharedEnv.REDIS_KEY_PREFIX ?? undefined,
+              keyPrefix: process.env.REDIS_KEY_PREFIX ?? undefined,
               enableAutoPipelining: false,
               enableOfflineQueue: false,
               lazyConnect: true,

--- a/web/src/features/auth-credentials/server/authRateLimit.ts
+++ b/web/src/features/auth-credentials/server/authRateLimit.ts
@@ -21,7 +21,7 @@ const AUTH_RATE_LIMITS: Record<
   AuthRateLimitResource,
   {
     ip: { points: number; durationInSec: number };
-    email: { points: number; durationInSec: number };
+    email?: { points: number; durationInSec: number };
   }
 > = {
   // Login is high-volume in shared NAT offices; keep IP generous and email tighter.
@@ -29,10 +29,10 @@ const AUTH_RATE_LIMITS: Record<
     ip: { points: 30, durationInSec: 15 * 60 },
     email: { points: 10, durationInSec: 15 * 60 },
   },
-  // Signup is rare; tighter to stop dummy-account floods and email enumeration.
+  // Signup is unauthenticated: never key by email. An attacker can put a
+  // victim's address in the body and exhaust that bucket (429 for up to an hour).
   "auth-signup": {
     ip: { points: 10, durationInSec: 60 * 60 },
-    email: { points: 5, durationInSec: 60 * 60 },
   },
 };
 
@@ -170,7 +170,7 @@ export class AuthRateLimitService {
       return ipHit;
     }
 
-    if (!params.email) {
+    if (!params.email || !limits.email) {
       return undefined;
     }
 

--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -7,6 +7,7 @@ import { ENTERPRISE_SSO_REQUIRED_MESSAGE } from "@/src/features/auth/constants";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { logger } from "@langfuse/shared/src/server";
 import { isEmailVerificationRequired } from "@/src/features/auth-credentials/lib/credentialsUtils";
+import { applyAuthRateLimit } from "@/src/features/auth-credentials/server/authRateLimit";
 
 export function getSSOBlockedDomains() {
   return (
@@ -62,6 +63,10 @@ export async function signupApiHandler(
 ) {
   if (req.method !== "POST") {
     return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  if (await applyAuthRateLimit(req, res, "auth-signup")) {
+    return;
   }
 
   // Block direct signup when email verification is required

--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -3,6 +3,7 @@ import { getAdClickIdsFromRequest } from "@/src/features/auth/lib/signupAttribut
 import { getCookieName } from "@/src/server/utils/cookies";
 import { isValidCallbackUrl } from "@/src/server/utils/nextAuthCallbackUrl";
 import { env } from "@/src/env.mjs";
+import { applyAuthRateLimit } from "@/src/features/auth-credentials/server/authRateLimit";
 import { logger } from "@langfuse/shared/src/server";
 import type { NextApiRequest, NextApiResponse } from "next";
 import NextAuth from "next-auth";
@@ -82,6 +83,12 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
     );
     res.setHeader("Allow", "POST");
     return res.status(405).json({ message: "Method Not Allowed" });
+  }
+  if (
+    isCredentialsCallback &&
+    (await applyAuthRateLimit(req, res, "auth-login"))
+  ) {
+    return;
   }
 
   // next-auth rejects malformed callbackUrl values (query param or cookie)


### PR DESCRIPTION
## What does this PR do?

Fixes #16501.

Signup (`POST /api/auth/signup`) and the NextAuth credentials callback (`POST /api/auth/callback/credentials`) had no application-level rate limiting. Public REST routes already throttle via `RateLimitService`, but that helper is org-scoped and **disabled for self-hosted** (`NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` unset), so it cannot protect these unauthenticated auth paths.

This adds a dedicated Redis limiter (`AuthRateLimitService`) keyed by client IP and hashed email:

| Resource | IP | Email |
| --- | --- | --- |
| `auth-login` | 30 / 15 min | 10 / 15 min |
| `auth-signup` | 10 / hour | 5 / hour |

Behavior:

- Runs **before** user creation and **before** NextAuth on credentials POST only (other NextAuth routes are unchanged).
- Returns `429` with `Retry-After` when a bucket is exhausted.
- **Fails open** if Redis is missing, not ready, or `LANGFUSE_RATE_LIMITS_ENABLED=false`, matching the other web limiters.
- Applies on self-hosted **and** cloud whenever Redis is available.

The suggested `RateLimitService` + fake `projectId` pattern is not used: it would no-op on self-hosted (the deployments this issue calls out).

**Does this hide a real error?** No. Valid logins/signups under the cap are unchanged. Exhausted buckets get 429 instead of proceeding to bcrypt/Prisma.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Targeted server-unit tests for limiter buckets, fail-open, 429 responses, and handler wiring
- Pre-commit format on touched files (`prettier --write` on the 5 files)

## Impacted packages

- `web`

## Verification

- `pnpm exec vitest run --project server-unit src/__tests__/server/unit/auth-rate-limit.servertest.ts src/__tests__/server/unit/auth-handler-rate-limit.servertest.ts` — Tests 11 passed (11)
- `pnpm exec vitest run --project server-unit src/__tests__/server/unit/nextauth-invalid-callback-url.servertest.ts` — Tests 19 passed (19)
- `NEXTAUTH_URL=http://localhost:3000 pnpm exec vitest run --project server-unit src/__tests__/server/unit/next-auth-route-malformed-input.servertest.ts` — Tests 11 passed (11)

Skipped: full-package typecheck/lint (auth-only change); live brute-force against a running stack (unit tests cover the 429 and fail-open paths). Happy-path login/signup is unchanged under the cap.

## What to doubt in review

- Limits are guesses (login 30/15m per IP so shared NAT offices are not locked out; signup is tighter). Tell me if cloud/self-hosted should differ or if these should be env-configurable.
- IP is taken from `x-forwarded-for` (first hop), then `x-real-ip`, then `cf-connecting-ip`. Spoofable if a self-hosted proxy does not overwrite that header.
- Email keys are SHA-256 of the normalized address so Redis does not store raw emails. Empty/invalid bodies only consume the IP bucket.
- Credentials rate limiting is a pre-handler around NextAuth, not inside `authorize()`, so it cannot distinguish failed vs successful logins (successful attempts still count). That is intentional for brute-force protection.
- `RateLimitService` is still unused here on purpose (self-hosted no-op).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces Redis-backed, fail-open rate limiting for credentials login and signup, using separate IP and hashed-email buckets.
- Applies throttling before the signup and NextAuth credentials handlers.
- Returns 429 responses with retry and quota headers when a bucket is exhausted.
- Adds focused unit coverage for limiter behavior, Redis failures, and handler wiring.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until unauthenticated signup requests can no longer exhaust a victim-controlled email bucket before validation or ownership checks.

Any caller can submit a victim's email five times to the public signup endpoint, causing the victim's legitimate request to receive 429 for up to an hour before signup processing begins.

**Files Needing Attention:** web/src/features/auth-credentials/server/signupApiHandler.ts, web/src/features/auth-credentials/server/authRateLimit.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

The signup email bucket can be exhausted by any unauthenticated caller before request validation or account checks, allowing an attacker to block a victim's legitimate signup for up to an hour.
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Client
  participant H as Auth handler
  participant L as Auth rate limiter
  participant R as Redis
  participant A as Signup or NextAuth
  C->>H: Authentication request
  H->>L: IP and normalized email
  L->>R: Consume IP bucket
  alt IP exhausted
    R-->>L: Rate-limit hit
    L-->>C: 429 with Retry-After
  else IP allowed
    L->>R: Consume hashed-email bucket
    alt Email exhausted
      R-->>L: Rate-limit hit
      L-->>C: 429 with Retry-After
    else Allowed or Redis unavailable
      L-->>H: Continue
      H->>A: Process authentication
    end
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/auth-credentials/server/signupApiHandler.ts:65-68
**Attacker-controlled signup bucket**

When an attacker submits five signup requests containing a victim's email, the limiter consumes the shared email bucket before request validation or account checks, causing the victim's legitimate signup to receive `429` with `Retry-After` for up to an hour.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(auth): isolate auth rate-limit unit..."](https://github.com/langfuse/langfuse/commit/3e6c99041fcce2ad2b20538742b3bf09a99bc8d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56962957)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)

<!-- /greptile_comment -->