### PR TITLE
fix(api): avoid evaluator error name collisions

### DIFF
--- a/fern/apis/server/definition/evaluation-errors.yml
+++ b/fern/apis/server/definition/evaluation-errors.yml
@@ -91,19 +91,19 @@ errors:
     docs: Request validation failed or the requested state is invalid.
     status-code: 400
     type: PublicApiError
-  UnauthorizedError:
+  EvaluationUnauthorizedError:
     docs: Authentication failed.
     status-code: 401
     type: PublicApiError
-  AccessDeniedError:
+  EvaluationAccessDeniedError:
     docs: The caller is not allowed to access this resource.
     status-code: 403
     type: PublicApiError
-  NotFoundError:
+  EvaluationNotFoundError:
     docs: The requested evaluator or evaluation rule was not found in the authenticated project.
     status-code: 404
     type: PublicApiError
-  MethodNotAllowedError:
+  EvaluationMethodNotAllowedError:
     docs: The HTTP method is not supported by this endpoint.
     status-code: 405
     type: PublicApiError

--- a/fern/apis/server/definition/evaluation-rules.yml
+++ b/fern/apis/server/definition/evaluation-rules.yml
@@ -29,10 +29,10 @@ service:
         type: EvaluationRule
       errors:
         - errors.BadRequestError
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.ConflictError
         - errors.TooManyRequestsError
         - errors.InternalServerError
@@ -56,9 +56,9 @@ service:
       response: EvaluationRulesPage
       errors:
         - errors.BadRequestError
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationMethodNotAllowedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
 
@@ -72,10 +72,10 @@ service:
           docs: Stable evaluation-rule identifier returned by the evaluation-rule endpoints.
       response: EvaluationRule
       errors:
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
 
@@ -96,10 +96,10 @@ service:
       response: EvaluationRule
       errors:
         - errors.BadRequestError
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.ConflictError
         - errors.TooManyRequestsError
         - errors.InternalServerError
@@ -119,10 +119,10 @@ service:
           docs: Stable evaluation-rule identifier returned by the evaluation-rule endpoints.
       response: DeletedEvaluationRule
       errors:
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
 

--- a/fern/apis/server/definition/evaluators.yml
+++ b/fern/apis/server/definition/evaluators.yml
@@ -22,9 +22,9 @@ service:
         type: Evaluator
       errors:
         - errors.BadRequestError
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationMethodNotAllowedError
         - errors.PreconditionFailedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
@@ -48,9 +48,9 @@ service:
       response: EvaluatorsPage
       errors:
         - errors.BadRequestError
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationMethodNotAllowedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
 
@@ -67,10 +67,10 @@ service:
           docs: Stable evaluator identifier returned by the evaluator endpoints.
       response: Evaluator
       errors:
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
 
@@ -93,10 +93,10 @@ service:
       response: Evaluator
       errors:
         - errors.BadRequestError
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.ConflictError
         - errors.PreconditionFailedError
         - errors.TooManyRequestsError
@@ -115,10 +115,10 @@ service:
           docs: Stable evaluator identifier returned by the evaluator endpoints.
       response: DeletedEvaluator
       errors:
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
 
@@ -145,10 +145,10 @@ service:
       response: EvaluatorVersionsPage
       errors:
         - errors.BadRequestError
-        - errors.UnauthorizedError
-        - errors.AccessDeniedError
-        - errors.NotFoundError
-        - errors.MethodNotAllowedError
+        - errors.EvaluationUnauthorizedError
+        - errors.EvaluationAccessDeniedError
+        - errors.EvaluationNotFoundError
+        - errors.EvaluationMethodNotAllowedError
         - errors.TooManyRequestsError
         - errors.InternalServerError
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16691.preview.langfuse.com](https://pr-16691.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

Rename the four new stable evaluator error declarations that collide with existing shared errors, and update their references.

## Reasoning

- Fern requires unique error declaration names.
- Existing shared SDK error names stay unchanged.
- The structured stable evaluator error response model stays unchanged.

## Verification

- `npx fern-api generate --api server --force` - Python and TypeScript SDK generation finished successfully
- `pnpm run lint` - `Tasks: 7 successful, 7 total`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR resolves Fern declaration-name collisions by giving four stable evaluator errors evaluation-specific names while preserving their status codes and response model.

- Renames the stable authentication, authorization, not-found, and method-not-allowed error declarations.
- Updates evaluator and evaluation-rule endpoints to reference the renamed declarations.
- Leaves unstable evaluator definitions and the structured wire response unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the renamed declarations resolve consistently and preserve the existing wire-level error contract.

All changed endpoint references point to declarations in the imported evaluation error definition, with no stale stable references or response-model changes found.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): avoid evaluator error name col..."](https://github.com/langfuse/langfuse/commit/df7a4d8d43644563bdf283d66a8482eb4669833f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57517632)</sub>

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->