### PR TITLE
fix(traces): stop clipping cost breakdown tooltips

### DIFF
--- a/web/src/features/traces/components/BreakdownTooltip.stories.tsx
+++ b/web/src/features/traces/components/BreakdownTooltip.stories.tsx
@@ -19,6 +19,20 @@ const costDetails = {
   total: 0.001725,
 };
 
+const cacheCostDetails = {
+  cache_read_input_tokens: 0.0266155,
+  cache_creation_input_tokens: 0.0034625,
+  input: 0.00115,
+  output: 0.0066,
+  total: 0.037828,
+};
+
+const longUsageTypeCostDetails = {
+  ...cacheCostDetails,
+  prompt_cache_creation_ephemeral_5m_input_tokens: 0.00042,
+  total: 0.038248,
+};
+
 const priceSource = {
   projectId: "project-1",
   modelId: "gpt-5.6/priority",
@@ -63,6 +77,39 @@ export const AggregatedCost = meta.story({
   },
 });
 
+export const CostWithLongUsageTypes = meta.story({
+  args: {
+    details: longUsageTypeCostDetails,
+    children: <span>$0.038248</span>,
+    isCost: true,
+    priceSource: {
+      ...priceSource,
+      pricingTierName: "Standard",
+    },
+  },
+});
+
+async function openBreakdownTooltip(
+  canvasElement: HTMLElement,
+  triggerName: string,
+) {
+  const canvas = within(canvasElement);
+  const trigger = canvas.getByRole("button", { name: triggerName });
+  trigger.click();
+  await waitFor(() =>
+    expect(trigger.getAttribute("data-state")).toMatch(/-open$/),
+  );
+  await waitFor(() => expect(trigger).toHaveAttribute("aria-describedby"));
+
+  const tooltipId = trigger.getAttribute("aria-describedby");
+  const tooltip = tooltipId
+    ? canvasElement.ownerDocument.getElementById(tooltipId)
+    : null;
+  if (!tooltip) throw new Error("Tooltip content was not rendered");
+
+  return { trigger, content: within(tooltip) };
+}
+
 export const TestLinksMatchedPricingTier = meta.story({
   name: "(Test) Opens matched pricing tier breakdown",
   args: {
@@ -72,21 +119,7 @@ export const TestLinksMatchedPricingTier = meta.story({
     priceSource,
   },
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const trigger = canvas.getByRole("button", { name: "$0.001725" });
-    trigger.click();
-    await waitFor(() =>
-      expect(trigger.getAttribute("data-state")).toMatch(/-open$/),
-    );
-    await waitFor(() => expect(trigger).toHaveAttribute("aria-describedby"));
-
-    const tooltipId = trigger.getAttribute("aria-describedby");
-    const tooltip = tooltipId
-      ? canvasElement.ownerDocument.getElementById(tooltipId)
-      : null;
-    if (!tooltip) throw new Error("Tooltip content was not rendered");
-
-    const content = within(tooltip);
+    const { content } = await openBreakdownTooltip(canvasElement, "$0.001725");
     await expect(content.getByText("Cost breakdown")).toBeInTheDocument();
     await expect(content.getByText("Total cost")).toBeInTheDocument();
     const link = content.getByRole("link");
@@ -96,5 +129,29 @@ export const TestLinksMatchedPricingTier = meta.story({
       "/project/project-1/settings/models/gpt-5.6%2Fpriority?pricingTier=tier-priority",
     );
     await expect(link).toHaveClass("text-xs", "italic");
+  },
+});
+
+export const TestCostFormattingAndTruncation = meta.story({
+  name: "(Test) Formats costs without padded decimals",
+  args: {
+    details: cacheCostDetails,
+    children: <span>$0.037828</span>,
+    isCost: true,
+  },
+  play: async ({ canvasElement }) => {
+    const { content } = await openBreakdownTooltip(canvasElement, "$0.037828");
+
+    await expect(content.getAllByText("$0.0066")).not.toHaveLength(0);
+    await expect(content.queryByText("$0.0066000")).not.toBeInTheDocument();
+    await expect(content.getByText("$0.037828")).toBeInTheDocument();
+    await expect(content.queryByText("$0.0378280")).not.toBeInTheDocument();
+
+    const longLabel = content.getByText("cache_creation_input_tokens");
+    await expect(longLabel).toHaveClass("truncate");
+    await expect(longLabel).toHaveAttribute(
+      "title",
+      "cache_creation_input_tokens",
+    );
   },
 });

--- a/web/src/features/traces/components/BreakdownTooltip.stories.tsx
+++ b/web/src/features/traces/components/BreakdownTooltip.stories.tsx
@@ -24,13 +24,14 @@ const cacheCostDetails = {
   cache_creation_input_tokens: 0.0034625,
   input: 0.00115,
   output: 0.0066,
-  total: 0.037828,
+  cached_tokens: 9e-8,
+  total: 0.03782809,
 };
 
 const longUsageTypeCostDetails = {
   ...cacheCostDetails,
   prompt_cache_creation_ephemeral_5m_input_tokens: 0.00042,
-  total: 0.038248,
+  total: 0.03824809,
 };
 
 const priceSource = {
@@ -80,7 +81,7 @@ export const AggregatedCost = meta.story({
 export const CostWithLongUsageTypes = meta.story({
   args: {
     details: longUsageTypeCostDetails,
-    children: <span>$0.038248</span>,
+    children: <span>$0.03824809</span>,
     isCost: true,
     priceSource: {
       ...priceSource,
@@ -136,16 +137,20 @@ export const TestCostFormattingAndTruncation = meta.story({
   name: "(Test) Formats costs without padded decimals",
   args: {
     details: cacheCostDetails,
-    children: <span>$0.037828</span>,
+    children: <span>$0.03782809</span>,
     isCost: true,
   },
   play: async ({ canvasElement }) => {
-    const { content } = await openBreakdownTooltip(canvasElement, "$0.037828");
+    const { content } = await openBreakdownTooltip(
+      canvasElement,
+      "$0.03782809",
+    );
 
     await expect(content.getAllByText("$0.0066")).not.toHaveLength(0);
     await expect(content.queryByText("$0.0066000")).not.toBeInTheDocument();
-    await expect(content.getByText("$0.037828")).toBeInTheDocument();
+    await expect(content.getByText("$0.03782809")).toBeInTheDocument();
     await expect(content.queryByText("$0.0378280")).not.toBeInTheDocument();
+    await expect(content.getAllByText("$0.00000009")).not.toHaveLength(0);
 
     const longLabel = content.getByText("cache_creation_input_tokens");
     await expect(longLabel).toHaveClass("truncate");

--- a/web/src/features/traces/components/BreakdownTooltip.tsx
+++ b/web/src/features/traces/components/BreakdownTooltip.tsx
@@ -50,7 +50,7 @@ export const BreakdownTooltip = ({
     : details;
 
   const formatValue = (value: number) =>
-    isCost ? usdFormatter(value) : value ? value.toLocaleString() : "0";
+    isCost ? usdFormatter(value, 2, 12) : value ? value.toLocaleString() : "0";
 
   return (
     <TooltipProvider>

--- a/web/src/features/traces/components/BreakdownTooltip.tsx
+++ b/web/src/features/traces/components/BreakdownTooltip.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import { type Details } from "@/src/features/traces/fns/calculateAggregatedUsage";
 import { ExternalLink } from "lucide-react";
 import { usdFormatter } from "@/src/utils/numbers";
-import { cn } from "@/src/utils/tailwind";
+import { cva, type VariantProps } from "class-variance-authority";
 
 export interface PriceSource {
   projectId: string;
@@ -135,6 +135,19 @@ export const BreakdownTooltip = ({
   );
 };
 
+const breakdownRowVariants = cva("flex min-w-0 items-center gap-3 text-xs", {
+  variants: {
+    variant: {
+      item: "text-muted-foreground",
+      section: "border-b pb-1 font-bold",
+      total: "border-t border-b-4 border-double py-1 font-bold",
+    },
+  },
+  defaultVariants: {
+    variant: "item",
+  },
+});
+
 function BreakdownRow({
   label,
   value,
@@ -142,32 +155,15 @@ function BreakdownRow({
 }: {
   label: string;
   value: string;
-  variant: "item" | "section" | "total";
+  variant: NonNullable<VariantProps<typeof breakdownRowVariants>["variant"]>;
 }) {
-  const isEmphasis = variant !== "item";
-
   return (
-    <div
-      className={cn(
-        "flex min-w-0 items-center gap-3",
-        variant === "section" && "border-b pb-1",
-        variant === "total" && "border-t border-b-4 border-double py-1",
-      )}
-    >
-      <span
-        className={cn(
-          "min-w-0 flex-1 truncate text-xs",
-          isEmphasis ? "font-bold" : "text-muted-foreground",
-        )}
-        title={label}
-      >
+    <div className={breakdownRowVariants({ variant })}>
+      <span className="min-w-0 flex-1 truncate" title={label}>
         {label}
       </span>
       <span
-        className={cn(
-          "max-w-[50%] min-w-0 truncate text-right font-mono text-xs tabular-nums",
-          isEmphasis ? "font-bold" : "text-muted-foreground",
-        )}
+        className="max-w-[50%] min-w-0 truncate text-right font-mono tabular-nums"
         title={value}
       >
         {value}

--- a/web/src/features/traces/components/BreakdownTooltip.tsx
+++ b/web/src/features/traces/components/BreakdownTooltip.tsx
@@ -7,9 +7,10 @@ import {
 import { useState } from "react";
 import Decimal from "decimal.js";
 import Link from "next/link";
-import { getMaxDecimals } from "@/src/features/models/fns/getMaxDecimals";
 import { type Details } from "@/src/features/traces/fns/calculateAggregatedUsage";
 import { ExternalLink } from "lucide-react";
+import { usdFormatter } from "@/src/utils/numbers";
+import { cn } from "@/src/utils/tailwind";
 
 export interface PriceSource {
   projectId: string;
@@ -48,19 +49,8 @@ export const BreakdownTooltip = ({
       }, {})
     : details;
 
-  const formatValueWithPadding = (value: number, maxDecimals: number) => {
-    return !value
-      ? "0"
-      : isCost
-        ? `$${value.toFixed(maxDecimals)}`
-        : value.toLocaleString();
-  };
-
-  const maxDecimals = isCost
-    ? Math.max(
-        ...Object.values(aggregatedDetails).map((v) => getMaxDecimals(v)),
-      )
-    : 0;
+  const formatValue = (value: number) =>
+    isCost ? usdFormatter(value) : value ? value.toLocaleString() : "0";
 
   return (
     <TooltipProvider>
@@ -71,8 +61,8 @@ export const BreakdownTooltip = ({
         >
           {children}
         </TooltipTrigger>
-        <TooltipContent className="w-64 p-4">
-          <div className="flex flex-col gap-4">
+        <TooltipContent className="w-max max-w-80 min-w-52 p-4">
+          <div className="flex min-w-0 flex-col gap-4">
             <div className="flex flex-col gap-1">
               <span className="font-bold">
                 {isCost ? "Cost breakdown" : "Usage breakdown"}
@@ -81,12 +71,17 @@ export const BreakdownTooltip = ({
               {isCost && priceSource && (
                 <Link
                   href={`/project/${encodeURIComponent(priceSource.projectId)}/settings/models/${encodeURIComponent(priceSource.modelId)}?pricingTier=${encodeURIComponent(priceSource.pricingTierId)}`}
-                  className="text-muted-foreground flex flex-row gap-1 text-xs italic underline-offset-4 hover:underline"
+                  className="text-muted-foreground flex min-w-0 flex-row gap-1 text-xs italic underline-offset-4 hover:underline"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {priceSource.pricingTierName} Tier Pricing
-                  <ExternalLink className="h-3 w-3" />
+                  <span
+                    className="min-w-0 truncate"
+                    title={`${priceSource.pricingTierName} Tier Pricing`}
+                  >
+                    {priceSource.pricingTierName} Tier Pricing
+                  </span>
+                  <ExternalLink className="h-3 w-3 shrink-0" />
                 </Link>
               )}
               {Array.isArray(details) && details.length > 0 && (
@@ -96,10 +91,11 @@ export const BreakdownTooltip = ({
                 </span>
               )}
               {pricingTierName && (
-                <div className="text-muted-foreground flex justify-between text-xs">
-                  <span>Pricing Tier:</span>
-                  <span className="font-mono">{pricingTierName}</span>
-                </div>
+                <BreakdownRow
+                  label="Pricing Tier:"
+                  value={pricingTierName}
+                  variant="item"
+                />
               )}
             </div>
 
@@ -108,7 +104,7 @@ export const BreakdownTooltip = ({
               title={isCost ? "Input cost" : "Input usage"}
               details={aggregatedDetails}
               filterFn={(key) => key.includes("input")}
-              formatValue={(v) => formatValueWithPadding(v, maxDecimals)}
+              formatValue={formatValue}
             />
 
             {/* Output Section */}
@@ -116,34 +112,69 @@ export const BreakdownTooltip = ({
               title={isCost ? "Output cost" : "Output usage"}
               details={aggregatedDetails}
               filterFn={(key) => key.includes("output")}
-              formatValue={(v) => formatValueWithPadding(v, maxDecimals)}
+              formatValue={formatValue}
             />
 
             {/* Other Section */}
             <OtherSection
               details={aggregatedDetails}
               isCost={isCost}
-              formatValue={(v) => formatValueWithPadding(v, maxDecimals)}
+              formatValue={formatValue}
             />
 
             {/* Total */}
-            <div className="flex justify-between border-t border-b-4 border-double py-1">
-              <span className="text-xs font-bold">
-                {isCost ? "Total cost" : "Total usage"}
-              </span>
-              <span className="font-mono text-xs font-bold">
-                {formatValueWithPadding(
-                  aggregatedDetails.total ?? 0,
-                  maxDecimals,
-                )}
-              </span>
-            </div>
+            <BreakdownRow
+              label={isCost ? "Total cost" : "Total usage"}
+              value={formatValue(aggregatedDetails.total ?? 0)}
+              variant="total"
+            />
           </div>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );
 };
+
+function BreakdownRow({
+  label,
+  value,
+  variant,
+}: {
+  label: string;
+  value: string;
+  variant: "item" | "section" | "total";
+}) {
+  const isEmphasis = variant !== "item";
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 items-center gap-3",
+        variant === "section" && "border-b pb-1",
+        variant === "total" && "border-t border-b-4 border-double py-1",
+      )}
+    >
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-xs",
+          isEmphasis ? "font-bold" : "text-muted-foreground",
+        )}
+        title={label}
+      >
+        {label}
+      </span>
+      <span
+        className={cn(
+          "max-w-[50%] min-w-0 truncate text-right font-mono text-xs tabular-nums",
+          isEmphasis ? "font-bold" : "text-muted-foreground",
+        )}
+        title={value}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
 
 interface SectionProps {
   title: string;
@@ -164,21 +195,19 @@ const Section = ({ title, details, filterFn, formatValue }: SectionProps) => {
   );
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex justify-between border-b pb-1">
-        <span className="text-xs font-bold">{title}</span>
-        <span className="text-right font-mono text-xs font-bold">
-          {formatValue(sectionTotal)}
-        </span>
-      </div>
+    <div className="flex min-w-0 flex-col gap-2">
+      <BreakdownRow
+        label={title}
+        value={formatValue(sectionTotal)}
+        variant="section"
+      />
       {filteredEntries.map(([key, value]) => (
-        <div
+        <BreakdownRow
           key={key}
-          className="text-muted-foreground flex justify-between text-xs"
-        >
-          <span className="mr-4">{key}</span>
-          <span className="font-mono">{formatValue(value ?? 0)}</span>
-        </div>
+          label={key}
+          value={formatValue(value ?? 0)}
+          variant="item"
+        />
       ))}
     </div>
   );
@@ -207,23 +236,19 @@ const OtherSection = ({ details, isCost, formatValue }: OtherSectionProps) => {
   }, 0);
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex justify-between border-b pb-2">
-        <span className="text-xs font-bold">
-          {isCost ? "Other cost" : "Other usage"}
-        </span>
-        <span className="text-right font-mono text-xs font-bold">
-          {formatValue(otherTotal)}
-        </span>
-      </div>
+    <div className="flex min-w-0 flex-col gap-2">
+      <BreakdownRow
+        label={isCost ? "Other cost" : "Other usage"}
+        value={formatValue(otherTotal)}
+        variant="section"
+      />
       {otherEntries.map(([key, value]) => (
-        <div
+        <BreakdownRow
           key={key}
-          className="text-muted-foreground flex justify-between text-xs"
-        >
-          <span className="mr-4">{key}</span>
-          <span className="font-mono">{formatValue(value ?? 0)}</span>
-        </div>
+          label={key}
+          value={formatValue(value ?? 0)}
+          variant="item"
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16688.preview.langfuse.com](https://pr-16688.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The observation/trace cost breakdown tooltip used a fixed 16rem width and padded every cost to the longest decimal place. Long usage-type keys like `cache_creation_input_tokens` were clipped by the tooltip's `overflow-hidden` instead of ellipsizing, and values like `$0.0066` rendered as `$0.0066000`.

This makes the tooltip size to its content (capped at 20rem), gives labels the leftover width with ellipsis, lets values ellipsis if they overflow, and formats costs with `usdFormatter` using 2–12 fraction digits (no padding, tiny nonzero costs stay distinct from `$0.00`).

Impacted packages: `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Code follows the style guidelines of this project (`pnpm run format`)
- [x] Added Storybook coverage that proves padded decimals are gone, long labels truncate, and sub-microdollar costs stay visible
- [x] Targeted Storybook tests pass locally
- [x] Pre-commit lint: `Tasks: 7 successful, 7 total`

## Verification

- `pnpm --filter web run test-storybook src/features/traces/components/BreakdownTooltip.stories.tsx` → `Tests  7 passed (7)`
- Pre-commit `turbo run lint` → `Tasks: 7 successful, 7 total`
- Skipped full web typecheck and e2e: isolated tooltip layout/formatting change, covered by the component stories. Docker was not available in this environment, so the live trace UI was not exercised; Storybook covers the same component.

## Proof

Long usage-type keys ellipsis; costs are no longer padded to 7 decimals:

[Cost breakdown with long usage types](https://cursor.com/agents/bc-e69a9d85-59e6-4237-b96f-8a30f8ccfe2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcost_breakdown_long_usage_types.webp)

Simple cost breakdown, zeros as `$0.00`:

[Simple cost breakdown](https://cursor.com/agents/bc-e69a9d85-59e6-4237-b96f-8a30f8ccfe2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcost_breakdown_simple.webp)

Usage breakdown still shows integer token counts:

[Usage breakdown](https://cursor.com/agents/bc-e69a9d85-59e6-4237-b96f-8a30f8ccfe2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage_breakdown.webp)

[cost_breakdown_tooltip_ellipsis_and_decimals.mp4](https://cursor.com/agents/bc-e69a9d85-59e6-4237-b96f-8a30f8ccfe2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcost_breakdown_tooltip_ellipsis_and_decimals.mp4)

## Test this

Preview: https://pr-16688.preview.langfuse.com (once the preview is up)

1. Open a generation with cache token cost details.
2. Click the cost badge info icon.
3. Confirm long keys ellipsis instead of clipping, and costs look like `$0.0066` not `$0.0066000`.

Sandbox: Storybook `Features / Traces / BreakdownTooltip / Cost With Long Usage Types` on http://localhost:6006, or the same cost badge on http://localhost:3000 after the cloud stack is up. Demo project is enough.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15708](https://linear.app/clickhouse/issue/LFE-15708/trace-ui-cost-is-truncated-shitty)

<div><a href="https://cursor.com/agents/bc-e69a9d85-59e6-4237-b96f-8a30f8ccfe2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e69a9d85-59e6-4237-b96f-8a30f8ccfe2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates trace cost breakdown tooltips to use content-aware sizing, truncatable labels and values, and shared USD formatting.
- Introduces a reusable row layout for item, section, pricing-tier, and total values.
- Adds stories for long usage-type labels and unpadded cost formatting.
- Refactors tooltip-opening logic shared by Storybook interaction tests.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking gap in the Storybook assertion for the visual clipping fix.

The component changes form a consistent shrink-and-truncate layout, but the added test can pass based on static classes even if the longest label is not visibly ellipsized.

**Files Needing Attention:** web/src/features/traces/components/BreakdownTooltip.stories.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/traces/components/BreakdownTooltip.stories.tsx:150-155
**Truncation test checks classes**

The test checks only the static `truncate` class and `title` attribute, so it continues passing when computed dimensions fail to produce visible ellipsis. Assert rendered overflow using the longest usage-type label so the test detects a recurrence of the clipping regression.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): stop clipping cost breakdow..."](https://github.com/langfuse/langfuse/commit/fd43fa6755945729a12084a51e7bceaffafffbb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57506600)</sub>

<!-- /greptile_comment -->