### PR TITLE
refactor(web): Extend `createNumberTableColumn`

### DIFF
--- a/web/src/components/design-system/Table/columns/README.md
+++ b/web/src/components/design-system/Table/columns/README.md
@@ -23,7 +23,7 @@ createNumberTableColumn<Row>({
     return row.outputTokens / row.latency;
   },
   header: "Tokens per second",
-  maximumFractionDigits: 1,
+  formatter: (value) => numberFormatter(value, 0, 1),
 });
 ```
 

--- a/web/src/components/design-system/Table/columns/createNumberTableColumn.stories.tsx
+++ b/web/src/components/design-system/Table/columns/createNumberTableColumn.stories.tsx
@@ -4,18 +4,22 @@ import {
   DataTable,
   type AsyncTableData,
 } from "@/src/components/table/data-table";
+import { numberFormatter } from "@/src/utils/numbers";
 import { createNumberTableColumn } from "./createNumberTableColumn";
 
 type Row = {
+  isNumberLoading?: boolean;
   outputTokens: number;
   latency: number | null;
 };
 
 function NumberTableColumnStory({
   data,
+  emptyValue,
   fractionDigits,
 }: {
   data: AsyncTableData<Row[]>;
+  emptyValue?: string;
   fractionDigits: number;
 }) {
   const columns = [
@@ -24,8 +28,15 @@ function NumberTableColumnStory({
       accessorFn: (row) =>
         row.latency ? row.outputTokens / row.latency : null,
       header: "Number",
-      minimumFractionDigits: fractionDigits,
-      maximumFractionDigits: fractionDigits,
+      emptyValue,
+      formatter: (value) =>
+        numberFormatter(value, fractionDigits, fractionDigits),
+      getValue: (value, { row }) => {
+        if (row.original.isNumberLoading) return { type: "loading" };
+        if (value === null || value === undefined) return undefined;
+
+        return value;
+      },
     }),
   ];
 
@@ -88,6 +99,31 @@ export const EmptyValue = meta.story({
       isLoading: false,
       isError: false,
       data: [{ outputTokens: 2469, latency: null }],
+    },
+  },
+});
+
+export const EmptyPlaceholder = meta.story({
+  name: "Empty Placeholder",
+  args: {
+    emptyValue: "—",
+    fractionDigits: 1,
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ outputTokens: 2469, latency: null }],
+    },
+  },
+});
+
+export const CellLoading = meta.story({
+  name: "Cell Loading",
+  args: {
+    fractionDigits: 1,
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ isNumberLoading: true, outputTokens: 2469, latency: null }],
     },
   },
 });

--- a/web/src/components/design-system/Table/columns/createNumberTableColumn.tsx
+++ b/web/src/components/design-system/Table/columns/createNumberTableColumn.tsx
@@ -13,7 +13,7 @@ export function createNumberTableColumn<TData extends RowData>({
   getValue,
   ...options
 }: TableColumnOptions<TData, number> & {
-  emptyValue?: React.ReactNode;
+  emptyValue?: string;
   formatter?: (value: number) => string;
   getValue?: (
     value: number | null | undefined,

--- a/web/src/components/design-system/Table/columns/createNumberTableColumn.tsx
+++ b/web/src/components/design-system/Table/columns/createNumberTableColumn.tsx
@@ -1,4 +1,4 @@
-import { type RowData } from "@tanstack/react-table";
+import { type CellContext, type RowData } from "@tanstack/react-table";
 
 import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
 import { numberFormatter } from "@/src/utils/numbers";
@@ -8,25 +8,33 @@ import {
 } from "./utils/createTableColumn";
 
 export function createNumberTableColumn<TData extends RowData>({
-  minimumFractionDigits,
-  maximumFractionDigits,
+  emptyValue,
+  formatter = numberFormatter,
+  getValue,
   ...options
 }: TableColumnOptions<TData, number> & {
-  minimumFractionDigits?: number;
-  maximumFractionDigits?: number;
+  emptyValue?: React.ReactNode;
+  formatter?: (value: number) => string;
+  getValue?: (
+    value: number | null | undefined,
+    context: CellContext<TData, number | null | undefined>,
+  ) => number | { type: "loading" } | undefined;
 }) {
-  const minimumDigits =
-    minimumFractionDigits ?? (maximumFractionDigits === undefined ? 2 : 0);
-  const maximumDigits = Math.max(
-    maximumFractionDigits ?? minimumDigits,
-    minimumDigits,
-  );
   return createTableColumn<TData, number>({
     ...options,
     loadingCell: <TableTextLoadingCell />,
-    renderCell: (value) =>
-      value === null || value === undefined ? null : (
-        <span>{numberFormatter(value, minimumDigits, maximumDigits)}</span>
-      ),
+    renderCell: (value, context) => {
+      if (!getValue) {
+        if (value === null || value === undefined) return emptyValue ?? null;
+        return <span>{formatter(value)}</span>;
+      }
+
+      const resolvedValue = getValue(value, context);
+
+      if (resolvedValue === undefined) return emptyValue ?? null;
+      if (typeof resolvedValue !== "number") return <TableTextLoadingCell />;
+
+      return <span>{formatter(resolvedValue)}</span>;
+    },
   });
 }

--- a/web/src/components/table/DataTable.stories.tsx
+++ b/web/src/components/table/DataTable.stories.tsx
@@ -48,7 +48,7 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { formatIntervalSeconds } from "@/src/utils/dates";
-import { usdFormatter } from "@/src/utils/numbers";
+import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import {
   Copy,
   InfoIcon,
@@ -1053,8 +1053,7 @@ function buildGroupedColumns(
         accessorKey: "observationCount",
         header: "Observations",
         size: 110,
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
+        formatter: (value) => numberFormatter(value, 0, 0),
       }),
       {
         accessorKey: "latency",
@@ -1070,20 +1069,19 @@ function buildGroupedColumns(
     id: "usageGroup",
     header: "Cost & usage",
     columns: [
-      {
-        accessorKey: "totalCost",
+      createNumberTableColumn<TraceRow>({
         id: "totalCostGrouped",
+        accessorFn: (row) => row.totalCost.toNumber(),
         header: "Cost (USD)",
         size: 110,
-        cell: ({ row }) => usdFormatter(row.original.totalCost.toNumber()),
-      },
+        formatter: usdFormatter,
+      }),
       createNumberTableColumn<TraceRow>({
         id: "totalTokensGrouped",
         accessorFn: (row) => row.usage.totalUsage,
         header: "Tokens",
         size: 100,
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
+        formatter: (value) => numberFormatter(value, 0, 0),
       }),
     ] satisfies LangfuseColumnDef<TraceRow>[],
   };

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1100,60 +1100,36 @@ export default function ObservationsTable({
           enableHiding: true,
           enableSorting,
         }),
-        {
-          accessorKey: "inputTokens",
+        createNumberTableColumn<ObservationsTableRow>({
+          accessorFn: (row) => row.usage.inputUsage,
           id: "inputTokens",
           header: "Input Tokens",
           size: 100,
-          loadingCell: <TableTextLoadingCell />,
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-          cell: ({ row }) => {
-            const value: {
-              inputUsage: number;
-              outputUsage: number;
-              totalUsage: number;
-            } = row.getValue("usage");
-            return <span>{numberFormatter(value.inputUsage, 0)}</span>;
-          },
-        },
-        {
-          accessorKey: "outputTokens",
+          formatter: (value) => numberFormatter(value, 0),
+        }),
+        createNumberTableColumn<ObservationsTableRow>({
+          accessorFn: (row) => row.usage.outputUsage,
           id: "outputTokens",
           header: "Output Tokens",
           size: 100,
-          loadingCell: <TableTextLoadingCell />,
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-          cell: ({ row }) => {
-            const value: {
-              inputUsage: number;
-              outputUsage: number;
-              totalUsage: number;
-            } = row.getValue("usage");
-            return <span>{numberFormatter(value.outputUsage, 0)}</span>;
-          },
-        },
-        {
-          accessorKey: "totalTokens",
+          formatter: (value) => numberFormatter(value, 0),
+        }),
+        createNumberTableColumn<ObservationsTableRow>({
+          accessorFn: (row) => row.usage.totalUsage,
           id: "totalTokens",
           header: "Total Tokens",
           size: 100,
-          loadingCell: <TableTextLoadingCell />,
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-          cell: ({ row }) => {
-            const value: {
-              inputUsage: number;
-              outputUsage: number;
-              totalUsage: number;
-            } = row.getValue("usage");
-            return <span>{numberFormatter(value.totalUsage, 0)}</span>;
-          },
-        },
+          formatter: (value) => numberFormatter(value, 0),
+        }),
       ] satisfies LangfuseColumnDef<ObservationsTableRow>[],
     },
     {

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -863,7 +863,7 @@ export default function ObservationsTable({
       enableHiding: true,
       enableSorting,
       defaultHidden: true,
-      maximumFractionDigits: 0,
+      formatter: (value) => numberFormatter(value, 0, 0),
     }),
     createNumberTableColumn<ObservationsTableRow>({
       accessorKey: "toolCalls",
@@ -872,7 +872,7 @@ export default function ObservationsTable({
       enableHiding: true,
       enableSorting,
       defaultHidden: true,
-      maximumFractionDigits: 0,
+      formatter: (value) => numberFormatter(value, 0, 0),
     }),
     {
       accessorKey: "timeToFirstToken",
@@ -1095,7 +1095,7 @@ export default function ObservationsTable({
           },
           header: "Tokens per second",
           size: 200,
-          maximumFractionDigits: 1,
+          formatter: (value) => numberFormatter(value, 0, 1),
           defaultHidden: true,
           enableHiding: true,
           enableSorting,

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -8,6 +8,7 @@ import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
 import { createBadgeTableColumn } from "@/src/components/design-system/Table/columns/createBadgeTableColumn";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
@@ -564,62 +565,53 @@ export default function SessionsTable({
         return value ? <span>{numberFormatter(value, 0)}</span> : undefined;
       },
     },
-    {
-      accessorKey: "inputCost",
+    createNumberTableColumn<SessionTableRow>({
+      accessorFn: (row) => row.inputCost?.toNumber(),
       id: "inputCost",
       header: "Input Cost",
       size: 110,
       enableHiding: true,
       defaultHidden: true,
       enableSorting: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["inputCost"] = row.getValue("inputCost");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value ? (
-          <span>{usdFormatter(value.toNumber())}</span>
-        ) : undefined;
+      formatter: usdFormatter,
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
-    {
-      accessorKey: "outputCost",
+    }),
+    createNumberTableColumn<SessionTableRow>({
+      accessorFn: (row) => row.outputCost?.toNumber(),
       id: "outputCost",
       header: "Output Cost",
       size: 110,
       enableHiding: true,
       enableSorting: true,
       defaultHidden: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["outputCost"] = row.getValue("outputCost");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value ? (
-          <span>{usdFormatter(value.toNumber())}</span>
-        ) : undefined;
+      formatter: usdFormatter,
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
-    {
-      accessorKey: "totalCost",
+    }),
+    createNumberTableColumn<SessionTableRow>({
+      accessorFn: (row) => row.totalCost?.toNumber(),
       id: "totalCost",
       header: "Total Cost",
       size: 110,
       enableHiding: true,
       enableSorting: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["totalCost"] = row.getValue("totalCost");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value ? (
-          <span>{usdFormatter(value.toNumber())}</span>
-        ) : undefined;
+      formatter: usdFormatter,
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
+    }),
     {
       accessorKey: "inputTokens",
       id: "inputTokens",

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -483,25 +483,20 @@ export default function SessionsTable({
       enableHiding: true,
       enableSorting: true,
     }),
-    {
+    createNumberTableColumn<SessionTableRow>({
       accessorKey: "sessionDuration",
-      id: "sessionDuration",
       header: "Duration",
       size: 130,
       enableHiding: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["sessionDuration"] =
-          row.getValue("sessionDuration");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value && typeof value === "number"
-          ? formatIntervalSeconds(value)
-          : undefined;
+      formatter: formatIntervalSeconds,
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
       enableSorting: true,
-    },
+    }),
     createBadgeTableColumn<SessionTableRow>({
       accessorKey: "environment",
       header: "Environment",
@@ -545,9 +540,8 @@ export default function SessionsTable({
         ) : undefined;
       },
     },
-    {
+    createNumberTableColumn<SessionTableRow>({
       accessorKey: "countTraces",
-      id: "countTraces",
       header: "Traces",
       size: 100,
       headerTooltip: {
@@ -555,16 +549,14 @@ export default function SessionsTable({
       },
       enableHiding: true,
       enableSorting: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["countTraces"] =
-          row.getValue("countTraces");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value ? <span>{numberFormatter(value, 0)}</span> : undefined;
+      formatter: (value) => numberFormatter(value, 0),
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
+    }),
     createNumberTableColumn<SessionTableRow>({
       accessorFn: (row) => row.inputCost?.toNumber(),
       id: "inputCost",
@@ -612,66 +604,51 @@ export default function SessionsTable({
         return value;
       },
     }),
-    {
+    createNumberTableColumn<SessionTableRow>({
       accessorKey: "inputTokens",
-      id: "inputTokens",
       header: "Input Tokens",
       size: 110,
       enableHiding: true,
       defaultHidden: true,
       enableSorting: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["inputTokens"] =
-          row.getValue("inputTokens");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value ? (
-          <span>{numberFormatter(Number(value), 0)}</span>
-        ) : undefined;
+      formatter: (value) => numberFormatter(value, 0),
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
-    {
+    }),
+    createNumberTableColumn<SessionTableRow>({
       accessorKey: "outputTokens",
-      id: "outputTokens",
       header: "Output Tokens",
       size: 110,
       enableHiding: true,
       defaultHidden: true,
       enableSorting: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["outputTokens"] =
-          row.getValue("outputTokens");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value ? (
-          <span>{numberFormatter(Number(value), 0)}</span>
-        ) : undefined;
+      formatter: (value) => numberFormatter(value, 0),
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
-    {
+    }),
+    createNumberTableColumn<SessionTableRow>({
       accessorKey: "totalTokens",
-      id: "totalTokens",
       header: "Total Tokens",
       size: 110,
       enableHiding: true,
       defaultHidden: true,
       enableSorting: true,
-      loadingCell: <TableTextLoadingCell />,
-      cell: ({ row }) => {
-        const value: SessionTableRow["totalTokens"] =
-          row.getValue("totalTokens");
-        if (!sessionMetrics.isSuccess) {
-          return <TableTextLoadingCell />;
-        }
-        return value ? (
-          <span>{numberFormatter(Number(value), 0)}</span>
-        ) : undefined;
+      formatter: (value) => numberFormatter(value, 0),
+      getValue: (value) => {
+        if (!sessionMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
+    }),
     {
       accessorKey: "usage",
       id: "usage",

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -7,6 +7,7 @@ import {
 import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
 import { createBadgeTableColumn } from "@/src/components/design-system/Table/columns/createBadgeTableColumn";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 import { createTagsTableColumn } from "@/src/components/design-system/Table/columns/createTagsTableColumn";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
@@ -1129,54 +1130,36 @@ export default function TracesTable({
         return traceMetrics.isPending ? <TableTextLoadingCell /> : null;
       },
       columns: [
-        {
-          accessorKey: "inputCost",
+        createNumberTableColumn<TracesTableRow>({
+          accessorFn: (row) => row.cost?.inputCost?.toNumber(),
           id: "inputCost",
           header: "Input Cost",
           size: 100,
-          loadingCell: <TableTextLoadingCell />,
-          cell: ({ row }) => {
-            const cost: TracesTableRow["cost"] = row.getValue("cost");
-            if (isMetricPending(row.original.id))
-              return <TableTextLoadingCell />;
-            return (
-              <div>
-                {cost?.inputCost ? (
-                  <span>{usdFormatter(cost.inputCost.toNumber())}</span>
-                ) : (
-                  <span>-</span>
-                )}
-              </div>
-            );
+          emptyValue: "-",
+          formatter: usdFormatter,
+          getValue: (value, { row }) => {
+            if (isMetricPending(row.original.id)) return { type: "loading" };
+            return value ?? undefined;
           },
           defaultHidden: true,
           enableHiding: true,
           enableSorting,
-        },
-        {
-          accessorKey: "outputCost",
+        }),
+        createNumberTableColumn<TracesTableRow>({
+          accessorFn: (row) => row.cost?.outputCost?.toNumber(),
           id: "outputCost",
           header: "Output Cost",
           size: 100,
-          loadingCell: <TableTextLoadingCell />,
-          cell: ({ row }) => {
-            const cost: TracesTableRow["cost"] = row.getValue("cost");
-            if (isMetricPending(row.original.id))
-              return <TableTextLoadingCell />;
-            return (
-              <div>
-                {cost?.outputCost ? (
-                  <span>{usdFormatter(cost.outputCost.toNumber())}</span>
-                ) : (
-                  <span>-</span>
-                )}
-              </div>
-            );
+          emptyValue: "-",
+          formatter: usdFormatter,
+          getValue: (value, { row }) => {
+            if (isMetricPending(row.original.id)) return { type: "loading" };
+            return value ?? undefined;
           },
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
+        }),
       ] satisfies LangfuseColumnDef<TracesTableRow>[],
     },
     {

--- a/web/src/ee/features/billing/components/BillingInvoiceTable.tsx
+++ b/web/src/ee/features/billing/components/BillingInvoiceTable.tsx
@@ -1,10 +1,11 @@
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 import { Button } from "@/src/components/ui/button";
 import { Badge, type BadgeProps } from "@/src/components/ui/badge";
 import { api } from "@/src/utils/api";
-import { usdFormatter } from "@/src/utils/numbers";
+import { costFormatter } from "@/src/utils/numbers";
 import { Download, ExternalLink } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -142,56 +143,41 @@ export function BillingInvoiceTable() {
         return <Badge variant={variant}>{status}</Badge>;
       },
     },
-    {
-      accessorKey: "breakdown.subscriptionCents",
+    createNumberTableColumn<InvoiceRow>({
+      accessorFn: (row) => (row.breakdown?.subscriptionCents ?? 0) / 100,
       id: "subscription",
       header: "Subscription",
       size: 100,
-      cell: ({ row }) => {
-        const cents = row.original.breakdown?.subscriptionCents ?? 0;
-        return usdFormatter(cents / 100, 2, 2);
-      },
-    },
-    {
-      accessorKey: "breakdown.usageCents",
+      formatter: costFormatter,
+    }),
+    createNumberTableColumn<InvoiceRow>({
+      accessorFn: (row) => (row.breakdown?.usageCents ?? 0) / 100,
       id: "usage",
       header: "Usage",
       size: 90,
-      cell: ({ row }) => {
-        const cents = row.original.breakdown?.usageCents ?? 0;
-        return usdFormatter(cents / 100, 2, 2);
-      },
-    },
-    {
-      accessorKey: "breakdown.discountCents",
+      formatter: costFormatter,
+    }),
+    createNumberTableColumn<InvoiceRow>({
+      accessorFn: (row) => (row.breakdown?.discountCents ?? 0) / 100,
       id: "discounts",
       header: "Discounts",
       size: 90,
-      cell: ({ row }) => {
-        const cents = row.original.breakdown?.discountCents ?? 0;
-        return usdFormatter(cents / 100, 2, 2);
-      },
-    },
-    {
-      accessorKey: "breakdown.taxCents",
+      formatter: costFormatter,
+    }),
+    createNumberTableColumn<InvoiceRow>({
+      accessorFn: (row) => (row.breakdown?.taxCents ?? 0) / 100,
       id: "tax",
       header: "Tax",
       size: 90,
-      cell: ({ row }) => {
-        const cents = row.original.breakdown?.taxCents ?? 0;
-        return usdFormatter(cents / 100, 2, 2);
-      },
-    },
-    {
-      accessorKey: "breakdown.totalCents",
+      formatter: costFormatter,
+    }),
+    createNumberTableColumn<InvoiceRow>({
+      accessorFn: (row) => (row.breakdown?.totalCents ?? 0) / 100,
       id: "total",
       header: "Total",
       size: 90,
-      cell: ({ row }) => {
-        const cents = row.original.breakdown?.totalCents ?? 0;
-        return usdFormatter(cents / 100, 2, 2);
-      },
-    },
+      formatter: costFormatter,
+    }),
     {
       accessorKey: "actions",
       id: "actions",

--- a/web/src/ee/features/billing/components/SpendAlerts/SpendAlertsTable.tsx
+++ b/web/src/ee/features/billing/components/SpendAlerts/SpendAlertsTable.tsx
@@ -16,8 +16,9 @@ import { DeleteSpendAlertDialog } from "./DeleteSpendAlertDialog";
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/Table/columns/createTextTableColumn";
-import { usdFormatter } from "@/src/utils/numbers";
+import { costFormatter } from "@/src/utils/numbers";
 
 interface SpendAlertsTableProps {
   orgId: string;
@@ -77,13 +78,13 @@ export function SpendAlertsTable({ orgId }: SpendAlertsTableProps) {
       header: "Title",
       size: 160,
     }),
-    {
-      accessorKey: "Limit",
+    createNumberTableColumn<AlertRow>({
+      accessorFn: (row) => row.threshold,
       id: "limit",
       header: "Limit (USD)",
       size: 140,
-      cell: ({ row }) => usdFormatter(row.original.threshold, 2, 2),
-    },
+      formatter: costFormatter,
+    }),
     {
       accessorKey: "status",
       id: "status",

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -13,6 +13,7 @@ import { ClipboardPen, Lock } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 import Link from "next/link";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { DeleteAnnotationQueueButton } from "@/src/features/annotation-queues/components/DeleteAnnotationQueueButton";
@@ -82,20 +83,20 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
       enableHiding: true,
       size: 200,
     },
-    {
+    createNumberTableColumn<RowData>({
       accessorKey: "countCompletedItems",
       header: "Completed Items",
-      id: "countCompletedItems",
       enableHiding: true,
       size: 90,
-    },
-    {
+      formatter: String,
+    }),
+    createNumberTableColumn<RowData>({
       accessorKey: "countPendingItems",
       header: "Pending Items",
-      id: "countPendingItems",
       enableHiding: true,
       size: 90,
-    },
+      formatter: String,
+    }),
     {
       accessorKey: "scoreConfigs",
       header: "Score Configs",

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -55,6 +55,7 @@ import {
   shouldShowEvalTemplate,
 } from "@/src/features/evals/utils/code-eval-template-utils";
 import { SiPython, SiTypescript } from "react-icons/si";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 
 export type EvalsTemplateRow = {
   name: string;
@@ -383,24 +384,22 @@ export default function EvalsTemplateTable({
         return row.getValue()?.toLocaleDateString();
       },
     }),
-    columnHelper.accessor("usageCount", {
+    createNumberTableColumn<EvalsTemplateRow>({
+      accessorKey: "usageCount",
       header: "Usage Count",
-      id: "usageCount",
       enableHiding: true,
       size: 80,
-      cell: (row) => {
-        const count = row.getValue();
-        return !!count ? count : null;
+      formatter: String,
+      getValue: (value) => {
+        return value || undefined;
       },
     }),
-    columnHelper.accessor("latestVersion", {
+    createNumberTableColumn<EvalsTemplateRow>({
+      accessorKey: "latestVersion",
       header: "Latest Version",
-      id: "latestVersion",
       enableHiding: true,
       size: 80,
-      cell: (row) => {
-        return row.getValue();
-      },
+      formatter: String,
     }),
     columnHelper.accessor("id", {
       header: "Id",

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -46,6 +46,7 @@ import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-to
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { usdFormatter } from "@/src/utils/numbers";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 import {
   type EvaluatorDataRow,
   useEvaluatorTableData,
@@ -221,21 +222,18 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
         );
       },
     }),
-    columnHelper.accessor("totalCost", {
+    createNumberTableColumn<EvaluatorDataRow>({
+      accessorKey: "totalCost",
       header: "Total Cost (7d)",
-      id: "totalCost",
       enableSorting: false,
       size: 120,
-      cell: (row) => {
-        const totalCost = row.getValue();
+      emptyValue: "–",
+      formatter: (value) => usdFormatter(value, 2, 4),
+      getValue: (value, { row }) => {
+        if (row.original.isCostLoading) return { type: "loading" };
+        if (value === null || value === undefined) return undefined;
 
-        if (row.row.original.isCostLoading) {
-          return <Skeleton className="h-4 w-16" />;
-        }
-
-        if (totalCost != null) return usdFormatter(totalCost, 2, 4);
-
-        return "–";
+        return value;
       },
     }),
     columnHelper.accessor("result", {

--- a/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
+++ b/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
@@ -65,6 +65,7 @@ import {
   evaluationRuleTableFilterOptions,
 } from "@/src/features/evals/v2/constants/tableFilterColumns";
 import { omitFilterFacets } from "@/src/features/filters/lib/filter-config";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 
 function RelativeDate({ date }: { date: Date }) {
   return (
@@ -274,18 +275,21 @@ export function RulesTable({
           />
         ),
       },
-      {
-        accessorKey: "totalCost",
+      createNumberTableColumn<RuleTableRow>({
+        accessorFn: (row) => costs.data?.[row.id],
         id: "totalCost",
         header: "Total cost (7d)",
         size: 140,
         enableHiding: true,
-        cell: ({ row }) => {
-          if (costs.isPending) return <Skeleton className="h-4 w-16" />;
-          const cost = costs.data?.[row.original.id];
-          return cost == null ? "—" : usdFormatter(cost, 2, 4);
+        emptyValue: "—",
+        formatter: (value) => usdFormatter(value, 2, 4),
+        getValue: (value) => {
+          if (costs.isPending) return { type: "loading" };
+          if (value === null || value === undefined) return undefined;
+
+          return value;
         },
-      },
+      }),
       {
         accessorKey: "executionTraces",
         id: "executionTraces",

--- a/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
@@ -65,6 +65,7 @@ import {
 } from "../constants/tableFilterColumns";
 import type { GalleryTemplate } from "../types/templateGallery";
 import { V4MigrationUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 
 type EvaluatorRow = RouterOutputs["evalsV2"]["list"]["evaluators"][number];
 
@@ -398,20 +399,23 @@ export default function EvaluatorsPage() {
         enableHiding: true,
         cell: ({ row }) => <EvaluatorTypeBadge type={row.original.type} />,
       },
-      {
-        accessorKey: "totalCost",
+      createNumberTableColumn<EvaluatorRow>({
+        accessorFn: (row) => costs.data?.[row.id],
         id: "totalCost",
         header: "Total cost (7d)",
         size: 140,
         enableHiding: true,
-        cell: ({ row }) => {
+        emptyValue: "—",
+        formatter: (value) => usdFormatter(value, 2, 4),
+        getValue: (value) => {
           if (costs.isPending && hasExecutionReadAccess) {
-            return <Skeleton className="h-4 w-16" />;
+            return { type: "loading" };
           }
-          const cost = costs.data?.[row.original.id];
-          return cost == null ? "—" : usdFormatter(cost, 2, 4);
+          if (value === null || value === undefined) return undefined;
+
+          return value;
         },
-      },
+      }),
       {
         accessorKey: "model",
         id: "model",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1454,31 +1454,24 @@ export default function ObservationsEventsTable({
         ) : null;
       },
       columns: [
-        {
-          accessorKey: "tokensPerSecond",
+        createNumberTableColumn<EventsTableRow>({
+          accessorFn: (row) => {
+            const { latency, usage } = row;
+            if (latency === undefined) return undefined;
+            if (usage.outputUsage === 0 && usage.totalUsage === 0)
+              return undefined;
+            if (!usage.outputUsage || !latency) return undefined;
+
+            return Number((usage.outputUsage / latency).toFixed(1));
+          },
           id: "tokensPerSecond",
           header: "Tokens per second",
           size: 200,
-          cell: ({ row }) => {
-            const latency: number | undefined = row.getValue("latency");
-            const usage = row.getValue("usage") as {
-              inputUsage: number;
-              outputUsage: number;
-              totalUsage: number;
-            };
-            return latency !== undefined &&
-              (usage.outputUsage !== 0 || usage.totalUsage !== 0) ? (
-              <span>
-                {usage.outputUsage && latency
-                  ? Number((usage.outputUsage / latency).toFixed(1))
-                  : undefined}
-              </span>
-            ) : undefined;
-          },
+          formatter: String,
           defaultHidden: true,
           enableHiding: true,
           enableSorting,
-        },
+        }),
         createNumberTableColumn<EventsTableRow>({
           id: "inputTokens",
           accessorFn: (row) => row.usage.inputUsage,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -47,7 +47,11 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
 import { cn } from "@/src/utils/tailwind";
 import { getLevelColors } from "@/src/components/level-colors";
-import { compactNumberFormatter, usdFormatter } from "@/src/utils/numbers";
+import {
+  compactNumberFormatter,
+  numberFormatter,
+  usdFormatter,
+} from "@/src/utils/numbers";
 import {
   formatObservationCost,
   isObservationCostDisplayable,
@@ -1409,8 +1413,7 @@ export default function ObservationsEventsTable({
       enableHiding: true,
       enableSorting,
       defaultHidden: true,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
+      formatter: (value) => numberFormatter(value, 0, 0),
     }),
     createNumberTableColumn<EventsTableRow>({
       accessorKey: "toolCalls",
@@ -1419,8 +1422,7 @@ export default function ObservationsEventsTable({
       enableHiding: true,
       enableSorting,
       defaultHidden: true,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
+      formatter: (value) => numberFormatter(value, 0, 0),
     }),
     {
       accessorKey: "timeToFirstToken",
@@ -1485,8 +1487,7 @@ export default function ObservationsEventsTable({
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 0,
+          formatter: (value) => numberFormatter(value, 0, 0),
         }),
         createNumberTableColumn<EventsTableRow>({
           id: "outputTokens",
@@ -1496,8 +1497,7 @@ export default function ObservationsEventsTable({
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 0,
+          formatter: (value) => numberFormatter(value, 0, 0),
         }),
         createNumberTableColumn<EventsTableRow>({
           id: "totalTokens",
@@ -1507,8 +1507,7 @@ export default function ObservationsEventsTable({
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 0,
+          formatter: (value) => numberFormatter(value, 0, 0),
         }),
       ] satisfies LangfuseColumnDef<EventsTableRow>[],
     },

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -579,33 +579,23 @@ export default function ExperimentsTable({
         );
       },
     },
-    {
+    createNumberTableColumn<ExperimentsTableRow>({
       accessorKey: "latencyAvg",
-      id: "latencyAvg",
       header: getExperimentsColumnName("latencyAvg"),
       size: 100,
       enableHiding: true,
       headerTooltip: {
         description: "Average duration of the root span per experiment item.",
       },
-      cell: ({ row }) => {
-        const value: number | undefined = row.getValue("latencyAvg");
-        if (value === undefined || value === null) return undefined;
-        return <span>{numberFormatter(value / 1000, 4)}s</span>;
-      },
-    },
-    {
+      formatter: (value) => `${numberFormatter(value / 1000, 4)}s`,
+    }),
+    createNumberTableColumn<ExperimentsTableRow>({
       accessorKey: "totalCost",
-      id: "totalCost",
       header: getExperimentsColumnName("totalCost"),
       size: 100,
       enableHiding: true,
-      cell: ({ row }) => {
-        const value: number | undefined = row.getValue("totalCost");
-        if (value === undefined || value === null) return undefined;
-        return <span>${numberFormatter(value, 6)}</span>;
-      },
-    },
+      formatter: (value) => `$${numberFormatter(value, 6)}`,
+    }),
     {
       accessorKey: "traceItemScores",
       header: "Trace Item Scores",

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -485,8 +485,7 @@ export default function ExperimentsTable({
       accessorKey: "itemCount",
       header: getExperimentsColumnName("itemCount"),
       size: 100,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
+      formatter: (value) => numberFormatter(value, 0, 0),
     }),
     {
       accessorKey: "errorCount",

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -8,6 +8,7 @@ import { api } from "@/src/utils/api";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { type RouterOutput } from "@/src/utils/types";
 import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
 import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
@@ -258,21 +259,19 @@ export default function PromptVersionTable({
         return !!value ? <span>{String(value)}</span> : undefined;
       },
     },
-    {
+    createNumberTableColumn<PromptVersionTableRow>({
       accessorKey: "medianCost",
-      id: "medianCost",
       header: "Median cost",
       size: 120,
-      cell: ({ row }) => {
-        const value: number | undefined | null = row.getValue("medianCost");
-        if (!promptMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
+      formatter: usdFormatter,
+      getValue: (value) => {
+        if (!promptMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
 
-        return !!value ? <span>{usdFormatter(value)}</span> : undefined;
+        return value;
       },
       enableHiding: true,
-    },
+    }),
     {
       accessorKey: "generationCount",
       id: "generationCount",

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -209,56 +209,45 @@ export default function PromptVersionTable({
       },
       enableHiding: true,
     },
-    {
+    createNumberTableColumn<PromptVersionTableRow>({
       accessorKey: "medianLatency",
-      id: "medianLatency",
       header: "Median latency",
       size: 140,
-      cell: ({ row }) => {
-        const latency: number | undefined | null =
-          row.getValue("medianLatency");
-        if (!promptMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
+      formatter: (value) => formatIntervalSeconds(value / 1000, 3),
+      getValue: (value) => {
+        if (!promptMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
 
-        return !!latency ? (
-          // latency is in milliseconds, divide by 1000 to get seconds
-          <span>{formatIntervalSeconds(latency / 1000, 3)}</span>
-        ) : undefined;
+        return value;
       },
       enableHiding: true,
-    },
-    {
+    }),
+    createNumberTableColumn<PromptVersionTableRow>({
       accessorKey: "medianInputTokens",
-      id: "medianInputTokens",
       header: "Median input tokens",
       size: 160,
       enableHiding: true,
-      cell: ({ row }) => {
-        const value: number | undefined | null =
-          row.getValue("medianInputTokens");
-        if (!promptMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
+      formatter: String,
+      getValue: (value) => {
+        if (!promptMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
 
-        return !!value ? <span>{String(value)}</span> : undefined;
+        return value;
       },
-    },
-    {
+    }),
+    createNumberTableColumn<PromptVersionTableRow>({
       accessorKey: "medianOutputTokens",
-      id: "medianOutputTokens",
       header: "Median output tokens",
       size: 170,
       enableHiding: true,
-      cell: ({ row }) => {
-        const value: number | undefined | null =
-          row.getValue("medianOutputTokens");
-        if (!promptMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
-        return !!value ? <span>{String(value)}</span> : undefined;
+      formatter: String,
+      getValue: (value) => {
+        if (!promptMetrics.isSuccess) return { type: "loading" };
+        if (!value) return undefined;
+
+        return value;
       },
-    },
+    }),
     createNumberTableColumn<PromptVersionTableRow>({
       accessorKey: "medianCost",
       header: "Median cost",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16611.preview.langfuse.com](https://pr-16611.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends the shared numeric table-column creator with custom formatting, empty-value, and cell-loading support, then migrates numeric columns across the web application.
- Adds configurable formatter, placeholder, and value-resolution callbacks.
- Consolidates numeric formatting and loading behavior in production tables.
- Expands Storybook coverage and updates the column-creator documentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["Extend to more columns"](https://github.com/langfuse/langfuse/commit/0181ac440a58313efb94b8b8685f2dcf5ed7d57f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57044731)</sub>

<!-- /greptile_comment -->