### PR TITLE
fix(v4-ui): remove query param from metrics path guidance

### DIFF
--- a/web/src/features/v4-migration/apiMigrationGuidance.clienttest.ts
+++ b/web/src/features/v4-migration/apiMigrationGuidance.clienttest.ts
@@ -75,8 +75,7 @@ describe("getApiMigrationGuidance", () => {
         undefined,
       ),
     ).toEqual({
-      replacement:
-        "GET /api/public/v2/metrics?query=<URL-encoded JSON with view, metrics, fromTimestamp, and toTimestamp>",
+      replacement: "GET /api/public/v2/metrics",
     });
   });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes the expected v4 migration guidance for the legacy daily-metrics endpoint to a path-only replacement.
- Removes the query-parameter template from the client-test expectation.
- Does not make the corresponding production mapping change.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The production mapping must be updated before merging because the changed expectation currently makes the client test fail.

The test expects a bare metrics endpoint, while getApiMigrationGuidance still returns the existing query-suffixed replacement.

**Files Needing Attention:** web/src/features/v4-migration/apiMigrationGuidance.clienttest.ts and web/src/features/v4-migration/apiMigrationGuidance.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/v4-migration/apiMigrationGuidance.clienttest.ts:78
**Metrics guidance assertion diverges**

When this test calls `getApiMigrationGuidance` for the legacy daily-metrics endpoint, it expects a bare path while the production mapping still returns the query-suffixed replacement, causing the assertion to fail.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4-ui): remove query param from metr..."](https://github.com/langfuse/langfuse/commit/317325246dfbeee2ea4a2a80a1ce6118bf52a9bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57552348)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->