### PR TITLE
fix(annotation-queues): skip audit log for idempotent re-assignments

### DIFF
--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -583,7 +583,18 @@ export const createAnnotationQueueAssignmentForApi = async ({
     userId: input.userId,
   };
 
-  // Create the assignment (upsert to handle duplicates gracefully)
+  // Create the assignment (upsert to handle duplicates gracefully). The
+  // pre-check distinguishes a real grant from an idempotent re-assignment so
+  // the audit trail only records actual state changes - this endpoint is
+  // reachable from the public API, where clients may re-sync assignments on
+  // a schedule.
+  const existingAssignment = await prisma.annotationQueueAssignment.findUnique({
+    where: {
+      projectId_queueId_userId: assignmentWhere,
+    },
+    select: { id: true },
+  });
+
   const assignment = await prisma.annotationQueueAssignment.upsert({
     where: {
       projectId_queueId_userId: assignmentWhere,
@@ -592,8 +603,7 @@ export const createAnnotationQueueAssignmentForApi = async ({
     update: {},
   });
 
-  // TODO: only create audit log if upsert actually creates a new record
-  if (auditScope) {
+  if (auditScope && !existingAssignment) {
     await auditLog({
       action: "create",
       resourceType: "annotationQueueAssignment",

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -583,18 +583,13 @@ export const createAnnotationQueueAssignmentForApi = async ({
     userId: input.userId,
   };
 
-  // Create the assignment (upsert to handle duplicates gracefully). The
-  // pre-check distinguishes a real grant from an idempotent re-assignment so
-  // the audit trail only records actual state changes - this endpoint is
-  // reachable from the public API, where clients may re-sync assignments on
-  // a schedule.
-  const existingAssignment = await prisma.annotationQueueAssignment.findUnique({
-    where: {
-      projectId_queueId_userId: assignmentWhere,
-    },
-    select: { id: true },
-  });
-
+  // Use the upsert result itself to decide whether to audit: a freshly
+  // created row has createdAt === updatedAt (Prisma @updatedAt is only
+  // bumped on update). This is atomic - no extra read, so concurrent
+  // re-assigns cannot both observe "no existing row" and double-log.
+  // update:{} is intentionally empty for the idempotent path; the
+  // timestamp comparison still works because @updatedAt stays equal to
+  // createdAt only on insertion.
   const assignment = await prisma.annotationQueueAssignment.upsert({
     where: {
       projectId_queueId_userId: assignmentWhere,
@@ -603,7 +598,10 @@ export const createAnnotationQueueAssignmentForApi = async ({
     update: {},
   });
 
-  if (auditScope && !existingAssignment) {
+  const isNewlyCreated =
+    assignment.createdAt.getTime() === assignment.updatedAt.getTime();
+
+  if (auditScope && isNewlyCreated) {
     await auditLog({
       action: "create",
       resourceType: "annotationQueueAssignment",


### PR DESCRIPTION
## What does this PR do?

`createAnnotationQueueAssignment` upserts with an empty `update: {}` branch and then unconditionally wrote an `action: "create"` audit log, so re-assigning an already-assigned user appended a spurious grant record every time. Clients syncing assignments via the public API on a schedule inflated the compliance trail with entries that do not correspond to state changes.

Pre-check the assignment with `findUnique` before the upsert and audit only a genuine first grant. The `TODO` asking for exactly this is removed.

Fixes #15735

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] My code follows the style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR suppresses spurious assignment grant audit records by checking whether an assignment exists before upserting it. The new pre-check is not atomic with the mutation, so concurrent assignment operations can still corrupt the audit trail.

- Adds an assignment existence lookup before the existing upsert.
- Writes a create audit record only when the lookup reports no existing assignment.
- Removes the TODO covering idempotent assignment auditing.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until the assignment mutation and audit decision are made atomic, because concurrent requests can leave an inaccurate compliance trail.

The public and MCP assignment paths can overlap, and the separate existence check, upsert, and audit transaction allow one state transition to receive duplicate records or a recreated assignment to receive none.

**Files Needing Attention:** web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

The non-atomic existence check permits concurrent public assignment operations to produce duplicate or missing grant records, undermining the integrity of the access-sensitive audit trail.
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Request A
  participant B as Request B
  participant DB as PostgreSQL
  participant Audit as Audit log
  A->>DB: findUnique()
  DB-->>A: not found
  B->>DB: findUnique()
  DB-->>B: not found
  A->>DB: upsert (insert)
  B->>DB: upsert (no-op update)
  A->>Audit: create grant record
  B->>Audit: create grant record
  Note over Audit: Two records for one state transition
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/annotation-queues/server/publicAnnotationQueueService.ts:591-596
**Non-atomic audit decision**

If assignment requests overlap, both calls can observe no assignment before their upserts and write two create audit records for one grant; a concurrent deletion can likewise make this call recreate the assignment while suppressing its create record. The audit decision must be coupled atomically to the assignment state transition.

**How this was verified:** The existence check, upsert, and audit write execute as separate database operations, while the assignment uniqueness constraint protects only the upsert itself.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(annotation-queues): skip audit log f..."](https://github.com/langfuse/langfuse/commit/e38fce1b72b9381b6500661ea15a2b102ff1e1fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57108714)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Identity, access, and tenancy](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/identity-access-and-tenancy.md)

<!-- /greptile_comment -->