### PR TITLE
fix(comments): stop mention capture from crossing mention tokens

### DIFF
--- a/web/src/features/comments/lib/mentionParser.clienttest.ts
+++ b/web/src/features/comments/lib/mentionParser.clienttest.ts
@@ -252,6 +252,22 @@ describe("mentionParser", () => {
 
         expect(result).toEqual(["alice123", "bob456"]);
       });
+
+      it("should not merge a malformed mention with a later valid one", () => {
+        // The malformed userId cannot complete, and the display-name capture
+        // must not expand through the following mention token
+        const content = "@[A](user:bad!id) keep me @[Bob](user:bob456)";
+        const result = extractUniqueMentionedUserIds(content);
+
+        expect(result).toEqual(["bob456"]);
+      });
+
+      it("should resolve display names ending with brackets", () => {
+        const content = "@[Team [X]](user:bob456)";
+        const result = extractUniqueMentionedUserIds(content);
+
+        expect(result).toEqual(["bob456"]);
+      });
     });
 
     describe("ReDoS prevention", () => {
@@ -387,6 +403,19 @@ describe("mentionParser", () => {
 
         expect(result.sanitizedContent).toBe("User1 User2");
         expect(result.validMentionedUserIds).toEqual([]);
+      });
+
+      it("should preserve text between a malformed mention and a later valid one", () => {
+        // Regression test: the display-name capture must not span the
+        // "](user:" delimiter of another mention, which would replace the
+        // whole merged span and silently delete user-authored text
+        const content = "@[A](user:bad!id) keep me @[Bob](user:bob456)";
+        const result = sanitizeMentions(content, mockMembers);
+
+        expect(result.sanitizedContent).toBe(
+          "@[A](user:bad!id) keep me @[Bob Jones](user:bob456)",
+        );
+        expect(result.validMentionedUserIds).toEqual(["bob456"]);
       });
     });
 

--- a/web/src/features/comments/lib/mentionParser.ts
+++ b/web/src/features/comments/lib/mentionParser.ts
@@ -19,11 +19,17 @@ export const MENTION_USER_PREFIX = "user:";
  * literal newline matches, matching the pre-PR behavior of the negated
  * class `[^[\]]{1,100}` which also matched line terminators. The hard
  * 1-100 cap on the capture keeps the engine bounded.
+ * A tempered lookahead additionally forbids the capture from spanning
+ * another mention's `](user:` delimiter: without it, a malformed mention
+ * (userId failing the charset check) followed by a valid one within 100
+ * characters makes the lazy capture expand through the later token, and
+ * sanitizeMentions then replaces the whole merged span - silently deleting
+ * the user-authored text between the two mentions.
  * User ID: 1-30 characters (CUID is 25 chars, custom IDs may include
  * hyphens/underscores).
  */
 const MENTION_REGEX = new RegExp(
-  `@\\[([\\s\\S]{1,100}?)\\]\\(${MENTION_USER_PREFIX}([a-z0-9_-]{1,30})\\)`,
+  `@\\[((?:(?!\\]\\(${MENTION_USER_PREFIX})[\\s\\S]){1,100}?)\\]\\(${MENTION_USER_PREFIX}([a-z0-9_-]{1,30})\\)`,
   "gi",
 );
 

--- a/worker/src/features/notifications/commentMentionHandler.ts
+++ b/worker/src/features/notifications/commentMentionHandler.ts
@@ -136,9 +136,11 @@ export async function handleCommentMentionNotification(
       // Convert @[DisplayName](user:userId) to @DisplayName. Mirrors
       // MENTION_REGEX in web/src/features/comments/lib/mentionParser.ts so
       // display names containing square brackets or line breaks survive
-      // both the parser and this preview stripper.
+      // both the parser and this preview stripper. The tempered lookahead
+      // keeps the capture from spanning a later mention's "](user:"
+      // delimiter, which would swallow the text between two mentions.
       return truncated.replace(
-        /@\[([\s\S]{1,100}?)\]\(user:[a-z0-9_-]{1,30}\)/gi,
+        /@\[((?:(?!\]\(user:)[\s\S]){1,100}?)\]\(user:[a-z0-9_-]{1,30}\)/gi,
         "@$1",
       );
     })();


### PR DESCRIPTION
﻿## What does this PR do?

Follow-up to #15092. #15092 allowed brackets in display names via a lazy-dot capture (`[\s\S]{1,100}?`) anchored on the literal `](user:` terminator. That capture can cross token boundaries: when a malformed mention (userId failing the `[a-z0-9_-]{1,30}` charset) precedes a valid mention within 100 characters, the lazy capture expands through the later token and `sanitizeMentions` replaces the entire merged span — silently deleting the user-authored text between the two mentions.

This PR tempers the capture with a per-character negative lookahead `(?!\]\(user:)` so a match can never span another mention's delimiter. Bracketed names still parse (including names ending in `]` before the closer), while a malformed mention now fails in isolation and any later valid mention resolves on its own. The worker email preview (`commentMentionHandler.ts`) mirrors the same guard.

Related to #14836, follow-up to #15092. Supersedes the boundary-crossing aspect of closed #16452 (which landed the same feature independently).

Fixes #14836 (residual)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] My code follows the style guidelines (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective (4 regression tests: malformed+valid boundary preservation on extraction + sanitization, bracket-suffixed names)
- [x] I have checked if new and existing unit tests pass locally (61/61 parser tests pass via `pnpm --filter web run test-client src/features/comments/lib/mentionParser.clienttest.ts`)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents malformed mention captures from consuming a later valid mention and mirrors that boundary handling in email previews.
- Tempers the web parser’s display-name capture at mention delimiters.
- Applies the same regex behavior to worker-generated email previews.
- Adds extraction and sanitization regression coverage for malformed neighboring mentions and bracket-suffixed names.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The mention-boundary fix should not merge until valid generated mentions with delimiter-like display-name text continue to resolve and notify their intended recipients.

The new negative lookahead can reject mention markup generated from an unrestricted canonical member name, dropping that member from extraction and notification delivery.

**Files Needing Attention:** web/src/features/comments/lib/mentionParser.ts and worker/src/features/notifications/commentMentionHandler.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/comments/lib/mentionParser.ts:33
**Delimiter-like names lose mentions**

When a member's canonical display name contains the literal `](user:` substring, the new lookahead rejects the generated mention, causing its user ID to be omitted from notification processing and the intended recipient to receive no email.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(comments): stop mention capture from..."](https://github.com/langfuse/langfuse/commit/7e0490ec1b2438644f1d5468918a76fec23538c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57100726)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Trace exploration workflows](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-exploration-workflows.md)
- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)

<!-- /greptile_comment -->