### PR TITLE
refactor(web): Extract `createUserTableColumn`

### DIFF
--- a/web/src/components/design-system/Table/columns/createUserTableColumn.stories.tsx
+++ b/web/src/components/design-system/Table/columns/createUserTableColumn.stories.tsx
@@ -9,9 +9,9 @@ import { createUserTableColumn } from "./createUserTableColumn";
 type Row = {
   isUserLoading?: boolean;
   user: {
-    name: string | null;
-    email: string | null;
-    image: string | null;
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
   } | null;
 };
 
@@ -105,6 +105,18 @@ export const TextOnly = meta.story({
 
 export const EmptyValue = meta.story({
   name: "Empty Value",
+  args: {
+    variant: "avatar",
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ user: {} }],
+    },
+  },
+});
+
+export const AbsentUser = meta.story({
+  name: "Absent User",
   args: {
     variant: "avatar",
     data: {

--- a/web/src/components/design-system/Table/columns/createUserTableColumn.stories.tsx
+++ b/web/src/components/design-system/Table/columns/createUserTableColumn.stories.tsx
@@ -1,0 +1,138 @@
+import preview from "../../../../../.storybook/preview";
+
+import {
+  DataTable,
+  type AsyncTableData,
+} from "@/src/components/table/data-table";
+import { createUserTableColumn } from "./createUserTableColumn";
+
+type Row = {
+  isUserLoading?: boolean;
+  user: {
+    name: string | null;
+    email: string | null;
+    image: string | null;
+  } | null;
+};
+
+const avatarColumns = [
+  createUserTableColumn<Row>({
+    accessorKey: "user",
+    header: "User",
+    variant: "avatar",
+    emptyValue: "Unknown",
+    getUser: (user, { row }) => {
+      if (row.original.isUserLoading) return { type: "loading" };
+      if (!user) return undefined;
+
+      return { type: "user", user };
+    },
+  }),
+];
+
+const textColumns = [
+  createUserTableColumn<Row>({
+    accessorKey: "user",
+    header: "User",
+    variant: "text",
+    emptyValue: "API",
+  }),
+];
+
+function UserTableColumnStory({
+  data,
+  variant,
+}: {
+  data: AsyncTableData<Row[]>;
+  variant: "avatar" | "text";
+}) {
+  return (
+    <DataTable
+      tableName="user-column-story"
+      columns={variant === "avatar" ? avatarColumns : textColumns}
+      data={data}
+      hidePagination
+      cellPadding="comfortable"
+    />
+  );
+}
+
+const meta = preview.meta({
+  component: UserTableColumnStory,
+  parameters: {
+    layout: "fullscreen",
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    variant: "avatar",
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [
+        {
+          user: {
+            name: "Ada Lovelace",
+            email: "ada@example.com",
+            image: null,
+          },
+        },
+      ],
+    },
+  },
+});
+
+export const TextOnly = meta.story({
+  name: "Text Only",
+  args: {
+    variant: "text",
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [
+        {
+          user: {
+            name: null,
+            email: "ada@example.com",
+            image: null,
+          },
+        },
+      ],
+    },
+  },
+});
+
+export const EmptyValue = meta.story({
+  name: "Empty Value",
+  args: {
+    variant: "avatar",
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ user: null }],
+    },
+  },
+});
+
+export const CellLoading = meta.story({
+  name: "Cell Loading",
+  args: {
+    variant: "avatar",
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ isUserLoading: true, user: null }],
+    },
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    variant: "avatar",
+    data: {
+      isLoading: true,
+      isError: false,
+    },
+  },
+});

--- a/web/src/components/design-system/Table/columns/createUserTableColumn.tsx
+++ b/web/src/components/design-system/Table/columns/createUserTableColumn.tsx
@@ -32,6 +32,10 @@ export function createUserTableColumn<
 }: TableColumnOptions<TData, TValue> &
   UserTableColumnPresentation & {
     emptyValue: string;
+    /**
+     * Return undefined when the row has no associated user. Return a user with
+     * an empty object when a user exists but their identity is unknown.
+     */
     getUser?: (
       value: TValue | null | undefined,
       context: CellContext<TData, TValue | null | undefined>,
@@ -57,9 +61,10 @@ export function createUserTableColumn<
       const cell = getUser
         ? getUser(value, context)
         : { type: "user" as const, user: value ?? {} };
-      if (cell?.type === "loading") return loadingCell;
+      if (!cell) return null;
+      if (cell.type === "loading") return loadingCell;
 
-      const { name, email, image, id } = cell?.user ?? {};
+      const { name, email, image, id } = cell.user;
       const label = name ?? email ?? id ?? emptyValue;
       if (variant === "text") {
         return (

--- a/web/src/components/design-system/Table/columns/createUserTableColumn.tsx
+++ b/web/src/components/design-system/Table/columns/createUserTableColumn.tsx
@@ -1,0 +1,89 @@
+import { type CellContext, type RowData } from "@tanstack/react-table";
+
+import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/src/components/ui/avatar";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  createTableColumn,
+  type TableColumnOptions,
+} from "./utils/createTableColumn";
+
+type UserTableColumnValue = {
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  id?: string | null;
+};
+
+type UserTableColumnPresentation = { variant: "avatar" } | { variant: "text" };
+
+export function createUserTableColumn<
+  TData extends RowData,
+  TValue extends UserTableColumnValue = UserTableColumnValue,
+>({
+  getUser,
+  emptyValue,
+  variant,
+  ...options
+}: TableColumnOptions<TData, TValue> &
+  UserTableColumnPresentation & {
+    emptyValue: string;
+    getUser?: (
+      value: TValue | null | undefined,
+      context: CellContext<TData, TValue | null | undefined>,
+    ) =>
+      | { type: "loading" }
+      | { type: "user"; user: UserTableColumnValue }
+      | undefined;
+  }) {
+  const loadingCell =
+    variant === "avatar" ? (
+      <div className="flex items-center space-x-2">
+        <Skeleton className="h-7 w-7 shrink-0 rounded-full" />
+        <TableTextLoadingCell />
+      </div>
+    ) : (
+      <TableTextLoadingCell />
+    );
+
+  return createTableColumn<TData, TValue>({
+    ...options,
+    loadingCell,
+    renderCell: (value, context) => {
+      const cell = getUser
+        ? getUser(value, context)
+        : { type: "user" as const, user: value ?? {} };
+      if (cell?.type === "loading") return loadingCell;
+
+      const { name, email, image, id } = cell?.user ?? {};
+      const label = name ?? email ?? id ?? emptyValue;
+      if (variant === "text") {
+        return (
+          <span className="block truncate" title={label}>
+            {label}
+          </span>
+        );
+      }
+
+      const initials = name
+        ?.split(" ")
+        .map((word) => word[0])
+        .slice(0, 2)
+        .join("");
+
+      return (
+        <div className="flex items-center space-x-2">
+          <Avatar className="h-7 w-7">
+            <AvatarImage src={image ?? undefined} alt={name ?? "User Avatar"} />
+            <AvatarFallback>{initials}</AvatarFallback>
+          </Avatar>
+          <span>{label}</span>
+        </div>
+      );
+    },
+  });
+}

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -10,10 +10,10 @@ import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
 import { createBadgeTableColumn } from "@/src/components/design-system/Table/columns/createBadgeTableColumn";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
+import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { IOTableCell } from "../../ui/IOTableCell";
-import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import {
   type UseSidebarFilterStateOptions,
@@ -880,30 +880,24 @@ export default function ScoresTable({
         };
       },
     }),
-    {
+    createUserTableColumn<ScoresTableRow, ScoresTableRow["author"]>({
       accessorKey: "author",
-      id: "author",
       header: "Author",
       enableHiding: true,
       defaultHidden: true,
       size: 150,
-      cell: ({ row }) => {
-        const { userId, name, image } = row.getValue(
-          "author",
-        ) as ScoresTableRow["author"];
-        return (
-          <div className="flex items-center space-x-2">
-            <Avatar className="h-7 w-7">
-              <AvatarImage
-                src={image ?? undefined}
-                alt={name ?? "User Avatar"}
-              />
-            </Avatar>
-            <span>{name ?? userId}</span>
-          </div>
-        );
+      variant: "avatar",
+      emptyValue: "",
+      getUser: (author) => {
+        if (!author) return undefined;
+
+        const { userId, name, image } = author;
+        return {
+          type: "user",
+          user: { id: userId, name, image },
+        };
       },
-    },
+    }),
     createLinkTableColumn<ScoresTableRow>({
       accessorKey: "jobConfigurationId",
       header: isBetaEnabled ? "Evaluator" : "Eval Configuration ID",

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -9,11 +9,6 @@ import { type AnnotationQueueStatus } from "@langfuse/shared";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { ChevronDown, ListTree, Trash } from "lucide-react";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/src/components/ui/avatar";
 import { type RouterOutput } from "@/src/utils/types";
 import { type RowSelectionState } from "@tanstack/react-table";
 import { useState } from "react";
@@ -37,6 +32,7 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { createIdTableColumn } from "@/src/components/design-system/Table/columns/createIdTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
+import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
 
 const QueueItemTableMultiSelectAction = ({
   selectedItemIds,
@@ -320,40 +316,23 @@ export function AnnotationQueueItemsTable({
       enableHiding: true,
       size: 60,
     },
-    {
+    createUserTableColumn<QueueItemRowData, QueueItemRowData["annotatorUser"]>({
       accessorKey: "annotatorUser",
       header: "Completed by",
-      id: "annotatorUser",
       enableHiding: true,
       size: 80,
-      cell: ({ row }) => {
-        const annotatorUser: QueueItemRowData["annotatorUser"] =
-          row.getValue("annotatorUser");
-        if (!annotatorUser || !annotatorUser.userId) return null;
+      variant: "avatar",
+      emptyValue: "",
+      getUser: (annotatorUser) => {
+        if (!annotatorUser || !annotatorUser.userId) return undefined;
 
         const { userId, userName, image } = annotatorUser;
-        return (
-          <div className="flex items-center space-x-2">
-            <Avatar className="h-7 w-7">
-              <AvatarImage
-                src={image ?? undefined}
-                alt={userName ?? "User Avatar"}
-              />
-              <AvatarFallback>
-                {userName
-                  ? userName
-                      .split(" ")
-                      .map((word) => word[0])
-                      .slice(0, 2)
-                      .concat("")
-                  : null}
-              </AvatarFallback>
-            </Avatar>
-            <span>{userName ?? userId}</span>
-          </div>
-        );
+        return {
+          type: "user",
+          user: { id: userId, name: userName, image },
+        };
       },
-    },
+    }),
   ];
 
   const convertToTableRow = (

--- a/web/src/features/batch-actions/components/BatchActionsTable.tsx
+++ b/web/src/features/batch-actions/components/BatchActionsTable.tsx
@@ -5,7 +5,6 @@ import { safeExtract } from "@/src/utils/map-utils";
 import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { InfoIcon } from "lucide-react";
-import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -14,6 +13,7 @@ import {
 } from "@/src/components/ui/tooltip";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
+import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
 
 type BatchActionRow = {
   id: string;
@@ -125,29 +125,13 @@ export function BatchActionsTable(props: { projectId: string }) {
         );
       },
     },
-    {
+    createUserTableColumn<BatchActionRow>({
       accessorKey: "user",
-      id: "user",
       header: "Created By",
       size: 150,
-      cell: ({ row }) => {
-        const user = row.getValue("user") as {
-          name: string | null;
-          image: string | null;
-        } | null;
-        return (
-          <div className="flex items-center space-x-2">
-            <Avatar className="h-7 w-7">
-              <AvatarImage
-                src={user?.image ?? undefined}
-                alt={user?.name ?? "User Avatar"}
-              />
-            </Avatar>
-            <span>{user?.name ?? "Unknown"}</span>
-          </div>
-        );
-      },
-    },
+      variant: "avatar",
+      emptyValue: "Unknown",
+    }),
     {
       accessorKey: "log",
       id: "log",

--- a/web/src/features/batch-exports/components/BatchExportsTable.tsx
+++ b/web/src/features/batch-exports/components/BatchExportsTable.tsx
@@ -7,7 +7,6 @@ import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { ActionButton } from "@/src/components/ActionButton";
 import { DownloadIcon, InfoIcon } from "lucide-react";
-import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -27,6 +26,7 @@ import {
 } from "@/src/components/ui/alert-dialog";
 import { useState } from "react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
 
 type BatchExportRow = RouterOutputs["batchExport"]["all"]["exports"][number];
 
@@ -243,29 +243,13 @@ export function BatchExportsTable(props: { projectId: string }) {
       header: "Format",
       size: 70,
     },
-    {
+    createUserTableColumn<BatchExportRow>({
       accessorKey: "user",
-      id: "user",
       header: "Created By",
       size: 150,
-      cell: ({ row }) => {
-        const user = row.getValue("user") as {
-          name: string | null;
-          image: string | null;
-        } | null;
-        return (
-          <div className="flex items-center space-x-2">
-            <Avatar className="h-7 w-7">
-              <AvatarImage
-                src={user?.image ?? undefined}
-                alt={user?.name ?? "User Avatar"}
-              />
-            </Avatar>
-            <span>{user?.name ?? "Unknown"}</span>
-          </div>
-        );
-      },
-    },
+      variant: "avatar",
+      emptyValue: "Unknown",
+    }),
   ] as LangfuseColumnDef<BatchExportRow>[];
 
   return (

--- a/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
+++ b/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/src/features/evals/v2/constants/tableFilterColumns";
 import { omitFilterFacets } from "@/src/features/filters/lib/filter-config";
 import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
+import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
 
 function RelativeDate({ date }: { date: Date }) {
   return (
@@ -348,24 +349,14 @@ export function RulesTable({
         enableHiding: true,
         cell: ({ row }) => `${Math.round(row.original.sampling * 100)}%`,
       },
-      {
+      createUserTableColumn<RuleTableRow>({
         accessorKey: "createdByUser",
-        id: "createdByUser",
         header: "Created by",
         size: 180,
         enableHiding: true,
-        cell: ({ row }) => {
-          const creator =
-            row.original.createdByUser?.name ??
-            row.original.createdByUser?.email ??
-            "API";
-          return (
-            <span className="block truncate" title={creator}>
-              {creator}
-            </span>
-          );
-        },
-      },
+        variant: "text",
+        emptyValue: "API",
+      }),
       {
         accessorKey: "createdAt",
         id: "createdAt",

--- a/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
@@ -66,6 +66,7 @@ import {
 import type { GalleryTemplate } from "../types/templateGallery";
 import { V4MigrationUpdateRequiredBadge } from "@/src/features/v4-migration/V4MigrationDelayBadge";
 import { createNumberTableColumn } from "@/src/components/design-system/Table/columns/createNumberTableColumn";
+import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
 
 type EvaluatorRow = RouterOutputs["evalsV2"]["list"]["evaluators"][number];
 
@@ -433,24 +434,14 @@ export default function EvaluatorsPage() {
           );
         },
       },
-      {
+      createUserTableColumn<EvaluatorRow>({
         accessorKey: "createdByUser",
-        id: "createdByUser",
         header: "Created by",
         size: 180,
         enableHiding: true,
-        cell: ({ row }) => {
-          const creator =
-            row.original.createdByUser?.name ??
-            row.original.createdByUser?.email ??
-            "API";
-          return (
-            <span className="block truncate" title={creator}>
-              {creator}
-            </span>
-          );
-        },
-      },
+        variant: "text",
+        emptyValue: "API",
+      }),
       {
         accessorKey: "createdAt",
         id: "createdAt",

--- a/web/src/features/rbac/components/MembershipInvitesPage.tsx
+++ b/web/src/features/rbac/components/MembershipInvitesPage.tsx
@@ -1,11 +1,6 @@
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/src/components/ui/avatar";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
@@ -15,6 +10,7 @@ import { type Organization, type Role } from "@langfuse/shared";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import Header from "@/src/components/layouts/header";
 import useSessionStorage from "@/src/components/useSessionStorage";
+import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
 
 export type tmp = Organization;
 export type InvitesTableRow = {
@@ -124,37 +120,12 @@ export function MembershipInvitesPage({
           },
         ]
       : []),
-    {
+    createUserTableColumn<InvitesTableRow>({
       accessorKey: "invitedByUser",
-      id: "invitedByUser",
       header: "Invited By",
-      cell: ({ row }) => {
-        const invitedByUser = row.getValue(
-          "invitedByUser",
-        ) as InvitesTableRow["invitedByUser"];
-        const { name, image } = invitedByUser || {};
-        return (
-          <div className="flex items-center space-x-2">
-            <Avatar className="h-7 w-7">
-              <AvatarImage
-                src={image ?? undefined}
-                alt={name ?? "User Avatar"}
-              />
-              <AvatarFallback>
-                {name
-                  ? name
-                      .split(" ")
-                      .map((word) => word[0])
-                      .slice(0, 2)
-                      .concat("")
-                  : null}
-              </AvatarFallback>
-            </Avatar>
-            <span>{name ?? "-"}</span>
-          </div>
-        );
-      },
-    },
+      variant: "avatar",
+      emptyValue: "-",
+    }),
     {
       accessorKey: "meta",
       id: "meta",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16684.preview.langfuse.com](https://pr-16684.preview.langfuse.com)**
<!-- aws-preview-pin:end -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts repeated user-column rendering into a shared `createUserTableColumn` helper and migrates several tables to use it.
- Adds reusable avatar and text variants with loading and empty-user handling.
- Adds Storybook coverage for populated, absent, empty, and loading states.
- Preserves an empty annotation-queue cell when no completing user exists.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["Clarify user table column states"](https://github.com/langfuse/langfuse/commit/9d8d152360229cfbbe002d92e36946537e4299e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57478544)</sub>

<!-- /greptile_comment -->