### PR TITLE
fix(models): show Test Model Match hits without usage details

### DIFF
--- a/web/src/__tests__/server/unit/evaluate-test-model-match.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluate-test-model-match.servertest.ts
@@ -8,6 +8,18 @@ vi.mock("@langfuse/shared/src/server", () => ({
   hasPricingTierUsageDetails: (usage?: Record<string, number>) =>
     Object.keys(usage ?? {}).length > 0,
   matchPricingTier: mockMatchPricingTier,
+  redis: null,
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn(async () => undefined),
+    }),
+  },
 }));
 
 import { evaluateTestModelMatch } from "@/src/features/models/server/evaluateTestModelMatch";

--- a/web/src/__tests__/server/unit/evaluate-test-model-match.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluate-test-model-match.servertest.ts
@@ -1,0 +1,86 @@
+import { Decimal } from "decimal.js";
+
+const { mockMatchPricingTier } = vi.hoisted(() => ({
+  mockMatchPricingTier: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  hasPricingTierUsageDetails: (usage?: Record<string, number>) =>
+    Object.keys(usage ?? {}).length > 0,
+  matchPricingTier: mockMatchPricingTier,
+}));
+
+import { evaluateTestModelMatch } from "@/src/features/models/server/evaluateTestModelMatch";
+
+const model = {
+  id: "model-1",
+  modelName: "ltx2",
+  matchPattern: "(?i)^(ltx2)$",
+  projectId: "project-1",
+};
+
+const defaultTier = {
+  id: "tier-default",
+  name: "Standard",
+  isDefault: true,
+  priority: 0,
+  conditions: [],
+  prices: [{ usageType: "seconds", price: new Decimal("0.01") }],
+};
+
+describe("evaluateTestModelMatch", () => {
+  beforeEach(() => {
+    mockMatchPricingTier.mockReset();
+  });
+
+  it("returns unmatched only when no model pattern matched", () => {
+    expect(
+      evaluateTestModelMatch({
+        model: null,
+        pricingTiers: [defaultTier],
+        usageDetails: { seconds: 1 },
+      }),
+    ).toEqual({ matched: false });
+  });
+
+  it("returns a model match without a tier when usage details are empty", () => {
+    expect(
+      evaluateTestModelMatch({
+        model,
+        pricingTiers: [defaultTier],
+        usageDetails: {},
+      }),
+    ).toEqual({
+      matched: true,
+      model,
+      matchedTier: null,
+    });
+    expect(mockMatchPricingTier).not.toHaveBeenCalled();
+  });
+
+  it("returns the matched pricing tier when usage details are present", () => {
+    mockMatchPricingTier.mockReturnValue({
+      pricingTierId: "tier-default",
+      pricingTierName: "Standard",
+      prices: { seconds: new Decimal("0.01") },
+    });
+
+    expect(
+      evaluateTestModelMatch({
+        model,
+        pricingTiers: [defaultTier],
+        usageDetails: { seconds: 20.424 },
+      }),
+    ).toEqual({
+      matched: true,
+      model,
+      matchedTier: {
+        id: "tier-default",
+        name: "Standard",
+        priority: 0,
+        isDefault: true,
+        prices: { seconds: 0.01 },
+      },
+    });
+  });
+});

--- a/web/src/features/models/components/test-match/TestModelMatchDialog.clienttest.tsx
+++ b/web/src/features/models/components/test-match/TestModelMatchDialog.clienttest.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    models: {
+      testMatch: {
+        useQuery: mockUseQuery,
+      },
+    },
+  },
+}));
+
+import { TestModelMatchDialog } from "./TestModelMatchDialog";
+
+const model = {
+  id: "model-1",
+  modelName: "ltx2",
+  matchPattern: "(?i)^(ltx2)$",
+  projectId: "project-1",
+};
+
+describe("TestModelMatchDialog", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("shows a model match when the pattern hits and usage is empty", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        matched: true,
+        model,
+        matchedTier: null,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <TestModelMatchDialog
+        projectId="project-1"
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. gpt-4-turbo"), {
+      target: { value: "ltx2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Test Match" }));
+
+    expect(screen.getByText("Model matched")).toBeInTheDocument();
+    expect(screen.getByText("ltx2")).toBeInTheDocument();
+    expect(screen.getByText("(?i)^(ltx2)$")).toBeInTheDocument();
+    expect(screen.getByText(/No pricing tier matched/i)).toBeInTheDocument();
+    expect(screen.queryByText("No Match Found")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/models/components/test-match/TestModelMatchDialog.tsx
+++ b/web/src/features/models/components/test-match/TestModelMatchDialog.tsx
@@ -88,8 +88,8 @@ export function TestModelMatchDialog({
           <DialogHeader>
             <DialogTitle>Test Model Match</DialogTitle>
             <DialogDescription className="mt-1">
-              Test which model and pricing tier your ingestion data would match
-              against.
+              Test which model definition your generation model name would
+              match. Add usage details to also see the pricing tier and prices.
             </DialogDescription>
           </DialogHeader>
 
@@ -181,11 +181,19 @@ export function TestModelMatchDialog({
                             <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-2.5 dark:border-green-900 dark:bg-green-950">
                               <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
                               <span className="text-sm font-bold text-green-900 dark:text-green-100">
-                                Match Found
+                                Model matched
                               </span>
                             </div>
                             <MatchedModelCard model={data.model} />
-                            <MatchedTierCard tier={data.matchedTier} />
+                            {data.matchedTier ? (
+                              <MatchedTierCard tier={data.matchedTier} />
+                            ) : (
+                              <div className="bg-muted/30 text-muted-foreground rounded-lg border p-4 text-sm">
+                                No pricing tier matched. Add usage details (same
+                                keys as on the generation) to see prices. Cost
+                                is not calculated without usage.
+                              </div>
+                            )}
                           </>
                         ) : (
                           <NoMatchDisplay modelName={modelName} />
@@ -201,7 +209,11 @@ export function TestModelMatchDialog({
                 <div className="border-t pt-4">
                   <Button variant="outline" asChild className="w-full">
                     <Link
-                      href={`/project/${projectId}/settings/models/${data.model.id}?pricingTier=${data.matchedTier.id}`}
+                      href={
+                        data.matchedTier
+                          ? `/project/${projectId}/settings/models/${data.model.id}?pricingTier=${data.matchedTier.id}`
+                          : `/project/${projectId}/settings/models/${data.model.id}`
+                      }
                       target="_blank"
                     >
                       View Model Details

--- a/web/src/features/models/server/evaluateTestModelMatch.ts
+++ b/web/src/features/models/server/evaluateTestModelMatch.ts
@@ -1,0 +1,91 @@
+import {
+  hasPricingTierUsageDetails,
+  matchPricingTier,
+  type PricingTierWithPrices,
+} from "@langfuse/shared/src/server";
+
+export type TestModelMatchModel = {
+  id: string;
+  modelName: string;
+  matchPattern: string;
+  projectId: string | null;
+};
+
+export type TestModelMatchTier = {
+  id: string;
+  name: string;
+  priority: number;
+  isDefault: boolean;
+  prices: Record<string, number>;
+};
+
+export type TestModelMatchResult =
+  | { matched: false }
+  | {
+      matched: true;
+      model: TestModelMatchModel;
+      matchedTier: TestModelMatchTier | null;
+    };
+
+const toModelPayload = (model: TestModelMatchModel): TestModelMatchModel => ({
+  id: model.id,
+  modelName: model.modelName,
+  matchPattern: model.matchPattern,
+  projectId: model.projectId,
+});
+
+const toTierPayload = (tier: PricingTierWithPrices): TestModelMatchTier => ({
+  id: tier.id,
+  name: tier.name,
+  priority: tier.priority,
+  isDefault: tier.isDefault,
+  prices: Object.fromEntries(
+    tier.prices.map((price) => [price.usageType, price.price.toNumber()]),
+  ),
+});
+
+/**
+ * Pattern match is independent of usage. Pricing tiers (and therefore cost)
+ * need usage details, matching ingestion. Returning matched:false when the
+ * pattern hit but usage was empty made Test Model Match look broken.
+ */
+export function evaluateTestModelMatch(params: {
+  model: TestModelMatchModel | null;
+  pricingTiers: PricingTierWithPrices[];
+  usageDetails?: Record<string, number>;
+  modelParameters?: Record<string, string>;
+  metadata?: Record<string, string>;
+}): TestModelMatchResult {
+  if (!params.model) {
+    return { matched: false };
+  }
+
+  const model = toModelPayload(params.model);
+
+  if (!hasPricingTierUsageDetails(params.usageDetails)) {
+    return { matched: true, model, matchedTier: null };
+  }
+
+  const matchResult = matchPricingTier(
+    params.pricingTiers,
+    params.usageDetails ?? {},
+    {
+      modelParameters: params.modelParameters,
+      metadata: params.metadata,
+    },
+  );
+
+  if (!matchResult) {
+    return { matched: true, model, matchedTier: null };
+  }
+
+  const matchedTier = params.pricingTiers.find(
+    (tier) => tier.id === matchResult.pricingTierId,
+  );
+
+  return {
+    matched: true,
+    model,
+    matchedTier: matchedTier ? toTierPayload(matchedTier) : null,
+  };
+}

--- a/web/src/server/api/routers/models.ts
+++ b/web/src/server/api/routers/models.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { evaluateTestModelMatch } from "@/src/features/models/server/evaluateTestModelMatch";
 import { isValidPostgresRegex } from "@/src/features/models/server/isValidPostgresRegex";
 import {
   GetModelResultSchema,
@@ -18,8 +19,6 @@ import {
   clearModelCacheForProject,
   queryClickhouse,
   findModel,
-  hasPricingTierUsageDetails,
-  matchPricingTier,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 
@@ -436,50 +435,19 @@ export const modelRouter = createTRPCRouter({
         model: modelName,
       });
 
-      if (!model) {
-        return { matched: false as const };
-      }
-
-      // Step 2: Mirror ingestion: without usage there is no priced observation
-      // and therefore no pricing tier match, even for attribute-only tiers.
-      if (!hasPricingTierUsageDetails(usageDetails)) {
-        return { matched: false as const };
-      }
-
-      const matchResult = matchPricingTier(pricingTiers, usageDetails ?? {}, {
+      return evaluateTestModelMatch({
+        model: model
+          ? {
+              id: model.id,
+              modelName: model.modelName,
+              matchPattern: model.matchPattern,
+              projectId: model.projectId,
+            }
+          : null,
+        pricingTiers,
+        usageDetails,
         modelParameters,
         metadata,
       });
-
-      if (!matchResult) {
-        return { matched: false as const };
-      }
-
-      // Step 3: Find the full tier details
-      const matchedTier = pricingTiers.find(
-        (t) => t.id === matchResult.pricingTierId,
-      );
-      if (!matchedTier) {
-        return { matched: false as const };
-      }
-
-      return {
-        matched: true as const,
-        model: {
-          id: model.id,
-          modelName: model.modelName,
-          matchPattern: model.matchPattern,
-          projectId: model.projectId,
-        },
-        matchedTier: {
-          id: matchedTier.id,
-          name: matchedTier.name,
-          priority: matchedTier.priority,
-          isDefault: matchedTier.isDefault,
-          prices: Object.fromEntries(
-            matchedTier.prices.map((p) => [p.usageType, p.price.toNumber()]),
-          ),
-        },
-      };
     }),
 });


### PR DESCRIPTION
## What does this PR do?

Fixes #16575 (Test Model Match UI).

Typing a model name that matches a `match_pattern` (e.g. `ltx2` against `(?i)^(ltx2)$`) still showed **No Match Found**. `models.testMatch` required non-empty usage details before treating anything as a match, so it returned `matched: false` even after `findModel` succeeded. The dialog only marks model name as required, so this is the path a user actually hits.

Pattern match and pricing-tier match are now separate:

- Pattern hit, no usage → show the model, explain that usage is needed for a tier/prices
- Pattern hit + usage → show model and tier
- No pattern hit → keep **No Match Found**

`(?i)^(ltx2)$` is unchanged. That is the same Postgres `~` flavor Langfuse default models use; it is not why the checker failed.

Ingestion/cost on traces is out of scope here. Cost still needs `provided_model_name` on the observation (flat OTel keys like `langfuse.observation.model.name`, not `attributes.*` metadata) and usage types that exist on the model.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Unit tests for empty usage vs missing model vs tier match
- Client test for the empty-usage success UI

## Impacted packages

- `web`

## Verification

- `pnpm exec vitest run --project server-unit src/__tests__/server/unit/evaluate-test-model-match.servertest.ts` — Tests 3 passed (3)
- `pnpm run test-client src/features/models/components/test-match/TestModelMatchDialog.clienttest.tsx` — Tests 1 passed (1)

Skipped: live UI against a saved `ltx2` model (no running web stack in this environment).

## What to doubt in review

- `matched: true` with `matchedTier: null` is a response-shape change. Confirm clients besides this dialog do not assume `matchedTier` is always present when `matched` is true (only this dialog consumes `testMatch`).
- Ingestion still skips pricing when usage is empty. The checker now reports the pattern hit instead of pretending the model did not match.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR separates model-pattern matching from pricing-tier evaluation so a recognized model can be shown even when usage details are absent.
- Adds a shared evaluator that returns a model match with a nullable pricing tier.
- Updates the dialog to render the model-only state and build a tier-optional details link.
- Adds server and client coverage for empty usage, missing models, and successful tier matching.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking import-organization issue in the new tests.

The nullable pricing-tier response is handled by the sole client consumer and remains aligned with the existing ingestion matching gate; only the test files violate the repository's import-placement convention.

**Files Needing Attention:** web/src/__tests__/server/unit/evaluate-test-model-match.servertest.ts; web/src/features/models/components/test-match/TestModelMatchDialog.clienttest.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/__tests__/server/unit/evaluate-test-model-match.servertest.ts:27
**Imports follow mock setup**

The module-under-test import appears after executable `vi.mock(...)` declarations here and in `TestModelMatchDialog.clienttest.tsx`, violating the repository convention that imports remain at the top and making dependencies less consistently discoverable.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(models): stub shared teardown expor..."](https://github.com/langfuse/langfuse/commit/6b1e383c0b1c3fff9987b68d24023f62e7e5f67c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56969162)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->