### PR TITLE
fix(evals): make evaluator model choice explicit and surface save errors

### DIFF
--- a/web/src/features/evals/components/template-form.clienttest.tsx
+++ b/web/src/features/evals/components/template-form.clienttest.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const defaultModelQueryMock = vi.fn(() => ({ data: undefined }));
+const createTemplateMutateAsyncMock = vi.fn();
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    defaultLlmModel: {
+      fetchDefaultModel: { useQuery: () => defaultModelQueryMock() },
+    },
+    evals: {
+      createTemplate: {
+        useMutation: () => ({
+          mutateAsync: createTemplateMutateAsyncMock,
+          isPending: false,
+        }),
+      },
+      allTemplates: { useQuery: () => ({ data: undefined }) },
+    },
+    useUtils: () => ({ models: { invalidate: vi.fn() } }),
+  },
+  reportTrpcErrorWithoutToast: vi.fn(),
+}));
+
+vi.mock("next/router", () => ({ default: { push: vi.fn() } }));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+vi.mock("@/src/features/playground/page/hooks/useModelParams", () => ({
+  useModelParams: () => ({
+    modelParams: {
+      provider: { value: "", enabled: true },
+      model: { value: "", enabled: true },
+    },
+    setModelParams: vi.fn(),
+    updateModelParamValue: vi.fn(),
+    setModelParamEnabled: vi.fn(),
+    availableModels: [],
+    providerModelCombinations: [],
+    availableProviders: [],
+  }),
+}));
+
+vi.mock("@/src/features/evals/hooks/useEvaluationModel", () => ({
+  useEvaluationModel: vi.fn(),
+}));
+
+vi.mock("@/src/features/evals/hooks/useValidateCustomModel", () => ({
+  useValidateCustomModel: () => ({ isCustomModelValid: true }),
+}));
+
+vi.mock("@/src/features/evals/hooks/useIsCodeEvalEnabled", () => ({
+  useIsCodeEvalEnabled: () => ({ enabled: false, isLoading: false }),
+}));
+
+vi.mock("@/src/features/evals/hooks/useEvalCapabilities", () => ({
+  useEvalCapabilities: () => ({
+    isNewCompatible: true,
+    compatibilityCheckWasPerformed: false,
+    allowLegacy: true,
+    isLoading: false,
+    hasLegacyEvals: false,
+    forceV3Experience: false,
+  }),
+}));
+
+vi.mock("@/src/features/evals/hooks/useCodeEvalSourceValidation", () => ({
+  useCodeEvalSourceValidation: () => ({
+    isValid: true,
+    isPending: false,
+    validationResult: undefined,
+    validate: vi.fn(async () => true),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/components/ModelParameters", () => ({
+  ModelParameters: () => <div data-testid="model-parameters" />,
+}));
+
+vi.mock("@/src/components/editor", () => ({
+  CodeMirrorEditor: () => null,
+}));
+
+vi.mock("@/src/features/evals/utils/code-eval-template-validation", () => ({
+  getCodeEvalSourceForEditor: ({ sourceCode }: { sourceCode: string }) =>
+    sourceCode,
+  getDefaultCodeEvalSource: () => "",
+  formatAndStripCodeEvalSourceForSubmit: vi.fn(async () => ""),
+}));
+
+vi.mock("@/src/features/evals/components/code-eval-template-form-body", () => ({
+  CodeEvalTemplateFormBody: () => null,
+}));
+
+vi.mock("@/src/features/evals/components/eval-template-type-selector", () => ({
+  EvalTemplateTypeSelector: () => null,
+}));
+
+vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
+}));
+
+vi.mock("@/src/features/notifications/showSuccessToast", () => ({
+  showSuccessToast: vi.fn(),
+}));
+
+import { EvalTemplateForm } from "./template-form";
+
+const validPreFill = {
+  name: "my-evaluator",
+  prompt: "Rate the response {{input}}",
+  vars: [],
+};
+
+describe("EvalTemplateForm model configuration feedback", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("announces save-blocking errors in an alert region", async () => {
+    defaultModelQueryMock.mockReturnValue({ data: undefined });
+
+    render(
+      <EvalTemplateForm
+        projectId="project-1"
+        useDialog={false}
+        isEditing
+        preFilledFormValues={validPreFill}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/no default evaluation model set/i);
+  });
+
+  it("shows the active model source as a checked radio option", () => {
+    render(
+      <EvalTemplateForm
+        projectId="project-1"
+        useDialog={false}
+        isEditing={false}
+        preFilledFormValues={{ ...validPreFill, shouldUseDefaultModel: false }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("radio", { name: /custom model/i }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("radio", { name: /default evaluation model/i }),
+    ).toHaveAttribute("aria-checked", "false");
+  });
+});

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -73,7 +73,10 @@ import {
   EvalTemplateTypeSelector,
   type EvalTemplateTypeSelectorMode,
 } from "@/src/features/evals/components/eval-template-type-selector";
-import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { RadioGroup, RadioGroupItem } from "@/src/components/ui/radio-group";
+import { Label } from "@/src/components/ui/label";
+import { cn } from "@/src/utils/tailwind";
 import {
   useEvalCapabilities,
   type EvalCapabilities,
@@ -136,6 +139,12 @@ export const EvalTemplateForm = (props: {
       />
     </div>
   );
+};
+
+// Stable callback ref: paired with keying the alert by its message, it scrolls
+// the alert into view once per new error instead of on every render.
+const scrollAlertIntoView = (node: HTMLDivElement | null) => {
+  node?.scrollIntoView({ behavior: "smooth", block: "center" });
 };
 
 const selectedModelSchema = z.object({
@@ -294,7 +303,6 @@ const InnerEvalTemplateForm = (props: {
     name: "categories",
   });
 
-  const useDefaultModel = form.watch("shouldUseDefaultModel");
   const evalTemplateType = form.watch("type");
   const sourceCodeLanguage =
     form.watch("sourceCodeLanguage") ??
@@ -452,6 +460,7 @@ const InnerEvalTemplateForm = (props: {
   }
 
   async function onSubmit(values: z.infer<typeof templateFormSchema>) {
+    setFormError(null);
     capture(
       props.isEditing
         ? "eval_templates:update_form_submit"
@@ -645,74 +654,128 @@ const InnerEvalTemplateForm = (props: {
                 control={form.control}
                 name="shouldUseDefaultModel"
                 render={({ field }) => (
-                  <FormItem className="mt-3 flex flex-row items-center space-y-0 space-x-3">
+                  <FormItem className="mt-3">
                     <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
+                      <RadioGroup
+                        value={field.value ? "default" : "custom"}
+                        onValueChange={(value) =>
+                          field.onChange(value === "default")
+                        }
                         disabled={!props.isEditing}
-                      />
+                      >
+                        <div
+                          className={cn(
+                            "flex items-start gap-3 rounded-md border p-3 transition-colors",
+                            field.value
+                              ? "bg-muted/50"
+                              : props.isEditing && "hover:bg-muted/30",
+                          )}
+                        >
+                          <RadioGroupItem
+                            value="default"
+                            id="eval-model-source-default"
+                            className="mt-0.5"
+                          />
+                          <div className="min-w-0 space-y-1 leading-none">
+                            <Label
+                              htmlFor="eval-model-source-default"
+                              className={cn(
+                                "font-bold",
+                                props.isEditing && "cursor-pointer",
+                              )}
+                            >
+                              Default evaluation model
+                            </Label>
+                            <FormDescription className="text-xs">
+                              <ManageDefaultEvalModel
+                                projectId={props.projectId}
+                                variant="color-coded"
+                                setUpMessage={
+                                  <>
+                                    No default model set. LLM-as-a-judge
+                                    evaluations require an LLM connection for
+                                    scoring. This default is used by all
+                                    templates that don&apos;t specify their own
+                                    model.{" "}
+                                    <a
+                                      href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge#how-llm-as-a-judge-works"
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="underline"
+                                    >
+                                      Learn more.
+                                    </a>
+                                  </>
+                                }
+                                className="text-sm font-normal"
+                              />
+                            </FormDescription>
+                          </div>
+                        </div>
+                        <div
+                          className={cn(
+                            "flex items-start gap-3 rounded-md border p-3 transition-colors",
+                            !field.value
+                              ? "bg-muted/50"
+                              : props.isEditing && "hover:bg-muted/30",
+                          )}
+                        >
+                          <RadioGroupItem
+                            value="custom"
+                            id="eval-model-source-custom"
+                            className="mt-0.5"
+                          />
+                          <div className="min-w-0 flex-1 space-y-1 leading-none">
+                            <Label
+                              htmlFor="eval-model-source-custom"
+                              className={cn(
+                                "font-bold",
+                                props.isEditing && "cursor-pointer",
+                              )}
+                            >
+                              Custom model
+                            </Label>
+                            {!field.value &&
+                              (!props.isEditing && !isCustomModelValid ? (
+                                <div className="text-destructive flex items-center gap-1 pt-2 text-sm">
+                                  <AlertCircle className="h-4 w-4" />
+                                  <p>
+                                    This evaluator is configured to use{" "}
+                                    {modelParams.provider.value}s models but no
+                                    API key exists. Add a key or choose another
+                                    provider.
+                                  </p>
+                                </div>
+                              ) : (
+                                <div className="pt-2">
+                                  <ModelParameters
+                                    customHeader={
+                                      <span className="sr-only">
+                                        Custom model configuration
+                                      </span>
+                                    }
+                                    {...{
+                                      modelParams,
+                                      availableModels,
+                                      providerModelCombinations,
+                                      availableProviders,
+                                      updateModelParamValue:
+                                        updateModelParamValue,
+                                      setModelParamEnabled,
+                                      modelParamsDescription:
+                                        "Select a model which supports function calling.",
+                                    }}
+                                    formDisabled={!props.isEditing}
+                                  />
+                                </div>
+                              ))}
+                          </div>
+                        </div>
+                      </RadioGroup>
                     </FormControl>
-                    <div className="space-y-0 leading-none">
-                      <FormLabel>Use default evaluation model</FormLabel>
-                      <FormDescription className="text-xs">
-                        <ManageDefaultEvalModel
-                          projectId={props.projectId}
-                          variant="color-coded"
-                          setUpMessage={
-                            <>
-                              No default model set. LLM-as-a-judge evaluations
-                              require an LLM connection for scoring. This
-                              default is used by all templates that don&apos;t
-                              specify their own model.{" "}
-                              <a
-                                href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge#how-llm-as-a-judge-works"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="underline"
-                              >
-                                Learn more.
-                              </a>
-                            </>
-                          }
-                          className="text-sm font-normal"
-                        />
-                      </FormDescription>
-                    </div>
                   </FormItem>
                 )}
               />
-              {/* Only show model parameters if using custom model */}
-              {!useDefaultModel &&
-                (!props.isEditing && !isCustomModelValid ? (
-                  <div className="text-destructive mt-2 flex items-center space-x-1 text-sm">
-                    <AlertCircle className="h-4 w-4" />
-                    <p>
-                      This evaluator is configured to use{" "}
-                      {modelParams.provider.value}s models but no API key
-                      exists. Add a key or choose another provider.
-                    </p>
-                  </div>
-                ) : (
-                  <ModelParameters
-                    customHeader={
-                      <p className="text-sm leading-none font-bold">
-                        Custom model configuration
-                      </p>
-                    }
-                    {...{
-                      modelParams,
-                      availableModels,
-                      providerModelCombinations,
-                      availableProviders,
-                      updateModelParamValue: updateModelParamValue,
-                      setModelParamEnabled,
-                      modelParamsDescription:
-                        "Select a model which supports function calling.",
-                    }}
-                    formDisabled={!props.isEditing}
-                  />
-                ))}
             </CardContent>
           </Card>
 
@@ -980,7 +1043,14 @@ const InnerEvalTemplateForm = (props: {
   );
 
   const formFooter = (
-    <div className="flex w-full flex-col items-end gap-4">
+    <div className="flex w-full flex-col gap-4">
+      {formError ? (
+        <Alert variant="destructive" key={formError} ref={scrollAlertIntoView}>
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Could not save</AlertTitle>
+          <AlertDescription>{formError}</AlertDescription>
+        </Alert>
+      ) : null}
       {props.isEditing && (
         <Button
           type="submit"
@@ -991,16 +1061,15 @@ const InnerEvalTemplateForm = (props: {
           Save
         </Button>
       )}
-      {formError ? (
-        <p className="text-destructive text-sm">{formError}</p>
-      ) : null}
     </div>
   );
 
   return (
     <Form {...form}>
       <form
-        onSubmit={form.handleSubmit(onSubmit)}
+        onSubmit={form.handleSubmit(onSubmit, () =>
+          setFormError("Fix the highlighted fields above and try again."),
+        )}
         className="mt-2 w-full space-y-4"
       >
         {props.useDialog ? <DialogBody>{formBody}</DialogBody> : formBody}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16595.preview.langfuse.com](https://pr-16595.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

On the evaluator template form, the "use default evaluation model" checkbox was nearly invisible in dark mode, so users assumed the default model was active while a custom model was configured. And save failures rendered as small text below the Save button (or, for field-validation failures, nothing at the form level at all).

## Changes

- Replace the single checkbox with a two-option radio group: "Default evaluation model" vs "Custom model". The selected option is a highlighted row with a filled radio, and the custom model configuration now nests inside its option, so the active model source is unambiguous in both themes, including view (non-edit) mode.
- Render save errors as a destructive alert (with title and icon) directly above the Save button instead of small text below it, and scroll the alert into view when it appears.
- Add a form-level fallback alert when client-side field validation blocks submission, which previously gave no form-level feedback.
- Clear stale form errors at the start of each submit.

The form value stays the same boolean (`shouldUseDefaultModel`), so nothing changes in the submit payload or API.

## How to test

On the preview (`pr-<N>.preview.langfuse.com`) or locally (`pnpm run dev:web`, `pnpm run seed`):

1. Go to Evaluators → create a custom evaluator (LLM-as-judge). The Model card shows the two radio options; toggle between them and check the selected row is obvious in dark mode.
2. With no default evaluation model set for the project, fill name + prompt, keep "Default evaluation model" selected, and hit Save → a red "Could not save" alert appears above the Save button and scrolls into view.
3. Clear the name and hit Save → the fallback "fix the highlighted fields" alert appears.
4. Open an existing evaluator template with a custom model in view mode → the "Custom model" option is visibly selected.

## What a reviewer should doubt

- The custom model configuration (`ModelParameters`) now renders nested inside the "Custom model" radio row; check this looks right in the dialog variant of the form (evaluator setup wizard), which I only verified on the standalone page.
- `ModelParameters` gets an `sr-only` custom header since the radio label already names the section; if the header should stay visible, that's a one-line change.
- The scroll-into-view uses a module-level callback ref keyed by the error message (no effect); if the same error message occurs twice in a row, it will not re-scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes evaluator model selection explicit through default/custom radio options and improves save-failure feedback with prominent, scrollable alerts.
- Nests custom model configuration under its selected radio option.
- Adds form-level feedback for client-side validation failures.
- Clears stale submission errors and adds focused component tests.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking footer regression that makes the Save button span the full available width.

The model-selection and error-feedback behavior remains functional, but removing the footer’s end alignment changes the existing Save button’s sizing and placement.

**Files Needing Attention:** web/src/features/evals/components/template-form.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/components/template-form.tsx:1046
**Save button stretches**

Removing `items-end` makes the column flex container stretch the Save button across the full footer width in both form variants, creating an unrelated layout regression while adding the full-width alert.

```suggestion
    <div className="flex w-full flex-col items-end gap-4">
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): make evaluator model choice ..."](https://github.com/langfuse/langfuse/commit/bceb0e12910ad47c6200082847a093a8c9c97098) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57025727)</sub>

<!-- /greptile_comment -->