### PR TITLE
refactor(web): Extract `createLinkTableColumn`

### DIFF
--- a/web/src/components/design-system/Table/columns/createLinkTableColumn.stories.tsx
+++ b/web/src/components/design-system/Table/columns/createLinkTableColumn.stories.tsx
@@ -1,0 +1,90 @@
+import preview from "../../../../../.storybook/preview";
+
+import {
+  DataTable,
+  type AsyncTableData,
+} from "@/src/components/table/data-table";
+import { createLinkTableColumn } from "./createLinkTableColumn";
+
+type Row = {
+  id: string;
+  isLinkLoading?: boolean;
+  name: string | null;
+};
+
+const columns = [
+  createLinkTableColumn<Row>({
+    id: "name",
+    accessorFn: (row) => row.name,
+    header: "Link",
+    getCell: (name, { row }) => {
+      if (row.original.isLinkLoading) return { type: "loading" };
+      if (!name) return undefined;
+
+      return {
+        type: "link",
+        props: { path: `/items/${row.original.id}`, value: name },
+      };
+    },
+  }),
+];
+
+function LinkTableColumnStory({ data }: { data: AsyncTableData<Row[]> }) {
+  return (
+    <DataTable
+      tableName="link-column-story"
+      columns={columns}
+      data={data}
+      hidePagination
+      cellPadding="comfortable"
+    />
+  );
+}
+
+const meta = preview.meta({
+  component: LinkTableColumnStory,
+  parameters: {
+    layout: "fullscreen",
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ id: "item-1", name: "Production generation" }],
+    },
+  },
+});
+
+export const EmptyValue = meta.story({
+  name: "Empty Value",
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ id: "item-1", name: null }],
+    },
+  },
+});
+
+export const CellLoading = meta.story({
+  name: "Cell Loading",
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ id: "item-1", isLinkLoading: true, name: null }],
+    },
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    data: {
+      isLoading: true,
+      isError: false,
+    },
+  },
+});

--- a/web/src/components/design-system/Table/columns/createLinkTableColumn.tsx
+++ b/web/src/components/design-system/Table/columns/createLinkTableColumn.tsx
@@ -1,0 +1,49 @@
+import { type CellContext, type RowData } from "@tanstack/react-table";
+import { type LucideIcon } from "lucide-react";
+
+import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
+import TableLink, {
+  type TableLinkProps,
+} from "@/src/components/table/table-link";
+import {
+  createTableColumn,
+  type TableColumnOptions,
+} from "./utils/createTableColumn";
+
+type LinkTableColumnProps = Pick<
+  TableLinkProps,
+  "path" | "value" | "title" | "onClick"
+> & {
+  icon?: LucideIcon;
+};
+
+export function createLinkTableColumn<TData extends RowData, TValue = string>({
+  getCell,
+  ...options
+}: TableColumnOptions<TData, TValue> & {
+  getCell: (
+    value: TValue | null | undefined,
+    context: CellContext<TData, TValue | null | undefined>,
+  ) =>
+    | { type: "loading" }
+    | { type: "link"; props: LinkTableColumnProps }
+    | undefined;
+}) {
+  return createTableColumn<TData, TValue>({
+    ...options,
+    loadingCell: <TableTextLoadingCell />,
+    renderCell: (value, context) => {
+      const cell = getCell(value, context);
+      if (!cell) return null;
+      if (cell.type === "loading") return <TableTextLoadingCell />;
+
+      const { icon: Icon, ...tableLinkProps } = cell.props;
+      return (
+        <TableLink
+          {...tableLinkProps}
+          icon={Icon ? <Icon className="h-4 w-4" /> : undefined}
+        />
+      );
+    },
+  });
+}

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -9,8 +9,8 @@ import {
 import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
 import { createBadgeTableColumn } from "@/src/components/design-system/Table/columns/createBadgeTableColumn";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
-import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { IOTableCell } from "../../ui/IOTableCell";
 import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
@@ -732,119 +732,133 @@ export default function ScoresTable({
       enableHiding: true,
       defaultHidden: true,
     },
-    {
+    createLinkTableColumn<ScoresTableRow>({
       accessorKey: "traceName",
       header: "Trace Name",
-      id: "traceName",
       enableHiding: true,
       enableSorting: true,
       defaultHidden: true,
       size: 150,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        if (isBetaEnabled && !scoreMetrics.data)
-          return <TableTextLoadingCell />;
-        const value = row.getValue("traceName") as ScoresTableRow["traceName"];
+      getCell: (value) => {
+        if (isBetaEnabled && !scoreMetrics.data) return { type: "loading" };
+        if (!value) return undefined;
+
         const filter = encodeURIComponent(
           `name;stringOptions;;any of;${value}`,
         );
-        return value ? (
-          <TableLink
-            path={`/project/${projectId}/traces?filter=${value ? filter : ""}`}
-            value={value}
-          />
-        ) : undefined;
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/traces?filter=${filter}`,
+            value,
+          },
+        };
       },
-    },
-    {
+    }),
+    createLinkTableColumn<ScoresTableRow>({
       accessorKey: "traceId",
-      id: "traceId",
       enableColumnFilter: true,
       header: "Trace",
       enableSorting: true,
       size: 100,
-      cell: ({ row }) => {
-        const value = row.getValue("traceId");
-        return typeof value === "string" ? (
-          <>
-            <TableLink
-              path={`/project/${projectId}/traces/${encodeURIComponent(value)}`}
-              value={value}
+      getCell: (value) => {
+        if (typeof value !== "string") return undefined;
+
+        if (peekEnabled) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${encodeURIComponent(value)}`,
+              value,
               // Opens the trace in the peek side panel instead of navigating
-              // away; a modifier-click (cmd/ctrl, middle-click) still opens
-              // the real page in a new tab via the href above.
-              onClick={peekEnabled ? () => openScorePeek(value) : undefined}
-            />
-          </>
-        ) : undefined;
+              // away; a modifier-click still opens the href in a new tab.
+              onClick: () => openScorePeek(value),
+            },
+          };
+        }
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/traces/${encodeURIComponent(value)}`,
+            value,
+            onClick: undefined,
+          },
+        };
       },
-    },
-    {
+    }),
+    createLinkTableColumn<ScoresTableRow>({
       accessorKey: "observationId",
-      id: "observationId",
       header: "Observation",
       enableSorting: true,
       size: 100,
-      cell: ({ row }) => {
-        const observationId = row.getValue(
-          "observationId",
-        ) as ScoresTableRow["observationId"];
+      getCell: (observationId, { row }) => {
         const traceId = row.getValue("traceId") as ScoresTableRow["traceId"];
-        return traceId && observationId ? (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(observationId)}`}
-            value={observationId}
-            // extractParamsValuesFromRow reads `row.observationId` (the
-            // original, not the table row wrapper) to add `?observation=`
-            // to the peek URL, focusing this observation within the trace.
-            onClick={
-              peekEnabled
-                ? () => openScorePeek(traceId, row.original)
-                : undefined
-            }
-          />
-        ) : undefined;
+        if (!traceId || !observationId) return undefined;
+
+        if (peekEnabled) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(observationId)}`,
+              value: observationId,
+              // extractParamsValuesFromRow reads the original row to focus
+              // this observation within the trace in the peek URL.
+              onClick: () => openScorePeek(traceId, row.original),
+            },
+          };
+        }
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(observationId)}`,
+            value: observationId,
+            onClick: undefined,
+          },
+        };
       },
-    },
-    {
+    }),
+    createLinkTableColumn<ScoresTableRow>({
       accessorKey: "executionTraceId",
-      id: "executionTraceId",
       header: "Execution Trace",
       enableSorting: false,
       enableHiding: true,
       defaultHidden: true,
       size: 100,
-      cell: ({ row }) => {
-        const value = row.getValue("executionTraceId");
-        return typeof value === "string" ? (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(value)}`}
-            value={value}
-          />
-        ) : undefined;
+      getCell: (value) => {
+        if (typeof value !== "string") return undefined;
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/traces/${encodeURIComponent(value)}`,
+            value,
+          },
+        };
       },
-    },
-    {
+    }),
+    createLinkTableColumn<ScoresTableRow>({
       accessorKey: "sessionId",
       header: "Session",
-      id: "sessionId",
       enableHiding: true,
       enableSorting: true,
       size: 100,
-      cell: ({ row }) => {
-        const value = row.getValue("sessionId");
-        return typeof value === "string" ? (
-          <TableLink
-            path={`/project/${projectId}/sessions/${encodeURIComponent(value)}`}
-            value={value}
-          />
-        ) : undefined;
+      getCell: (value) => {
+        if (typeof value !== "string") return undefined;
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/sessions/${encodeURIComponent(value)}`,
+            value,
+          },
+        };
       },
-    },
-    {
+    }),
+    createLinkTableColumn<ScoresTableRow>({
       accessorKey: "userId",
       header: "User",
-      id: "userId",
       headerTooltip: {
         description: "The user ID associated with the trace.",
         href: "https://langfuse.com/docs/observability/features/users",
@@ -853,21 +867,19 @@ export default function ScoresTable({
       enableSorting: true,
       defaultHidden: true,
       size: 100,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        if (isBetaEnabled && !scoreMetrics.data)
-          return <TableTextLoadingCell />;
-        const value = row.getValue("userId");
-        return typeof value === "string" ? (
-          <>
-            <TableLink
-              path={`/project/${projectId}/users/${encodeURIComponent(value)}`}
-              value={value}
-            />
-          </>
-        ) : undefined;
+      getCell: (value) => {
+        if (isBetaEnabled && !scoreMetrics.data) return { type: "loading" };
+        if (typeof value !== "string") return undefined;
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/users/${encodeURIComponent(value)}`,
+            value,
+          },
+        };
       },
-    },
+    }),
     {
       accessorKey: "author",
       id: "author",
@@ -892,10 +904,9 @@ export default function ScoresTable({
         );
       },
     },
-    {
+    createLinkTableColumn<ScoresTableRow>({
       accessorKey: "jobConfigurationId",
       header: isBetaEnabled ? "Evaluator" : "Eval Configuration ID",
-      id: "jobConfigurationId",
       headerTooltip: {
         description: isBetaEnabled
           ? "The evaluator associated with the score."
@@ -906,24 +917,32 @@ export default function ScoresTable({
       enableSorting: false,
       defaultHidden: true,
       size: 150,
-      cell: ({ row }) => {
-        const value = isBetaEnabled
-          ? row.original.evaluatorId
-          : row.getValue("jobConfigurationId");
+      getCell: (_, { row }) => {
+        if (isBetaEnabled) {
+          const value = row.original.evaluatorId;
+          if (typeof value !== "string") return undefined;
+
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/evals/${value}`,
+              value,
+            },
+          };
+        }
+
+        const value = row.getValue("jobConfigurationId");
         if (typeof value !== "string") return undefined;
 
-        return (
-          <TableLink
-            path={
-              isBetaEnabled
-                ? `/project/${projectId}/evals/${value}`
-                : `/project/${projectId}/evals/legacy/${value}`
-            }
-            value={value}
-          />
-        );
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/evals/legacy/${value}`,
+            value,
+          },
+        };
       },
-    },
+    }),
   ];
 
   const tableActions: TableAction[] = [

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -7,6 +7,7 @@ import {
 import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
 import { createBadgeTableColumn } from "@/src/components/design-system/Table/columns/createBadgeTableColumn";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
@@ -456,23 +457,24 @@ export default function SessionsTable({
 
   const columns: LangfuseColumnDef<SessionTableRow>[] = [
     selectActionColumn,
-    {
+    createLinkTableColumn<SessionTableRow>({
       accessorKey: "id",
-      id: "id",
       header: "ID",
       size: 200,
       isFixedPosition: true,
-      cell: ({ row }) => {
-        const value: SessionTableRow["id"] = row.getValue("id");
-        return value && typeof value === "string" ? (
-          <TableLink
-            path={`/project/${projectId}/sessions/${encodeURIComponent(value)}`}
-            value={value}
-          />
-        ) : undefined;
+      getCell: (value) => {
+        if (!value || typeof value !== "string") return undefined;
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/sessions/${encodeURIComponent(value)}`,
+            value,
+          },
+        };
       },
       enableSorting: true,
-    },
+    }),
     createDateTableColumn<SessionTableRow>({
       accessorKey: "createdAt",
       header: "Created At",

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -1,5 +1,4 @@
 import { DataTable } from "@/src/components/table/data-table";
-import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
@@ -37,6 +36,7 @@ import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { createIdTableColumn } from "@/src/components/design-system/Table/columns/createIdTableColumn";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 
 const QueueItemTableMultiSelectAction = ({
   selectedItemIds,
@@ -221,22 +221,25 @@ export function AnnotationQueueItemsTable({
         );
       },
     },
-    {
+    createLinkTableColumn<QueueItemRowData>({
       accessorKey: "id",
       header: "Id",
-      id: "id",
       size: 70,
       isFixedPosition: true,
-      cell: ({ row }) => {
-        const id: QueueItemRowData["id"] = row.getValue("id");
-        return (
-          <TableLink
-            path={`/project/${projectId}/annotation-queues/${queueId}/items/${id}?singleItem=true`}
-            value={id}
-          />
-        );
+      getCell: (id) => {
+        if (id) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/annotation-queues/${queueId}/items/${id}?singleItem=true`,
+              value: id,
+            },
+          };
+        }
+
+        return undefined;
       },
-    },
+    }),
     {
       accessorKey: "objectType",
       header: "Type",
@@ -248,49 +251,50 @@ export function AnnotationQueueItemsTable({
         return <span className="capitalize">{objectType.toLowerCase()}</span>;
       },
     },
-    {
+    createLinkTableColumn<QueueItemRowData, QueueItemRowData["source"]>({
       accessorKey: "source",
       header: "Source",
       headerTooltip: {
         description:
           "Link to the source trace, observation or session based on which this item was added",
       },
-      id: "source",
       size: 50,
-      cell: ({ row }) => {
+      getCell: (_, { row }) => {
         const rowData = row.original;
-        if (!rowData.source) return null;
+        if (!rowData.source) return undefined;
 
-        switch (rowData.objectType) {
-          case "OBSERVATION":
-            return (
-              <TableLink
-                path={`/project/${projectId}/traces/${rowData.source.traceId}?observation=${rowData.source.observationId}`}
-                value={`Observation: ${rowData.source.observationId}`}
-                icon={<ListTree className="h-4 w-4" />}
-              />
-            );
-          case "TRACE":
-            return (
-              <TableLink
-                path={`/project/${projectId}/traces/${rowData.source.traceId}`}
-                value={`Trace: ${rowData.source.traceId}`}
-                icon={<ListTree className="h-4 w-4" />}
-              />
-            );
-          case "SESSION":
-            return (
-              <TableLink
-                path={`/project/${projectId}/sessions/${rowData.source.sessionId}`}
-                value={`Session: ${rowData.source.sessionId}`}
-                icon={<ListTree className="h-4 w-4" />}
-              />
-            );
-          default:
-            throw new Error(`Unknown object type`);
+        if (rowData.objectType === "OBSERVATION") {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${rowData.source.traceId}?observation=${rowData.source.observationId}`,
+              value: `Observation: ${rowData.source.observationId}`,
+              icon: ListTree,
+            },
+          };
         }
+
+        if (rowData.objectType === "TRACE") {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${rowData.source.traceId}`,
+              value: `Trace: ${rowData.source.traceId}`,
+              icon: ListTree,
+            },
+          };
+        }
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/sessions/${rowData.source.sessionId}`,
+            value: `Session: ${rowData.source.sessionId}`,
+            icon: ListTree,
+          },
+        };
       },
-    },
+    }),
     createIdTableColumn<QueueItemRowData>({
       accessorKey: "sourceId",
       header: "Source ID",

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -12,7 +12,7 @@ import { CreateOrEditAnnotationQueueButton } from "@/src/features/annotation-que
 import { ClipboardPen, Lock } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
-import TableLink from "@/src/components/table/table-link";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import Link from "next/link";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { DeleteAnnotationQueueButton } from "@/src/features/annotation-queues/components/DeleteAnnotationQueueButton";
@@ -55,23 +55,26 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
   });
 
   const columns: LangfuseColumnDef<RowData>[] = [
-    {
+    createLinkTableColumn<RowData, RowData["key"]>({
       accessorKey: "key",
       header: "Name",
-      id: "key",
       size: 150,
       isPinnedLeft: true,
       isFixedPosition: true,
-      cell: ({ row }) => {
-        const key: RowData["key"] = row.getValue("key");
-        return key && "id" in key && typeof key.id === "string" ? (
-          <TableLink
-            path={`/project/${projectId}/annotation-queues/${key.id}`}
-            value={key.name}
-          />
-        ) : undefined;
+      getCell: (key) => {
+        if (key && "id" in key && typeof key.id === "string") {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/annotation-queues/${key.id}`,
+              value: key.name,
+            },
+          };
+        }
+
+        return undefined;
       },
-    },
+    }),
     {
       accessorKey: "description",
       header: "Description",

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -7,8 +7,8 @@ import { safeExtract } from "@/src/utils/map-utils";
 import { DataTable } from "@/src/components/table/data-table";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { createColumnHelper } from "@tanstack/react-table";
-import TableLink from "@/src/components/table/table-link";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/Table/columns/createTextTableColumn";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { Button } from "@/src/components/ui/button";
@@ -211,19 +211,23 @@ export function DashboardTable() {
 
   const columnHelper = createColumnHelper<DashboardTableRow>();
   const dashboardColumns = [
-    columnHelper.accessor("name", {
+    createLinkTableColumn<DashboardTableRow>({
+      accessorKey: "name",
       header: "Name",
-      id: "name",
       enableSorting: true,
       size: 200,
-      cell: (row) => {
-        const name = row.getValue();
-        return name ? (
-          <TableLink
-            path={`/project/${projectId}/dashboards/${encodeURIComponent(row.row.original.id)}`}
-            value={name}
-          />
-        ) : undefined;
+      getCell: (name, { row }) => {
+        if (name) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/dashboards/${encodeURIComponent(row.original.id)}`,
+              value: name,
+            },
+          };
+        }
+
+        return undefined;
       },
     }),
     createTextTableColumn<DashboardTableRow>({

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -1,8 +1,8 @@
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { FilteredRunPills } from "@/src/components/table/filtered-run-pills";
-import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { getDatasetRunAggregateColumnProps } from "@/src/features/datasets/components/DatasetRunAggregateColumnHelpers";
@@ -136,23 +136,23 @@ function DatasetCompareRunsTableInternal(props: {
     });
 
   const columns: LangfuseColumnDef<DatasetCompareRunRowData>[] = [
-    {
+    createLinkTableColumn<DatasetCompareRunRowData>({
       accessorKey: "id",
       header: "Item id",
-      id: "id",
       size: 90,
       enableHiding: true,
       defaultHidden: true,
-      cell: ({ row }) => {
-        const id: string = row.getValue("id");
-        return (
-          <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/items/${id}`}
-            value={id}
-          />
-        );
+      getCell: (id) => {
+        if (!id) return undefined;
+        return {
+          type: "link",
+          props: {
+            path: `/project/${props.projectId}/datasets/${props.datasetId}/items/${id}`,
+            value: id,
+          },
+        };
       },
-    },
+    }),
     {
       accessorKey: "input",
       header: "Input",

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -1,5 +1,5 @@
 import { DataTable } from "@/src/components/table/data-table";
-import TableLink from "@/src/components/table/table-link";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
 import { type RouterOutput } from "@/src/utils/types";
@@ -142,52 +142,56 @@ export function DatasetItemsTable({
   );
 
   const columns: LangfuseColumnDef<RowData>[] = [
-    {
+    createLinkTableColumn<RowData>({
       accessorKey: "id",
       header: "Item id",
-      id: "id",
       size: 90,
       isFixedPosition: true,
-      cell: ({ row }) => {
-        const id: string = row.getValue("id");
-        const versionParam = selectedVersion
-          ? `?version=${encodeURIComponent(selectedVersion.toISOString())}`
-          : "";
-        return (
-          <TableLink
-            path={`/project/${projectId}/datasets/${datasetId}/items/${id}${versionParam}`}
-            value={id}
-          />
-        );
+      getCell: (id) => {
+        if (!id) return undefined;
+        let versionParam = "";
+        if (selectedVersion) {
+          versionParam = `?version=${encodeURIComponent(selectedVersion.toISOString())}`;
+        }
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/datasets/${datasetId}/items/${id}${versionParam}`,
+            value: id,
+          },
+        };
       },
-    },
-    {
+    }),
+    createLinkTableColumn<RowData, RowData["source"]>({
       accessorKey: "source",
       header: "Source",
       headerTooltip: {
         description:
           "Link to the source trace based on which this item was added",
       },
-      id: "source",
       size: 90,
-      cell: ({ row }) => {
-        const source: RowData["source"] = row.getValue("source");
-        if (!source) return null;
-        return source.observationId ? (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(source.traceId)}?observation=${encodeURIComponent(source.observationId)}`}
-            value={source.observationId}
-            icon={<ListTree className="h-4 w-4" />}
-          />
-        ) : (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(source.traceId)}`}
-            value={source.traceId}
-            icon={<ListTree className="h-4 w-4" />}
-          />
-        );
+      getCell: (source) => {
+        if (!source) return undefined;
+        if (source.observationId) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${encodeURIComponent(source.traceId)}?observation=${encodeURIComponent(source.observationId)}`,
+              value: source.observationId,
+              icon: ListTree,
+            },
+          };
+        }
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/traces/${encodeURIComponent(source.traceId)}`,
+            value: source.traceId,
+            icon: ListTree,
+          },
+        };
       },
-    },
+    }),
     {
       accessorKey: "status",
       header: "Status",

--- a/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
@@ -1,6 +1,6 @@
 import { DataTable } from "@/src/components/table/data-table";
-import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
@@ -144,30 +144,35 @@ export function DatasetRunItemsByItemTable(props: {
         />
       ),
     },
-    {
+    createLinkTableColumn<
+      DatasetRunItemByItemRowData,
+      DatasetRunItemByItemRowData["trace"]
+    >({
       accessorKey: "trace",
       header: "Trace",
-      id: "trace",
       size: 60,
-      cell: ({ row }) => {
-        const trace: DatasetRunItemByItemRowData["trace"] =
-          row.getValue("trace");
-        if (!trace) return null;
-        return trace.observationId ? (
-          <TableLink
-            path={`/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}?observation=${encodeURIComponent(trace.observationId)}`}
-            value={`Trace: ${trace.traceId}, Observation: ${trace.observationId}`}
-            icon={<ListTree className="h-4 w-4" />}
-          />
-        ) : (
-          <TableLink
-            path={`/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}`}
-            value={`Trace: ${trace.traceId}`}
-            icon={<ListTree className="h-4 w-4" />}
-          />
-        );
+      getCell: (trace) => {
+        if (!trace) return undefined;
+        if (trace.observationId) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}?observation=${encodeURIComponent(trace.observationId)}`,
+              value: `Trace: ${trace.traceId}, Observation: ${trace.observationId}`,
+              icon: ListTree,
+            },
+          };
+        }
+        return {
+          type: "link",
+          props: {
+            path: `/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}`,
+            value: `Trace: ${trace.traceId}`,
+            icon: ListTree,
+          },
+        };
       },
-    },
+    }),
     {
       accessorKey: "latency",
       header: "Latency",

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -1,6 +1,6 @@
 import { DataTable } from "@/src/components/table/data-table";
-import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
@@ -98,54 +98,60 @@ export function DatasetRunItemsByRunTable(props: {
     });
 
   const columns: LangfuseColumnDef<DatasetRunItemByRunRowData>[] = [
-    {
+    createLinkTableColumn<DatasetRunItemByRunRowData>({
       accessorKey: "datasetItemId",
       header: "Dataset Item",
-      id: "datasetItemId",
       size: 110,
       isPinnedLeft: true,
-      cell: ({ row }) => {
-        const datasetItemId: string = row.getValue("datasetItemId");
-        const versionParam = datasetVersion
-          ? `?version=${datasetVersion.toISOString()}`
-          : "";
-        return (
-          <TableLink
-            path={`/project/${projectId}/datasets/${datasetId}/items/${datasetItemId}${versionParam}`}
-            value={datasetItemId}
-          />
-        );
+      getCell: (datasetItemId) => {
+        if (!datasetItemId) return undefined;
+        let versionParam = "";
+        if (datasetVersion) {
+          versionParam = `?version=${datasetVersion.toISOString()}`;
+        }
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/datasets/${datasetId}/items/${datasetItemId}${versionParam}`,
+            value: datasetItemId,
+          },
+        };
       },
-    },
+    }),
     createDateTableColumn<DatasetRunItemByRunRowData>({
       accessorKey: "runAt",
       header: "Run At",
       size: 150,
     }),
-    {
+    createLinkTableColumn<
+      DatasetRunItemByRunRowData,
+      DatasetRunItemByRunRowData["trace"]
+    >({
       accessorKey: "trace",
       header: "Trace",
-      id: "trace",
       size: 60,
-      cell: ({ row }) => {
-        const trace: DatasetRunItemByRunRowData["trace"] =
-          row.getValue("trace");
-        if (!trace) return null;
-        return trace.observationId ? (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(trace.traceId)}?observation=${encodeURIComponent(trace.observationId)}`}
-            value={`Trace: ${trace.traceId}, Observation: ${trace.observationId}`}
-            icon={<ListTree className="h-4 w-4" />}
-          />
-        ) : (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(trace.traceId)}`}
-            value={`Trace: ${trace.traceId}`}
-            icon={<ListTree className="h-4 w-4" />}
-          />
-        );
+      getCell: (trace) => {
+        if (!trace) return undefined;
+        if (trace.observationId) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${encodeURIComponent(trace.traceId)}?observation=${encodeURIComponent(trace.observationId)}`,
+              value: `Trace: ${trace.traceId}, Observation: ${trace.observationId}`,
+              icon: ListTree,
+            },
+          };
+        }
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/traces/${encodeURIComponent(trace.traceId)}`,
+            value: `Trace: ${trace.traceId}`,
+            icon: ListTree,
+          },
+        };
       },
-    },
+    }),
     {
       accessorKey: "latency",
       header: "Latency",

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -1,6 +1,6 @@
 import { DataTable } from "@/src/components/table/data-table";
-import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
@@ -383,41 +383,40 @@ export function DatasetRunsTable(props: {
         );
       },
     },
-    {
+    createLinkTableColumn<DatasetRunRowData>({
       accessorKey: "name",
       header: "Name",
-      id: "name",
       size: 150,
       isFixedPosition: true,
       isPinnedLeft: true,
-      cell: ({ row }) => {
-        const name: DatasetRunRowData["name"] = row.getValue("name");
-        const id: DatasetRunRowData["id"] = row.getValue("id");
-        return (
-          <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`}
-            value={name}
-          />
-        );
+      getCell: (name, { row }) => {
+        if (!name) return undefined;
+        return {
+          type: "link",
+          props: {
+            path: `/project/${props.projectId}/datasets/${props.datasetId}/runs/${row.original.id}`,
+            value: name,
+          },
+        };
       },
-    },
-    {
+    }),
+    createLinkTableColumn<DatasetRunRowData>({
       accessorKey: "id",
       header: "Id",
-      id: "id",
       size: 150,
       enableHiding: true,
       defaultHidden: true,
-      cell: ({ row }) => {
-        const id: DatasetRunRowData["id"] = row.getValue("id");
-        return (
-          <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`}
-            value={id}
-          />
-        );
+      getCell: (id) => {
+        if (!id) return undefined;
+        return {
+          type: "link",
+          props: {
+            path: `/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`,
+            value: id,
+          },
+        };
       },
-    },
+    }),
     {
       accessorKey: "description",
       header: "Description",

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -10,8 +10,8 @@ import {
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
-import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
@@ -172,61 +172,77 @@ export default function EvalLogTable({
         );
       },
     }),
-    columnHelper.accessor("traceId", {
-      id: "traceId",
+    createLinkTableColumn<JobExecutionRow>({
+      accessorKey: "traceId",
       header: "Target Trace",
-      cell: (row) => {
-        const traceId = row.getValue();
-        return traceId ? (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(traceId)}`}
-            value={traceId}
-          />
-        ) : undefined;
+      getCell: (traceId) => {
+        if (traceId) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${encodeURIComponent(traceId)}`,
+              value: traceId,
+            },
+          };
+        }
+
+        return undefined;
       },
     }),
-    columnHelper.accessor("executionTraceId", {
-      id: "executionTraceId",
+    createLinkTableColumn<JobExecutionRow>({
+      accessorKey: "executionTraceId",
       header: "Execution Trace",
       enableHiding: true,
-      cell: (row) => {
-        const traceId = row.getValue();
-        return traceId ? (
-          <TableLink
-            path={`/project/${projectId}/traces/${encodeURIComponent(traceId)}`}
-            value={traceId}
-          />
-        ) : undefined;
+      getCell: (traceId) => {
+        if (traceId) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/traces/${encodeURIComponent(traceId)}`,
+              value: traceId,
+            },
+          };
+        }
+
+        return undefined;
       },
     }),
-    columnHelper.accessor("templateId", {
-      id: "templateId",
+    createLinkTableColumn<JobExecutionRow>({
+      accessorKey: "templateId",
       header: "Template",
-      cell: (row) => {
-        const templateId = row.getValue();
-        return templateId ? (
-          <TableLink
-            path={`/project/${projectId}/evals/templates/${encodeURIComponent(templateId)}`}
-            value={templateId}
-          />
-        ) : undefined;
+      getCell: (templateId) => {
+        if (templateId) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/evals/templates/${encodeURIComponent(templateId)}`,
+              value: templateId,
+            },
+          };
+        }
+
+        return undefined;
       },
     }),
   ] as LangfuseColumnDef<JobExecutionRow>[];
 
   if (!jobConfigurationId) {
     columns.push(
-      columnHelper.accessor("evaluatorId", {
-        id: "evaluatorId",
+      createLinkTableColumn<JobExecutionRow>({
+        accessorKey: "evaluatorId",
         header: "Evaluator",
-        cell: (row) => {
-          const evaluatorId = row.getValue();
-          return evaluatorId ? (
-            <TableLink
-              path={`/project/${projectId}/evals/legacy/${encodeURIComponent(evaluatorId)}`}
-              value={evaluatorId}
-            />
-          ) : undefined;
+        getCell: (evaluatorId) => {
+          if (evaluatorId) {
+            return {
+              type: "link",
+              props: {
+                path: `/project/${projectId}/evals/legacy/${encodeURIComponent(evaluatorId)}`,
+                value: evaluatorId,
+              },
+            };
+          }
+
+          return undefined;
         },
       }) as LangfuseColumnDef<JobExecutionRow>,
     );

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -6,8 +6,8 @@ import { api } from "@/src/utils/api";
 import { DataTable } from "@/src/components/table/data-table";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { createColumnHelper } from "@tanstack/react-table";
-import TableLink from "@/src/components/table/table-link";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/Table/columns/createTextTableColumn";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import startCase from "lodash/startCase";
@@ -274,19 +274,23 @@ export function DashboardWidgetTable() {
 
   const columnHelper = createColumnHelper<WidgetTableRow>();
   const widgetColumns = [
-    columnHelper.accessor("name", {
+    createLinkTableColumn<WidgetTableRow>({
+      accessorKey: "name",
       header: "Name",
-      id: "name",
       enableSorting: true,
       size: 200,
-      cell: (row) => {
-        const name = row.getValue();
-        return name ? (
-          <TableLink
-            path={`/project/${projectId}/widgets/${encodeURIComponent(row.row.original.id)}`}
-            value={name}
-          />
-        ) : undefined;
+      getCell: (name, { row }) => {
+        if (name) {
+          return {
+            type: "link",
+            props: {
+              path: `/project/${projectId}/widgets/${encodeURIComponent(row.original.id)}`,
+              value: name,
+            },
+          };
+        }
+
+        return undefined;
       },
     }),
     createTextTableColumn<WidgetTableRow>({

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { type RouterOutput } from "@/src/utils/types";
-import TableLink from "@/src/components/table/table-link";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
@@ -170,22 +170,23 @@ export default function PromptVersionTable({
   });
 
   const columns: LangfuseColumnDef<PromptVersionTableRow>[] = [
-    {
+    createLinkTableColumn<PromptVersionTableRow, number>({
       accessorKey: "version",
-      id: "version",
       header: "Version",
       isPinnedLeft: true,
       size: 80,
-      cell: ({ row }) => {
-        const version = row.getValue("version");
-        return typeof version === "number" ? (
-          <TableLink
-            path={`/project/${projectId}/prompts/${encodeURIComponent(promptName)}/?version=${version}`}
-            value={String(version)}
-          />
-        ) : null;
+      getCell: (version) => {
+        if (typeof version !== "number") return undefined;
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/prompts/${encodeURIComponent(promptName)}/?version=${version}`,
+            value: String(version),
+          },
+        };
       },
-    },
+    }),
     {
       accessorKey: "labels",
       id: "labels",

--- a/web/src/pages/project/[projectId]/users/index.tsx
+++ b/web/src/pages/project/[projectId]/users/index.tsx
@@ -11,7 +11,7 @@ import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { DataTable } from "@/src/components/table/data-table";
 import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
 import { createBadgeTableColumn } from "@/src/components/design-system/Table/columns/createBadgeTableColumn";
-import TableLink from "@/src/components/table/table-link";
+import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
@@ -290,7 +290,7 @@ const UsersTable = ({
   }, [users.isSuccess, users.data]);
 
   const columns: LangfuseColumnDef<RowData>[] = [
-    {
+    createLinkTableColumn<RowData>({
       accessorKey: "userId",
       enableColumnFilter: true,
       header: "User ID",
@@ -300,18 +300,18 @@ const UsersTable = ({
         href: "https://langfuse.com/docs/observability/features/users",
       },
       size: 150,
-      cell: ({ row }) => {
-        const value: RowData["userId"] = row.getValue("userId");
-        return typeof value === "string" ? (
-          <>
-            <TableLink
-              path={`/project/${projectId}/users/${encodeURIComponent(value)}`}
-              value={value}
-            />
-          </>
-        ) : undefined;
+      getCell: (value) => {
+        if (typeof value !== "string") return undefined;
+
+        return {
+          type: "link",
+          props: {
+            path: `/project/${projectId}/users/${encodeURIComponent(value)}`,
+            value,
+          },
+        };
       },
-    },
+    }),
     createBadgeTableColumn<RowData>({
       accessorKey: "environment",
       header: "Environment",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16598.preview.langfuse.com](https://pr-16598.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts repeated linked-table-cell rendering into a typed `createLinkTableColumn` helper and migrates link columns across table-based product surfaces.
- Adds the shared helper and Storybook states for links, empty values, cell loading, and table loading.
- Migrates score, session, annotation queue, dashboard, dataset, evaluation, widget, prompt, and user table columns.
- Preserves existing column identities, link destinations, icons, and trace-peek click behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete behavioral, build, or contract regressions identified.

The shared helper matches the existing table-column type and loading contracts, and the migrated columns preserve their IDs, destinations, icons, nullable handling, and click behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Extract \`createLinkTableC..."](https://github.com/langfuse/langfuse/commit/eed1160750c64e24981b23f1ea91d5f372695834) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57026716)</sub>

<!-- /greptile_comment -->