### PR TITLE
security(api-keys): gate organization API key creation on the admin-api entitlement (v3 backport of #16596)

### DIFF
--- a/web/src/__tests__/server/organizations-api-key-trpc.servertest.ts
+++ b/web/src/__tests__/server/organizations-api-key-trpc.servertest.ts
@@ -10,6 +10,7 @@ import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { createAndAddApiKeysToDb } from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
 
 describe("organization API keys trpc", () => {
   const organizationId = "seed-org-id";
@@ -31,6 +32,9 @@ describe("organization API keys trpc", () => {
     });
   });
 
+  // Instance admins bypass both RBAC and entitlement checks, so this session
+  // cannot cover plan gating. `entitledOwnerCaller` / `unentitledOwnerCaller`
+  // below are the non-admin owners used for that.
   const ownerSession: Session = {
     expires: "1",
     user: {
@@ -129,6 +133,48 @@ describe("organization API keys trpc", () => {
 
   const unAuthedCtx = createInnerTRPCContext({ session: null, headers: {} });
   const unAuthedCaller = appRouter.createCaller({ ...unAuthedCtx, prisma });
+
+  // Organization-scoped API keys are a paid feature (`admin-api` entitlement).
+  // These owners are deliberately not instance admins so the plan gate applies.
+  const ownerSessionOnPlan = (plan: SessionOrg["plan"]): Session => ({
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: organizationId,
+          name: "Test Organization",
+          role: "OWNER",
+          plan,
+          cloudConfig: undefined,
+          metadata: {},
+          projects: [] as SessionOrg["projects"],
+        } as SessionOrg,
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      } as SessionFeatureFlags,
+      admin: false,
+    },
+    environment: {} as any,
+  });
+
+  const callerForSession = (session: Session) =>
+    appRouter.createCaller({
+      ...createInnerTRPCContext({ session, headers: {} }),
+      prisma,
+    });
+
+  // cloud:hobby lacks `admin-api`; cloud:team carries it.
+  const unentitledOwnerCaller = callerForSession(
+    ownerSessionOnPlan("cloud:hobby"),
+  );
+  const entitledOwnerCaller = callerForSession(
+    ownerSessionOnPlan("cloud:team"),
+  );
 
   describe("organizationApiKeys.byOrganizationId", () => {
     it("owner can fetch organization API keys", async () => {
@@ -256,6 +302,42 @@ describe("organization API keys trpc", () => {
           note: "Test API Key",
         }),
       ).rejects.toThrow(TRPCError);
+    });
+
+    it("owner on a plan without admin-api cannot create organization API keys", async () => {
+      // Unique note so the persistence assertion stays independent of other
+      // tests and of keys left behind by earlier runs.
+      const note = `unentitled-create-${randomUUID()}`;
+
+      await expect(
+        unentitledOwnerCaller.organizationApiKeys.create({
+          orgId: organizationId,
+          note,
+        }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: "FORBIDDEN",
+          message: expect.stringContaining("admin-api"),
+        }),
+      );
+
+      // The rejection must happen before the key is persisted, otherwise the
+      // plan gate would only hide a key that already works.
+      await expect(
+        prisma.apiKey.findFirst({ where: { orgId: organizationId, note } }),
+      ).resolves.toBeNull();
+    });
+
+    it("owner on a plan with admin-api can create organization API keys", async () => {
+      const apiKeyResult = await entitledOwnerCaller.organizationApiKeys.create(
+        {
+          orgId: organizationId,
+          note: "Entitled plan key",
+        },
+      );
+
+      expect(apiKeyResult.secretKey).toBeDefined();
+      expect(apiKeyResult.publicKey).toBeDefined();
     });
   });
 
@@ -415,6 +497,33 @@ describe("organization API keys trpc", () => {
           id: apiKeyResult.id,
         }),
       ).rejects.toThrow(TRPCError);
+    });
+
+    it("owner on a plan without admin-api can still list and revoke existing keys", async () => {
+      // Only creation is plan-gated. A downgraded organization must keep the
+      // ability to see and revoke keys that were issued while entitled,
+      // otherwise a downgrade would strand live credentials.
+      const existingKey = await createAndAddApiKeysToDb({
+        prisma,
+        entityId: organizationId,
+        scope: "ORGANIZATION",
+        note: "Issued before downgrade",
+      });
+
+      const apiKeys =
+        await unentitledOwnerCaller.organizationApiKeys.byOrganizationId({
+          orgId: organizationId,
+        });
+      expect(apiKeys.map((key) => key.id)).toContain(existingKey.id);
+
+      await unentitledOwnerCaller.organizationApiKeys.delete({
+        orgId: organizationId,
+        id: existingKey.id,
+      });
+
+      await expect(
+        prisma.apiKey.findUnique({ where: { id: existingKey.id } }),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/web/src/features/public-api/server/organizationApiKeyRouter.ts
+++ b/web/src/features/public-api/server/organizationApiKeyRouter.ts
@@ -1,5 +1,6 @@
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import {
   createTRPCRouter,
   protectedOrganizationProcedure,
@@ -68,6 +69,14 @@ export const organizationApiKeysRouter = createTRPCRouter({
         session: ctx.session,
         organizationId: input.orgId,
         scope: "organization:CRUD_apiKeys",
+      });
+      // Issuing organization-scoped keys is a paid feature. Reads and deletes
+      // stay ungated so a downgraded organization can still revoke keys that
+      // were issued while it was entitled.
+      throwIfNoEntitlement({
+        entitlement: "admin-api",
+        sessionUser: ctx.session.user,
+        orgId: input.orgId,
       });
 
       const apiKeyMeta = await createAndAddApiKeysToDb({


### PR DESCRIPTION
**TL;DR** — v3 backport of langfuse/langfuse#16596. The RBAC-only `organizationApiKeys.create` mutation is now also gated on the `admin-api` entitlement, matching the UI and every consuming endpoint. Reported upstream via Bugcrowd. Cherry-pick applied to v3 with no conflicts and no adaptation.

Source PR: langfuse/langfuse#16596 (`c8d72e7213b0762a56e5a62325007fbad473f7a2`)

## What this closes

`organizationApiKeys.create` checked only OWNER RBAC (`organization:CRUD_apiKeys`), so an owner on a plan without `admin-api` could mint organization-scoped API keys. The organization settings UI already hides the feature behind `useHasEntitlement("admin-api")`, and every consuming org-scoped endpoint enforces `admin-api` independently, so a key created this way stayed inert until the organization upgraded — the gap is a commercial restriction bypass, not cross-tenant access.

Only **creation** is gated. Listing, renaming and deleting stay open so an organization that downgrades can still see and revoke keys it was issued while entitled; gating those would strand live credentials. There is a test asserting exactly that.

## v3 divergence check

This one was not dry-run tested before the batch, so the entitlement and RBAC helpers were compared explicitly:

- `web/src/features/entitlements/server/hasEntitlement.ts` is **byte-identical** between v3 and main (`git diff origin/v3 origin/main -- <file>` is empty), so `throwIfNoEntitlement({ entitlement, sessionUser, orgId })` has the same signature and semantics.
- The `admin-api` entitlement exists on v3 and the plan mapping the new tests rely on holds: `cloud:hobby` carries only `cloudAllPlansEntitlements` (no `admin-api`); `cloud:team`, `cloud:enterprise` and `self-hosted:enterprise` list it.
- v3's `organizationApiKeyRouter.ts` differs from main only in the import path for `createAndAddApiKeysToDb` (`@langfuse/shared/src/server/auth/apiKeys` vs `@langfuse/shared/src/server`) — untouched by this patch. All four procedures (`byOrganizationId` / `create` / `updateNote` / `delete`) exist on v3, so no procedure-shape adaptation was needed.
- v3's copy of the test file was already identical to main's pre-commit state, so the 109 added lines applied verbatim.

## Verification

Run against a dedicated `langfuse_v3_test` Postgres at 424/424 applied migrations — deliberately **not** the shared `langfuse_test`, which sits at 436 and has applied main-only migrations that *drop* tables v3 still reads.

- **Patch identity** — `git diff origin/v3..HEAD` is line-for-line identical to `git show c8d72e7213` (hunk headers stripped).
- **Suite on the branch** — `pnpm --filter web run test organizations-api-key-trpc` → `Tests  21 passed (21)`.
- **Revert-check — the vulnerability is real on v3.** Restoring v3's original router (`git checkout origin/v3 -- web/src/features/public-api/server/organizationApiKeyRouter.ts`) and re-running the suite gives `Tests  1 failed | 20 passed (21)`, and the failure shows the unentitled owner successfully minting a **live** organization API key rather than being rejected:

  ```
  FAIL  owner on a plan without admin-api cannot create organization API keys
  AssertionError: promise resolved "{ …(6) }" instead of rejecting
  + {
  +   "displaySecretKey": "sk-lf-...bbdc",
  +   "publicKey":  "pk-lf-1fb2bf80-c928-4d33-bf32-e4dcaf9a7153",
  +   "secretKey":  "sk-lf-2f64c3a0-0dc2-4624-99e0-00130596bbdc",
  +   ...
  ```

  The two companion tests (`owner on a plan with admin-api can create…` and `owner on a plan without admin-api can still list and revoke existing keys`) pass both before and after, which is the point — they are guardrails against over-gating, not regression detectors. The prod file was restored afterwards and `git status --porcelain` is empty.
- `pnpm run format:check` → `All matched files use Prettier code style!`
- `pnpm run typecheck` → `Tasks: 7 successful, 7 total`
- `pnpm run lint` → `Tasks: 7 successful, 7 total`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport adds server-side `admin-api` entitlement enforcement before organization API-key creation while intentionally preserving listing, renaming, and deletion after a downgrade.
- Adds the entitlement check after organization RBAC validation and before key persistence.
- Adds tests covering denied unentitled creation, successful entitled creation, non-persistence after rejection, and post-downgrade listing and revocation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the new gate closes the entitlement bypass while retaining the intended credential-revocation lifecycle.

The creation mutation now verifies both organization RBAC and the current session organization’s `admin-api` entitlement before writing a key, and the added tests cover both plan outcomes and downgrade cleanup behavior.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Authenticated organization owner] --> B[Organization RBAC check]
    B --> C{admin-api entitlement?}
    C -- No --> D[403 Forbidden]
    C -- Yes --> E[Create organization API key]
    F[Downgraded organization] --> G[List or delete existing keys]
    G --> H[Existing credentials remain manageable]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["security(api-keys): gate organization AP..."](https://github.com/langfuse/langfuse/commit/2077d580539388d6b0430c72356755c89d6827ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57464613)</sub>

<!-- /greptile_comment -->