### PR TITLE
fix: prevent OTel prototype-chain clobbering on v3

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1456,11 +1456,16 @@ export class OtelIngestionProcessor {
       for (let i = 0; i < path.length - 1; i++) {
         const key = path[i];
         if (DANGEROUS_KEYS.has(key)) return;
-        if (!(key in current)) {
+        if (!Object.hasOwn(current, key)) {
           // Check if next key is a number to decide if we need an array or object
-          current[key] = /^\d+$/.test(path[i + 1]) ? [] : {};
+          current[key] = /^\d+$/.test(path[i + 1]) ? [] : Object.create(null);
         }
-        current = current[key];
+        const next = current[key];
+        if (typeof next !== "object" || next === null) {
+          // Preserve an earlier leaf value when a later attribute conflicts.
+          return;
+        }
+        current = next;
       }
       const finalKey = path[path.length - 1];
       if (!DANGEROUS_KEYS.has(finalKey)) {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -8504,6 +8504,159 @@ describe("OTel Resource Span Mapping", () => {
 
   describe("Prototype pollution protection", () => {
     const publicKey = "pk-lf-1234567890";
+    const traceId = "abcdef1234567890abcdef1234567890";
+    const spanId = "abcdef1234567890";
+
+    const createResourceSpan = (
+      attributes: Array<{ key: string; value: Record<string, unknown> }>,
+    ): ResourceSpan => ({
+      resource: {
+        attributes: [
+          {
+            key: "service.name",
+            value: { stringValue: "test-service" },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: {
+            name: "langfuse-sdk",
+            version: "2.0.0",
+            attributes: [
+              {
+                key: "public_key",
+                value: { stringValue: publicKey },
+              },
+            ],
+          },
+          spans: [
+            {
+              traceId: Buffer.from(traceId, "hex"),
+              spanId: Buffer.from(spanId, "hex"),
+              name: "prototype-protection-test",
+              kind: 1,
+              startTimeUnixNano: {
+                low: 1000000000,
+                high: 0,
+              },
+              endTimeUnixNano: {
+                low: 2000000000,
+                high: 0,
+              },
+              attributes,
+              status: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    const convertAndObserveHasOwnPropertyCall = async (
+      attributes: Array<{ key: string; value: Record<string, unknown> }>,
+    ) => {
+      const hasOwnPropertyFunction = Object.prototype.hasOwnProperty;
+      const originalCall = hasOwnPropertyFunction.call;
+      const originalCallDescriptor = Object.getOwnPropertyDescriptor(
+        hasOwnPropertyFunction,
+        "call",
+      );
+
+      try {
+        const events = await convertOtelSpanToIngestionEvent(
+          createResourceSpan(attributes),
+          new Set([traceId]),
+          publicKey,
+        );
+        return {
+          events,
+          observedCall: hasOwnPropertyFunction.call,
+          originalCall,
+        };
+      } finally {
+        if (originalCallDescriptor) {
+          Object.defineProperty(
+            hasOwnPropertyFunction,
+            "call",
+            originalCallDescriptor,
+          );
+        } else {
+          delete (hasOwnPropertyFunction as { call?: unknown }).call;
+        }
+      }
+    };
+
+    it("should not traverse inherited properties in nested gen_ai.prompt attributes", async () => {
+      const { events, observedCall, originalCall } =
+        await convertAndObserveHasOwnPropertyCall([
+          {
+            key: "gen_ai.prompt.a.safe",
+            value: { stringValue: "still-here" },
+          },
+          {
+            key: "gen_ai.prompt.a.hasOwnProperty.call",
+            value: { stringValue: "pwned" },
+          },
+        ]);
+
+      expect(observedCall).toBe(originalCall);
+      expect(
+        events.find((event) => event.type === "span-create")?.body.input,
+      ).toMatchObject({
+        a: {
+          safe: "still-here",
+          hasOwnProperty: { call: "pwned" },
+        },
+      });
+    });
+
+    it("should not traverse inherited properties through an array branch", async () => {
+      const { events, observedCall, originalCall } =
+        await convertAndObserveHasOwnPropertyCall([
+          {
+            key: "gen_ai.prompt.a.0",
+            value: { stringValue: "seed" },
+          },
+          {
+            key: "gen_ai.prompt.a.hasOwnProperty.call",
+            value: { stringValue: "pwned" },
+          },
+        ]);
+
+      expect(observedCall).toBe(originalCall);
+      const input = events.find((event) => event.type === "span-create")?.body
+        .input as { a?: unknown[] } | undefined;
+      expect(input?.a?.[0]).toBe("seed");
+      expect(Object.hasOwn(input?.a ?? [], "hasOwnProperty")).toBe(true);
+      expect(Reflect.get(input?.a ?? [], "hasOwnProperty")).toMatchObject({
+        call: "pwned",
+      });
+    });
+
+    it("should preserve a scalar leaf and ignore a conflicting nested attribute", () => {
+      const events = createTestOtelProcessor({ publicKey }).processToEvent([
+        createResourceSpan([
+          {
+            key: "gen_ai.prompt.a",
+            value: { stringValue: "leaf" },
+          },
+          {
+            key: "gen_ai.prompt.a.b",
+            value: { stringValue: "nested" },
+          },
+          {
+            key: "gen_ai.prompt.safe",
+            value: { stringValue: "still-here" },
+          },
+        ]),
+      ]);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].input).toMatchObject({
+        a: "leaf",
+        safe: "still-here",
+      });
+    });
 
     it("should not pollute Object.prototype via __proto__ in gen_ai.prompt attributes", async () => {
       const traceId = "abcdef1234567890abcdef1234567890";


### PR DESCRIPTION
## Summary

- Backport #16616 onto the supported v3 line.
- Avoid inherited-property traversal while constructing nested OTel attributes.
- Use null-prototype intermediate objects and preserve an earlier scalar when a later nested path conflicts.
- Add regression coverage for object and array branches that attempt to clobber `Object.prototype.hasOwnProperty.call`.

## Impacted packages

- `packages/shared`
- `web` (server regression coverage)

## Verification

- Regression-only baseline: `Tests 3 failed | 1 passed` (confirmed the vulnerable v3 behavior).
- `pnpm --filter web run test src/__tests__/server/api/otel/otelMapping.servertest.ts`
  - `Tests 224 passed | 1 skipped (225)`
- `pnpm --filter worker run test src/queues/__tests__/otelFlueMapping.test.ts`
  - `Tests 6 passed (6)`
- `pnpm run lint`
  - `Tasks: 7 successful, 7 total`
- `pnpm run typecheck`
  - `Tasks: 7 successful, 7 total`
- Stable Git patch ID matches the upstream squash commit exactly: `77a88aa435a9b8372f86428f0cbba2991df75f5f`.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport hardens nested OpenTelemetry attribute mapping against inherited-property traversal and scalar-path conflicts.
- Uses own-property checks and null-prototype intermediate objects.
- Preserves an earlier scalar when a later nested path conflicts.
- Adds regression coverage for object and array prototype-chain clobbering paths.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: retrigger backport checks"](https://github.com/langfuse/langfuse/commit/4b6bdcf87c2f1e25ed5b3fe2adf161e6ef0832da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57114056)</sub>

<!-- /greptile_comment -->