### PR TITLE
security(auth)!: reduce default JWT session max age to 14 days (v3 backport of #16593)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -60,7 +60,7 @@ OTEL_SERVICE_NAME="langfuse"
 # AUTH_IGNORE_ACCOUNT_FIELDS=foo,bar
 # AUTH_DISABLE_USERNAME_PASSWORD=true
 # AUTH_DISABLE_SIGNUP=true
-# AUTH_SESSION_MAX_AGE=43200 # 30 days in minutes (default)
+# AUTH_SESSION_MAX_AGE=20160 # 14 days in minutes (default)
 
 # SSO, each group is optional
 # AUTH_GOOGLE_CLIENT_ID=

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -292,7 +292,7 @@ export const env = createEnv({
         "AUTH_SESSION_MAX_AGE must be > 5 as session JWT tokens are refreshed every 5 minutes",
       )
       .optional()
-      .default(30 * 24 * 60), // default to 30 days
+      .default(14 * 24 * 60), // default to 14 days
     AUTH_HTTP_PROXY: z.url().optional(),
     AUTH_HTTPS_PROXY: z.url().optional(),
     AUTH_SSO_TIMEOUT: z.coerce.number().int().positive().optional(),

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -745,7 +745,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
     logger: nextAuthLogger,
     session: {
       strategy: "jwt",
-      maxAge: env.AUTH_SESSION_MAX_AGE * 60, // convert minutes to seconds, default is set in env.mjs
+      maxAge: env.AUTH_SESSION_MAX_AGE * 60, // minutes → seconds
     },
     callbacks: {
       // Harden the callback-URL redirect against malformed input. NextAuth's


### PR DESCRIPTION
**TL;DR** — v3 backport of langfuse/langfuse#16593. Unset `AUTH_SESSION_MAX_AGE` now expires idle UI sessions after 14 days instead of 30. Cherry-pick applied to v3 with no conflicts and no adaptation.

Source PR: langfuse/langfuse#16593 (`f0308f0e504b31982f1db26c7f6883b0d6930ffc`)

## Breaking change

Self-hosters who want to keep the old 30-day idle-session window should set:

```
AUTH_SESSION_MAX_AGE=43200
```

Active tabs keep refreshing either way — the JWT is refreshed every 5 minutes, so this only affects how long a session survives while idle.

## What changed

| File | Change |
| --- | --- |
| `web/src/env.mjs` | `.default(30 * 24 * 60)` → `.default(14 * 24 * 60)` |
| `.env.prod.example` | commented default `43200` → `20160` |
| `web/src/server/auth.ts` | comment only (`convert minutes to seconds, default is set in env.mjs` → `minutes → seconds`) |

## Verification

- **Patch identity** — `git diff origin/v3..HEAD` is line-for-line identical to `git show f0308f0e50` (hunk headers stripped; v3 sits at different line offsets). Stronger claim than "cherry-picked cleanly": the applied change *is* main's patch.
- **Post-image on v3 confirmed** — `env.mjs:295` now reads `.default(14 * 24 * 60), // default to 14 days`; `.env.prod.example:63` reads `# AUTH_SESSION_MAX_AGE=20160 # 14 days in minutes (default)`.
- `pnpm run format:check` → `All matched files use Prettier code style!`
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `pnpm run lint` → `Tasks: 7 successful, 7 total`

No tests accompany this change: upstream deliberately dropped its `AUTH_SESSION_MAX_AGE` unit tests in the same PR, and a `git grep` over v3 confirms no remaining test asserts the old default (the constant appears only in `env.mjs` and `auth.ts`), so there was nothing to update or re-point.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Reduces the default maximum age for idle JWT sessions from 30 days to 14 days while preserving explicit deployment overrides.
- Changes the `AUTH_SESSION_MAX_AGE` schema default to 20,160 minutes.
- Updates the production environment example to document the new default.
- Simplifies the unit-conversion comment where the setting is passed to NextAuth.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the implementation and deployment example consistently apply the intended shorter default without changing explicit overrides.

The behavioral change is limited to reducing the unset session maximum-age default, while the existing validation, minute-to-second conversion, and active-tab refresh configuration remain aligned.
</details>

<sub>Reviews (1): Last reviewed commit: ["security(auth)!: reduce default JWT sess..."](https://github.com/langfuse/langfuse/commit/e8c3418321b9043bbd80c6c911eb7d0936303bd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57464565)</sub>

<!-- /greptile_comment -->