### PR TITLE
fix(notifications): retry failed comment-mention emails without duplicates

### DIFF
--- a/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.test.ts
+++ b/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSendMail, mockCreateMailTransport } = vi.hoisted(() => {
+  const mockSendMail = vi.fn();
+  return {
+    mockSendMail,
+    mockCreateMailTransport: vi.fn(() => ({ sendMail: mockSendMail })),
+  };
+});
+
+vi.mock("../transport", () => ({
+  createMailTransport: mockCreateMailTransport,
+}));
+
+vi.mock("@react-email/render", () => ({
+  render: vi.fn(async () => "<html>mention</html>"),
+}));
+
+vi.mock("./CommentMentionEmailTemplate", () => ({
+  CommentMentionEmailTemplate: vi.fn(() => null),
+}));
+
+vi.mock("../../../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { sendCommentMentionEmail } from "./sendCommentMentionEmail";
+
+const params = {
+  env: {
+    EMAIL_FROM_ADDRESS: "noreply@example.com",
+    SMTP_CONNECTION_URL: "smtp://localhost",
+  },
+  mentionedUserName: "Ada",
+  mentionedUserEmail: "ada@example.com",
+  authorName: "Bob",
+  projectName: "Demo",
+  commentPreview: "hello",
+  commentLink: "https://example.com/comment",
+  settingsLink: "https://example.com/settings",
+};
+
+describe("sendCommentMentionEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendMail.mockResolvedValue({});
+    mockCreateMailTransport.mockReturnValue({ sendMail: mockSendMail });
+  });
+
+  it("returns delivered:true after sendMail succeeds", async () => {
+    await expect(sendCommentMentionEmail(params)).resolves.toEqual({
+      delivered: true,
+    });
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns delivered:false when SMTP env is missing", async () => {
+    await expect(
+      sendCommentMentionEmail({
+        ...params,
+        env: {},
+      }),
+    ).resolves.toEqual({ delivered: false });
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+
+  it("rethrows SMTP failures so the mention job can retry", async () => {
+    mockSendMail.mockRejectedValue(new Error("smtp timeout"));
+    await expect(sendCommentMentionEmail(params)).rejects.toThrow(
+      "smtp timeout",
+    );
+  });
+});

--- a/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.ts
+++ b/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.ts
@@ -27,10 +27,10 @@ export const sendCommentMentionEmail = async ({
   commentPreview,
   commentLink,
   settingsLink,
-}: SendCommentMentionEmailParams) => {
+}: SendCommentMentionEmailParams): Promise<{ delivered: boolean }> => {
   if (!env.EMAIL_FROM_ADDRESS || !env.SMTP_CONNECTION_URL) {
     logger.error("Missing environment variables for sending email.");
-    return;
+    return { delivered: false };
   }
 
   try {
@@ -70,7 +70,9 @@ export const sendCommentMentionEmail = async ({
     });
 
     logger.info("Comment mention email sent successfully");
+    return { delivered: true };
   } catch (error) {
     logger.error("Failed to send comment mention email", error);
+    throw error;
   }
 };

--- a/worker/src/features/notifications/commentMentionHandler.test.ts
+++ b/worker/src/features/notifications/commentMentionHandler.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedis, mockSendCommentMentionEmail, mockGetUserProjectRoles } =
+  vi.hoisted(() => ({
+    mockRedis: {
+      exists: vi.fn(),
+      set: vi.fn(),
+    },
+    mockSendCommentMentionEmail: vi.fn(),
+    mockGetUserProjectRoles: vi.fn(),
+  }));
+
+vi.mock("../../env", () => ({
+  env: {
+    NEXTAUTH_URL: "http://localhost:3000",
+    EMAIL_FROM_ADDRESS: "noreply@example.com",
+    SMTP_CONNECTION_URL: "smtp://localhost",
+  },
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  Prisma: { empty: {} },
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    comment: {
+      findFirst: vi.fn(),
+    },
+    notificationPreference: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  redis: mockRedis,
+  sendCommentMentionEmail: mockSendCommentMentionEmail,
+  getObservationById: vi.fn(),
+  getUserProjectRoles: mockGetUserProjectRoles,
+}));
+
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  commentMentionSentRedisKey,
+  COMMENT_MENTION_SENT_TTL_SECONDS,
+  handleCommentMentionNotification,
+} from "./commentMentionHandler";
+
+const commentId = "comment-1";
+const projectId = "project-1";
+const userA = "user-a";
+const userB = "user-b";
+
+const commentRow = {
+  id: commentId,
+  projectId,
+  objectType: "TRACE",
+  objectId: "trace-1",
+  content: "Hey @[Ada](user:user-a) and @[Bob](user:user-b)",
+  authorUserId: "author-1",
+  project: { id: projectId, name: "Demo", orgId: "org-1" },
+};
+
+const projectUser = (id: string, email: string) => ({
+  id,
+  name: id,
+  email,
+});
+
+describe("handleCommentMentionNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedis.exists.mockResolvedValue(0);
+    mockRedis.set.mockResolvedValue("OK");
+    mockSendCommentMentionEmail.mockResolvedValue({ delivered: true });
+    (
+      prisma.notificationPreference.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
+    (prisma.comment.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      commentRow,
+    );
+    mockGetUserProjectRoles.mockResolvedValue([
+      projectUser(userA, "a@example.com"),
+      projectUser(userB, "b@example.com"),
+      projectUser("author-1", "author@example.com"),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends to every mentioned user and marks each send in Redis", async () => {
+    await handleCommentMentionNotification({
+      commentId,
+      projectId,
+      mentionedUserIds: [userA, userB],
+    });
+
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      commentMentionSentRedisKey(commentId, userA),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      commentMentionSentRedisKey(commentId, userB),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+  });
+
+  it("throws after the loop when one recipient fails so BullMQ can retry", async () => {
+    mockSendCommentMentionEmail.mockImplementation(
+      async ({ mentionedUserEmail }: { mentionedUserEmail: string }) => {
+        if (mentionedUserEmail === "a@example.com") {
+          throw new Error("smtp timeout");
+        }
+        return { delivered: true };
+      },
+    );
+
+    await expect(
+      handleCommentMentionNotification({
+        commentId,
+        projectId,
+        mentionedUserIds: [userA, userB],
+      }),
+    ).rejects.toThrow(/user-a/);
+
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
+    expect(mockRedis.set).toHaveBeenCalledTimes(1);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      commentMentionSentRedisKey(commentId, userB),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+  });
+
+  it("skips recipients that already have a sent marker on redelivery", async () => {
+    mockRedis.exists.mockImplementation(async (key: string) =>
+      key === commentMentionSentRedisKey(commentId, userA) ? 1 : 0,
+    );
+
+    await handleCommentMentionNotification({
+      commentId,
+      projectId,
+      mentionedUserIds: [userA, userB],
+    });
+
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ mentionedUserEmail: "b@example.com" }),
+    );
+  });
+});

--- a/worker/src/features/notifications/commentMentionHandler.ts
+++ b/worker/src/features/notifications/commentMentionHandler.ts
@@ -3,6 +3,7 @@ import {
   logger,
   sendCommentMentionEmail,
   getObservationById,
+  redis,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Prisma } from "@langfuse/shared";
@@ -13,6 +14,53 @@ type CommentMentionPayload = Omit<
   Extract<NotificationEventType, { type: "COMMENT_MENTION" }>,
   "type"
 >;
+
+export const COMMENT_MENTION_SENT_TTL_SECONDS = 60 * 60 * 24 * 14;
+
+export const commentMentionSentRedisKey = (commentId: string, userId: string) =>
+  `comment-mention-sent:${commentId}:${userId}`;
+
+async function hasCommentMentionEmailBeenSent(
+  commentId: string,
+  userId: string,
+): Promise<boolean> {
+  if (!redis) {
+    return false;
+  }
+
+  try {
+    return (
+      (await redis.exists(commentMentionSentRedisKey(commentId, userId))) === 1
+    );
+  } catch (error) {
+    logger.warn(
+      "Failed to read comment mention sent marker; proceeding to send",
+      { commentId, userId, error },
+    );
+    return false;
+  }
+}
+
+async function markCommentMentionEmailSent(commentId: string, userId: string) {
+  if (!redis) {
+    return;
+  }
+
+  try {
+    await redis.set(
+      commentMentionSentRedisKey(commentId, userId),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+  } catch (error) {
+    logger.warn("Failed to persist comment mention sent marker", {
+      commentId,
+      userId,
+      error,
+    });
+  }
+}
 
 async function buildCommentLink(opts: {
   baseUrl: string;
@@ -137,7 +185,11 @@ export async function handleCommentMentionNotification(
       return truncated.replace(/@\[([^\]]+)\]\(user:[^)]+\)/g, "@$1");
     })();
 
-    // Process each mentioned user
+    // Process each mentioned user. Per-user failures are collected so the rest
+    // of the loop can finish; the job then throws so BullMQ retries only the
+    // recipients that were not marked sent.
+    const failedUserIds: string[] = [];
+
     for (const userId of mentionedUserIds) {
       try {
         // Verify user has access to the project (from our single query above)
@@ -176,6 +228,13 @@ export async function handleCommentMentionNotification(
           continue;
         }
 
+        if (await hasCommentMentionEmailBeenSent(commentId, userId)) {
+          logger.info(
+            `Comment mention email already sent for comment ${commentId} to user ${userId}. Skipping.`,
+          );
+          continue;
+        }
+
         // Construct comment link using NEXTAUTH_URL (which includes basePath if configured)
         const baseUrl = env.NEXTAUTH_URL || "http://localhost:3000";
 
@@ -196,8 +255,7 @@ export async function handleCommentMentionNotification(
 
         const settingsLink = `${baseUrl}/project/${encodeURIComponent(projectId)}/settings/notifications`;
 
-        // Send email
-        await sendCommentMentionEmail({
+        const { delivered } = await sendCommentMentionEmail({
           env: {
             EMAIL_FROM_ADDRESS: env.EMAIL_FROM_ADDRESS,
             SMTP_CONNECTION_URL: env.SMTP_CONNECTION_URL,
@@ -211,16 +269,25 @@ export async function handleCommentMentionNotification(
           settingsLink,
         });
 
-        logger.info(
-          `Comment mention email sent successfully for comment ${commentId} to user ${userId}`,
-        );
+        if (delivered) {
+          await markCommentMentionEmailSent(commentId, userId);
+          logger.info(
+            `Comment mention email sent successfully for comment ${commentId} to user ${userId}`,
+          );
+        }
       } catch (error) {
         logger.error(
           `Failed to send comment mention notification to user ${userId}`,
           error,
         );
-        // Continue processing other users even if one fails
+        failedUserIds.push(userId);
       }
+    }
+
+    if (failedUserIds.length > 0) {
+      throw new Error(
+        `Failed to send comment mention emails for comment ${commentId} to ${failedUserIds.length} user(s): ${failedUserIds.join(", ")}`,
+      );
     }
 
     logger.info(


### PR DESCRIPTION
## What does this PR do?

Fixes #16497.

Comment-mention emails are sent in a per-user loop. The inner `catch` logged SMTP failures and continued, so the BullMQ job still completed. Combined with `NotificationQueue` `attempts: 5`, that was inconsistent:

1. **Silent loss** — user B succeeds, user A throws, job is green, A is never retried.
2. **Duplicates** — a worker crash / stall mid-loop redelivers the whole job, so users who already got the mail get it again.

`sendCommentMentionEmail` also swallowed errors, so even throwing from the handler would not have retried SMTP failures.

This change:

- Rethrows after logging in `sendCommentMentionEmail` (missing SMTP env still returns `{ delivered: false }` and does not fail the job — retries cannot fix missing config).
- Continues the loop so remaining recipients still get mail on this attempt.
- Throws after the loop if any recipient failed, so BullMQ's existing retry budget applies.
- Records a Redis sent marker (`comment-mention-sent:{commentId}:{userId}`, 14-day TTL) after a successful send, and skips those keys on redelivery.

Redis is used instead of a new `(commentId, userId)` table because this worker already requires Redis for the notification queue. A crash in the tiny window after SMTP success and before `SET` can still duplicate once; that is accepted over a schema migration for this path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Targeted unit tests for rethrow, partial-failure throw, and sent-marker skip
- Prettier on touched files

## Impacted packages

- `packages/shared`
- `worker`

## Verification

- `pnpm --filter @langfuse/shared exec vitest run src/server/services/email/commentMention/sendCommentMentionEmail.test.ts` — Tests 3 passed (3)
- `pnpm --filter worker exec vitest run src/features/notifications/commentMentionHandler.test.ts` — Tests 3 passed (3)

Skipped: live SMTP / SIGKILL redelivery against a running worker (unit tests cover the throw and skip paths).

## What to doubt in review

- Redis markers vs a durable unique row: a Redis flush or the post-send crash window can still duplicate. Say if you want the Prisma unique constraint from the issue instead.
- Missing SMTP env still completes the job without retry. Confirm that is preferred over failing closed.
- Successful sends still count toward the job even when a later recipient fails (then retry skips them). Confirm that is the intended partial-progress behavior.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes comment-mention transport failures retryable and adds recipient-level Redis markers to skip successful deliveries on redelivery.
- Returns an explicit delivery result and rethrows SMTP failures from the shared email sender.
- Collects recipient failures and fails the BullMQ job after processing the remaining recipients.
- Adds 14-day Redis sent markers and focused tests for retries and marker-based skips.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The Redis marker failure path should be fixed before merging because it can duplicate an email that was already delivered.

The retry design depends entirely on recipient sent markers, but both marker reads and writes fail open, allowing a successful SMTP side effect to be repeated when the job is redelivered.

**Files Needing Attention:** worker/src/features/notifications/commentMentionHandler.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  J[Comment mention job] --> R[Process recipient]
  R --> C{Sent marker exists?}
  C -->|Yes| S[Skip recipient]
  C -->|No| E[Send email]
  E -->|Failure| F[Record recipient failure]
  E -->|Success| M[Write Redis sent marker]
  M --> N[Process next recipient]
  F --> N
  N --> D{Any failures?}
  D -->|No| OK[Complete job]
  D -->|Yes| T[Throw and retry job]
  T --> J
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/notifications/commentMentionHandler.ts:55-61
**Sent markers fail open**

When SMTP delivery succeeds but the Redis marker write fails, this catch allows processing to continue without recording the delivery. If another recipient then fails and BullMQ retries the job, the unmarked recipient is sent the same email again; the marker-read catch has the same fail-open behavior when an existing marker cannot be read.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): retry failed comment..."](https://github.com/langfuse/langfuse/commit/113e38c86e8f0a7a8f0671bfab3a72d44b54fe6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56965412)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)
- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)

<!-- /greptile_comment -->