### PR TITLE
fix(v4): shorten migration detection lookback

### DIFF
--- a/packages/shared/src/server/v4/legacyApiUsage.test.ts
+++ b/packages/shared/src/server/v4/legacyApiUsage.test.ts
@@ -75,12 +75,12 @@ describe("v4LegacyApiHourBucketTtlSeconds", () => {
   });
 
   it("shortens TTL for hole-repaired older hours so they expire with the window", () => {
-    const tenDaysAgo = nowMs - 10 * 24 * HOUR_MS;
-    const hourStartMs = Math.floor(tenDaysAgo / HOUR_MS) * HOUR_MS;
+    const twoDaysAgo = nowMs - 2 * 24 * HOUR_MS;
+    const hourStartMs = Math.floor(twoDaysAgo / HOUR_MS) * HOUR_MS;
     const ttl = v4LegacyApiHourBucketTtlSeconds(hourStartMs, nowMs);
-    // ~5 days remaining of the 15d horizon
-    expect(ttl).toBeGreaterThan(4 * 24 * 60 * 60);
-    expect(ttl).toBeLessThan(6 * 24 * 60 * 60);
+    // ~2 days remaining of the 4d horizon
+    expect(ttl).toBeGreaterThan(1 * 24 * 60 * 60);
+    expect(ttl).toBeLessThan(3 * 24 * 60 * 60);
   });
 
   it("clamps to at least 1 second when the hour is already past the horizon", () => {

--- a/packages/shared/src/server/v4/legacyApiUsage.ts
+++ b/packages/shared/src/server/v4/legacyApiUsage.ts
@@ -36,15 +36,15 @@ import { z } from "zod/v4";
 const HOUR_MS = 60 * 60 * 1000;
 
 /** Detection window served to the UI; must match the web-side window. */
-export const V4_LEGACY_API_USAGE_WINDOW_MS = 14 * 24 * HOUR_MS;
+export const V4_LEGACY_API_USAGE_WINDOW_MS = 3 * 24 * HOUR_MS;
 
 /** GC horizon for hour buckets: window plus one day of slack. */
-export const V4_LEGACY_API_HOUR_BUCKET_TTL_SECONDS = 15 * 24 * 60 * 60;
+export const V4_LEGACY_API_HOUR_BUCKET_TTL_SECONDS = 4 * 24 * 60 * 60;
 
 /**
  * Redis TTL for an hour bucket keyed by that hour's start, not by write time.
- * A hole-repaired bucket from 10 days ago must expire in ~5 days (horizon
- * minus age), not live another full 15 days from the repair write.
+ * A hole-repaired bucket from two days ago must expire in ~2 days (horizon
+ * minus age), not live another full 4 days from the repair write.
  */
 export const v4LegacyApiHourBucketTtlSeconds = (
   hourStartMs: number,

--- a/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
+++ b/web/src/__tests__/server/unit/v4TransitionRouter.servertest.ts
@@ -463,7 +463,7 @@ const accessibleProjectsFindManyArgs = {
 const TEST_NOW = new Date("2026-06-25T00:30:00Z");
 const HOT_START_ISO = "2026-06-25T00:00:00.000Z";
 const HOT_START_CLICKHOUSE = "2026-06-25 00:00:00.000";
-const WINDOW_START_CLICKHOUSE = "2026-06-11 01:00:00.000";
+const WINDOW_START_CLICKHOUSE = "2026-06-22 01:00:00.000";
 // Recent SDK gap cutoff: TEST_NOW floored to the minute (zero
 // seconds/millis) so repeated calls within the minute share one ClickHouse
 // query-cache key.
@@ -2006,15 +2006,15 @@ describe("v4TransitionRouter", () => {
       });
     });
 
-    it("drops cached SDK series that aged out of the 14-day window", async () => {
+    it("drops cached SDK series that aged out of the 3-day window", async () => {
       await seedRedisCache({
         [sdkUsageCacheKey]: sdkUsageBlob([
           cachedSdkSeries(),
           cachedSdkSeries({
             sdkVersion: "2.0.0",
-            // Older than now - 14d (2026-06-11T00:30Z): trimmed at read time.
-            firstSeen: "2026-06-08T00:00:00Z",
-            lastSeen: "2026-06-10T00:00:00Z",
+            // Older than now - 3d (2026-06-22T00:30Z): trimmed at read time.
+            firstSeen: "2026-06-20T00:00:00Z",
+            lastSeen: "2026-06-21T00:00:00Z",
           }),
         ]),
         [experimentPostUsageCacheKey]: experimentPostBlob(false),

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -504,7 +504,7 @@ describe("V4MigrationDetailsContent", () => {
 
     expect(
       screen.getByText(
-        "SDK, instrumentation, experiment, and API checks cover activity from the last 14 days. API and experiment usage counts refresh about every 15 minutes, so recent calls may not appear yet.",
+        `SDK, instrumentation, experiment, and API checks cover activity from the last ${V4_MIGRATION_LOOKBACK_DAYS} days. API and experiment usage counts refresh about every 15 minutes, so recent calls may not appear yet.`,
       ),
     ).toBeInTheDocument();
     expect(
@@ -675,7 +675,7 @@ describe("V4MigrationDetailsContent", () => {
           "ingestionSource;stringOptions;;any of;ingestion-api-dual-write," +
           "ingestionSdkName;stringOptions;;any of;python," +
           "ingestionSdkVersion;stringOptions;;any of;2.60.3",
-      )}&dateRange=14d`,
+      )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`,
     );
     expect(evidenceLink).toHaveAttribute("target", "_blank");
     expect(evidenceLink).toHaveAttribute("rel", "noopener noreferrer");
@@ -799,7 +799,7 @@ describe("V4MigrationDetailsContent", () => {
       `/project/project-1/observations?filter=${encodeURIComponent(
         "ingestionApiKey;stringOptions;;any of;," +
           "ingestionSource;stringOptions;;any of;otel-dual-write",
-      )}&dateRange=14d`,
+      )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`,
     );
     expect(evidenceLink).toHaveAttribute("target", "_blank");
     expect(evidenceLink).toHaveAttribute("rel", "noopener noreferrer");
@@ -1069,7 +1069,7 @@ describe("V4MigrationDetailsContent", () => {
       `/project/project-1/observations?filter=${encodeURIComponent(
         "ingestionApiKey;stringOptions;;any of;pk-lf-1234567890abcdef," +
           "ingestionSource;stringOptions;;any of;ingestion-api-dual-write",
-      )}&dateRange=14d`,
+      )}&dateRange=${V4_MIGRATION_LOOKBACK_DAYS}d`,
     );
     expect(evidenceLink).toHaveAttribute("target", "_blank");
     expect(evidenceLink).toHaveAttribute("rel", "noopener noreferrer");

--- a/web/src/features/v4-migration/migrationData.ts
+++ b/web/src/features/v4-migration/migrationData.ts
@@ -1,7 +1,7 @@
 import { type RouterOutputs } from "@/src/utils/api";
 import { type V4MigrationSdkState } from "@/src/features/v4-migration/sdkVersionStatus";
 
-export const V4_MIGRATION_LOOKBACK_DAYS = 14;
+export const V4_MIGRATION_LOOKBACK_DAYS = 3;
 
 export type MigrationCountState =
   | { status: "loading"; count: 0 }

--- a/web/src/features/v4/server/v4TransitionCache.ts
+++ b/web/src/features/v4/server/v4TransitionCache.ts
@@ -19,7 +19,7 @@ import {
  * blob covers the detection window up to an hour-aligned `hotStart` boundary;
  * readers always query the small `[hotStart, now]` gap live and merge it with
  * the blob so new SDK versions register within minutes. The TTL is one hour so
- * left-edge overcount on the sliding 14-day window (and stale classification
+ * left-edge overcount on the sliding 3-day window (and stale classification
  * fields embedded in the blob) stay bounded to ~1h.
  *
  * Deprecated public API and experiment POST usage are maintained by the
@@ -176,7 +176,7 @@ const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
 
 /** Trailing detection window used for SDK cache blobs and usage queries. */
-export const V4_TRANSITION_DETECTION_WINDOW_MS = 14 * 24 * HOUR_MS;
+export const V4_TRANSITION_DETECTION_WINDOW_MS = 3 * 24 * HOUR_MS;
 
 /**
  * Detection windows are computed server-side so cache entries are shared

--- a/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
+++ b/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
@@ -113,8 +113,8 @@ const loggedError = (message: string) =>
 // 10:30 UTC: a regular run (the deep re-scan happens at 03:xx UTC only).
 const TEST_NOW = new Date("2026-06-25T10:30:00Z");
 const CURRENT_HOUR_ISO = "2026-06-25T10:00:00Z";
-// floor(now - 14d) to the hour.
-const COVERAGE_START_CLICKHOUSE = "2026-06-11 10:00:00.000";
+// floor(now - 3d) to the hour.
+const COVERAGE_START_CLICKHOUSE = "2026-06-22 10:00:00.000";
 
 const usageRow = (overrides: {
   hourStart?: string;
@@ -155,7 +155,7 @@ const emptyBucket = () =>
 const seedCoverageBuckets = (skipHourIsos: string[] = []) => {
   const skip = new Set(skipHourIsos.map((iso) => Date.parse(iso)));
   for (const hourStartMs of listV4LegacyApiHourStarts(
-    Date.parse("2026-06-11T10:00:00Z"),
+    Date.parse("2026-06-22T10:00:00Z"),
     Date.parse(CURRENT_HOUR_ISO),
   )) {
     if (skip.has(hourStartMs)) continue;
@@ -189,7 +189,7 @@ describe("handleV4LegacyApiUsageJob", () => {
     vi.clearAllMocks();
   });
 
-  it("cold start: scans the full 14-day window once and materializes buckets, rollups, cursor, and heartbeat", async () => {
+  it("cold start: scans the full 3-day window once and materializes buckets, rollups, cursor, and heartbeat", async () => {
     const rows = [
       usageRow({}),
       usageRow({
@@ -219,8 +219,8 @@ describe("handleV4LegacyApiUsageJob", () => {
       "toStartOfHour(event_time, 'UTC')",
     );
 
-    // One bucket per hour in the window, empty ones included: 14*24 + 1.
-    expect(bucketKeyCount()).toBe(337);
+    // One bucket per hour in the window, empty ones included: 3*24 + 1.
+    expect(bucketKeyCount()).toBe(73);
     expect(
       readJson(v4LegacyApiHourBucketKey(Date.parse("2026-06-25T09:00:00Z"))),
     ).toMatchObject({
@@ -278,11 +278,11 @@ describe("handleV4LegacyApiUsageJob", () => {
     expect(redisState.store.has(V4_LEGACY_API_USAGE_LOCK_KEY)).toBe(false);
 
     expect(loggedInfo("Running v4 legacy API usage job")).toMatchObject({
-      scanStart: "2026-06-11T10:00:00Z",
-      hours: 337,
+      scanStart: "2026-06-22T10:00:00Z",
+      hours: 73,
       coldStart: true,
       repairedHole: false,
-      missingBucketCount: 337,
+      missingBucketCount: 73,
       clickhouseServices: ["ReadWrite", "ReadOnly"],
     });
     expect(
@@ -296,7 +296,7 @@ describe("handleV4LegacyApiUsageJob", () => {
       experimentPostRowCount: 1,
     });
     expect(loggedInfo("Completed v4 legacy API usage job")).toMatchObject({
-      scannedHours: 337,
+      scannedHours: 73,
       nonEmptyBuckets: 2,
       projectsWithLegacyApiUsage: 1,
       projectsWithExperimentPostUsage: 1,

--- a/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
+++ b/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
@@ -410,16 +410,16 @@ describe("handleV4LegacyApiUsageJob", () => {
     // Existing bucket from an earlier run, outside the re-scan range: its
     // counts must survive and merge into the rollup.
     redisState.store.set(
-      v4LegacyApiHourBucketKey(Date.parse("2026-06-20T00:00:00Z")),
+      v4LegacyApiHourBucketKey(Date.parse("2026-06-23T00:00:00Z")),
       JSON.stringify({
         version: 1,
-        computedAt: "2026-06-20T01:00:00.000Z",
+        computedAt: "2026-06-23T01:00:00.000Z",
         apiRows: [
           {
             projectId: "project-a",
             entrypoint: "publicapi: GET /api/public/traces",
             count: 2,
-            lastSeen: "2026-06-20T00:30:00.000000Z",
+            lastSeen: "2026-06-23T00:30:00.000000Z",
           },
         ],
         experimentPostRows: [],
@@ -502,21 +502,21 @@ describe("handleV4LegacyApiUsageJob", () => {
     seedRecentDeepRescan();
     // One bucket is missing well before the cursor margin; without repair the
     // rollup would silently lose that hour while the heartbeat stays fresh.
-    seedCoverageBuckets(["2026-06-21T05:00:00Z"]);
+    seedCoverageBuckets(["2026-06-23T05:00:00Z"]);
 
     await handleV4LegacyApiUsageJob();
 
     expect(mocks.queryClickhouse.mock.calls[0]?.[0].params).toMatchObject({
-      fromTimestamp: "2026-06-21 05:00:00.000",
+      fromTimestamp: "2026-06-23 05:00:00.000",
     });
     expect(
       redisState.store.has(
-        v4LegacyApiHourBucketKey(Date.parse("2026-06-21T05:00:00Z")),
+        v4LegacyApiHourBucketKey(Date.parse("2026-06-23T05:00:00Z")),
       ),
     ).toBe(true);
     expect(loggedInfo("Running v4 legacy API usage job")).toMatchObject({
       repairedHole: true,
-      repairedHoleHour: "2026-06-21T05:00:00Z",
+      repairedHoleHour: "2026-06-23T05:00:00Z",
       missingBucketCount: 1,
     });
   });
@@ -660,7 +660,7 @@ describe("handleV4LegacyApiUsageJob", () => {
     seedRecentDeepRescan();
     seedCoverageBuckets();
     redisState.store.set(
-      v4LegacyApiHourBucketKey(Date.parse("2026-06-21T05:00:00Z")),
+      v4LegacyApiHourBucketKey(Date.parse("2026-06-23T05:00:00Z")),
       "not-json",
     );
 
@@ -670,11 +670,11 @@ describe("handleV4LegacyApiUsageJob", () => {
       loggedWarn("v4 legacy API usage: unparsable hour buckets"),
     ).toMatchObject({
       count: 1,
-      hourStarts: ["2026-06-21T05:00:00Z"],
+      hourStarts: ["2026-06-23T05:00:00Z"],
     });
     expect(loggedInfo("Running v4 legacy API usage job")).toMatchObject({
       repairedHole: true,
-      repairedHoleHour: "2026-06-21T05:00:00Z",
+      repairedHoleHour: "2026-06-23T05:00:00Z",
       unparsableBucketCount: 1,
     });
   });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16710.preview.langfuse.com](https://pr-16710.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Shortens the v4 migration sidebar and panel detection lookback from 14 days to 3 days across the UI, tRPC SDK usage checks, and the worker-maintained legacy API usage rollups.

The SDK and project caches keep their existing keys because read-time `lastSeen` trimming makes the sidebar state correct immediately. The hourly bucket TTL is reduced from 15 days to 4 days (3-day window plus one day of slack) so unused historical buckets are garbage-collected sooner.

<a href="https://cursor.com/agents/bc-a58b975d-1c07-4ed5-8ac5-070e81fdf408/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv4_migration_three_day_lookback.mp4"><img src="https://cursor.com/artifacts/c/art-21b0008b-ef66-40e8-93c8-3c471652f762" alt="v4_migration_three_day_lookback.mp4" /></a>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` — `All matched files use Prettier code style!`
- `turbo run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter @langfuse/shared run test legacyApiUsage` — `Tests 9 passed (9)`
- `pnpm --filter worker run test handleV4LegacyApiUsageJob` — `Tests 11 passed (11)`
- `pnpm --filter web run test v4TransitionRouter.servertest` — `Tests 42 passed (42)`
- `pnpm --filter web run test-client V4MigrationContent.clienttest` — `Tests 43 passed (43)`
- Browser: expanded/collapsed the Update SDK section and confirmed the visible copy says `last 3 days`.
- Preview: `https://pr-16710.preview.langfuse.com/v4-migration` loads and shows the clean demo project as up to date.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a58b975d-1c07-4ed5-8ac5-070e81fdf408?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a58b975d-1c07-4ed5-8ac5-070e81fdf408&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Shortens the v4 migration activity-detection window from 14 days to 3 days while preserving consistent read-time cache trimming.

- Aligns UI messaging, evidence links, SDK checks, and legacy API rollups with the three-day window.
- Reduces hourly Redis bucket retention to four days, leaving one day of slack.
- Updates shared, server, client, and worker tests for the shortened window.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the UI, server cache reads, worker rollups, and Redis retention aligned to the shortened lookback.

Cached records are trimmed at read time using the new three-day threshold, worker coverage uses the corresponding shared window, and the four-day bucket horizon preserves one day of operational slack.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): shorten migration detection loo..."](https://github.com/langfuse/langfuse/commit/682d93aaef870ce026043f2532877d8314e9f771) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57567846)</sub>

<!-- /greptile_comment -->