### PR TITLE
feat(evals): track evaluator creation configuration

### DIFF
--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
@@ -3,43 +3,57 @@ import { describe, expect, it } from "vitest";
 import { getEvaluatorCreationAnalyticsProperties } from "./getEvaluatorCreationAnalyticsProperties";
 
 describe("getEvaluatorCreationAnalyticsProperties", () => {
-  it("reports which managed catalog template was used", () => {
+  it("reports all evaluator creation attributes", () => {
+    expect(
+      getEvaluatorCreationAnalyticsProperties({
+        evaluatorType: "LLM_AS_JUDGE",
+        creationSource: { type: "managed", templateKey: "hallucination" },
+        evaluatorConfig: {
+          usesDefaultModel: false,
+          hasCustomModelParams: true,
+          scoreType: "CATEGORICAL",
+        },
+        variableMapping: [
+          {
+            templateVariable: "question",
+            selectedColumnId: "input",
+            jsonSelector: null,
+          },
+          {
+            templateVariable: "answer",
+            selectedColumnId: "output",
+            jsonSelector: "$.answer",
+          },
+          {
+            templateVariable: "context",
+            selectedColumnId: "input",
+            jsonSelector: null,
+          },
+        ],
+      }),
+    ).toEqual({
+      evaluatorType: "LLM_AS_JUDGE",
+      managedTemplateKey: "hallucination",
+      isCustomTemplate: false,
+      isFromScratch: false,
+      usesDefaultModel: false,
+      hasCustomModelParams: true,
+      scoreType: "CATEGORICAL",
+      hasNarrowedVariableMapping: true,
+      variableMappingSources: ["input", "output"],
+    });
+
     expect(
       getEvaluatorCreationAnalyticsProperties({
         evaluatorType: "CODE",
-        creationSource: { type: "managed", templateKey: "exact-match" },
+        creationSource: { type: "scratch" },
+        sourceCodeLanguage: "PYTHON",
       }),
     ).toEqual({
       evaluatorType: "CODE",
-      managedTemplateKey: "exact-match",
-      isCustomTemplate: false,
-      isFromScratch: false,
-    });
-  });
-
-  it("reports custom templates without exposing their identity", () => {
-    expect(
-      getEvaluatorCreationAnalyticsProperties({
-        evaluatorType: "LLM_AS_JUDGE",
-        creationSource: { type: "custom" },
-      }),
-    ).toEqual({
-      evaluatorType: "LLM_AS_JUDGE",
-      isCustomTemplate: true,
-      isFromScratch: false,
-    });
-  });
-
-  it("reports evaluators created from scratch", () => {
-    expect(
-      getEvaluatorCreationAnalyticsProperties({
-        evaluatorType: "LLM_AS_JUDGE",
-        creationSource: { type: "scratch" },
-      }),
-    ).toEqual({
-      evaluatorType: "LLM_AS_JUDGE",
       isCustomTemplate: false,
       isFromScratch: true,
+      sourceCodeLanguage: "PYTHON",
     });
   });
 });

--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
@@ -22,7 +22,7 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
           {
             templateVariable: "answer",
             selectedColumnId: "output",
-            jsonSelector: "$.answer",
+            jsonSelector: "$",
           },
           {
             templateVariable: "context",
@@ -39,7 +39,7 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
       usesDefaultModel: false,
       hasCustomModelParams: true,
       scoreType: "CATEGORICAL",
-      hasNarrowedVariableMapping: true,
+      hasNarrowedVariableMapping: false,
       variableMappingSources: ["input", "output"],
     });
 

--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
@@ -1,4 +1,8 @@
-import type { EvalTemplateType } from "@langfuse/shared";
+import type {
+  EvalTemplateSourceCodeLanguage,
+  EvalTemplateType,
+} from "@langfuse/shared";
+import type { ScoreOutputDataType } from "@/src/features/evals/v2/scoreOutputTypes";
 
 export type EvaluatorCreationSource =
   | { type: "managed"; templateKey: string }
@@ -8,16 +12,55 @@ export type EvaluatorCreationSource =
 export function getEvaluatorCreationAnalyticsProperties({
   evaluatorType,
   creationSource,
+  evaluatorConfig,
+  sourceCodeLanguage,
+  variableMapping,
 }: {
   evaluatorType: EvalTemplateType;
   creationSource: EvaluatorCreationSource;
+  evaluatorConfig?: {
+    usesDefaultModel: boolean;
+    hasCustomModelParams: boolean;
+    scoreType: ScoreOutputDataType;
+  };
+  sourceCodeLanguage?: EvalTemplateSourceCodeLanguage;
+  variableMapping?: Array<{
+    templateVariable?: string;
+    selectedColumnId: string | null;
+    jsonSelector?: string | null;
+  }>;
 }) {
+  const configProperties = evaluatorConfig
+    ? {
+        usesDefaultModel: evaluatorConfig.usesDefaultModel,
+        hasCustomModelParams: evaluatorConfig.hasCustomModelParams,
+        scoreType: evaluatorConfig.scoreType,
+      }
+    : {};
+  const variableMappingProperties = variableMapping
+    ? {
+        hasNarrowedVariableMapping: variableMapping.some((mapping) =>
+          Boolean(mapping.jsonSelector),
+        ),
+        variableMappingSources: [
+          ...new Set(
+            variableMapping
+              .map((mapping) => mapping.selectedColumnId)
+              .filter((source): source is string => Boolean(source)),
+          ),
+        ],
+      }
+    : {};
+
   if (creationSource.type === "managed") {
     return {
       evaluatorType,
       managedTemplateKey: creationSource.templateKey,
       isCustomTemplate: false,
       isFromScratch: false,
+      ...configProperties,
+      ...variableMappingProperties,
+      ...(sourceCodeLanguage ? { sourceCodeLanguage } : {}),
     };
   }
 
@@ -25,5 +68,8 @@ export function getEvaluatorCreationAnalyticsProperties({
     evaluatorType,
     isCustomTemplate: creationSource.type === "custom",
     isFromScratch: creationSource.type === "scratch",
+    ...configProperties,
+    ...variableMappingProperties,
+    ...(sourceCodeLanguage ? { sourceCodeLanguage } : {}),
   };
 }

--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
@@ -39,8 +39,9 @@ export function getEvaluatorCreationAnalyticsProperties({
     : {};
   const variableMappingProperties = variableMapping
     ? {
-        hasNarrowedVariableMapping: variableMapping.some((mapping) =>
-          Boolean(mapping.jsonSelector),
+        hasNarrowedVariableMapping: variableMapping.some(
+          (mapping) =>
+            Boolean(mapping.jsonSelector) && mapping.jsonSelector !== "$",
         ),
         variableMappingSources: [
           ...new Set(

--- a/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
@@ -458,6 +458,22 @@ export function EvaluatorSetupPage(
         getEvaluatorCreationAnalyticsProperties({
           evaluatorType: state.type,
           creationSource: props.creationSource,
+          sourceCodeLanguage:
+            state.type === "CODE" ? state.sourceCodeLanguage : undefined,
+          variableMapping:
+            definition.type === "LLM_AS_JUDGE"
+              ? definition.variableMapping
+              : undefined,
+          evaluatorConfig:
+            state.type === "LLM_AS_JUDGE"
+              ? {
+                  usesDefaultModel: state.modelMode === "default",
+                  hasCustomModelParams:
+                    state.modelMode === "custom" &&
+                    Object.keys(state.modelParams ?? {}).length > 0,
+                  scoreType: state.scoreOutput.dataType,
+                }
+              : undefined,
         }),
       );
       initialSnapshot.current = getCurrentSnapshot(state);


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16624.preview.langfuse.com](https://pr-16624.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Expands the `evaluators:create` analytics event with the evaluator configuration users choose:

- default model usage, custom model parameters, and score type
- source language for code evaluators
- whether variable mappings use a narrower JSON selector
- unique variable sources such as `input`, `output`, or `metadata`

Only configuration summaries are tracked. Model parameters, JSON selectors, and mapped values are not included.

Rule creation already tracks `samplingPercent`, so no rule event change is needed.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm --filter web run test-client getEvaluatorCreationAnalyticsProperties.clienttest.ts`
- `pnpm run lint`
- `pnpm --filter web run typecheck`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands evaluator-creation analytics with model, score, code-language, and variable-mapping summaries.

- Adds a helper for deriving the new analytics properties.
- Captures those properties after successful evaluator creation.
- Adds coverage for LLM-as-a-judge and code evaluator attributes.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The analytics classification should be corrected before merging because whole-value JSONPath mappings are currently reported as narrowed.

The new helper uses selector truthiness to classify narrowing, so the valid whole-value selector `$` produces incorrect evaluator-creation analytics.

**Files Needing Attention:** web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts:42-44
**Whole selector misclassified**

When a user applies `$`, this truthiness check reports the mapping as narrowed even though `$` selects the entire source, causing evaluator-creation analytics to overcount narrowed mappings.

```suggestion
        hasNarrowedVariableMapping: variableMapping.some(
          (mapping) =>
            Boolean(mapping.jsonSelector) && mapping.jsonSelector !== "$",
        ),
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): expand evaluator creation a..."](https://github.com/langfuse/langfuse/commit/75306f99c73232bc100d13308c7e80b6f57c582b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57070810)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->