### PR TITLE
refactor(web): Clean up trace ui badge rendering

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -11,6 +11,7 @@ import {
 
 const STORY_EXTENSIONS = "@(js|jsx|mjs|ts|tsx)";
 const DESIGN_COMPONENT_STORIES = [
+  "Badge/Badge",
   "Callout/Callout",
   "Checkbox/Checkbox",
   "Codeblock/Codeblock",

--- a/web/src/components/GroupedScoreBadges.stories.tsx
+++ b/web/src/components/GroupedScoreBadges.stories.tsx
@@ -63,11 +63,30 @@ export const WithOverflow = meta.story({
 
 export const DetailsInsideBadge = meta.story({
   name: "(Test) Details Inside Badge",
-  args: { scores },
+  args: {
+    scores: [
+      scores[0],
+      {
+        ...scores[1],
+        id: "quality-with-details",
+        name: "quality",
+      },
+    ],
+  },
   play: async ({ canvasElement }) => {
-    const label = canvasElement.querySelector('[title="helpfulness: 0.81"]');
+    const value = canvasElement.querySelector('[title="0.81"]');
 
-    await expect(label).not.toBeNull();
-    await expect(label?.parentElement?.querySelectorAll("svg")).toHaveLength(2);
+    await expect(value).not.toBeNull();
+    await expect(value?.parentElement?.querySelectorAll("svg")).toHaveLength(2);
+    await expect(
+      value?.parentElement?.querySelector(
+        '[aria-label="View comment for quality: 0.81"]',
+      ),
+    ).not.toBeNull();
+    await expect(
+      value?.parentElement?.querySelector(
+        '[aria-label="View metadata for quality: 0.81"]',
+      ),
+    ).not.toBeNull();
   },
 });

--- a/web/src/components/GroupedScoreBadges.stories.tsx
+++ b/web/src/components/GroupedScoreBadges.stories.tsx
@@ -1,0 +1,73 @@
+import { type LastUserScore } from "@langfuse/shared";
+import { expect } from "storybook/test";
+
+import preview from "../../.storybook/preview";
+import { GroupedScoreBadges } from "./grouped-score-badge";
+
+const meta = preview.meta({
+  component: GroupedScoreBadges,
+  args: {
+    scores: [],
+  },
+});
+
+const scores = [
+  {
+    id: "quality",
+    name: "quality",
+    dataType: "NUMERIC",
+    source: "API",
+    value: 0.92,
+    timestamp: new Date("2026-01-01T00:00:00.000Z"),
+    traceId: "trace-id",
+    observationId: "observation-id",
+    userId: "user-id",
+  },
+  {
+    id: "helpfulness",
+    name: "helpfulness",
+    dataType: "NUMERIC",
+    source: "API",
+    value: 0.81,
+    comment: "Clear and useful response",
+    metadata: { evaluator: "human" },
+    timestamp: new Date("2026-01-01T00:00:00.000Z"),
+    traceId: "trace-id",
+    observationId: null,
+    userId: "user-id",
+  },
+] satisfies LastUserScore[];
+
+export const Default = meta.story({
+  args: { scores },
+});
+
+export const Compact = meta.story({
+  args: { scores, compact: true },
+});
+
+export const WithOverflow = meta.story({
+  args: {
+    scores: [
+      ...scores,
+      {
+        ...scores[0],
+        id: "accuracy",
+        name: "accuracy",
+        value: 0.95,
+      },
+    ],
+    maxVisible: 2,
+  },
+});
+
+export const DetailsInsideBadge = meta.story({
+  name: "(Test) Details Inside Badge",
+  args: { scores },
+  play: async ({ canvasElement }) => {
+    const label = canvasElement.querySelector('[title="helpfulness: 0.81"]');
+
+    await expect(label).not.toBeNull();
+    await expect(label?.parentElement?.querySelectorAll("svg")).toHaveLength(2);
+  },
+});

--- a/web/src/components/ScoreBadge/ScoreBadge.stories.tsx
+++ b/web/src/components/ScoreBadge/ScoreBadge.stories.tsx
@@ -1,0 +1,52 @@
+import { type LastUserScore } from "@langfuse/shared";
+import { expect } from "storybook/test";
+
+import preview from "../../../.storybook/preview";
+import { ScoreBadge } from "./ScoreBadge";
+
+const score = {
+  id: "quality",
+  name: "quality",
+  dataType: "NUMERIC",
+  source: "API",
+  value: 0.92,
+  timestamp: new Date("2026-01-01T00:00:00.000Z"),
+  traceId: "trace-id",
+  observationId: "observation-id",
+  userId: "user-id",
+} satisfies LastUserScore;
+
+const meta = preview.meta({
+  component: ScoreBadge,
+});
+
+export const Default = meta.story({
+  args: {
+    name: score.name,
+    scores: [score],
+  },
+});
+
+export const Constrained = meta.story({
+  name: "(Test) Constrained",
+  args: {
+    name: "groundedness against retrieved context",
+    scores: [score],
+  },
+  render: (args) => (
+    <div className="max-w-48">
+      <ScoreBadge {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const name = canvasElement.querySelector<HTMLElement>(
+      '[title="groundedness against retrieved context"]',
+    );
+    const value = canvasElement.querySelector<HTMLElement>('[title="0.92"]');
+
+    await expect(name).not.toBeNull();
+    await expect(value).not.toBeNull();
+    await expect(name!.scrollWidth).toBeGreaterThan(name!.clientWidth);
+    await expect(value!.scrollWidth).toBeLessThanOrEqual(value!.clientWidth);
+  },
+});

--- a/web/src/components/ScoreBadge/ScoreBadge.tsx
+++ b/web/src/components/ScoreBadge/ScoreBadge.tsx
@@ -1,0 +1,137 @@
+import { type LastUserScore, type ScoreDomain } from "@langfuse/shared";
+import {
+  BracesIcon,
+  ExternalLinkIcon,
+  MessageCircleMoreIcon,
+} from "lucide-react";
+import Link from "next/link";
+
+import { BadgeShell } from "@/src/components/design-system/Badge/Badge";
+import { JSONView } from "@/src/components/ui/CodeJsonViewer";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/src/components/ui/hover-card";
+import { ScoreTag, scoreLevelFromScore } from "@/src/components/score-tag";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+
+const hasMetadata = (
+  score: WithStringifiedMetadata<ScoreDomain> | LastUserScore,
+) => {
+  if (!score.metadata) return false;
+  try {
+    const metadata =
+      typeof score.metadata === "string"
+        ? JSON.parse(score.metadata)
+        : score.metadata;
+    return Object.keys(metadata).length > 0;
+  } catch {
+    return false;
+  }
+};
+
+const ExecutionTraceLink = ({
+  executionTraceId,
+}: {
+  executionTraceId: string;
+}) => {
+  const projectId = useProjectIdFromURL();
+  if (!projectId) return null;
+
+  return (
+    <Link
+      href={`/project/${projectId}/traces/${encodeURIComponent(executionTraceId)}`}
+      className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
+      target="_blank"
+    >
+      <ExternalLinkIcon className="h-3 w-3" />
+      View execution trace
+    </Link>
+  );
+};
+
+export const ScoreBadge = <
+  T extends WithStringifiedMetadata<ScoreDomain> | LastUserScore,
+>({
+  name,
+  scores,
+  compact,
+  showLevels,
+}: {
+  name: string;
+  scores: T[];
+  compact?: boolean;
+  /** Render this group's level tags when the selection mixes score levels. */
+  showLevels?: boolean;
+}) => {
+  const levels = showLevels
+    ? Array.from(new Set(scores.map((score) => scoreLevelFromScore(score))))
+    : [];
+
+  return (
+    <span className="inline-flex max-w-full min-w-0 items-center gap-1">
+      {levels.map((level) => (
+        <ScoreTag key={level} level={level} />
+      ))}
+      <BadgeShell color="neutral" size={compact ? "sm" : "default"}>
+        <span className="min-w-0 flex-1 truncate" title={name}>
+          {name}:
+        </span>
+        <span className="flex min-w-0 items-center gap-1 text-nowrap">
+          {scores.map((score, index) => {
+            const value = score.stringValue ?? score.value?.toFixed(2) ?? "";
+
+            return (
+              <span
+                key={index}
+                className="inline-flex min-w-0 items-center gap-1"
+              >
+                <span className="truncate" title={value}>
+                  {value}
+                </span>
+                {score.comment && (
+                  <HoverCard>
+                    <HoverCardTrigger
+                      aria-label={`View comment for ${name}: ${value}`}
+                      className="inline-block shrink-0"
+                    >
+                      <MessageCircleMoreIcon className="mb-0.25 size-3!" />
+                    </HoverCardTrigger>
+                    <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
+                      <p className="whitespace-pre-wrap">{score.comment}</p>
+                      {"executionTraceId" in score &&
+                        score.executionTraceId && (
+                          <ExecutionTraceLink
+                            executionTraceId={score.executionTraceId}
+                          />
+                        )}
+                    </HoverCardContent>
+                  </HoverCard>
+                )}
+                {hasMetadata(score) && (
+                  <HoverCard>
+                    <HoverCardTrigger
+                      aria-label={`View metadata for ${name}: ${value}`}
+                      className="inline-block shrink-0"
+                    >
+                      <BracesIcon className="mb-0.25 size-3!" />
+                    </HoverCardTrigger>
+                    <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
+                      <JSONView
+                        codeClassName="rounded-md!"
+                        json={score.metadata}
+                      />
+                    </HoverCardContent>
+                  </HoverCard>
+                )}
+                {index < scores.length - 1 && <span>,</span>}
+              </span>
+            );
+          })}
+        </span>
+      </BadgeShell>
+    </span>
+  );
+};

--- a/web/src/components/ScoreTag.mdx
+++ b/web/src/components/ScoreTag.mdx
@@ -21,8 +21,8 @@ with `<ScoreTag>`.**
 
 The coding is **global**: one hue per level, identical on every surface
 (filter bar, sidebar facets, trace Scores tab, tree/timeline, tables). The
-hues are theme tokens in `globals.css` (light + dark) and live only in
-`score-tag.tsx` — never restate them at a call site.
+hues are theme tokens in `globals.css` (light + dark) and are applied through
+the design-system `Badge` — never restate them at a call site.
 
 <Canvas of={ScoreTagStories.VariantMatrix} />
 

--- a/web/src/components/design-system/Badge/Badge.stories.tsx
+++ b/web/src/components/design-system/Badge/Badge.stories.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { ExternalLinkIcon } from "lucide-react";
+import { expect } from "storybook/test";
+
+import preview from "../../../../.storybook/preview";
+import { Badge } from "./Badge";
+
+type ComponentProps = React.ComponentProps<typeof Badge>;
+type Color = NonNullable<ComponentProps["color"]>;
+type Size = NonNullable<ComponentProps["size"]>;
+
+const meta = preview.meta({
+  component: Badge,
+  args: {
+    text: "Badge",
+  },
+});
+
+const allColors = Object.keys({
+  primary: true,
+  neutral: true,
+  red: true,
+  yellow: true,
+  blue: true,
+  violet: true,
+  teal: true,
+  green: true,
+} satisfies Record<Color, true>) as Color[];
+
+const allSizes = Object.keys({
+  default: true,
+  sm: true,
+} satisfies Record<Size, true>) as Size[];
+
+export const Default = meta.story({});
+
+export const WithTrailingIcon = meta.story({
+  name: "(Test) With Trailing Icon",
+  args: {
+    text: "Linked badge",
+    trailingIcon: ExternalLinkIcon,
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("svg")).not.toBeNull();
+  },
+});
+
+export const VariantMatrix = meta.story({
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <div className="grid grid-cols-[repeat(2,max-content)] items-center gap-3">
+      {allColors.map((color) =>
+        allSizes.map((size) => (
+          <Badge
+            key={`${color}-${size}`}
+            color={color}
+            size={size}
+            text={`${color} / ${size}`}
+          />
+        )),
+      )}
+    </div>
+  ),
+});

--- a/web/src/components/design-system/Badge/Badge.tsx
+++ b/web/src/components/design-system/Badge/Badge.tsx
@@ -1,0 +1,75 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { type LucideIcon } from "lucide-react";
+import { type ComponentPropsWithoutRef } from "react";
+
+const badgeVariants = cva(
+  "inline-flex w-fit max-w-full min-w-0 shrink-0 items-center rounded-sm border border-transparent text-xs font-normal",
+  {
+    variants: {
+      color: {
+        primary: "bg-primary text-primary-foreground",
+        neutral: "bg-tertiary text-tertiary-foreground",
+        red: "bg-light-red text-dark-red",
+        yellow: "bg-light-yellow text-dark-yellow",
+        blue: "bg-light-blue text-dark-blue",
+        violet: "bg-light-violet text-dark-violet",
+        teal: "bg-light-teal text-dark-teal",
+        green: "bg-light-green text-dark-green",
+      },
+      size: {
+        default: "gap-1 px-2.5 py-0.5",
+        sm: "gap-1 px-1 py-0 leading-tight",
+      },
+    },
+    defaultVariants: {
+      color: "neutral",
+      size: "default",
+    },
+  },
+);
+
+type BadgeShellProps = Omit<ComponentPropsWithoutRef<"span">, "className"> &
+  VariantProps<typeof badgeVariants> & {
+    asChild?: boolean;
+  };
+
+/**
+ * Low-level primitive for specialized badges that require custom content.
+ * Prefer `Badge` in most cases!
+ * This export is against the file-structure rules of the codebase,
+ * it was added intentionally and should not be changed!
+ */
+export function BadgeShell({
+  asChild = false,
+  color,
+  size,
+  ...props
+}: BadgeShellProps) {
+  const Component = asChild ? Slot : "span";
+
+  return <Component className={badgeVariants({ color, size })} {...props} />;
+}
+
+type BadgeProps = Omit<BadgeShellProps, "asChild" | "children"> & {
+  text: string;
+  trailingIcon?: LucideIcon;
+};
+
+export function Badge({
+  color,
+  size,
+  text,
+  title,
+  trailingIcon: TrailingIcon,
+  ...props
+}: BadgeProps) {
+  return (
+    <BadgeShell color={color} size={size} {...props}>
+      <span className="truncate" title={title ?? text}>
+        {text}
+      </span>
+      {TrailingIcon && <TrailingIcon aria-hidden className="size-3 shrink-0" />}
+    </BadgeShell>
+  );
+}

--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -7,16 +7,9 @@ import {
 } from "@/src/components/ui/hover-card";
 import { cn } from "@/src/utils/tailwind";
 import { type LastUserScore, type ScoreDomain } from "@langfuse/shared";
-import {
-  BracesIcon,
-  MessageCircleMoreIcon,
-  ExternalLinkIcon,
-} from "lucide-react";
-import { JSONView } from "@/src/components/ui/CodeJsonViewer";
-import Link from "next/link";
-import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
-import { ScoreTag, scoreLevelFromScore } from "@/src/components/score-tag";
+import { scoreLevelFromScore } from "@/src/components/score-tag";
+import { ScoreBadge } from "@/src/components/ScoreBadge/ScoreBadge";
 
 /**
  * Bucket scores by name, the way the badges group them. Exported so a caller that
@@ -49,109 +42,6 @@ const partitionScores = <
   const visibleScores = sortedScores.slice(0, maxVisible);
   const hiddenScores = sortedScores.slice(maxVisible);
   return { visibleScores, hiddenScores };
-};
-
-const hasMetadata = (
-  score: WithStringifiedMetadata<ScoreDomain> | LastUserScore,
-) => {
-  if (!score.metadata) return false;
-  try {
-    const metadata =
-      typeof score.metadata === "string"
-        ? JSON.parse(score.metadata)
-        : score.metadata;
-    return Object.keys(metadata).length > 0;
-  } catch {
-    return false;
-  }
-};
-
-const ExecutionTraceLink = ({
-  executionTraceId,
-}: {
-  executionTraceId: string;
-}) => {
-  const projectId = useProjectIdFromURL();
-  if (!projectId) return null;
-
-  return (
-    <Link
-      href={`/project/${projectId}/traces/${encodeURIComponent(executionTraceId)}`}
-      className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
-      target="_blank"
-    >
-      <ExternalLinkIcon className="h-3 w-3" />
-      View execution trace
-    </Link>
-  );
-};
-
-const ScoreGroupBadge = <
-  T extends WithStringifiedMetadata<ScoreDomain> | LastUserScore,
->({
-  name,
-  scores,
-  compact,
-  showLevels,
-}: {
-  name: string;
-  scores: T[];
-  compact?: boolean;
-  /** Render this group's level tag(s). Set by GroupedScoreBadges only when
-   *  the whole selection mixes levels (LFE-10596). */
-  showLevels?: boolean;
-}) => {
-  // Score-level color coding (LFE-10596): one full tag per distinct level in
-  // the group (a name can exist at both trace and observation level). Full
-  // pill, not the compact dot — the level must be readable without hovering.
-  const levels = showLevels
-    ? Array.from(new Set(scores.map((score) => scoreLevelFromScore(score))))
-    : [];
-  const text = `${name}: ${scores
-    .map((score) => score.stringValue ?? score.value?.toFixed(2) ?? "")
-    .join(", ")}`;
-
-  return (
-    <span className="inline-flex max-w-full min-w-0 items-center gap-1">
-      {levels.map((level) => (
-        <ScoreTag key={level} level={level} />
-      ))}
-      <BadgeShell color="neutral" size={compact ? "sm" : "default"}>
-        <span className="truncate" title={text}>
-          {text}
-        </span>
-        {scores.map((score, index) => (
-          <span key={index} className="inline-flex shrink-0 items-center gap-1">
-            {score.comment && (
-              <HoverCard>
-                <HoverCardTrigger className="inline-block shrink-0">
-                  <MessageCircleMoreIcon className="mb-0.25 size-3!" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
-                  <p className="whitespace-pre-wrap">{score.comment}</p>
-                  {"executionTraceId" in score && score.executionTraceId && (
-                    <ExecutionTraceLink
-                      executionTraceId={score.executionTraceId}
-                    />
-                  )}
-                </HoverCardContent>
-              </HoverCard>
-            )}
-            {hasMetadata(score) && (
-              <HoverCard>
-                <HoverCardTrigger className="inline-block shrink-0">
-                  <BracesIcon className="mb-0.25 size-3!" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
-                  <JSONView codeClassName="rounded-md!" json={score.metadata} />
-                </HoverCardContent>
-              </HoverCard>
-            )}
-          </span>
-        ))}
-      </BadgeShell>
-    </span>
-  );
 };
 
 export const GroupedScoreBadges = <
@@ -204,7 +94,7 @@ export const GroupedScoreBadges = <
   return (
     <>
       {visibleScores.map(([name, scores]) => (
-        <ScoreGroupBadge
+        <ScoreBadge
           key={name}
           name={name}
           scores={scores}
@@ -244,7 +134,7 @@ export const GroupedScoreBadges = <
           <HoverCardContent className="max-h-[300px] w-max max-w-[min(420px,90vw)] overflow-y-auto p-2">
             <div className="flex flex-wrap gap-1">
               {hiddenScores.map(([name, scores]) => (
-                <ScoreGroupBadge
+                <ScoreBadge
                   key={name}
                   name={name}
                   scores={scores}

--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable @repo/no-style-props */
 import { useState } from "react";
-import { Badge, badgeVariants } from "@/src/components/ui/badge";
+import { BadgeShell } from "@/src/components/design-system/Badge/Badge";
 import {
   HoverCard,
   HoverCardContent,
@@ -67,97 +66,91 @@ const hasMetadata = (
   }
 };
 
+const ExecutionTraceLink = ({
+  executionTraceId,
+}: {
+  executionTraceId: string;
+}) => {
+  const projectId = useProjectIdFromURL();
+  if (!projectId) return null;
+
+  return (
+    <Link
+      href={`/project/${projectId}/traces/${encodeURIComponent(executionTraceId)}`}
+      className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
+      target="_blank"
+    >
+      <ExternalLinkIcon className="h-3 w-3" />
+      View execution trace
+    </Link>
+  );
+};
+
 const ScoreGroupBadge = <
   T extends WithStringifiedMetadata<ScoreDomain> | LastUserScore,
 >({
   name,
   scores,
   compact,
-  badgeClassName,
   showLevels,
 }: {
   name: string;
   scores: T[];
   compact?: boolean;
-  badgeClassName?: string;
   /** Render this group's level tag(s). Set by GroupedScoreBadges only when
    *  the whole selection mixes levels (LFE-10596). */
   showLevels?: boolean;
 }) => {
-  const projectId = useProjectIdFromURL();
-
   // Score-level color coding (LFE-10596): one full tag per distinct level in
   // the group (a name can exist at both trace and observation level). Full
   // pill, not the compact dot — the level must be readable without hovering.
   const levels = showLevels
     ? Array.from(new Set(scores.map((score) => scoreLevelFromScore(score))))
     : [];
+  const text = `${name}: ${scores
+    .map((score) => score.stringValue ?? score.value?.toFixed(2) ?? "")
+    .join(", ")}`;
 
   return (
-    <Badge
-      variant="tertiary"
-      key={name}
-      className={`flex max-w-full min-w-0 items-center gap-1 ${compact ? "px-1.5 leading-tight" : "px-2.5"} text-xs font-normal${badgeClassName ? " " + badgeClassName : ""}`}
-    >
+    <span className="inline-flex max-w-full min-w-0 items-center gap-1">
       {levels.map((level) => (
         <ScoreTag key={level} level={level} />
       ))}
-      <div
-        className={`w-fit max-w-20 shrink-0 truncate ${compact ? "leading-tight" : ""}`}
-        title={name}
-      >
-        {name}:
-      </div>
-      <div className="flex min-w-0 items-center gap-1 text-nowrap">
-        {scores.map((s, i) => {
-          const scoreDisplayValue = s.stringValue ?? s.value?.toFixed(2) ?? "";
-
-          return (
-            <span
-              key={i}
-              className="group/score ml-1 flex min-w-0 items-center gap-1 rounded-sm first:ml-0"
-            >
-              <span className="truncate" title={scoreDisplayValue}>
-                {scoreDisplayValue}
-              </span>
-              {s.comment && (
-                <HoverCard>
-                  <HoverCardTrigger className="inline-block shrink-0">
-                    <MessageCircleMoreIcon className="mb-0.25 size-3!" />
-                  </HoverCardTrigger>
-                  <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
-                    <p className="whitespace-pre-wrap">{s.comment}</p>
-                    {"executionTraceId" in s &&
-                      s.executionTraceId &&
-                      projectId && (
-                        <Link
-                          href={`/project/${projectId}/traces/${encodeURIComponent(s.executionTraceId)}`}
-                          className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
-                          target="_blank"
-                        >
-                          <ExternalLinkIcon className="h-3 w-3" />
-                          View execution trace
-                        </Link>
-                      )}
-                  </HoverCardContent>
-                </HoverCard>
-              )}
-              {hasMetadata(s) && (
-                <HoverCard>
-                  <HoverCardTrigger className="inline-block shrink-0">
-                    <BracesIcon className="mb-0.25 size-3!" />
-                  </HoverCardTrigger>
-                  <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
-                    <JSONView codeClassName="rounded-md!" json={s.metadata} />
-                  </HoverCardContent>
-                </HoverCard>
-              )}
-              <span className="group-last/score:hidden">,</span>
-            </span>
-          );
-        })}
-      </div>
-    </Badge>
+      <BadgeShell color="neutral" size={compact ? "sm" : "default"}>
+        <span className="truncate" title={text}>
+          {text}
+        </span>
+        {scores.map((score, index) => (
+          <span key={index} className="inline-flex shrink-0 items-center gap-1">
+            {score.comment && (
+              <HoverCard>
+                <HoverCardTrigger className="inline-block shrink-0">
+                  <MessageCircleMoreIcon className="mb-0.25 size-3!" />
+                </HoverCardTrigger>
+                <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
+                  <p className="whitespace-pre-wrap">{score.comment}</p>
+                  {"executionTraceId" in score && score.executionTraceId && (
+                    <ExecutionTraceLink
+                      executionTraceId={score.executionTraceId}
+                    />
+                  )}
+                </HoverCardContent>
+              </HoverCard>
+            )}
+            {hasMetadata(score) && (
+              <HoverCard>
+                <HoverCardTrigger className="inline-block shrink-0">
+                  <BracesIcon className="mb-0.25 size-3!" />
+                </HoverCardTrigger>
+                <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
+                  <JSONView codeClassName="rounded-md!" json={score.metadata} />
+                </HoverCardContent>
+              </HoverCard>
+            )}
+          </span>
+        ))}
+      </BadgeShell>
+    </span>
   );
 };
 
@@ -167,13 +160,11 @@ export const GroupedScoreBadges = <
   scores,
   maxVisible,
   compact,
-  badgeClassName,
   expandable = true,
 }: {
   scores: T[];
   maxVisible?: number;
   compact?: boolean;
-  badgeClassName?: string;
   /**
    * Whether "+N" expands the hidden chips IN PLACE. A caller that has measured a
    * box for exactly `maxVisible` chips has to say no: expanding is unbounded by
@@ -205,11 +196,9 @@ export const GroupedScoreBadges = <
   );
 
   const overflowButtonClassName = cn(
-    badgeVariants({ variant: "tertiary" }),
     expandable ? "cursor-pointer" : "cursor-default",
     compact ? "px-0.5 py-0 leading-tight" : "px-1",
     "text-xs font-bold",
-    badgeClassName,
   );
 
   return (
@@ -220,30 +209,35 @@ export const GroupedScoreBadges = <
           name={name}
           scores={scores}
           compact={compact}
-          badgeClassName={badgeClassName}
           showLevels={showLevels}
         />
       ))}
       {Boolean(hiddenScores.length) && (
         <HoverCard>
           <HoverCardTrigger asChild>
-            <button
-              type="button"
-              // aria-label, not title: a native tooltip would stack on top of
-              // the hover-card preview.
-              aria-label={`Show ${hiddenScores.length} more score${hiddenScores.length === 1 ? "" : "s"}`}
-              // Chips render inside clickable rows (tree nodes, table rows) —
-              // expanding must not also select/navigate the row. Still swallowed
-              // when expansion is off, or the row would react to a click aimed at
-              // the preview.
-              onClick={(event) => {
-                event.stopPropagation();
-                if (expandable) setExpanded(true);
-              }}
-              className={overflowButtonClassName}
+            <BadgeShell
+              asChild
+              color="neutral"
+              size={compact ? "sm" : "default"}
             >
-              +{hiddenScores.length}
-            </button>
+              <button
+                type="button"
+                className={overflowButtonClassName}
+                // aria-label, not title: a native tooltip would stack on top of
+                // the hover-card preview.
+                aria-label={`Show ${hiddenScores.length} more score${hiddenScores.length === 1 ? "" : "s"}`}
+                // Chips render inside clickable rows (tree nodes, table rows) —
+                // expanding must not also select/navigate the row. Still swallowed
+                // when expansion is off, or the row would react to a click aimed at
+                // the preview.
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (expandable) setExpanded(true);
+                }}
+              >
+                +{hiddenScores.length}
+              </button>
+            </BadgeShell>
           </HoverCardTrigger>
           {/* w-max overrides the fixed w-64 base so the card adapts to its
               chips; the cap makes long selections wrap instead of clipping. */}
@@ -255,7 +249,6 @@ export const GroupedScoreBadges = <
                   name={name}
                   scores={scores}
                   compact={compact}
-                  badgeClassName={badgeClassName}
                   showLevels={showLevels}
                 />
               ))}
@@ -264,18 +257,20 @@ export const GroupedScoreBadges = <
         </HoverCard>
       )}
       {expanded && overflows && (
-        <button
-          type="button"
-          title="Show fewer scores"
-          aria-label="Show fewer scores"
-          onClick={(event) => {
-            event.stopPropagation();
-            setExpanded(false);
-          }}
-          className={overflowButtonClassName}
-        >
-          −
-        </button>
+        <BadgeShell asChild color="neutral" size={compact ? "sm" : "default"}>
+          <button
+            type="button"
+            className={overflowButtonClassName}
+            title="Show fewer scores"
+            aria-label="Show fewer scores"
+            onClick={(event) => {
+              event.stopPropagation();
+              setExpanded(false);
+            }}
+          >
+            −
+          </button>
+        </BadgeShell>
       )}
     </>
   );

--- a/web/src/components/score-tag.tsx
+++ b/web/src/components/score-tag.tsx
@@ -1,11 +1,11 @@
-/* eslint-disable @repo/no-style-props */
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
+import { Badge } from "@/src/components/design-system/Badge/Badge";
 import { cn } from "@/src/utils/tailwind";
 
 /**
@@ -58,22 +58,17 @@ export const scoreLevelFromScore = (score: {
           : "trace";
 
 // The global score-level color coding: one hue per level, used identically on
-// every surface (do not restate these colors at call sites). Hue pairs live in
-// globals.css (light + dark themes): observation=blue, trace=violet,
-// session=teal, experiment=yellow.
-const scoreTagVariants = cva(
-  "inline-flex shrink-0 items-center rounded-sm px-1 py-0 text-xs",
-  {
-    variants: {
-      level: {
-        observation: "bg-light-blue text-dark-blue",
-        trace: "bg-light-violet text-dark-violet",
-        session: "bg-light-teal text-dark-teal",
-        experiment: "bg-light-yellow text-dark-yellow",
-      },
-    },
-  },
-);
+// every surface. Hue pairs live in the design-system Badge and globals.css:
+// observation=blue, trace=violet, session=teal, experiment=yellow.
+const scoreTagColors: Record<
+  ScoreLevel,
+  "blue" | "violet" | "teal" | "yellow"
+> = {
+  observation: "blue",
+  trace: "violet",
+  session: "teal",
+  experiment: "yellow",
+};
 
 const scoreDotVariants = cva("inline-block size-2 shrink-0 rounded-full", {
   variants: {
@@ -86,14 +81,13 @@ const scoreDotVariants = cva("inline-block size-2 shrink-0 rounded-full", {
   },
 });
 
-export interface ScoreTagProps extends VariantProps<typeof scoreTagVariants> {
+export interface ScoreTagProps {
   level: ScoreLevel;
   /**
    * Dense-view variant (trace tree / timeline rows): a color dot carrying the
    * level name via tooltip + aria-label instead of a visible word.
    */
   compact?: boolean;
-  className?: string;
 }
 
 /**
@@ -101,11 +95,7 @@ export interface ScoreTagProps extends VariantProps<typeof scoreTagVariants> {
  * color coding. Never color-alone: the full variant shows the level word, the
  * compact dot carries it via tooltip and aria-label.
  */
-export const ScoreTag = ({
-  level,
-  compact = false,
-  className,
-}: ScoreTagProps) => {
+export const ScoreTag = ({ level, compact = false }: ScoreTagProps) => {
   if (compact) {
     return (
       <Tooltip>
@@ -113,7 +103,7 @@ export const ScoreTag = ({
           <span
             role="img"
             aria-label={SCORE_LEVEL_DESCRIPTIONS[level]}
-            className={cn(scoreDotVariants({ level }), className)}
+            className={cn(scoreDotVariants({ level }))}
           />
         </TooltipTrigger>
         <TooltipContent className="text-xs">
@@ -126,9 +116,11 @@ export const ScoreTag = ({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className={cn(scoreTagVariants({ level }), className)}>
-          {SCORE_LEVEL_LABELS[level]}
-        </span>
+        <Badge
+          color={scoreTagColors[level]}
+          size="sm"
+          text={SCORE_LEVEL_LABELS[level]}
+        />
       </TooltipTrigger>
       <TooltipContent className="text-xs">
         {SCORE_LEVEL_DESCRIPTIONS[level]}

--- a/web/src/components/table/key-value-filter-builder.tsx
+++ b/web/src/components/table/key-value-filter-builder.tsx
@@ -486,11 +486,9 @@ export function KeyValueFilterBuilder(props: KeyValueFilterBuilderProps) {
                                 {option}
                               </span>
                               {keyLevels?.[option]?.map((level) => (
-                                <ScoreTag
-                                  key={level}
-                                  level={level}
-                                  className="ml-1.5"
-                                />
+                                <span key={level} className="ml-1.5">
+                                  <ScoreTag level={level} />
+                                </span>
                               ))}
                             </InputCommandItem>
                           ))}

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -47,4 +47,4 @@ function Badge({ className, variant, size, ...props }: BadgeProps) {
   );
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/web/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog.clienttest.tsx
+++ b/web/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog.clienttest.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   render,
   screen,
+  within,
   waitFor,
 } from "@testing-library/react";
 
@@ -45,6 +46,7 @@ vi.mock("@/src/components/editor", () => ({
 }));
 
 import { UpsertModelFormDialog } from "./UpsertModelFormDialog";
+import { ModelBadge } from "@/src/features/traces/components/ObservationDetailView/components/ModelBadge";
 
 const defaultTier = {
   id: "tier-default",
@@ -164,6 +166,24 @@ describe("UpsertModelFormDialog price editor", () => {
 
   beforeEach(() => {
     upsertMutateAsync.mockClear();
+  });
+
+  it("keeps an unlinked model badge intact as the dialog trigger", () => {
+    render(
+      <ModelBadge
+        model="claude-sonnet-4-5"
+        internalModelId={null}
+        projectId="p1"
+        usageDetails={undefined}
+      />,
+    );
+
+    const trigger = screen.getByTitle("Create model definition");
+    const label = within(trigger).getByText("claude-sonnet-4-5");
+
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(label.parentElement).toHaveClass("bg-tertiary");
+    expect(label.parentElement?.querySelector("svg")).not.toBeNull();
   });
 
   it("keeps every keystroke of a usage type that extends an existing one", () => {

--- a/web/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog.clienttest.tsx
+++ b/web/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog.clienttest.tsx
@@ -9,6 +9,8 @@ import {
 } from "@testing-library/react";
 
 import { type GetModelResult } from "@/src/features/models/validation";
+import { ModelBadge } from "@/src/features/traces/components/ObservationDetailView/components/ModelBadge";
+import { UpsertModelFormDialog } from "./UpsertModelFormDialog";
 
 const upsertMutateAsync = vi.fn().mockResolvedValue({
   id: "model-1",
@@ -44,9 +46,6 @@ vi.mock("@/src/features/notifications/showSuccessToast", () => ({
 vi.mock("@/src/components/editor", () => ({
   CodeMirrorEditor: () => null,
 }));
-
-import { UpsertModelFormDialog } from "./UpsertModelFormDialog";
-import { ModelBadge } from "@/src/features/traces/components/ObservationDetailView/components/ModelBadge";
 
 const defaultTier = {
   id: "tier-default",

--- a/web/src/features/search-bar/components/AutocompleteListbox.tsx
+++ b/web/src/features/search-bar/components/AutocompleteListbox.tsx
@@ -137,7 +137,7 @@ export function AutocompleteListbox({
               </span>
               {o.kind === "field" &&
                 o.scoreLevels?.map((level) => (
-                  <ScoreTag key={level} level={level} className="flex-none" />
+                  <ScoreTag key={level} level={level} />
                 ))}
               {o.kind === "value" && o.active && (
                 <Check

--- a/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.stories.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.stories.tsx
@@ -1,0 +1,14 @@
+import preview from "../../../../../../.storybook/preview";
+import { ModelBadge } from "./ModelBadge";
+
+const meta = preview.meta({
+  component: ModelBadge,
+  args: {
+    model: "gpt-5.4",
+    internalModelId: "model-id",
+    projectId: "project-id",
+    usageDetails: undefined,
+  },
+});
+
+export const Linked = meta.story({});

--- a/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ModelBadge.tsx
@@ -3,7 +3,7 @@
  * Handles linked models (with external link) and unlinked models (with create form)
  */
 
-import { Badge } from "@/src/components/ui/badge";
+import { Badge } from "@/src/components/design-system/Badge/Badge";
 import { ExternalLinkIcon, PlusCircle } from "lucide-react";
 import Link from "next/link";
 import { UpsertModelFormDialog } from "@/src/features/models/components/UpsertModelFormDialog/UpsertModelFormDialog";
@@ -24,18 +24,13 @@ export function ModelBadge({
   // Linked model - show link to model settings
   if (internalModelId) {
     return (
-      <Badge>
-        <Link
-          href={`/project/${projectId}/settings/models/${internalModelId}`}
-          className="flex items-center"
-          title="View model details"
-        >
-          <span className="truncate" title={model}>
-            {model}
-          </span>
-          <ExternalLinkIcon className="ml-1 h-3 w-3" />
-        </Link>
-      </Badge>
+      <Link
+        href={`/project/${projectId}/settings/models/${internalModelId}`}
+        className="inline-flex"
+        title="View model details"
+      >
+        <Badge text={model} trailingIcon={ExternalLinkIcon} />
+      </Link>
     );
   }
 
@@ -59,12 +54,10 @@ export function ModelBadge({
                 )
             : undefined,
       }}
-      className="cursor-pointer"
     >
-      <Badge variant="tertiary" className="flex items-center gap-1">
-        <span>{model}</span>
-        <PlusCircle className="h-3 w-3" />
-      </Badge>
+      <button type="button" className="inline-flex cursor-pointer">
+        <Badge text={model} trailingIcon={PlusCircle} />
+      </button>
     </UpsertModelFormDialog>
   );
 }

--- a/web/src/features/traces/components/ObservationDetailView/components/ModelParametersBadges.stories.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ModelParametersBadges.stories.tsx
@@ -1,0 +1,23 @@
+import preview from "../../../../../../.storybook/preview";
+import { ModelParametersBadges } from "./ModelParametersBadges";
+
+const meta = preview.meta({
+  component: ModelParametersBadges,
+  args: {
+    modelParameters: {
+      temperature: 0.7,
+      maxTokens: 2048,
+      responseFormat: { type: "json_object" },
+    },
+  },
+});
+
+export const Default = meta.story({});
+
+export const LongValue = meta.story({
+  args: {
+    modelParameters: {
+      stop: "A long model parameter value that should truncate when space is constrained",
+    },
+  },
+});

--- a/web/src/features/traces/components/ObservationDetailView/components/ModelParametersBadges.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ModelParametersBadges.tsx
@@ -4,7 +4,7 @@
  */
 
 import { type JsonNested } from "@langfuse/shared";
-import { Badge } from "@/src/components/ui/badge";
+import { Badge } from "@/src/components/design-system/Badge/Badge";
 
 export function ModelParametersBadges({
   modelParameters,
@@ -34,15 +34,11 @@ export function ModelParametersBadges({
             ? JSON.stringify(value)
             : value?.toString();
 
+        const text = `${key}: ${valueString}`;
         return (
-          <Badge variant="tertiary" key={key} className="max-w-md">
-            <span
-              className="overflow-hidden text-ellipsis whitespace-nowrap"
-              title={valueString}
-            >
-              {key}: {valueString}
-            </span>
-          </Badge>
+          <span key={key} className="inline-flex max-w-md">
+            <Badge text={text} title={text} />
+          </span>
         );
       })}
     </>

--- a/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader.tsx
+++ b/web/src/features/traces/components/ObservationDetailView/components/ObservationDetailViewHeader.tsx
@@ -33,8 +33,8 @@ import {
   EnvironmentBadge,
   ReleaseBadge,
   VersionBadge,
-  LevelBadge,
 } from "../../ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple";
+import { ObservationLevelBadge } from "@/src/features/traces/components/ObservationLevelBadge";
 import { SessionBadge, UserIdBadge } from "../../TraceMetadataBadges";
 import { CostBadge, UsageBadge } from "../../ObservationMetadataBadgesTooltip";
 import { ModelBadge } from "./ModelBadge";
@@ -594,7 +594,12 @@ export const ObservationDetailViewHeader = memo(
               <ModelParametersBadges
                 modelParameters={observation.modelParameters}
               />
-              <LevelBadge level={observation.level} />
+              {observation.level !== "DEFAULT" && (
+                <ObservationLevelBadge
+                  level={observation.level}
+                  size="default"
+                />
+              )}
               {observation.promptId && (
                 <PromptBadge
                   promptId={observation.promptId}

--- a/web/src/features/traces/components/ObservationLevelBadge.tsx
+++ b/web/src/features/traces/components/ObservationLevelBadge.tsx
@@ -1,0 +1,31 @@
+import { type ComponentProps } from "react";
+import { type ObservationLevelType } from "@langfuse/shared";
+
+import { Badge } from "@/src/components/design-system/Badge/Badge";
+
+type DisplayedObservationLevel = Exclude<ObservationLevelType, "DEFAULT">;
+
+const observationLevelBadgeColors: Record<
+  DisplayedObservationLevel,
+  "neutral" | "yellow" | "red"
+> = {
+  DEBUG: "neutral",
+  WARNING: "yellow",
+  ERROR: "red",
+};
+
+export function ObservationLevelBadge({
+  level,
+  size,
+}: {
+  level: DisplayedObservationLevel;
+  size: ComponentProps<typeof Badge>["size"];
+}) {
+  return (
+    <Badge
+      color={observationLevelBadgeColors[level]}
+      size={size}
+      text={level}
+    />
+  );
+}

--- a/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesSimple/ObservationMetadataBadgesSimple.tsx
@@ -3,7 +3,7 @@
  * Each badge handles its own null checks and returns null when data is unavailable
  */
 
-import { Badge } from "@/src/components/ui/badge";
+import { Badge } from "@/src/components/design-system/Badge/Badge";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 
 export function LatencyBadge({
@@ -13,11 +13,7 @@ export function LatencyBadge({
 }) {
   if (latencySeconds == null) return null;
 
-  return (
-    <Badge variant="tertiary">
-      Latency: {formatIntervalSeconds(latencySeconds)}
-    </Badge>
-  );
+  return <Badge text={`Latency: ${formatIntervalSeconds(latencySeconds)}`} />;
 }
 
 export function TimeToFirstTokenBadge({
@@ -28,9 +24,9 @@ export function TimeToFirstTokenBadge({
   if (timeToFirstToken == null) return null;
 
   return (
-    <Badge variant="tertiary">
-      Time to first token: {formatIntervalSeconds(timeToFirstToken)}
-    </Badge>
+    <Badge
+      text={`Time to first token: ${formatIntervalSeconds(timeToFirstToken)}`}
+    />
   );
 }
 
@@ -41,7 +37,7 @@ export function EnvironmentBadge({
 }) {
   if (!environment) return null;
 
-  return <Badge variant="tertiary">Env: {environment}</Badge>;
+  return <Badge text={`Env: ${environment}`} />;
 }
 
 export function ReleaseBadge({
@@ -51,7 +47,7 @@ export function ReleaseBadge({
 }) {
   if (!release) return null;
 
-  return <Badge variant="tertiary">Release: {release}</Badge>;
+  return <Badge text={`Release: ${release}`} />;
 }
 
 export function VersionBadge({
@@ -61,23 +57,5 @@ export function VersionBadge({
 }) {
   if (!version) return null;
 
-  return <Badge variant="tertiary">Version: {version}</Badge>;
-}
-
-export function LevelBadge({ level }: { level: string | null | undefined }) {
-  if (!level || level === "DEFAULT") return null;
-
-  return (
-    <Badge
-      variant={
-        level === "ERROR"
-          ? "destructive"
-          : level === "WARNING"
-            ? "warning"
-            : "tertiary"
-      }
-    >
-      {level}
-    </Badge>
-  );
+  return <Badge text={`Version: ${version}`} />;
 }

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -4,10 +4,7 @@
  */
 
 import { type ObservationType, isGenerationLike } from "@langfuse/shared";
-import {
-  Badge,
-  BadgeShell,
-} from "@/src/components/design-system/Badge/Badge";
+import { Badge, BadgeShell } from "@/src/components/design-system/Badge/Badge";
 import {
   BreakdownTooltip,
   type PriceSource,

--- a/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/features/traces/components/ObservationMetadataBadgesTooltip.tsx
@@ -4,7 +4,10 @@
  */
 
 import { type ObservationType, isGenerationLike } from "@langfuse/shared";
-import { Badge } from "@/src/components/ui/badge";
+import {
+  Badge,
+  BadgeShell,
+} from "@/src/components/design-system/Badge/Badge";
 import {
   BreakdownTooltip,
   type PriceSource,
@@ -30,10 +33,7 @@ export function CostBadge({
       isCost={true}
       priceSource={priceSource}
     >
-      <Badge variant="tertiary" className="flex items-center gap-1">
-        <span>{usdFormatter(totalCost)}</span>
-        <InfoIcon className="h-3 w-3" />
-      </Badge>
+      <Badge text={usdFormatter(totalCost)} trailingIcon={InfoIcon} />
     </BreakdownTooltip>
   );
 }
@@ -60,17 +60,16 @@ export function UsageBadge({
     totalUsage,
     true,
   );
-  const hasText = tokenText.length > 0;
 
   return (
     <BreakdownTooltip details={usageDetails} isCost={false}>
-      <Badge
-        variant="tertiary"
-        className={`flex items-center gap-1 ${!hasText ? "h-6 pl-2" : ""}`}
-      >
-        {hasText && <span>{tokenText}</span>}
-        <InfoIcon className="h-3 w-3" />
-      </Badge>
+      {tokenText ? (
+        <Badge text={tokenText} trailingIcon={InfoIcon} />
+      ) : (
+        <BadgeShell aria-label="View usage breakdown">
+          <InfoIcon aria-hidden className="size-3" />
+        </BadgeShell>
+      )}
     </BreakdownTooltip>
   );
 }

--- a/web/src/features/traces/components/PromptBadge.tsx
+++ b/web/src/features/traces/components/PromptBadge.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { ExternalLinkIcon } from "lucide-react";
-import { Badge } from "@/src/components/ui/badge";
+import { Badge } from "@/src/components/design-system/Badge/Badge";
 import { api } from "@/src/utils/api";
 
 export const PromptBadge = (props: { promptId: string; projectId: string }) => {
@@ -18,12 +18,7 @@ export const PromptBadge = (props: { promptId: string; projectId: string }) => {
       href={`/project/${props.projectId}/prompts/${encodeURIComponent(prompt.data.name)}?version=${prompt.data.version}`}
       className="inline-flex"
     >
-      <Badge variant="tertiary">
-        <span className="truncate" title={text}>
-          {text}
-        </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
+      <Badge text={text} trailingIcon={ExternalLinkIcon} />
     </Link>
   );
 };

--- a/web/src/features/traces/components/SpanContent.tsx
+++ b/web/src/features/traces/components/SpanContent.tsx
@@ -20,7 +20,7 @@
 
 import { type TreeNode } from "../types/treeNode";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
-import { getLevelColors } from "@/src/components/level-colors";
+import { ObservationLevelBadge } from "@/src/features/traces/components/ObservationLevelBadge";
 import { CommentCountIcon } from "@/src/features/comments/CommentCountIcon";
 import { cn } from "@/src/utils/tailwind";
 import { formatIntervalSeconds } from "@/src/utils/dates";
@@ -139,17 +139,7 @@ export function SpanContent({
             {node.type !== "TRACE" &&
               node.level &&
               node.level !== "DEFAULT" && (
-                <div className="flex">
-                  <span
-                    className={cn(
-                      "rounded-sm p-0.5 text-xs",
-                      getLevelColors(node.level).bg,
-                      getLevelColors(node.level).text,
-                    )}
-                  >
-                    {node.level}
-                  </span>
-                </div>
+                <ObservationLevelBadge level={node.level} size="sm" />
               )}
           </div>
         </div>

--- a/web/src/features/traces/components/TraceMetadataBadges.clienttest.tsx
+++ b/web/src/features/traces/components/TraceMetadataBadges.clienttest.tsx
@@ -2,10 +2,12 @@
 
 import { render, screen } from "@testing-library/react";
 import {
+  EnvironmentBadge,
   SessionBadge,
   TargetTraceBadge,
   UserIdBadge,
 } from "./TraceMetadataBadges";
+import { UsageBadge } from "./ObservationMetadataBadgesTooltip";
 
 describe("TraceMetadataBadges session replay privacy", () => {
   it("blocks trace identifiers from PostHog session recordings", () => {
@@ -14,6 +16,7 @@ describe("TraceMetadataBadges session replay privacy", () => {
         <SessionBadge sessionId="customer-session" projectId="project" />
         <UserIdBadge userId="customer-user" projectId="project" />
         <TargetTraceBadge targetTraceId="target-trace" projectId="project" />
+        <EnvironmentBadge environment="production" />
       </>,
     );
 
@@ -26,5 +29,36 @@ describe("TraceMetadataBadges session replay privacy", () => {
     expect(
       screen.getByText("Target Trace: target-trace").closest("a"),
     ).toHaveClass("ph-no-capture");
+
+    expect(
+      screen.getByText("Session: customer-session").parentElement,
+    ).toHaveClass("bg-primary");
+    expect(
+      screen.getByText("User ID: customer-user").parentElement,
+    ).toHaveClass("bg-primary");
+    expect(
+      screen.getByText("Target Trace: target-trace").parentElement,
+    ).toHaveClass("bg-primary");
+    expect(screen.getByText("Env: production").parentElement).toHaveClass(
+      "bg-tertiary",
+    );
+  });
+});
+
+describe("UsageBadge", () => {
+  it("keeps custom usage details accessible without aggregate token totals", () => {
+    render(
+      <UsageBadge
+        type="GENERATION"
+        inputUsage={0}
+        outputUsage={0}
+        totalUsage={0}
+        usageDetails={{ audio_seconds: 12 }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "View usage breakdown" }),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/features/traces/components/TraceMetadataBadges.tsx
+++ b/web/src/features/traces/components/TraceMetadataBadges.tsx
@@ -7,7 +7,7 @@
 
 import Link from "next/link";
 import { ExternalLinkIcon } from "lucide-react";
-import { Badge } from "@/src/components/ui/badge";
+import { Badge } from "@/src/components/design-system/Badge/Badge";
 
 export function SessionBadge({
   sessionId,
@@ -25,12 +25,7 @@ export function SessionBadge({
       href={`/project/${projectId}/sessions/${encodeURIComponent(sessionId)}`}
       className="ph-no-capture inline-flex"
     >
-      <Badge>
-        <span className="truncate" title={text}>
-          {text}
-        </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
+      <Badge color="primary" text={text} trailingIcon={ExternalLinkIcon} />
     </Link>
   );
 }
@@ -51,12 +46,7 @@ export function UserIdBadge({
       href={`/project/${projectId}/users/${encodeURIComponent(userId)}`}
       className="ph-no-capture inline-flex"
     >
-      <Badge>
-        <span className="truncate" title={text}>
-          {text}
-        </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
+      <Badge color="primary" text={text} trailingIcon={ExternalLinkIcon} />
     </Link>
   );
 }
@@ -77,12 +67,7 @@ export function TargetTraceBadge({
       href={`/project/${projectId}/traces/${encodeURIComponent(targetTraceId)}`}
       className="ph-no-capture inline-flex"
     >
-      <Badge>
-        <span className="truncate" title={text}>
-          {text}
-        </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
+      <Badge color="primary" text={text} trailingIcon={ExternalLinkIcon} />
     </Link>
   );
 }
@@ -93,15 +78,15 @@ export function EnvironmentBadge({
   environment: string | null;
 }) {
   if (!environment) return null;
-  return <Badge variant="tertiary">Env: {environment}</Badge>;
+  return <Badge text={`Env: ${environment}`} />;
 }
 
 export function ReleaseBadge({ release }: { release: string | null }) {
   if (!release) return null;
-  return <Badge variant="tertiary">Release: {release}</Badge>;
+  return <Badge text={`Release: ${release}`} />;
 }
 
 export function VersionBadge({ version }: { version: string | null }) {
   if (!version) return null;
-  return <Badge variant="tertiary">Version: {version}</Badge>;
+  return <Badge text={`Version: ${version}`} />;
 }

--- a/web/src/features/traces/types/treeNode.ts
+++ b/web/src/features/traces/types/treeNode.ts
@@ -5,7 +5,10 @@
  * TraceSearchListItem: Flattened representation of tree nodes for search/list views.
  */
 
-import { type ObservationType } from "@langfuse/shared";
+import {
+  type ObservationLevelType,
+  type ObservationType,
+} from "@langfuse/shared";
 import type Decimal from "decimal.js";
 
 /**
@@ -18,7 +21,7 @@ export type TreeNode = {
   name: string;
   startTime: Date;
   endTime?: Date | null;
-  level?: string;
+  level?: ObservationLevelType;
   children: TreeNode[];
   // Token usage
   inputUsage?: number | null;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16708 app preview](https://pr-16708.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consolidates trace metadata, score, model, prompt, usage, and observation-level badges onto a new design-system badge primitive.
- Adds shared `Badge`, `BadgeShell`, `ScoreBadge`, and `ObservationLevelBadge` components.
- Updates trace UI badge composition, truncation, colors, links, and interactive details.
- Adds Storybook coverage and focused client tests for badge rendering and trigger behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix PR review issues"](https://github.com/langfuse/langfuse/commit/7f8fd139130846c2a9c18ee1af819420f36c0b8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57883854)</sub>

<!-- /greptile_comment -->