### PR TITLE
feat(in-app-agent): default Assistant worker surfaces to LANGFUSE_IN_APP_AGENT_ENABLED

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -231,8 +231,11 @@ LANGFUSE_IN_APP_AGENT_AWS_PROFILE="playground"
 # Optional: overrides Lambda's default INTERNET_EGRESS connector.
 # LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN="arn:aws:lambda:us-east-1:123456789012:network-connector:langfuse-in-app-agent-sandbox-egress"
 
-# Workers with LANGFUSE_IN_APP_AGENT_ENABLED=true consume the run queue and
-# reconcile stale runs. Without that flag, queued turns die at queue_timeout.
+# Workers follow LANGFUSE_IN_APP_AGENT_ENABLED for the run queue and integrity
+# runner. Without that flag, queued turns die at queue_timeout. Split-role
+# workers can opt out without turning the instance off:
+# QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED=false
+# LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED=false
 # LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY=5
 # LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_INTERVAL_MS=900000
 

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -231,12 +231,9 @@ LANGFUSE_IN_APP_AGENT_AWS_PROFILE="playground"
 # Optional: overrides Lambda's default INTERNET_EGRESS connector.
 # LANGFUSE_IN_APP_AGENT_SANDBOX_AWS_LAMBDA_MICROVM_EGRESS_NETWORK_CONNECTOR_ARN="arn:aws:lambda:us-east-1:123456789012:network-connector:langfuse-in-app-agent-sandbox-egress"
 
-# Turns run in background by default; without the consumer they die at queue_timeout.
-QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED="true"
+# Workers with LANGFUSE_IN_APP_AGENT_ENABLED=true consume the run queue and
+# reconcile stale runs. Without that flag, queued turns die at queue_timeout.
 # LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY=5
-
-# Reconciles stale runs that nobody reopened, then reports remainders.
-# LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED="false"
 # LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_INTERVAL_MS=900000
 
 # Web-only admission ceilings.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -304,10 +304,9 @@ LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=true
 # Origin only, the app appends /v1
 # LANGFUSE_AI_BASE_URL=https://api.anthropic.com
 
-# Worker that executes Assistant runs. Without the consumer, runs never start.
-# The integrity runner reconciles runs abandoned by a crashed worker.
-# QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED=true
-# LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED=true
+# Workers with LANGFUSE_IN_APP_AGENT_ENABLED=true consume the run queue and
+# reconcile stale runs. Unset it on workers that should not execute Assistant
+# jobs (ingestion-only).
 # LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY=5
 
 # Admission ceilings for concurrent Assistant runs, web only

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -304,9 +304,11 @@ LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=true
 # Origin only, the app appends /v1
 # LANGFUSE_AI_BASE_URL=https://api.anthropic.com
 
-# Workers with LANGFUSE_IN_APP_AGENT_ENABLED=true consume the run queue and
-# reconcile stale runs. Unset it on workers that should not execute Assistant
-# jobs (ingestion-only).
+# Workers follow LANGFUSE_IN_APP_AGENT_ENABLED for the run queue and integrity
+# runner. Split-role workers (ingestion-only) can opt out without turning the
+# instance off:
+# QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED=false
+# LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED=false
 # LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY=5
 
 # Admission ceilings for concurrent Assistant runs, web only

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -95,9 +95,6 @@ services:
     environment:
       <<: *langfuse-web-env
       # In-app agent worker settings (ignored by the web service).
-      # Compose defaults the queue consumer on; the worker schema defaults it
-      # off so ingestion-only processes do not consume agent jobs.
-      QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED: ${QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED:-true}
       LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY: ${LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY:-}
       LANGFUSE_IN_APP_AGENT_AWS_PROFILE: ${LANGFUSE_IN_APP_AGENT_AWS_PROFILE:-}
       LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER: ${LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,6 @@ services:
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
       AWS_PROFILE: ${AWS_PROFILE:-}
       # In-app agent worker settings (ignored by the web service).
-      # Compose defaults the queue consumer on; the worker schema defaults it
-      # off so ingestion-only processes do not consume agent jobs.
-      QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED: ${QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED:-true}
       LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY: ${LANGFUSE_IN_APP_AGENT_RUN_QUEUE_PROCESSING_CONCURRENCY:-}
       LANGFUSE_IN_APP_AGENT_AWS_PROFILE: ${LANGFUSE_IN_APP_AGENT_AWS_PROFILE:-}
       LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER: ${LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER:-}

--- a/packages/shared/src/in-app-agent/server/modelProvider.test.ts
+++ b/packages/shared/src/in-app-agent/server/modelProvider.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { env } from "../../env";
 import { logger } from "../../server/logger";
-import { getInAppAgentModelConfig } from "./modelProvider";
+import {
+  getInAppAgentModelConfig,
+  isInAppAgentInstanceEnabled,
+} from "./modelProvider";
 
 const original = {
   LANGFUSE_AI_PROVIDER: env.LANGFUSE_AI_PROVIDER,
@@ -11,6 +14,7 @@ const original = {
   LANGFUSE_AI_API_KEY: env.LANGFUSE_AI_API_KEY,
   LANGFUSE_AI_BASE_URL: env.LANGFUSE_AI_BASE_URL,
   LANGFUSE_AI_AWS_BEDROCK_REGION: env.LANGFUSE_AI_AWS_BEDROCK_REGION,
+  LANGFUSE_IN_APP_AGENT_ENABLED: env.LANGFUSE_IN_APP_AGENT_ENABLED,
   NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
 };
 
@@ -145,5 +149,25 @@ describe("getInAppAgentModelConfig", () => {
       titleModelId: "eu.anthropic.claude-opus-5",
       region: undefined,
     });
+  });
+});
+
+describe("isInAppAgentInstanceEnabled", () => {
+  it("enables the self-hosted worker when LANGFUSE_IN_APP_AGENT_ENABLED is true", () => {
+    Object.assign(env, {
+      NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+      LANGFUSE_IN_APP_AGENT_ENABLED: "true",
+    });
+
+    expect(isInAppAgentInstanceEnabled()).toBe(true);
+  });
+
+  it("disables the self-hosted worker when LANGFUSE_IN_APP_AGENT_ENABLED is unset", () => {
+    Object.assign(env, {
+      NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+      LANGFUSE_IN_APP_AGENT_ENABLED: undefined,
+    });
+
+    expect(isInAppAgentInstanceEnabled()).toBe(false);
   });
 });

--- a/web/src/features/in-app-agent/README.md
+++ b/web/src/features/in-app-agent/README.md
@@ -154,9 +154,9 @@ separate click event would answer.
 Rollback is a code revert; background execution does not require a schema
 rollback.
 
-`QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED` must be on wherever turns run
-in background, otherwise runs commit as `QUEUED` and die at `queue_timeout`. It
-is already enabled in every Langfuse Cloud region. Check
+Workers with `LANGFUSE_IN_APP_AGENT_ENABLED` set consume the run queue and
+reconcile stale runs; without it, runs commit as `QUEUED` and die at
+`queue_timeout`. Cloud is on unless the flag is `"false"`. Check
 `LANGFUSE_IN_APP_AGENT_MAX_ACTIVE_RUNS_PER_ORG` against execution capacity too:
 its default of 20 equals full US capacity and exceeds JP and staging.
 
@@ -165,8 +165,9 @@ statuses remain separate project concerns.
 
 Environment ownership:
 
-- Worker: queue enable/concurrency, sandbox provider and Lambda MicroVM values,
-  and development-only `LANGFUSE_IN_APP_AGENT_AWS_PROFILE`.
+- Worker: queue concurrency, sandbox provider and Lambda MicroVM values,
+  and development-only `LANGFUSE_IN_APP_AGENT_AWS_PROFILE`. Enablement is
+  `LANGFUSE_IN_APP_AGENT_ENABLED` (shared with web).
 - Fixed lifecycle policy: queue timeout (300000 ms), maximum run duration
   (900000 ms), and approval TTL (86400000 ms). These are shared constants, so
   web and worker cannot diverge.

--- a/web/src/features/in-app-agent/README.md
+++ b/web/src/features/in-app-agent/README.md
@@ -156,7 +156,11 @@ rollback.
 
 Workers with `LANGFUSE_IN_APP_AGENT_ENABLED` set consume the run queue and
 reconcile stale runs; without it, runs commit as `QUEUED` and die at
-`queue_timeout`. Cloud is on unless the flag is `"false"`. Check
+`queue_timeout`. Cloud is on unless the flag is `"false"`. Split-role workers
+can keep the instance on and set
+`QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED=false` (and
+`LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED=false`) to skip those
+surfaces. Check
 `LANGFUSE_IN_APP_AGENT_MAX_ACTIVE_RUNS_PER_ORG` against execution capacity too:
 its default of 20 equals full US capacity and exceeds JP and staging.
 
@@ -167,7 +171,8 @@ Environment ownership:
 
 - Worker: queue concurrency, sandbox provider and Lambda MicroVM values,
   and development-only `LANGFUSE_IN_APP_AGENT_AWS_PROFILE`. Enablement is
-  `LANGFUSE_IN_APP_AGENT_ENABLED` (shared with web).
+  `LANGFUSE_IN_APP_AGENT_ENABLED` (shared with web); optional `"false"`
+  queue and integrity flags opt a split-role worker out.
 - Fixed lifecycle policy: queue timeout (300000 ms), maximum run duration
   (900000 ms), and approval TTL (86400000 ms). These are shared constants, so
   web and worker cannot diverge.

--- a/worker/AGENTS.md
+++ b/worker/AGENTS.md
@@ -68,8 +68,10 @@
 - `src/features/in-app-agent/runtime/` owns Mastra adaptation, agent execution,
   instrumentation, prompt loading, continuation handling, tools, skills, and
   sandbox providers.
-- Worker env owns queue consumer/concurrency, sandbox configuration, and the
-  development-only in-app-agent AWS profile. Shared lifecycle policy values
+- Worker env owns queue concurrency, sandbox configuration, and the
+  development-only in-app-agent AWS profile. Enablement is
+  `LANGFUSE_IN_APP_AGENT_ENABLED` via `isInAppAgentInstanceEnabled()` (queue
+  consumer, DLQ retry, and integrity runner). Shared lifecycle policy values
   are fixed constants, so web and worker cannot diverge.
 - Persisted/queued contracts, lifecycle, storage, MCP policy, tool-result
   handling, and the seeded system prompt remain explicit shared subpaths.

--- a/worker/AGENTS.md
+++ b/worker/AGENTS.md
@@ -70,9 +70,12 @@
   sandbox providers.
 - Worker env owns queue concurrency, sandbox configuration, and the
   development-only in-app-agent AWS profile. Enablement is
-  `LANGFUSE_IN_APP_AGENT_ENABLED` via `isInAppAgentInstanceEnabled()` (queue
-  consumer, DLQ retry, and integrity runner). Shared lifecycle policy values
-  are fixed constants, so web and worker cannot diverge.
+  `LANGFUSE_IN_APP_AGENT_ENABLED` via `isInAppAgentInstanceEnabled()`. Optional
+  `QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED=false` and
+  `LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED=false` opt a split-role
+  worker out of the queue consumer (and nested DLQ retry) or integrity runner.
+  Shared lifecycle policy values are fixed constants, so web and worker cannot
+  diverge.
 - Persisted/queued contracts, lifecycle, storage, MCP policy, tool-result
   handling, and the seeded system prompt remain explicit shared subpaths.
 

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -49,6 +49,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { monitorProcessorTtl } from "@langfuse/shared/monitors/server";
 import { IN_APP_AGENT_RUN_MAX_DURATION_MS } from "@langfuse/shared/in-app-agent/server/tunables";
+import { isInAppAgentInstanceEnabled } from "@langfuse/shared/in-app-agent/server/modelProvider";
 import { env, v4WritesToEventsTable } from "./env";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
 import { BackgroundMigrationManager } from "./backgroundMigrations/backgroundMigrationManager";
@@ -429,7 +430,7 @@ if (env.QUEUE_CONSUMER_MONITOR_QUEUE_IS_ENABLED === "true") {
 
 export let inAppAgentDlqRetryRunner: InAppAgentDlqRetryRunner | null = null;
 
-if (env.QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED === "true") {
+if (isInAppAgentInstanceEnabled()) {
   WorkerManager.register(
     QueueName.InAppAgentRunQueue,
     inAppAgentRunQueueProcessor,
@@ -777,7 +778,7 @@ if (env.LANGFUSE_TRACE_DELETE_BATCH_ACTION_RUNNER_ENABLED === "true") {
 // Reconciles stale in-app agent runs that nobody reopened, then reports remainders.
 export let inAppAgentIntegrityRunner: InAppAgentIntegrityRunner | null = null;
 
-if (env.LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED === "true") {
+if (isInAppAgentInstanceEnabled()) {
   inAppAgentIntegrityRunner = new InAppAgentIntegrityRunner();
   inAppAgentIntegrityRunner.start();
 }

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -49,8 +49,8 @@ import {
 } from "@langfuse/shared/src/server";
 import { monitorProcessorTtl } from "@langfuse/shared/monitors/server";
 import { IN_APP_AGENT_RUN_MAX_DURATION_MS } from "@langfuse/shared/in-app-agent/server/tunables";
-import { isInAppAgentInstanceEnabled } from "@langfuse/shared/in-app-agent/server/modelProvider";
 import { env, v4WritesToEventsTable } from "./env";
+import { isInAppAgentWorkerSurfaceEnabled } from "./features/in-app-agent/enablement";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
 import { BackgroundMigrationManager } from "./backgroundMigrations/backgroundMigrationManager";
 import { prisma } from "@langfuse/shared/src/db";
@@ -430,7 +430,11 @@ if (env.QUEUE_CONSUMER_MONITOR_QUEUE_IS_ENABLED === "true") {
 
 export let inAppAgentDlqRetryRunner: InAppAgentDlqRetryRunner | null = null;
 
-if (isInAppAgentInstanceEnabled()) {
+if (
+  isInAppAgentWorkerSurfaceEnabled(
+    env.QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED,
+  )
+) {
   WorkerManager.register(
     QueueName.InAppAgentRunQueue,
     inAppAgentRunQueueProcessor,
@@ -778,7 +782,11 @@ if (env.LANGFUSE_TRACE_DELETE_BATCH_ACTION_RUNNER_ENABLED === "true") {
 // Reconciles stale in-app agent runs that nobody reopened, then reports remainders.
 export let inAppAgentIntegrityRunner: InAppAgentIntegrityRunner | null = null;
 
-if (isInAppAgentInstanceEnabled()) {
+if (
+  isInAppAgentWorkerSurfaceEnabled(
+    env.LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED,
+  )
+) {
   inAppAgentIntegrityRunner = new InAppAgentIntegrityRunner();
   inAppAgentIntegrityRunner.start();
 }

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -234,6 +234,11 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_MONITOR_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
+  // Optional opt-out for split-role workers. Unset follows
+  // LANGFUSE_IN_APP_AGENT_ENABLED; "false" skips this surface.
+  QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .optional(),
   // The ambient host profile takes precedence over the agent-specific default
   // so local developer credentials win when both are configured.
   AWS_PROFILE: z.string().optional(),
@@ -646,6 +651,11 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(5),
+  // Optional opt-out for split-role workers. Unset follows
+  // LANGFUSE_IN_APP_AGENT_ENABLED; "false" skips this surface.
+  LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED: z
+    .enum(["true", "false"])
+    .optional(),
   // Default 15 minutes. Do not go below the heartbeat-stale window (60s) or a
   // live worker can lose the race. Faster also adds no resolution: every
   // deadline this runner reports against is 5 minutes or longer.

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -234,16 +234,6 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_MONITOR_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
-  // Opt-in because only workers provisioned for agent execution should consume
-  // durable runs; ingestion-only workers must leave this disabled.
-  QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED: z
-    .enum(["true", "false"])
-    .default("false"),
-  // Reconciles stale runs that nobody reopened. Off by default: one elected
-  // worker per region is enough.
-  LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED: z
-    .enum(["true", "false"])
-    .default("false"),
   // The ambient host profile takes precedence over the agent-specific default
   // so local developer credentials win when both are configured.
   AWS_PROFILE: z.string().optional(),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -234,9 +234,12 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_MONITOR_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
-  // Optional opt-out for split-role workers. Unset follows
-  // LANGFUSE_IN_APP_AGENT_ENABLED; "false" skips this surface.
+  // Optional opt-outs for split-role workers. Unset follows
+  // LANGFUSE_IN_APP_AGENT_ENABLED; "false" skips that surface.
   QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .optional(),
+  LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED: z
     .enum(["true", "false"])
     .optional(),
   // The ambient host profile takes precedence over the agent-specific default
@@ -651,11 +654,6 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(5),
-  // Optional opt-out for split-role workers. Unset follows
-  // LANGFUSE_IN_APP_AGENT_ENABLED; "false" skips this surface.
-  LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED: z
-    .enum(["true", "false"])
-    .optional(),
   // Default 15 minutes. Do not go below the heartbeat-stale window (60s) or a
   // live worker can lose the race. Faster also adds no resolution: every
   // deadline this runner reports against is 5 minutes or longer.

--- a/worker/src/features/in-app-agent/enablement.test.ts
+++ b/worker/src/features/in-app-agent/enablement.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isInAppAgentWorkerSurfaceEnabled } from "./enablement";
+
+const mocks = vi.hoisted(() => ({
+  instanceEnabled: true,
+}));
+
+vi.mock("@langfuse/shared/in-app-agent/server/modelProvider", () => ({
+  isInAppAgentInstanceEnabled: () => mocks.instanceEnabled,
+}));
+
+afterEach(() => {
+  mocks.instanceEnabled = true;
+});
+
+describe("isInAppAgentWorkerSurfaceEnabled", () => {
+  it("follows the instance switch when the override is unset", () => {
+    expect(isInAppAgentWorkerSurfaceEnabled(undefined)).toBe(true);
+  });
+
+  it("opts out when the override is false even if the instance is on", () => {
+    expect(isInAppAgentWorkerSurfaceEnabled("false")).toBe(false);
+  });
+
+  it("stays off when the instance is off even if the override is true", () => {
+    mocks.instanceEnabled = false;
+
+    expect(isInAppAgentWorkerSurfaceEnabled("true")).toBe(false);
+  });
+});

--- a/worker/src/features/in-app-agent/enablement.ts
+++ b/worker/src/features/in-app-agent/enablement.ts
@@ -1,0 +1,11 @@
+import { isInAppAgentInstanceEnabled } from "@langfuse/shared/in-app-agent/server/modelProvider";
+
+/**
+ * Instance switch is the default. Explicit `"false"` opts a split-role
+ * worker out of this surface.
+ */
+export function isInAppAgentWorkerSurfaceEnabled(
+  override?: "true" | "false",
+): boolean {
+  return isInAppAgentInstanceEnabled() && override !== "false";
+}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16646.preview.langfuse.com](https://pr-16646.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Workers follow `LANGFUSE_IN_APP_AGENT_ENABLED` for the Assistant run queue (and nested DLQ retry) and the integrity runner. OSS operators set one switch.
- Optional opt-outs stay in the worker schema with no default: `QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED` and `LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED`. Unset follows the instance flag. `"false"` skips that surface on this worker even when the instance is on. `"true"` is redundant with the instance being on.
- Split-role Cloud already sets both opt-outs to `"false"` on the ingestion worker. No infra change is required for that role to stay out of Assistant work.
- Do not derive availability from “is a model configured”: `LANGFUSE_AI_*` is shared with Ask AI, which is deliberately *not* gated by this flag.

**Impacted packages:** `worker`, `@langfuse/shared` (tests), env examples, in-app-agent README.

## Operator notes

Self-hosted with one worker: set `LANGFUSE_IN_APP_AGENT_ENABLED=true`. Leave the two opt-outs unset.

Self-hosted or Cloud with an ingestion-only worker: keep the instance flag on for the product, and set `QUEUE_CONSUMER_IN_APP_AGENT_RUN_QUEUE_IS_ENABLED=false` and `LANGFUSE_IN_APP_AGENT_INTEGRITY_RUNNER_ENABLED=false` on that worker.

Cloud is on unless `LANGFUSE_IN_APP_AGENT_ENABLED` is `"false"`. Unset opt-outs on Cloud therefore follow the instance and start consuming.

Stock Compose still has one worker and does not forward the opt-outs.

## Docs coupling

[langfuse-docs#3619](https://github.com/langfuse/langfuse-docs/pull/3619) should treat `LANGFUSE_IN_APP_AGENT_ENABLED` as the operator switch and mention the two opt-outs only as split-role extras. That PR is blocked on this change plus #16581, and it carries a `{/* TODO before merge */}` to bump the stated `>=v4.21.0` floor. `v4.21.0` is already tagged, so the docs floor should become **`>=v4.22.0`** (or whichever release ships this and #16581).

Unrelated one-line docs fix: `langfuse-docs` `content/self-hosting/configuration/index.mdx` documents `QUEUE_CONSUMER_CODE_EVAL_EXECUTION_QUEUE_IS_ENABLED` as defaulting to `false`, but `worker/src/env.ts` says `.default("true")`.

## Type of change

- [x] Breaking change (self-hosted workers that set the instance flag and previously relied on the queue consumer defaulting to `false` will start consuming)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Test plan

- [x] `pnpm --filter @langfuse/shared run test src/in-app-agent/server/modelProvider.test.ts` — `Tests 9 passed (9)`
- [x] `pnpm --filter worker run test enablement.test.ts` — `Tests 3 passed (3)`
- [x] `pnpm --filter worker run test` for in-app-agent suites — `Tests 37 passed (37)`
- [x] `pnpm run lint` — `Tasks: 7 successful, 7 total`
- [x] `pnpm tc` — `Tasks: 8 successful, 8 total`
- [x] Boot worker with `LANGFUSE_IN_APP_AGENT_ENABLED=true`: run queue, DLQ retry, and integrity start; health 200
- [x] Boot with the flag unset: none of those three start; health 200
- [x] Confirm Cloud ingestion worker already sets both opt-outs to `"false"` (no infra PR)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes Assistant worker surfaces inherit the instance-level in-app-agent switch while retaining per-worker opt-outs.
- Gates the run queue, nested dead-letter retry, and integrity runner through shared enablement logic.
- Makes both worker-specific surface flags optional.
- Updates Compose configuration, environment examples, tests, and operator documentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  I[LANGFUSE_IN_APP_AGENT_ENABLED] --> H{Instance enabled?}
  H -->|No| O[Worker surfaces remain off]
  H -->|Yes| Q{Run queue override is false?}
  Q -->|No| C[Start run queue consumer and DLQ retry]
  Q -->|Yes| QO[Skip run queue surface]
  H -->|Yes| R{Integrity override is false?}
  R -->|No| IR[Start integrity runner]
  R -->|Yes| RO[Skip integrity surface]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into lfe-15655-colla..."](https://github.com/langfuse/langfuse/commit/f0516f7b3ffddce287b666286883ea61f51cb183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57152810)</sub>

**Context used:**

- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)
- Knowledge Base — [In-app agent execution](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent-execution.md)

<!-- /greptile_comment -->