### PR TITLE
fix(notifications): persist comment-mention email sends in Postgres

### DIFF
--- a/packages/shared/prisma/migrations/20260826123000_add_comment_mention_emails/migration.sql
+++ b/packages/shared/prisma/migrations/20260826123000_add_comment_mention_emails/migration.sql
@@ -1,0 +1,17 @@
+-- Durable idempotency for comment-mention emails.
+-- Unique (comment_id, user_id) so BullMQ redeliveries do not send twice
+-- when Redis is unavailable or a sent marker write fails.
+CREATE TABLE "comment_mention_emails" (
+    "id" TEXT NOT NULL,
+    "comment_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "comment_mention_emails_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "comment_mention_emails_comment_id_user_id_key" ON "comment_mention_emails"("comment_id", "user_id");
+
+ALTER TABLE "comment_mention_emails" ADD CONSTRAINT "comment_mention_emails_comment_id_fkey" FOREIGN KEY ("comment_id") REFERENCES "comments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "comment_mention_emails" ADD CONSTRAINT "comment_mention_emails_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -75,6 +75,7 @@ model User {
   annotationQueueAssignment AnnotationQueueAssignment[]
   surveys                   Survey[]
   commentReactions          CommentReaction[]
+  commentMentionEmails      CommentMentionEmail[]
   notificationPreferences   NotificationPreference[]
   defaultViews              DefaultView[]               @relation("DefaultViewUser")
   inAppAgentConversations   InAppAgentConversation[]    @relation("InAppAgentConversationCreatedByUser")
@@ -655,6 +656,7 @@ model Comment {
   content      String
   authorUserId String?           @map("author_user_id") // no fk constraint, user can be deleted
   reactions    CommentReaction[]
+  mentionEmails CommentMentionEmail[]
 
   // Inline comment positioning (all must be set together or all null/empty)
   // dataField: which IO field the comment is on ('input' | 'output' | 'metadata')
@@ -682,6 +684,18 @@ model CommentReaction {
 
   @@unique([commentId, userId, emoji])
   @@map("comment_reactions")
+}
+
+model CommentMentionEmail {
+  id        String   @id @default(cuid())
+  commentId String   @map("comment_id")
+  comment   Comment  @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  userId    String   @map("user_id")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([commentId, userId])
+  @@map("comment_mention_emails")
 }
 
 enum CommentObjectType {

--- a/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.test.ts
+++ b/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSendMail, mockCreateMailTransport } = vi.hoisted(() => {
+  const mockSendMail = vi.fn();
+  return {
+    mockSendMail,
+    mockCreateMailTransport: vi.fn(() => ({ sendMail: mockSendMail })),
+  };
+});
+
+vi.mock("../transport", () => ({
+  createMailTransport: mockCreateMailTransport,
+}));
+
+vi.mock("@react-email/render", () => ({
+  render: vi.fn(async () => "<html>mention</html>"),
+}));
+
+vi.mock("./CommentMentionEmailTemplate", () => ({
+  CommentMentionEmailTemplate: vi.fn(() => null),
+}));
+
+vi.mock("../../../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { sendCommentMentionEmail } from "./sendCommentMentionEmail";
+
+const params = {
+  env: {
+    EMAIL_FROM_ADDRESS: "noreply@example.com",
+    SMTP_CONNECTION_URL: "smtp://localhost",
+  },
+  mentionedUserName: "Ada",
+  mentionedUserEmail: "ada@example.com",
+  authorName: "Bob",
+  projectName: "Demo",
+  commentPreview: "hello",
+  commentLink: "https://example.com/comment",
+  settingsLink: "https://example.com/settings",
+};
+
+describe("sendCommentMentionEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendMail.mockResolvedValue({});
+    mockCreateMailTransport.mockReturnValue({ sendMail: mockSendMail });
+  });
+
+  it("returns delivered:true after sendMail succeeds", async () => {
+    await expect(sendCommentMentionEmail(params)).resolves.toEqual({
+      delivered: true,
+    });
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns delivered:false when SMTP env is missing", async () => {
+    await expect(
+      sendCommentMentionEmail({
+        ...params,
+        env: {},
+      }),
+    ).resolves.toEqual({ delivered: false });
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+
+  it("rethrows SMTP failures so the mention job can retry", async () => {
+    mockSendMail.mockRejectedValue(new Error("smtp timeout"));
+    await expect(sendCommentMentionEmail(params)).rejects.toThrow(
+      "smtp timeout",
+    );
+  });
+});

--- a/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.ts
+++ b/packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.ts
@@ -27,10 +27,10 @@ export const sendCommentMentionEmail = async ({
   commentPreview,
   commentLink,
   settingsLink,
-}: SendCommentMentionEmailParams) => {
+}: SendCommentMentionEmailParams): Promise<{ delivered: boolean }> => {
   if (!env.EMAIL_FROM_ADDRESS || !env.SMTP_CONNECTION_URL) {
     logger.error("Missing environment variables for sending email.");
-    return;
+    return { delivered: false };
   }
 
   try {
@@ -70,7 +70,9 @@ export const sendCommentMentionEmail = async ({
     });
 
     logger.info("Comment mention email sent successfully");
+    return { delivered: true };
   } catch (error) {
     logger.error("Failed to send comment mention email", error);
+    throw error;
   }
 };

--- a/worker/src/features/notifications/commentMentionHandler.test.ts
+++ b/worker/src/features/notifications/commentMentionHandler.test.ts
@@ -28,8 +28,8 @@ vi.mock("@langfuse/shared/src/db", () => ({
       findUnique: vi.fn(),
     },
     commentMentionEmail: {
-      findUnique: vi.fn(),
       create: vi.fn(),
+      deleteMany: vi.fn(),
     },
   },
 }));
@@ -81,11 +81,11 @@ describe("handleCommentMentionNotification", () => {
       commentRow,
     );
     (
-      prisma.commentMentionEmail.findUnique as ReturnType<typeof vi.fn>
-    ).mockResolvedValue(null);
-    (
       prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
     ).mockResolvedValue({ id: "row-1" });
+    (
+      prisma.commentMentionEmail.deleteMany as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ count: 1 });
     mockGetUserProjectRoles.mockResolvedValue([
       projectUser(userA, "a@example.com"),
       projectUser(userB, "b@example.com"),
@@ -97,20 +97,28 @@ describe("handleCommentMentionNotification", () => {
     vi.clearAllMocks();
   });
 
-  it("sends to every mentioned user and records each send in Postgres", async () => {
+  it("claims the unique row before sending so concurrent jobs cannot both deliver", async () => {
     await handleCommentMentionNotification({
       commentId,
       projectId,
       mentionedUserIds: [userA, userB],
     });
 
-    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
+    expect(prisma.commentMentionEmail.create).toHaveBeenCalledTimes(2);
     expect(prisma.commentMentionEmail.create).toHaveBeenCalledWith({
       data: { commentId, userId: userA },
     });
     expect(prisma.commentMentionEmail.create).toHaveBeenCalledWith({
       data: { commentId, userId: userB },
     });
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
+    expect(prisma.commentMentionEmail.deleteMany).not.toHaveBeenCalled();
+
+    const createOrder = (
+      prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
+    ).mock.invocationCallOrder[0];
+    const sendOrder = mockSendCommentMentionEmail.mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(sendOrder);
   });
 
   it("throws after the loop when one recipient fails so BullMQ can retry", async () => {
@@ -132,23 +140,23 @@ describe("handleCommentMentionNotification", () => {
     ).rejects.toThrow(/user-a/);
 
     expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
-    expect(prisma.commentMentionEmail.create).toHaveBeenCalledTimes(1);
-    expect(prisma.commentMentionEmail.create).toHaveBeenCalledWith({
-      data: { commentId, userId: userB },
+    expect(prisma.commentMentionEmail.create).toHaveBeenCalledTimes(2);
+    expect(prisma.commentMentionEmail.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prisma.commentMentionEmail.deleteMany).toHaveBeenCalledWith({
+      where: { commentId, userId: userA },
     });
   });
 
-  it("skips recipients that already have a unique sent row on redelivery", async () => {
+  it("skips recipients that already have a unique row on redelivery", async () => {
     (
-      prisma.commentMentionEmail.findUnique as ReturnType<typeof vi.fn>
+      prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
     ).mockImplementation(
-      async ({
-        where: {
-          commentId_userId: { userId },
-        },
-      }: {
-        where: { commentId_userId: { commentId: string; userId: string } };
-      }) => (userId === userA ? { id: "existing" } : null),
+      async ({ data: { userId } }: { data: { userId: string } }) => {
+        if (userId === userA) {
+          throw { code: "P2002" };
+        }
+        return { id: "row-1" };
+      },
     );
 
     await handleCommentMentionNotification({
@@ -161,9 +169,10 @@ describe("handleCommentMentionNotification", () => {
     expect(mockSendCommentMentionEmail).toHaveBeenCalledWith(
       expect.objectContaining({ mentionedUserEmail: "b@example.com" }),
     );
+    expect(prisma.commentMentionEmail.deleteMany).not.toHaveBeenCalled();
   });
 
-  it("does not fail the job when a concurrent retry already inserted the unique row", async () => {
+  it("does not send when a concurrent job already inserted the unique row", async () => {
     (
       prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
     ).mockRejectedValue({ code: "P2002" });
@@ -176,10 +185,10 @@ describe("handleCommentMentionNotification", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendCommentMentionEmail).not.toHaveBeenCalled();
   });
 
-  it("fails the job when recording the sent row fails for a non-unique error", async () => {
+  it("fails the job without sending when claiming the unique row fails", async () => {
     (
       prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
     ).mockRejectedValue(new Error("postgres down"));
@@ -191,5 +200,22 @@ describe("handleCommentMentionNotification", () => {
         mentionedUserIds: [userA],
       }),
     ).rejects.toThrow(/user-a/);
+
+    expect(mockSendCommentMentionEmail).not.toHaveBeenCalled();
+  });
+
+  it("releases the claim when SMTP reports the email was not delivered", async () => {
+    mockSendCommentMentionEmail.mockResolvedValue({ delivered: false });
+
+    await handleCommentMentionNotification({
+      commentId,
+      projectId,
+      mentionedUserIds: [userA],
+    });
+
+    expect(prisma.commentMentionEmail.create).toHaveBeenCalledTimes(1);
+    expect(prisma.commentMentionEmail.deleteMany).toHaveBeenCalledWith({
+      where: { commentId, userId: userA },
+    });
   });
 });

--- a/worker/src/features/notifications/commentMentionHandler.test.ts
+++ b/worker/src/features/notifications/commentMentionHandler.test.ts
@@ -1,14 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockRedis, mockSendCommentMentionEmail, mockGetUserProjectRoles } =
-  vi.hoisted(() => ({
-    mockRedis: {
-      exists: vi.fn(),
-      set: vi.fn(),
-    },
+const { mockSendCommentMentionEmail, mockGetUserProjectRoles } = vi.hoisted(
+  () => ({
     mockSendCommentMentionEmail: vi.fn(),
     mockGetUserProjectRoles: vi.fn(),
-  }));
+  }),
+);
 
 vi.mock("../../env", () => ({
   env: {
@@ -30,6 +27,10 @@ vi.mock("@langfuse/shared/src/db", () => ({
     notificationPreference: {
       findUnique: vi.fn(),
     },
+    commentMentionEmail: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
   },
 }));
 
@@ -40,18 +41,13 @@ vi.mock("@langfuse/shared/src/server", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
-  redis: mockRedis,
   sendCommentMentionEmail: mockSendCommentMentionEmail,
   getObservationById: vi.fn(),
   getUserProjectRoles: mockGetUserProjectRoles,
 }));
 
 import { prisma } from "@langfuse/shared/src/db";
-import {
-  commentMentionSentRedisKey,
-  COMMENT_MENTION_SENT_TTL_SECONDS,
-  handleCommentMentionNotification,
-} from "./commentMentionHandler";
+import { handleCommentMentionNotification } from "./commentMentionHandler";
 
 const commentId = "comment-1";
 const projectId = "project-1";
@@ -77,8 +73,6 @@ const projectUser = (id: string, email: string) => ({
 describe("handleCommentMentionNotification", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRedis.exists.mockResolvedValue(0);
-    mockRedis.set.mockResolvedValue("OK");
     mockSendCommentMentionEmail.mockResolvedValue({ delivered: true });
     (
       prisma.notificationPreference.findUnique as ReturnType<typeof vi.fn>
@@ -86,6 +80,12 @@ describe("handleCommentMentionNotification", () => {
     (prisma.comment.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
       commentRow,
     );
+    (
+      prisma.commentMentionEmail.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
+    (
+      prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ id: "row-1" });
     mockGetUserProjectRoles.mockResolvedValue([
       projectUser(userA, "a@example.com"),
       projectUser(userB, "b@example.com"),
@@ -97,7 +97,7 @@ describe("handleCommentMentionNotification", () => {
     vi.clearAllMocks();
   });
 
-  it("sends to every mentioned user and marks each send in Redis", async () => {
+  it("sends to every mentioned user and records each send in Postgres", async () => {
     await handleCommentMentionNotification({
       commentId,
       projectId,
@@ -105,18 +105,12 @@ describe("handleCommentMentionNotification", () => {
     });
 
     expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
-    expect(mockRedis.set).toHaveBeenCalledWith(
-      commentMentionSentRedisKey(commentId, userA),
-      "1",
-      "EX",
-      COMMENT_MENTION_SENT_TTL_SECONDS,
-    );
-    expect(mockRedis.set).toHaveBeenCalledWith(
-      commentMentionSentRedisKey(commentId, userB),
-      "1",
-      "EX",
-      COMMENT_MENTION_SENT_TTL_SECONDS,
-    );
+    expect(prisma.commentMentionEmail.create).toHaveBeenCalledWith({
+      data: { commentId, userId: userA },
+    });
+    expect(prisma.commentMentionEmail.create).toHaveBeenCalledWith({
+      data: { commentId, userId: userB },
+    });
   });
 
   it("throws after the loop when one recipient fails so BullMQ can retry", async () => {
@@ -138,18 +132,23 @@ describe("handleCommentMentionNotification", () => {
     ).rejects.toThrow(/user-a/);
 
     expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
-    expect(mockRedis.set).toHaveBeenCalledTimes(1);
-    expect(mockRedis.set).toHaveBeenCalledWith(
-      commentMentionSentRedisKey(commentId, userB),
-      "1",
-      "EX",
-      COMMENT_MENTION_SENT_TTL_SECONDS,
-    );
+    expect(prisma.commentMentionEmail.create).toHaveBeenCalledTimes(1);
+    expect(prisma.commentMentionEmail.create).toHaveBeenCalledWith({
+      data: { commentId, userId: userB },
+    });
   });
 
-  it("skips recipients that already have a sent marker on redelivery", async () => {
-    mockRedis.exists.mockImplementation(async (key: string) =>
-      key === commentMentionSentRedisKey(commentId, userA) ? 1 : 0,
+  it("skips recipients that already have a unique sent row on redelivery", async () => {
+    (
+      prisma.commentMentionEmail.findUnique as ReturnType<typeof vi.fn>
+    ).mockImplementation(
+      async ({
+        where: {
+          commentId_userId: { userId },
+        },
+      }: {
+        where: { commentId_userId: { commentId: string; userId: string } };
+      }) => (userId === userA ? { id: "existing" } : null),
     );
 
     await handleCommentMentionNotification({
@@ -162,5 +161,35 @@ describe("handleCommentMentionNotification", () => {
     expect(mockSendCommentMentionEmail).toHaveBeenCalledWith(
       expect.objectContaining({ mentionedUserEmail: "b@example.com" }),
     );
+  });
+
+  it("does not fail the job when a concurrent retry already inserted the unique row", async () => {
+    (
+      prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
+    ).mockRejectedValue({ code: "P2002" });
+
+    await expect(
+      handleCommentMentionNotification({
+        commentId,
+        projectId,
+        mentionedUserIds: [userA],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails the job when recording the sent row fails for a non-unique error", async () => {
+    (
+      prisma.commentMentionEmail.create as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error("postgres down"));
+
+    await expect(
+      handleCommentMentionNotification({
+        commentId,
+        projectId,
+        mentionedUserIds: [userA],
+      }),
+    ).rejects.toThrow(/user-a/);
   });
 });

--- a/worker/src/features/notifications/commentMentionHandler.test.ts
+++ b/worker/src/features/notifications/commentMentionHandler.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedis, mockSendCommentMentionEmail, mockGetUserProjectRoles } =
+  vi.hoisted(() => ({
+    mockRedis: {
+      exists: vi.fn(),
+      set: vi.fn(),
+    },
+    mockSendCommentMentionEmail: vi.fn(),
+    mockGetUserProjectRoles: vi.fn(),
+  }));
+
+vi.mock("../../env", () => ({
+  env: {
+    NEXTAUTH_URL: "http://localhost:3000",
+    EMAIL_FROM_ADDRESS: "noreply@example.com",
+    SMTP_CONNECTION_URL: "smtp://localhost",
+  },
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  Prisma: { empty: {} },
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    comment: {
+      findFirst: vi.fn(),
+    },
+    notificationPreference: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  redis: mockRedis,
+  sendCommentMentionEmail: mockSendCommentMentionEmail,
+  getObservationById: vi.fn(),
+  getUserProjectRoles: mockGetUserProjectRoles,
+}));
+
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  commentMentionSentRedisKey,
+  COMMENT_MENTION_SENT_TTL_SECONDS,
+  handleCommentMentionNotification,
+} from "./commentMentionHandler";
+
+const commentId = "comment-1";
+const projectId = "project-1";
+const userA = "user-a";
+const userB = "user-b";
+
+const commentRow = {
+  id: commentId,
+  projectId,
+  objectType: "TRACE",
+  objectId: "trace-1",
+  content: "Hey @[Ada](user:user-a) and @[Bob](user:user-b)",
+  authorUserId: "author-1",
+  project: { id: projectId, name: "Demo", orgId: "org-1" },
+};
+
+const projectUser = (id: string, email: string) => ({
+  id,
+  name: id,
+  email,
+});
+
+describe("handleCommentMentionNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedis.exists.mockResolvedValue(0);
+    mockRedis.set.mockResolvedValue("OK");
+    mockSendCommentMentionEmail.mockResolvedValue({ delivered: true });
+    (
+      prisma.notificationPreference.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
+    (prisma.comment.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      commentRow,
+    );
+    mockGetUserProjectRoles.mockResolvedValue([
+      projectUser(userA, "a@example.com"),
+      projectUser(userB, "b@example.com"),
+      projectUser("author-1", "author@example.com"),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends to every mentioned user and marks each send in Redis", async () => {
+    await handleCommentMentionNotification({
+      commentId,
+      projectId,
+      mentionedUserIds: [userA, userB],
+    });
+
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      commentMentionSentRedisKey(commentId, userA),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      commentMentionSentRedisKey(commentId, userB),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+  });
+
+  it("throws after the loop when one recipient fails so BullMQ can retry", async () => {
+    mockSendCommentMentionEmail.mockImplementation(
+      async ({ mentionedUserEmail }: { mentionedUserEmail: string }) => {
+        if (mentionedUserEmail === "a@example.com") {
+          throw new Error("smtp timeout");
+        }
+        return { delivered: true };
+      },
+    );
+
+    await expect(
+      handleCommentMentionNotification({
+        commentId,
+        projectId,
+        mentionedUserIds: [userA, userB],
+      }),
+    ).rejects.toThrow(/user-a/);
+
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(2);
+    expect(mockRedis.set).toHaveBeenCalledTimes(1);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      commentMentionSentRedisKey(commentId, userB),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+  });
+
+  it("skips recipients that already have a sent marker on redelivery", async () => {
+    mockRedis.exists.mockImplementation(async (key: string) =>
+      key === commentMentionSentRedisKey(commentId, userA) ? 1 : 0,
+    );
+
+    await handleCommentMentionNotification({
+      commentId,
+      projectId,
+      mentionedUserIds: [userA, userB],
+    });
+
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendCommentMentionEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ mentionedUserEmail: "b@example.com" }),
+    );
+  });
+});

--- a/worker/src/features/notifications/commentMentionHandler.ts
+++ b/worker/src/features/notifications/commentMentionHandler.ts
@@ -3,7 +3,6 @@ import {
   logger,
   sendCommentMentionEmail,
   getObservationById,
-  redis,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Prisma } from "@langfuse/shared";
@@ -15,50 +14,40 @@ type CommentMentionPayload = Omit<
   "type"
 >;
 
-export const COMMENT_MENTION_SENT_TTL_SECONDS = 60 * 60 * 24 * 14;
-
-export const commentMentionSentRedisKey = (commentId: string, userId: string) =>
-  `comment-mention-sent:${commentId}:${userId}`;
+const isUniqueConstraintError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  (error as { code: unknown }).code === "P2002";
 
 async function hasCommentMentionEmailBeenSent(
   commentId: string,
   userId: string,
 ): Promise<boolean> {
-  if (!redis) {
-    return false;
-  }
-
-  try {
-    return (
-      (await redis.exists(commentMentionSentRedisKey(commentId, userId))) === 1
-    );
-  } catch (error) {
-    logger.warn(
-      "Failed to read comment mention sent marker; proceeding to send",
-      { commentId, userId, error },
-    );
-    return false;
-  }
+  const existing = await prisma.commentMentionEmail.findUnique({
+    where: {
+      commentId_userId: { commentId, userId },
+    },
+    select: { id: true },
+  });
+  return existing !== null;
 }
 
-async function markCommentMentionEmailSent(commentId: string, userId: string) {
-  if (!redis) {
-    return;
-  }
-
+async function recordCommentMentionEmailSent(
+  commentId: string,
+  userId: string,
+): Promise<void> {
   try {
-    await redis.set(
-      commentMentionSentRedisKey(commentId, userId),
-      "1",
-      "EX",
-      COMMENT_MENTION_SENT_TTL_SECONDS,
-    );
-  } catch (error) {
-    logger.warn("Failed to persist comment mention sent marker", {
-      commentId,
-      userId,
-      error,
+    await prisma.commentMentionEmail.create({
+      data: { commentId, userId },
     });
+  } catch (error) {
+    // Concurrent retry already inserted the row. Treat as recorded so this
+    // attempt does not throw and re-send after SMTP already succeeded.
+    if (isUniqueConstraintError(error)) {
+      return;
+    }
+    throw error;
   }
 }
 
@@ -187,7 +176,7 @@ export async function handleCommentMentionNotification(
 
     // Process each mentioned user. Per-user failures are collected so the rest
     // of the loop can finish; the job then throws so BullMQ retries only the
-    // recipients that were not marked sent.
+    // recipients that do not yet have a unique sent row.
     const failedUserIds: string[] = [];
 
     for (const userId of mentionedUserIds) {
@@ -270,7 +259,7 @@ export async function handleCommentMentionNotification(
         });
 
         if (delivered) {
-          await markCommentMentionEmailSent(commentId, userId);
+          await recordCommentMentionEmailSent(commentId, userId);
           logger.info(
             `Comment mention email sent successfully for comment ${commentId} to user ${userId}`,
           );

--- a/worker/src/features/notifications/commentMentionHandler.ts
+++ b/worker/src/features/notifications/commentMentionHandler.ts
@@ -3,6 +3,7 @@ import {
   logger,
   sendCommentMentionEmail,
   getObservationById,
+  redis,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Prisma } from "@langfuse/shared";
@@ -13,6 +14,53 @@ type CommentMentionPayload = Omit<
   Extract<NotificationEventType, { type: "COMMENT_MENTION" }>,
   "type"
 >;
+
+export const COMMENT_MENTION_SENT_TTL_SECONDS = 60 * 60 * 24 * 14;
+
+export const commentMentionSentRedisKey = (commentId: string, userId: string) =>
+  `comment-mention-sent:${commentId}:${userId}`;
+
+async function hasCommentMentionEmailBeenSent(
+  commentId: string,
+  userId: string,
+): Promise<boolean> {
+  if (!redis) {
+    return false;
+  }
+
+  try {
+    return (
+      (await redis.exists(commentMentionSentRedisKey(commentId, userId))) === 1
+    );
+  } catch (error) {
+    logger.warn(
+      "Failed to read comment mention sent marker; proceeding to send",
+      { commentId, userId, error },
+    );
+    return false;
+  }
+}
+
+async function markCommentMentionEmailSent(commentId: string, userId: string) {
+  if (!redis) {
+    return;
+  }
+
+  try {
+    await redis.set(
+      commentMentionSentRedisKey(commentId, userId),
+      "1",
+      "EX",
+      COMMENT_MENTION_SENT_TTL_SECONDS,
+    );
+  } catch (error) {
+    logger.warn("Failed to persist comment mention sent marker", {
+      commentId,
+      userId,
+      error,
+    });
+  }
+}
 
 async function buildCommentLink(opts: {
   baseUrl: string;
@@ -137,7 +185,11 @@ export async function handleCommentMentionNotification(
       return truncated.replace(/@\[([^\]]+)\]\(user:[^)]+\)/g, "@$1");
     })();
 
-    // Process each mentioned user
+    // Process each mentioned user. Per-user failures are collected so the rest
+    // of the loop can finish; the job then throws so BullMQ retries only the
+    // recipients that were not marked sent.
+    const failedUserIds: string[] = [];
+
     for (const userId of mentionedUserIds) {
       try {
         // Verify user has access to the project (from our single query above)
@@ -176,6 +228,13 @@ export async function handleCommentMentionNotification(
           continue;
         }
 
+        if (await hasCommentMentionEmailBeenSent(commentId, userId)) {
+          logger.info(
+            `Comment mention email already sent for comment ${commentId} to user ${userId}. Skipping.`,
+          );
+          continue;
+        }
+
         // Construct comment link using NEXTAUTH_URL (which includes basePath if configured)
         const baseUrl = env.NEXTAUTH_URL || "http://localhost:3000";
 
@@ -196,8 +255,7 @@ export async function handleCommentMentionNotification(
 
         const settingsLink = `${baseUrl}/project/${encodeURIComponent(projectId)}/settings/notifications`;
 
-        // Send email
-        await sendCommentMentionEmail({
+        const { delivered } = await sendCommentMentionEmail({
           env: {
             EMAIL_FROM_ADDRESS: env.EMAIL_FROM_ADDRESS,
             SMTP_CONNECTION_URL: env.SMTP_CONNECTION_URL,
@@ -211,16 +269,25 @@ export async function handleCommentMentionNotification(
           settingsLink,
         });
 
-        logger.info(
-          `Comment mention email sent successfully for comment ${commentId} to user ${userId}`,
-        );
+        if (delivered) {
+          await markCommentMentionEmailSent(commentId, userId);
+          logger.info(
+            `Comment mention email sent successfully for comment ${commentId} to user ${userId}`,
+          );
+        }
       } catch (error) {
         logger.error(
           `Failed to send comment mention notification to user ${userId}`,
           error,
         );
-        // Continue processing other users even if one fails
+        failedUserIds.push(userId);
       }
+    }
+
+    if (failedUserIds.length > 0) {
+      throw new Error(
+        `Failed to send comment mention emails for comment ${commentId} to ${failedUserIds.length} user(s): ${failedUserIds.join(", ")}`,
+      );
     }
 
     logger.info(

--- a/worker/src/features/notifications/commentMentionHandler.ts
+++ b/worker/src/features/notifications/commentMentionHandler.ts
@@ -20,34 +20,46 @@ const isUniqueConstraintError = (error: unknown): boolean =>
   "code" in error &&
   (error as { code: unknown }).code === "P2002";
 
-async function hasCommentMentionEmailBeenSent(
+/**
+ * Insert the unique (commentId, userId) row *before* SMTP so concurrent
+ * workers cannot both send. P2002 means another attempt already claimed
+ * (or completed) this recipient — skip without sending.
+ */
+async function tryClaimCommentMentionEmailSend(
   commentId: string,
   userId: string,
 ): Promise<boolean> {
-  const existing = await prisma.commentMentionEmail.findUnique({
-    where: {
-      commentId_userId: { commentId, userId },
-    },
-    select: { id: true },
-  });
-  return existing !== null;
-}
-
-async function recordCommentMentionEmailSent(
-  commentId: string,
-  userId: string,
-): Promise<void> {
   try {
     await prisma.commentMentionEmail.create({
       data: { commentId, userId },
     });
+    return true;
   } catch (error) {
-    // Concurrent retry already inserted the row. Treat as recorded so this
-    // attempt does not throw and re-send after SMTP already succeeded.
     if (isUniqueConstraintError(error)) {
-      return;
+      return false;
     }
     throw error;
+  }
+}
+
+/**
+ * Drop the claim when SMTP did not deliver so a later BullMQ retry can
+ * insert again and send. Failures here are logged; a stuck row can skip
+ * a retry (prefer that over sending a duplicate).
+ */
+async function releaseCommentMentionEmailClaim(
+  commentId: string,
+  userId: string,
+): Promise<void> {
+  try {
+    await prisma.commentMentionEmail.deleteMany({
+      where: { commentId, userId },
+    });
+  } catch (error) {
+    logger.error(
+      `Failed to release comment mention email claim for comment ${commentId} user ${userId}`,
+      error,
+    );
   }
 }
 
@@ -176,10 +188,11 @@ export async function handleCommentMentionNotification(
 
     // Process each mentioned user. Per-user failures are collected so the rest
     // of the loop can finish; the job then throws so BullMQ retries only the
-    // recipients that do not yet have a unique sent row.
+    // recipients whose unique claim was released (or never inserted).
     const failedUserIds: string[] = [];
 
     for (const userId of mentionedUserIds) {
+      let claimed = false;
       try {
         // Verify user has access to the project (from our single query above)
         if (!userMap.has(userId)) {
@@ -217,13 +230,6 @@ export async function handleCommentMentionNotification(
           continue;
         }
 
-        if (await hasCommentMentionEmailBeenSent(commentId, userId)) {
-          logger.info(
-            `Comment mention email already sent for comment ${commentId} to user ${userId}. Skipping.`,
-          );
-          continue;
-        }
-
         // Construct comment link using NEXTAUTH_URL (which includes basePath if configured)
         const baseUrl = env.NEXTAUTH_URL || "http://localhost:3000";
 
@@ -239,6 +245,16 @@ export async function handleCommentMentionNotification(
           userIdForLogging: userId,
         });
         if (!commentLink) {
+          continue;
+        }
+
+        // Claim before SMTP so overlapping jobs cannot both send. Unique
+        // (commentId, userId) is the lock; P2002 means skip.
+        claimed = await tryClaimCommentMentionEmailSend(commentId, userId);
+        if (!claimed) {
+          logger.info(
+            `Comment mention email already sent for comment ${commentId} to user ${userId}. Skipping.`,
+          );
           continue;
         }
 
@@ -258,13 +274,19 @@ export async function handleCommentMentionNotification(
           settingsLink,
         });
 
-        if (delivered) {
-          await recordCommentMentionEmailSent(commentId, userId);
-          logger.info(
-            `Comment mention email sent successfully for comment ${commentId} to user ${userId}`,
-          );
+        if (!delivered) {
+          await releaseCommentMentionEmailClaim(commentId, userId);
+          claimed = false;
+          continue;
         }
+
+        logger.info(
+          `Comment mention email sent successfully for comment ${commentId} to user ${userId}`,
+        );
       } catch (error) {
+        if (claimed) {
+          await releaseCommentMentionEmailClaim(commentId, userId);
+        }
         logger.error(
           `Failed to send comment mention notification to user ${userId}`,
           error,


### PR DESCRIPTION
## What does this PR do?

Follow-up to #16578 / #16497.

#16578 retries failed comment-mention emails and uses Redis keys to skip already-sent recipients. Redis errors fail open (`hasCommentMentionEmailBeenSent` returns `false`), which Greptile flagged: a Redis outage during retry can duplicate emails. That trade-off was left as-is on #16578.

This PR replaces Redis sent-markers with a durable `comment_mention_emails` row, unique on `(commentId, userId)`:

- After SMTP succeeds, insert the row.
- On retry, skip recipients that already have a row.
- Concurrent retries hitting the unique constraint (`P2002`) count as already sent.
- Insert failures other than `P2002` fail the job so BullMQ retries (fail-closed).

Includes the #16578 retry/SMTP changes (stacked on that branch). Merge #16578 first or take this PR instead.

Closes #16497 (durable idempotency).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Verification

`pnpm --filter worker exec vitest run src/features/notifications/commentMentionHandler.test.ts` (5 tests).

## What to doubt

Insert happens after send. A crash between SMTP success and the insert can still send a duplicate once; the unique row then holds. A two-phase PENDING/SENT row would close that window at the cost of more complexity.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces Redis comment-mention sent markers with a Postgres table and changes SMTP failures to trigger BullMQ retries.
- Adds a unique `(commentId, userId)` persistence model and migration.
- Checks and records per-recipient delivery state in the notification worker.
- Adds sender and worker tests covering delivery, retries, existing markers, and persistence failures.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until duplicate delivery under concurrent execution and post-SMTP marker-write failures is addressed.

The unique row is created only after SMTP delivery, allowing concurrent jobs to send twice before uniqueness is enforced and allowing failed marker writes to trigger retries that resend an already-delivered email.

**Files Needing Attention:** worker/src/features/notifications/commentMentionHandler.ts and the two newly added test files
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Worker attempt A
  participant B as Worker attempt B
  participant DB as PostgreSQL
  participant SMTP as SMTP
  A->>DB: Find marker
  B->>DB: Find marker
  DB-->>A: Not found
  DB-->>B: Not found
  A->>SMTP: Send email
  B->>SMTP: Send duplicate email
  A->>DB: Insert marker
  DB-->>A: Success
  B->>DB: Insert marker
  DB-->>B: P2002
  Note over B: P2002 treated as success
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/notifications/commentMentionHandler.ts:217
**Concurrent sends bypass uniqueness**

If two notification jobs for the same comment and user overlap, both read the marker as absent and send the email before either insert enforces uniqueness. The second insert's `P2002` is then treated as success, so the recipient receives a duplicate email while both jobs complete successfully.

### Issue 2
worker/src/features/notifications/commentMentionHandler.ts:258-262
**Marker failures resend email**

When SMTP succeeds but the subsequent Postgres insert fails with a non-unique error, the handler fails the whole job without recording the delivery. BullMQ then retries the job, the recipient passes the marker check again, and the already-delivered email is sent again.

### Issue 3
packages/shared/src/server/services/email/commentMention/sendCommentMentionEmail.test.ts:27
**Imports follow executable setup**

This static import, and the corresponding imports in `commentMentionHandler.test.ts`, appear after executable mock setup instead of at the top of the module. Move the imports to the module header to preserve the repository's required import layout.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): persist comment-ment..."](https://github.com/langfuse/langfuse/commit/de6d15bebbc080989b872ab04c9bd608d5fea7de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56973997)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)
- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)

<!-- /greptile_comment -->