### PR TITLE
fix(models): use default pricing tier when testing without usage

### DIFF
--- a/web/src/server/api/routers/models.ts
+++ b/web/src/server/api/routers/models.ts
@@ -440,16 +440,16 @@ export const modelRouter = createTRPCRouter({
         return { matched: false as const };
       }
 
-      // Step 2: Mirror ingestion: without usage there is no priced observation
-      // and therefore no pricing tier match, even for attribute-only tiers.
-      if (!hasPricingTierUsageDetails(usageDetails)) {
-        return { matched: false as const };
-      }
-
-      const matchResult = matchPricingTier(pricingTiers, usageDetails ?? {}, {
-        modelParameters,
-        metadata,
-      });
+      // Without usage details, fall back to the model's default pricing tier.
+      const defaultTier = pricingTiers.find((tier) => tier.isDefault);
+      const matchResult = hasPricingTierUsageDetails(usageDetails)
+        ? matchPricingTier(pricingTiers, usageDetails ?? {}, {
+            modelParameters,
+            metadata,
+          })
+        : defaultTier
+          ? { pricingTierId: defaultTier.id }
+          : null;
 
       if (!matchResult) {
         return { matched: false as const };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16584.preview.langfuse.com](https://pr-16584.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Use the model default pricing tier when Test Model Match has no usage details.
- Preserve existing conditional pricing-tier matching when usage details are provided.
- Keep the change limited to the model test-match endpoint.

## Verification

- `git diff --check`
- Tests not run per request.

This does not change OpenTelemetry ingestion or persisted cost calculation behavior.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the model test-match endpoint to return a model’s default pricing tier when usage details are absent, while preserving conditional tier matching when usage is supplied.

- Finds the configured default pricing tier for the matched model.
- Uses that tier only when the request contains no pricing-tier usage details.
- Leaves ingestion and persisted cost-calculation paths unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The synthesized match result supplies the only field consumed downstream, resolves to a tier already present on the model, and implements the endpoint-specific behavior explicitly described by the PR.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): use default tier for empty ..."](https://github.com/langfuse/langfuse/commit/c575584d0a1fd77e5ac86614788aec333ecfedb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56988489)</sub>

<!-- /greptile_comment -->