### PR TITLE
fix(media): chunk datasetItemMedia query to respect PostgreSQL bind variable limit (#16656)

### DIFF
--- a/web/src/features/media/server/datasetItemMediaReferences.ts
+++ b/web/src/features/media/server/datasetItemMediaReferences.ts
@@ -37,16 +37,24 @@ export async function resolveDatasetItemMediaReferences(props: {
   }
   if (props.items.length === 0) return referencesByItem;
 
-  const referenceRows = await prisma.datasetItemMedia.findMany({
-    where: {
-      projectId: props.projectId,
-      OR: props.items.map((item) => ({
-        datasetItemId: item.id,
-        datasetItemValidFrom: item.validFrom,
-      })),
-    },
-    orderBy: [{ field: "asc" }, { jsonPath: "asc" }],
-  });
+  // Chunk queries to stay well within PostgreSQL's 32,767 bind variable limit
+  // (each item adds 2 bind parameters + 1 for projectId).
+  const CHUNK_SIZE = 5000;
+  const referenceRows = [];
+  for (let i = 0; i < props.items.length; i += CHUNK_SIZE) {
+    const chunk = props.items.slice(i, i + CHUNK_SIZE);
+    const chunkRows = await prisma.datasetItemMedia.findMany({
+      where: {
+        projectId: props.projectId,
+        OR: chunk.map((item) => ({
+          datasetItemId: item.id,
+          datasetItemValidFrom: item.validFrom,
+        })),
+      },
+      orderBy: [{ field: "asc" }, { jsonPath: "asc" }],
+    });
+    referenceRows.push(...chunkRows);
+  }
   // The exact-version query never returns pending rows, so claimed rows always
   // have validFrom/jsonPath/referenceString set; this narrows their types.
   const claimedRows = referenceRows.filter(


### PR DESCRIPTION
## Summary

Fixes #16656.

`GET /api/public/datasets/{datasetName}` threw a 500 error when datasets contained more than 16,383 items due to exceeding PostgreSQL's 32,767 bind variable limit in Prisma's `datasetItemMedia.findMany` query.

### Changes
- Chunks `datasetItemMedia.findMany` queries into batches of 5,000 items inside `resolveDatasetItemMediaReferences` to safely bound bind parameters.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR chunks dataset-item media-reference lookups into batches of 5,000 to avoid PostgreSQL's bind-variable limit. However, the resolved media IDs subsequently remain part of one unbounded query.

- Replaces one large `datasetItemMedia` query with sequential bounded queries.
- Preserves per-item field and JSON-path ordering within each batch.
- Leaves the downstream media lookup susceptible to the same database limit.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the downstream media lookup is also bounded for media-heavy datasets.

The initial bind-limit failure is removed, but sufficiently large datasets can now reach a second unbounded IN query and continue returning a server error.

**Files Needing Attention:** web/src/features/media/server/datasetItemMediaReferences.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[All dataset items] --> B[Chunk into batches of 5,000]
  B --> C[Bounded datasetItemMedia queries]
  C --> D[Accumulate all reference rows]
  D --> E[Collect all distinct media IDs]
  E --> F[Single unbounded media.findMany query]
  F --> G{Bind limit exceeded?}
  G -->|Yes| H[Dataset API returns 500]
  G -->|No| I[Resolve media references]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/media/server/datasetItemMediaReferences.ts:56
**Downstream query remains unbounded**

If a dataset contains more than PostgreSQL's bind-variable limit in distinct referenced media IDs, the chunked queries accumulate those IDs and pass all of them to one `media.findMany` `IN` predicate, causing the dataset API to continue returning a 500 response.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(media): chunk datasetItemMedia query..."](https://github.com/langfuse/langfuse/commit/0babd234e33301780ec06ad042c9d97265734756) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57386788)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->