### PR TITLE
fix(auth): trim whitespace around emails on sign-up and sign-in

### DIFF
--- a/web/src/features/auth-credentials/lib/credentialsServerUtils.ts
+++ b/web/src/features/auth-credentials/lib/credentialsServerUtils.ts
@@ -24,11 +24,15 @@ export async function createUserEmailPassword(
   if (!isValidPassword(password))
     throw new Error("Password needs to be at least 8 characters long.");
 
+  // Trim before lookup and storage: sign-in looks the email up with
+  // .trim().toLowerCase(), so storing an untrimmed variant would make the
+  // account unreachable through the normal sign-in path.
+  const normalizedEmail = email.trim().toLowerCase();
   const hashedPassword = await hashPassword(password);
   // check that no user exists with this email
   const user = await prisma.user.findUnique({
     where: {
-      email: email.toLowerCase(),
+      email: normalizedEmail,
     },
   });
   if (user !== null) {
@@ -41,7 +45,7 @@ export async function createUserEmailPassword(
 
   const newUser = await prisma.user.create({
     data: {
-      email: email.toLowerCase(),
+      email: normalizedEmail,
       password: hashedPassword,
       name,
     },

--- a/web/src/features/auth/lib/signupSchema.ts
+++ b/web/src/features/auth/lib/signupSchema.ts
@@ -32,7 +32,7 @@ export const nameSchema = StringNoHTMLNonEmpty.max(
 
 export const signupSchema = z.object({
   name: nameSchema,
-  email: z.email(),
+  email: z.string().trim().pipe(z.email()),
   password: passwordSchema,
   referralSource: z.string().optional(),
 });

--- a/web/src/pages/api/auth/signup-verify.ts
+++ b/web/src/pages/api/auth/signup-verify.ts
@@ -44,7 +44,7 @@ export default async function handler(
   }
 
   const { email, name } = parsed.data;
-  const normalizedEmail = email.toLowerCase();
+  const normalizedEmail = email.trim().toLowerCase();
 
   // Run eligibility checks (signup disabled, SSO enforcement, etc.)
   const eligibilityError = await validateSignupEligibility({

--- a/web/src/pages/api/auth/signup-verify.ts
+++ b/web/src/pages/api/auth/signup-verify.ts
@@ -10,7 +10,7 @@ import { z } from "zod/v4";
 import { noUrlCheck, StringNoHTMLNonEmpty } from "@langfuse/shared";
 
 const signupVerifySchema = z.object({
-  email: z.email(),
+  email: z.string().trim().pipe(z.email()),
   name: StringNoHTMLNonEmpty.refine((value) => noUrlCheck(value), {
     message: "Input should not contain a URL",
   }).refine((value) => /^[a-zA-Z0-9\s]+$/.test(value), {

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -99,7 +99,11 @@ const staticProviders: Provider[] = [
         );
 
       const blockedDomains = getSSOBlockedDomains();
-      const domain = credentials.email.split("@")[1]?.toLowerCase();
+      // Trim before any use: iOS/Android keyboards and autofill providers
+      // routinely append a trailing space, and Postgres email lookups are
+      // exact-match, so " a@b.com " would fail against the stored a@b.com.
+      const email = credentials.email.trim().toLowerCase();
+      const domain = email.split("@")[1];
       if (domain && blockedDomains.includes(domain)) {
         throw new Error(
           "Sign in with email and password is disabled for this domain. Please use SSO.",
@@ -115,7 +119,7 @@ const staticProviders: Provider[] = [
 
       const dbUser = await prisma.user.findUnique({
         where: {
-          email: credentials.email.toLowerCase(),
+          email,
         },
       });
 


### PR DESCRIPTION
## What does this PR do?

Autofill providers and mobile keyboards routinely append a trailing space to email inputs. Email lookups are exact-match on `email` (Postgres), so a user whose signup stored `a@b.com` cannot sign in with `a@b.com ` — the lookup misses and returns `Invalid credentials` with no hint why.

Normalize with `.trim().toLowerCase()` at every credentials boundary:
- `web/src/server/auth.ts` `authorize()` lookup (and its SSO domain check)
- `web/src/features/auth-credentials/lib/credentialsServerUtils.ts` `createUserEmailPassword` (lookup + storage)
- `web/src/pages/api/auth/signup-verify.ts` `normalizedEmail`

Fixes #15780

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] My code follows the style guidelines
- [x] I have checked if my changes generate no new warnings


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR trims and lowercases email addresses during credentials sign-in, credentials-user creation, and email-verification signup. However, signup validation still precedes trimming, and direct signup applies SSO eligibility checks to a different representation than the one now persisted.
- Normalizes credentials lookups and SSO-domain extraction during password sign-in.
- Normalizes credentials email lookup and storage during account creation.
- Normalizes the email used by the signup-verification handler after schema validation.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

This PR should not merge until signup trims before validation and direct-signup SSO eligibility uses the same canonical email that is persisted.

The email-verification path can reject whitespace before reaching the new normalization, while direct signup can check an altered raw domain and then create the canonical account for an SSO-enforced identity.

**Files Needing Attention:** web/src/pages/api/auth/signup-verify.ts, web/src/features/auth-credentials/lib/credentialsServerUtils.ts, and the direct-signup eligibility call in web/src/features/auth-credentials/server/signupApiHandler.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

Direct signup can evaluate SSO enforcement against an untrimmed domain and then persist the trimmed canonical identity, allowing an SSO-enforced address to be created through password signup. **How this was verified:** The direct-signup caller passes raw email to domain eligibility checks before the changed creation function trims and persists it.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Raw signup email] --> B{Email schema validation}
  B -->|Rejected before trim| C[422 response]
  B -->|Accepted| D[Eligibility and SSO checks]
  D -->|Direct signup uses raw domain| E[Whitespace can alter domain comparison]
  D --> F[Trim and lowercase]
  E --> F
  F --> G[Canonical user lookup or creation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/pages/api/auth/signup-verify.ts:47
**Validation precedes email trimming**

When autofill or a mobile keyboard adds surrounding whitespace, `z.email()` validates the raw value and returns 422 before this normalization executes, so the email-verification signup flow still rejects the input this change is intended to accept.

### Issue 2
web/src/features/auth-credentials/lib/credentialsServerUtils.ts:30
**Canonicalization bypasses SSO enforcement**

When direct signup receives an SSO-enforced address with trailing whitespace, the caller checks the untrimmed domain before this function trims and stores the canonical address, allowing password signup to create the canonical user and initial memberships for a domain that requires SSO.

**How this was verified:** The direct-signup caller passes the raw email to domain eligibility checks before this changed function trims and persists it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): trim whitespace around emails..."](https://github.com/langfuse/langfuse/commit/09e60bf9890425e701699f536277f5c431ba5917) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57107751)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)

<!-- /greptile_comment -->