### PR TITLE
feat(worker): export dashboards and widgets in the core data S3 export

### DIFF
--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -4,6 +4,7 @@ import { type StorageService } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   coreDataTableExports,
+  mapDashboardWidgetToCoreDataRow,
   mapEvaluationRuleToCoreDataRow,
   mapJobConfigurationToCoreDataRow,
   mapUserToCoreDataRow,
@@ -129,6 +130,8 @@ describe("coreDataTableExports", () => {
       prisma.evaluationRule,
       prisma.evaluationRuleEvaluatorAssignment,
       prisma.jobConfiguration,
+      prisma.dashboard,
+      prisma.dashboardWidget,
     ];
     for (const delegate of delegates) {
       vi.spyOn(delegate, "findMany").mockResolvedValue([]);
@@ -157,8 +160,54 @@ describe("coreDataTableExports", () => {
         "core/evaluatorVersions.jsonl",
         "core/evaluationRules.jsonl",
         "core/evaluationRuleEvaluatorAssignments.jsonl",
+        "core/dashboards.jsonl",
+        "core/dashboardWidgets.jsonl",
       ]),
     );
+  });
+});
+
+describe("mapDashboardWidgetToCoreDataRow", () => {
+  it("keeps filter shape but strips customer-entered values and keys", () => {
+    const row = mapDashboardWidgetToCoreDataRow({
+      id: "widget-1",
+      projectId: "project-1",
+      view: "OBSERVATIONS",
+      metrics: [{ measure: "toolCalls", agg: "sum" }],
+      filters: [
+        {
+          column: "userId",
+          operator: "any of",
+          value: ["customer-user-42"],
+          type: "stringOptions",
+        },
+        {
+          column: "metadata",
+          key: "customer-secret-key",
+          operator: "=",
+          value: "customer-value",
+          type: "stringObject",
+        },
+      ],
+    });
+
+    expect(row.filters).toStrictEqual([
+      { column: "userId", operator: "any of", type: "stringOptions" },
+      { column: "metadata", operator: "=", type: "stringObject" },
+    ]);
+    const serialized = JSON.stringify(row);
+    expect(serialized).not.toContain("customer-user-42");
+    expect(serialized).not.toContain("customer-secret-key");
+    expect(serialized).not.toContain("customer-value");
+  });
+
+  it("normalizes a non-array filters column to an empty list", () => {
+    const row = mapDashboardWidgetToCoreDataRow({
+      id: "widget-2",
+      filters: null,
+    });
+
+    expect(row.filters).toStrictEqual([]);
   });
 });
 

--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -4,6 +4,7 @@ import { type StorageService } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   coreDataTableExports,
+  mapDashboardToCoreDataRow,
   mapDashboardWidgetToCoreDataRow,
   mapEvaluationRuleToCoreDataRow,
   mapJobConfigurationToCoreDataRow,
@@ -168,12 +169,52 @@ describe("coreDataTableExports", () => {
 });
 
 describe("mapDashboardWidgetToCoreDataRow", () => {
+  it("allowlists dimensions/metrics and replaces unknown strings with a sentinel", () => {
+    const row = mapDashboardWidgetToCoreDataRow({
+      id: "widget-1",
+      dimensions: [
+        { field: "calledToolNames" },
+        { field: "customer entered free text" },
+      ],
+      metrics: [
+        { measure: "toolCalls", agg: "sum" },
+        { measure: "leaked customer string", agg: "not-an-agg" },
+      ],
+      filters: [],
+      chartConfig: {
+        type: "PIVOT_TABLE",
+        row_limit: 20,
+        defaultSort: { column: "customer column text", order: "DESC" },
+      },
+    });
+
+    expect(row.dimensions).toStrictEqual([
+      { field: "calledToolNames" },
+      { field: "__invalid__" },
+    ]);
+    expect(row.metrics).toStrictEqual([
+      { measure: "toolCalls", agg: "sum" },
+      { measure: "__invalid__", agg: "__invalid__" },
+    ]);
+    expect(row.chartConfig).toStrictEqual({
+      type: "PIVOT_TABLE",
+      row_limit: 20,
+      bins: null,
+    });
+    const serialized = JSON.stringify(row);
+    expect(serialized).not.toContain("customer entered free text");
+    expect(serialized).not.toContain("leaked customer string");
+    expect(serialized).not.toContain("customer column text");
+  });
+
   it("keeps filter shape but strips customer-entered values and keys", () => {
     const row = mapDashboardWidgetToCoreDataRow({
       id: "widget-1",
       projectId: "project-1",
       view: "OBSERVATIONS",
+      dimensions: [],
       metrics: [{ measure: "toolCalls", agg: "sum" }],
+      chartConfig: { type: "LINE_TIME_SERIES" },
       filters: [
         {
           column: "userId",
@@ -204,10 +245,52 @@ describe("mapDashboardWidgetToCoreDataRow", () => {
   it("normalizes a non-array filters column to an empty list", () => {
     const row = mapDashboardWidgetToCoreDataRow({
       id: "widget-2",
+      dimensions: null,
+      metrics: null,
       filters: null,
+      chartConfig: null,
     });
 
     expect(row.filters).toStrictEqual([]);
+    expect(row.dimensions).toStrictEqual([]);
+    expect(row.metrics).toStrictEqual([]);
+  });
+});
+
+describe("mapDashboardToCoreDataRow", () => {
+  it("exports only known placement fields from the definition", () => {
+    const row = mapDashboardToCoreDataRow({
+      id: "dashboard-1",
+      definition: {
+        widgets: [
+          {
+            type: "widget",
+            widgetId: "widget-1",
+            x: 0,
+            y: 0,
+            x_size: 6,
+            y_size: 4,
+            id: "placement-1",
+            unexpectedCustomerField: "customer text",
+          },
+        ],
+        unexpectedTopLevel: "more customer text",
+      },
+    });
+
+    expect(row.definition).toStrictEqual({
+      widgets: [
+        {
+          type: "widget",
+          widgetId: "widget-1",
+          x: 0,
+          y: 0,
+          x_size: 6,
+          y_size: 4,
+        },
+      ],
+    });
+    expect(JSON.stringify(row)).not.toContain("customer text");
   });
 });
 

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -6,6 +6,7 @@ import {
   StorageServiceFactory,
   type StorageService,
 } from "@langfuse/shared/src/server";
+import { metricAggregations, viewDeclarations } from "@langfuse/shared/query";
 import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 
@@ -83,26 +84,107 @@ export const mapEvaluationRuleToCoreDataRow = ({
   sampling: sampling.toNumber(),
 });
 
+// Widget dimensions/metrics/chart config are persisted as free-form strings
+// (DimensionSchema/MetricSchema accept any z.string()), so an API client can
+// smuggle arbitrary text into them. The export therefore allowlists every
+// string against the query-model declarations and replaces unknown values
+// with a sentinel instead of forwarding them.
+const KNOWN_WIDGET_MEASURES = new Set(
+  Object.values(viewDeclarations).flatMap((versionViews) =>
+    Object.values(versionViews).flatMap((view) => Object.keys(view.measures)),
+  ),
+);
+const KNOWN_WIDGET_DIMENSIONS = new Set(
+  Object.values(viewDeclarations).flatMap((versionViews) =>
+    Object.values(versionViews).flatMap((view) => Object.keys(view.dimensions)),
+  ),
+);
+const KNOWN_WIDGET_AGGREGATIONS = new Set<string>(metricAggregations.options);
+const INVALID_SENTINEL = "__invalid__";
+
+const allowlisted = (value: unknown, allowlist: Set<string>): string | null =>
+  value == null
+    ? null
+    : typeof value === "string" && allowlist.has(value)
+      ? value
+      : INVALID_SENTINEL;
+
 type DashboardWidgetCoreDataInput = {
+  dimensions: unknown;
+  metrics: unknown;
   filters: unknown;
+  chartConfig: unknown;
 } & Record<string, unknown>;
 
 // Widget filters carry customer-entered values (user ids, metadata values,
 // tool names, ...). Analytics only needs which columns/operators are used, so
-// the values (and metadata keys) are stripped before export.
+// the values (and metadata keys) are stripped before export; every other
+// string field is allowlisted (see above).
 export const mapDashboardWidgetToCoreDataRow = ({
+  dimensions,
+  metrics,
   filters,
+  chartConfig,
   ...widget
-}: DashboardWidgetCoreDataInput) => ({
-  ...widget,
-  filters: Array.isArray(filters)
-    ? filters.map((filter: Record<string, unknown>) => ({
-        column: filter.column ?? null,
-        operator: filter.operator ?? null,
-        type: filter.type ?? null,
-      }))
-    : [],
-});
+}: DashboardWidgetCoreDataInput) => {
+  const config = (chartConfig ?? {}) as Record<string, unknown>;
+  return {
+    ...widget,
+    dimensions: Array.isArray(dimensions)
+      ? dimensions.map((dimension: Record<string, unknown>) => ({
+          field: allowlisted(dimension.field, KNOWN_WIDGET_DIMENSIONS),
+        }))
+      : [],
+    metrics: Array.isArray(metrics)
+      ? metrics.map((metric: Record<string, unknown>) => ({
+          measure: allowlisted(metric.measure, KNOWN_WIDGET_MEASURES),
+          agg: allowlisted(metric.agg, KNOWN_WIDGET_AGGREGATIONS),
+        }))
+      : [],
+    filters: Array.isArray(filters)
+      ? filters.map((filter: Record<string, unknown>) => ({
+          column: filter.column ?? null,
+          operator: filter.operator ?? null,
+          type: filter.type ?? null,
+        }))
+      : [],
+    // Explicit safe scalars only; defaultSort.column is a free string and is
+    // deliberately not exported.
+    chartConfig: {
+      type: typeof config.type === "string" ? config.type : null,
+      row_limit: typeof config.row_limit === "number" ? config.row_limit : null,
+      bins: typeof config.bins === "number" ? config.bins : null,
+    },
+  };
+};
+
+type DashboardCoreDataInput = {
+  definition: unknown;
+} & Record<string, unknown>;
+
+// Dashboard definitions hold widget placements; explicit field picks keep any
+// unexpected persisted keys out of the export.
+export const mapDashboardToCoreDataRow = ({
+  definition,
+  ...dashboard
+}: DashboardCoreDataInput) => {
+  const widgets = (definition as { widgets?: unknown })?.widgets;
+  return {
+    ...dashboard,
+    definition: {
+      widgets: Array.isArray(widgets)
+        ? widgets.map((placement: Record<string, unknown>) => ({
+            type: placement.type ?? null,
+            widgetId: placement.widgetId ?? null,
+            x: placement.x ?? null,
+            y: placement.y ?? null,
+            x_size: placement.x_size ?? null,
+            y_size: placement.y_size ?? null,
+          }))
+        : [],
+    },
+  };
+};
 
 type TablePageArgs<TCursor> = {
   lastRow: TCursor | null;
@@ -665,6 +747,7 @@ export const coreDataTableExports: Array<
             updatedAt: true,
           },
         }),
+      mapRow: mapDashboardToCoreDataRow,
     }),
   (args) =>
     uploadTableCoreDataJsonl({

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -83,6 +83,27 @@ export const mapEvaluationRuleToCoreDataRow = ({
   sampling: sampling.toNumber(),
 });
 
+type DashboardWidgetCoreDataInput = {
+  filters: unknown;
+} & Record<string, unknown>;
+
+// Widget filters carry customer-entered values (user ids, metadata values,
+// tool names, ...). Analytics only needs which columns/operators are used, so
+// the values (and metadata keys) are stripped before export.
+export const mapDashboardWidgetToCoreDataRow = ({
+  filters,
+  ...widget
+}: DashboardWidgetCoreDataInput) => ({
+  ...widget,
+  filters: Array.isArray(filters)
+    ? filters.map((filter: Record<string, unknown>) => ({
+        column: filter.column ?? null,
+        operator: filter.operator ?? null,
+        type: filter.type ?? null,
+      }))
+    : [],
+});
+
 type TablePageArgs<TCursor> = {
   lastRow: TCursor | null;
   take: number;
@@ -622,6 +643,59 @@ export const coreDataTableExports: Array<
             updatedAt: true,
           },
         }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "dashboards",
+      // Customer-authored name/description are free text and intentionally
+      // excluded; the definition JSON holds only widget placements (ids,
+      // positions, sizes). projectId NULL marks Langfuse-owned templates.
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.dashboard.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            projectId: true,
+            createdBy: true,
+            definition: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+    }),
+  (args) =>
+    uploadTableCoreDataJsonl({
+      ...args,
+      tableName: "dashboardWidgets",
+      // Customer-authored name/description are free text and intentionally
+      // excluded; filter values are stripped in the mapper. The remaining
+      // shape (view, metrics, dimensions, chart type) is what dashboard
+      // product decisions need (e.g. which aggregation users pair with a
+      // measure). projectId NULL marks Langfuse-owned template widgets.
+      fetchPage: ({ lastRow, take }: TablePageArgs<{ id: string }>) =>
+        prisma.dashboardWidget.findMany({
+          take,
+          ...(lastRow ? { cursor: { id: lastRow.id }, skip: 1 } : {}),
+          orderBy: { id: "asc" },
+          select: {
+            id: true,
+            projectId: true,
+            createdBy: true,
+            view: true,
+            dimensions: true,
+            metrics: true,
+            filters: true,
+            chartType: true,
+            chartConfig: true,
+            minVersion: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+      mapRow: mapDashboardWidgetToCoreDataRow,
     }),
 ];
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16621.preview.langfuse.com](https://pr-16621.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

Implements [LFE-15636](https://linear.app/clickhouse/issue/LFE-15636/replicate-dashboard-widgets-to-the-analytics-dwh): the analytics DWH cannot answer how customers configure dashboard widgets (which measure/aggregation pairs, views, chart types are used), because `dashboards`/`dashboard_widgets` never reach it. The core-data pipeline is worker → S3 → Airbyte → `langfuse_raw_data`, and the exported-table list lives in `coreDataTableExports` — so this adds the two tables there.

| Change | Where | Detail |
|---|---|---|
| `dashboards` export | `worker/src/queues/coreDataS3ExportQueue.ts` | id, projectId, createdBy, definition (widget placements only), timestamps. Customer-authored name/description excluded. |
| `dashboardWidgets` export | same | id, projectId, createdBy, view, dimensions, metrics, chartType, chartConfig, minVersion, timestamps. Name/description excluded; **filter values and metadata keys stripped** via `mapDashboardWidgetToCoreDataRow` — only column/operator/type shape is exported. |
| Tests | `coreDataS3ExportQueue.test.ts` | Table-list coverage extended; new mapper tests assert customer values/keys never reach the serialized row. |

Privacy follows the existing precedent (evaluators exclude free text; users export strips password hashes): no customer-entered strings leave Postgres.

**Downstream step (not in this PR):** the Airbyte S3 connection needs the two new object prefixes enabled as streams, plus optional dbt source/staging models in `langfuse/analytics` — noted on the Linear ticket.

## Verification

- Worker export tests: `Tests 13 passed (13)` (incl. 3 new)
- Worker lint (exit 0) + typecheck clean; pre-commit repo lint passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds dashboard and dashboard-widget records to the worker's core-data S3 export.
- Exports dashboard ownership, placement definitions, and timestamps.
- Exports widget query and chart configuration while stripping filter values and metadata keys.
- Extends export-list and mapper coverage in worker tests.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until all customer-controlled widget strings are sanitized or strictly allowlisted before entering the analytics export.

The new export strips filter values but still forwards arbitrary strings accepted by the dashboard-widget write path in dimensions, metrics, and chart configuration, allowing customer-authored content to cross the stated S3 privacy boundary.

**Files Needing Attention:** worker/src/queues/coreDataS3ExportQueue.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

The new widget export still forwards customer-controlled strings from dimensions, metrics, and chart configuration into S3 and the analytics DWH because the corresponding write path does not strictly constrain those values.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Dashboard widget create or update] --> B[(PostgreSQL dashboard_widgets)]
  B --> C[Worker core-data export]
  C --> D[Strip filter values and keys]
  D --> E[S3 JSONL]
  E --> F[Airbyte]
  F --> G[Analytics DWH]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/queues/coreDataS3ExportQueue.ts:687-694
**Unsanitized widget fields exported**

When a dashboard-widget request supplies arbitrary strings in `dimensions[].field`, `metrics[].measure`, or `chartConfig.defaultSort.column`, the write path persists them and this export forwards them unchanged, causing customer-authored content to enter S3 and the analytics DWH despite the stated privacy boundary. **How this was verified:** The customer-facing schemas accept strings, server validation permits unknown dimensions and measures, and the export mapper sanitizes only `filters`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): export dashboards and dash..."](https://github.com/langfuse/langfuse/commit/62373c84098581bda55f79e56b5d1565ec196db5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57063432)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->