### PR TITLE
feat(web): automatically assign semantic status colors to chart series

### DIFF
--- a/web/src/components/design-system/ThemeTokens/Charts.tsx
+++ b/web/src/components/design-system/ThemeTokens/Charts.tsx
@@ -26,6 +26,14 @@ const seriesEntries = rootEntries
       Number(/\d+/.exec(b.name)?.[0] ?? 0),
   );
 const gridEntry = rootEntries.find((entry) => entry.name === "--chart-grid");
+const STATUS_ORDER = ["ok", "neutral", "warning", "error"];
+const statusEntries = rootEntries
+  .filter((entry) => entry.name.startsWith("--chart-status-"))
+  .sort(
+    (a, b) =>
+      STATUS_ORDER.indexOf(a.name.replace("--chart-status-", "")) -
+      STATUS_ORDER.indexOf(b.name.replace("--chart-status-", "")),
+  );
 const scaleEntries = rootEntries
   .filter((entry) => /^--color-\d+$/.test(entry.name))
   .sort(
@@ -51,7 +59,8 @@ function PaletteStrip({
             style={{ background: ctx.color(entry.name) }}
           />
           <code className="text-muted-foreground font-mono text-[9px]">
-            {/\d+/.exec(entry.name)?.[0]}
+            {/\d+/.exec(entry.name)?.[0] ??
+              entry.name.split("-").filter(Boolean).at(-1)}
           </code>
         </div>
       ))}
@@ -146,8 +155,9 @@ export function Charts() {
           }
           meta={
             <>
-              {seriesEntries.length} series colors · {scaleEntries.length} score
-              base colors · 1 grid color
+              {seriesEntries.length} series colors · {statusEntries.length}{" "}
+              status colors · {scaleEntries.length} score base colors · 1 grid
+              color
             </>
           }
         />
@@ -170,6 +180,33 @@ export function Charts() {
               entry={entry}
               {...rowProps}
               sample={<ChartBarSample ctx={ctx} name={entry.name} />}
+            />
+          ))}
+        </TokenSection>
+
+        <TokenSection
+          title="Status series"
+          blurb="Reserved fills for semantically-recognized series (ERROR red, WARNING amber, pass green, n/a gray — prepareSeriesColors, LFE-15467). Full colors consumed as var(--chart-status-*), never wrapped in hsl(); status colors never impersonate a categorical slot and vice versa."
+          count={statusEntries.length}
+          sectionSample={<PaletteStrip ctx={ctx} entries={statusEntries} />}
+        >
+          {statusEntries.map((entry) => (
+            <TokenRow
+              key={entry.name}
+              name={entry.name}
+              entry={entry}
+              {...rowProps}
+              sample={
+                <div
+                  className="rounded-md border px-2.5 py-1.5"
+                  style={{ background: ctx.color("--background") }}
+                >
+                  <span
+                    className="inline-block h-4 w-14 rounded-sm"
+                    style={{ background: ctx.color(entry.name) }}
+                  />
+                </div>
+              }
             />
           ))}
         </TokenSection>

--- a/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
+++ b/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
@@ -115,6 +115,12 @@ export function CategoricalScoreChart(props: {
           row_limit: 100,
           subtle_fill: true,
         }}
+        // This chart shows exactly one score's categorical values — unlock
+        // verdict coloring and True/False polarity by name. (LFE-15467)
+        semanticContext={{
+          field: "score-categorical",
+          scoreName: props.scoreData.name,
+        }}
       />
     </div>
   );

--- a/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
+++ b/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
@@ -115,12 +115,10 @@ export function CategoricalScoreChart(props: {
           row_limit: 100,
           subtle_fill: true,
         }}
-        // This chart shows exactly one score's categorical values — unlock
-        // verdict coloring and True/False polarity by name. (LFE-15467)
-        semanticContext={{
-          field: "score-categorical",
-          scoreName: props.scoreData.name,
-        }}
+        // No semanticContext: scoreChartDataToDataPoints emits bin labels
+        // ("Aggregation" / timestamps) as `dimension`, not category values, so
+        // verdict coloring (LFE-15467) can't apply until this chart's adapter
+        // carries categories as series.
       />
     </div>
   );

--- a/web/src/features/widgets/chart-library/ARCHITECTURE.md
+++ b/web/src/features/widgets/chart-library/ARCHITECTURE.md
@@ -143,15 +143,20 @@ different — and sometimes wrong — dates. One source of truth per decision.)
   crosshair, a tooltip that opens only on the hovered chart, and a vertical
   proximity highlight.
 - **Known visual debts** (drawn but not yet matching the direction above):
-  series color is assigned by index and cycles every 8 rather than being a
-  stable identity (V6) — a visualiser default to migrate into the preparer.
-  (V1's smooth-by-default debt is paid: lines and areas draw straight
+  series color moved into a preparer (`prepareSeriesColors`, LFE-15467):
+  status-meaning values (ERROR, pass, healthy, …) wear reserved
+  `--chart-status-*` colors — recognized universally for unambiguous words and
+  per-field (level, categorical score values incl. True/False polarity by
+  score name) via the `semanticContext` hint — while everything else keeps the
+  index-cycled 8-slot rotation. The remaining V6 debt: that non-semantic
+  rotation is still positional, not a stable per-entity identity across
+  charts. (V1's smooth-by-default debt is paid: lines and areas draw straight
   (`type="linear"`) since LFE-10694.)
-- **Next:** move the remaining decisions — series colors (V6), curve/interpolation
-  opt-ins (V1), legend summaries, units, axis type & scale — out of the components and
-  into the preparer, until the visualiser is purely presentational and the
-  preparer is the single, tested place where "what should this look like" is
-  answered.
+- **Next:** move the remaining decisions — stable non-semantic color identity
+  (V6), curve/interpolation opt-ins (V1), legend summaries, units, axis type &
+  scale — out of the components and into the preparer, until the visualiser is
+  purely presentational and the preparer is the single, tested place where
+  "what should this look like" is answered.
 
 The target: adding a new chart should mean teaching the **preparer** a new shape,
 not teaching every component a new special case.

--- a/web/src/features/widgets/chart-library/AreaChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/AreaChartTimeSeries.tsx
@@ -24,7 +24,10 @@ import { prepareTimeAxis } from "@/src/features/widgets/chart-library/prepareTim
 import { temporalAxisTickProp } from "@/src/features/widgets/chart-library/TimeAxisTick";
 import { prepareVisibleSeries } from "@/src/features/widgets/chart-library/prepareVisibleSeries";
 import {
-  seriesColor,
+  matchSeriesStatus,
+  prepareSeriesColors,
+} from "@/src/features/widgets/chart-library/prepareSeriesColors";
+import {
   SeriesOverflowNote,
   TimeSeriesLegend,
   useSeriesLegend,
@@ -51,9 +54,18 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
   missingValue = "gap",
   connectNulls = false,
   hideXAxisLabels = false,
+  semanticContext,
 }) => {
   const [selfHovered, setSelfHovered] = useState(false);
   const allDimensions = useMemo(() => getUniqueDimensions(data), [data]);
+  // A status-colored series (ERROR, failed, ...) must survive the series cap
+  // and the top-N legend seeding — it's the series the chart exists for.
+  const isStatusSeries = useMemo(() => {
+    return (dimension: string) => {
+      const status = matchSeriesStatus(dimension, semanticContext);
+      return status !== undefined && status !== "neutral";
+    };
+  }, [semanticContext]);
   // Make every (bucket, series) cell explicit — 0 for additive metrics, null
   // (a real gap) otherwise — so areas never draw across no-data buckets. (LFE-10694)
   const groupedData = useMemo(
@@ -74,10 +86,15 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
   // Cap how many series we draw (data -> preparer seam): a high-cardinality
   // breakdown of hundreds of series is both unreadable and slow to hover. (LFE-10549)
   const series = useMemo(
-    () => prepareVisibleSeries(data, allDimensions),
-    [data, allDimensions],
+    () => prepareVisibleSeries(data, allDimensions, undefined, isStatusSeries),
+    [data, allDimensions, isStatusSeries],
   );
   const dimensions = series.visible;
+  // Color is identity, resolved once for chart + legend + dots (V6).
+  const seriesColors = useMemo(
+    () => prepareSeriesColors(dimensions, semanticContext),
+    [dimensions, semanticContext],
+  );
   const { ref: containerRef, maxTicks } = useChartTickBudget();
   const chartBoxRef = useRef<HTMLDivElement>(null);
   const timeAxis = useMemo(
@@ -97,6 +114,8 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
     legendSummary,
     legendInteraction,
     maxVisibleSeries,
+    colorOf: seriesColors.colorOf,
+    seedAlwaysVisible: isStatusSeries,
   });
 
   const tooltipFormatter = (value: number) =>
@@ -166,10 +185,11 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
             niceTicks="auto"
             tickFormatter={(value) => tooltipFormatter(Number(value))}
           />
-          {dimensions.map((dimension, index) => {
+          {dimensions.map((dimension) => {
             if (!isRendered(dimension)) return null;
             const muted = isDimmed(dimension);
             const isolated = isolatedPoints.get(dimension);
+            const color = seriesColors.colorOf(dimension);
             return (
               <Area
                 key={dimension}
@@ -178,12 +198,10 @@ export const AreaChartTimeSeries: React.FC<ChartProps> = ({
                 // Neighborless points span no area segment; a dot is the only
                 // thing that keeps them visible. (LFE-10694)
                 dot={
-                  isolated
-                    ? isolatedPointDot(isolated, seriesColor(index), muted)
-                    : false
+                  isolated ? isolatedPointDot(isolated, color, muted) : false
                 }
-                stroke={seriesColor(index)}
-                fill={seriesColor(index)}
+                stroke={color}
+                fill={color}
                 fillOpacity={muted ? 0.15 : subtleFill ? 0.3 : 0.75}
                 strokeWidth={2.5}
                 strokeOpacity={muted ? 0.2 : 1}

--- a/web/src/features/widgets/chart-library/Chart.clienttest.tsx
+++ b/web/src/features/widgets/chart-library/Chart.clienttest.tsx
@@ -10,11 +10,33 @@ import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props
  * `isLoading` gate dropped) — only rendering the real dispatcher can.
  *
  * jsdom has no `ResizeObserver`; recharts' `ResponsiveContainer` (via
- * `useChartTickBudget`) needs one to mount without throwing. A minimal stub
- * is enough — this suite never asserts on measured width.
+ * `useChartTickBudget`) needs one to mount without throwing. The stub reports
+ * a real box on observe — with jsdom's 0x0 layout recharts would otherwise
+ * draw no marks at all, and the semantic-color assertions below need actual
+ * SVG shapes to inspect.
  */
 class ResizeObserverStub {
-  observe() {}
+  private readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    const contentRect = {
+      width: 800,
+      height: 400,
+      top: 0,
+      left: 0,
+      bottom: 400,
+      right: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    };
+    this.callback(
+      [{ target, contentRect } as unknown as ResizeObserverEntry],
+      this as unknown as ResizeObserver,
+    );
+  }
   unobserve() {}
   disconnect() {}
 }
@@ -72,5 +94,86 @@ describe("Chart dispatcher — empty-state guard (LFE-14333)", () => {
     cleanup();
     render(<Chart chartType="BAR_TIME_SERIES" data={[]} rowLimit={100} />);
     expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+});
+
+/**
+ * Render-level coverage for semantic series colors (LFE-15467): a unit test
+ * on `prepareSeriesColors` can't catch the category-bar specificity trap —
+ * the `fill-(--color-metric)` CLASS on <Bar> overrides per-<Cell> fill
+ * ATTRIBUTES, so per-category colors only render if the class is dropped.
+ * Only mounting the real chart proves the fills survive to the SVG.
+ */
+describe("Chart dispatcher — semantic series colors (LFE-15467)", () => {
+  const bars = (dimensions: string[]): DataPoint[] =>
+    dimensions.map((dimension, i) => point(10 * (i + 1), dimension));
+
+  it("colors category bars per status value and drops the uniform class fill", () => {
+    const { container } = render(
+      <Chart
+        chartType="HORIZONTAL_BAR"
+        data={bars(["pass", "borderline", "fail"])}
+        rowLimit={100}
+        semanticContext={{ field: "score-categorical" }}
+      />,
+    );
+    expect(
+      container.querySelector('[fill="var(--chart-status-ok)"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[fill="var(--chart-status-warning)"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[fill="var(--chart-status-error)"]'),
+    ).toBeInTheDocument();
+    // The class fill would override the per-cell attributes — must be gone.
+    expect(
+      container.querySelector('[class*="fill-(--color-metric)"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the uniform metric fill when no status value is present", () => {
+    const { container } = render(
+      <Chart
+        chartType="VERTICAL_BAR"
+        data={bars(["alpha", "beta", "gamma"])}
+        rowLimit={100}
+      />,
+    );
+    expect(
+      container.querySelector('[class*="fill-(--color-metric)"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[fill^="var(--chart-status-"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it("colors pie slices by the level vocabulary under the level gate", () => {
+    const { container } = render(
+      <Chart
+        chartType="PIE"
+        data={bars(["DEFAULT", "DEBUG", "WARNING", "ERROR"])}
+        rowLimit={100}
+        semanticContext={{ field: "level" }}
+      />,
+    );
+    for (const token of ["ok", "neutral", "warning", "error"]) {
+      expect(
+        container.querySelector(`[fill="var(--chart-status-${token})"]`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("does NOT color the 'default' environment green without the level gate", () => {
+    const { container } = render(
+      <Chart
+        chartType="PIE"
+        data={bars(["default", "staging", "production"])}
+        rowLimit={100}
+      />,
+    );
+    expect(
+      container.querySelector('[fill^="var(--chart-status-"]'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -9,6 +9,7 @@ import {
   type LegendInteraction,
   type MissingBucketValue,
 } from "@/src/features/widgets/chart-library/chart-props";
+import { type SeriesSemanticContext } from "@/src/features/widgets/chart-library/prepareSeriesColors";
 import { formatMetric } from "@/src/features/widgets/chart-library/utils";
 import { isChartDataEmpty } from "@/src/features/widgets/chart-library/isChartDataEmpty";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
@@ -64,6 +65,7 @@ const ChartComponent = ({
   thresholds,
   missingValue,
   hideXAxisLabels,
+  semanticContext,
 }: {
   chartType: DashboardWidgetChartType;
   data: DataPoint[];
@@ -102,6 +104,12 @@ const ChartComponent = ({
    * dataset-compare charts.
    */
   hideXAxisLabels?: boolean;
+  /**
+   * Which semantic vocabulary the dimension values belong to, when the caller
+   * knows (see `prepareSeriesColors`). Forwarded to every series-colored
+   * chart; the universal status words apply even without it.
+   */
+  semanticContext?: SeriesSemanticContext;
 }) => {
   const [forceRender, setForceRender] = useState(overrideWarning);
   const shouldWarn = data.length > 2000 && !forceRender;
@@ -172,6 +180,7 @@ const ChartComponent = ({
             thresholds={thresholds}
             missingValue={missingValue}
             hideXAxisLabels={hideXAxisLabels}
+            semanticContext={semanticContext}
           />
         );
       case "AREA_TIME_SERIES":
@@ -188,6 +197,7 @@ const ChartComponent = ({
             subtleFill={chartConfig?.subtle_fill}
             missingValue={missingValue}
             hideXAxisLabels={hideXAxisLabels}
+            semanticContext={semanticContext}
           />
         );
       case "BAR_TIME_SERIES":
@@ -203,6 +213,7 @@ const ChartComponent = ({
             syncId={syncId}
             subtleFill={chartConfig?.subtle_fill}
             hideXAxisLabels={hideXAxisLabels}
+            semanticContext={semanticContext}
           />
         );
       case "HORIZONTAL_BAR":
@@ -213,6 +224,7 @@ const ChartComponent = ({
             showValueLabels={chartConfig?.show_value_labels}
             metricFormatter={metricFormatter}
             subtleFill={chartConfig?.subtle_fill}
+            semanticContext={semanticContext}
           />
         );
       case "VERTICAL_BAR":
@@ -222,6 +234,7 @@ const ChartComponent = ({
             config={resolvedConfig}
             metricFormatter={metricFormatter}
             subtleFill={chartConfig?.subtle_fill}
+            semanticContext={semanticContext}
           />
         );
       case "PIE":
@@ -231,6 +244,7 @@ const ChartComponent = ({
             config={resolvedConfig}
             metricFormatter={metricFormatter}
             subtleFill={chartConfig?.subtle_fill}
+            semanticContext={semanticContext}
           />
         );
       case "HISTOGRAM":

--- a/web/src/features/widgets/chart-library/HorizontalBarChart.tsx
+++ b/web/src/features/widgets/chart-library/HorizontalBarChart.tsx
@@ -7,12 +7,15 @@ import {
 import {
   Bar,
   BarChart,
+  type BarShapeProps,
   LabelList,
+  Rectangle,
   type RenderableText,
   XAxis,
   YAxis,
 } from "recharts";
 import { type ChartProps } from "@/src/features/widgets/chart-library/chart-props";
+import { prepareSeriesColors } from "@/src/features/widgets/chart-library/prepareSeriesColors";
 import {
   formatAxisLabel,
   formatMetric,
@@ -42,12 +45,22 @@ export const HorizontalBarChart: React.FC<ChartProps> = ({
   showValueLabels = false,
   metricFormatter = (value, options) => formatMetric(value, options),
   subtleFill = false,
+  semanticContext,
 }) => {
   const formatValue = useCallback(
     (value: number) =>
       toFullMetricString(metricFormatter(value, { style: "compact" })),
     [metricFormatter],
   );
+
+  // All-or-nothing per-category coloring: only when a status-meaning value
+  // (ERROR, pass, ...) is present do the bars color per category — a lone red
+  // bar among uniform bars reads as selection, and uniform-when-nominal is
+  // the correct default for single-series bars. (LFE-15467)
+  const seriesColors = useMemo(() => {
+    const names = data.map((item) => item.dimension || "Unknown");
+    return { names, ...prepareSeriesColors(names, semanticContext) };
+  }, [data, semanticContext]);
 
   const rightMargin = useMemo(() => {
     if (!showValueLabels || !data?.length) return 8;
@@ -125,9 +138,26 @@ export const HorizontalBarChart: React.FC<ChartProps> = ({
           dataKey="metric"
           radius={[0, 4, 4, 0]}
           maxBarSize={28}
-          className="fill-(--color-metric)"
+          // The class fill would override the per-shape fill attribute (CSS
+          // beats SVG presentation attributes), so it must be absent when the
+          // bars color per category.
+          className={
+            seriesColors.hasStatusColor ? undefined : "fill-(--color-metric)"
+          }
           fillOpacity={subtleFill ? 0.3 : 1}
           isAnimationActive={false}
+          shape={
+            seriesColors.hasStatusColor
+              ? (props: BarShapeProps) => (
+                  <Rectangle
+                    {...props}
+                    fill={seriesColors.colorOf(
+                      String(props.payload?.dimension ?? "Unknown"),
+                    )}
+                  />
+                )
+              : undefined
+          }
         >
           {showValueLabels ? (
             <LabelList

--- a/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/LineChartTimeSeries.tsx
@@ -37,7 +37,10 @@ import { prepareTimeAxis } from "@/src/features/widgets/chart-library/prepareTim
 import { temporalAxisTickProp } from "@/src/features/widgets/chart-library/TimeAxisTick";
 import { prepareVisibleSeries } from "@/src/features/widgets/chart-library/prepareVisibleSeries";
 import {
-  seriesColor,
+  matchSeriesStatus,
+  prepareSeriesColors,
+} from "@/src/features/widgets/chart-library/prepareSeriesColors";
+import {
   SeriesOverflowNote,
   TimeSeriesLegend,
   useSeriesLegend,
@@ -206,10 +209,19 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
   missingValue = "gap",
   connectNulls = false,
   hideXAxisLabels = false,
+  semanticContext,
 }) => {
   const metricExtent = useMemo(() => computeMetricExtent(data), [data]);
 
   const allDimensions = useMemo(() => getUniqueDimensions(data), [data]);
+  // A status-colored series (ERROR, failed, ...) must survive the series cap
+  // and the top-N legend seeding — it's the series the chart exists for.
+  const isStatusSeries = useMemo(() => {
+    return (dimension: string) => {
+      const status = matchSeriesStatus(dimension, semanticContext);
+      return status !== undefined && status !== "neutral";
+    };
+  }, [semanticContext]);
   // Make every (bucket, series) cell explicit — 0 for additive metrics, null
   // (a real gap) otherwise — so lines never draw across no-data buckets. (LFE-10694)
   const groupedData = useMemo(
@@ -230,10 +242,15 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
   // Cap how many series we draw (data -> preparer seam): a high-cardinality
   // breakdown of hundreds of series is both unreadable and slow to hover. (LFE-10549)
   const series = useMemo(
-    () => prepareVisibleSeries(data, allDimensions),
-    [data, allDimensions],
+    () => prepareVisibleSeries(data, allDimensions, undefined, isStatusSeries),
+    [data, allDimensions, isStatusSeries],
   );
   const dimensions = series.visible;
+  // Color is identity, resolved once for chart + legend + dots (V6).
+  const seriesColors = useMemo(
+    () => prepareSeriesColors(dimensions, semanticContext),
+    [dimensions, semanticContext],
+  );
   const { ref: containerRef, maxTicks } = useChartTickBudget();
   const chartBoxRef = useRef<HTMLDivElement>(null);
   const timeAxis = useMemo(
@@ -259,6 +276,8 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
     legendSummary,
     legendInteraction,
     maxVisibleSeries,
+    colorOf: seriesColors.colorOf,
+    seedAlwaysVisible: isStatusSeries,
   });
 
   const renderedDimensions = dimensions.filter(isRendered);
@@ -343,11 +362,12 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
             niceTicks="auto"
             tickFormatter={(value) => tooltipFormatter(Number(value))}
           />
-          {dimensions.map((dimension, index) => {
+          {dimensions.map((dimension) => {
             if (!isRendered(dimension)) return null;
             const nearest = proximityActive && nearestSet.has(dimension);
             const muted = isDimmed(dimension) || (proximityActive && !nearest);
             const isolated = isolatedPoints.get(dimension);
+            const color = seriesColors.colorOf(dimension);
             return (
               <Line
                 key={dimension}
@@ -360,13 +380,13 @@ export const LineChartTimeSeries: React.FC<ChartProps> = ({
                     : // Neighborless points span no line segment; a dot is the
                       // only thing that keeps them visible. (LFE-10694)
                       isolated
-                      ? isolatedPointDot(isolated, seriesColor(index), muted)
+                      ? isolatedPointDot(isolated, color, muted)
                       : false
                 }
                 // The hover marker is independent of the static-dot setting: even
                 // a dotless line reveals the point under the cursor.
                 activeDot={muted ? false : { r: 5, strokeWidth: 0 }}
-                stroke={seriesColor(index)}
+                stroke={color}
                 strokeOpacity={muted ? 0.2 : 1}
                 connectNulls={connectNulls}
                 isAnimationActive={false}

--- a/web/src/features/widgets/chart-library/PieChart.tsx
+++ b/web/src/features/widgets/chart-library/PieChart.tsx
@@ -12,6 +12,7 @@ import {
   type PieSectorShapeProps,
 } from "recharts";
 import { type ChartProps } from "@/src/features/widgets/chart-library/chart-props";
+import { prepareSeriesColors } from "@/src/features/widgets/chart-library/prepareSeriesColors";
 import {
   formatMetric,
   toFullMetricString,
@@ -36,6 +37,7 @@ export const PieChart: React.FC<ChartProps> = ({
   accessibilityLayer = true,
   metricFormatter = (value, options) => formatMetric(value, options),
   subtleFill = false,
+  semanticContext,
 }) => {
   const formatValue = (value: number) =>
     toFullMetricString(metricFormatter(value, { style: "compact" }));
@@ -45,14 +47,18 @@ export const PieChart: React.FC<ChartProps> = ({
     return data.reduce((acc, curr) => acc + (curr.metric as number), 0);
   }, [data]);
 
-  // Transform data for PieChart
+  // Transform data for PieChart. Slice color is identity, resolved by the
+  // preparer: status-meaning slices (ERROR, pass, ...) wear the reserved
+  // status colors, the rest keep the palette rotation (V6, LFE-15467).
   const chartData = useMemo(() => {
+    const names = data.map((item) => item.dimension || "Unknown");
+    const colors = prepareSeriesColors(names, semanticContext);
     return data.map((item, index) => ({
-      name: item.dimension || "Unknown",
+      name: names[index],
       value: item.metric,
-      fill: `hsl(var(--chart-${(index % 8) + 1}))`,
+      fill: colors.colorOf(names[index]),
     }));
-  }, [data]);
+  }, [data, semanticContext]);
 
   const renderSector = (props: PieSectorShapeProps) => {
     const outerRadius =

--- a/web/src/features/widgets/chart-library/TimeSeriesLegend.tsx
+++ b/web/src/features/widgets/chart-library/TimeSeriesLegend.tsx
@@ -6,12 +6,9 @@ import {
   type LegendSummaryMode,
 } from "@/src/features/widgets/chart-library/chart-props";
 import { getDimensionSummaries } from "@/src/features/widgets/chart-library/utils";
+import { seriesColor } from "@/src/features/widgets/chart-library/prepareSeriesColors";
 import { getPlainTextFromReactNode } from "@/src/utils/react-node-plain-text";
 import { cn } from "@/src/utils/tailwind";
-
-/** The 8-slot chart palette, cycled by series index (matches the series fills). */
-export const seriesColor = (index: number): string =>
-  `hsl(var(--chart-${(index % 8) + 1}))`;
 
 export type LegendItem = {
   dimension: string;
@@ -22,8 +19,10 @@ export type LegendItem = {
    * what a series is called. (LFE-10576)
    */
   label: React.ReactNode;
-  /** Position in the dimension list — pins the swatch color to the series fill. */
-  colorIndex: number;
+  /**
+   * The series' resolved color — the same value the chart paints the series
+   * with (`prepareSeriesColors`), so swatch and line can never diverge (V6).
+   */
   color: string;
   /** Per-series summary under the active mode, or `null` when there's nothing to show. */
   summary: number | null;
@@ -48,6 +47,8 @@ export function useSeriesLegend({
   legendSummary = "none",
   legendInteraction = "highlight",
   maxVisibleSeries,
+  colorOf,
+  seedAlwaysVisible,
 }: {
   data: DataPoint[];
   dimensions: string[];
@@ -56,6 +57,18 @@ export function useSeriesLegend({
   legendSummary?: LegendSummaryMode;
   legendInteraction?: LegendInteraction;
   maxVisibleSeries?: number;
+  /**
+   * The series' resolved color (from `prepareSeriesColors`). Falls back to the
+   * index-cycled palette for callers that haven't adopted the preparer yet.
+   */
+  colorOf?: (dimension: string, index: number) => string;
+  /**
+   * Series that must survive the top-N default-visibility seeding regardless
+   * of magnitude — status-colored series like ERROR are usually small by
+   * construction on a healthy system, and hiding them defeats the point of a
+   * production-health chart. (LFE-15467)
+   */
+  seedAlwaysVisible?: (dimension: string) => boolean;
 }): {
   legendItems: LegendItem[];
   onLegendClick: (dimension: string) => void;
@@ -71,6 +84,7 @@ export function useSeriesLegend({
 
   // Seed the top-N visible set by additive magnitude (chart metrics are
   // non-negative, so a plain sum ranks "biggest series" well enough).
+  // `seedAlwaysVisible` series rank ahead of magnitude — see its JSDoc.
   const initialHidden = useMemo(() => {
     if (legendInteraction !== "toggle" || maxVisibleSeries === undefined) {
       return new Set<string>();
@@ -78,14 +92,25 @@ export function useSeriesLegend({
     const magnitude = getDimensionSummaries(data);
     const keep = new Set(
       [...dimensions]
-        .sort(
-          (a, b) =>
-            (magnitude.get(b) ?? -Infinity) - (magnitude.get(a) ?? -Infinity),
-        )
+        .sort((a, b) => {
+          const mustKeepDiff =
+            Number(seedAlwaysVisible?.(b) ?? false) -
+            Number(seedAlwaysVisible?.(a) ?? false);
+          if (mustKeepDiff !== 0) return mustKeepDiff;
+          return (
+            (magnitude.get(b) ?? -Infinity) - (magnitude.get(a) ?? -Infinity)
+          );
+        })
         .slice(0, Math.max(0, maxVisibleSeries)),
     );
     return new Set(dimensions.filter((dimension) => !keep.has(dimension)));
-  }, [data, dimensions, legendInteraction, maxVisibleSeries]);
+  }, [
+    data,
+    dimensions,
+    legendInteraction,
+    maxVisibleSeries,
+    seedAlwaysVisible,
+  ]);
 
   const [highlighted, setHighlighted] = useState<string | null>(null);
   const [hidden, setHidden] = useState<Set<string>>(initialHidden);
@@ -127,8 +152,7 @@ export function useSeriesLegend({
   const legendItems: LegendItem[] = dimensions.map((dimension, index) => ({
     dimension,
     label: config?.[dimension]?.label ?? dimension,
-    colorIndex: index,
-    color: seriesColor(index),
+    color: colorOf ? colorOf(dimension, index) : seriesColor(index),
     summary: summaries?.get(dimension) ?? null,
     dimmed: isDimmed(dimension),
     focused: legendInteraction !== "toggle" && highlighted === dimension,

--- a/web/src/features/widgets/chart-library/VerticalBarChart.tsx
+++ b/web/src/features/widgets/chart-library/VerticalBarChart.tsx
@@ -1,11 +1,19 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/src/components/ui/chart";
-import { Bar, BarChart, XAxis, YAxis } from "recharts";
+import {
+  Bar,
+  BarChart,
+  type BarShapeProps,
+  Rectangle,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { type ChartProps } from "@/src/features/widgets/chart-library/chart-props";
+import { prepareSeriesColors } from "@/src/features/widgets/chart-library/prepareSeriesColors";
 import {
   formatMetric,
   toFullMetricString,
@@ -30,9 +38,16 @@ export const VerticalBarChart: React.FC<ChartProps> = ({
   accessibilityLayer = true,
   metricFormatter = (value, options) => formatMetric(value, options),
   subtleFill = false,
+  semanticContext,
 }) => {
   const formatValue = (value: number) =>
     toFullMetricString(metricFormatter(value, { style: "compact" }));
+
+  // All-or-nothing per-category coloring — see HorizontalBarChart. (LFE-15467)
+  const seriesColors = useMemo(() => {
+    const names = data.map((item) => item.dimension || "Unknown");
+    return { names, ...prepareSeriesColors(names, semanticContext) };
+  }, [data, semanticContext]);
 
   return (
     <ChartContainer
@@ -60,9 +75,26 @@ export const VerticalBarChart: React.FC<ChartProps> = ({
         <Bar
           dataKey="metric"
           radius={[4, 4, 0, 0]}
-          className="fill-(--color-metric)"
+          // The class fill would override the per-shape fill attribute (CSS
+          // beats SVG presentation attributes), so it must be absent when the
+          // bars color per category.
+          className={
+            seriesColors.hasStatusColor ? undefined : "fill-(--color-metric)"
+          }
           fillOpacity={subtleFill ? 0.3 : 1}
           isAnimationActive={false}
+          shape={
+            seriesColors.hasStatusColor
+              ? (props: BarShapeProps) => (
+                  <Rectangle
+                    {...props}
+                    fill={seriesColors.colorOf(
+                      String(props.payload?.dimension ?? "Unknown"),
+                    )}
+                  />
+                )
+              : undefined
+          }
         />
         <ChartTooltip
           cursor={false}

--- a/web/src/features/widgets/chart-library/VerticalBarChartTimeSeries.tsx
+++ b/web/src/features/widgets/chart-library/VerticalBarChartTimeSeries.tsx
@@ -18,7 +18,10 @@ import { useChartTickBudget } from "@/src/features/widgets/chart-library/useChar
 import { prepareTimeAxis } from "@/src/features/widgets/chart-library/prepareTimeAxis";
 import { prepareVisibleSeries } from "@/src/features/widgets/chart-library/prepareVisibleSeries";
 import {
-  seriesColor,
+  matchSeriesStatus,
+  prepareSeriesColors,
+} from "@/src/features/widgets/chart-library/prepareSeriesColors";
+import {
   SeriesOverflowNote,
   TimeSeriesLegend,
   useSeriesLegend,
@@ -50,17 +53,31 @@ export const VerticalBarChartTimeSeries: React.FC<ChartProps> = ({
   syncId,
   subtleFill = false,
   hideXAxisLabels = false,
+  semanticContext,
 }) => {
   const [selfHovered, setSelfHovered] = useState(false);
   const groupedData = useMemo(() => groupDataByTimeDimension(data), [data]);
   const allDimensions = useMemo(() => getUniqueDimensions(data), [data]);
+  // A status-colored series (ERROR, failed, ...) must survive the series cap
+  // and the top-N legend seeding — it's the series the chart exists for.
+  const isStatusSeries = useMemo(() => {
+    return (dimension: string) => {
+      const status = matchSeriesStatus(dimension, semanticContext);
+      return status !== undefined && status !== "neutral";
+    };
+  }, [semanticContext]);
   // Cap how many series we draw (data -> preparer seam): a high-cardinality
   // breakdown of hundreds of series is both unreadable and slow to hover. (LFE-10549)
   const series = useMemo(
-    () => prepareVisibleSeries(data, allDimensions),
-    [data, allDimensions],
+    () => prepareVisibleSeries(data, allDimensions, undefined, isStatusSeries),
+    [data, allDimensions, isStatusSeries],
   );
   const dimensions = series.visible;
+  // Color is identity, resolved once for chart + legend (V6).
+  const seriesColors = useMemo(
+    () => prepareSeriesColors(dimensions, semanticContext),
+    [dimensions, semanticContext],
+  );
   const { ref: containerRef, maxTicks } = useChartTickBudget();
   const chartBoxRef = useRef<HTMLDivElement>(null);
   const timeAxis = useMemo(
@@ -80,6 +97,8 @@ export const VerticalBarChartTimeSeries: React.FC<ChartProps> = ({
     legendSummary,
     legendInteraction,
     maxVisibleSeries,
+    colorOf: seriesColors.colorOf,
+    seedAlwaysVisible: isStatusSeries,
   });
 
   const formatValue = (value: number) =>
@@ -151,16 +170,17 @@ export const VerticalBarChartTimeSeries: React.FC<ChartProps> = ({
             niceTicks="auto"
             tickFormatter={(value) => formatValue(Number(value))}
           />
-          {dimensions.map((dimension, index) => {
+          {dimensions.map((dimension) => {
             if (!isRendered(dimension)) return null;
             const muted = isDimmed(dimension);
+            const color = seriesColors.colorOf(dimension);
             return (
               <Bar
                 key={dimension}
                 dataKey={dimension}
-                stroke={seriesColor(index)}
+                stroke={color}
                 strokeOpacity={muted ? 0.2 : 1}
-                fill={seriesColor(index)}
+                fill={color}
                 fillOpacity={muted ? 0.2 : subtleFill ? 0.3 : 1}
                 stackId={renderedDimensions.length > 1 ? "stack" : undefined}
                 isAnimationActive={false}

--- a/web/src/features/widgets/chart-library/chart-props.ts
+++ b/web/src/features/widgets/chart-library/chart-props.ts
@@ -1,4 +1,5 @@
 import { type ChartConfig } from "@/src/components/ui/chart";
+import { type SeriesSemanticContext } from "@/src/features/widgets/chart-library/prepareSeriesColors";
 import type tailwindColors from "tailwindcss/colors";
 
 export interface DataPoint {
@@ -150,4 +151,10 @@ export interface ChartProps {
    * affects a categorical axis — a temporal axis keeps its timestamp labels.
    */
   hideXAxisLabels?: boolean;
+  /**
+   * Which semantic vocabulary the dimension values belong to, when the caller
+   * knows (the widget's group-by field). Unlocks field-gated status coloring
+   * in `prepareSeriesColors`; the universal status words apply regardless.
+   */
+  semanticContext?: SeriesSemanticContext;
 }

--- a/web/src/features/widgets/chart-library/prepareSeriesColors.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareSeriesColors.clienttest.ts
@@ -99,6 +99,14 @@ describe("matchSeriesStatus", () => {
     expect(matchSeriesStatus("False", ctx("unsuccessful_resolution"))).toBe(
       "ok",
     );
+    // Negator words flip the concept the keywords would read — inference must
+    // bail out to uncolored, never invert ("no_hallucination: True" is GOOD).
+    expect(matchSeriesStatus("True", ctx("no_hallucination"))).toBeUndefined();
+    expect(matchSeriesStatus("True", ctx("error_free"))).toBeUndefined();
+    expect(matchSeriesStatus("True", ctx("without errors"))).toBeUndefined();
+    expect(matchSeriesStatus("False", ctx("zero-toxicity"))).toBeUndefined();
+    // ...while stems containing negator letters stay unaffected.
+    expect(matchSeriesStatus("True", ctx("unanswered_question"))).toBe("error");
     // Violation-detector names: VALIDATOR is stripped before the positive
     // scan; polarity comes from the rest of the name or not at all.
     expect(

--- a/web/src/features/widgets/chart-library/prepareSeriesColors.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareSeriesColors.clienttest.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  matchSeriesStatus,
+  prepareSeriesColors,
+  seriesColor,
+} from "@/src/features/widgets/chart-library/prepareSeriesColors";
+
+const ERROR = "var(--chart-status-error)";
+const WARNING = "var(--chart-status-warning)";
+const OK = "var(--chart-status-ok)";
+const NEUTRAL = "var(--chart-status-neutral)";
+
+describe("matchSeriesStatus", () => {
+  it("matches universal status words in any context, case-insensitively", () => {
+    expect(matchSeriesStatus("ERROR")).toBe("error");
+    expect(matchSeriesStatus("error")).toBe("error");
+    expect(matchSeriesStatus("  Failed  ")).toBe("error");
+    expect(matchSeriesStatus("warn")).toBe("warning");
+    expect(matchSeriesStatus("PASS")).toBe("ok");
+    expect(matchSeriesStatus("healthy")).toBe("ok");
+    expect(matchSeriesStatus("n/a")).toBe("neutral");
+    expect(matchSeriesStatus("Unknown")).toBe("neutral");
+  });
+
+  it("never substring-matches: unrelated values stay uncolored", () => {
+    expect(matchSeriesStatus("error_handler")).toBeUndefined();
+    expect(matchSeriesStatus("en")).toBeUndefined();
+    expect(matchSeriesStatus("gpt-4o")).toBeUndefined();
+  });
+
+  it("gates level words on the level field — the 'default' environment stays uncolored", () => {
+    expect(matchSeriesStatus("DEFAULT", { field: "level" })).toBe("ok");
+    expect(matchSeriesStatus("INFO", { field: "level" })).toBe("ok");
+    expect(matchSeriesStatus("DEBUG", { field: "level" })).toBe("neutral");
+    // No field hint (e.g. an environment breakdown): no match.
+    expect(matchSeriesStatus("default")).toBeUndefined();
+    expect(matchSeriesStatus("DEFAULT")).toBeUndefined();
+    expect(
+      matchSeriesStatus("default", { field: "score-categorical" }),
+    ).toBeUndefined();
+  });
+
+  it("gates verdict words on the score field", () => {
+    const score = { field: "score-categorical" } as const;
+    expect(matchSeriesStatus("correct", score)).toBe("ok");
+    expect(matchSeriesStatus("hallucinated", score)).toBe("error");
+    expect(matchSeriesStatus("borderline", score)).toBe("warning");
+    expect(matchSeriesStatus("none", score)).toBe("neutral");
+    // Ungated, these are just words.
+    expect(matchSeriesStatus("correct")).toBeUndefined();
+    expect(matchSeriesStatus("none")).toBeUndefined();
+  });
+
+  it("infers True/False polarity from the score name, never without one", () => {
+    const negative = {
+      field: "score-categorical",
+      scoreName: "hallucination",
+    } as const;
+    expect(matchSeriesStatus("True", negative)).toBe("error");
+    expect(matchSeriesStatus("False", negative)).toBe("ok");
+
+    const positive = {
+      field: "score-categorical",
+      scoreName: "user-feedback",
+    } as const;
+    expect(matchSeriesStatus("True", positive)).toBe("ok");
+    expect(matchSeriesStatus("no", positive)).toBe("error");
+
+    // Unknown score name: no polarity guess.
+    const unknown = {
+      field: "score-categorical",
+      scoreName: "vibe_check_9000",
+    } as const;
+    expect(matchSeriesStatus("True", unknown)).toBeUndefined();
+    // No score name at all (multi-score chart): no polarity guess.
+    expect(
+      matchSeriesStatus("True", { field: "score-categorical" }),
+    ).toBeUndefined();
+  });
+
+  it("checks negated stems before positive roots, and VALID never fires inside VALIDATOR", () => {
+    const ctx = (scoreName: string) => ({
+      field: "score-categorical" as const,
+      scoreName,
+    });
+    // "unsafe" must not match its "safe" root.
+    expect(matchSeriesStatus("True", ctx("unsafe_content"))).toBe("error");
+    expect(matchSeriesStatus("True", ctx("schema_valid"))).toBe("ok");
+    // Violation-detector names: VALIDATOR is stripped before the positive
+    // scan; polarity comes from the rest of the name or not at all.
+    expect(
+      matchSeriesStatus("True", ctx("eval_validator_forbidden_response")),
+    ).toBe("error");
+    expect(
+      matchSeriesStatus("True", ctx("eval_validator_empty_result")),
+    ).toBeUndefined();
+  });
+
+  it("does not color high/medium/low or intent-dependent boolean names", () => {
+    const ctx = { field: "score-categorical", scoreName: "risk" } as const;
+    expect(matchSeriesStatus("high", ctx)).toBeUndefined();
+    expect(matchSeriesStatus("medium", ctx)).toBeUndefined();
+    expect(matchSeriesStatus("low", ctx)).toBeUndefined();
+    for (const name of ["guardrail_blocked", "escalated", "cache_hit"]) {
+      expect(
+        matchSeriesStatus("True", {
+          field: "score-categorical",
+          scoreName: name,
+        }),
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("prepareSeriesColors", () => {
+  it("keeps today's exact palette rotation when nothing matches (zero repaint)", () => {
+    const dims = Array.from({ length: 10 }, (_, i) => `service-${i}`);
+    const colors = prepareSeriesColors(dims);
+    dims.forEach((dim, index) => {
+      expect(colors.colorOf(dim)).toBe(seriesColor(index));
+    });
+    expect(colors.hasStatusColor).toBe(false);
+  });
+
+  it("colors the flagship level breakdown with status colors", () => {
+    const colors = prepareSeriesColors(
+      ["DEFAULT", "DEBUG", "WARNING", "ERROR"],
+      { field: "level" },
+    );
+    expect(colors.colorOf("DEFAULT")).toBe(OK);
+    expect(colors.colorOf("DEBUG")).toBe(NEUTRAL);
+    expect(colors.colorOf("WARNING")).toBe(WARNING);
+    expect(colors.colorOf("ERROR")).toBe(ERROR);
+    expect(colors.hasStatusColor).toBe(true);
+  });
+
+  it("re-rotates non-semantic series over the non-status slots beside a status color", () => {
+    const colors = prepareSeriesColors(["checkout", "ERROR", "search", "auth"]);
+    expect(colors.colorOf("ERROR")).toBe(ERROR);
+    // Non-semantic series take slots 1, 2, 4 (blue, cyan, purple) — never the
+    // withheld status-lookalike slots 3/5/6/7.
+    expect(colors.colorOf("checkout")).toBe("hsl(var(--chart-1))");
+    expect(colors.colorOf("search")).toBe("hsl(var(--chart-2))");
+    expect(colors.colorOf("auth")).toBe("hsl(var(--chart-4))");
+  });
+
+  it("neutral matches tint themselves without repainting the rest of the chart", () => {
+    // "n/a" is ubiquitous (every nullable breakdown) — it must NOT narrow the
+    // palette for everything else.
+    const colors = prepareSeriesColors(["checkout", "n/a", "search"]);
+    expect(colors.hasStatusColor).toBe(false);
+    expect(colors.colorOf("n/a")).toBe(NEUTRAL);
+    // Others keep their exact pre-existing slot (by original index).
+    expect(colors.colorOf("checkout")).toBe(seriesColor(0));
+    expect(colors.colorOf("search")).toBe(seriesColor(2));
+  });
+
+  it("returns only well-formed CSS color strings, total for unknown series", () => {
+    const colors = prepareSeriesColors(["ERROR", "other-series"]);
+    for (const dim of ["ERROR", "other-series", "never-seen"]) {
+      expect(colors.colorOf(dim)).toMatch(
+        /^(hsl\(var\(--chart-[1-8]\)\)|var\(--chart-status-(error|warning|ok|neutral)\))$/,
+      );
+    }
+    expect(colors.statusOf("ERROR")).toBe("error");
+    expect(colors.statusOf("other-series")).toBeUndefined();
+  });
+});

--- a/web/src/features/widgets/chart-library/prepareSeriesColors.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareSeriesColors.clienttest.ts
@@ -87,6 +87,18 @@ describe("matchSeriesStatus", () => {
     // "unsafe" must not match its "safe" root.
     expect(matchSeriesStatus("True", ctx("unsafe_content"))).toBe("error");
     expect(matchSeriesStatus("True", ctx("schema_valid"))).toBe("ok");
+    // Noun-form negations must not fall through to their positive root
+    // ("irrelevance" contains RELEVAN — polarity would invert).
+    expect(matchSeriesStatus("True", ctx("answer_irrelevance"))).toBe("error");
+    expect(matchSeriesStatus("True", ctx("response_incoherence"))).toBe(
+      "error",
+    );
+    expect(matchSeriesStatus("True", ctx("factual_inaccuracy"))).toBe("error");
+    expect(matchSeriesStatus("True", ctx("noncompliance"))).toBe("error");
+    expect(matchSeriesStatus("True", ctx("ungrounded_claims"))).toBe("error");
+    expect(matchSeriesStatus("False", ctx("unsuccessful_resolution"))).toBe(
+      "ok",
+    );
     // Violation-detector names: VALIDATOR is stripped before the positive
     // scan; polarity comes from the rest of the name or not at all.
     expect(

--- a/web/src/features/widgets/chart-library/prepareSeriesColors.ts
+++ b/web/src/features/widgets/chart-library/prepareSeriesColors.ts
@@ -252,12 +252,34 @@ const BINARY_SCORE_VALUES: Record<string, boolean> = {
 // have not validated against production. Below the confidence bar for
 // automatic coloring until that data exists (LFE-15467 research).
 
+/**
+ * Standalone words that negate whatever concept the rest of the name carries
+ * ("no_hallucination", "error_free", "without_errors"): the keyword lists
+ * would read the concept and INVERT polarity. Inference bails out to
+ * uncolored instead — the fail-safe. Matched as whole words so stems like
+ * NOTICE or UNANSWERED are unaffected. None of the top production boolean
+ * score names contain these, so the guard costs no validated coverage.
+ */
+const NEGATOR_SCORE_NAME_WORDS = new Set([
+  "NO",
+  "NOT",
+  "NON",
+  "WITHOUT",
+  "FREE",
+  "ZERO",
+]);
+
 const normalize = (value: string): string => value.trim().toUpperCase();
 
 const booleanScorePolarity = (
   scoreName: string,
 ): "good" | "bad" | undefined => {
   const name = normalize(scoreName);
+  if (
+    name.split(/[^A-Z0-9]+/).some((word) => NEGATOR_SCORE_NAME_WORDS.has(word))
+  ) {
+    return undefined;
+  }
   if (NEGATIVE_SCORE_NAME_KEYWORDS.some((k) => name.includes(k))) return "bad";
   // "VALIDATOR" names are violation detectors, not validity checks — strip
   // the word so its VALID stem can't read as positive (their real polarity,

--- a/web/src/features/widgets/chart-library/prepareSeriesColors.ts
+++ b/web/src/features/widgets/chart-library/prepareSeriesColors.ts
@@ -175,8 +175,18 @@ const NEGATIVE_SCORE_NAME_KEYWORDS = [
   "INVALID",
   "INCORRECT",
   "UNHELPFUL",
-  "IRRELEVANT",
+  // Negated stems must cover every word-form variant, or a noun form falls
+  // through to its positive root and INVERTS polarity ("irrelevance" contains
+  // RELEVAN): stem the negation at least as short as the positive stem.
+  "IRRELEVAN",
   "UNFAITHFUL",
+  "INACCURA",
+  "INCOHEREN",
+  "NONCOMPLIAN",
+  "NON-COMPLIAN",
+  "NON_COMPLIAN",
+  "UNSUCCESS",
+  "UNGROUNDED",
   "INJECTION",
   "JAILBREAK",
   "PROFANIT",

--- a/web/src/features/widgets/chart-library/prepareSeriesColors.ts
+++ b/web/src/features/widgets/chart-library/prepareSeriesColors.ts
@@ -1,0 +1,364 @@
+/**
+ * Preparer (data -> visualiser seam): decides the COLOR of every series, so no
+ * chart component re-derives it (manifesto V6 — "color is identity").
+ *
+ * Two-signal semantic recognition, so production-health charts read correctly
+ * without any per-widget configuration (LFE-15467):
+ *
+ * 1. A UNIVERSAL vocabulary of status words whose meaning is unambiguous in
+ *    any dimension (`ERROR`, `WARN`, `SUCCESS`, `HEALTHY`, ...) always maps to
+ *    the reserved status colors.
+ * 2. FIELD-GATED vocabularies unlock only when the caller says which semantic
+ *    field the dimension values come from (`semanticContext.field`): the
+ *    observation `level` vocabulary (incl. the OTel aliases the ingestion
+ *    layer accepts — see OBSERVATION_LEVEL_ALIASES in
+ *    `@langfuse/shared`'s OtelIngestionProcessor) and the categorical-score
+ *    verdict vocabulary (grounded in the most-adopted production score
+ *    values). Words that are ambiguous outside their field never match without
+ *    the gate: `DEFAULT` is a level, but also the default environment name.
+ *
+ * Matching is exact on the trimmed, upper-cased value — never substring — so
+ * unrelated values (language codes, entity names) can't false-match.
+ *
+ * Boolean verdicts (`True`/`False`) carry no polarity of their own — it lives
+ * in the score NAME (`hallucination: True` is bad, `is_helpful: True` is
+ * good). They only color when `semanticContext.scoreName` matches a curated
+ * polarity keyword list; unknown score names leave them on the categorical
+ * rotation rather than risking an inverted signal.
+ *
+ * Non-semantic series keep today's palette rotation. When a chart contains at
+ * least one status-colored series, the rotation narrows to the slots that
+ * cannot impersonate a status hue; NEUTRAL matches (n/a, unknown, debug) tint
+ * themselves gray without narrowing anything, so the ubiquitous null bucket
+ * never repaints its chart.
+ *
+ * Returned colors are complete CSS color strings — either
+ * `hsl(var(--chart-N))` (the palette slots are HSL triplets) or
+ * `var(--chart-status-*)` (the status tokens are full colors). Consumers use
+ * them verbatim; wrapping a status token in `hsl()` would silently render
+ * black.
+ */
+
+export type SeriesStatus = "error" | "warning" | "ok" | "neutral";
+
+export type SemanticSeriesField = "level" | "score-categorical";
+
+export interface SeriesSemanticContext {
+  /** Which semantic vocabulary the dimension values belong to, when known. */
+  field?: SemanticSeriesField;
+  /**
+   * The score name behind categorical values, when the chart shows exactly
+   * one score. Unlocks polarity inference for `True`/`False`.
+   */
+  scoreName?: string;
+}
+
+const STATUS_COLOR: Record<SeriesStatus, string> = {
+  error: "var(--chart-status-error)",
+  warning: "var(--chart-status-warning)",
+  ok: "var(--chart-status-ok)",
+  neutral: "var(--chart-status-neutral)",
+};
+
+/** The 8-slot chart palette, cycled by series index (matches the series fills). */
+export const seriesColor = (index: number): string =>
+  `hsl(var(--chart-${(index % 8) + 1}))`;
+
+/**
+ * Palette slots that stay in rotation next to status-colored series: blue,
+ * cyan, purple, pink. The withheld slots read as a status at a glance —
+ * chart-3 (gray), chart-5 (yellow), chart-6 (red), chart-7 (green) — and a
+ * categorical series must never impersonate one (a reserved-color rule).
+ */
+const NON_STATUS_SLOTS = [1, 2, 4, 8] as const;
+
+const asVocabulary = (
+  entries: Partial<Record<SeriesStatus, readonly string[]>>,
+): Map<string, SeriesStatus> => {
+  const map = new Map<string, SeriesStatus>();
+  for (const [status, values] of Object.entries(entries)) {
+    for (const value of values ?? []) map.set(value, status as SeriesStatus);
+  }
+  return map;
+};
+
+// Words with one meaning wherever they appear. Kept deliberately short —
+// every entry here widens the false-positive surface for every dimension in
+// the product (a trace or environment literally named like a status still
+// colors, which is intended; anything less clear-cut belongs behind a gate).
+const UNIVERSAL_VOCABULARY = asVocabulary({
+  error: [
+    "ERROR",
+    "FATAL",
+    "CRITICAL",
+    "FAIL",
+    "FAILED",
+    "FAILURE",
+    "TIMEOUT",
+    "UNHEALTHY",
+  ],
+  warning: ["WARNING", "WARN", "DEGRADED"],
+  ok: ["SUCCESS", "SUCCEEDED", "OK", "PASS", "PASSED", "HEALTHY"],
+  // The null bucket ("n/a" from the widget transform, "Unknown" from the pie
+  // fallback) is not an identity — gray it everywhere.
+  neutral: ["N/A", "UNKNOWN"],
+});
+
+// Observation `level`: the enum plus the foreign aliases ingestion accepts
+// (and which persist raw in pre-normalization rows, LFE-14567). DEFAULT is
+// green per the tracing status-facet convention — inside a level breakdown it
+// means "nothing wrong", and gray would collapse it into DEBUG.
+const LEVEL_VOCABULARY = asVocabulary({
+  ok: ["DEFAULT", "INFO", "LOG", "NOTICE"],
+  neutral: ["DEBUG", "TRACE", "VERBOSE"],
+});
+
+// Categorical score verdicts, grounded in the most project-adopted production
+// values (LFE-15467 research). Only meaningful when we know the values are
+// verdicts, hence the gate.
+const SCORE_VOCABULARY = asVocabulary({
+  ok: [
+    "CORRECT",
+    "POSITIVE",
+    "GOOD",
+    "ACCEPTED",
+    "APPROVED",
+    "RESOLVED",
+    "COMPLETED",
+    "GROUNDED",
+    "FAITHFUL",
+    "RELEVANT",
+    "CLEAN",
+  ],
+  error: [
+    "INCORRECT",
+    "NEGATIVE",
+    "BAD",
+    "POOR",
+    "REJECTED",
+    "HALLUCINATED",
+    "IRRELEVANT",
+    "TOXIC",
+    "UNSAFE",
+  ],
+  warning: ["PARTIAL", "PARTIALLY RELEVANT", "PARTIALLY CORRECT", "BORDERLINE"],
+  neutral: [
+    "NONE",
+    "OTHER",
+    "NOT_APPLICABLE",
+    "NOT APPLICABLE",
+    "NEUTRAL",
+    "SKIPPED",
+    "CANCELLED",
+    "CANCELED",
+  ],
+});
+
+/**
+ * Score-name keywords whose boolean `True` means something went WRONG (so
+ * True -> error, False -> ok). Checked before the positive list so negated
+ * stems (`unsafe`, `invalid`, `incorrect`) never match their positive root.
+ * Substring match on the normalized score name — names are compound
+ * ("contains_pii", "hallucination_check"), values are not. Grounded in the
+ * top production boolean score names by project adoption (LFE-15467
+ * research CSVs on the ticket).
+ */
+const NEGATIVE_SCORE_NAME_KEYWORDS = [
+  "HALLUCINAT",
+  "TOXIC",
+  "ERROR",
+  "PII",
+  "LEAK",
+  "VIOLAT",
+  "HARMFUL",
+  "UNSAFE",
+  "INVALID",
+  "INCORRECT",
+  "UNHELPFUL",
+  "IRRELEVANT",
+  "UNFAITHFUL",
+  "INJECTION",
+  "JAILBREAK",
+  "PROFANIT",
+  "FLAGGED",
+  "SPAM",
+  "NSFW",
+  "FAIL",
+  "MISMATCH",
+  "UNANSWERED",
+  "INCOMPLETE",
+  "DISAGREE",
+  "OUT-OF-SCOPE",
+  "OUT_OF_SCOPE",
+  "OUT OF SCOPE",
+  "DISTRESS",
+  "FORBIDDEN",
+  "ALL_CAPS",
+  "ALL CAPS",
+  // NOT here despite production adoption: escalated, fallback, blocked —
+  // for those, `True` can mean the system working as designed (a guardrail
+  // blocking IS success). Intent-dependent polarity fails the confidence bar
+  // for automatic coloring; the eventual per-widget override is their home.
+];
+
+/** Score-name keywords whose boolean `True` means things are RIGHT. */
+const POSITIVE_SCORE_NAME_KEYWORDS = [
+  "CORRECT",
+  "ACCURA",
+  "HELPFUL",
+  "RELEVAN",
+  "FAITHFUL",
+  "GROUNDED",
+  "SAFE",
+  "VALID",
+  "SUCCESS",
+  "PASS",
+  "COMPLIAN",
+  "COHEREN",
+  "FEEDBACK",
+  "THUMBS",
+  "MATCH",
+  "ANSWERED",
+  "COMPLETE",
+  // NOT here despite production adoption: cache_hit (a miss would render
+  // error-red via the inverse branch — misses aren't errors) and assert
+  // (polarity inferred from name shape alone). Confidence bar, see above.
+];
+
+/**
+ * Binary verdict values and whether they affirm the score's concept. Polarity
+ * then comes from the score name: `hallucination: yes` is red,
+ * `is_helpful: yes` is green.
+ */
+const BINARY_SCORE_VALUES: Record<string, boolean> = {
+  TRUE: true,
+  FALSE: false,
+  YES: true,
+  NO: false,
+};
+
+// Deliberately NO high/medium/low handling: direction (severity-like high=bad
+// vs quality-like high=good) would have to be inferred from score names we
+// have not validated against production. Below the confidence bar for
+// automatic coloring until that data exists (LFE-15467 research).
+
+const normalize = (value: string): string => value.trim().toUpperCase();
+
+const booleanScorePolarity = (
+  scoreName: string,
+): "good" | "bad" | undefined => {
+  const name = normalize(scoreName);
+  if (NEGATIVE_SCORE_NAME_KEYWORDS.some((k) => name.includes(k))) return "bad";
+  // "VALIDATOR" names are violation detectors, not validity checks — strip
+  // the word so its VALID stem can't read as positive (their real polarity,
+  // if any, comes from the rest of the name via the lists above).
+  const nameForPositive = name.replaceAll("VALIDATOR", "");
+  if (POSITIVE_SCORE_NAME_KEYWORDS.some((k) => nameForPositive.includes(k)))
+    return "good";
+  return undefined;
+};
+
+/**
+ * The semantic status of a single dimension value, or `undefined` when it has
+ * none (then it stays on the categorical rotation). Total for any string —
+ * dimension values are user-controlled open strings (LFE-14567).
+ */
+export function matchSeriesStatus(
+  value: string,
+  context?: SeriesSemanticContext,
+): SeriesStatus | undefined {
+  const normalized = normalize(value);
+
+  const universal = UNIVERSAL_VOCABULARY.get(normalized);
+  if (universal) return universal;
+
+  if (context?.field === "level") {
+    return LEVEL_VOCABULARY.get(normalized);
+  }
+
+  if (context?.field === "score-categorical") {
+    const gated = SCORE_VOCABULARY.get(normalized);
+    if (gated) return gated;
+
+    if (!context.scoreName) return undefined;
+
+    const affirms = BINARY_SCORE_VALUES[normalized];
+    if (affirms !== undefined) {
+      const polarity = booleanScorePolarity(context.scoreName);
+      if (!polarity) return undefined;
+      return (polarity === "bad") === affirms ? "error" : "ok";
+    }
+  }
+
+  return undefined;
+}
+
+export type PreparedSeriesColors = {
+  /** Resolved CSS color for a series; total (rotation fallback for strays). */
+  colorOf: (dimension: string) => string;
+  /** The semantic status behind `colorOf`, when there is one. */
+  statusOf: (dimension: string) => SeriesStatus | undefined;
+  /**
+   * True when any series wears a status color (error/warning/ok — neutral
+   * doesn't count). Category bar charts use this as their all-or-nothing
+   * switch between the uniform metric color and per-category fills.
+   */
+  hasStatusColor: boolean;
+};
+
+/**
+ * Resolve every series' color once, in the caller's series order (the order
+ * that owned the palette rotation before this preparer existed):
+ *
+ * - no status-colored series -> non-semantic series keep exactly the color
+ *   they had before semantic recognition existed (slot by original index), so
+ *   existing dashboards don't repaint;
+ * - any status-colored series -> non-semantic series re-rotate over the
+ *   non-status slots (by their order among themselves), so nothing beside a
+ *   red ERROR wears categorical red. The switch depends on the queried data,
+ *   so a series' color can change when an ERROR series enters the window —
+ *   accepted: the alternative (a categorical slot impersonating a status) is
+ *   worse, and the narrowed palette is itself stable per chart.
+ */
+export function prepareSeriesColors(
+  dimensions: string[],
+  context?: SeriesSemanticContext,
+): PreparedSeriesColors {
+  const statuses = new Map<string, SeriesStatus | undefined>(
+    dimensions.map((dimension) => [
+      dimension,
+      matchSeriesStatus(dimension, context),
+    ]),
+  );
+
+  const hasStatusColor = [...statuses.values()].some(
+    (status) => status !== undefined && status !== "neutral",
+  );
+
+  const colors = new Map<string, string>();
+  let nonSemanticRank = 0;
+  dimensions.forEach((dimension, index) => {
+    const status = statuses.get(dimension);
+    if (status) {
+      colors.set(dimension, STATUS_COLOR[status]);
+      return;
+    }
+    colors.set(
+      dimension,
+      hasStatusColor
+        ? `hsl(var(--chart-${NON_STATUS_SLOTS[nonSemanticRank % NON_STATUS_SLOTS.length]}))`
+        : seriesColor(index),
+    );
+    nonSemanticRank += 1;
+  });
+
+  return {
+    colorOf: (dimension) =>
+      colors.get(dimension) ??
+      // A dimension the preparer never saw (shouldn't happen) still gets a
+      // deterministic color rather than crashing or going invisible.
+      seriesColor(dimensions.length),
+    statusOf: (dimension) => statuses.get(dimension),
+    hasStatusColor,
+  };
+}

--- a/web/src/features/widgets/chart-library/prepareVisibleSeries.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareVisibleSeries.clienttest.ts
@@ -82,6 +82,29 @@ describe("prepareVisibleSeries", () => {
     expect(result.visible).toEqual(["zero"]);
   });
 
+  it("keeps mustKeep series ahead of magnitude when capping (LFE-15467)", () => {
+    const dimensions = ["big-a", "big-b", "ERROR", "big-c"];
+    const data = [
+      ...series("big-a", [100]),
+      ...series("big-b", [90]),
+      // The one series a production-health chart exists for is tiny by
+      // construction on a healthy system.
+      ...series("ERROR", [1]),
+      ...series("big-c", [80]),
+    ];
+    const withoutMustKeep = prepareVisibleSeries(data, dimensions, 2);
+    expect(withoutMustKeep.visible).toEqual(["big-a", "big-b"]);
+
+    const withMustKeep = prepareVisibleSeries(
+      data,
+      dimensions,
+      2,
+      (dimension) => dimension === "ERROR",
+    );
+    expect(withMustKeep.visible).toEqual(["ERROR", "big-a"]);
+    expect(withMustKeep.hidden).toBe(2);
+  });
+
   it("defaults to the shared render cap", () => {
     const dimensions = Array.from(
       { length: DEFAULT_MAX_RENDERED_SERIES + 30 },

--- a/web/src/features/widgets/chart-library/prepareVisibleSeries.ts
+++ b/web/src/features/widgets/chart-library/prepareVisibleSeries.ts
@@ -35,6 +35,11 @@ export type PreparedSeries = {
  * top `maxSeries`. Series with no finite value rank last. Ties break by name so
  * the selection is deterministic across reloads.
  *
+ * `mustKeep` series rank ahead of magnitude: a status-colored series like
+ * ERROR is usually small by construction on a healthy system, and a
+ * production-health chart that silently caps out its ERROR series is
+ * worthless. (LFE-15467)
+ *
  * Pure and side-effect free: presentation components consume the result, they
  * don't re-decide it. See ARCHITECTURE.md.
  */
@@ -42,6 +47,7 @@ export function prepareVisibleSeries(
   data: DataPoint[],
   dimensions: string[],
   maxSeries: number = DEFAULT_MAX_RENDERED_SERIES,
+  mustKeep?: (dimension: string) => boolean,
 ): PreparedSeries {
   const total = dimensions.length;
   if (total <= maxSeries) {
@@ -53,6 +59,9 @@ export function prepareVisibleSeries(
     summaries.get(dimension) ?? -Infinity;
 
   const ranked = [...dimensions].sort((a, b) => {
+    const mustKeepDiff =
+      Number(mustKeep?.(b) ?? false) - Number(mustKeep?.(a) ?? false);
+    if (mustKeepDiff !== 0) return mustKeepDiff;
     const diff = magnitude(b) - magnitude(a);
     if (diff !== 0 && !Number.isNaN(diff)) return diff;
     return a < b ? -1 : a > b ? 1 : 0;

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -58,6 +58,7 @@ import {
   sanitizePivotTableDefaultSort,
   getWidgetMetricPresentation,
   getWidgetMissingBucketValue,
+  deriveWidgetSemanticContext,
 } from "@/src/features/widgets/utils";
 import { ChartLoadingState } from "@/src/features/widgets/chart-library/ChartLoadingState";
 import {
@@ -469,6 +470,19 @@ export function DashboardWidget({
     [chartPresentation],
   );
 
+  // Semantic-color hint (LFE-15467) — see deriveWidgetSemanticContext.
+  const semanticContext = useMemo(
+    () =>
+      widget.data
+        ? deriveWidgetSemanticContext({
+            view: widget.data.view,
+            dimensionField: widget.data.dimensions[0]?.field,
+            filters: widget.data.filters ?? [],
+          })
+        : undefined,
+    [widget.data],
+  );
+
   // "View as table" navigation: the widget's own filters (config + dashboard
   // global) translated to the traces/observations table's applicable filters,
   // plus the widget's time range. Filters the table can't express are dropped
@@ -815,6 +829,7 @@ export function DashboardWidget({
               missingValue={getWidgetMissingBucketValue(
                 widget.data.metrics[0]?.agg ?? "count",
               )}
+              semanticContext={semanticContext}
             />
             <ChartLoadingState
               isLoading={chartLoadingState.isLoading}

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -90,6 +90,7 @@ import {
   formatMetricName,
   getWidgetMetricPresentation,
   getWidgetMissingBucketValue,
+  deriveWidgetSemanticContext,
 } from "@/src/features/widgets/utils";
 import {
   MAX_PIVOT_TABLE_DIMENSIONS,
@@ -1101,6 +1102,13 @@ export function WidgetForm({
                       ? { metric: { label: chartPresentation.label } }
                       : undefined
                   }
+                  // Same semantic-color hint as the saved-widget renderer, so
+                  // the preview colors exactly like the dashboard. (LFE-15467)
+                  semanticContext={deriveWidgetSemanticContext({
+                    view: query.view,
+                    dimensionField: query.dimensions[0]?.field,
+                    filters: query.filters,
+                  })}
                   rowLimit={values.chart.rowLimit}
                   chartConfig={
                     chartType === "PIVOT_TABLE"

--- a/web/src/features/widgets/utils.clienttest.ts
+++ b/web/src/features/widgets/utils.clienttest.ts
@@ -1,6 +1,9 @@
 import { type FilterState } from "@langfuse/shared";
 import { mapLegacyUiTableFilterToView } from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
-import { mergeWidgetAndDashboardFilters } from "./utils";
+import {
+  deriveWidgetSemanticContext,
+  mergeWidgetAndDashboardFilters,
+} from "./utils";
 
 /**
  * LFE-14333: on a dashboard, each widget's query is built from the widget's own
@@ -252,5 +255,78 @@ describe("mergeWidgetAndDashboardFilters", () => {
     expect(remapped.find((f) => f.column === "environment")).toMatchObject({
       value: ["langfuse-eval"],
     });
+  });
+});
+
+describe("deriveWidgetSemanticContext", () => {
+  it("extracts the score name from a canonical view-space name filter", () => {
+    const context = deriveWidgetSemanticContext({
+      view: "scores-categorical",
+      dimensionField: "stringValue",
+      filters: [
+        { column: "name", type: "string", operator: "=", value: "verdict" },
+      ],
+    });
+    expect(context).toEqual({
+      field: "score-categorical",
+      scoreName: "verdict",
+    });
+  });
+
+  it("extracts the score name from a LEGACY UI-table filter column", () => {
+    // Saved widgets can carry the legacy "Score Name" column; the saved chart
+    // must keep its True/False polarity colors, same as the builder preview.
+    const context = deriveWidgetSemanticContext({
+      view: "scores-boolean",
+      dimensionField: "booleanValue",
+      filters: [
+        {
+          column: "Score Name",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["hallucination"],
+        },
+      ],
+    });
+    expect(context).toEqual({
+      field: "score-categorical",
+      scoreName: "hallucination",
+    });
+  });
+
+  it("omits the score name when the widget shows more than one score", () => {
+    const context = deriveWidgetSemanticContext({
+      view: "scores-categorical",
+      dimensionField: "stringValue",
+      filters: [
+        {
+          column: "name",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["a", "b"],
+        },
+      ],
+    });
+    expect(context).toEqual({
+      field: "score-categorical",
+      scoreName: undefined,
+    });
+  });
+
+  it("returns the level gate for level breakdowns and nothing otherwise", () => {
+    expect(
+      deriveWidgetSemanticContext({
+        view: "observations",
+        dimensionField: "level",
+        filters: [],
+      }),
+    ).toEqual({ field: "level" });
+    expect(
+      deriveWidgetSemanticContext({
+        view: "traces",
+        dimensionField: "environment",
+        filters: [],
+      }),
+    ).toBeUndefined();
   });
 });

--- a/web/src/features/widgets/utils.ts
+++ b/web/src/features/widgets/utils.ts
@@ -13,6 +13,45 @@ import {
   type MissingBucketValue,
 } from "@/src/features/widgets/chart-library/chart-props";
 import { mapLegacyUiTableFilterToView } from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
+import { type SeriesSemanticContext } from "@/src/features/widgets/chart-library/prepareSeriesColors";
+
+/**
+ * Semantic-color hint for a widget's chart (LFE-15467): which vocabulary the
+ * breakdown values belong to. Only two group-by fields carry status
+ * semantics — observation/event `level`, and categorical/boolean score
+ * values. The score name (present when the widget filters to exactly one
+ * score) unlocks True/False polarity inference in `prepareSeriesColors`.
+ * Shared by the saved-widget renderer and the builder preview so both color
+ * identically.
+ */
+export function deriveWidgetSemanticContext(params: {
+  view: string;
+  dimensionField: string | undefined;
+  filters: FilterState;
+}): SeriesSemanticContext | undefined {
+  if (params.dimensionField === "level") return { field: "level" };
+  if (
+    (params.view === "scores-categorical" &&
+      params.dimensionField === "stringValue") ||
+    (params.view === "scores-boolean" &&
+      params.dimensionField === "booleanValue")
+  ) {
+    const nameFilters = params.filters.filter(
+      (filter) => filter.column === "name",
+    );
+    const nameFilter = nameFilters.length === 1 ? nameFilters[0] : undefined;
+    const scoreName =
+      nameFilter?.type === "string" && nameFilter.operator === "="
+        ? nameFilter.value
+        : nameFilter?.type === "stringOptions" &&
+            nameFilter.operator === "any of" &&
+            nameFilter.value.length === 1
+          ? nameFilter.value[0]
+          : undefined;
+    return { field: "score-categorical", scoreName };
+  }
+  return undefined;
+}
 
 // Shared widget chart configuration types
 export type WidgetChartConfig = {

--- a/web/src/features/widgets/utils.ts
+++ b/web/src/features/widgets/utils.ts
@@ -25,20 +25,30 @@ import { type SeriesSemanticContext } from "@/src/features/widgets/chart-library
  * identically.
  */
 export function deriveWidgetSemanticContext(params: {
+  /** Accepts any query view (incl. ones outside the `views` enum, e.g.
+   * scores-listable-count) — only the two score views below ever gate. */
   view: string;
   dimensionField: string | undefined;
   filters: FilterState;
 }): SeriesSemanticContext | undefined {
   if (params.dimensionField === "level") return { field: "level" };
+  const scoreView =
+    params.view === "scores-categorical" || params.view === "scores-boolean"
+      ? params.view
+      : undefined;
   if (
-    (params.view === "scores-categorical" &&
+    (scoreView === "scores-categorical" &&
       params.dimensionField === "stringValue") ||
-    (params.view === "scores-boolean" &&
-      params.dimensionField === "booleanValue")
+    (scoreView === "scores-boolean" && params.dimensionField === "booleanValue")
   ) {
-    const nameFilters = params.filters.filter(
-      (filter) => filter.column === "name",
-    );
+    // Saved widgets can carry legacy UI-table filter columns ("Score Name")
+    // rather than the view-space "name". Normalize exactly like the query
+    // layer does (idempotent for already-canonical columns), so a legacy
+    // widget keeps its score-name polarity colors.
+    const nameFilters = mapLegacyUiTableFilterToView(
+      scoreView,
+      params.filters,
+    ).filter((filter) => filter.column === "name");
     const nameFilter = nameFilters.length === 1 ? nameFilters[0] : undefined;
     const scoreName =
       nameFilter?.type === "string" && nameFilter.operator === "="

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -412,6 +412,16 @@
     --chart-7: 84 81% 44%;
     --chart-8: 330 81% 60%;
     --chart-grid: var(--muted-gray);
+    /* Reserved status fills for semantically-recognized chart series
+       (prepareSeriesColors, LFE-15467). Full colors, NOT hsl triplets —
+       consume as var(--chart-status-*), never wrapped in hsl(). Fill-grade
+       (vivid, unlike the --dark-* text tokens); neutral is chroma-free by
+       design (a null bucket is not an identity). CVD-validated per mode
+       against the level-chart adjacency [ok, neutral, warning, error]. */
+    --chart-status-error: #ef4444;
+    --chart-status-warning: #f59e0b;
+    --chart-status-ok: #16a34a;
+    --chart-status-neutral: #a2a2aa;
     --color-1: oklch(66.2% 0.225 25.9);
     --color-2: oklch(60.4% 0.26 302);
     --color-3: oklch(69.6% 0.165 251);
@@ -585,6 +595,15 @@
     --chart-7: 84 81% 44%;
     --chart-8: 330 81% 60%;
     --chart-grid: var(--muted-gray);
+    /* Dark-mode pair for the reserved status fills (see :root block). Brighter
+       green/amber steps than the categorical lightness band on purpose: on a
+       dark surface the red↔amber CVD separation collapses at darker steps
+       (validated ΔE 4.4 vs 15.4), and separation outranks the band for
+       reserved status colors. */
+    --chart-status-error: #ef4444;
+    --chart-status-warning: #fbbf24;
+    --chart-status-ok: #22c55e;
+    --chart-status-neutral: #7a7a85;
     --color-1: oklch(66.2% 0.225 25.9);
     --color-2: oklch(60.4% 0.26 302);
     --color-3: oklch(69.6% 0.165 251);


### PR DESCRIPTION
Closes [LFE-15467](https://linear.app/clickhouse/issue/LFE-15467/dashboard-widgets-automatically-assign-colors-based-on-semantic). Design rationale, production research data, and before/after screenshots live on the ticket and its [approach doc](https://linear.app/clickhouse/document/semantic-series-colors-approach-lfe-15467-9a99af230ef9).

## What changed

| Change | Where | Why / evidence |
|---|---|---|
| `prepareSeriesColors` preparer: status-meaning dimension values (ERROR, WARNING, pass, healthy, …) wear reserved status colors; everything else keeps the existing rotation | `web/src/features/widgets/chart-library/prepareSeriesColors.ts` | Pays down ARCHITECTURE.md V6 debt; vocabulary grounded in prod adoption data (CSVs on the ticket) |
| Two-signal matching: universal unambiguous words plus field-gated vocabularies (`level`, categorical/boolean score values). True/False and yes/no polarity inferred from the score name; negator names (no_hallucination, error_free) and unknown names stay uncolored | same file | Field gate prevents the `default` *environment* from matching the `DEFAULT` level; intent-dependent polarity (high/low, escalated, cache_hit) deliberately excluded |
| New fill-grade `--chart-status-*` token pairs (light and dark), registered on the design-system Charts token page | `globals.css`, `ThemeTokens/Charts.tsx` | CVD-validated per mode (worst adjacent pair ΔE 12.3 light / 17.6 dark) |
| All seven color-bearing charts consume the preparer; legend swatches read the same resolved colors; isolated-point dots included; category bars color all-or-nothing via the recharts `shape` prop (`Cell` is deprecated) | chart-library components | Swatch and series can never diverge; no lone red bar among uniform bars |
| Status series survive the >25-series cap and default legend seeding | `prepareVisibleSeries.ts`, `TimeSeriesLegend.tsx` | An ERROR series is the one a production-health chart exists for |
| Semantic context derived once (`deriveWidgetSemanticContext`, legacy filter columns normalized) and threaded from the saved-widget renderer and the builder preview | `widgets/utils.ts` | Preview and dashboard color identically, incl. legacy saved widgets |

**Unchanged by design:** charts with no status-meaning values render pixel-identical to before; the rotation code path is untouched.

## Verification

- `pnpm --filter web run test-client src/features/widgets src/features/dashboard`: `Tests  468 passed (468)` (incl. new preparer suite and render-level fill assertions covering the CSS-class-vs-SVG-attribute trap)
- `pnpm --filter web run lint`: exit 0
- `pnpm --filter web run typecheck`: exit 0
- Palette validator pass in both modes; browser pass on local seed data (level pie/line, score verdict pie, dark mode); screenshots on the ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)