### PR TITLE
feat(worker): log structured fields on BullMQ job failure

### DIFF
--- a/worker/src/__tests__/workerManagerMetrics.test.ts
+++ b/worker/src/__tests__/workerManagerMetrics.test.ts
@@ -73,6 +73,8 @@ vi.mock("../utils/hostId", () => ({
   WORKER_HOST_ID: "test-host",
 }));
 
+import { logger } from "@langfuse/shared/src/server";
+
 import { WorkerManager } from "../queues/workerManager";
 
 describe("WorkerManager queue metrics", () => {
@@ -116,9 +118,16 @@ describe("WorkerManager queue metrics", () => {
     expect(mocks.legacyRecordHistogram).not.toHaveBeenCalled();
 
     mocks.recordIncrement.mockClear();
+    const failedError = new Error("boom");
     mocks.handlers.get("failed")?.(
-      { id: "job-id", name: "job" },
-      new Error("failed"),
+      {
+        id: "job-id",
+        name: "job",
+        attemptsMade: 6,
+        opts: { attempts: 6 },
+        failedReason: "job stalled more than allowable limit",
+      },
+      failedError,
     );
     mocks.handlers.get("error")?.(new Error("errored"));
     mocks.handlers.get("stalled")?.("job-id");
@@ -128,6 +137,20 @@ describe("WorkerManager queue metrics", () => {
       ["langfuse.queue.trace_delete.rate", 1, { type: "error" }],
       ["langfuse.queue.trace_delete.rate", 1, { type: "stalled" }],
     ]);
+
+    // Every type:failed increment carries a co-timestamped structured log.
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("failed"),
+      expect.objectContaining({
+        queueName: "trace-delete",
+        jobId: "job-id",
+        jobName: "job",
+        attemptsMade: 6,
+        attempts: 6,
+        failedReason: "job stalled more than allowable limit",
+        error: failedError,
+      }),
+    );
   });
 
   it("emits a rate counter for completed jobs but not for active ones", () => {

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -170,11 +170,23 @@ export class WorkerManager {
       });
     });
 
-    // Add error handling
+    // Add error handling. Log structured fields so every type:failed increment
+    // is attributable, including BullMQ out-of-band failures (stall beyond
+    // limit, lock loss, forced fail) where the processor never threw and would
+    // otherwise leave no correlating log.
     worker.on("failed", (job: Job | undefined, err: Error) => {
       logger.error(
         `Queue job ${job?.name} with id ${job?.id} in ${queueName} failed`,
-        err,
+        {
+          queueName,
+          ...shardTag,
+          jobId: job?.id,
+          jobName: job?.name,
+          attemptsMade: job?.attemptsMade,
+          attempts: job?.opts?.attempts,
+          failedReason: job?.failedReason ?? err?.message,
+          error: err,
+        },
       );
       traceException(err);
       recordIncrement(baseMetric + ".rate", 1, {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16667.preview.langfuse.com](https://pr-16667.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The shared BullMQ `worker.on("failed")` handler increments the `langfuse.queue.<queue>.rate{type:failed}` metric, but its log line was a bare interpolated string with the raw error. When a job is failed **out-of-band** by BullMQ (stall beyond the retry limit, lock loss, forced fail, process replacement) the processor never throws, so there was no structured, queryable log to root-cause the failure — the metric would spike (and page) with nothing correlating it in the logs.

This adds structured fields to that single log call so every `type:failed` increment is attributable from logs alone:

- `queueName`, `shard` (present for sharded queues, matching the metric's shard tag)
- `jobId`, `jobName`
- `attemptsMade`, `attempts`
- `failedReason` (BullMQ's `job.failedReason`, falling back to the error message)
- `error` (the raw Error, so winston's `errors({ stack: true })` format keeps the stack)

Applies to **every** queue using the shared wrapper, not just OTEL ingestion. No change to retry/DLQ behavior; log volume is unchanged (one line per failed attempt, same cardinality as the existing metric increment).

## Type of change

- [x] Chore / maintenance (observability, no behavior change)

## How to test

- `pnpm --filter worker run test workerManagerMetrics` — the failed-handler test now asserts the co-timestamped structured log carrying queue, jobId, attempts, and failedReason.

## Checklist

- [x] Targeted worker test passing
- [x] `lint` + `typecheck` green for `worker`
- [x] No retry/DLQ behavior change


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches the shared BullMQ failed-job log with queue, shard, job, attempt, failure-reason, and Error metadata while extending the worker metric test.
- Adds structured context to every shared failed-event log.
- Tests the populated, non-sharded failure-log arguments alongside existing metrics.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, but the Error should be represented in a stack-preserving form so the new failure log provides the diagnostic detail it promises.

The queue and attempt metadata are safely extracted and aligned with existing shard tags, but the nested Error bypasses the logger's top-level stack handling and can be serialized without its stack.

**Files Needing Attention:** worker/src/queues/workerManager.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/queues/workerManager.ts:189
**Nested Error Loses Stack**

Passing the Error as `metadata.error` prevents `winston.format.errors({ stack: true })` from promoting its non-enumerable stack to `info.stack`; JSON output serializes the nested Error without useful details and text output omits the stack, undermining the diagnostic purpose of this log.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): log structured fields on B..."](https://github.com/langfuse/langfuse/commit/5d7fb867123e96303c6c1c1c55d9852e3eb9553f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57422930)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->