### PR TITLE
security(api-keys): gate organization API key creation on the admin-api entitlement

### DIFF
--- a/web/src/__tests__/server/organizations-api-key-trpc.servertest.ts
+++ b/web/src/__tests__/server/organizations-api-key-trpc.servertest.ts
@@ -10,6 +10,7 @@ import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { createAndAddApiKeysToDb } from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
 
 describe("organization API keys trpc", () => {
   const organizationId = "seed-org-id";
@@ -31,6 +32,9 @@ describe("organization API keys trpc", () => {
     });
   });
 
+  // Instance admins bypass both RBAC and entitlement checks, so this session
+  // cannot cover plan gating. `entitledOwnerCaller` / `unentitledOwnerCaller`
+  // below are the non-admin owners used for that.
   const ownerSession: Session = {
     expires: "1",
     user: {
@@ -129,6 +133,48 @@ describe("organization API keys trpc", () => {
 
   const unAuthedCtx = createInnerTRPCContext({ session: null, headers: {} });
   const unAuthedCaller = appRouter.createCaller({ ...unAuthedCtx, prisma });
+
+  // Organization-scoped API keys are a paid feature (`admin-api` entitlement).
+  // These owners are deliberately not instance admins so the plan gate applies.
+  const ownerSessionOnPlan = (plan: SessionOrg["plan"]): Session => ({
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: organizationId,
+          name: "Test Organization",
+          role: "OWNER",
+          plan,
+          cloudConfig: undefined,
+          metadata: {},
+          projects: [] as SessionOrg["projects"],
+        } as SessionOrg,
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      } as SessionFeatureFlags,
+      admin: false,
+    },
+    environment: {} as any,
+  });
+
+  const callerForSession = (session: Session) =>
+    appRouter.createCaller({
+      ...createInnerTRPCContext({ session, headers: {} }),
+      prisma,
+    });
+
+  // cloud:hobby lacks `admin-api`; cloud:team carries it.
+  const unentitledOwnerCaller = callerForSession(
+    ownerSessionOnPlan("cloud:hobby"),
+  );
+  const entitledOwnerCaller = callerForSession(
+    ownerSessionOnPlan("cloud:team"),
+  );
 
   describe("organizationApiKeys.byOrganizationId", () => {
     it("owner can fetch organization API keys", async () => {
@@ -256,6 +302,42 @@ describe("organization API keys trpc", () => {
           note: "Test API Key",
         }),
       ).rejects.toThrow(TRPCError);
+    });
+
+    it("owner on a plan without admin-api cannot create organization API keys", async () => {
+      // Unique note so the persistence assertion stays independent of other
+      // tests and of keys left behind by earlier runs.
+      const note = `unentitled-create-${randomUUID()}`;
+
+      await expect(
+        unentitledOwnerCaller.organizationApiKeys.create({
+          orgId: organizationId,
+          note,
+        }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: "FORBIDDEN",
+          message: expect.stringContaining("admin-api"),
+        }),
+      );
+
+      // The rejection must happen before the key is persisted, otherwise the
+      // plan gate would only hide a key that already works.
+      await expect(
+        prisma.apiKey.findFirst({ where: { orgId: organizationId, note } }),
+      ).resolves.toBeNull();
+    });
+
+    it("owner on a plan with admin-api can create organization API keys", async () => {
+      const apiKeyResult = await entitledOwnerCaller.organizationApiKeys.create(
+        {
+          orgId: organizationId,
+          note: "Entitled plan key",
+        },
+      );
+
+      expect(apiKeyResult.secretKey).toBeDefined();
+      expect(apiKeyResult.publicKey).toBeDefined();
     });
   });
 
@@ -415,6 +497,33 @@ describe("organization API keys trpc", () => {
           id: apiKeyResult.id,
         }),
       ).rejects.toThrow(TRPCError);
+    });
+
+    it("owner on a plan without admin-api can still list and revoke existing keys", async () => {
+      // Only creation is plan-gated. A downgraded organization must keep the
+      // ability to see and revoke keys that were issued while entitled,
+      // otherwise a downgrade would strand live credentials.
+      const existingKey = await createAndAddApiKeysToDb({
+        prisma,
+        entityId: organizationId,
+        scope: "ORGANIZATION",
+        note: "Issued before downgrade",
+      });
+
+      const apiKeys =
+        await unentitledOwnerCaller.organizationApiKeys.byOrganizationId({
+          orgId: organizationId,
+        });
+      expect(apiKeys.map((key) => key.id)).toContain(existingKey.id);
+
+      await unentitledOwnerCaller.organizationApiKeys.delete({
+        orgId: organizationId,
+        id: existingKey.id,
+      });
+
+      await expect(
+        prisma.apiKey.findUnique({ where: { id: existingKey.id } }),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/web/src/features/public-api/server/organizationApiKeyRouter.ts
+++ b/web/src/features/public-api/server/organizationApiKeyRouter.ts
@@ -1,5 +1,6 @@
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import {
   createTRPCRouter,
   protectedOrganizationProcedure,
@@ -68,6 +69,14 @@ export const organizationApiKeysRouter = createTRPCRouter({
         session: ctx.session,
         organizationId: input.orgId,
         scope: "organization:CRUD_apiKeys",
+      });
+      // Issuing organization-scoped keys is a paid feature. Reads and deletes
+      // stay ungated so a downgraded organization can still revoke keys that
+      // were issued while it was entitled.
+      throwIfNoEntitlement({
+        entitlement: "admin-api",
+        sessionUser: ctx.session.user,
+        orgId: input.orgId,
       });
 
       const apiKeyMeta = await createAndAddApiKeysToDb({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16596.preview.langfuse.com](https://pr-16596.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

The `organizationApiKeys.create` tRPC mutation checked OWNER RBAC but never checked the `admin-api` entitlement, so an owner on a plan without that entitlement could mint organization-scoped API keys. This adds the missing `throwIfNoEntitlement` call.

## What was wrong

`create` enforced only `organization:CRUD_apiKeys`:

```ts
throwIfNoOrganizationAccess({ session, organizationId, scope: "organization:CRUD_apiKeys" });
// ...straight to createAndAddApiKeysToDb
```

The organization settings UI already hides the whole API keys page behind `useHasEntitlement("admin-api")`, so this was only reachable by calling tRPC directly. Every consuming org-scoped endpoint (`/api/public/organizations/*`, `/api/admin/organizations/*`) checks `admin-api` on its own, so a key created this way was inert until the organization upgraded. The impact is a commercial restriction bypass — no cross-tenant access.

## Fix

`throwIfNoEntitlement({ entitlement: "admin-api", ... })` after the RBAC check, the same pattern the admin API routes use around the same key-creation handler.

**Only creation is gated.** Listing, renaming and deleting stay open on purpose: an organization that downgrades must still be able to see and revoke keys issued while it was entitled. Gating those would strand live credentials, which would be a worse outcome than the bug being fixed. There is a test pinning that.

## Test evidence

Extended the existing suite in `web/src/__tests__/server/organizations-api-key-trpc.servertest.ts`. The existing `ownerSession` fixture is `admin: true`, and instance admins short-circuit `hasEntitlement`, so it could never have caught this — the new tests use non-admin OWNER sessions on `cloud:hobby` (no `admin-api`) and `cloud:team` (has it).

Three tests: unentitled owner is rejected with FORBIDDEN **and no key row is written**; entitled owner still succeeds; unentitled owner can still list and revoke a pre-existing key.

Revert-check — with the router change reverted, exactly the new gate test fails:

```
FAIL src/__tests__/server/organizations-api-key-trpc.servertest.ts > organizationApiKeys.create > owner on a plan without admin-api cannot create organization API keys
AssertionError: promise resolved "{ …(6) }" instead of rejecting
+   "secretKey": "sk-lf-...",
Tests  1 failed | 20 passed (21)
```

With the fix in place:

| Check | Result |
| --- | --- |
| `pnpm --filter web run test organizations-api-key-trpc` | `Tests  21 passed (21)` |
| `pnpm --filter web run test-client organization-settings-pages` | `Tests  4 passed (4)` |
| `pnpm run lint` | `Tasks: 7 successful, 7 total` |
| `pnpm --filter web run typecheck` | clean |

## Manual test steps

No UI change — the settings page was already hidden on unentitled plans, and the fix is server-side. To exercise it on `pr-<N>.preview.langfuse.com`, call `organizationApiKeys.create` via tRPC as an org owner whose plan lacks `admin-api`; it now returns FORBIDDEN instead of a key.

## Scope check

`organizationApiKeys.create` was the only ungated org-key creation path. I audited every `createAndAddApiKeysToDb` caller: the two admin API entry points already check `admin-api`, `initialize.ts` is PROJECT-scoped self-host provisioning, and the worker's in-app-agent key is a separate entitlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR closes a server-side commercial entitlement bypass by requiring the `admin-api` entitlement before organization API-key creation, while intentionally preserving listing and revocation after a downgrade.
- Adds the entitlement check after organization RBAC and before key persistence.
- Adds coverage for denied unentitled creation, successful entitled creation, and post-downgrade key listing and revocation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and correctly narrows organization API-key creation without preventing credential cleanup after downgrades.

The requested organization is authorized before the entitlement check, current plan information is reconstructed for each request, and key persistence occurs only after both guards pass; the tests cover both plan outcomes and intentional downgrade behavior.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Organization owner calls create] --> B[Authenticate session]
    B --> C[Check organization membership and API-key RBAC]
    C --> D{Has admin-api entitlement?}
    D -- No --> E[Return FORBIDDEN]
    D -- Yes --> F[Create organization API key]
    F --> G[Persist key and write audit log]
    H[List or revoke existing key] --> I[Check organization RBAC]
    I --> J[Allow downgrade cleanup without entitlement gate]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["security(api-keys): gate organization AP..."](https://github.com/langfuse/langfuse/commit/970e6245b8f212a0fdd316c1b9eee20174fdab85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57025757)</sub>

<!-- /greptile_comment -->