### PR TITLE
fix(evals): align evaluator dialog close button

### DIFF
--- a/web/src/features/evals/v2/AGENTS.md
+++ b/web/src/features/evals/v2/AGENTS.md
@@ -14,3 +14,8 @@ The new data model is
 
 Traces captured during the eval executions in the past only captured `job_configuration_id`.
 Only new runs capture `evaluator_id` and `evaluation_rule_id`.
+
+## Testing
+
+- Do not write tautological React client tests or tests that assert pixel positioning.
+- Only add component tests when they enforce meaningful behavior.

--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialog/EvaluatorSavedDialog.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSavedDialog/EvaluatorSavedDialog.tsx
@@ -76,7 +76,7 @@ export function EvaluatorSavedDialog({
         closeOnInteractionOutside
         onCloseAutoFocus={onCloseAnimationEnd}
       >
-        <DialogHeader>
+        <DialogHeader className="[&>div]:items-start [&>div>button]:-mt-1">
           <DialogTitle>Evaluator saved</DialogTitle>
           <DialogDescription>
             Would you like to run this evaluator on incoming observations?


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16704.preview.langfuse.com](https://pr-16704.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Aligns the evaluator saved dialog close button with the top of the header instead of centering it across the title and description.

Also documents that visual positioning should not be covered by tautological client tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code.

## Testing

- `pnpm --filter web run test-client EvaluatorSavedDialog.clienttest.tsx` - `Tests  2 passed (2)`
- `pnpm run lint` - `Tasks: 7 successful, 7 total`
- `pnpm run agents:check` - passed


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns the evaluator-saved dialog’s close button with the top of its title and description.
- Adds targeted header alignment utilities consistent with the existing dialog structure.
- Documents that component tests should verify meaningful behavior rather than pixel positioning or tautological implementation details.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new selectors match the current DialogHeader structure, uniquely aligning the intended flex row and close button without changing dialog behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): align evaluator dialog close..."](https://github.com/langfuse/langfuse/commit/0a80d3ac6d06394a9cf1d32388ce55d94e7f0d16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57548586)</sub>

<!-- /greptile_comment -->