### PR TITLE
fix(blob-export): half-open export time window to stop chunk-boundary double-count

### DIFF
--- a/packages/shared/src/server/repositories/blobStorageExportWindow.test.ts
+++ b/packages/shared/src/server/repositories/blobStorageExportWindow.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The blob-export builders must filter their time window half-open:
+// `timestamp >= minTimestamp AND timestamp < maxTimestamp`. Every run/chunk
+// handoff sets the next window's inclusive `minTimestamp` to the previous
+// window's `maxTimestamp` (lastSyncAt = maxTimestamp). With an inclusive upper
+// bound a row landing exactly on the boundary was exported in BOTH adjacent
+// windows (duplicate); with a half-open upper bound it moves to the next window
+// and is exported exactly once. See the analytics-integration exporters, which
+// already use `< maxTimestamp`.
+
+const mockQueryClickhouseStream = vi.hoisted(() =>
+  vi.fn(() => (async function* () {})()),
+);
+
+vi.mock("./clickhouse", () => ({
+  queryClickhouse: vi.fn(),
+  queryClickhouseStream: mockQueryClickhouseStream,
+  queryClickhouseStreamRawText: mockQueryClickhouseStream,
+  queryClickhouseExecRaw: vi.fn(),
+  commandClickhouse: vi.fn(),
+  upsertClickhouse: vi.fn(),
+  parseClickhouseUTCDateTimeFormat: vi.fn(),
+  clickhouseCompliantRandomCharacters: vi.fn(() => "x"),
+  BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: {},
+}));
+
+// Break the query-options -> server-barrel import cycle and avoid a real
+// ClickHouse round-trip for the observations FINAL decision.
+vi.mock("../queries/clickhouse-sql/query-options", () => ({
+  shouldSkipObservationsFinal: vi.fn().mockResolvedValue(false),
+}));
+
+import { getTracesForBlobStorageExport } from "./traces";
+import { getObservationsForBlobStorageExport } from "./observations";
+import { getScoresForBlobStorageExport } from "./scores";
+import { getEventsForBlobStorageExport } from "./events";
+
+const PROJECT = "proj-1";
+const MIN = new Date("2026-01-01T00:00:00.000Z");
+const MAX = new Date("2026-01-01T01:00:00.000Z");
+
+const capturedQuery = (): string => {
+  expect(mockQueryClickhouseStream).toHaveBeenCalledTimes(1);
+  const call = mockQueryClickhouseStream.mock.calls[0] as unknown as [
+    { query: string },
+  ];
+  return call[0].query;
+};
+
+const builders = [
+  {
+    name: "getTracesForBlobStorageExport",
+    run: async () => {
+      getTracesForBlobStorageExport(PROJECT, MIN, MAX);
+    },
+  },
+  {
+    name: "getObservationsForBlobStorageExport",
+    // async generator: iterate once to run the body up to the yield*
+    run: async () => {
+      await getObservationsForBlobStorageExport(PROJECT, MIN, MAX).next();
+    },
+  },
+  {
+    name: "getScoresForBlobStorageExport",
+    run: async () => {
+      getScoresForBlobStorageExport(PROJECT, MIN, MAX);
+    },
+  },
+  {
+    name: "getEventsForBlobStorageExport",
+    run: async () => {
+      getEventsForBlobStorageExport(PROJECT, MIN, MAX);
+    },
+  },
+];
+
+describe("blob-storage export window is half-open", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(builders)(
+    "$name uses an exclusive upper bound and inclusive lower bound",
+    async ({ run }) => {
+      await run();
+      const query = capturedQuery();
+
+      // Inclusive lower bound
+      expect(query).toContain(">= {minTimestamp");
+      // Exclusive upper bound
+      expect(query).toContain("< {maxTimestamp");
+      // Never inclusive on the upper bound — that is the double-count bug
+      expect(query).not.toContain("<= {maxTimestamp");
+    },
+  );
+
+  it("boundary row belongs to the next window only (traces)", async () => {
+    // Window 1: [MIN, MAX). A row at exactly MAX is excluded here...
+    getTracesForBlobStorageExport(PROJECT, MIN, MAX);
+    const window1 = capturedQuery();
+    expect(window1).toContain("< {maxTimestamp");
+
+    vi.clearAllMocks();
+
+    // ...and included in window 2, whose inclusive minTimestamp = prior MAX.
+    const next = new Date("2026-01-01T02:00:00.000Z");
+    getTracesForBlobStorageExport(PROJECT, MAX, next);
+    const window2 = capturedQuery();
+    expect(window2).toContain(">= {minTimestamp");
+  });
+});

--- a/packages/shared/src/server/repositories/blobStorageExportWindow.test.ts
+++ b/packages/shared/src/server/repositories/blobStorageExportWindow.test.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// The blob-export builders must filter their time window half-open:
-// `timestamp >= minTimestamp AND timestamp < maxTimestamp`. Every run/chunk
-// handoff sets the next window's inclusive `minTimestamp` to the previous
-// window's `maxTimestamp` (lastSyncAt = maxTimestamp). With an inclusive upper
-// bound a row landing exactly on the boundary was exported in BOTH adjacent
-// windows (duplicate); with a half-open upper bound it moves to the next window
-// and is exported exactly once. See the analytics-integration exporters, which
-// already use `< maxTimestamp`.
-
 const mockQueryClickhouseStream = vi.hoisted(() =>
   vi.fn(() => (async function* () {})()),
 );
@@ -25,8 +16,6 @@ vi.mock("./clickhouse", () => ({
   BLOB_EXPORT_PARQUET_CLICKHOUSE_SETTINGS: {},
 }));
 
-// Break the query-options -> server-barrel import cycle and avoid a real
-// ClickHouse round-trip for the observations FINAL decision.
 vi.mock("../queries/clickhouse-sql/query-options", () => ({
   shouldSkipObservationsFinal: vi.fn().mockResolvedValue(false),
 }));
@@ -57,7 +46,7 @@ const builders = [
   },
   {
     name: "getObservationsForBlobStorageExport",
-    // async generator: iterate once to run the body up to the yield*
+    // async generator: iterate once to run the builder
     run: async () => {
       await getObservationsForBlobStorageExport(PROJECT, MIN, MAX).next();
     },
@@ -87,24 +76,21 @@ describe("blob-storage export window is half-open", () => {
       await run();
       const query = capturedQuery();
 
-      // Inclusive lower bound
       expect(query).toContain(">= {minTimestamp");
-      // Exclusive upper bound
       expect(query).toContain("< {maxTimestamp");
-      // Never inclusive on the upper bound — that is the double-count bug
       expect(query).not.toContain("<= {maxTimestamp");
     },
   );
 
   it("boundary row belongs to the next window only (traces)", async () => {
-    // Window 1: [MIN, MAX). A row at exactly MAX is excluded here...
+    // Window 1 [MIN, MAX) excludes a row at exactly MAX...
     getTracesForBlobStorageExport(PROJECT, MIN, MAX);
     const window1 = capturedQuery();
     expect(window1).toContain("< {maxTimestamp");
 
     vi.clearAllMocks();
 
-    // ...and included in window 2, whose inclusive minTimestamp = prior MAX.
+    // ...window 2's inclusive min = prior MAX includes it.
     const next = new Date("2026-01-01T02:00:00.000Z");
     getTracesForBlobStorageExport(PROJECT, MAX, next);
     const window2 = capturedQuery();

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3171,7 +3171,7 @@ const buildEventsForBlobStorageExportQuery = (
 
   queryBuilder
     .whereRaw(
-      "e.start_time >= {minTimestamp: DateTime64(3)} AND e.start_time <= {maxTimestamp: DateTime64(3)}",
+      "e.start_time >= {minTimestamp: DateTime64(3)} AND e.start_time < {maxTimestamp: DateTime64(3)}",
       {
         minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
         maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1755,7 +1755,7 @@ const buildObservationsForBlobStorageExportQuery = (
     FROM observations
     WHERE project_id = {projectId: String}
     AND start_time >= {minTimestamp: DateTime64(3)}
-    AND start_time <= {maxTimestamp: DateTime64(3)}
+    AND start_time < {maxTimestamp: DateTime64(3)}
     ${
       skipDedup
         ? ""

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2323,7 +2323,7 @@ const buildScoresForBlobStorageExportQuery = (
     FROM scores FINAL
     WHERE project_id = {projectId: String}
     AND timestamp >= {minTimestamp: DateTime64(3)}
-    AND timestamp <= {maxTimestamp: DateTime64(3)}
+    AND timestamp < {maxTimestamp: DateTime64(3)}
     AND data_type IN ({dataTypes: Array(String)})
   `;
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1222,7 +1222,7 @@ const buildTracesForBlobStorageExportQuery = (
     FROM ${traceTable} FINAL
     WHERE project_id = {projectId: String}
     AND timestamp >= {minTimestamp: DateTime64(3)}
-    AND timestamp <= {maxTimestamp: DateTime64(3)}
+    AND timestamp < {maxTimestamp: DateTime64(3)}
   `;
 
   return {

--- a/worker/src/features/blobstorage/manifest.ts
+++ b/worker/src/features/blobstorage/manifest.ts
@@ -24,8 +24,9 @@ export type BlobExportManifest = {
   projectId: string;
   exportSource: string;
   /**
-   * Export window, both bounds inclusive — a row at exactly maxTimestamp also
-   * falls into the next run's window.
+   * Export window, half-open `[minTimestamp, maxTimestamp)` — the lower bound is
+   * inclusive and the upper bound is exclusive, so a row at exactly maxTimestamp
+   * belongs to the next run's window only (exported exactly once at the seam).
    */
   window: { minTimestamp: string; maxTimestamp: string };
   /** Equals window.maxTimestamp; also the manifest key stem. */

--- a/worker/src/features/blobstorage/manifest.ts
+++ b/worker/src/features/blobstorage/manifest.ts
@@ -23,11 +23,7 @@ export type BlobExportManifest = {
   version: number;
   projectId: string;
   exportSource: string;
-  /**
-   * Export window, half-open `[minTimestamp, maxTimestamp)` — the lower bound is
-   * inclusive and the upper bound is exclusive, so a row at exactly maxTimestamp
-   * belongs to the next run's window only (exported exactly once at the seam).
-   */
+  /** Half-open `[minTimestamp, maxTimestamp)`. */
   window: { minTimestamp: string; maxTimestamp: string };
   /** Equals window.maxTimestamp; also the manifest key stem. */
   maxTimestamp: string;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16613.preview.langfuse.com](https://pr-16613.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The four blob-storage export ClickHouse query builders filtered their time window **inclusive on both ends** (`timestamp >= min AND timestamp <= max`). Every run/chunk handoff sets the next window's inclusive `minTimestamp` to the previous window's `maxTimestamp` (`lastSyncAt = maxTimestamp`), so a row whose timestamp landed **exactly** on a window boundary was exported in **both** adjacent windows — a silent duplicate for consumers doing exactly-once/idempotent processing across windows.

Fix: make the upper bound **exclusive** (`timestamp < max`) in all four builders, matching the sibling analytics-integration exporters (PostHog/Mixpanel), which already use the half-open convention. Because the next window's inclusive `minTimestamp` equals this window's exclusive `maxTimestamp`, a boundary row moves to the next window and is still exported exactly once — no row is dropped at the seam.

Affected builders (Parquet and raw variants share these, so all output formats are covered):
- `buildTracesForBlobStorageExportQuery`
- `buildObservationsForBlobStorageExportQuery`
- `buildScoresForBlobStorageExportQuery`
- `buildEventsForBlobStorageExportQuery`

Adds a construction regression test (`blobStorageExportWindow.test.ts`) asserting each builder emits an inclusive lower bound and an exclusive upper bound, plus an explicit two-window seam assertion. The test fails against the previous inclusive-inclusive code and passes after the fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm run lint` / typecheck pass (shared: 4/4 tasks)
- [x] Targeted tests pass: shared `blobStorageExportWindow` (5/5), worker `blobStorageTuningWiring.unit` (3/3)
- [x] Confirmed the regression test is red against the old behavior and green after the fix

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes all four blob-storage export queries to use half-open time windows, preventing records exactly on a chunk boundary from being emitted by both adjacent exports.
- Replaces inclusive upper bounds with exclusive upper bounds for trace, observation, score, and event exports.
- Adds regression coverage for the generated lower and upper time-window predicates.
- Confirms the adjacent-window convention in which the previous maximum becomes the next inclusive minimum.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the exclusive upper bounds match the export worker’s adjacent-window handoff and preserve each boundary record exactly once.

The worker advances a successful export’s position to the exact prior maximum, which becomes the next window’s inclusive minimum, so the changed predicates remove boundary duplicates without creating a gap.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["Window N: min ≤ timestamp < max"] --> B["Persist lastSyncAt = max"]
  B --> C["Window N+1: max ≤ timestamp < nextMax"]
  D["Row timestamp = max"] --> C
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-export): make export time windo..."](https://github.com/langfuse/langfuse/commit/3812e3cb99037aa8d29b4ada4ec59088f5a25419) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57045067)</sub>

**Context used:**

- Knowledge Base — [Media and blob processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/media-and-blob-processing.md)

<!-- /greptile_comment -->