### PR TITLE
chore(billing): drop user emails from billing logs

### DIFF
--- a/web/src/ee/features/billing/server/stripe/stripeBillingService.ts
+++ b/web/src/ee/features/billing/server/stripe/stripeBillingService.ts
@@ -282,7 +282,6 @@ class BillingService {
           idempotencyKey,
           opId,
           userId: this.ctx.session.user?.id,
-          userEmail: this.ctx.session.user?.email,
         });
         await client.subscriptionSchedules.release(
           schedule.id,
@@ -408,7 +407,6 @@ class BillingService {
                   "StripeBillingService.getSubscriptionInfo:stripe.subscription.schedule.nextPhase.item.price.notExpanded",
                   {
                     userId: this.ctx.session.user?.id,
-                    userEmail: this.ctx.session.user?.email,
                     customerId: parsedOrg.cloudConfig?.stripe?.customerId,
                     subscriptionId:
                       parsedOrg.cloudConfig?.stripe?.activeSubscriptionId,
@@ -425,7 +423,6 @@ class BillingService {
                   "StripeBillingService.getSubscriptionInfo:stripe.subscription.schedule.nextPhase.item.price.deleted",
                   {
                     userId: this.ctx.session.user?.id,
-                    userEmail: this.ctx.session.user?.email,
                     customerId: parsedOrg.cloudConfig?.stripe?.customerId,
                     subscriptionId:
                       parsedOrg.cloudConfig?.stripe?.activeSubscriptionId,
@@ -523,7 +520,6 @@ class BillingService {
               "StripeBillingService.getSubscriptionInfo:failed to check payment method",
               {
                 userId: this.ctx.session.user?.id,
-                userEmail: this.ctx.session.user?.email,
                 customerId:
                   typeof subscription.customer === "string"
                     ? subscription.customer
@@ -726,7 +722,6 @@ class BillingService {
           customerId: stripeCustomerId,
           productId: stripeProductId,
           userId: this.ctx.session.user.id,
-          userEmail: this.ctx.session.user.email,
         });
 
         try {
@@ -891,7 +886,6 @@ class BillingService {
             idempotencyKey: legacyUpdateKey,
             opId,
             userId: this.ctx.session.user?.id,
-            userEmail: this.ctx.session.user.email,
           });
           await client.subscriptions.update(
             stripeSubscriptionId,
@@ -937,7 +931,6 @@ class BillingService {
             orgId: parsedOrg.id,
             opId,
             userId: this.ctx.session.user.id,
-            userEmail: this.ctx.session.user.email,
           });
           await client.subscriptions.migrate(
             stripeSubscriptionId,
@@ -1003,7 +996,6 @@ class BillingService {
             idempotencyKey: upgradeKey,
             opId,
             userId: this.ctx.session.user.id,
-            userEmail: this.ctx.session.user.email,
           });
           await client.subscriptions.update(
             stripeSubscriptionId,
@@ -1068,7 +1060,6 @@ class BillingService {
             idempotencyKey: createScheduleKey,
             opId,
             userId: this.ctx.session.user.id,
-            userEmail: this.ctx.session.user.email,
           },
         );
         const initialSchedule = await client.subscriptionSchedules.create(
@@ -1121,7 +1112,6 @@ class BillingService {
           idempotencyKey: updateScheduleKey,
           opId,
           userId: this.ctx.session.user.id,
-          userEmail: this.ctx.session.user.email,
         });
         await client.subscriptionSchedules.update(
           initialSchedule.id,
@@ -1219,7 +1209,6 @@ class BillingService {
           idempotencyKey: cancelKey,
           opId,
           userId: this.ctx.session.user.id,
-          userEmail: this.ctx.session.user.email,
         });
 
         try {
@@ -1238,7 +1227,6 @@ class BillingService {
               subscriptionId,
               orgId: parsedOrg.id,
               userId: this.ctx.session.user.id,
-              userEmail: this.ctx.session.user.email,
               idempotencyKey: cancelKey,
               error,
               stripeRequestId: error?.requestId,
@@ -1323,7 +1311,6 @@ class BillingService {
           idempotencyKey: reactivateKey,
           opId,
           userId: this.ctx.session.user.id,
-          userEmail: this.ctx.session.user.email,
         });
 
         try {
@@ -1437,7 +1424,6 @@ class BillingService {
           idempotencyKey: cancelNowKey,
           opId,
           userId: this.ctx.session.user?.id,
-          userEmail: this.ctx.session.user?.email,
         });
 
         try {
@@ -2019,7 +2005,6 @@ class BillingService {
           idempotencyKey,
           opId,
           userId: this.ctx.session.user?.id,
-          userEmail: this.ctx.session.user?.email,
         });
 
         try {
@@ -2036,7 +2021,6 @@ class BillingService {
             "StripeBillingService.applyPromotionCode:stripe.subscription.update.failed",
             {
               userId: this.ctx.session.user?.id,
-              userEmail: this.ctx.session.user?.email,
               customerId: subscription.customer,
               subscriptionId,
               orgId: parsedOrg.id,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16590.preview.langfuse.com](https://pr-16590.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Billing log lines carried the acting user's email address into Datadog. This removes it; nothing else changes.

Sixteen `logger` calls in `stripeBillingService` passed `userEmail` next to a `userId` that already identifies the actor, so the email only added PII to log retention. Every call keeps `userId` plus the domain context it already had — subscription, customer, schedule or product id, and `orgId` on nine of them — so correlation is unaffected.

Removal only. Seven of the sixteen have no `orgId`; enriching those is a separate change, not folded in here.

The matching four call sites on the ClickHouse Billing path are removed in #15462, which owns that file.

## Verification

- `pnpm run typecheck` — `Tasks: 8 successful, 8 total`
- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test stripe-webhook-handler billingCycleHelpers` — `Tests 42 passed (42)`

No test asserted on the removed field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes users’ email addresses from Stripe billing log metadata to avoid retaining redundant PII while preserving user IDs and existing billing context.
- Removes `userEmail` from sixteen logger calls in `stripeBillingService`.
- Retains `userId` and existing subscription, customer, schedule, product, operation, and organization identifiers.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only removes redundant email metadata while retaining canonical user and billing identifiers.

All changed logging paths remain attributable through the authenticated user ID, and no runtime behavior, API contract, or billing state transition is altered.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(billing): drop user emails from St..."](https://github.com/langfuse/langfuse/commit/d3e69cb81ce191ca876a879ae3c43c82145d39f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57006860)</sub>

<!-- /greptile_comment -->