### PR TITLE
fix(blobstorage): suppress sub-second remainder chunk to prevent silent key collision (v3 backport of #16592)

### DIFF
--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -60,6 +60,7 @@ import { Job } from "bullmq";
 import {
   handleBlobStorageIntegrationProjectJob,
   BLOB_STORAGE_LAG_BUFFER_MS,
+  BLOB_STORAGE_REMAINDER_COALESCE_MS,
 } from "../features/blobstorage/handleBlobStorageIntegrationProjectJob";
 import {
   BlobStorageIntegrationType,
@@ -1602,6 +1603,86 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         updatedIntegration.nextSyncAt.getTime() - now.getTime(),
       );
       expect(timeDiff).toBeLessThan(5000); // Within 5 seconds
+    });
+
+    it("should coalesce a sub-second remainder instead of emitting a colliding chunk", async () => {
+      // Regression for the silent object-key collision: a caught-up run whose
+      // full-interval chunk ends only a sub-second before the frontier used to
+      // re-enqueue a tiny remainder chunk. Both keys truncate to the same
+      // wall-clock second, so the remainder overwrote the full window. Position
+      // lastSyncAt so the interval-capped maxTimestamp lands just below the
+      // frontier (remainder < BLOB_STORAGE_REMAINDER_COALESCE_MS): the run must
+      // be treated as caught up (schedule one interval out), not re-enqueued.
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      const now = new Date();
+      const frequencyIntervalMs = 60 * 60 * 1000; // hourly
+      // gap = frontier - (minTimestamp + interval). Kept tiny (well under the
+      // coalesce threshold) so it stays below threshold even after the handler's
+      // own `now` advances a few ms past the test's.
+      const gapMs = 50;
+      const lastSyncAt = new Date(
+        now.getTime() -
+          BLOB_STORAGE_LAG_BUFFER_MS -
+          frequencyIntervalMs -
+          gapMs,
+      );
+
+      // A trace inside the full window so a real chunk is exported.
+      const trace = createTrace({
+        project_id: projectId,
+        timestamp: lastSyncAt.getTime() + frequencyIntervalMs / 2,
+        name: "Windowed Trace",
+      });
+      await createTracesCh([trace]);
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId: minioAccessKeyId,
+          secretAccessKey: encrypt(minioAccessKeySecret),
+          region: region ? region : "auto",
+          endpoint: minioEndpoint,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "hourly",
+          lastSyncAt,
+          compressed: false,
+        },
+      });
+
+      await handleBlobStorageIntegrationProjectJob({
+        data: { payload: { projectId } },
+      } as Job);
+
+      const updatedIntegration = await prisma.blobStorageIntegration.findUnique(
+        {
+          where: { projectId },
+        },
+      );
+
+      expect(updatedIntegration).toBeDefined();
+      if (!updatedIntegration?.nextSyncAt || !updatedIntegration?.lastSyncAt) {
+        expect.fail("nextSyncAt and lastSyncAt should be set");
+      }
+
+      // Caught up: nextSyncAt is one interval past the exported boundary, far in
+      // the future — not the near-`now` value a catch-up re-enqueue would set.
+      expect(
+        updatedIntegration.nextSyncAt.getTime() - now.getTime(),
+      ).toBeGreaterThan(frequencyIntervalMs / 2);
+
+      // lastSyncAt advances only to the interval-capped boundary; the sub-second
+      // tail up to the frontier is deferred to the next scheduled run.
+      const frontier = now.getTime() - BLOB_STORAGE_LAG_BUFFER_MS;
+      expect(updatedIntegration.lastSyncAt.getTime()).toBeLessThan(frontier);
+      expect(frontier - updatedIntegration.lastSyncAt.getTime()).toBeLessThan(
+        BLOB_STORAGE_REMAINDER_COALESCE_MS + 2000, // + handler-clock drift tolerance
+      );
     });
 
     it("should schedule normally when caught up", async () => {

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -133,6 +133,17 @@ function resolveBlobExportFormat(
 
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
 
+// When a catch-up run lands within this distance of the frontier, treat it as
+// caught up rather than emitting a tiny trailing chunk. Object keys are truncated
+// to whole-second precision (formatBlobExportTimestamp), so a sub-second remainder
+// chunk can share a wall-clock second with the full-interval chunk it follows and
+// silently overwrite that window's files and manifest. Suppressing the remainder
+// removes the collision at its source; the deferred tail is picked up by the next
+// scheduled run (its minTimestamp = lastSyncAt already covers it). Must be >= 1000ms
+// (the key granularity) and well below any frequencyInterval so no meaningful data
+// is deferred.
+export const BLOB_STORAGE_REMAINDER_COALESCE_MS = 1000;
+
 export async function* enrichObservationStream(
   stream: AsyncGenerator<Record<string, unknown>>,
   projectId: string,
@@ -1459,8 +1470,14 @@ export const handleBlobStorageIntegrationProjectJob = async (
       }
     }
 
-    // Determine if we've caught up with present-day data
-    const caughtUp = maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime();
+    // Determine if we've caught up with present-day data. A remainder below
+    // BLOB_STORAGE_REMAINDER_COALESCE_MS is treated as caught up so we never emit
+    // a sub-second trailing chunk that would collide with the full-interval chunk
+    // on the same second-precision object key (see the constant's doc comment).
+    const remainderMs = uncappedMaxTimestamp.getTime() - maxTimestamp.getTime();
+    const caughtUp =
+      maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime() ||
+      remainderMs < BLOB_STORAGE_REMAINDER_COALESCE_MS;
 
     let nextSyncAt: Date;
     if (caughtUp) {


### PR DESCRIPTION
**TL;DR** — v3 backport of langfuse/langfuse#16592. A caught-up scheduled blob export could emit a full-interval chunk followed by a sub-second remainder chunk that landed on the *same* second-precision object key, silently overwriting the full window's data files and manifest. Cherry-pick applied to v3 with no conflicts and no adaptation.

Source PR: langfuse/langfuse#16592 (`9b955df9c289eb63601109128eb62c9889187067`)

## The bug, and why v3 is affected identically

Object keys and manifest keys are built from `formatBlobExportTimestamp`, which on v3 is:

```ts
// worker/src/features/blobstorage/manifest.ts:39
export const formatBlobExportTimestamp = (date: Date): string =>
  date.toISOString().replace(/:/g, "-").substring(0, 19);
```

`substring(0, 19)` truncates to whole seconds — no milliseconds. So when a catch-up run's interval-capped `maxTimestamp` ends a few hundred milliseconds short of the frontier, the run re-enqueues immediately, and the tiny remainder chunk's key collides with the chunk that just preceded it. On buckets without versioning that is silent, permanent data loss (~7–8 windows/day on an hourly integration).

The fix treats a remainder below `BLOB_STORAGE_REMAINDER_COALESCE_MS` (1000 ms — the key granularity) as caught up, so the remainder is never emitted. The deferred sub-second tail is picked up by the next scheduled run, whose `minTimestamp = lastSyncAt` already covers it. No change to the object-key format or the queue payload contract.

## Verification

Run against a v3 worktree with a **fresh** ClickHouse volume (v3's own 37 migrations, not a main-contaminated one) and a dedicated `langfuse_v3_test` Postgres at 424/424 applied migrations.

- **Patch identity** — `git diff origin/v3..HEAD` is line-for-line identical to `git show 9b955df9c2` (hunk headers stripped). The surrounding file has diverged substantially between v3 and main (462 lines), but every line this commit touches is byte-identical, and the `caughtUp` / `uncappedMaxTimestamp` / `nextSyncAt` logic it modifies is unchanged on v3.
- **Full suite on the branch** — `pnpm --filter worker run test blobStorageIntegrationProcessing` → `Tests  32 passed (32)`. Worth noting explicitly: the change alters `caughtUp` semantics, and none of the 31 pre-existing tests (including `should schedule normally when caught up` and the other chunked-historic-export cases) regress.
- **Revert-check — the test genuinely catches v3's bug.** Reverting just the `caughtUp` logic to v3's original two lines, while leaving the new constant exported so the test compiles unchanged, fails the new test decisively:

  ```
  FAIL  should coalesce a sub-second remainder instead of emitting a colliding chunk
  AssertionError: expected 71 to be greater than 1800000
   ❯ expect(updatedIntegration.nextSyncAt.getTime() - now.getTime())
       .toBeGreaterThan(frequencyIntervalMs / 2);
  ```

  On v3's logic `nextSyncAt` is set **71 ms** past `now` — the immediate catch-up re-enqueue that emits the colliding chunk. With the fix it is one full hour out. The prod file was restored afterwards and `git status --porcelain` is empty.
- `pnpm run format:check` → `All matched files use Prettier code style!`
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `pnpm run lint` → `Tasks: 7 successful, 7 total`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport prevents sub-second catch-up remainder chunks from overwriting full export windows that share the same second-precision object key.

- Adds a 1000 ms coalescing threshold aligned with blob-export key granularity.
- Treats smaller remainders as caught up while retaining the capped timestamp as the next export position.
- Adds regression coverage for scheduling and retained-boundary behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the deferred tail remains reachable through the next run’s inclusive lower boundary and receives a non-colliding export key.

The new threshold exactly matches the object-key timestamp granularity, all supported export frequencies are substantially larger, and persisted synchronization state ensures deferred records are exported by the next scheduled run.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Calculate capped export max timestamp] --> B[Export window and persist manifest]
  B --> C{Remainder below 1000 ms?}
  C -->|No| D[Immediately enqueue catch-up run]
  C -->|Yes| E[Persist capped max as lastSyncAt]
  E --> F[Schedule next regular run]
  F --> G[Next run starts inclusively at lastSyncAt]
  G --> H[Export deferred sub-second tail under a later key]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blobstorage): suppress sub-second re..."](https://github.com/langfuse/langfuse/commit/4d63d75a787cf7d622bd434861bbdaf21be24072) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57464602)</sub>

**Context used:**

- Knowledge Base — [Media and blob processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/media-and-blob-processing.md)

<!-- /greptile_comment -->