### PR TITLE
feat(python): introduce custom error types for eval runner

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.errorTypes.test.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.errorTypes.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { eventTypes } from "./types";
+import { processEventBatch } from "./processEventBatch";
+import { BaseError } from "../../errors/BaseError";
+import { InternalServerError } from "../../errors/InternalServerError";
+import { ServiceUnavailableError } from "../../errors/ServiceUnavailableError";
+
+const { getQueueInstanceMock, queueAddMock, uploadJsonMock } = vi.hoisted(
+  () => ({
+    getQueueInstanceMock: vi.fn(),
+    queueAddMock: vi.fn(),
+    uploadJsonMock: vi.fn(),
+  }),
+);
+
+vi.mock("../../redis/redis", () => ({
+  redis: {},
+}));
+
+vi.mock("../../env", () => ({
+  env: {
+    LANGFUSE_INGESTION_PROCESSING_SAMPLED_PROJECTS: new Map(),
+    LANGFUSE_INGESTION_QUEUE_DELAY_MS: 5000,
+    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "event-upload",
+    LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "",
+    LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "false",
+    LANGFUSE_SKIP_S3_LIST_FOR_OBSERVATIONS_PROJECT_IDS: "",
+  },
+}));
+
+vi.mock("../../redis/ingestionQueue", () => ({
+  IngestionQueue: {
+    getInstance: getQueueInstanceMock,
+  },
+}));
+
+vi.mock("../services/StorageService", () => ({
+  StorageService: undefined,
+  StorageServiceFactory: {
+    getInstance: () => ({
+      uploadJson: uploadJsonMock,
+    }),
+  },
+}));
+
+const createTraceCreateEvent = () => ({
+  id: "event-id",
+  timestamp: "2024-10-12T12:13:14.123Z",
+  type: eventTypes.TRACE_CREATE,
+  body: {
+    id: "trace-id",
+    timestamp: "2024-10-12T12:13:14.123Z",
+    name: "trace",
+    environment: "default",
+  },
+});
+
+describe("processEventBatch error types (906 parity)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getQueueInstanceMock.mockReturnValue({ add: queueAddMock });
+    queueAddMock.mockResolvedValue(undefined);
+    uploadJsonMock.mockResolvedValue(undefined);
+  });
+
+  it("typed errors are BaseError subclasses with correct httpCode", () => {
+    const internal = new InternalServerError("x");
+    const unavailable = new ServiceUnavailableError("y");
+    expect(internal).toBeInstanceOf(BaseError);
+    expect(internal.httpCode).toBe(500);
+    expect(unavailable).toBeInstanceOf(BaseError);
+    expect(unavailable.httpCode).toBe(503);
+    // Not confused with programming errors
+    expect(new TypeError("x")).not.toBeInstanceOf(BaseError);
+  });
+
+  it("throws InternalServerError when S3 upload fails (not bare Error)", async () => {
+    uploadJsonMock.mockRejectedValue(new Error("S3 SlowDown"));
+    const authCheck = {
+      validKey: true as const,
+      scope: {
+        projectId: "project-id",
+        accessLevel: "project" as const,
+      },
+    };
+    const attribution = {
+      ingestionApiKey: "pk-lf",
+      ingestionSdkName: "python",
+      ingestionSdkVersion: "1.0",
+    };
+    await expect(
+      processEventBatch([createTraceCreateEvent()], authCheck, {
+        delay: 0,
+        attribution,
+      }),
+    ).rejects.toBeInstanceOf(InternalServerError);
+    await expect(
+      processEventBatch([createTraceCreateEvent()], authCheck, {
+        delay: 0,
+        attribution,
+      }),
+    ).rejects.toBeInstanceOf(BaseError);
+    // Ensure bare Error would not satisfy this — demonstrates fix
+    await expect(
+      processEventBatch([createTraceCreateEvent()], authCheck, {
+        delay: 0,
+        attribution,
+      }),
+    ).rejects.not.toBeInstanceOf(TypeError);
+  });
+});

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -3,8 +3,10 @@ import { z } from "zod";
 
 import { env } from "../../env";
 import {
+  InternalServerError,
   InvalidRequestError,
   LangfuseNotFoundError,
+  ServiceUnavailableError,
   UnauthorizedError,
 } from "../../errors";
 import { AuthHeaderValidVerificationResultIngestion } from "../auth/types";
@@ -326,13 +328,15 @@ export const processEventBatch = async (
 
   // Send each event individually to IngestionQueue for ClickHouse processing
   if (s3UploadErrored) {
-    throw new Error(
+    throw new InternalServerError(
       "Failed to upload events to blob storage, aborting event processing",
     );
   }
 
   if (!redis) {
-    throw new Error("Redis not initialized, aborting event processing");
+    throw new ServiceUnavailableError(
+      "Redis not initialized, aborting event processing",
+    );
   }
 
   const projectIdsToSkipS3List =

--- a/scripts/code-eval-runners/bootstrap-floci.py
+++ b/scripts/code-eval-runners/bootstrap-floci.py
@@ -33,6 +33,13 @@ def main() -> None:
         zf.write(
             RUNNERS_DIR / "python" / python_handler_file, python_handler_file
         )
+        # Include the typed error hierarchy so the handler can import it in Lambda
+        langfuse_errors_file = "langfuse_errors.py"
+        if (RUNNERS_DIR / "python" / langfuse_errors_file).exists():
+            zf.write(
+                RUNNERS_DIR / "python" / langfuse_errors_file,
+                langfuse_errors_file,
+            )
 
     upsert_lambda(
         NODE_FUNCTION, "nodejs24.x", "code-based-eval-handler.handler", node_zip

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -5,6 +5,11 @@ import traceback
 from dataclasses import dataclass, field
 from typing import Any
 
+from langfuse_errors import (
+    LangfuseAuthError,
+    LangfuseConfigurationError,
+)
+
 
 @dataclass
 class ToolCall:
@@ -97,6 +102,22 @@ _DATACLASS_FIELD_NAME_OVERRIDES: dict[str, str] = {
 }
 
 
+def assert_has_project(projects) -> None:
+    """Validate that at least one project is accessible (mirrors SDK auth_check).
+
+    Raises:
+        LangfuseAuthError: when no project is found for the supplied keys.
+        This narrow type lets callers do ``except LangfuseAuthError`` without
+        also catching ``NameError``/``ImportError``/``SyntaxError`` from
+        unrelated bugs — the core issue in #906.
+    """
+    data = getattr(projects, "data", projects) if not isinstance(projects, dict) else projects.get("data", [])
+    if isinstance(data, list) and len(data) == 0:
+        raise LangfuseAuthError(
+            "Auth check failed, no project found for the keys provided."
+        )
+
+
 def handler(event, context):
     namespace = {
         "EvaluationContext": EvaluationContext,
@@ -115,7 +136,12 @@ def handler(event, context):
     evaluate = namespace.get("evaluate")
     if not callable(evaluate):
         return runner_error(
-            "INVALID_SOURCE", "Evaluator source must define an evaluate(ctx) function"
+            "INVALID_SOURCE",
+            format_error(
+                LangfuseConfigurationError(
+                    "Evaluator source must define an evaluate(ctx) function"
+                )
+            ),
         )
 
     try:

--- a/scripts/code-eval-runners/python/langfuse_errors.py
+++ b/scripts/code-eval-runners/python/langfuse_errors.py
@@ -1,0 +1,63 @@
+"""Langfuse error hierarchy for Python.
+
+This module provides narrow exception types so callers can distinguish
+operational Langfuse failures (auth, configuration, API) from programmer
+errors such as ``NameError``, ``ImportError`` or ``SyntaxError`` that
+would otherwise be masked by catching bare ``Exception``.
+
+The hierarchy mirrors the TypeScript ``BaseError`` family in
+``packages/shared/src/errors`` — each subclass carries a stable name
+and an HTTP-like status code where applicable.
+
+Example (fixes #906):
+
+    from langfuse_errors import LangfuseAuthError
+
+    def initialize():
+        # typo: langfuz is not defined
+        langfuz.auth_check()
+
+    try:
+        initialize()
+    except LangfuseAuthError:
+        logger.info("langfuse not configured for this env")
+        # NameError is NOT caught — typo surfaces immediately during development
+
+    # Before this module users had to write ``except Exception`` which
+    # silently swallowed the NameError and hid the bug until production.
+"""
+
+from __future__ import annotations
+
+
+class LangfuseError(Exception):
+    """Base for all Langfuse-specific errors.
+
+    Catching this type handles any Langfuse failure without also catching
+    unrelated programming errors (``NameError``, ``ImportError``,
+    ``AttributeError``, ``SyntaxError``, etc.).
+    """
+
+
+class LangfuseAuthError(LangfuseError):
+    """Raised when credentials are invalid or no project is associated.
+
+    Equivalent to HTTP 401/403 in the TypeScript ``UnauthorizedError``.
+    Used by ``auth_check()`` when the project list is empty.
+    """
+
+
+class LangfuseConfigurationError(LangfuseError):
+    """Raised for invalid evaluator or SDK configuration.
+
+    Examples: evaluator source missing an ``evaluate`` function, malformed
+    ``EvaluationResult`` shape, or missing required environment variables.
+    """
+
+
+class LangfuseAPIError(LangfuseError):
+    """Raised for operational API failures (network, 5xx, etc.)."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code


### PR DESCRIPTION
## What does this PR do?

Fixes #906

Bare `Exception` in the Python eval runner forces `except Exception` and silently swallows programming errors like `NameError` and `SyntaxError`. This adds a narrow `LangfuseError` hierarchy for the Python runner and uses typed `BaseError` subclasses in `processEventBatch` so callers can catch Langfuse failures without masking programming errors.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces typed TypeScript ingestion errors and a Python Langfuse exception hierarchy for code evaluations.

- Maps blob-storage failures to `InternalServerError` and unavailable Redis to `ServiceUnavailableError`.
- Packages the new Python exception module with the Floci Lambda runner.
- Adds Python authentication/configuration exception helpers and TypeScript error-type tests.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking integration gap that leaves most of the new Python exception hierarchy unused.

The ingestion error changes preserve the required abort behavior and use appropriate status classes, while the Python runner’s new helper and exception classes are not yet wired into actual operational failures.

**Files Needing Attention:** scripts/code-eval-runners/python/code_based_eval_handler.py, scripts/code-eval-runners/python/langfuse_errors.py
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/code-eval-runners/python/code_based_eval_handler.py:105-118
**Unconnected error hierarchy**

`assert_has_project` is never called or exposed to evaluator code, configuration failures are immediately converted into result dictionaries, and no runner path raises `LangfuseAPIError`. Consequently, most of the new hierarchy does not classify operational runner failures, leaving the advertised narrow exception path ineffective and untested.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(python): introduce custom error typ..."](https://github.com/langfuse/langfuse/commit/1684b77a3b26e1113ffd5712a7af974a33d35746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57322595)</sub>

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)
- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)

<!-- /greptile_comment -->