### PR TITLE
fix(sessions): parse ClickHouse session created-at as UTC

### DIFF
--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -245,7 +245,7 @@ export const sessionRouter = createTRPCRouter({
             userIds: s.user_ids,
             countTraces: s.trace_count,
             traceTags: s.trace_tags,
-            createdAt: new Date(s.min_timestamp),
+            createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
             bookmarked:
               prismaSessionInfo.find((p) => p.id === s.session_id)
                 ?.bookmarked ?? false,
@@ -307,7 +307,7 @@ export const sessionRouter = createTRPCRouter({
             userIds: s.user_ids,
             countTraces: s.trace_count,
             traceTags: s.trace_tags,
-            createdAt: new Date(s.min_timestamp),
+            createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
             bookmarked:
               prismaSessionInfo.find((p) => p.id === s.session_id)
                 ?.bookmarked ?? false,
@@ -439,7 +439,7 @@ export const sessionRouter = createTRPCRouter({
         userIds: s.user_ids,
         countTraces: s.trace_count,
         traceTags: s.trace_tags,
-        createdAt: new Date(s.min_timestamp),
+        createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
         bookmarked:
           prismaSessionInfo.find((p) => p.id === s.session_id)?.bookmarked ??
           false,
@@ -506,7 +506,7 @@ export const sessionRouter = createTRPCRouter({
         userIds: s.user_ids,
         countTraces: s.trace_count,
         traceTags: s.trace_tags,
-        createdAt: new Date(s.min_timestamp),
+        createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
         bookmarked:
           prismaSessionInfo.find((p) => p.id === s.session_id)?.bookmarked ??
           false,

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -29,6 +29,7 @@ import {
   getScoresForTraces,
   getDatasetItems,
   type PreferredClickhouseService,
+  parseClickhouseUTCDateTimeFormat,
 } from "@langfuse/shared/src/server";
 import Decimal from "decimal.js";
 import { env } from "../../env";
@@ -324,7 +325,7 @@ export const getDatabaseReadStreamPaginated = async ({
               totalCost: new Decimal(s.session_total_cost),
               totalTokens: BigInt(s.session_total_usage),
               traceTags: s.trace_tags,
-              createdAt: new Date(s.min_timestamp),
+              createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
               bookmarked:
                 prismaSessionInfo.find((p) => p.id === s.session_id)
                   ?.bookmarked ?? false,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16703.preview.langfuse.com](https://pr-16703.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Parse session-list `createdAt` (and session CSV export) with `parseClickhouseUTCDateTimeFormat` instead of `new Date(...)`.
- ClickHouse stores these as UTC datetime strings without a timezone; `new Date` treats them as local time, so the Sessions UI clock is shifted by the host timezone. Session detail already used the UTC helper.

Impacted packages: `web`, `worker`.

Extracted from the in-app-agent production OTel ingestion PR so this timezone change can be reviewed on its own.

## Test plan
- [ ] Open Sessions in a timezone other than UTC and confirm list `createdAt` matches the session detail timestamps (not shifted by local offset).
- [ ] Export sessions as CSV and confirm `createdAt` is the same UTC instant.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Corrects session timestamp interpretation by parsing ClickHouse-created timestamps as UTC rather than host-local time.
- Applies UTC parsing consistently to legacy and events-backed session list and metrics responses.
- Applies the same parsing to streamed session CSV exports.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the UTC parser matching the timestamp format returned by all changed ClickHouse session query paths.

The changes consistently replace host-local parsing with the existing UTC parser, and the legacy and events-backed queries supply compatible non-null ClickHouse DateTime64 strings.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sessions): parse ClickHouse session ..."](https://github.com/langfuse/langfuse/commit/bcfb2bca76367ecf4d0480e60e3561f1445704a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57570288)</sub>

<!-- /greptile_comment -->