### PR TITLE
fix(billing): natively calculate cost for reasoning tokens in otel traces and model pricing

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2924,7 +2924,20 @@ export class OtelIngestionProcessor {
     // and are therefore subtracted from output below to avoid double counting.
     const outputReasoningTokens =
       rawUsageDetails["reasoning.output_tokens"] ??
-      rawUsageDetails["completion_details.reasoning"];
+      rawUsageDetails["reasoning_tokens"] ??
+      rawUsageDetails["reasoning_token_count"] ??
+      rawUsageDetails["thoughts_tokens"] ??
+      rawUsageDetails["thought_tokens"] ??
+      rawUsageDetails["output_reasoning_tokens"] ??
+      rawUsageDetails["output_reasoning"] ??
+      rawUsageDetails["reasoning"] ??
+      rawUsageDetails["details.reasoning_tokens"] ??
+      rawUsageDetails["details.reasoning"] ??
+      rawUsageDetails["details.reasoning.output_tokens"] ??
+      rawUsageDetails["details.thoughts_tokens"] ??
+      rawUsageDetails["details.thought_tokens"] ??
+      rawUsageDetails["completion_details.reasoning"] ??
+      rawUsageDetails["completion_details.reasoning_tokens"];
     const outputAudioTokens = rawUsageDetails["completion_details.audio"];
 
     const normalizedUsageDetails = Object.entries(rawUsageDetails).reduce(
@@ -2954,7 +2967,20 @@ export class OtelIngestionProcessor {
             "prompt_details.cache_write",
             "input_cache_creation",
             "reasoning.output_tokens",
+            "reasoning_tokens",
+            "reasoning_token_count",
+            "thoughts_tokens",
+            "thought_tokens",
+            "output_reasoning_tokens",
+            "output_reasoning",
+            "reasoning",
+            "details.reasoning_tokens",
+            "details.reasoning",
+            "details.reasoning.output_tokens",
+            "details.thoughts_tokens",
+            "details.thought_tokens",
             "completion_details.reasoning",
+            "completion_details.reasoning_tokens",
             "completion_details.audio",
           ].includes(key)
         ) {

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.usageDetails.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.usageDetails.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "./OtelIngestionProcessor";
+
+describe("OtelIngestionProcessor usage details reasoning tokens", () => {
+  it("normalizes gen_ai.usage.reasoning_tokens and adjusts output tokens", () => {
+    const batch: ResourceSpan[] = [
+      {
+        scopeSpans: [
+          {
+            scope: {
+              name: "openinference.instrumentation.openai",
+              version: "0.1.0",
+            },
+            spans: [
+              {
+                traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+                spanId: Buffer.from("0123456789abcdef", "hex"),
+                name: "chat o1-mini",
+                kind: 3,
+                startTimeUnixNano: "1752384000000000000",
+                endTimeUnixNano: "1752384001000000000",
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "chat" },
+                  },
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: { intValue: 100 },
+                  },
+                  {
+                    key: "gen_ai.usage.output_tokens",
+                    value: { intValue: 600 },
+                  },
+                  {
+                    key: "gen_ai.usage.reasoning_tokens",
+                    value: { intValue: 500 },
+                  },
+                  {
+                    key: "gen_ai.usage.total_tokens",
+                    value: { intValue: 700 },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const events = new OtelIngestionProcessor({
+      projectId: "project-1",
+      publicKey: "pk-test",
+      sdkName: "openinference",
+      sdkVersion: "0.1.0",
+    }).processToEvent(batch);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].providedUsageDetails).toEqual({
+      input: 100,
+      output: 100, // 600 - 500
+      output_reasoning_tokens: 500,
+      total: 700,
+    });
+  });
+
+  it("normalizes gen_ai.usage.reasoning.output_tokens and thoughts_tokens", () => {
+    const batch: ResourceSpan[] = [
+      {
+        scopeSpans: [
+          {
+            scope: { name: "traceloop.instrumentation", version: "0.1.0" },
+            spans: [
+              {
+                traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+                spanId: Buffer.from("0123456789abcdef", "hex"),
+                name: "chat gemini-2.0-flash-thinking",
+                kind: 3,
+                startTimeUnixNano: "1752384000000000000",
+                endTimeUnixNano: "1752384001000000000",
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "chat" },
+                  },
+                  {
+                    key: "gen_ai.usage.prompt_tokens",
+                    value: { intValue: 50 },
+                  },
+                  {
+                    key: "gen_ai.usage.completion_tokens",
+                    value: { intValue: 300 },
+                  },
+                  {
+                    key: "gen_ai.usage.thoughts_tokens",
+                    value: { intValue: 200 },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const events = new OtelIngestionProcessor({
+      projectId: "project-1",
+      publicKey: "pk-test",
+      sdkName: "traceloop",
+      sdkVersion: "0.1.0",
+    }).processToEvent(batch);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].providedUsageDetails).toEqual({
+      input: 50,
+      output: 100, // 300 - 200
+      output_reasoning_tokens: 200,
+    });
+  });
+
+  it("normalizes llm.token_count.reasoning_tokens", () => {
+    const batch: ResourceSpan[] = [
+      {
+        scopeSpans: [
+          {
+            scope: { name: "custom-otel", version: "1.0.0" },
+            spans: [
+              {
+                traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+                spanId: Buffer.from("0123456789abcdef", "hex"),
+                name: "llm call",
+                kind: 3,
+                startTimeUnixNano: "1752384000000000000",
+                endTimeUnixNano: "1752384001000000000",
+                attributes: [
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "chat" },
+                  },
+                  {
+                    key: "llm.token_count.prompt",
+                    value: { intValue: 80 },
+                  },
+                  {
+                    key: "llm.token_count.completion",
+                    value: { intValue: 150 },
+                  },
+                  {
+                    key: "llm.token_count.reasoning_tokens",
+                    value: { intValue: 120 },
+                  },
+                  {
+                    key: "llm.token_count.total",
+                    value: { intValue: 230 },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const events = new OtelIngestionProcessor({
+      projectId: "project-1",
+      publicKey: "pk-test",
+      sdkName: "custom",
+      sdkVersion: "1.0.0",
+    }).processToEvent(batch);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].providedUsageDetails).toEqual({
+      input: 80,
+      output: 30, // 150 - 120
+      output_reasoning_tokens: 120,
+      total: 230,
+    });
+  });
+});

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1658,7 +1658,14 @@ export class IngestionService {
     const finalCostEntries: [string, number][] = [];
 
     for (const [key, units] of Object.entries(usageUnits)) {
-      const price = modelPrices?.find((price) => price.usageType === key);
+      let price = modelPrices?.find((price) => price.usageType === key);
+
+      if (
+        !price &&
+        ["output_reasoning_tokens", "output_reasoning"].includes(key)
+      ) {
+        price = modelPrices?.find((price) => price.usageType === "output");
+      }
 
       if (units != null && price) {
         finalCostEntries.push([key, price.price.mul(units).toNumber()]);

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -190,6 +190,37 @@ describe("Token Cost Calculation", () => {
     expect(costs.total_cost).toBe(9.0);
   });
 
+  it("should fall back to output price for output_reasoning_tokens when explicit reasoning price is not defined", async () => {
+    const prices = [
+      { usageType: "input", price: new Decimal(0.01) },
+      { usageType: "output", price: new Decimal(0.02) },
+    ];
+
+    const usageUnits = {
+      input: 100,
+      output: 100,
+      output_reasoning_tokens: 500,
+      total: 700,
+    };
+
+    const userProvidedCosts = {
+      input: null,
+      output: null,
+      total: null,
+    };
+
+    const costs = (IngestionService as any).calculateUsageCosts(
+      prices as any,
+      userProvidedCosts,
+      usageUnits,
+    );
+
+    expect(costs.cost_details.input).toBe(1.0); // 100 * 0.01
+    expect(costs.cost_details.output).toBe(2.0); // 100 * 0.02
+    expect(costs.cost_details.output_reasoning_tokens).toBe(10.0); // 500 * 0.02 (output price fallback)
+    expect(costs.total_cost).toBe(13.0);
+  });
+
   it("should correctly calculate token costs with user provided costs", async () => {
     const prices = await prisma.price.findMany({
       where: {


### PR DESCRIPTION
### Description
Fixes #16508: reasoning/thought tokens from OpenTelemetry traces were not normalized or priced correctly.

**Changes:**
1. **OTel normalization**: Added rules to normalize various reasoning token fields (`reasoning_tokens`, `thoughts_tokens`, etc.) to `output_reasoning_tokens` and prevent double-counting.
2. **Pricing fallback**: `output_reasoning_tokens` now inherits standard `output` token price when no explicit reasoning price tier exists.
3. **Tests**: Added unit tests for extraction and cost calculation.

Fixes #16508

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR normalizes additional OpenTelemetry reasoning-token attributes into a canonical usage bucket and applies the standard output-token price when a model has no explicit reasoning price.
- Expands generic OTel reasoning and thought-token alias handling.
- Separates reasoning tokens from inclusive output counts to avoid duplicate usage.
- Adds output-price fallback behavior for reasoning usage.
- Adds focused normalization and cost-calculation tests.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete correctness or security failures identified.

The changed normalization keeps output and reasoning usage disjoint, and the pricing fallback applies only when no explicit reasoning tier exists.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[OTel usage attributes] --> B[Normalize reasoning aliases]
  B --> C[Separate output and reasoning units]
  C --> D[Worker usage-cost calculation]
  D --> E{Explicit reasoning price?}
  E -->|Yes| F[Use reasoning price]
  E -->|No| G[Use output price]
  F --> H[Persist usage and costs]
  G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): natively calculate cost fo..."](https://github.com/langfuse/langfuse/commit/b950ed411e662194f1f1ef60061c90fff8dbccc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57401004)</sub>

<!-- /greptile_comment -->