### PR TITLE
feat(web): instrument experiments UI product analytics

### DIFF
--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -1282,9 +1282,9 @@ export const getExperimentNamesFromEvents = async (props: {
 }) => {
   const queryBuilder = new EventsAggQueryBuilder({
     projectId: props.projectId,
-    groupByColumn: "e.experiment_name",
+    groupByColumn: "e.experiment_id",
     selectExpression:
-      "e.experiment_name as experimentName, any(e.experiment_id) as experimentId, nullIf(any(e.experiment_dataset_id), '') as datasetId",
+      "any(e.experiment_name) as experimentName, e.experiment_id as experimentId, nullIf(any(e.experiment_dataset_id), '') as datasetId",
   })
     .whereRaw("e.experiment_name IS NOT NULL AND length(e.experiment_name) > 0")
     .limit(1000, 0);

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -1284,7 +1284,7 @@ export const getExperimentNamesFromEvents = async (props: {
     projectId: props.projectId,
     groupByColumn: "e.experiment_name",
     selectExpression:
-      "e.experiment_name as experimentName, any(e.experiment_id) as experimentId",
+      "e.experiment_name as experimentName, any(e.experiment_id) as experimentId, nullIf(any(e.experiment_dataset_id), '') as datasetId",
   })
     .whereRaw("e.experiment_name IS NOT NULL AND length(e.experiment_name) > 0")
     .limit(1000, 0);
@@ -1294,6 +1294,7 @@ export const getExperimentNamesFromEvents = async (props: {
   const res = await queryClickhouse<{
     experimentName: string;
     experimentId: string;
+    datasetId: string | null;
   }>({
     query,
     params,

--- a/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
@@ -1235,6 +1235,62 @@ describe("Clickhouse Experiment Repository Test", () => {
       // Experiment without metadata should not match
       expect(excludedExperiment).toBeUndefined();
     });
+
+    it("returns a row per experiment id when two experiments share a name", async () => {
+      const isolatedProjectId = randomUUID();
+      const sharedName = `v1-${randomUUID()}`;
+      const experimentIdA = randomUUID();
+      const experimentIdB = randomUUID();
+      const datasetIdA = randomUUID();
+      const datasetIdB = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: isolatedProjectId,
+          trace_id: randomUUID(),
+          type: "GENERATION",
+          experiment_id: experimentIdA,
+          experiment_name: sharedName,
+          experiment_dataset_id: datasetIdA,
+          experiment_item_id: randomUUID(),
+          experiment_item_root_span_id: randomUUID(),
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: isolatedProjectId,
+          trace_id: randomUUID(),
+          type: "GENERATION",
+          experiment_id: experimentIdB,
+          experiment_name: sharedName,
+          experiment_dataset_id: datasetIdB,
+          experiment_item_id: randomUUID(),
+          experiment_item_root_span_id: randomUUID(),
+        }),
+      ]);
+
+      const result = await getExperimentNamesFromEvents({
+        projectId: isolatedProjectId,
+      });
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            experimentId: experimentIdA,
+            experimentName: sharedName,
+            datasetId: datasetIdA,
+          },
+          {
+            experimentId: experimentIdB,
+            experimentName: sharedName,
+            datasetId: datasetIdB,
+          },
+        ]),
+      );
+      expect(result).toHaveLength(2);
+    });
   });
 
   maybe("getExperimentItemsFilterOptions", () => {
@@ -1662,62 +1718,6 @@ describe("Clickhouse Experiment Repository Test", () => {
           },
         ]),
       );
-    });
-
-    it("returns a row per experiment id when two experiments share a name", async () => {
-      const isolatedProjectId = randomUUID();
-      const sharedName = `v1-${randomUUID()}`;
-      const experimentIdA = randomUUID();
-      const experimentIdB = randomUUID();
-      const datasetIdA = randomUUID();
-      const datasetIdB = randomUUID();
-
-      await createEventsCh([
-        createEvent({
-          id: randomUUID(),
-          span_id: randomUUID(),
-          project_id: isolatedProjectId,
-          trace_id: randomUUID(),
-          type: "GENERATION",
-          experiment_id: experimentIdA,
-          experiment_name: sharedName,
-          experiment_dataset_id: datasetIdA,
-          experiment_item_id: randomUUID(),
-          experiment_item_root_span_id: randomUUID(),
-        }),
-        createEvent({
-          id: randomUUID(),
-          span_id: randomUUID(),
-          project_id: isolatedProjectId,
-          trace_id: randomUUID(),
-          type: "GENERATION",
-          experiment_id: experimentIdB,
-          experiment_name: sharedName,
-          experiment_dataset_id: datasetIdB,
-          experiment_item_id: randomUUID(),
-          experiment_item_root_span_id: randomUUID(),
-        }),
-      ]);
-
-      const result = await getExperimentNamesFromEvents({
-        projectId: isolatedProjectId,
-      });
-
-      expect(result).toEqual(
-        expect.arrayContaining([
-          {
-            experimentId: experimentIdA,
-            experimentName: sharedName,
-            datasetId: datasetIdA,
-          },
-          {
-            experimentId: experimentIdB,
-            experimentName: sharedName,
-            datasetId: datasetIdB,
-          },
-        ]),
-      );
-      expect(result).toHaveLength(2);
     });
   });
 });

--- a/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
@@ -7,6 +7,7 @@ import {
   getExperimentsFromEvents,
   getExperimentMetricsFromEvents,
   getExperimentItemsFilterOptions,
+  getExperimentNamesFromEvents,
   getExperimentScoreOptions,
   createTraceScore,
   createDatasetRunScore,
@@ -1661,6 +1662,62 @@ describe("Clickhouse Experiment Repository Test", () => {
           },
         ]),
       );
+    });
+
+    it("returns a row per experiment id when two experiments share a name", async () => {
+      const isolatedProjectId = randomUUID();
+      const sharedName = `v1-${randomUUID()}`;
+      const experimentIdA = randomUUID();
+      const experimentIdB = randomUUID();
+      const datasetIdA = randomUUID();
+      const datasetIdB = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: isolatedProjectId,
+          trace_id: randomUUID(),
+          type: "GENERATION",
+          experiment_id: experimentIdA,
+          experiment_name: sharedName,
+          experiment_dataset_id: datasetIdA,
+          experiment_item_id: randomUUID(),
+          experiment_item_root_span_id: randomUUID(),
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: isolatedProjectId,
+          trace_id: randomUUID(),
+          type: "GENERATION",
+          experiment_id: experimentIdB,
+          experiment_name: sharedName,
+          experiment_dataset_id: datasetIdB,
+          experiment_item_id: randomUUID(),
+          experiment_item_root_span_id: randomUUID(),
+        }),
+      ]);
+
+      const result = await getExperimentNamesFromEvents({
+        projectId: isolatedProjectId,
+      });
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            experimentId: experimentIdA,
+            experimentName: sharedName,
+            datasetId: datasetIdA,
+          },
+          {
+            experimentId: experimentIdB,
+            experimentName: sharedName,
+            datasetId: datasetIdB,
+          },
+        ]),
+      );
+      expect(result).toHaveLength(2);
     });
   });
 });

--- a/web/src/components/layouts/page-tabs.clienttest.tsx
+++ b/web/src/components/layouts/page-tabs.clienttest.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PageTabs } from "./page-tabs";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    onClick,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: { pathname: string };
+    onClick?: () => void;
+    className?: string;
+  }) => (
+    <a
+      href={href.pathname}
+      className={className}
+      onClick={(event) => {
+        event.preventDefault();
+        onClick?.();
+      }}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { projectId: "p1" } }),
+}));
+
+describe("PageTabs", () => {
+  it("fires onClick on a tab that also has an href", () => {
+    const onAnalyticsClick = vi.fn();
+    render(
+      <PageTabs
+        activeTab="results"
+        tabs={[
+          {
+            value: "results",
+            label: "Results",
+            href: "/project/p1/experiments/results",
+          },
+          {
+            value: "analytics",
+            label: "Analytics",
+            href: "/project/p1/experiments/analytics",
+            onClick: onAnalyticsClick,
+          },
+        ]}
+      />,
+    );
+
+    const analytics = screen.getByRole("link", { name: "Analytics" });
+    expect(analytics).toHaveAttribute(
+      "href",
+      "/project/p1/experiments/analytics",
+    );
+    fireEvent.click(analytics);
+    expect(onAnalyticsClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/layouts/page-tabs.tsx
+++ b/web/src/components/layouts/page-tabs.tsx
@@ -55,6 +55,22 @@ export const PageTabs = ({
             tab.className,
           );
 
+          if (tab.href) {
+            return (
+              <Link
+                key={tab.value}
+                href={{
+                  pathname: tab.href ?? "",
+                  query: tab.querySelector?.(router.query),
+                }}
+                className={tabClassName}
+                onClick={tab.onClick}
+              >
+                {tab.label}
+              </Link>
+            );
+          }
+
           if (tab.onClick) {
             return (
               <button
@@ -69,18 +85,7 @@ export const PageTabs = ({
             );
           }
 
-          return (
-            <Link
-              key={tab.value}
-              href={{
-                pathname: tab.href ?? "",
-                query: tab.querySelector?.(router.query),
-              }}
-              className={tabClassName}
-            >
-              {tab.label}
-            </Link>
-          );
+          return null;
         })}
       </div>
     </div>

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -439,6 +439,8 @@ export const SessionPage: React.FC<{
       // traceId: not written here, but cleared so a v4-dialect shared URL
       // cannot pin the trace peek (LFE-11041).
       queryParams: ["observation", "display", "timestamp", "traceId"],
+      tableName: "sessions",
+      isV4: false,
       extractParamsValuesFromRow: (row: any) => ({
         timestamp: row.timestamp.toISOString(),
       }),
@@ -825,6 +827,8 @@ export const SessionPage: React.FC<{
           closePeek={closePeek}
           expandPeek={expandPeek}
           resolveDetailNavigationPath={resolveDetailNavigationPath}
+          tableName="sessions"
+          isV4={false}
           projectId={projectId}
         />
       </Page>
@@ -1013,6 +1017,8 @@ const LoadedSessionEventsPage: React.FC<{
       // traceId: not written here, but cleared so a v4-dialect shared URL
       // cannot pin the trace peek (LFE-11041).
       queryParams: ["observation", "display", "timestamp", "traceId"],
+      tableName: "session-events",
+      isV4: true,
       // observationId: set by a card's "Open in trace view" on a truncated
       // observation so the peek opens AT that observation (LFE-10958).
       extractParamsValuesFromRow: (row: any) => ({
@@ -1939,6 +1945,8 @@ const LoadedSessionEventsPage: React.FC<{
           closePeek={closePeek}
           expandPeek={expandPeek}
           resolveDetailNavigationPath={resolveDetailNavigationPath}
+          tableName="session-events"
+          isV4={true}
           projectId={projectId}
         />
       </Page>

--- a/web/src/components/table/data-table-column-visibility-filter.clienttest.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.clienttest.tsx
@@ -5,8 +5,13 @@ import { DataTableColumnVisibilityFilter } from "@/src/components/table/data-tab
 import { LAYER_ORDER } from "@/src/components/ui/layer";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 
+const h = vi.hoisted(() => ({
+  capture: vi.fn(),
+  onColumnGroupToggle: vi.fn(),
+}));
+
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
-  usePostHogClientCapture: () => vi.fn(),
+  usePostHogClientCapture: () => h.capture,
 }));
 
 const columns: LangfuseColumnDef<{ id: string }>[] = [
@@ -22,6 +27,31 @@ const columns: LangfuseColumnDef<{ id: string }>[] = [
   },
 ];
 
+const groupedColumns: LangfuseColumnDef<{ id: string }>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    enableHiding: true,
+  },
+  {
+    accessorKey: "traceItemScores",
+    header: "Trace Item Scores",
+    enableHiding: true,
+    columns: [
+      {
+        accessorKey: "traceItemScores-accuracy",
+        header: "accuracy",
+        enableHiding: true,
+      },
+      {
+        accessorKey: "traceItemScores-helpfulness",
+        header: "helpfulness",
+        enableHiding: true,
+      },
+    ],
+  },
+];
+
 function ColumnVisibilityFilterHarness() {
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     startTime: true,
@@ -33,6 +63,27 @@ function ColumnVisibilityFilterHarness() {
       columns={columns}
       columnVisibility={columnVisibility}
       setColumnVisibility={setColumnVisibility}
+      tableName="experiments"
+      isV4={true}
+    />
+  );
+}
+
+function GroupedColumnVisibilityHarness() {
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
+    name: true,
+    "traceItemScores-accuracy": false,
+    "traceItemScores-helpfulness": false,
+  });
+
+  return (
+    <DataTableColumnVisibilityFilter
+      columns={groupedColumns}
+      columnVisibility={columnVisibility}
+      setColumnVisibility={setColumnVisibility}
+      tableName="experiments"
+      isV4={true}
+      onColumnGroupToggle={h.onColumnGroupToggle}
     />
   );
 }
@@ -76,6 +127,8 @@ describe("DataTableColumnVisibilityFilter", () => {
   });
 
   beforeEach(() => {
+    h.capture.mockClear();
+    h.onColumnGroupToggle.mockClear();
     installOverlayLayers();
   });
 
@@ -94,5 +147,36 @@ describe("DataTableColumnVisibilityFilter", () => {
     fireEvent.click(screen.getByText("Input"));
 
     expect(screen.getByRole("checkbox", { name: "Input" })).not.toBeChecked();
+  });
+
+  it("captures column_visibility_changed once with tableName and isV4", () => {
+    render(<ColumnVisibilityFilterHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: /columns/i }));
+    fireEvent.click(screen.getByText("Input"));
+
+    expect(h.capture).toHaveBeenCalledTimes(1);
+    expect(h.capture).toHaveBeenCalledWith("table:column_visibility_changed", {
+      selectedColumns: ["startTime"],
+      tableName: "experiments",
+      isV4: true,
+    });
+  });
+
+  it("notifies onColumnGroupToggle with the group id, not score names", () => {
+    render(<GroupedColumnVisibilityHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: /columns/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Select All" }));
+
+    expect(h.onColumnGroupToggle).toHaveBeenCalledTimes(1);
+    expect(h.onColumnGroupToggle).toHaveBeenCalledWith({
+      groupId: "traceItemScores",
+      enabledCount: 2,
+      totalCount: 2,
+    });
+    expect(JSON.stringify(h.onColumnGroupToggle.mock.calls[0][0])).not.toMatch(
+      /helpfulness|accuracy/,
+    );
   });
 });

--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -49,6 +49,12 @@ import {
 import { Checkbox } from "@/src/components/design-system/Checkbox/Checkbox";
 import { Separator } from "@/src/components/ui/separator";
 
+export type ColumnGroupTogglePayload = {
+  groupId: string;
+  enabledCount: number;
+  totalCount: number;
+};
+
 interface DataTableColumnVisibilityFilterProps<TData, TValue> {
   columns: LangfuseColumnDef<TData, TValue>[];
   columnVisibility: VisibilityState;
@@ -56,6 +62,9 @@ interface DataTableColumnVisibilityFilterProps<TData, TValue> {
   columnOrder?: ColumnOrderState;
   setColumnOrder?: Dispatch<SetStateAction<ColumnOrderState>>;
   triggerSize?: ComponentProps<typeof Button>["size"];
+  tableName?: string;
+  isV4?: boolean;
+  onColumnGroupToggle?: (payload: ColumnGroupTogglePayload) => void;
 }
 
 const calculateColumnCounts = <TData, TValue>(
@@ -300,6 +309,9 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
   columnOrder,
   setColumnOrder,
   triggerSize,
+  tableName = "unknown",
+  isV4 = false,
+  onColumnGroupToggle,
 }: DataTableColumnVisibilityFilterProps<TData, TValue>) {
   const capture = usePostHogClientCapture();
   const [openGroups, setOpenGroups] = React.useState<Record<string, boolean>>(
@@ -331,13 +343,15 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
         );
         capture("table:column_visibility_changed", {
           selectedColumns: selectedColumns,
+          tableName,
+          isV4,
         });
         return newColumnVisibility;
       });
     },
     // eslint disable is because we don't want the posthog capture as deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setColumnVisibility, columnVisibility],
+    [setColumnVisibility, columnVisibility, tableName, isV4],
   );
 
   const toggleAllColumns = useCallback(
@@ -490,11 +504,18 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
                               column.header &&
                               typeof column.header === "string"
                             ) {
+                              const enabling =
+                                groupVisibleCount !== groupTotalCount;
                               toggleAllColumns(
                                 groupVisibleCount,
                                 groupTotalCount,
                                 column.header,
                               );
+                              onColumnGroupToggle?.({
+                                groupId: column.accessorKey,
+                                enabledCount: enabling ? groupTotalCount : 0,
+                                totalCount: groupTotalCount,
+                              });
                             }
                           }}
                         >

--- a/web/src/components/table/data-table-row-height-switch.tsx
+++ b/web/src/components/table/data-table-row-height-switch.tsx
@@ -63,9 +63,13 @@ export function useRowHeightLocalStorage(
 export const DataTableRowHeightSwitch = ({
   rowHeight,
   setRowHeight,
+  tableName = "unknown",
+  isV4 = false,
 }: {
   rowHeight: RowHeight;
   setRowHeight: (e: RowHeight) => void;
+  tableName?: string;
+  isV4?: boolean;
 }) => {
   const capture = usePostHogClientCapture();
   return (
@@ -88,6 +92,8 @@ export const DataTableRowHeightSwitch = ({
                 e.preventDefault();
                 capture("table:row_height_switch_select", {
                   rowHeight: id,
+                  tableName,
+                  isV4,
                 });
                 setRowHeight(id);
               }}

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable @repo/no-style-props */
 import React, { type Dispatch, type SetStateAction, useState } from "react";
 import { SearchInput } from "@/src/components/design-system/SearchInput/SearchInput";
-import { DataTableColumnVisibilityFilter } from "@/src/components/table/data-table-column-visibility-filter";
+import {
+  DataTableColumnVisibilityFilter,
+  type ColumnGroupTogglePayload,
+} from "@/src/components/table/data-table-column-visibility-filter";
 import { FilterToggleButton } from "@/src/components/table/FilterToggleButton";
 import { PopoverFilterBuilder } from "@/src/features/filters/components/filter-builder";
 import {
@@ -146,6 +149,10 @@ interface DataTableToolbarProps<TData, TValue> {
    * already supply it via `viewConfig.tableName`; tables WITHOUT one (users,
    * dataset runs/items) must pass this so the event isn't labeled "unknown". */
   tableName?: string;
+  /** Surface dimension for table:* events. Forward from the owning table —
+   * do not rely on the default. v4 events / experiments = true; v3 traces = false. */
+  isV4?: boolean;
+  onColumnGroupToggle?: (payload: ColumnGroupTogglePayload) => void;
   filterWithAI?: boolean;
   className?: string;
   rowClassName?: string;
@@ -219,6 +226,8 @@ export function DataTableToolbar<TData, TValue>({
   orderByState,
   viewConfig,
   tableName,
+  isV4,
+  onColumnGroupToggle,
   filterWithAI = false,
   viewModeToggle,
   leadingControls,
@@ -228,6 +237,10 @@ export function DataTableToolbar<TData, TValue>({
   );
 
   const capture = usePostHogClientCapture();
+  const analyticsTableName = tableName ?? viewConfig?.tableName ?? "unknown";
+  const analyticsIsV4 =
+    isV4 ??
+    viewConfig?.tableName === TableViewPresetTableName.ObservationsEvents;
   const showSearchTypeSelector = Boolean(
     searchConfig?.setSearchType && searchConfig.tableAllowsFullTextSearch,
   );
@@ -308,7 +321,10 @@ export function DataTableToolbar<TData, TValue>({
                 }
               }}
               onSubmit={(value) => {
-                capture("table:search_submit");
+                capture("table:search_submit", {
+                  tableName: analyticsTableName,
+                  isV4: analyticsIsV4,
+                });
                 submitSearch(value);
               }}
               dropdown={
@@ -447,11 +463,8 @@ export function DataTableToolbar<TData, TValue>({
             // filters via the grammar bar (it omits filterColumnDefinition here,
             // so this popover is a v3/legacy surface); derive isV4 from the
             // ObservationsEvents view for consistency + future-proofing.
-            tableName={tableName ?? viewConfig?.tableName ?? "unknown"}
-            isV4={
-              viewConfig?.tableName ===
-              TableViewPresetTableName.ObservationsEvents
-            }
+            tableName={analyticsTableName}
+            isV4={analyticsIsV4}
           />
         )}
 
@@ -463,12 +476,17 @@ export function DataTableToolbar<TData, TValue>({
               setColumnVisibility={setColumnVisibility}
               columnOrder={columnOrder}
               setColumnOrder={setColumnOrder}
+              tableName={analyticsTableName}
+              isV4={analyticsIsV4}
+              onColumnGroupToggle={onColumnGroupToggle}
             />
           )}
           {!!rowHeight && !!setRowHeight && (
             <DataTableRowHeightSwitch
               rowHeight={rowHeight}
               setRowHeight={setRowHeight}
+              tableName={analyticsTableName}
+              isV4={analyticsIsV4}
             />
           )}
           {actionButtons}

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -16,7 +16,6 @@ import { PeekHeader } from "@/src/components/table/peek/PeekHeader";
 import { usePeekPanelState } from "@/src/components/table/peek/usePeekPanelState";
 import { shouldIgnoreOutsideInteraction } from "@/src/utils/outside-interaction";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 // Peek view-mode URL param (also cleared by usePeekNavigation on close). When
 // `expanded`, the desktop peek widens to viewport − sidebar — shareable + back-able.
@@ -59,6 +58,10 @@ export type DataTablePeekViewProps = {
   expandPeek?: (openInNewTab: boolean) => void;
   /** Additional peek event options */
   peekEventOptions?: PeekEventControlOptions;
+  /** Analytics table identity for peek:* events. Forward from the owning table. */
+  tableName: string;
+  /** Surface dimension at the moment of the action. */
+  isV4: boolean;
 };
 
 type TablePeekViewProps = Pick<
@@ -73,6 +76,8 @@ type TablePeekViewProps = Pick<
   // longer rendered.
   | "expandPeek"
   | "peekEventOptions"
+  | "tableName"
+  | "isV4"
 > & {
   title?: string;
   /**
@@ -156,10 +161,9 @@ export const shouldClosePeekAfterDelete = (
 ): boolean => currentPeekTraceId === deletedTraceId;
 
 function TablePeekViewComponent(props: TablePeekViewProps) {
-  const { title, children, footer } = props;
+  const { title, children, footer, tableName, isV4 } = props;
   const router = useRouter();
   const capture = usePostHogClientCapture();
-  const { isBetaEnabled: isV4 } = useV4Beta();
   const itemId = router.query.peek as string | undefined;
   const isExpanded = router.query[PEEK_VIEW_PARAM] === PEEK_VIEW_EXPANDED;
   // Handheld, not width-only: a phone in landscape is wider than `md` but is
@@ -184,6 +188,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
         isExpanded: expanded,
         routePattern: router.pathname,
         isV4,
+        tableName,
       });
       if (expanded) params.set(PEEK_VIEW_PARAM, PEEK_VIEW_EXPANDED);
       else params.delete(PEEK_VIEW_PARAM);
@@ -196,7 +201,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
         { shallow: true },
       );
     },
-    [router, capture, isV4],
+    [router, capture, isV4, tableName],
   );
 
   const panel = usePeekPanelState({
@@ -211,9 +216,10 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
           trigger,
           routePattern: router.pathname,
           isV4,
+          tableName,
         });
       },
-      [capture, router.pathname, isV4],
+      [capture, router.pathname, isV4, tableName],
     ),
   });
   const ignoredSelectors = props.peekEventOptions?.ignoredSelectors ?? [];

--- a/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
@@ -3,11 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
 
-const { mockPush, mockPathname, capture, isBetaEnabled } = vi.hoisted(() => ({
+const { mockPush, mockPathname, capture } = vi.hoisted(() => ({
   mockPush: vi.fn(),
   mockPathname: { value: "/project/[projectId]/traces" },
   capture: vi.fn(),
-  isBetaEnabled: { value: false },
 }));
 
 vi.mock("next/router", () => ({
@@ -16,9 +15,6 @@ vi.mock("next/router", () => ({
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
   usePostHogClientCapture: () => capture,
 }));
-vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
-  useV4Beta: () => ({ isBetaEnabled: isBetaEnabled.value }),
-}));
 
 // expandPeek builds the standalone-page path from `expandConfig.pathParam`.
 // The trace reader's expand must survive both peek URL dialects (LFE-11041):
@@ -26,6 +22,8 @@ vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
 describe("usePeekNavigation expandPeek", () => {
   const config = {
     queryParams: ["observation", "display", "timestamp", "traceId"],
+    tableName: "traces",
+    isV4: false,
     expandConfig: {
       basePath: "/project/p1/traces",
       pathParam: "traceId",
@@ -117,7 +115,6 @@ describe("usePeekNavigation analytics", () => {
   beforeEach(() => {
     mockPush.mockReset();
     capture.mockReset();
-    isBetaEnabled.value = true;
   });
 
   it("captures peek:opened once with tableName and surface isV4", () => {
@@ -142,24 +139,25 @@ describe("usePeekNavigation analytics", () => {
     expect(JSON.stringify(capture.mock.calls[0][1])).not.toMatch(/item-1/);
   });
 
-  it("uses the config isV4 even when the global v4 flag is true (v3 traces)", () => {
-    window.history.replaceState({}, "", "/project/p1/traces");
-    mockPathname.value = "/project/[projectId]/traces";
+  it("uses the owning surface tableName and isV4 (v3 observations)", () => {
+    window.history.replaceState({}, "", "/project/p1/observations");
+    mockPathname.value = "/project/[projectId]/observations";
 
     const { result } = renderHook(() =>
       usePeekNavigation({
-        tableName: "traces",
+        tableName: "observations",
         isV4: false,
       }),
     );
-    result.current.openPeek("trace-1");
+    result.current.openPeek("obs-1");
 
     expect(capture).toHaveBeenCalledWith("peek:opened", {
-      routePattern: "/project/[projectId]/traces",
+      routePattern: "/project/[projectId]/observations",
       wasOpen: false,
       isV4: false,
-      tableName: "traces",
+      tableName: "observations",
     });
+    expect(JSON.stringify(capture.mock.calls[0][1])).not.toMatch(/unknown/);
   });
 
   it("does not recapture when re-opening the same peeked row", () => {

--- a/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.clienttest.tsx
@@ -3,19 +3,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
 
-const { mockPush, mockPathname } = vi.hoisted(() => ({
+const { mockPush, mockPathname, capture, isBetaEnabled } = vi.hoisted(() => ({
   mockPush: vi.fn(),
   mockPathname: { value: "/project/[projectId]/traces" },
+  capture: vi.fn(),
+  isBetaEnabled: { value: false },
 }));
 
 vi.mock("next/router", () => ({
   useRouter: () => ({ push: mockPush, pathname: mockPathname.value }),
 }));
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
-  usePostHogClientCapture: () => vi.fn(),
+  usePostHogClientCapture: () => capture,
 }));
 vi.mock("@/src/features/events/hooks/useV4Beta", () => ({
-  useV4Beta: () => ({ isBetaEnabled: false }),
+  useV4Beta: () => ({ isBetaEnabled: isBetaEnabled.value }),
 }));
 
 // expandPeek builds the standalone-page path from `expandConfig.pathParam`.
@@ -33,6 +35,8 @@ describe("usePeekNavigation expandPeek", () => {
 
   beforeEach(() => {
     mockPush.mockReset();
+    capture.mockReset();
+    mockPathname.value = "/project/[projectId]/traces";
   });
 
   it("v4-dialect URL: expands to the traceId param, not the observation id in peek", () => {
@@ -106,5 +110,74 @@ describe("usePeekNavigation expandPeek", () => {
     const target = mockPush.mock.calls[0][0] as string;
     expect(target.startsWith("/project/p1/traces/trace-1?")).toBe(true);
     expect(target).toContain("timestamp=");
+  });
+});
+
+describe("usePeekNavigation analytics", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    capture.mockReset();
+    isBetaEnabled.value = true;
+  });
+
+  it("captures peek:opened once with tableName and surface isV4", () => {
+    window.history.replaceState({}, "", "/project/p1/experiments/results");
+    mockPathname.value = "/project/[projectId]/experiments/results";
+
+    const { result } = renderHook(() =>
+      usePeekNavigation({
+        tableName: "experiment-items",
+        isV4: true,
+      }),
+    );
+    result.current.openPeek("item-1");
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith("peek:opened", {
+      routePattern: "/project/[projectId]/experiments/results",
+      wasOpen: false,
+      isV4: true,
+      tableName: "experiment-items",
+    });
+    expect(JSON.stringify(capture.mock.calls[0][1])).not.toMatch(/item-1/);
+  });
+
+  it("uses the config isV4 even when the global v4 flag is true (v3 traces)", () => {
+    window.history.replaceState({}, "", "/project/p1/traces");
+    mockPathname.value = "/project/[projectId]/traces";
+
+    const { result } = renderHook(() =>
+      usePeekNavigation({
+        tableName: "traces",
+        isV4: false,
+      }),
+    );
+    result.current.openPeek("trace-1");
+
+    expect(capture).toHaveBeenCalledWith("peek:opened", {
+      routePattern: "/project/[projectId]/traces",
+      wasOpen: false,
+      isV4: false,
+      tableName: "traces",
+    });
+  });
+
+  it("does not recapture when re-opening the same peeked row", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/project/p1/experiments/results?peek=item-1",
+    );
+    mockPathname.value = "/project/[projectId]/experiments/results";
+
+    const { result } = renderHook(() =>
+      usePeekNavigation({
+        tableName: "experiment-items",
+        isV4: true,
+      }),
+    );
+    result.current.openPeek("item-1");
+
+    expect(capture).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/table/peek/hooks/usePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.ts
@@ -5,7 +5,6 @@ import { useCallback } from "react";
 import { urlSearchParamsToQuery } from "@/src/utils/navigation";
 import { resolvePeekTraceParams } from "@/src/components/table/peek/resolvePeekTraceParams";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 const PEEK_PARAM = "peek";
 // View-mode param shared with the peek component (cleared whenever the peek closes).
@@ -13,9 +12,9 @@ const PEEK_VIEW_PARAM = "peekView";
 
 interface BasePeekConfig {
   /** Analytics table identity for peek:* events. Forward from the owning table. */
-  tableName?: string;
-  /** Surface dimension at the moment of the action. Prefer this over the global v4 flag. */
-  isV4?: boolean;
+  tableName: string;
+  /** Surface dimension at the moment of the action. Do not derive from the global v4 flag. */
+  isV4: boolean;
   /** Additional URL parameters to clear when closing peek view and persist when expanding peek view */
   queryParams?: string[];
   /**
@@ -60,6 +59,9 @@ interface BasePeekNavigation {
   closePeek: () => void;
   /** Resolve the navigation path for a detail entry */
   resolveDetailNavigationPath: (entry: ListEntry) => string;
+  /** Analytics dimensions forwarded onto TablePeekView expand/resize events. */
+  tableName: string;
+  isV4: boolean;
 }
 
 interface PeekNavigation extends BasePeekNavigation {}
@@ -77,18 +79,16 @@ interface PeekNavigationWithExpand extends BasePeekNavigation {
 export function usePeekNavigation(
   config: PeekConfigWithExpand,
 ): PeekNavigationWithExpand;
-export function usePeekNavigation(config?: PeekConfig): PeekNavigation;
-export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
+export function usePeekNavigation(config: PeekConfig): PeekNavigation;
+export function usePeekNavigation(config: PeekConfig | PeekConfigWithExpand) {
   const router = useRouter();
   const capture = usePostHogClientCapture();
-  const { isBetaEnabled: isV4Beta } = useV4Beta();
   // Every peek is opened/closed through this hook, so open/close/new-tab
   // analytics live here once instead of in each consuming table. Props are
   // metadata-only: `routePattern` is the Next.js route PATTERN
   // (`/project/[projectId]/traces`), never a concrete URL with ids.
   const routePattern = router.pathname;
-  const isV4 = config?.isV4 ?? isV4Beta;
-  const tableName = config?.tableName ?? "unknown";
+  const { isV4, tableName } = config;
 
   const openPeek = useCallback(
     (id?: string, row?: any) => {
@@ -263,6 +263,8 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
     openPeek,
     closePeek,
     resolveDetailNavigationPath,
+    tableName,
+    isV4,
   };
 
   if (config?.expandConfig) {

--- a/web/src/components/table/peek/hooks/usePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/usePeekNavigation.ts
@@ -12,6 +12,10 @@ const PEEK_PARAM = "peek";
 const PEEK_VIEW_PARAM = "peekView";
 
 interface BasePeekConfig {
+  /** Analytics table identity for peek:* events. Forward from the owning table. */
+  tableName?: string;
+  /** Surface dimension at the moment of the action. Prefer this over the global v4 flag. */
+  isV4?: boolean;
   /** Additional URL parameters to clear when closing peek view and persist when expanding peek view */
   queryParams?: string[];
   /**
@@ -77,12 +81,14 @@ export function usePeekNavigation(config?: PeekConfig): PeekNavigation;
 export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
   const router = useRouter();
   const capture = usePostHogClientCapture();
-  const { isBetaEnabled: isV4 } = useV4Beta();
+  const { isBetaEnabled: isV4Beta } = useV4Beta();
   // Every peek is opened/closed through this hook, so open/close/new-tab
   // analytics live here once instead of in each consuming table. Props are
   // metadata-only: `routePattern` is the Next.js route PATTERN
   // (`/project/[projectId]/traces`), never a concrete URL with ids.
   const routePattern = router.pathname;
+  const isV4 = config?.isV4 ?? isV4Beta;
+  const tableName = config?.tableName ?? "unknown";
 
   const openPeek = useCallback(
     (id?: string, row?: any) => {
@@ -94,7 +100,7 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
       if (!id) {
         // Close peek view - clear all peek-related params
         if (currentPeekId !== null) {
-          capture("peek:closed", { routePattern, isV4 });
+          capture("peek:closed", { routePattern, isV4, tableName });
         }
         params.delete(PEEK_PARAM);
         params.delete(PEEK_VIEW_PARAM);
@@ -106,6 +112,7 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
             routePattern,
             wasOpen: currentPeekId !== null,
             isV4,
+            tableName,
           });
         }
         // Clear all query params that are set in the config
@@ -137,7 +144,7 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
         { shallow: true },
       );
     },
-    [router, config, capture, routePattern, isV4],
+    [router, config, capture, routePattern, isV4, tableName],
   );
 
   const closePeek = useCallback(() => {
@@ -147,7 +154,7 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
 
     // Guarded so programmatic cleanup with no peek open emits nothing.
     if (params.get(PEEK_PARAM) !== null) {
-      capture("peek:closed", { routePattern, isV4 });
+      capture("peek:closed", { routePattern, isV4, tableName });
     }
 
     // Close peek view - clear all peek-related params
@@ -163,7 +170,7 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
       undefined,
       { shallow: true },
     );
-  }, [router, config, capture, routePattern, isV4]);
+  }, [router, config, capture, routePattern, isV4, tableName]);
 
   const resolveDetailNavigationPath = useCallback(
     (entry: ListEntry) => {
@@ -242,14 +249,14 @@ export function usePeekNavigation(config?: PeekConfig | PeekConfigWithExpand) {
       const pathnameWithQuery = `${pathname}?${queryParams}`;
 
       if (openInNewTab) {
-        capture("peek:open_in_new_tab", { routePattern, isV4 });
+        capture("peek:open_in_new_tab", { routePattern, isV4, tableName });
         const pathnameWithBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${pathnameWithQuery}`;
         window.open(pathnameWithBasePath, "_blank");
       } else {
         router.push(pathnameWithQuery);
       }
     },
-    [router, config, capture, routePattern, isV4],
+    [router, config, capture, routePattern, isV4, tableName],
   );
 
   const baseNavigation = {

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1209,6 +1209,8 @@ export default function ObservationsTable({
       "traceId",
       "startTime",
     ],
+    tableName: observationsFilterConfig.tableName,
+    isV4: false,
     paramsToMirrorPeekValue: ["observation"],
     extractParamsValuesFromRow: (row: ObservationsTableRow) => ({
       traceId: row.traceId || "",

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -238,6 +238,8 @@ export default function ScoresTable({
     // the peek to that trace instead of the one just clicked — matches the
     // same guard `traces.tsx`/`EventsTable.tsx` already have.
     queryParams: ["observation", "display", "timestamp", "traceId"],
+    tableName: scoresFilterConfig.tableName,
+    isV4: isBetaEnabled,
     extractParamsValuesFromRow: (
       row: ScoresTableRow,
     ): Record<string, string> =>
@@ -1254,6 +1256,8 @@ export default function ScoresTable({
             closePeek={closeScorePeek}
             expandPeek={expandScorePeek}
             itemType="TRACE"
+            tableName={scoresFilterConfig.tableName}
+            isV4={isBetaEnabled}
             projectId={projectId}
           />
         )}

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1274,6 +1274,8 @@ export default function TracesTable({
     // URLs (LFE-11041); listing it clears it on open/navigate/close so it
     // cannot pin the peek to the originally shared trace.
     queryParams: ["observation", "display", "timestamp", "traceId"],
+    tableName: tracesFilterConfig.tableName,
+    isV4: false,
     extractParamsValuesFromRow: (row: TracesTableRow) => ({
       timestamp: row.timestamp?.toISOString() || "",
     }),
@@ -1406,6 +1408,8 @@ export default function TracesTable({
             columns={columns}
             filterWithAI
             filterState={queryFilter.explicitFilterState}
+            tableName={tracesFilterConfig.tableName}
+            isV4={false}
             viewConfig={{
               tableName: TableViewPresetTableName.Traces,
               projectId,

--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -24,7 +24,6 @@ import { DiffLabel } from "@/src/features/datasets/components/DiffLabel";
 import { useResourceMetricsDiff } from "@/src/features/datasets/hooks/useResourceMetricsDiff";
 import { NotFoundCard } from "@/src/features/datasets/components/NotFoundCard";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 const DatasetAggregateCellContent = ({
   projectId,
@@ -43,7 +42,6 @@ const DatasetAggregateCellContent = ({
 }) => {
   const router = useRouter();
   const capture = usePostHogClientCapture();
-  const { isBetaEnabled: isV4 } = useV4Beta();
   const silentHttpCodes = [404];
   const { selectedFields } = useDatasetCompareFields();
   const { activeCell, setActiveCell } = useActiveCell();
@@ -114,7 +112,8 @@ const DatasetAggregateCellContent = ({
       capture("peek:opened", {
         routePattern: router.pathname,
         wasOpen: router.query.peek !== undefined,
-        isV4,
+        isV4: false,
+        tableName: "datasetCompareRuns",
       });
     }
     const newQuery: Record<string, string | string[] | undefined> = {

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -111,6 +111,8 @@ function DatasetCompareRunsTableInternal(props: {
     // reader) so a stray param cannot pin the peek to a foreign trace
     // (LFE-11041).
     queryParams: ["observation", "display", "timestamp", "traceId"],
+    tableName: "datasetCompareRuns",
+    isV4: false,
     expandConfig: {
       basePath: `/project/${props.projectId}/traces`,
     },
@@ -121,6 +123,8 @@ function DatasetCompareRunsTableInternal(props: {
       itemType: "TRACE" as const,
       closePeek,
       expandPeek,
+      tableName: "datasetCompareRuns",
+      isV4: false,
       // openPeek is handled by DatasetAggregateTableCell's custom handleOpenPeek
     }),
     [closePeek, expandPeek],

--- a/web/src/features/evals/components/code-eval-test-run-card.tsx
+++ b/web/src/features/evals/components/code-eval-test-run-card.tsx
@@ -78,6 +78,8 @@ export function CodeEvalTestRunCard({
     // reader) so a stray param cannot pin the peek to a foreign trace
     // (LFE-11041).
     queryParams: ["observation", "display", "timestamp", "traceId"],
+    tableName: "evalTemplates",
+    isV4: isBetaEnabled,
     expandConfig: {
       basePath: `/project/${projectId}/traces`,
     },

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -480,6 +480,8 @@ export default function EvalsTemplateTable({
     );
 
   const peekNavigationProps = usePeekNavigation({
+    tableName: "evalTemplates",
+    isV4: false,
     expandConfig: {
       basePath: `/project/${projectId}/evals/templates`,
     },

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -415,7 +415,10 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       columns,
     );
 
-  const peekNavigationProps = usePeekNavigation();
+  const peekNavigationProps = usePeekNavigation({
+    tableName: evaluatorFilterConfig.tableName,
+    isV4: false,
+  });
 
   const peekConfig = useMemo(
     () => ({

--- a/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
+++ b/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
@@ -177,7 +177,10 @@ export function RulesTable({
     "rule",
     withDefault(StringParam, null),
   );
-  const legacyPeekNavigation = usePeekNavigation();
+  const legacyPeekNavigation = usePeekNavigation({
+    tableName: "evaluation-rules-v2",
+    isV4: true,
+  });
   const legacyPeekConfig = useMemo(
     () => ({
       itemType: "RUNNING_EVALUATOR" as const,

--- a/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
@@ -234,6 +234,8 @@ export function EvaluatorSetupPage(
   );
   const sampleTracePeekNavigation = usePeekNavigation({
     queryParams: ["observation", "display", "timestamp", "traceId"],
+    tableName: "evaluators-v2",
+    isV4: true,
     expandConfig: {
       basePath: `/project/${projectId}/traces`,
       reader: "trace",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1655,6 +1655,8 @@ export default function ObservationsEventsTable({
 
   const peekNavigationProps = usePeekNavigation({
     queryParams: ["observation", "display", "timestamp", "traceId"],
+    tableName: eventsFilterConfig.tableName,
+    isV4: true,
     paramsToMirrorPeekValue: ["observation"],
     extractParamsValuesFromRow: (row: EventsTableRow) => ({
       traceId: row.traceId || "",
@@ -1870,6 +1872,8 @@ export default function ObservationsEventsTable({
                     updateQuery={setSearchQuery}
                     tableAllowsFullTextSearch
                     metadataSearchFields={["ID", "Name", "Trace Name", "Model"]}
+                    tableName={eventsFilterConfig.tableName}
+                    isV4
                   />
                 )
               }
@@ -1987,6 +1991,8 @@ export default function ObservationsEventsTable({
               columns={columns}
               rowClassName={searchBarMode ? "my-1" : undefined}
               filterState={queryFilter.explicitFilterState}
+              tableName={eventsFilterConfig.tableName}
+              isV4={true}
               searchConfig={
                 // In search-bar mode full-text search (bare text +
                 // content:/input:/output:) lives inline in the bar, so the

--- a/web/src/features/events/components/MobileFullTextSearch.tsx
+++ b/web/src/features/events/components/MobileFullTextSearch.tsx
@@ -24,11 +24,15 @@ export function MobileFullTextSearch({
   updateQuery,
   tableAllowsFullTextSearch,
   metadataSearchFields,
+  tableName = "observations-events",
+  isV4 = true,
 }: {
   currentQuery?: string;
   updateQuery: (query: string) => void;
   tableAllowsFullTextSearch?: boolean;
   metadataSearchFields?: string[];
+  tableName?: string;
+  isV4?: boolean;
 }) {
   const capture = usePostHogClientCapture();
   const committed = currentQuery ?? "";
@@ -45,7 +49,10 @@ export function MobileFullTextSearch({
   }
 
   const submit = (query: string) => {
-    capture("table:search_submit");
+    capture("table:search_submit", {
+      tableName,
+      isV4,
+    });
     updateQuery(query);
   };
 

--- a/web/src/features/experiments/components/ExperimentBaselineControls.clienttest.tsx
+++ b/web/src/features/experiments/components/ExperimentBaselineControls.clienttest.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExperimentBaselineControls } from "./ExperimentBaselineControls";
+import { LAYER_ORDER } from "@/src/components/ui/layer";
+
+const h = vi.hoisted(() => ({
+  capture: vi.fn(),
+  onBaselineChange: vi.fn(),
+  onBaselineClear: vi.fn(),
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => h.capture,
+}));
+
+vi.mock("@/src/features/experiments/hooks/useExperimentNames", () => ({
+  useExperimentNames: () => ({
+    experimentNames: [
+      {
+        experimentId: "exp-a",
+        experimentName: "My Experiment A",
+        datasetId: "ds-1",
+      },
+      {
+        experimentId: "exp-b",
+        experimentName: "My Experiment B",
+        datasetId: "ds-2",
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+function installOverlayLayers() {
+  const overlayRoot = document.createElement("div");
+  overlayRoot.setAttribute("data-overlay-root", "");
+  for (const layer of LAYER_ORDER) {
+    const layerNode = document.createElement("div");
+    layerNode.setAttribute("data-layer", layer);
+    overlayRoot.appendChild(layerNode);
+  }
+  document.body.appendChild(overlayRoot);
+}
+
+describe("ExperimentBaselineControls analytics", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  beforeEach(() => {
+    h.capture.mockClear();
+    h.onBaselineChange.mockClear();
+    h.onBaselineClear.mockClear();
+    installOverlayLayers();
+  });
+
+  afterEach(() => {
+    document.querySelector("[data-overlay-root]")?.remove();
+  });
+
+  it("captures baseline_changed from the picker once, without the experiment name", () => {
+    render(
+      <ExperimentBaselineControls
+        projectId="p1"
+        baselineId="exp-a"
+        baselineName="My Experiment A"
+        onBaselineChange={h.onBaselineChange}
+        onBaselineClear={h.onBaselineClear}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("My Experiment B"));
+
+    expect(h.capture).toHaveBeenCalledTimes(1);
+    expect(h.capture).toHaveBeenCalledWith("experiment:baseline_changed", {
+      isV4: true,
+      tableName: "experiment-items",
+      source: "picker",
+    });
+    expect(h.onBaselineChange).toHaveBeenCalledWith("exp-b");
+    expect(JSON.stringify(h.capture.mock.calls[0][1])).not.toMatch(
+      /My Experiment|exp-b/,
+    );
+  });
+
+  it("captures baseline_changed from clear, and skips a no-op reselect", () => {
+    render(
+      <ExperimentBaselineControls
+        projectId="p1"
+        baselineId="exp-a"
+        baselineName="My Experiment A"
+        onBaselineChange={h.onBaselineChange}
+        onBaselineClear={h.onBaselineClear}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "My Experiment A" }));
+    expect(h.capture).not.toHaveBeenCalled();
+    expect(h.onBaselineChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear baseline" }));
+    expect(h.capture).toHaveBeenCalledTimes(1);
+    expect(h.capture).toHaveBeenCalledWith("experiment:baseline_changed", {
+      isV4: true,
+      tableName: "experiment-items",
+      source: "clear",
+    });
+    expect(h.onBaselineClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/features/experiments/components/ExperimentBaselineControls.tsx
+++ b/web/src/features/experiments/components/ExperimentBaselineControls.tsx
@@ -3,6 +3,8 @@ import { Combobox } from "@/src/components/ui/combobox";
 import { X } from "lucide-react";
 import { useExperimentNames } from "@/src/features/experiments/hooks/useExperimentNames";
 import { cn } from "@/src/utils/tailwind";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { baselineChangedProps } from "@/src/features/experiments/lib/analytics";
 
 type ExperimentBaselineControlsProps = {
   projectId: string;
@@ -19,6 +21,7 @@ export function ExperimentBaselineControls({
   onBaselineChange,
   onBaselineClear,
 }: ExperimentBaselineControlsProps) {
+  const capture = usePostHogClientCapture();
   const { experimentNames, isLoading } = useExperimentNames({
     projectId,
   });
@@ -33,7 +36,17 @@ export function ExperimentBaselineControls({
         <Combobox
           options={baselineOptions}
           value={baselineId}
-          onValueChange={onBaselineChange}
+          onValueChange={(id) => {
+            if (id === baselineId) return;
+            capture(
+              "experiment:baseline_changed",
+              baselineChangedProps({
+                tableName: "experiment-items",
+                source: "picker",
+              }),
+            );
+            onBaselineChange(id);
+          }}
           placeholder={baselineName ?? baselineId ?? "Select baseline..."}
           emptyText="No experiments found"
           searchPlaceholder="Search experiments..."
@@ -50,7 +63,16 @@ export function ExperimentBaselineControls({
           variant="outline"
           size="icon"
           className="-ml-px shrink-0 rounded-l-none"
-          onClick={onBaselineClear}
+          onClick={() => {
+            capture(
+              "experiment:baseline_changed",
+              baselineChangedProps({
+                tableName: "experiment-items",
+                source: "clear",
+              }),
+            );
+            onBaselineClear();
+          }}
           disabled={isLoading}
           title="Clear baseline"
           aria-label="Clear baseline"

--- a/web/src/features/experiments/components/ExperimentChartsGrid.clienttest.tsx
+++ b/web/src/features/experiments/components/ExperimentChartsGrid.clienttest.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExperimentChartsGrid } from "./ExperimentChartsGrid";
+
+const h = vi.hoisted(() => ({
+  capture: vi.fn(),
+  updateChart: vi.fn(),
+  charts: ["base:cost"],
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => h.capture,
+}));
+
+vi.mock(
+  "@/src/features/experiments/hooks/useExperimentChartsGridSelection",
+  () => ({
+    useExperimentChartsGridSelection: () => ({
+      charts: h.charts,
+      updateChart: h.updateChart,
+      addChart: vi.fn(),
+      removeChart: vi.fn(),
+      canAddChart: false,
+      canDeleteChart: false,
+      availableMetricOptions: [
+        { id: "base:cost", label: "Cost", group: "base" },
+        {
+          id: "obs-score-numeric:helpfulness",
+          label: "helpfulness",
+          group: "score",
+        },
+      ],
+      isLoading: false,
+    }),
+  }),
+);
+
+vi.mock("@/src/features/experiments/components/ExperimentChartSlot", () => ({
+  ExperimentChartSlot: ({
+    selectedMetricId,
+    onMetricChange,
+  }: {
+    selectedMetricId: string;
+    onMetricChange: (id: string) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => onMetricChange("obs-score-numeric:helpfulness")}
+    >
+      change-{selectedMetricId}
+    </button>
+  ),
+}));
+
+describe("ExperimentChartsGrid analytics", () => {
+  beforeEach(() => {
+    h.capture.mockClear();
+    h.updateChart.mockClear();
+    h.charts = ["base:cost"];
+  });
+
+  it("captures chart_metric_changed with metricGroup, not the score name", () => {
+    render(
+      <ExperimentChartsGrid
+        projectId="p1"
+        experiments={[{ id: "exp-a", name: "My Experiment A" }]}
+        fromTimestamp={new Date("2026-01-01")}
+        toTimestamp={new Date("2026-01-02")}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "change-base:cost" }));
+
+    expect(h.capture).toHaveBeenCalledTimes(1);
+    expect(h.capture).toHaveBeenCalledWith("experiment:chart_metric_changed", {
+      isV4: true,
+      tableName: "experiments",
+      metricGroup: "score",
+      chartIndex: 0,
+      slotCount: 1,
+    });
+    expect(JSON.stringify(h.capture.mock.calls[0][1])).not.toMatch(
+      /helpfulness|My Experiment/,
+    );
+    expect(h.updateChart).toHaveBeenCalledWith(
+      0,
+      "obs-score-numeric:helpfulness",
+    );
+  });
+
+  it("does not capture when the metric is unchanged", () => {
+    h.charts = ["obs-score-numeric:helpfulness"];
+    render(
+      <ExperimentChartsGrid
+        projectId="p1"
+        experiments={[{ id: "exp-a", name: "My Experiment A" }]}
+        fromTimestamp={new Date("2026-01-01")}
+        toTimestamp={new Date("2026-01-02")}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "change-obs-score-numeric:helpfulness",
+      }),
+    );
+
+    expect(h.capture).not.toHaveBeenCalled();
+    expect(h.updateChart).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/experiments/components/ExperimentChartsGrid.tsx
+++ b/web/src/features/experiments/components/ExperimentChartsGrid.tsx
@@ -2,6 +2,8 @@ import { Plus } from "lucide-react";
 import { useMemo } from "react";
 import { ExperimentChartSlot } from "./ExperimentChartSlot";
 import { useExperimentChartsGridSelection } from "../hooks/useExperimentChartsGridSelection";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { chartMetricChangedProps } from "@/src/features/experiments/lib/analytics";
 
 type ExperimentChartsGridProps = {
   projectId: string;
@@ -65,6 +67,7 @@ export function ExperimentChartsGrid({
   toTimestamp,
   isExternalLoading = false,
 }: ExperimentChartsGridProps) {
+  const capture = usePostHogClientCapture();
   const experimentIds = useMemo(
     () => experiments.map((experiment) => experiment.id),
     [experiments],
@@ -93,7 +96,19 @@ export function ExperimentChartsGrid({
           key={`${index}-${metricId}`}
           chartIndex={index}
           selectedMetricId={metricId}
-          onMetricChange={(newMetricId) => updateChart(index, newMetricId)}
+          onMetricChange={(newMetricId) => {
+            if (newMetricId === metricId) return;
+            capture(
+              "experiment:chart_metric_changed",
+              chartMetricChangedProps({
+                tableName: "experiments",
+                metricId: newMetricId,
+                chartIndex: index,
+                slotCount: charts.length,
+              }),
+            );
+            updateChart(index, newMetricId);
+          }}
           onRemove={() => removeChart(index)}
           canDelete={canDeleteChart}
           availableMetricOptions={availableMetricOptions}

--- a/web/src/features/experiments/components/ExperimentComparisonSelector.clienttest.tsx
+++ b/web/src/features/experiments/components/ExperimentComparisonSelector.clienttest.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExperimentComparisonSelector } from "./ExperimentComparisonSelector";
+
+const h = vi.hoisted(() => ({
+  capture: vi.fn(),
+  onSelectedIdsChange: vi.fn(),
+  searchQuery: "",
+  searchResults: [
+    {
+      experimentId: "exp-a",
+      experimentName: "My Experiment A",
+      datasetId: "ds-1",
+    },
+    {
+      experimentId: "exp-b",
+      experimentName: "My Experiment B",
+      datasetId: "ds-1",
+    },
+    {
+      experimentId: "exp-c",
+      experimentName: "My Experiment C",
+      datasetId: "ds-2",
+    },
+  ],
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => h.capture,
+}));
+
+vi.mock("@/src/features/experiments/hooks/useExperimentSearch", () => ({
+  useExperimentSearch: () => ({
+    searchResults: h.searchResults,
+    searchQuery: h.searchQuery,
+    setSearchQuery: vi.fn(),
+    isLoading: false,
+    availableExperimentNames: h.searchResults,
+  }),
+}));
+
+const payload = (call: unknown[]) => (call[1] ?? {}) as Record<string, unknown>;
+
+describe("ExperimentComparisonSelector analytics", () => {
+  beforeEach(() => {
+    h.capture.mockClear();
+    h.onSelectedIdsChange.mockClear();
+    h.searchQuery = "";
+  });
+
+  it("captures picker open once with option and dataset counts, not search text", () => {
+    render(
+      <ExperimentComparisonSelector
+        projectId="p1"
+        baselineExperimentId="exp-a"
+        selectedIds={[]}
+        selectedExperimentCount={1}
+        onSelectedIdsChange={h.onSelectedIdsChange}
+      />,
+    );
+
+    fireEvent.focus(screen.getByPlaceholderText("Search experiments..."));
+
+    expect(h.capture).toHaveBeenCalledTimes(1);
+    expect(h.capture).toHaveBeenCalledWith(
+      "experiment:comparison_picker_opened",
+      {
+        isV4: true,
+        tableName: "experiment-items",
+        optionCount: 2,
+        datasetCount: 2,
+        hasSearchQuery: false,
+        queryLength: 0,
+      },
+    );
+    expect(JSON.stringify(payload(h.capture.mock.calls[0]))).not.toMatch(
+      /My Experiment/,
+    );
+  });
+
+  it("captures comparison_changed once when a comparison is added", () => {
+    render(
+      <ExperimentComparisonSelector
+        projectId="p1"
+        baselineExperimentId="exp-a"
+        selectedIds={[]}
+        selectedExperimentCount={1}
+        onSelectedIdsChange={h.onSelectedIdsChange}
+      />,
+    );
+
+    fireEvent.focus(screen.getByPlaceholderText("Search experiments..."));
+    h.capture.mockClear();
+
+    fireEvent.click(screen.getByTitle("My Experiment B"));
+
+    expect(h.capture).toHaveBeenCalledTimes(1);
+    expect(h.capture).toHaveBeenCalledWith("experiment:comparison_changed", {
+      isV4: true,
+      tableName: "experiment-items",
+      comparisonCount: 1,
+      isSameDataset: true,
+      source: "picker",
+    });
+    expect(h.onSelectedIdsChange).toHaveBeenCalledWith(["exp-b"]);
+    expect(JSON.stringify(payload(h.capture.mock.calls[0]))).not.toMatch(
+      /exp-b|My Experiment|ds-1/,
+    );
+  });
+});

--- a/web/src/features/experiments/components/ExperimentComparisonSelector.tsx
+++ b/web/src/features/experiments/components/ExperimentComparisonSelector.tsx
@@ -13,7 +13,7 @@ import {
 export type ExperimentOption = {
   experimentId: string;
   experimentName: string;
-  datasetId?: string | null;
+  datasetId: string | null;
 };
 
 type ExperimentComparisonSelectorProps = {
@@ -51,16 +51,14 @@ export function ExperimentComparisonSelector({
 
   // Map selected IDs to full experiment objects
   const selectedExperiments = useMemo(() => {
-    return selectedIds
-      .map((id) => {
-        const found = availableExperimentNames.find(
-          (exp) => exp.experimentId === id,
-        );
-        if (found) return found;
-        // If not in current results, create placeholder with ID as name
-        return { experimentId: id, experimentName: id, datasetId: null };
-      })
-      .filter((exp): exp is ExperimentOption => exp !== undefined);
+    return selectedIds.map((id) => {
+      const found = availableExperimentNames.find(
+        (exp) => exp.experimentId === id,
+      );
+      if (found) return found;
+      // If not in current results, create placeholder with ID as name
+      return { experimentId: id, experimentName: id, datasetId: null };
+    });
   }, [selectedIds, availableExperimentNames]);
 
   const handleItemsChange = (items: ExperimentOption[]) => {

--- a/web/src/features/experiments/components/ExperimentComparisonSelector.tsx
+++ b/web/src/features/experiments/components/ExperimentComparisonSelector.tsx
@@ -4,10 +4,16 @@ import { MultiSelectCombobox } from "@/src/components/ui/multi-select-combobox";
 import { Badge } from "@/src/components/ui/badge";
 import { useExperimentSearch } from "@/src/features/experiments/hooks/useExperimentSearch";
 import { MAX_SELECTED_EXPERIMENTS } from "@/src/features/experiments/constants/comparison";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  comparisonChangedProps,
+  comparisonPickerOpenedProps,
+} from "@/src/features/experiments/lib/analytics";
 
 export type ExperimentOption = {
   experimentId: string;
   experimentName: string;
+  datasetId?: string | null;
 };
 
 type ExperimentComparisonSelectorProps = {
@@ -25,6 +31,7 @@ export function ExperimentComparisonSelector({
   selectedExperimentCount,
   onSelectedIdsChange,
 }: ExperimentComparisonSelectorProps) {
+  const capture = usePostHogClientCapture();
   const {
     searchResults,
     searchQuery,
@@ -51,7 +58,7 @@ export function ExperimentComparisonSelector({
         );
         if (found) return found;
         // If not in current results, create placeholder with ID as name
-        return { experimentId: id, experimentName: id };
+        return { experimentId: id, experimentName: id, datasetId: null };
       })
       .filter((exp): exp is ExperimentOption => exp !== undefined);
   }, [selectedIds, availableExperimentNames]);
@@ -67,7 +74,45 @@ export function ExperimentComparisonSelector({
             (selectedExperimentCount - selectedIds.length),
         ),
       );
+    if (
+      newIds.length === selectedIds.length &&
+      newIds.every((id, index) => id === selectedIds[index])
+    ) {
+      return;
+    }
+    const baselineDatasetId = availableExperimentNames.find(
+      (exp) => exp.experimentId === baselineExperimentId,
+    )?.datasetId;
+    capture(
+      "experiment:comparison_changed",
+      comparisonChangedProps({
+        tableName: "experiment-items",
+        comparisonCount: newIds.length,
+        datasetIds: [
+          baselineDatasetId,
+          ...newIds.map(
+            (id) =>
+              availableExperimentNames.find((exp) => exp.experimentId === id)
+                ?.datasetId,
+          ),
+        ],
+        source: "picker",
+      }),
+    );
     onSelectedIdsChange(newIds);
+  };
+
+  const handlePickerOpenChange = (open: boolean) => {
+    if (!open) return;
+    capture(
+      "experiment:comparison_picker_opened",
+      comparisonPickerOpenedProps({
+        tableName: "experiment-items",
+        optionCount: searchResultsExclBaseline.length,
+        datasetIds: searchResultsExclBaseline.map((exp) => exp.datasetId),
+        queryLength: searchQuery.length,
+      }),
+    );
   };
 
   const isMaxReached = selectedExperimentCount >= MAX_SELECTED_EXPERIMENTS;
@@ -78,6 +123,7 @@ export function ExperimentComparisonSelector({
         labelLeft="Experiment selection"
         selectedItems={selectedExperiments}
         onItemsChange={handleItemsChange}
+        onOpenChange={handlePickerOpenChange}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         searchResults={searchResultsExclBaseline}

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -28,6 +28,12 @@ import {
   BatchActionType,
 } from "@langfuse/shared";
 import { ExperimentFilterPills } from "./ExperimentFilterPills";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  itemRegressionFilterAppliedProps,
+  scoreColumnScopeToggledProps,
+} from "@/src/features/experiments/lib/analytics";
+import { type ColumnGroupTogglePayload } from "@/src/components/table/data-table-column-visibility-filter";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
@@ -340,10 +346,11 @@ export default function ExperimentItemsTable({
 
   // Use sidebar filter state for the sidebar UI (provides proper facets, options, etc.)
   // This is the single source of truth for filters
+  const capture = usePostHogClientCapture();
   const queryFilter = useSidebarFilterState(
     experimentItemsFilterConfig,
     scoreFilterOptions,
-    { stateLocation: "url", loading: isFilterOptionsLoading },
+    { stateLocation: "url", loading: isFilterOptionsLoading, isV4: true },
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates
@@ -413,12 +420,31 @@ export default function ExperimentItemsTable({
       }
 
       // Update the target for this filter
+      if (toExperimentId !== _fromExperimentId) {
+        const props = itemRegressionFilterAppliedProps({
+          tableName: "experiment-items",
+          column: _filter.column,
+          operator: _filter.operator,
+          toExperimentId,
+          baselineId,
+          comparisonIds,
+        });
+        if (props) {
+          capture("experiment:item_regression_filter_applied", props);
+        }
+      }
       setFilterTargets((prev) => ({
         ...prev,
         [originalIndex]: toExperimentId,
       }));
     },
-    [filterTargets, defaultFilterTargetExperimentId],
+    [
+      filterTargets,
+      defaultFilterTargetExperimentId,
+      baselineId,
+      comparisonIds,
+      capture,
+    ],
   );
 
   // Handler for removing a filter via pill
@@ -922,6 +948,8 @@ export default function ExperimentItemsTable({
       "traceId",
       "peekExperimentId",
     ],
+    tableName: experimentItemsFilterConfig.tableName,
+    isV4: true,
     extractParamsValuesFromRow: (row: ExperimentItemsTableRow) => {
       // Use the explicit baseline when present. Without one, use the first
       // selected experiment only as the primary trace for URL-compatible peek
@@ -1053,6 +1081,20 @@ export default function ExperimentItemsTable({
     [filtersByExperiment, orderByState, allExperimentIds],
   );
 
+  const handleColumnGroupToggle = useCallback(
+    ({ groupId, enabledCount }: ColumnGroupTogglePayload) => {
+      const props = scoreColumnScopeToggledProps({
+        tableName: "experiment-items",
+        groupId,
+        enabledCount,
+      });
+      if (props) {
+        capture("experiment:score_column_scope_toggled", props);
+      }
+    },
+    [capture],
+  );
+
   const tableActions: TableAction[] = hasEvalAccess
     ? [
         {
@@ -1084,6 +1126,9 @@ export default function ExperimentItemsTable({
               projectId,
               controllers: viewControllers,
             }}
+            tableName={experimentItemsFilterConfig.tableName}
+            isV4={true}
+            onColumnGroupToggle={handleColumnGroupToggle}
             columnsWithCustomSelect={["datasetItemId"]}
             columnVisibility={columnVisibility}
             setColumnVisibility={setColumnVisibilityState}

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -69,6 +69,14 @@ import {
   type ExperimentsTableStore,
 } from "@/src/features/experiments/store/experimentsTableStore";
 import { useExperimentsTableSelectionSync } from "@/src/features/experiments/hooks/useExperimentsTableSelectionSync";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  baselineChangedProps,
+  comparisonChangedProps,
+  chartsSectionToggledProps,
+  scoreColumnScopeToggledProps,
+} from "@/src/features/experiments/lib/analytics";
+import { type ColumnGroupTogglePayload } from "@/src/components/table/data-table-column-visibility-filter";
 
 /**
  * LFE-10460: the metadata column's default position moved from last to right
@@ -104,11 +112,14 @@ const repositionTrailingMetadata = (order: string[]): string[] => {
 function ExperimentsMultiSelectActionMenu({
   projectId,
   store,
+  datasetIdByExperimentId,
 }: {
   projectId: string;
   store: ExperimentsTableStore;
+  datasetIdByExperimentId: Record<string, string>;
 }) {
   const router = useRouter();
+  const capture = usePostHogClientCapture();
   const [showRunEvaluationDialog, setShowRunEvaluationDialog] = useState(false);
   // Page-scoped and in table order, so the first id is the topmost selected
   // row — the compare baseline.
@@ -157,6 +168,24 @@ function ExperimentsMultiSelectActionMenu({
     if (selectedExperimentIds.length === 0) return;
 
     const [baseline, ...comparisons] = selectedExperimentIds;
+    capture(
+      "experiment:comparison_changed",
+      comparisonChangedProps({
+        tableName: "experiments",
+        comparisonCount: comparisons.length,
+        datasetIds: selectedExperimentIds.map(
+          (id) => datasetIdByExperimentId[id],
+        ),
+        source: "table-selection",
+      }),
+    );
+    capture(
+      "experiment:baseline_changed",
+      baselineChangedProps({
+        tableName: "experiments",
+        source: "table-selection",
+      }),
+    );
     const params = new URLSearchParams();
     params.set("baseline", baseline);
     comparisons.forEach((id) => {
@@ -320,6 +349,7 @@ export default function ExperimentsTable({
     loading: isFilterOptionsPending,
     stateLocation: "urlAndSessionStorage",
     sessionFilterContextId,
+    isV4: true,
   });
 
   // Apply default filter on mount (only if no existing filter)
@@ -703,8 +733,49 @@ export default function ExperimentsTable({
   }, [rows]);
 
   // Charts accordion collapsed state (persisted in session storage)
+  const capture = usePostHogClientCapture();
   const { accordionValue, setAccordionValue } =
     useExperimentChartsAccordion(projectId);
+
+  const datasetIdByExperimentId = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const row of rows) {
+      map[row.id] = row.datasetId;
+    }
+    return map;
+  }, [rows]);
+
+  const handleColumnGroupToggle = useCallback(
+    ({ groupId, enabledCount }: ColumnGroupTogglePayload) => {
+      const props = scoreColumnScopeToggledProps({
+        tableName: "experiments",
+        groupId,
+        enabledCount,
+      });
+      if (props) {
+        capture("experiment:score_column_scope_toggled", props);
+      }
+    },
+    [capture],
+  );
+
+  const handleChartsAccordionChange = useCallback(
+    (value: string) => {
+      const isExpanded = value === "charts";
+      const wasExpanded = accordionValue === "charts";
+      if (isExpanded !== wasExpanded) {
+        capture(
+          "experiment:charts_section_toggled",
+          chartsSectionToggledProps({
+            tableName: "experiments",
+            isExpanded,
+          }),
+        );
+      }
+      setAccordionValue(value);
+    },
+    [accordionValue, capture, setAccordionValue],
+  );
 
   // Mirror the visible page's rows into the store (in table order, so
   // selectedPageRowIds keeps the first-selected-in-table-order semantics
@@ -718,7 +789,7 @@ export default function ExperimentsTable({
 
   return (
     <>
-      <DataTableControlsProvider>
+      <DataTableControlsProvider tableName={filterConfig.tableName}>
         <div className="flex h-full w-full flex-col">
           {showControlsInPageHeader && (
             <TableHeaderControls
@@ -735,6 +806,9 @@ export default function ExperimentsTable({
               projectId,
               controllers: viewControllers,
             }}
+            tableName={filterConfig.tableName}
+            isV4={true}
+            onColumnGroupToggle={handleColumnGroupToggle}
             columnsWithCustomSelect={["name", "datasetId"]}
             columnVisibility={columnVisibility}
             setColumnVisibility={setColumnVisibilityState}
@@ -750,6 +824,7 @@ export default function ExperimentsTable({
                 key="experiments-multi-select-actions"
                 projectId={projectId}
                 store={experimentsTableStore}
+                datasetIdByExperimentId={datasetIdByExperimentId}
               />,
             ]}
           />
@@ -760,7 +835,7 @@ export default function ExperimentsTable({
               type="single"
               collapsible
               value={accordionValue}
-              onValueChange={setAccordionValue}
+              onValueChange={handleChartsAccordionChange}
             >
               <AccordionItem value="charts" className="border-t">
                 <AccordionTrigger className="px-3 pt-2 pb-1 hover:no-underline">

--- a/web/src/features/experiments/hooks/useExperimentNames.ts
+++ b/web/src/features/experiments/hooks/useExperimentNames.ts
@@ -2,7 +2,11 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { api } from "@/src/utils/api";
 
 type UseExperimentNamesResponse = {
-  experimentNames: { experimentId: string; experimentName: string }[];
+  experimentNames: {
+    experimentId: string;
+    experimentName: string;
+    datasetId: string | null;
+  }[];
   isLoading: boolean;
 };
 

--- a/web/src/features/experiments/lib/analytics.clienttest.ts
+++ b/web/src/features/experiments/lib/analytics.clienttest.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyticsTabOpenedProps,
+  baselineChangedProps,
+  chartMetricChangedProps,
+  chartMetricGroup,
+  chartsSectionToggledProps,
+  comparisonChangedProps,
+  comparisonPickerOpenedProps,
+  isSameDataset,
+  itemRegressionFilterAppliedProps,
+  scoreColumnGroupScope,
+  scoreColumnScopeToggledProps,
+  uniqueDatasetCount,
+} from "./analytics";
+
+const payloadKeys = (payload: object) => Object.keys(payload);
+
+const CONTENT_KEYS = new Set([
+  "name",
+  "value",
+  "query",
+  "search",
+  "prompt",
+  "experimentName",
+  "datasetName",
+  "filter",
+  "metricId",
+  "searchQuery",
+]);
+
+function expectMetadataOnly(payload: object) {
+  for (const key of payloadKeys(payload)) {
+    expect(CONTENT_KEYS.has(key), `payload must not include ${key}`).toBe(
+      false,
+    );
+  }
+  expect(JSON.stringify(payload)).not.toMatch(/helpfulness|My Experiment/i);
+}
+
+describe("experiment analytics payloads", () => {
+  it("treats a single known dataset as same-dataset", () => {
+    expect(isSameDataset(["ds-1"])).toBe(true);
+    expect(isSameDataset(["ds-1", "ds-1"])).toBe(true);
+    expect(isSameDataset(["ds-1", "ds-2"])).toBe(false);
+    expect(isSameDataset(["ds-1", null, "ds-1"])).toBe(true);
+    expect(uniqueDatasetCount(["ds-1", null, "ds-2", "ds-1"])).toBe(2);
+  });
+
+  it("maps chart metric ids to groups without keeping the id", () => {
+    expect(chartMetricGroup("base:cost")).toBe("base");
+    expect(chartMetricGroup("obs-score-numeric:helpfulness")).toBe("score");
+    const payload = chartMetricChangedProps({
+      tableName: "experiments",
+      metricId: "obs-score-numeric:helpfulness",
+      chartIndex: 1,
+      slotCount: 3,
+    });
+    expect(payload).toEqual({
+      isV4: true,
+      tableName: "experiments",
+      metricGroup: "score",
+      chartIndex: 1,
+      slotCount: 3,
+    });
+    expectMetadataOnly(payload);
+  });
+
+  it("maps score column groups to scopes and ignores unknown groups", () => {
+    expect(scoreColumnGroupScope("traceItemScores")).toBe("trace");
+    expect(scoreColumnGroupScope("traceScores")).toBe("trace");
+    expect(scoreColumnGroupScope("observationItemScores")).toBe("observation");
+    expect(scoreColumnGroupScope("observationScores")).toBe("observation");
+    expect(scoreColumnGroupScope("experimentScores")).toBe("experiment");
+    expect(scoreColumnGroupScope("name")).toBeNull();
+    expect(
+      scoreColumnScopeToggledProps({
+        tableName: "experiments",
+        groupId: "name",
+        enabledCount: 2,
+      }),
+    ).toBeNull();
+  });
+
+  it("builds comparison_changed without names or ids of experiments", () => {
+    const payload = comparisonChangedProps({
+      tableName: "experiment-items",
+      comparisonCount: 2,
+      datasetIds: ["ds-a", "ds-a", "ds-b"],
+      source: "picker",
+    });
+    expect(payload).toEqual({
+      isV4: true,
+      tableName: "experiment-items",
+      comparisonCount: 2,
+      isSameDataset: false,
+      source: "picker",
+    });
+    expectMetadataOnly(payload);
+  });
+
+  it("counts options and datasets on picker open from lengths, not query text", () => {
+    const payload = comparisonPickerOpenedProps({
+      tableName: "experiment-items",
+      optionCount: 12,
+      datasetIds: ["ds-1", "ds-2", "ds-1"],
+      queryLength: "My Experiment".length,
+    });
+    expect(payload).toEqual({
+      isV4: true,
+      tableName: "experiment-items",
+      optionCount: 12,
+      datasetCount: 2,
+      hasSearchQuery: true,
+      queryLength: 13,
+    });
+    expect(payload).not.toHaveProperty("query");
+    expectMetadataOnly(payload);
+  });
+
+  it("keeps baseline, charts toggle, and analytics tab on metadata only", () => {
+    expect(
+      baselineChangedProps({
+        tableName: "experiment-items",
+        source: "clear",
+      }),
+    ).toEqual({
+      isV4: true,
+      tableName: "experiment-items",
+      source: "clear",
+    });
+    expect(
+      chartsSectionToggledProps({
+        tableName: "experiments",
+        isExpanded: false,
+      }),
+    ).toEqual({
+      isV4: true,
+      tableName: "experiments",
+      isExpanded: false,
+    });
+    expect(
+      analyticsTabOpenedProps({
+        tableName: "experiment-items",
+        hasComparison: true,
+      }),
+    ).toEqual({
+      isV4: true,
+      tableName: "experiment-items",
+      hasComparison: true,
+    });
+  });
+
+  it("emits regression-filter props only when retargeting to a comparison", () => {
+    expect(
+      itemRegressionFilterAppliedProps({
+        tableName: "experiment-items",
+        column: "latency",
+        operator: ">",
+        toExperimentId: "baseline-1",
+        baselineId: "baseline-1",
+        comparisonIds: ["cmp-1"],
+      }),
+    ).toBeNull();
+    expect(
+      itemRegressionFilterAppliedProps({
+        tableName: "experiment-items",
+        column: "latency",
+        operator: ">",
+        toExperimentId: "cmp-1",
+        baselineId: "baseline-1",
+        comparisonIds: ["cmp-1", "cmp-2"],
+      }),
+    ).toEqual({
+      isV4: true,
+      tableName: "experiment-items",
+      column: "latency",
+      comparisonIndex: 0,
+      operator: ">",
+    });
+  });
+});

--- a/web/src/features/experiments/lib/analytics.ts
+++ b/web/src/features/experiments/lib/analytics.ts
@@ -1,0 +1,210 @@
+/**
+ * Experiments-UI PostHog payloads. Metadata only — counts, enums, booleans,
+ * field names. Never experiment/dataset names, score values, or item content.
+ */
+
+export const EXPERIMENT_TABLE_NAMES = {
+  list: "experiments",
+  items: "experiment-items",
+} as const;
+
+export type ExperimentTableName =
+  (typeof EXPERIMENT_TABLE_NAMES)[keyof typeof EXPERIMENT_TABLE_NAMES];
+
+export const EXPERIMENT_ANALYTICS_IS_V4 = true as const;
+
+export type ExperimentComparisonSource = "picker" | "table-selection" | "url";
+export type ExperimentBaselineSource = "picker" | "table-selection" | "clear";
+export type ExperimentScoreScope = "trace" | "observation" | "experiment";
+export type ExperimentChartMetricGroup = "base" | "score";
+
+export type ExperimentAnalyticsDimensions = {
+  isV4: typeof EXPERIMENT_ANALYTICS_IS_V4;
+  tableName: ExperimentTableName;
+};
+
+export function experimentAnalyticsDimensions(
+  tableName: ExperimentTableName,
+): ExperimentAnalyticsDimensions {
+  return { isV4: EXPERIMENT_ANALYTICS_IS_V4, tableName };
+}
+
+/** Unique non-empty dataset ids — missing ids are ignored, not treated as distinct. */
+export function isSameDataset(
+  datasetIds: Array<string | null | undefined>,
+): boolean {
+  const known = datasetIds.filter((id): id is string => Boolean(id));
+  if (known.length <= 1) return true;
+  return known.every((id) => id === known[0]);
+}
+
+export function uniqueDatasetCount(
+  datasetIds: Array<string | null | undefined>,
+): number {
+  return new Set(datasetIds.filter((id): id is string => Boolean(id))).size;
+}
+
+export function chartMetricGroup(metricId: string): ExperimentChartMetricGroup {
+  return metricId.startsWith("base:") ? "base" : "score";
+}
+
+const SCORE_COLUMN_GROUP_SCOPE: Record<string, ExperimentScoreScope> = {
+  traceItemScores: "trace",
+  traceScores: "trace",
+  observationItemScores: "observation",
+  observationScores: "observation",
+  experimentScores: "experiment",
+};
+
+export function scoreColumnGroupScope(
+  groupId: string,
+): ExperimentScoreScope | null {
+  return SCORE_COLUMN_GROUP_SCOPE[groupId] ?? null;
+}
+
+export function comparisonChangedProps({
+  tableName,
+  comparisonCount,
+  datasetIds,
+  source,
+}: {
+  tableName: ExperimentTableName;
+  comparisonCount: number;
+  datasetIds: Array<string | null | undefined>;
+  source: ExperimentComparisonSource;
+}) {
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    comparisonCount,
+    isSameDataset: isSameDataset(datasetIds),
+    source,
+  };
+}
+
+export function comparisonPickerOpenedProps({
+  tableName,
+  optionCount,
+  datasetIds,
+  queryLength,
+}: {
+  tableName: ExperimentTableName;
+  optionCount: number;
+  datasetIds: Array<string | null | undefined>;
+  queryLength: number;
+}) {
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    optionCount,
+    datasetCount: uniqueDatasetCount(datasetIds),
+    hasSearchQuery: queryLength > 0,
+    queryLength,
+  };
+}
+
+export function baselineChangedProps({
+  tableName,
+  source,
+}: {
+  tableName: ExperimentTableName;
+  source: ExperimentBaselineSource;
+}) {
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    source,
+  };
+}
+
+export function chartMetricChangedProps({
+  tableName,
+  metricId,
+  chartIndex,
+  slotCount,
+}: {
+  tableName: ExperimentTableName;
+  metricId: string;
+  chartIndex: number;
+  slotCount: number;
+}) {
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    metricGroup: chartMetricGroup(metricId),
+    chartIndex,
+    slotCount,
+  };
+}
+
+export function chartsSectionToggledProps({
+  tableName,
+  isExpanded,
+}: {
+  tableName: ExperimentTableName;
+  isExpanded: boolean;
+}) {
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    isExpanded,
+  };
+}
+
+export function analyticsTabOpenedProps({
+  tableName,
+  hasComparison,
+}: {
+  tableName: ExperimentTableName;
+  hasComparison: boolean;
+}) {
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    hasComparison,
+  };
+}
+
+export function scoreColumnScopeToggledProps({
+  tableName,
+  groupId,
+  enabledCount,
+}: {
+  tableName: ExperimentTableName;
+  groupId: string;
+  enabledCount: number;
+}) {
+  const scope = scoreColumnGroupScope(groupId);
+  if (!scope) return null;
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    scope,
+    enabledCount,
+  };
+}
+
+export function itemRegressionFilterAppliedProps({
+  tableName,
+  column,
+  operator,
+  toExperimentId,
+  baselineId,
+  comparisonIds,
+}: {
+  tableName: ExperimentTableName;
+  column: string;
+  operator: string;
+  toExperimentId: string;
+  baselineId: string | undefined;
+  comparisonIds: string[];
+}): {
+  isV4: true;
+  tableName: ExperimentTableName;
+  column: string;
+  comparisonIndex: number;
+  operator: string;
+} | null {
+  if (!baselineId || toExperimentId === baselineId) return null;
+  const comparisonIndex = comparisonIds.indexOf(toExperimentId);
+  if (comparisonIndex < 0) return null;
+  return {
+    ...experimentAnalyticsDimensions(tableName),
+    column,
+    comparisonIndex,
+    operator,
+  };
+}

--- a/web/src/features/experiments/lib/analytics.ts
+++ b/web/src/features/experiments/lib/analytics.ts
@@ -3,27 +3,21 @@
  * field names. Never experiment/dataset names, score values, or item content.
  */
 
-export const EXPERIMENT_TABLE_NAMES = {
-  list: "experiments",
-  items: "experiment-items",
-} as const;
+type ExperimentTableName = "experiments" | "experiment-items";
 
-export type ExperimentTableName =
-  (typeof EXPERIMENT_TABLE_NAMES)[keyof typeof EXPERIMENT_TABLE_NAMES];
-
-export const EXPERIMENT_ANALYTICS_IS_V4 = true as const;
+const EXPERIMENT_ANALYTICS_IS_V4 = true as const;
 
 export type ExperimentComparisonSource = "picker" | "table-selection" | "url";
 export type ExperimentBaselineSource = "picker" | "table-selection" | "clear";
 export type ExperimentScoreScope = "trace" | "observation" | "experiment";
 export type ExperimentChartMetricGroup = "base" | "score";
 
-export type ExperimentAnalyticsDimensions = {
+type ExperimentAnalyticsDimensions = {
   isV4: typeof EXPERIMENT_ANALYTICS_IS_V4;
   tableName: ExperimentTableName;
 };
 
-export function experimentAnalyticsDimensions(
+function experimentAnalyticsDimensions(
   tableName: ExperimentTableName,
 ): ExperimentAnalyticsDimensions {
   return { isV4: EXPERIMENT_ANALYTICS_IS_V4, tableName };

--- a/web/src/features/navigation/utils/experiment-run-tabs.ts
+++ b/web/src/features/navigation/utils/experiment-run-tabs.ts
@@ -9,6 +9,7 @@ export type ExperimentRunTab =
 export const getExperimentRunTabs = (
   projectId: string,
   onResultsClick?: () => void,
+  onAnalyticsClick?: () => void,
 ) => [
   {
     value: EXPERIMENT_RUN_TABS.RESULTS,
@@ -22,5 +23,6 @@ export const getExperimentRunTabs = (
     value: EXPERIMENT_RUN_TABS.ANALYTICS,
     label: "Analytics",
     href: `/project/${projectId}/experiments/analytics`,
+    onClick: onAnalyticsClick,
   },
 ];

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -283,6 +283,20 @@ const events = {
     "compare_run_added",
     "compare_run_removed",
   ],
+  // Experiments UI (v4). Metadata only — counts/enums/booleans/field names;
+  // never experiment or dataset names, score values, or item content.
+  // `isV4` + `tableName` on every event. `source` on comparison/baseline
+  // distinguishes picker vs table-selection vs url (deep link / redirect).
+  experiment: [
+    "comparison_changed",
+    "comparison_picker_opened",
+    "baseline_changed",
+    "chart_metric_changed",
+    "charts_section_toggled",
+    "analytics_tab_opened",
+    "score_column_scope_toggled",
+    "item_regression_filter_applied",
+  ],
   // Version-update reload notification (LFE-10978). `banner_shown` fires once
   // per appearance; the two actions measure the reload-vs-dismiss split. No
   // props carry user content.

--- a/web/src/pages/project/[projectId]/experiments/results.tsx
+++ b/web/src/pages/project/[projectId]/experiments/results.tsx
@@ -19,6 +19,8 @@ import {
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { ExperimentSelectionControls } from "@/src/features/experiments/components/ExperimentSelectionControls";
 import { useIoRenderModeLocalStorage } from "@/src/components/table/data-table-io-render-mode-switch";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { analyticsTabOpenedProps } from "@/src/features/experiments/lib/analytics";
 
 export default function ExperimentResults() {
   const router = useRouter();
@@ -57,6 +59,7 @@ export default function ExperimentResults() {
     setLastResultsUrl(window.location.pathname + window.location.search);
   }, [setLastResultsUrl]);
 
+  const capture = usePostHogClientCapture();
   const { isExperimentsBetaActive, isInitializing } = useExperimentAccess();
 
   useEffect(() => {
@@ -96,7 +99,15 @@ export default function ExperimentResults() {
           { name: "Experiments", href: `/project/${projectId}/experiments` },
         ],
         tabsProps: {
-          tabs: getExperimentRunTabs(projectId),
+          tabs: getExperimentRunTabs(projectId, undefined, () => {
+            capture(
+              "experiment:analytics_tab_opened",
+              analyticsTabOpenedProps({
+                tableName: "experiment-items",
+                hasComparison: comparisonIds.length > 0,
+              }),
+            );
+          }),
           activeTab: EXPERIMENT_RUN_TABS.RESULTS,
         },
         actionButtonsLeft: (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16713.preview.langfuse.com](https://pr-16713.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The v4 Experiments UI emitted no product analytics of its own. Filter events from those tables reported `isV4 = false`, generic table/peek events had no `tableName`, and comparison/chart/score-column behaviour was invisible. This adds a typed `experiment:*` taxonomy and forwards `isV4` + `tableName` on the shared table events so the revamp has a before/after.

### Tracking plan

| Event | Question | Props (metadata only) |
| -- | -- | -- |
| `experiment:comparison_changed` | Do people compare, how many at once, same dataset? | `comparisonCount`, `isSameDataset`, `source` (`picker` / `table-selection` / `url`) |
| `experiment:comparison_picker_opened` | How long is the list, do they search, mixed datasets? | `optionCount`, `datasetCount`, `hasSearchQuery`, `queryLength` |
| `experiment:baseline_changed` | Is the baseline control used? | `source` (`picker` / `table-selection` / `clear`) |
| `experiment:chart_metric_changed` | Do people move charts off Cost/Latency onto a score? | `metricGroup` (`base`/`score`), `chartIndex`, `slotCount` |
| `experiment:charts_section_toggled` | Do people collapse charts to get the table back? | `isExpanded` |
| `experiment:analytics_tab_opened` | Keep the "people want analysis here" funnel | `hasComparison` |
| `experiment:score_column_scope_toggled` | Which score family is toggled visible | `scope`, `enabledCount` |
| `experiment:item_regression_filter_applied` | Is comparison-column filtering used? | `column`, `comparisonIndex`, `operator` |

Every event also carries `isV4` and `tableName`. Generic `table:column_visibility_changed`, `table:row_height_switch_select`, `table:search_submit`, and `peek:opened`/`closed`/`open_in_new_tab` now include `tableName` + `isV4` as well.

**Not captured:** score values, experiment/dataset names, item input/output/metadata. Ids, counts, enums, booleans, and field names only.

`source: "url"` is in the type for a future deep-link path. It is **not** fired on URL hydrate/mount (intent-seam rule: not the setter / programmatic restore).

Also: `ExperimentsTable` and `ExperimentItemsTable` now pass `isV4: true` into `useSidebarFilterState` so `filters:*` events from those v4-only surfaces are no longer labeled v3.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Impacted packages: `web`, `packages/shared` (experiment names query now selects `datasetId` so `isSameDataset` / `datasetCount` do not need names)
- Verification:
  - `pnpm --filter web run test-client analytics.clienttest ExperimentComparisonSelector.clienttest ExperimentBaselineControls.clienttest ExperimentChartsGrid.clienttest data-table-column-visibility-filter.clienttest usePeekNavigation.clienttest page-tabs.clienttest` → `Tests 24 passed (24)`
  - Pre-commit `turbo run lint` → `Tasks: 7 successful, 7 total`
- Skipped: full `pnpm run typecheck` (pre-commit lint covers the changed packages; CI typecheck is the remaining gate). Playwright e2e spy on `window.posthog.capture` was not added; client tests spy on `usePostHogClientCapture()` instead (once-per-action, `isV4` true vs false on peek, payload keys have no names/values).

## How to test

Sandbox: `http://localhost:3000/project/<id>/experiments` (experiments beta on).

1. Open the experiments list, toggle a score column group Select All, change a chart metric, collapse Charts, select 2+ rows and Compare.
2. On results, open the comparison picker, change baseline, retarget a filter pill to a comparison, click Analytics.
3. Confirm in PostHog (or a `capture()` spy) that each action fires once, `isV4` is true, `tableName` is `experiments` or `experiment-items`, and payloads have no experiment/dataset names or score values.
4. Contrast: traces table peek/search/columns should report `isV4: false`, `tableName: traces`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15720](https://linear.app/clickhouse/issue/LFE-15720/instrument-the-experiments-ui-posthog-so-the-revamp-has-a-beforeafter)

<div><a href="https://cursor.com/agents/bc-3f40364f-67d0-4e95-b6eb-c1ef21369d0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f40364f-67d0-4e95-b6eb-c1ef21369d0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds typed product-analytics instrumentation throughout the v4 experiments UI and enriches shared table and peek events with table and version dimensions.

- Adds experiment comparison, baseline, chart, tab, score-column, and regression-filter events.
- Extends experiment-name queries with dataset identity for aggregate analytics.
- Propagates `tableName` and `isV4` through selected shared table, search, and peek surfaces.
- Adds focused client tests for analytics payloads and action-level emission.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The analytics feature needs the remaining peek callers migrated before merging so generic peek events do not report unknown tables or incorrect surface versions.

Most existing peek-enabled tables omit the newly introduced dimensions, causing their user actions to emit fallback analytics values rather than the owning table and surface identity.

**Files Needing Attention:** web/src/components/table/peek/hooks/usePeekNavigation.ts and its unmigrated callers
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[User action in experiment or table UI] --> B[Typed payload helper]
  B --> C[PostHog capture hook]
  D[Owning table configuration] --> E[Shared toolbar or peek hook]
  E --> C
  C --> F[Product analytics event]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/peek/hooks/usePeekNavigation.ts:90-91
**Peek dimensions use fallbacks**

When users open, close, or expand peeks from unmigrated tables such as observations, scores, or evaluators, the hook emits `tableName: "unknown"` and derives `isV4` from the global beta flag instead of the owning surface, causing incorrect per-table and v3/v4 analytics.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): instrument experiments UI pro..."](https://github.com/langfuse/langfuse/commit/00118fc8602938986239b0afd31d8c928399f2cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57574698)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->