### PR TITLE
fix(auth): stop leaking internal error details from signup endpoints

### DIFF
--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -101,11 +101,27 @@ export async function signupApiHandler(
       { adClickIds: getAdClickIdsFromRequest(req) },
     );
   } catch (error) {
-    const message =
-      "Signup: Error creating user: " +
-      (error instanceof Error ? error.message : JSON.stringify(error));
-    logger.warn(message, body.email.toLowerCase(), body.name);
-    res.status(422).json({ message: message });
+    const rawMessage =
+      error instanceof Error ? error.message : JSON.stringify(error);
+    logger.warn("Signup: Error creating user", {
+      error: rawMessage,
+      email: body.email.toLowerCase(),
+      name: body.name,
+    });
+    // Only forward known, user-facing validation messages from
+    // createUserEmailPassword. Anything else (Prisma/Postgres internals,
+    // constraint names, connection errors) must not reach an
+    // unauthenticated caller.
+    const userFacingMessages = new Set([
+      "Password needs to be at least 8 characters long.",
+      "User with email already exists. Please sign in.",
+      "You have already signed up via an identity provider. Please sign in.",
+    ]);
+    res.status(422).json({
+      message: userFacingMessages.has(rawMessage)
+        ? rawMessage
+        : "Unable to create account. Please try again or contact support.",
+    });
 
     return;
   }

--- a/web/src/pages/api/auth/signup-verify.ts
+++ b/web/src/pages/api/auth/signup-verify.ts
@@ -115,11 +115,18 @@ export default async function handler(
       res.status(200).json({ status: "ok" });
       return;
     }
-    const message =
-      "Signup verify: Error creating user: " +
-      (error instanceof Error ? error.message : JSON.stringify(error));
-    logger.warn(message, normalizedEmail, name);
-    res.status(500).json({ message });
+    // Log the raw error server-side only; the response must not carry
+    // Prisma/Postgres internals to an unauthenticated caller.
+    const rawMessage =
+      error instanceof Error ? error.message : JSON.stringify(error);
+    logger.warn("Signup verify: Error creating user", {
+      error: rawMessage,
+      email: normalizedEmail,
+      name,
+    });
+    res.status(500).json({
+      message: "Unable to complete sign-up. Please try again or contact support.",
+    });
     return;
   }
 


### PR DESCRIPTION
## What does this PR do?

`/api/auth/signup` and `/api/auth/signup-verify` returned raw error strings from user creation to unauthenticated callers (Prisma/Postgres messages including constraint names and connection details).

The sign-up form only needs the three intentional validation messages from `createUserEmailPassword`. Everything else now returns a generic message while the raw error stays in the server log. The `signup-verify` path keeps its Unique-constraint race handling (200) and genericizes the remaining 500 path.

Fixes #16504

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] My code follows the style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if new and existing unit tests pass locally (no existing tests assert on the leaked message; change preserves the three user-facing messages verbatim)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents unauthenticated signup endpoints from returning raw internal errors while retaining detailed server-side logging.
- Allows only three intentional account-creation validation messages through the standard signup endpoint.
- Returns a fixed generic server-error response from signup verification while preserving its unique-constraint race handling.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking maintainability issue around duplicated validation-message literals.

The changed handlers stop exposing internal errors as intended, and the current intentional validation messages are preserved exactly; only future divergence between duplicated message definitions could degrade signup feedback.

**Files Needing Attention:** web/src/features/auth-credentials/server/signupApiHandler.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/auth-credentials/server/signupApiHandler.ts:115-119
**Duplicated validation messages**

The exact message allowlist duplicates strings defined by `createUserEmailPassword`, so adding or rewording an intentional validation error without updating both locations makes the signup form display the generic error instead of actionable feedback. Share the definitions or otherwise keep this contract synchronized and tested.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): stop leaking internal error d..."](https://github.com/langfuse/langfuse/commit/8c5b39d7e1b66c41fbf3a9c2eb6cfdfab6f97b34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57101125)</sub>

<!-- /greptile_comment -->