### PR TITLE
fix: prevent prototype-chain clobbering in OTel attribute mapping

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1570,9 +1570,7 @@ export class OtelIngestionProcessor {
         if (DANGEROUS_KEYS.has(key)) return;
         if (!Object.hasOwn(current, key)) {
           // Check if next key is a number to decide if we need an array or object
-          current[key] = /^\d+$/.test(path[i + 1])
-            ? []
-            : Object.create(null);
+          current[key] = /^\d+$/.test(path[i + 1]) ? [] : Object.create(null);
         }
         current = current[key];
       }

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1568,9 +1568,11 @@ export class OtelIngestionProcessor {
       for (let i = 0; i < path.length - 1; i++) {
         const key = path[i];
         if (DANGEROUS_KEYS.has(key)) return;
-        if (!(key in current)) {
+        if (!Object.hasOwn(current, key)) {
           // Check if next key is a number to decide if we need an array or object
-          current[key] = /^\d+$/.test(path[i + 1]) ? [] : {};
+          current[key] = /^\d+$/.test(path[i + 1])
+            ? []
+            : Object.create(null);
         }
         current = current[key];
       }

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1572,7 +1572,12 @@ export class OtelIngestionProcessor {
           // Check if next key is a number to decide if we need an array or object
           current[key] = /^\d+$/.test(path[i + 1]) ? [] : Object.create(null);
         }
-        current = current[key];
+        const next = current[key];
+        if (typeof next !== "object" || next === null) {
+          // Preserve an earlier leaf value when a later attribute conflicts.
+          return;
+        }
+        current = next;
       }
       const finalKey = path[path.length - 1];
       if (!DANGEROUS_KEYS.has(finalKey)) {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -9612,6 +9612,99 @@ describe("OTel Resource Span Mapping", () => {
   describe("Prototype pollution protection", () => {
     const publicKey = "pk-lf-1234567890";
 
+    it("should not traverse inherited properties in nested gen_ai.prompt attributes", async () => {
+      const traceId = "abcdef1234567890abcdef1234567890";
+      const spanId = "abcdef1234567890";
+      const hasOwnPropertyFunction = Object.prototype.hasOwnProperty;
+      const originalCall = hasOwnPropertyFunction.call;
+      const originalCallDescriptor = Object.getOwnPropertyDescriptor(
+        hasOwnPropertyFunction,
+        "call",
+      );
+      let observedCall: unknown;
+      let events: TestIngestionEvent[] = [];
+
+      try {
+        events = await convertOtelSpanToIngestionEvent(
+          {
+            resource: {
+              attributes: [
+                {
+                  key: "service.name",
+                  value: { stringValue: "test-service" },
+                },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: {
+                  name: "langfuse-sdk",
+                  version: "2.0.0",
+                  attributes: [
+                    {
+                      key: "public_key",
+                      value: { stringValue: publicKey },
+                    },
+                  ],
+                },
+                spans: [
+                  {
+                    traceId: Buffer.from(traceId, "hex").toJSON(),
+                    spanId: Buffer.from(spanId, "hex").toJSON(),
+                    name: "prototype-chain-clobbering-test",
+                    kind: 1,
+                    startTimeUnixNano: {
+                      low: 1000000000,
+                      high: 0,
+                      unsigned: true,
+                    },
+                    endTimeUnixNano: {
+                      low: 2000000000,
+                      high: 0,
+                      unsigned: true,
+                    },
+                    attributes: [
+                      {
+                        key: "gen_ai.prompt.a.safe",
+                        value: { stringValue: "still-here" },
+                      },
+                      {
+                        key: "gen_ai.prompt.a.hasOwnProperty.call",
+                        value: { stringValue: "pwned" },
+                      },
+                    ],
+                    status: {},
+                  },
+                ],
+              },
+            ],
+          },
+          new Set([traceId]),
+          publicKey,
+        );
+        observedCall = hasOwnPropertyFunction.call;
+      } finally {
+        if (originalCallDescriptor) {
+          Object.defineProperty(
+            hasOwnPropertyFunction,
+            "call",
+            originalCallDescriptor,
+          );
+        } else {
+          delete (hasOwnPropertyFunction as { call?: unknown }).call;
+        }
+      }
+
+      expect(observedCall).toBe(originalCall);
+      expect(events.find((event) => event.type === "span-create")?.body.input)
+        .toMatchObject({
+          a: {
+            safe: "still-here",
+            hasOwnProperty: { call: "pwned" },
+          },
+        });
+    });
+
     it("should not pollute Object.prototype via __proto__ in gen_ai.prompt attributes", async () => {
       const traceId = "abcdef1234567890abcdef1234567890";
       const spanId = "abcdef1234567890";

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -9611,78 +9611,77 @@ describe("OTel Resource Span Mapping", () => {
 
   describe("Prototype pollution protection", () => {
     const publicKey = "pk-lf-1234567890";
+    const traceId = "abcdef1234567890abcdef1234567890";
+    const spanId = "abcdef1234567890";
 
-    it("should not traverse inherited properties in nested gen_ai.prompt attributes", async () => {
-      const traceId = "abcdef1234567890abcdef1234567890";
-      const spanId = "abcdef1234567890";
+    const createResourceSpan = (
+      attributes: Array<{ key: string; value: Record<string, unknown> }>,
+    ) => ({
+      resource: {
+        attributes: [
+          {
+            key: "service.name",
+            value: { stringValue: "test-service" },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: {
+            name: "langfuse-sdk",
+            version: "2.0.0",
+            attributes: [
+              {
+                key: "public_key",
+                value: { stringValue: publicKey },
+              },
+            ],
+          },
+          spans: [
+            {
+              traceId: Buffer.from(traceId, "hex").toJSON(),
+              spanId: Buffer.from(spanId, "hex").toJSON(),
+              name: "prototype-protection-test",
+              kind: 1,
+              startTimeUnixNano: {
+                low: 1000000000,
+                high: 0,
+                unsigned: true,
+              },
+              endTimeUnixNano: {
+                low: 2000000000,
+                high: 0,
+                unsigned: true,
+              },
+              attributes,
+              status: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    const convertAndObserveHasOwnPropertyCall = async (
+      attributes: Array<{ key: string; value: Record<string, unknown> }>,
+    ) => {
       const hasOwnPropertyFunction = Object.prototype.hasOwnProperty;
       const originalCall = hasOwnPropertyFunction.call;
       const originalCallDescriptor = Object.getOwnPropertyDescriptor(
         hasOwnPropertyFunction,
         "call",
       );
-      let observedCall: unknown;
-      let events: TestIngestionEvent[] = [];
 
       try {
-        events = await convertOtelSpanToIngestionEvent(
-          {
-            resource: {
-              attributes: [
-                {
-                  key: "service.name",
-                  value: { stringValue: "test-service" },
-                },
-              ],
-            },
-            scopeSpans: [
-              {
-                scope: {
-                  name: "langfuse-sdk",
-                  version: "2.0.0",
-                  attributes: [
-                    {
-                      key: "public_key",
-                      value: { stringValue: publicKey },
-                    },
-                  ],
-                },
-                spans: [
-                  {
-                    traceId: Buffer.from(traceId, "hex").toJSON(),
-                    spanId: Buffer.from(spanId, "hex").toJSON(),
-                    name: "prototype-chain-clobbering-test",
-                    kind: 1,
-                    startTimeUnixNano: {
-                      low: 1000000000,
-                      high: 0,
-                      unsigned: true,
-                    },
-                    endTimeUnixNano: {
-                      low: 2000000000,
-                      high: 0,
-                      unsigned: true,
-                    },
-                    attributes: [
-                      {
-                        key: "gen_ai.prompt.a.safe",
-                        value: { stringValue: "still-here" },
-                      },
-                      {
-                        key: "gen_ai.prompt.a.hasOwnProperty.call",
-                        value: { stringValue: "pwned" },
-                      },
-                    ],
-                    status: {},
-                  },
-                ],
-              },
-            ],
-          },
+        const events = await convertOtelSpanToIngestionEvent(
+          createResourceSpan(attributes),
           new Set([traceId]),
           publicKey,
         );
-        observedCall = hasOwnPropertyFunction.call;
+        return {
+          events,
+          observedCall: hasOwnPropertyFunction.call,
+          originalCall,
+        };
       } finally {
         if (originalCallDescriptor) {
           Object.defineProperty(
@@ -9694,6 +9693,20 @@ describe("OTel Resource Span Mapping", () => {
           delete (hasOwnPropertyFunction as { call?: unknown }).call;
         }
       }
+    };
+
+    it("should not traverse inherited properties in nested gen_ai.prompt attributes", async () => {
+      const { events, observedCall, originalCall } =
+        await convertAndObserveHasOwnPropertyCall([
+          {
+            key: "gen_ai.prompt.a.safe",
+            value: { stringValue: "still-here" },
+          },
+          {
+            key: "gen_ai.prompt.a.hasOwnProperty.call",
+            value: { stringValue: "pwned" },
+          },
+        ]);
 
       expect(observedCall).toBe(originalCall);
       expect(
@@ -9703,6 +9716,54 @@ describe("OTel Resource Span Mapping", () => {
           safe: "still-here",
           hasOwnProperty: { call: "pwned" },
         },
+      });
+    });
+
+    it("should not traverse inherited properties through an array branch", async () => {
+      const { events, observedCall, originalCall } =
+        await convertAndObserveHasOwnPropertyCall([
+          {
+            key: "gen_ai.prompt.a.0",
+            value: { stringValue: "seed" },
+          },
+          {
+            key: "gen_ai.prompt.a.hasOwnProperty.call",
+            value: { stringValue: "pwned" },
+          },
+        ]);
+
+      expect(observedCall).toBe(originalCall);
+      const input = events.find((event) => event.type === "span-create")?.body
+        .input as { a?: unknown[] } | undefined;
+      expect(input?.a?.[0]).toBe("seed");
+      expect(Object.hasOwn(input?.a ?? [], "hasOwnProperty")).toBe(true);
+      expect(Reflect.get(input?.a ?? [], "hasOwnProperty")).toMatchObject({
+        call: "pwned",
+      });
+    });
+
+    it("should preserve a scalar leaf and ignore a conflicting nested attribute", () => {
+      const events = createTestOtelProcessor({ publicKey }).processToEvent([
+        createResourceSpan([
+          {
+            key: "gen_ai.prompt.a",
+            value: { stringValue: "leaf" },
+          },
+          {
+            key: "gen_ai.prompt.a.b",
+            value: { stringValue: "nested" },
+          },
+          {
+            key: "gen_ai.prompt.safe",
+            value: { stringValue: "still-here" },
+          },
+        ]),
+      ]);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].input).toMatchObject({
+        a: "leaf",
+        safe: "still-here",
       });
     });
 

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -9696,13 +9696,14 @@ describe("OTel Resource Span Mapping", () => {
       }
 
       expect(observedCall).toBe(originalCall);
-      expect(events.find((event) => event.type === "span-create")?.body.input)
-        .toMatchObject({
-          a: {
-            safe: "still-here",
-            hasOwnProperty: { call: "pwned" },
-          },
-        });
+      expect(
+        events.find((event) => event.type === "span-create")?.body.input,
+      ).toMatchObject({
+        a: {
+          safe: "still-here",
+          hasOwnProperty: { call: "pwned" },
+        },
+      });
     });
 
     it("should not pollute Object.prototype via __proto__ in gen_ai.prompt attributes", async () => {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -9616,7 +9616,7 @@ describe("OTel Resource Span Mapping", () => {
 
     const createResourceSpan = (
       attributes: Array<{ key: string; value: Record<string, unknown> }>,
-    ) => ({
+    ): ResourceSpan => ({
       resource: {
         attributes: [
           {
@@ -9639,19 +9639,17 @@ describe("OTel Resource Span Mapping", () => {
           },
           spans: [
             {
-              traceId: Buffer.from(traceId, "hex").toJSON(),
-              spanId: Buffer.from(spanId, "hex").toJSON(),
+              traceId: Buffer.from(traceId, "hex"),
+              spanId: Buffer.from(spanId, "hex"),
               name: "prototype-protection-test",
               kind: 1,
               startTimeUnixNano: {
                 low: 1000000000,
                 high: 0,
-                unsigned: true,
               },
               endTimeUnixNano: {
                 low: 2000000000,
                 high: 0,
-                unsigned: true,
               },
               attributes,
               status: {},


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16616.preview.langfuse.com](https://pr-16616.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Avoid traversing inherited properties when building nested OTel attributes.
- Use null-prototype objects for dynamically created attribute maps.
- Add regression coverage for prototype-chain clobbering via `hasOwnProperty.call`.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens OpenTelemetry attribute mapping against prototype-chain clobbering.

- Checks only own properties while constructing nested attribute paths.
- Creates dynamic nested maps with null prototypes.
- Adds regression coverage for attempts to clobber `hasOwnProperty.call`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The hardening uses APIs supported by the repository’s declared build and runtime targets, while checked downstream consumers safely handle null-prototype attribute maps.
</details>

<sub>Reviews (1): Last reviewed commit: ["Prevent prototype-chain traversal in OTe..."](https://github.com/langfuse/langfuse/commit/1681f807d858a3be81516c1619c09ceb61903575) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57050327)</sub>

<!-- /greptile_comment -->