### PR TITLE
feat(web): instrument dashboard and widget usage in PostHog

### DIFF
--- a/web/src/features/dashboard/components/CloneFirstDialog.tsx
+++ b/web/src/features/dashboard/components/CloneFirstDialog.tsx
@@ -76,6 +76,9 @@ export function CloneFirstDialog({
         source: "clone_first_dialog",
         set_as_home: setAsHome,
         had_pending_change: Boolean(pendingDefinition),
+        dashboardId,
+        // The clone-first flow only exists for locked Langfuse-owned dashboards.
+        owner: "LANGFUSE",
       });
       showSuccessToast({
         title: "Editable copy created",

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -40,9 +40,11 @@ type DashboardTableRow = {
 function CloneDashboardButton({
   dashboardId,
   projectId,
+  owner,
 }: {
   dashboardId: string;
   projectId: string;
+  owner: DashboardTableRow["owner"];
 }) {
   const utils = api.useUtils();
   const hasAccess = useHasProjectAccess({ projectId, scope: "dashboards:CUD" });
@@ -51,7 +53,11 @@ function CloneDashboardButton({
   const mutCloneDashboard = api.dashboard.cloneDashboard.useMutation({
     onSuccess: () => {
       utils.dashboard.invalidate();
-      capture("dashboard:clone_dashboard", { source: "list_clone_button" });
+      capture("dashboard:clone_dashboard", {
+        source: "list_clone_button",
+        dashboardId,
+        owner,
+      });
       showSuccessToast({
         title: "Dashboard cloned",
         description: "The dashboard has been cloned successfully",
@@ -306,6 +312,7 @@ export function DashboardTable() {
                   <CloneDashboardButton
                     dashboardId={id}
                     projectId={projectId}
+                    owner={owner}
                   />
                 </DropdownMenuItem>
                 {owner === "PROJECT" && (

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -212,6 +212,7 @@ export const events = {
     "save_to_prompt_version_button_click",
   ],
   dashboard: [
+    "view",
     "clone_dashboard",
     "home_dashboard_viewed",
     "home_dashboard_peeked",

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -213,6 +213,7 @@ export const events = {
   ],
   dashboard: [
     "view",
+    "widget_saved",
     "clone_dashboard",
     "home_dashboard_viewed",
     "home_dashboard_peeked",

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -261,6 +261,11 @@ export function SelectWidgetDialog({
                             key={presetId}
                             type="button"
                             onClick={() => {
+                              capture("dashboard:widget_added", {
+                                kind: "home_preset",
+                                preset_id: presetId,
+                                dashboard_id: dashboardId,
+                              });
                               onSelectPreset(presetId);
                               onOpenChange(false);
                             }}

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -129,6 +129,16 @@ export default function DashboardDetail() {
   // route through the clone-first flow instead of mutating.
   const isLockedEditable = hasRbacCUDAccess && isLockedDashboard;
 
+  // PostHog is the external system: report one view per dashboard once the
+  // owner is known ("do the Langfuse-maintained templates get used?"). Keyed
+  // by id so client-side navigation between dashboards re-reports; `capture`
+  // has a stable identity.
+  const dashboardOwner = dashboard.data?.owner;
+  useEffect(() => {
+    if (!dashboardOwner) return;
+    capture("dashboard:view", { dashboardId, owner: dashboardOwner });
+  }, [capture, dashboardId, dashboardOwner]);
+
   // Access for cloning (independent of dashboard owner)
   const hasCloneAccess = hasRbacCUDAccess && isLockedDashboard;
 

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -130,12 +130,15 @@ export default function DashboardDetail() {
   const isLockedEditable = hasRbacCUDAccess && isLockedDashboard;
 
   // PostHog is the external system: report one view per dashboard once the
-  // owner is known ("do the Langfuse-maintained templates get used?"). Keyed
-  // by id so client-side navigation between dashboards re-reports; `capture`
-  // has a stable identity.
+  // owner is known ("do the Langfuse-maintained templates get used?"). The
+  // id ref dedupes Strict Mode double-mounts while still re-reporting on
+  // client-side navigation between dashboards (same pattern as
+  // dashboard:home_dashboard_viewed).
   const dashboardOwner = dashboard.data?.owner;
+  const viewedDashboardRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!dashboardOwner) return;
+    if (!dashboardOwner || viewedDashboardRef.current === dashboardId) return;
+    viewedDashboardRef.current = dashboardId;
     capture("dashboard:view", { dashboardId, owner: dashboardOwner });
   }, [capture, dashboardId, dashboardOwner]);
 

--- a/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
@@ -7,6 +7,7 @@ import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { type metricAggregations, type views } from "@langfuse/shared/query";
 import { type z } from "zod";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 export default function EditWidget() {
   const router = useRouter();
@@ -18,6 +19,7 @@ export default function EditWidget() {
 
   // Fetch the widget details
   const utils = api.useUtils();
+  const capture = usePostHogClientCapture();
   const { data: widgetData, isLoading: isWidgetLoading } =
     api.dashboardWidgets.get.useQuery(
       {
@@ -34,7 +36,16 @@ export default function EditWidget() {
     onSettled: () => {
       utils.dashboardWidgets.invalidate();
     },
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
+      // Which measure/aggregation/chart shapes do users actually save?
+      capture("dashboard:widget_saved", {
+        isNew: false,
+        view: variables.view,
+        chartType: variables.chartType,
+        measures: variables.metrics.map((m) => `${m.agg}:${m.measure}`),
+        dimensionCount: variables.dimensions.length,
+        filterCount: variables.filters.length,
+      });
       showSuccessToast({
         title: "Widget updated successfully",
         description: "Your widget has been updated.",

--- a/web/src/pages/project/[projectId]/widgets/new.tsx
+++ b/web/src/pages/project/[projectId]/widgets/new.tsx
@@ -11,6 +11,7 @@ import { SelectDashboardDialog } from "@/src/features/dashboard/components/Selec
 import { useState } from "react";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { getDefaultView } from "@/src/features/widgets/utils";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 export default function NewWidget() {
   const router = useRouter();
@@ -19,9 +20,19 @@ export default function NewWidget() {
     dashboardId?: string;
   };
   const { isBetaEnabled } = useV4Beta();
+  const capture = usePostHogClientCapture();
 
   const createWidgetMutation = api.dashboardWidgets.create.useMutation({
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
+      // Which measure/aggregation/chart shapes do users actually save?
+      capture("dashboard:widget_saved", {
+        isNew: true,
+        view: variables.view,
+        chartType: variables.chartType,
+        measures: variables.metrics.map((m) => `${m.agg}:${m.measure}`),
+        dimensionCount: variables.dimensions.length,
+        filterCount: variables.filters.length,
+      });
       showSuccessToast({
         title: "Widget created successfully",
         description: "Your widget has been created.",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16626.preview.langfuse.com](https://pr-16626.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

Implements [LFE-15638](https://linear.app/clickhouse/issue/LFE-15638/posthog-dashboard-view-event-with-owner-measure-ootb-dashboard): no event fires when a dashboard is viewed or a widget is saved, so template-dashboard adoption (#16597) and builder behavior (#16603) aren't measurable.

| Event | Fires | Properties (metadata only) |
|---|---|---|
| `dashboard:view` (new) | once per dashboard on the detail page, when owner is known | `dashboardId`, `owner` (LANGFUSE templates vs PROJECT) |
| `dashboard:clone_dashboard` (extended) | both clone paths | + `dashboardId`, `owner` |
| `dashboard:widget_saved` (new) | widget create + update success | `isNew`, `view`, `chartType`, `measures` (`agg:measure` pairs), `dimensionCount`, `filterCount` |
| `dashboard:widget_added` (extended) | home-preset adds (previously silent) | `kind: home_preset`, `preset_id`, `dashboard_id` |

Tracking plan: **"do the Langfuse-maintained templates get used?"** (view/clone by owner + deterministic template ids) and **"which measure/aggregation shapes do users save?"** (validates the #16603 Sum-default change post-ship). All properties are enum-ish metadata per the posthog-instrumentation skill — no user content.

## Verification

- Web typecheck clean; root lint `Tasks: 7 successful, 7 total` (standalone `--filter web` lint fails in fresh worktrees on unbuilt `@repo/eslint-plugin` — pre-existing, unrelated)
- Events registered in the typed allowlist (`usePostHogClientCapture.ts`), so unknown names fail typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PostHog instrumentation for dashboard views, dashboard cloning, widget saves, and Home preset additions.
- Registers the new typed dashboard analytics events.
- Adds dashboard identity and ownership metadata to view and clone events.
- Records saved widget configuration shapes after successful create and update mutations.
- Records Home preset selections as widget-added events.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking duplicate dashboard-view event in development that should be deduplicated for cleaner analytics.

The mutation-backed events use validated inputs and success callbacks, while the only accepted concern is that the new mount effect can emit twice under the repository’s enabled React Strict Mode.

**Files Needing Attention:** web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Dashboard detail loads] --> B[Owner becomes available]
  B --> C[Capture dashboard:view]
  D[Clone succeeds] --> E[Capture clone with owner and dashboard ID]
  F[Widget create or update succeeds] --> G[Capture saved configuration shape]
  H[Home preset selected] --> I[Capture widget_added]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx:137-140
**Dashboard views duplicate in development**

With React Strict Mode enabled, this unguarded mount effect runs twice and sends two `dashboard:view` events for one dashboard visit, inflating development analytics. The analogous Home dashboard instrumentation uses a dashboard-ID ref to enforce once-per-dashboard capture.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): instrument dashboard and widg..."](https://github.com/langfuse/langfuse/commit/c546125014dd6234eab8a029c8ac514de34f6c06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57075511)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Product web application](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/product-web-application.md)
- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)

<!-- /greptile_comment -->