### PR TITLE
fix(blobstorage): suppress sub-second remainder chunk to prevent silent key collision

### DIFF
--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -60,6 +60,7 @@ import { Job } from "bullmq";
 import {
   handleBlobStorageIntegrationProjectJob,
   BLOB_STORAGE_LAG_BUFFER_MS,
+  BLOB_STORAGE_REMAINDER_COALESCE_MS,
 } from "../features/blobstorage/handleBlobStorageIntegrationProjectJob";
 import { BLOB_INTEGRATION_DISABLED_METRIC } from "../features/blobstorage/isCustomerFaultError";
 import {
@@ -1789,6 +1790,86 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         updatedIntegration.nextSyncAt.getTime() - now.getTime(),
       );
       expect(timeDiff).toBeLessThan(5000); // Within 5 seconds
+    });
+
+    it("should coalesce a sub-second remainder instead of emitting a colliding chunk", async () => {
+      // Regression for the silent object-key collision: a caught-up run whose
+      // full-interval chunk ends only a sub-second before the frontier used to
+      // re-enqueue a tiny remainder chunk. Both keys truncate to the same
+      // wall-clock second, so the remainder overwrote the full window. Position
+      // lastSyncAt so the interval-capped maxTimestamp lands just below the
+      // frontier (remainder < BLOB_STORAGE_REMAINDER_COALESCE_MS): the run must
+      // be treated as caught up (schedule one interval out), not re-enqueued.
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      const now = new Date();
+      const frequencyIntervalMs = 60 * 60 * 1000; // hourly
+      // gap = frontier - (minTimestamp + interval). Kept tiny (well under the
+      // coalesce threshold) so it stays below threshold even after the handler's
+      // own `now` advances a few ms past the test's.
+      const gapMs = 50;
+      const lastSyncAt = new Date(
+        now.getTime() -
+          BLOB_STORAGE_LAG_BUFFER_MS -
+          frequencyIntervalMs -
+          gapMs,
+      );
+
+      // A trace inside the full window so a real chunk is exported.
+      const trace = createTrace({
+        project_id: projectId,
+        timestamp: lastSyncAt.getTime() + frequencyIntervalMs / 2,
+        name: "Windowed Trace",
+      });
+      await createTracesCh([trace]);
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId: minioAccessKeyId,
+          secretAccessKey: encrypt(minioAccessKeySecret),
+          region: region ? region : "auto",
+          endpoint: minioEndpoint,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "hourly",
+          lastSyncAt,
+          compressed: false,
+        },
+      });
+
+      await handleBlobStorageIntegrationProjectJob({
+        data: { payload: { projectId } },
+      } as Job);
+
+      const updatedIntegration = await prisma.blobStorageIntegration.findUnique(
+        {
+          where: { projectId },
+        },
+      );
+
+      expect(updatedIntegration).toBeDefined();
+      if (!updatedIntegration?.nextSyncAt || !updatedIntegration?.lastSyncAt) {
+        expect.fail("nextSyncAt and lastSyncAt should be set");
+      }
+
+      // Caught up: nextSyncAt is one interval past the exported boundary, far in
+      // the future — not the near-`now` value a catch-up re-enqueue would set.
+      expect(
+        updatedIntegration.nextSyncAt.getTime() - now.getTime(),
+      ).toBeGreaterThan(frequencyIntervalMs / 2);
+
+      // lastSyncAt advances only to the interval-capped boundary; the sub-second
+      // tail up to the frontier is deferred to the next scheduled run.
+      const frontier = now.getTime() - BLOB_STORAGE_LAG_BUFFER_MS;
+      expect(updatedIntegration.lastSyncAt.getTime()).toBeLessThan(frontier);
+      expect(frontier - updatedIntegration.lastSyncAt.getTime()).toBeLessThan(
+        BLOB_STORAGE_REMAINDER_COALESCE_MS + 2000, // + handler-clock drift tolerance
+      );
     });
 
     it("should schedule normally when caught up", async () => {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -134,6 +134,17 @@ function resolveBlobExportFormat(
 
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
 
+// When a catch-up run lands within this distance of the frontier, treat it as
+// caught up rather than emitting a tiny trailing chunk. Object keys are truncated
+// to whole-second precision (formatBlobExportTimestamp), so a sub-second remainder
+// chunk can share a wall-clock second with the full-interval chunk it follows and
+// silently overwrite that window's files and manifest. Suppressing the remainder
+// removes the collision at its source; the deferred tail is picked up by the next
+// scheduled run (its minTimestamp = lastSyncAt already covers it). Must be >= 1000ms
+// (the key granularity) and well below any frequencyInterval so no meaningful data
+// is deferred.
+export const BLOB_STORAGE_REMAINDER_COALESCE_MS = 1000;
+
 export async function* enrichObservationStream(
   stream: AsyncGenerator<Record<string, unknown>>,
   projectId: string,
@@ -1451,8 +1462,14 @@ export const handleBlobStorageIntegrationProjectJob = async (
       }
     }
 
-    // Determine if we've caught up with present-day data
-    const caughtUp = maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime();
+    // Determine if we've caught up with present-day data. A remainder below
+    // BLOB_STORAGE_REMAINDER_COALESCE_MS is treated as caught up so we never emit
+    // a sub-second trailing chunk that would collide with the full-interval chunk
+    // on the same second-precision object key (see the constant's doc comment).
+    const remainderMs = uncappedMaxTimestamp.getTime() - maxTimestamp.getTime();
+    const caughtUp =
+      maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime() ||
+      remainderMs < BLOB_STORAGE_REMAINDER_COALESCE_MS;
 
     let nextSyncAt: Date;
     if (caughtUp) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16592.preview.langfuse.com](https://pr-16592.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Fixes silent, permanent data loss in scheduled blob-storage exports.

When a scheduled export catches up, it can emit two chunks back-to-back: a
full-interval chunk ending at `T`, and a tiny "remainder" chunk ending a few
hundred ms later. Object keys are truncated to whole-second precision
(`formatBlobExportTimestamp`), so both chunks resolve to the **same key** — the
near-empty remainder overwrites the full window's data files *and* its manifest.
On buckets without object versioning the full window is unrecoverable, the run
reports success, and the cursor advances, so the loss is silent. Reported at
~7–8 lost windows/day on an hourly integration. Format-independent; Parquet only
makes it undetectable because `files[].rowCount` is `null`.

**Fix:** treat a run as caught up when the remaining gap to the frontier is below
`BLOB_STORAGE_REMAINDER_COALESCE_MS` (1s — the key granularity), so the
sub-second remainder chunk is never emitted. Its data is picked up by the next
scheduled run, whose `minTimestamp = lastSyncAt` already covers it. This removes
the collision at its source with **no change to the object-key/filename format**
and **no change to the queue payload contract**.

The deferred tail is safe under every export mode: after any full-window export
`lastSyncAt` is set to `maxTimestamp`, and `getMinTimestampForExport` returns
`lastSyncAt` whenever it is set — so FULL_HISTORY / FROM_CUSTOM_DATE only differ
on the *first* export, before any remainder can exist.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- New regression test in `blobStorageIntegrationProcessing.test.ts`
  ("should coalesce a sub-second remainder instead of emitting a colliding
  chunk"): positions `lastSyncAt` so the interval-capped `maxTimestamp` lands
  just below the frontier, and asserts the run is treated as caught up (schedules
  one interval out) rather than re-enqueued, and that `lastSyncAt` advances only
  to the exported boundary. Verified red against the pre-fix code (nextSyncAt was
  ~immediate) and green with the fix.
- Full "Chunked historic exports" suite: 4 passed.
- `pnpm turbo run lint typecheck --filter=worker`: 5 successful, 5 total.

## Checklist

- [x] Tests added/updated
- [x] Lint and typecheck pass


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents scheduled blob-storage exports from emitting sub-second remainder chunks whose second-precision object keys could overwrite the preceding full-window export.
- Adds a one-second remainder-coalescing threshold to caught-up detection.
- Defers the suppressed tail while retaining the exported boundary as `lastSyncAt`, allowing the next scheduled run to cover it.
- Adds a regression test verifying that a sub-second remainder schedules the next regular run instead of an immediate catch-up run.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the deferred tail remaining reachable through the next scheduled export window.

The threshold matches the second-level key granularity, prevents all potentially colliding remainder chunks, and persists the capped boundary so inclusive source queries cover deferred data on the next run.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Compute interval-capped max timestamp] --> B[Compare with lag-buffer frontier]
  B --> C{Remaining gap below 1 second?}
  C -- No --> D[Queue immediate catch-up export]
  C -- Yes --> E[Export through capped boundary]
  E --> F[Persist boundary as lastSyncAt]
  F --> G[Schedule next regular export]
  G --> H[Next run includes deferred tail]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blobstorage): suppress sub-second re..."](https://github.com/langfuse/langfuse/commit/19c11fc6c70d03b71b064713425a0a5bd1fcaa2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57009445)</sub>

**Context used:**

- Knowledge Base — [Media and blob processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/media-and-blob-processing.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->