### PR TITLE
refactor(web): Extract `createStatusTableColumn`

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -30,6 +30,7 @@ const DESIGN_COMPONENT_STORIES = [
   "Table/columns/createIdTableColumn",
   "Table/columns/createItemBadgeTableColumn",
   "Table/columns/createNumberTableColumn",
+  "Table/columns/createStatusTableColumn",
   "Table/columns/createTagsTableColumn",
   "Table/columns/createTextTableColumn",
 ] as const;

--- a/web/src/components/design-system/Table/columns/createStatusTableColumn.stories.tsx
+++ b/web/src/components/design-system/Table/columns/createStatusTableColumn.stories.tsx
@@ -1,0 +1,98 @@
+import preview from "../../../../../.storybook/preview";
+
+import {
+  DataTable,
+  type AsyncTableData,
+} from "@/src/components/table/data-table";
+import { createStatusTableColumn } from "./createStatusTableColumn";
+
+type Row = {
+  status: string | null;
+};
+
+function StatusTableColumnStory({
+  data,
+  isLive = true,
+}: {
+  data: AsyncTableData<Row[]>;
+  isLive?: boolean;
+}) {
+  const columns = [
+    createStatusTableColumn<Row, string>({
+      accessorKey: "status",
+      header: "Status",
+      getStatus: (status) => status ?? undefined,
+      isLive,
+    }),
+  ];
+
+  return (
+    <DataTable
+      tableName="status-column-story"
+      columns={columns}
+      data={data}
+      hidePagination
+      cellPadding="comfortable"
+    />
+  );
+}
+
+const meta = preview.meta({
+  component: StatusTableColumnStory,
+  parameters: {
+    layout: "fullscreen",
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ status: "running" }],
+    },
+  },
+});
+
+export const NotLive = meta.story({
+  name: "Not Live",
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ status: "completed" }],
+    },
+    isLive: false,
+  },
+});
+
+export const EmptyValue = meta.story({
+  name: "Empty Value",
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ status: null }],
+    },
+  },
+});
+
+export const UnknownStatus = meta.story({
+  name: "Unknown Status",
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ status: "legacy-status" }],
+    },
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    data: {
+      isLoading: true,
+      isError: false,
+    },
+  },
+});

--- a/web/src/components/design-system/Table/columns/createStatusTableColumn.tsx
+++ b/web/src/components/design-system/Table/columns/createStatusTableColumn.tsx
@@ -1,0 +1,35 @@
+import { type CellContext, type RowData } from "@tanstack/react-table";
+
+import { TableBadgeLoadingCell } from "@/src/components/table/loading-cells";
+import {
+  type Status,
+  StatusBadge,
+} from "@/src/components/ui/StatusBadge/StatusBadge";
+import {
+  createTableColumn,
+  type TableColumnOptions,
+} from "./utils/createTableColumn";
+
+export function createStatusTableColumn<
+  TData extends RowData,
+  TValue = Status,
+>({
+  getStatus,
+  isLive,
+  ...options
+}: TableColumnOptions<TData, TValue> & {
+  getStatus: (
+    value: TValue | null | undefined,
+    context: CellContext<TData, TValue | null | undefined>,
+  ) => Status | (string & {}) | undefined;
+  isLive?: boolean;
+}) {
+  return createTableColumn<TData, TValue>({
+    ...options,
+    loadingCell: <TableBadgeLoadingCell />,
+    renderCell: (value, context) => {
+      const status = getStatus(value, context);
+      return status ? <StatusBadge type={status} isLive={isLive} /> : null;
+    },
+  });
+}

--- a/web/src/components/ui/StatusBadge/StatusBadge.tsx
+++ b/web/src/components/ui/StatusBadge/StatusBadge.tsx
@@ -19,9 +19,9 @@ const statusBadgeVariants = cva(
 
 const statusCategories = {
   active: ["production", "live", "active", "public"],
-  pending: ["pending", "waiting", "queued", "running"],
+  pending: ["pending", "waiting", "queued", "running", "processing"],
   delayed: ["delayed"],
-  inactive: ["disabled", "inactive"],
+  inactive: ["disabled", "inactive", "archived", "cancelled"],
   paused: ["paused"],
   completed: ["completed", "done", "finished"],
   error: ["error", "failed"],

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -29,7 +29,8 @@ import {
 } from "@/src/components/ui/dialog";
 import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
+import { createStatusTableColumn } from "@/src/components/design-system/Table/columns/createStatusTableColumn";
+import { type Status } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { createIdTableColumn } from "@/src/components/design-system/Table/columns/createIdTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/Table/columns/createLinkTableColumn";
 import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
@@ -298,16 +299,21 @@ export function AnnotationQueueItemsTable({
       enableHiding: true,
       defaultHidden: true,
     }),
-    {
+    createStatusTableColumn<QueueItemRowData, AnnotationQueueStatus>({
       accessorKey: "status",
       header: "Status",
-      id: "status",
+      getStatus: (status) =>
+        status
+          ? (
+              {
+                PENDING: "pending",
+                COMPLETED: "completed",
+              } satisfies Record<AnnotationQueueStatus, Status>
+            )[status]
+          : undefined,
       size: 60,
-      cell: ({ row }) => {
-        const status: QueueItemRowData["status"] = row.getValue("status");
-        return <StatusBadge type={status.toLowerCase()} isLive={false} />;
-      },
-    },
+      isLive: false,
+    }),
     {
       accessorKey: "completedAt",
       header: "Completed At",

--- a/web/src/features/automations/components/AutomationExecutionsTable.tsx
+++ b/web/src/features/automations/components/AutomationExecutionsTable.tsx
@@ -3,16 +3,25 @@ import { api } from "@/src/utils/api";
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
-import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
+import { createStatusTableColumn } from "@/src/components/design-system/Table/columns/createStatusTableColumn";
 import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import { formatDistanceToNow } from "date-fns";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
+import { ActionExecutionStatus } from "@langfuse/shared";
+import { type Status } from "@/src/components/ui/StatusBadge/StatusBadge";
+
+const actionExecutionStatusToStatus = {
+  [ActionExecutionStatus.COMPLETED]: "completed",
+  [ActionExecutionStatus.ERROR]: "error",
+  [ActionExecutionStatus.PENDING]: "pending",
+  [ActionExecutionStatus.CANCELLED]: "cancelled",
+} satisfies Record<ActionExecutionStatus, Status>;
 
 type ActionExecutionRow = {
   id: string;
-  status: string;
+  status: ActionExecutionStatus;
   sourceId: string;
   input: any;
   output: any;
@@ -54,15 +63,12 @@ export const AutomationExecutionsTable: React.FC<
     );
 
   const columns: LangfuseColumnDef<ActionExecutionRow>[] = [
-    {
+    createStatusTableColumn<ActionExecutionRow, ActionExecutionStatus>({
       accessorKey: "status",
       header: "Status",
-      id: "status",
-      cell: ({ row }) => {
-        const status = row.getValue("status") as string;
-        return <StatusBadge type={status.toLowerCase()} />;
-      },
-    },
+      getStatus: (status) =>
+        status ? actionExecutionStatusToStatus[status] : undefined,
+    }),
     {
       accessorKey: "startedAt",
       header: "Started",

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -4,7 +4,7 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { api } from "@/src/utils/api";
 import { type BackgroundMigration } from "@langfuse/shared";
 import { RetryBackgroundMigrationPopoverController } from "@/src/features/background-migrations/components/retry-background-migration";
-import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
+import { createStatusTableColumn } from "@/src/components/design-system/Table/columns/createStatusTableColumn";
 import Page from "@/src/components/layouts/page";
 import { Button } from "@/src/components/ui/button";
 import { RotateCcw } from "lucide-react";
@@ -33,27 +33,21 @@ export default function BackgroundMigrationsTable() {
       size: 80,
       cell: (row) => JSON.stringify(row.getValue()),
     },
-    {
+    createStatusTableColumn<BackgroundMigration, BackgroundMigration>({
       id: "status",
+      accessorFn: (row) => row,
+      getStatus: (migration) => {
+        if (!migration) return undefined;
+        if (migration.failedAt) return "failed";
+        if (migration.finishedAt) return "finished";
+        if (migration.workerId) return "active";
+
+        return "queued";
+      },
       header: "Status",
       size: 80,
-      cell: (row) => {
-        const failedAt = row.row.original.failedAt;
-        if (failedAt) {
-          return <StatusBadge type="failed" />;
-        }
-        const finishedAt = row.row.original.finishedAt;
-        if (finishedAt) {
-          return <StatusBadge type="finished" />;
-        }
-        const workerId = row.row.original.workerId;
-        if (workerId) {
-          return <StatusBadge type="active" />;
-        }
-
-        return <StatusBadge type="queued" />;
-      },
-    },
+      enableSorting: false,
+    }),
     {
       accessorKey: "failedReason",
       id: "failedReason",

--- a/web/src/features/batch-actions/components/BatchActionsTable.tsx
+++ b/web/src/features/batch-actions/components/BatchActionsTable.tsx
@@ -2,7 +2,7 @@ import { DataTable } from "@/src/components/table/data-table";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
-import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
+import { createStatusTableColumn } from "@/src/components/design-system/Table/columns/createStatusTableColumn";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { InfoIcon } from "lucide-react";
 import {
@@ -14,6 +14,7 @@ import {
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
 import { createUserTableColumn } from "@/src/components/design-system/Table/columns/createUserTableColumn";
+import { BatchActionStatus } from "@langfuse/shared";
 
 type BatchActionRow = {
   id: string;
@@ -69,16 +70,21 @@ export function BatchActionsTable(props: { projectId: string }) {
         return <span className="capitalize">{tableName}</span>;
       },
     },
-    {
+    createStatusTableColumn<BatchActionRow, string>({
       accessorKey: "status",
-      id: "status",
+      getStatus: (status) => {
+        if (status === BatchActionStatus.Queued) return "queued";
+        if (status === BatchActionStatus.Processing) return "processing";
+        if (status === BatchActionStatus.Completed) return "completed";
+        if (status === BatchActionStatus.Failed) return "failed";
+        if (status === BatchActionStatus.Partial) return "partial";
+        if (!status) return undefined;
+
+        return status.toLowerCase();
+      },
       header: "Status",
       size: 110,
-      cell: ({ row }) => {
-        const status = row.getValue("status") as string;
-        return <StatusBadge type={status.toLowerCase()} />;
-      },
-    },
+    }),
     {
       accessorKey: "progress",
       id: "progress",

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -28,7 +28,8 @@ import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-
 import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
-import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
+import { createStatusTableColumn } from "@/src/components/design-system/Table/columns/createStatusTableColumn";
+import { type Status } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { createDateTableColumn } from "@/src/components/design-system/Table/columns/createDateTableColumn";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
@@ -50,6 +51,11 @@ type RowData = {
   expectedOutput: Prisma.JsonValue;
   metadata: Prisma.JsonValue;
 };
+
+const datasetStatusToStatus = {
+  [DatasetStatus.ACTIVE]: "active",
+  [DatasetStatus.ARCHIVED]: "archived",
+} satisfies Record<DatasetStatus, Status>;
 
 export function DatasetItemsTable({
   projectId,
@@ -192,16 +198,14 @@ export function DatasetItemsTable({
         };
       },
     }),
-    {
+    createStatusTableColumn<RowData, DatasetStatus>({
       accessorKey: "status",
       header: "Status",
-      id: "status",
+      getStatus: (status) =>
+        status ? datasetStatusToStatus[status] : undefined,
       size: 80,
-      cell: ({ row }) => {
-        const status: DatasetStatus = row.getValue("status");
-        return <StatusBadge type={status.toLowerCase()} isLive={false} />;
-      },
-    },
+      isLive: false,
+    }),
     createDateTableColumn<RowData>({
       accessorKey: "createdAt",
       header: "Created At",

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -1,4 +1,4 @@
-import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
+import { createStatusTableColumn } from "@/src/components/design-system/Table/columns/createStatusTableColumn";
 import { DataTable } from "@/src/components/table/data-table";
 import {
   type CustomHeights,
@@ -19,12 +19,21 @@ import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFi
 import { evalLogFilterConfig } from "@/src/features/filters/config/eval-logs-config";
 import { type RouterOutputs, api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
-import { type Prisma } from "@langfuse/shared";
+import { JobExecutionStatus, type Prisma } from "@langfuse/shared";
 import { createColumnHelper } from "@tanstack/react-table";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
+import { type Status } from "@/src/components/ui/StatusBadge/StatusBadge";
+
+const jobExecutionStatusToStatus = {
+  [JobExecutionStatus.COMPLETED]: "completed",
+  [JobExecutionStatus.ERROR]: "error",
+  [JobExecutionStatus.PENDING]: "pending",
+  [JobExecutionStatus.CANCELLED]: "cancelled",
+  [JobExecutionStatus.DELAYED]: "delayed",
+} satisfies Record<JobExecutionStatus, Status>;
 
 export type JobExecutionRow = {
-  status: string;
+  status: JobExecutionStatus;
   scoreName?: string;
   scoreValue?: number | string;
   scoreComment?: string;
@@ -78,17 +87,11 @@ export default function EvalLogTable({
 
   const columnHelper = createColumnHelper<JobExecutionRow>();
   const columns = [
-    columnHelper.accessor("status", {
+    createStatusTableColumn<JobExecutionRow, JobExecutionStatus>({
+      accessorKey: "status",
       header: "Status",
-      id: "status",
-      cell: (row) => {
-        const status = row.getValue();
-        return (
-          <div className="w-fit self-start">
-            <StatusBadge type={status.toLowerCase()} />
-          </div>
-        );
-      },
+      getStatus: (status) =>
+        status ? jobExecutionStatusToStatus[status] : undefined,
     }),
     columnHelper.accessor("startTime", {
       id: "startTime",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16694.preview.langfuse.com](https://pr-16694.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts a reusable status-table column factory and migrates status columns across several web tables while expanding supported badge categories.
- Adds the shared status-column helper and Storybook coverage.
- Replaces inline status cells with explicit enum-to-badge mappings.
- Adds processing, archived, and cancelled badge classifications.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking robustness issue in the batch-actions status renderer.

The refactor otherwise preserves the migrated columns' status mappings and identifiers, but the batch-actions table now throws on an unexpected value from an unconstrained persisted string instead of using the badge's unknown-state fallback.

**Files Needing Attention:** web/src/features/batch-actions/components/BatchActionsTable.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/batch-actions/components/BatchActionsTable.tsx:83
**Unexpected statuses throw**

If persisted batch-action data contains a legacy, case-mismatched, or newly introduced status, this branch throws while React renders the row, replacing the batch-actions view with the enclosing error state instead of using `StatusBadge`'s unknown-status fallback.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: [b992456](https://github.com/langfuse/langfuse/commit/b9924568ad0d90e29ed63baeaef8b489e7b6d290) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57520183)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->