### PR TITLE
feat(web): capture core-surface usage events for feature health tracking

### DIFF
--- a/web/src/components/BatchExportTableButton.tsx
+++ b/web/src/components/BatchExportTableButton.tsx
@@ -22,6 +22,7 @@ import React from "react";
 import { api } from "@/src/utils/api";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 export type BatchExportTableButtonProps = {
   projectId: string;
@@ -36,6 +37,7 @@ export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
   props,
 ) => {
   const [isExporting, setIsExporting] = React.useState(false);
+  const capture = usePostHogClientCapture();
   const createExport = api.batchExport.create.useMutation({
     onSettled: () => {
       setIsExporting(false);
@@ -58,6 +60,8 @@ export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
   });
 
   const handleExport = async (format: BatchExportFileFormat) => {
+    // Which tables get exported, in which format — never the query contents.
+    capture("table:export_clicked", { tableName: props.tableName, format });
     setIsExporting(true);
     await createExport.mutateAsync({
       projectId: props.projectId,

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -380,6 +380,17 @@ export const SessionPage: React.FC<{
     },
   );
 
+  // PostHog is the external system: report one view per session once it
+  // loaded (id-ref dedupes Strict Mode double-mounts; navigating between
+  // sessions re-reports) — same pattern as trace_detail:view.
+  const legacySessionLoaded = Boolean(session.data);
+  const viewedSessionRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!legacySessionLoaded || viewedSessionRef.current === sessionId) return;
+    viewedSessionRef.current = sessionId;
+    capture("session_detail:view", { isV4: false });
+  }, [capture, sessionId, legacySessionLoaded]);
+
   const [showCorrections, setShowCorrections] = useLocalStorage(
     "showCorrections",
     false,
@@ -836,6 +847,7 @@ export const SessionEventsPage: React.FC<{
   sessionId: string;
   projectId: string;
 }> = ({ sessionId, projectId }) => {
+  const capture = usePostHogClientCapture();
   const session = api.sessions.byIdWithScoresFromEvents.useQuery(
     {
       sessionId,
@@ -868,6 +880,17 @@ export const SessionEventsPage: React.FC<{
       },
     },
   );
+
+  // PostHog is the external system: report one view per session once it
+  // loaded (id-ref dedupes Strict Mode double-mounts; navigating between
+  // sessions re-reports) — same pattern as trace_detail:view.
+  const v4SessionLoaded = Boolean(session.data);
+  const viewedSessionRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!v4SessionLoaded || viewedSessionRef.current === sessionId) return;
+    viewedSessionRef.current = sessionId;
+    capture("session_detail:view", { isV4: true });
+  }, [capture, sessionId, v4SessionLoaded]);
 
   if (session.error?.data?.code === "UNAUTHORIZED")
     return <ErrorPage message="You do not have access to this session." />;

--- a/web/src/features/comments/CommentDrawerController.tsx
+++ b/web/src/features/comments/CommentDrawerController.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/src/components/ui/drawer";
 import { CommentList } from "@/src/features/comments/CommentList";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { type CommentObjectType } from "@langfuse/shared";
 import { useRouter } from "next/router";
 import { type ReactNode, useEffect, useRef, useState } from "react";
@@ -104,6 +105,7 @@ export function CommentDrawerController({
   onOpenChange: controlledOnOpenChange,
 }: CommentDrawerControllerProps) {
   const router = useRouter();
+  const capture = usePostHogClientCapture();
   const [isMentionDropdownOpen, setIsMentionDropdownOpen] = useState(false);
   const [internalIsOpen, setInternalIsOpen] = useState(false);
   const hasAutoOpenedRef = useRef(false);
@@ -160,7 +162,10 @@ export function CommentDrawerController({
   ]);
 
   const openDrawer = () => {
-    if (!disabled) setIsOpen(true);
+    if (disabled) return;
+    // Collaboration reach per object kind; objectType only, never content.
+    capture("comments:drawer_open", { objectType });
+    setIsOpen(true);
   };
 
   const handleOpenChange = (open: boolean) => {

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -54,6 +54,7 @@ import { MENTION_USER_PREFIX } from "@/src/features/comments/lib/mentionParser";
 import { type SelectionData } from "./contexts/InlineCommentSelectionContext";
 import { Badge } from "@/src/components/ui/badge";
 import { useTheme } from "next-themes";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 // IO field background colors - same as IOPreviewJSON.tsx
 const IO_FIELD_COLORS = {
@@ -107,6 +108,7 @@ export function CommentList({
 }) {
   const session = useSession();
   const router = useRouter();
+  const capture = usePostHogClientCapture();
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const [cursorPosition, setCursorPosition] = useState(0);
@@ -308,6 +310,8 @@ export function CommentList({
 
   const createCommentMutation = api.comments.create.useMutation({
     onSuccess: async () => {
+      // Collaboration activity per object kind; objectType only, never content.
+      capture("comments:created", { objectType });
       form.reset();
 
       // Clear pending selection after successful comment creation

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -255,7 +255,7 @@ export function PopoverFilterBuilder({
       <Popover
         onOpenChange={(open) => {
           if (open) {
-            capture("table:filter_builder_open");
+            capture("table:filter_builder_open", { tableName });
           }
           // Create empty filter when opening popover
           if (open && filterState.length === 0) addNewFilter();

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -18,9 +18,18 @@ export const events = {
     "column_visibility_change",
     "column_sorting_header_click",
     "column_visibility_changed",
+    // Export format chosen from the table export dropdown; tableName + format
+    // only, never query contents.
+    "export_clicked",
   ],
+  // Collaboration on trace/session/observation objects; objectType only,
+  // never comment content.
+  comments: ["drawer_open", "created"],
   trace: ["delete_form_open", "delete", "delete_form_submit"],
   trace_detail: [
+    // One view per trace on the full detail page (id-ref deduped); separates
+    // reach from engagement events like node_selected. isV4 = events read path.
+    "view",
     "publish_button_click",
     "observation_tree_collapse",
     "observation_tree_expand",
@@ -142,6 +151,9 @@ export const events = {
     "duplicate_form_submit",
   ],
   session_detail: [
+    // One view per session on the detail page (id-ref deduped); isV4 = which
+    // page variant rendered (SessionEventsPage vs legacy SessionPage).
+    "view",
     "publish_button_click",
     "download_button_click",
     "copy_session_id_click",

--- a/web/src/features/traces/TracePage.tsx
+++ b/web/src/features/traces/TracePage.tsx
@@ -1,5 +1,8 @@
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { useRouter } from "next/router";
+import { useEffect, useRef } from "react";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { ErrorPage } from "@/src/components/error-page";
 import { TraceDetailActions } from "@/src/features/traces/components/TraceDetailActions";
 import { useTraceDetailData } from "@/src/features/traces/hooks/useTraceDetailData";
@@ -35,6 +38,20 @@ export function TracePage({
   const hasProjectAccess = useIsAuthenticatedAndProjectMember(
     projectIdForAccessCheck,
   );
+
+  // PostHog is the external system: report one view per trace once it loaded
+  // (unauthorized/not-found never count). The id ref dedupes Strict Mode
+  // double-mounts while client-side navigation between traces re-reports —
+  // same pattern as dashboard:view and home_dashboard_viewed.
+  const capture = usePostHogClientCapture();
+  const { isBetaEnabled } = useV4Beta();
+  const traceLoaded = Boolean(trace.data);
+  const viewedTraceRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!traceLoaded || viewedTraceRef.current === traceId) return;
+    viewedTraceRef.current = traceId;
+    capture("trace_detail:view", { isV4: isBetaEnabled });
+  }, [capture, traceId, traceLoaded, isBetaEnabled]);
 
   if (trace.isUnauthorized)
     return <ErrorPage message="You do not have access to this trace." />;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16647.preview.langfuse.com](https://pr-16647.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

Implements [LFE-15656](https://linear.app/clickhouse/issue/LFE-15656/posthog-core-surface-usage-events-detail-views-exports-comments-filter): instrumentation gaps found while building the core-surface health dashboards for the weekly feature-health report.

| Event | Fires | Properties | Question it answers |
|---|---|---|---|
| `trace_detail:view` (new) | `TracePage` once the trace loaded (id-ref dedupe, same pattern as `dashboard:view`; full page only, peek not counted) | `isV4` | trace-view reach vs engagement (today proxied by `node_selected`) |
| `session_detail:view` (new) | both session page variants once loaded (`SessionEventsPage` → `isV4: true`, legacy `SessionPage` → `isV4: false`) | `isV4` | session-view reach + v4 rollout split |
| `table:export_clicked` (new) | `BatchExportTableButton` format selection | `tableName`, `format` | which tables get exported, in which format (previously invisible) |
| `comments:drawer_open` / `comments:created` (new group) | drawer open click / create-mutation success | `objectType` | collaboration usage per object kind (no comment events existed) |
| `table:filter_builder_open` (property fix) | unchanged | + `tableName` | breakdown was ~99% "None"; the prop already existed on the component |

All properties are enum-ish metadata per the posthog-instrumentation skill — no user content. Events registered in the typed allowlist, so unknown names fail typecheck.

## Verification

- Web typecheck clean; root lint `Tasks: 7 successful, 7 total`; prettier clean
- Nearest client test: `ModernSessionHeaderActionsController.clienttest.tsx` → `Tests 1 passed (1)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds typed PostHog instrumentation for trace and session detail views, table exports, comment activity, and filter-builder table attribution.
- Records trace and session detail-page reach with rollout metadata.
- Records export format and originating table.
- Records comment drawer opens and successful comment creation by object type.
- Adds `tableName` to filter-builder-open events.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should be corrected before merging because it misclassifies public v4 trace views and omits a current comment-drawer opening path from the new health metrics.

The trace event's rollout property does not follow the actual unauthenticated read-source selection, and drawer instrumentation covers only direct controller opens rather than the existing inline-comment flow.

**Files Needing Attention:** web/src/features/traces/TracePage.tsx; web/src/features/comments/CommentDrawerController.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Core web surface] --> B{User action}
  B --> C[Trace or session loaded]
  B --> D[Export format selected]
  B --> E[Comment drawer or creation]
  B --> F[Filter builder opened]
  C --> G[PostHog detail view event]
  D --> H[PostHog export event]
  E --> I[PostHog comment event]
  F --> J[PostHog filter event]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/TracePage.tsx:52
**Wrong trace rollout bucket**

When an unauthenticated user opens a shared trace in `dual` or `events_only` write mode, `useTraceDetailData` uses the events source while this event sends `isV4: false`, causing v4 views to be counted in the legacy rollout bucket.

### Issue 2
web/src/features/comments/CommentDrawerController.tsx:166
**Inline drawer opens untracked**

When a user starts an inline comment from trace or observation content, the controlled handlers open this drawer by setting state directly instead of calling `openDrawer`, causing those comment-surface opens to be omitted from the new usage metric.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): capture core-surface usage ev..."](https://github.com/langfuse/langfuse/commit/57813a254fa926b6e5a91e71a8cca8d6c40e39ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57153032)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->