### PR TITLE
feat(mcp): expose v4 migration data

### DIFF
--- a/packages/shared/src/in-app-agent/server/mcpPolicy.ts
+++ b/packages/shared/src/in-app-agent/server/mcpPolicy.ts
@@ -364,6 +364,10 @@ export const IN_APP_AGENT_LANGFUSE_MCP_TOOL_POLICIES = {
     approval: "approval",
     availability: { scope: "dashboards:CUD" },
   },
+  getV4MigrationData: {
+    approval: "auto",
+    availability: { scope: "project:read" },
+  },
 } satisfies Record<string, InAppAgentMcpToolPolicy>;
 
 export type InAppAgentLangfuseMcpToolName =

--- a/web/src/__tests__/server/unit/mcp-v4-migration.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-v4-migration.servertest.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getProjectV4MigrationData } = vi.hoisted(() => ({
+  getProjectV4MigrationData: vi.fn(),
+}));
+
+vi.mock("@/src/features/v4/server/v4TransitionService", () => ({
+  getProjectV4MigrationData,
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {},
+}));
+
+import {
+  getV4MigrationDataTool,
+  handleGetV4MigrationData,
+} from "@/src/features/mcp/features/v4Migration/tools/getV4MigrationData";
+import { mockServerContext } from "@/src/__tests__/server/mcp-helpers";
+
+describe("getV4MigrationData MCP tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the project-scoped data exposed by the v4 migration API", async () => {
+    const migrationData = {
+      projectId: "project-1",
+      forceV3Experience: false,
+      sdkUsage: {
+        projectId: "project-1",
+        experimentInstrumentationMigration: {
+          status: "not_required",
+          upgradePath: null,
+        },
+        sdkUsageSeries: [
+          {
+            sdkName: "langfuse-python",
+            sdkVersion: "3.10.0",
+            actionLevel: "required",
+          },
+        ],
+      },
+      legacyIntegrations: {
+        projectId: "project-1",
+        legacyIntegrationCount: 1,
+        legacyIntegrations: {
+          posthog: true,
+          mixpanel: false,
+          blobStorage: false,
+        },
+      },
+      legacyApiUsage: [
+        {
+          projectId: "project-1",
+          entrypoint: "publicapi: GET /api/public/traces",
+          count: 4,
+          lastSeen: "2026-08-26T12:00:00.000Z",
+        },
+      ],
+      traceLevelEvals: {
+        projectId: "project-1",
+        traceLevelEvalCount: 2,
+      },
+    };
+    getProjectV4MigrationData.mockResolvedValue(migrationData);
+    const context = mockServerContext({ projectId: "project-1" });
+
+    await expect(handleGetV4MigrationData({}, context)).resolves.toEqual(
+      migrationData,
+    );
+    expect(getProjectV4MigrationData).toHaveBeenCalledWith({
+      prisma: expect.anything(),
+      projectId: "project-1",
+    });
+  });
+
+  it("is discoverable as a read-only, expensive tool without project input", () => {
+    expect(getV4MigrationDataTool).toMatchObject({
+      name: "getV4MigrationData",
+      annotations: {
+        readOnlyHint: true,
+        expensiveHint: true,
+      },
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    });
+  });
+});

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -604,6 +604,85 @@ describe("v4TransitionRouter", () => {
     await expect(readRedisJson(legacyApiUsageCacheKey)).resolves.toBeNull();
   });
 
+  it("returns the complete project migration data for agent consumers", async () => {
+    await seedRedisCache({
+      [legacyApiUsageCacheKey]: legacyApiBlob([
+        {
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: 2,
+          lastSeen: "2026-06-24T15:00:00.000000Z",
+        },
+      ]),
+    });
+    mockedQueryClickhouse.mockResolvedValueOnce([
+      mockSdkUsageRow({
+        projectId,
+        sdkName: "python",
+        sdkVersion: "3.9.0",
+        actionLevel: "required",
+      }),
+    ]);
+    const caller = createCaller({
+      posthogIntegration: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            projectId,
+            enabled: true,
+            exportSource: "TRACES_OBSERVATIONS",
+          },
+        ]),
+      },
+      mixpanelIntegration: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      blobStorageIntegration: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      evaluationRule: {
+        groupBy: vi
+          .fn()
+          .mockResolvedValue([{ projectId, _count: { _all: 2 } }]),
+      },
+    });
+
+    const result = await caller.migrationData({ projectId });
+
+    expect(result).toMatchObject({
+      projectId,
+      forceV3Experience: false,
+      sdkUsage: {
+        projectId,
+        sdkUsageSeries: expect.arrayContaining([
+          expect.objectContaining({
+            sdkName: "python",
+            sdkVersion: "3.9.0",
+            actionLevel: "required",
+          }),
+        ]),
+      },
+      legacyIntegrations: {
+        projectId,
+        legacyIntegrationCount: 1,
+        legacyIntegrations: {
+          posthog: true,
+          mixpanel: false,
+          blobStorage: false,
+        },
+      },
+      legacyApiUsage: [
+        {
+          projectId,
+          entrypoint: "publicapi: GET /api/public/traces/{id}",
+          count: 2,
+        },
+      ],
+      traceLevelEvals: {
+        projectId,
+        traceLevelEvalCount: 2,
+      },
+    });
+  });
+
   it("queries SDK usage for only the authorized project", async () => {
     mockedQueryClickhouse.mockResolvedValueOnce([
       mockSdkUsageRow({
@@ -655,6 +734,11 @@ describe("v4TransitionRouter", () => {
       caller.legacyApiUsageSummary({
         projectId: outsideProjectId,
         ...range,
+      }),
+    ).rejects.toThrow("User is not a member of this project");
+    await expect(
+      caller.migrationData({
+        projectId: outsideProjectId,
       }),
     ).rejects.toThrow("User is not a member of this project");
     expect(mockedQueryClickhouse).not.toHaveBeenCalled();

--- a/web/src/features/in-app-agent/components/utils/side-effects.ts
+++ b/web/src/features/in-app-agent/components/utils/side-effects.ts
@@ -84,6 +84,7 @@ const IN_APP_AGENT_TOOL_TRPC_INVALIDATION_TARGETS = {
   langfuse_listExperimentItems: [],
   langfuse_submitFeedback: ["scores", "scoreAnalytics"],
   langfuse_getHealth: [],
+  langfuse_getV4MigrationData: [],
   langfuse_getMedia: [],
   langfuse_queryMetrics: [],
   langfuse_getMetricsSchema: [],

--- a/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
+++ b/web/src/features/in-app-agent/components/utils/utils.clienttest.ts
@@ -75,6 +75,7 @@ const ACCEPTED_AUTO_IN_APP_AGENT_PROGRESS_LABELS: Record<string, string> = {
   langfuse_getPrompt: "Inspecting prompt",
   langfuse_getScore: "Inspecting score",
   langfuse_getScoreConfig: "Inspecting score config",
+  langfuse_getV4MigrationData: "Inspecting v4 migration data",
   langfuse_listAlerts: "Browsing alerts",
   langfuse_listAnnotationQueueItems: "Browsing annotation queue items",
   langfuse_listAnnotationQueues: "Browsing annotation queues",

--- a/web/src/features/mcp/features/v4Migration/index.ts
+++ b/web/src/features/mcp/features/v4Migration/index.ts
@@ -1,0 +1,16 @@
+import type { McpFeatureModule } from "../../server/registry";
+import {
+  getV4MigrationDataTool,
+  handleGetV4MigrationData,
+} from "./tools/getV4MigrationData";
+
+export const v4MigrationFeature = {
+  name: "v4Migration",
+  description: "Inspect project-specific Langfuse v4 migration evidence",
+  tools: [
+    {
+      definition: getV4MigrationDataTool,
+      handler: handleGetV4MigrationData,
+    },
+  ],
+} as const satisfies McpFeatureModule;

--- a/web/src/features/mcp/features/v4Migration/tools/getV4MigrationData.ts
+++ b/web/src/features/mcp/features/v4Migration/tools/getV4MigrationData.ts
@@ -1,0 +1,28 @@
+import { prisma } from "@langfuse/shared/src/db";
+import { z } from "zod";
+
+import { getProjectV4MigrationData } from "@/src/features/v4/server/v4TransitionService";
+import { defineTool } from "@/src/features/mcp/core/define-tool";
+import { runMcpTool } from "@/src/features/mcp/core/run-mcp-tool";
+
+const GetV4MigrationDataInput = z.object({}).strict();
+
+export const [getV4MigrationDataTool, handleGetV4MigrationData] = defineTool({
+  name: "getV4MigrationData",
+  description:
+    "Get project-specific evidence for upgrading to Langfuse v4, including SDK versions and compatibility, experiment instrumentation, legacy integrations, deprecated API usage, and trace-level evaluators. Use this before giving v4 migration guidance.",
+  baseSchema: GetV4MigrationDataInput,
+  inputSchema: GetV4MigrationDataInput,
+  handler: async (_input, context) =>
+    runMcpTool({
+      spanName: "mcp.v4_migration.get",
+      context,
+      fn: () =>
+        getProjectV4MigrationData({
+          prisma,
+          projectId: context.projectId,
+        }),
+    }),
+  readOnlyHint: true,
+  expensiveHint: true,
+});

--- a/web/src/features/mcp/server/bootstrap.ts
+++ b/web/src/features/mcp/server/bootstrap.ts
@@ -26,6 +26,7 @@ import { dashboardWidgetsFeature } from "../features/dashboardWidgets";
 import { feedbackFeature } from "../features/feedback";
 import { experimentsFeature } from "../features/experiments";
 import { monitorsFeature } from "../features/monitors";
+import { v4MigrationFeature } from "../features/v4Migration";
 
 const MCP_FEATURES = [
   promptsFeature,
@@ -43,6 +44,7 @@ const MCP_FEATURES = [
   feedbackFeature,
   experimentsFeature,
   monitorsFeature,
+  v4MigrationFeature,
 ] as const satisfies readonly McpFeatureModule[];
 
 export type McpFeature = (typeof MCP_FEATURES)[number];

--- a/web/src/features/v4/server/v4TransitionRouter.ts
+++ b/web/src/features/v4/server/v4TransitionRouter.ts
@@ -7,6 +7,7 @@ import {
 import { isForceV3ExperienceProject } from "@langfuse/shared/src/server";
 import {
   getAccessibleOrganizationProjects,
+  getProjectV4MigrationData,
   getMigrationActions,
   getLegacyApiUsageSummaries,
   getLegacyIntegrationSummaries,
@@ -18,6 +19,15 @@ export const v4TransitionRouter = createTRPCRouter({
   forceV3Experience: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
     .query(({ input }) => isForceV3ExperienceProject(input.projectId)),
+
+  migrationData: protectedProjectProcedure
+    .input(z.object({ projectId: z.string() }))
+    .query(({ input, ctx }) =>
+      getProjectV4MigrationData({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+      }),
+    ),
 
   summary: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))

--- a/web/src/features/v4/server/v4TransitionService.ts
+++ b/web/src/features/v4/server/v4TransitionService.ts
@@ -14,14 +14,17 @@ import {
   readExperimentPostUsageCache,
   readLegacyApiUsageCache,
 } from "@/src/features/v4/server/v4TransitionCache";
-import { trimLegacyApiUsageRows } from "@/src/features/v4/server/v4TransitionQueryLogUsage";
+import {
+  getLegacyApiUsageSummaries,
+  trimLegacyApiUsageRows,
+} from "@/src/features/v4/server/v4TransitionQueryLogUsage";
 import {
   deriveExperimentInstrumentationMigration,
+  getSdkUsageSummaries,
   getSdkUsageSeriesByProject,
 } from "@/src/features/v4/server/v4TransitionSdkUsage";
 
-export { getSdkUsageSummaries } from "@/src/features/v4/server/v4TransitionSdkUsage";
-export { getLegacyApiUsageSummaries } from "@/src/features/v4/server/v4TransitionQueryLogUsage";
+export { getSdkUsageSummaries, getLegacyApiUsageSummaries };
 
 const legacyIntegrationExportSources =
   new Set<AnalyticsIntegrationExportSource>([
@@ -210,6 +213,36 @@ export const getTraceLevelEvalSummaries = async ({
     projectId,
     traceLevelEvalCount: countByProjectId.get(projectId) ?? 0,
   }));
+};
+
+/**
+ * Project-scoped migration evidence exposed by the v4 migration API.
+ * Keep MCP and UI consumers on the same data sources and detection windows.
+ */
+export const getProjectV4MigrationData = async ({
+  prisma,
+  projectId,
+}: {
+  prisma: V4TransitionPrisma;
+  projectId: string;
+}) => {
+  const projectIds = [projectId];
+  const [sdkUsage, legacyIntegrations, legacyApiUsage, traceLevelEvals] =
+    await Promise.all([
+      getSdkUsageSummaries({ projectIds }),
+      getLegacyIntegrationSummaries({ prisma, projectIds }),
+      getLegacyApiUsageSummaries({ projectIds }),
+      getTraceLevelEvalSummaries({ prisma, projectIds }),
+    ]);
+
+  return {
+    projectId,
+    forceV3Experience: isForceV3ExperienceProject(projectId),
+    sdkUsage: sdkUsage[0]!,
+    legacyIntegrations: legacyIntegrations[0]!,
+    legacyApiUsage,
+    traceLevelEvals: traceLevelEvals[0]!,
+  };
 };
 
 /**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16671.preview.langfuse.com](https://pr-16671.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a read-only `getV4MigrationData` MCP tool for project-specific v4 upgrade evidence. The tool reuses the v4 transition service used by the in-app migration API and returns SDK compatibility, experiment instrumentation, legacy integrations, deprecated API usage, and trace-level evaluator counts.

The in-app agent can call the tool automatically for users with project read access. The combined tRPC procedure and MCP tool remain project-scoped.

Impacted packages: `web`, `@langfuse/shared`, `worker` (policy compatibility verification).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web run test src/__tests__/server/unit/v4TransitionRouter.servertest.ts src/__tests__/server/unit/mcp-v4-migration.servertest.ts src/__tests__/server/unit/in-app-agent-mcp-policy.servertest.ts`
- `pnpm --filter web run test-client src/features/in-app-agent/components/utils/utils.clienttest.ts`
- `pnpm --filter worker run test src/features/in-app-agent/runtime/agent.test.ts`
- `pnpm run typecheck`
- `pnpm run lint` (pre-commit hook)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15663](https://linear.app/clickhouse/issue/LFE-15663/surface-v4-migration-data-in-the-in-app-agent)

<div><a href="https://cursor.com/agents/bc-a9386a9e-a374-417b-b524-8e140f0632cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9386a9e-a374-417b-b524-8e140f0632cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a project-scoped, read-only MCP tool and tRPC procedure that expose the existing v4 migration signals through one shared service.

- Aggregates SDK compatibility, experiment instrumentation, legacy integrations, deprecated API usage, and trace-level evaluator counts.
- Registers the tool for authenticated MCP clients and automatically permits in-app-agent callers with project read access.
- Adds server tests covering the aggregate response, project authorization, tool metadata, and service delegation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with project scoping and read-access enforcement preserved across both new entry points.

The MCP handler derives its project from authenticated context, the tRPC procedure uses the protected project boundary, and the aggregation helpers preserve the intended project-specific response shapes.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Authenticated project reader] --> B[MCP tool or tRPC procedure]
    B --> C[getProjectV4MigrationData]
    C --> D[SDK usage]
    C --> E[Legacy integrations]
    C --> F[Deprecated API usage]
    C --> G[Trace-level evaluators]
    D --> H[Combined migration evidence]
    E --> H
    F --> H
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mcp): expose v4 migration data"](https://github.com/langfuse/langfuse/commit/1eef099b4a7bfa44ba441b5a85896443f94dc4e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57441139)</sub>

<!-- /greptile_comment -->