### PR TITLE
feat(agents): add grill-me skill

### DIFF
--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase using subagents instead.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "grill-me": {
+      "source": "marksalpeter/skills",
+      "sourceType": "github",
+      "skillPath": "skills/grill-me/SKILL.md",
+      "computedHash": "eddf87f160d17e64bbdd3ab72e47b18c44d09e25c7630bf03722e58d09c35ed8"
+    }
+  }
+}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16614.preview.langfuse.com](https://pr-16614.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Contributors have no in-repo skill for stress-testing a plan or design before writing code (adapted from @mattpocock's version).

To achieve this we:
- Added the `grill-me` skill under `.agents/skills/`, which interviews the author one question at a time down each branch of the design tree, offering a recommended answer for each.
- Delegated any codebase-answerable question to subagents so the interview stays focused on genuine decisions.
- Recorded the skill's upstream source and hash in `skills-lock.json`.

## Verification

- [ ] Invoke `grill-me` on a sample plan and confirm it asks one question at a time with recommendations.

## Test plan

- [ ] Trigger the skill with "grill me" on a design and verify it walks the decision tree one question at a time.
- [ ] Confirm codebase-answerable questions are resolved via subagents rather than asked back.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a `grill-me` agent skill for interactively stress-testing plans and designs.
- Directs the agent to ask one question at a time and recommend an answer.
- Delegates codebase-answerable questions to code-exploration agents.
- Records the skill’s upstream source, path, and content hash in `skills-lock.json`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the added skill and lock metadata.

The change is limited to a declarative agent-skill prompt and its provenance record, and the reviewed content exposes no established build, runtime, contract, or security failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agents): added a version of the gri..."](https://github.com/langfuse/langfuse/commit/5c80366fa183b979944c61381f6782279eaa54cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57046419)</sub>

<!-- /greptile_comment -->