### PR TITLE
fix(dashboards): label chart date axes in UTC

### DIFF
--- a/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts
@@ -257,4 +257,52 @@ describe("prepareTimeAxis", () => {
     );
     expect(parseChartTimestamp("not a date")).toBeNull();
   });
+
+  describe("UTC calendar labels when the browser is west of UTC", () => {
+    const previousTz = process.env.TZ;
+
+    beforeEach(() => {
+      process.env.TZ = "America/Los_Angeles";
+    });
+
+    afterEach(() => {
+      if (previousTz === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previousTz;
+      }
+    });
+
+    it("date ticks and tooltips use the UTC calendar day, not the local previous evening", () => {
+      // UTC midnight Jun 28 is still Jun 27 evening in PT. Formatting in local
+      // time made the axis read one day early.
+      const values = Array.from({ length: 14 }, (_, d) =>
+        iso(Date.UTC(2026, 5, 28) + d * DAY),
+      );
+      const axis = prepareTimeAxis(values, 6);
+      expect(axis.mode).toBe("date");
+      expect(axis.formatTick(values[0])).toBe("Jun 28");
+      expect(axis.formatTooltip(values[0])).toBe("Jun 28, 2026");
+      expect(axis.formatTick("2026-06-28")).toBe("Jun 28");
+    });
+
+    it("month ticks use the UTC month (UTC midnight Jun 1 is still May locally)", () => {
+      const values = Array.from({ length: 200 }, (_, d) =>
+        iso(Date.UTC(2026, 5, 1) + d * DAY),
+      );
+      const axis = prepareTimeAxis(values, 6);
+      expect(axis.mode).toBe("month");
+      expect(axis.formatTick(values[0])).toBe("Jun 2026");
+    });
+
+    it("intraday time ticks stay in local time", () => {
+      const start = Date.UTC(2026, 5, 28, 18); // 11 AM PT
+      const values = Array.from({ length: 12 }, (_, h) =>
+        iso(start + h * HOUR),
+      );
+      const axis = prepareTimeAxis(values, 6);
+      expect(axis.mode).toBe("time");
+      expect(axis.formatTick(values[0])).toMatch(/11\s?AM/i);
+    });
+  });
 });

--- a/web/src/features/widgets/chart-library/prepareTimeAxis.ts
+++ b/web/src/features/widgets/chart-library/prepareTimeAxis.ts
@@ -268,10 +268,11 @@ export function prepareTimeAxis(
   const span = count >= 2 ? maxTs - minTs : 0;
   // Date ticks normally omit the year (one unit per scale), but show it when the
   // range straddles a year boundary so "Dec 29 → Jan 5" stays unambiguous.
-  // Use LOCAL year to match the tick formatter (toLocaleDateString renders in
-  // local time), so a range that crosses Jan 1 locally still shows the year.
+  // UTC year to match date/month formatters (buckets are UTC-aligned; local
+  // midnight would otherwise drop the year on a range that only crosses Jan 1
+  // in the browser timezone).
   const crossesYear =
-    new Date(minTs).getFullYear() !== new Date(maxTs).getFullYear();
+    new Date(minTs).getUTCFullYear() !== new Date(maxTs).getUTCFullYear();
 
   const mode: AxisMode =
     span > 0 && span <= TIME_SCALE_MAX
@@ -297,6 +298,10 @@ export function prepareTimeAxis(
   const subHour = bucketMs > 0 && bucketMs < HOUR;
   const subDay = bucketMs > 0 && bucketMs < DAY;
 
+  // Date/month labels use UTC so a UTC-midnight bucket is not formatted as the
+  // previous local evening. Intraday time ticks stay in the browser timezone.
+  const calendarTimeZone = mode === "time" ? undefined : "UTC";
+
   const formatTick = (raw: unknown): string => {
     const date = parseChartTimestamp(raw);
     if (!date) return typeof raw === "string" ? raw : "";
@@ -308,11 +313,13 @@ export function prepareTimeAxis(
     }
     if (mode === "month") {
       return date.toLocaleDateString("en-US", {
+        timeZone: calendarTimeZone,
         month: "short",
         year: "numeric",
       });
     }
     return date.toLocaleDateString("en-US", {
+      timeZone: calendarTimeZone,
       month: "short",
       day: "numeric",
       ...(crossesYear ? { year: "numeric" } : {}),
@@ -327,6 +334,7 @@ export function prepareTimeAxis(
     const date = parseChartTimestamp(raw);
     if (!date) return typeof raw === "string" ? raw : "";
     return date.toLocaleString("en-US", {
+      ...(calendarTimeZone ? { timeZone: calendarTimeZone } : {}),
       month: "short",
       day: "numeric",
       year: "numeric",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16625.preview.langfuse.com](https://pr-16625.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

UTC-midnight time buckets were formatted with `toLocaleDateString` in the browser timezone, so a `2026-06-28` day rendered as **Jun 27** west of UTC.

Date and month ticks (and their tooltips) now pass `timeZone: "UTC"` so the label matches the bucket. Intraday time ticks stay in local time.

Impacted packages: `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed

## Checklist

- Added client tests that set `TZ=America/Los_Angeles` and expect `Jun 28` / `Jun 2026`
- Intraday ticks still format as local time (`11 AM` PT for `18:00Z`)

## Verification

- `pnpm --filter web run test-client src/features/widgets/chart-library/prepareTimeAxis.clienttest.ts` — `Tests  23 passed (23)`
- `turbo run lint` (pre-commit) — `Tasks:    7 successful, 7 total`

Skipped `pnpm --filter web run lint` as a standalone invocation (workspace eslint plugin resolve failed outside turbo). Skipped browser signoff: this Cloud VM is UTC, so local and UTC date labels are identical; the regression is only visible west of UTC, which the client tests force.

This does **not** regroup events onto the viewer's local calendar day. A 10pm PT trace still sits in the UTC day bucket. Local-day grouping would need an IANA timezone on the metrics query.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-10372](https://linear.app/clickhouse/issue/LFE-10372/chart-x-axis-offset-by-one-day)

<div><a href="https://cursor.com/agents/bc-d2e64c0f-5c3a-4c9d-92f2-e2d973435155?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e64c0f-5c3a-4c9d-92f2-e2d973435155&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns date and month chart labels with UTC-based time buckets while preserving local-time formatting for intraday axes.
- Uses UTC years to determine whether date ticks need year disambiguation.
- Formats date/month ticks and tooltips in UTC.
- Adds timezone-specific regression tests for date, month, and intraday labels.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

UTC year detection now matches UTC date and month formatting, while the added timezone-specific tests verify the corrected calendar labels and unchanged intraday behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): label chart date axes i..."](https://github.com/langfuse/langfuse/commit/85ce09b4053098eeb27b5aab1402c5dd16196162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57071612)</sub>

<!-- /greptile_comment -->