### PR TITLE
fix(web): require audit log access for audit-log batch export downloads (v3 backport of #16567)

### DIFF
--- a/web/src/__tests__/server/batchExport-trpc.servertest.ts
+++ b/web/src/__tests__/server/batchExport-trpc.servertest.ts
@@ -5,6 +5,7 @@ import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
 import {
   BatchExportFileFormat,
+  BatchExportStatus,
   BatchTableNames,
   type Plan,
 } from "@langfuse/shared";
@@ -164,6 +165,114 @@ describe("batchExport tRPC – audit_logs table authorization", () => {
       expect(job?.query).toMatchObject({ tableName: "audit_logs" });
     },
   );
+});
+
+const seedCompletedExport = (opts: {
+  projectId: string;
+  name: string;
+  tableName: BatchTableNames;
+}) =>
+  prisma.batchExport.create({
+    data: {
+      projectId: opts.projectId,
+      userId: "user-test",
+      status: BatchExportStatus.COMPLETED,
+      name: opts.name,
+      format: BatchExportFileFormat.CSV,
+      url: "not-a-valid-url",
+      finishedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      query: {
+        tableName: opts.tableName,
+        filter: null,
+        orderBy: null,
+      },
+    },
+  });
+
+describe("batchExport tRPC – audit_logs list authorization", () => {
+  afterAll(async () => {
+    await prisma.organization.deleteMany({
+      where: { id: { in: __orgIds } },
+    });
+  });
+
+  it("hides audit_logs exports from all for a MEMBER without auditLogs:read", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "audit export hidden",
+      tableName: BatchTableNames.AuditLogs,
+    });
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "traces export visible",
+      tableName: BatchTableNames.Traces,
+    });
+
+    const memberCaller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "MEMBER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    const result = await memberCaller.batchExport.all({
+      projectId: project.id,
+      page: 0,
+      limit: 50,
+    });
+
+    expect(result.exports.map((e) => e.name)).toEqual([
+      "traces export visible",
+    ]);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it("includes audit_logs exports in all for an OWNER with entitlement", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "audit export listed",
+      tableName: BatchTableNames.AuditLogs,
+    });
+    await seedCompletedExport({
+      projectId: project.id,
+      name: "traces export listed",
+      tableName: BatchTableNames.Traces,
+    });
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "OWNER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    const result = await caller.batchExport.all({
+      projectId: project.id,
+      page: 0,
+      limit: 50,
+    });
+
+    expect(result.exports.map((e) => e.name).sort()).toEqual([
+      "audit export listed",
+      "traces export listed",
+    ]);
+    expect(result.totalCount).toBe(2);
+  });
 });
 
 describe("batchExport tRPC – useEventsTable snapshot", () => {

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -1,7 +1,14 @@
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
-import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
+  hasEntitlement,
+  throwIfNoEntitlement,
+} from "@/src/features/entitlements/server/hasEntitlement";
+import {
+  hasProjectAccess,
+  throwIfNoProjectAccess,
+} from "@/src/features/rbac/utils/checkProjectAccess";
+import {
+  type AuthedSession,
   createTRPCRouter,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
@@ -19,6 +26,24 @@ import {
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { assertLegacyTracingIoSearchCanCreateBatchJob } from "@/src/features/traces/server/legacyIoSearch";
+
+const canReadAuditLogs = (session: AuthedSession, projectId: string) =>
+  hasEntitlement({
+    entitlement: "audit-logs",
+    sessionUser: session.user,
+    projectId,
+  }) && hasProjectAccess({ session, projectId, scope: "auditLogs:read" });
+
+// An audit-log export holds actor identifiers and admin actions, so reading
+// one needs the audit-log gates too, not just the batch-export ones.
+const assertCanReadAuditLogs = (session: AuthedSession, projectId: string) => {
+  throwIfNoEntitlement({
+    entitlement: "audit-logs",
+    sessionUser: session.user,
+    projectId,
+  });
+  throwIfNoProjectAccess({ session, projectId, scope: "auditLogs:read" });
+};
 
 export const batchExportRouter = createTRPCRouter({
   create: protectedProjectProcedure
@@ -43,16 +68,7 @@ export const batchExportRouter = createTRPCRouter({
         };
 
         if (query.tableName === BatchExportTableName.AuditLogs) {
-          throwIfNoEntitlement({
-            entitlement: "audit-logs",
-            sessionUser: ctx.session.user,
-            projectId,
-          });
-          throwIfNoProjectAccess({
-            session: ctx.session,
-            projectId,
-            scope: "auditLogs:read",
-          });
+          assertCanReadAuditLogs(ctx.session, projectId);
         }
 
         assertLegacyTracingIoSearchCanCreateBatchJob({
@@ -140,11 +156,23 @@ export const batchExportRouter = createTRPCRouter({
         scope: "batchExports:read",
       });
 
+      const where = {
+        projectId: input.projectId,
+        ...(canReadAuditLogs(ctx.session, input.projectId)
+          ? {}
+          : {
+              NOT: {
+                query: {
+                  path: ["tableName"],
+                  equals: BatchExportTableName.AuditLogs,
+                },
+              },
+            }),
+      };
+
       const [exports, totalCount] = await Promise.all([
         ctx.prisma.batchExport.findMany({
-          where: {
-            projectId: input.projectId,
-          },
+          where,
           take: input.limit,
           skip: input.page * input.limit,
           orderBy: {
@@ -152,9 +180,7 @@ export const batchExportRouter = createTRPCRouter({
           },
         }),
         ctx.prisma.batchExport.count({
-          where: {
-            projectId: input.projectId,
-          },
+          where,
         }),
       ]);
 


### PR DESCRIPTION
Backport of #16567 to `v3`, **adapted** — please read the scope note before merging.

## TL;DR

v3 has no `downloadUrl` procedure, so the upstream fix does not transplant as written. The same authz bypass is reachable on v3 through `batchExport.all` instead, and worse there: the list hands back the live signed URL inline. This ports the list half and the shared helper, and drops the download half.

## Title mismatch — flagging deliberately

I kept the requested `<original subject> (v3 backport of #16567)` title for traceability, but on v3 it is inaccurate: there is no download path to guard. Since v3 squash-merges the PR title into public history, you may want to retitle to something like *"fix(web): require audit log access to list audit-log batch exports"* before merging. Your call — I did not want to silently diverge from the upstream subject.

## What v3 actually has

v3's `batchExportRouter` exposes `create`, `cancel` and `all` only. The signed URL is stored on the row and returned by `all` directly:

```ts
url: isExpired ? "expired" : url,   // isExpired = finishedAt older than 1h
```

`create` already gated `audit_logs` behind the `audit-logs` entitlement and `auditLogs:read`. `all` gated on `batchExports:read` alone — and on v3 `MEMBER` holds `batchExports:read` but not `auditLogs:read` (only OWNER/ADMIN do). So a project MEMBER could list an OWNER-created audit-log export, signed URL included, for the whole download window.

Confirmed empirically against unpatched v3 — a throwaway probe seeding an audit-log export and calling `all` as a MEMBER returned:

```json
[ { "name": "owner audit export",
    "url": "https://s3.example.com/audit.csv?X-Amz-Signature=DEADBEEF" } ]
```

The probe was deleted; it is not part of this branch.

## What was ported vs. omitted

Ported, byte-identical to upstream:
- `canReadAuditLogs` / `assertCanReadAuditLogs` helpers
- the `create` refactor onto `assertCanReadAuditLogs` (pure refactor, no behaviour change)
- the `all` where-clause that omits audit-log exports for callers who cannot read them, applied to both `findMany` and `count`

Omitted as non-existent on v3:
- the `downloadUrl` guard, and `isAuditLogExport` plus the `Prisma` type import that only it needed — keeping them would be dead code and an unused-binding lint failure
- `env` / `parseBatchExportFileKeyFromUrl` / `getBatchExportStorageServiceClient` imports and the `LEGACY_DOWNLOAD_WINDOW_MS` / `FRESH_DOWNLOAD_URL_TTL_SECONDS` / `isDownloadWindowExpired` constants — all belong to main's fresh-signed-URL feature; `batchExportFileKey.ts` and `getBatchExportStorageClient.ts` do not exist on v3
- the four `downloadUrl` test cases (the two `all` cases are kept verbatim), and the seed helper's comment about `downloadUrl` key parsing

## Reachability

Unchanged from upstream: the `audit-logs` entitlement is not in the default `oss` plan, so this is only reachable on `self-hosted:enterprise` and Cloud. Worth having on v3 for that self-hosted tier.

## Verification

```
pnpm --filter web run test batchExport-trpc     → Tests  9 passed (9)
pnpm run typecheck                             → Tasks: 7 successful, 7 total
pnpm run lint                                  → Tasks: 7 successful, 7 total
pnpm run format:check                          → All matched files use Prettier code style!
```

Servertests ran against a purpose-built `langfuse_v3_test` database at exactly v3's 424 migrations — the shared `langfuse_test` DB had been migrated by a main worktree to 436, including `drop_legacy_tracing_tables` and `drop_dataset_run_items_table`, which remove tables v3 still uses.

### Revert-check — does the adapted fix close a real v3 hole?

With `batchExport.ts` reverted to `origin/v3`, adapted tests untouched:

```
× hides audit_logs exports from all for a MEMBER without auditLogs:read
✓ includes audit_logs exports in all for an OWNER with entitlement

Tests  1 failed | 8 passed (9)
```

```
- Expected                         + Received
  [ "traces export visible",         [ "traces export visible",
  ]                                    "audit export hidden" ]
```

That is the bug, reproduced. The OWNER case passing on both sides is the intended non-regression signal.

Restored afterwards; suite re-runs green and `git status --porcelain` is empty.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport closes the v3 audit-log export disclosure by applying audit-log entitlement and read-scope checks when batch exports are listed.
- Adds shared audit-log authorization helpers and reuses the throwing helper during export creation.
- Filters audit-log exports from both the paginated query and matching count for callers without access.
- Adds server tests covering restricted members and entitled owners.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and closes the identified audit-log export listing authorization gap.

The production query applies the audit-log entitlement and project read-scope decision before pagination and uses the same filter for both returned rows and the total count, with focused regression coverage for permitted and denied callers.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Caller requests batchExport.all] --> B{Has batchExports:read?}
  B -- No --> C[Reject request]
  B -- Yes --> D{Audit-log entitlement and auditLogs:read?}
  D -- Yes --> E[List all project exports]
  D -- No --> F[Exclude audit-log exports]
  E --> G[Return paginated exports and count]
  F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): require audit log access for a..."](https://github.com/langfuse/langfuse/commit/6205d6b297b86ac2ae5e18d86dd048456b9483d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57026876)</sub>

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)
- Knowledge Base — [Identity, access, and tenancy](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/identity-access-and-tenancy.md)

<!-- /greptile_comment -->