### PR TITLE
feat(command-menu): navigate by tracing IDs

### DIFF
--- a/web/src/features/command-k-menu/CommandMenu.clienttest.ts
+++ b/web/src/features/command-k-menu/CommandMenu.clienttest.ts
@@ -11,11 +11,33 @@ describe("getIdNavigationItem", () => {
     });
   });
 
-  it("filters the traces table by an exact 16-character observation ID", () => {
-    expect(getIdNavigationItem("0123456789aBCDef", "project-1")).toEqual({
+  it("filters v4 traces by the trace ID column", () => {
+    expect(
+      getIdNavigationItem(
+        "0123456789abcdef0123456789ABCDEF",
+        "project-1",
+        true,
+      ),
+    ).toEqual({
+      type: "trace_id",
+      title: "Find trace by ID",
+      url: "/project/project-1/traces?filter=traceId%3Bstring%3B%3B%3D%3B0123456789abcdef0123456789ABCDEF",
+    });
+  });
+
+  it("filters the v4 traces table by an exact observation ID", () => {
+    expect(getIdNavigationItem("0123456789aBCDef", "project-1", true)).toEqual({
       type: "observation_id",
       title: "Find observation by ID",
       url: "/project/project-1/traces?filter=id%3Bstring%3B%3Bcontains%3B0123456789aBCDef",
+    });
+  });
+
+  it("filters the v3 observations table by an exact observation ID", () => {
+    expect(getIdNavigationItem("0123456789aBCDef", "project-1")).toEqual({
+      type: "observation_id",
+      title: "Find observation by ID",
+      url: "/project/project-1/observations?filter=id%3BstringOptions%3B%3Bany%20of%3B0123456789aBCDef",
     });
   });
 

--- a/web/src/features/command-k-menu/CommandMenu.clienttest.ts
+++ b/web/src/features/command-k-menu/CommandMenu.clienttest.ts
@@ -1,0 +1,41 @@
+import { getIdNavigationItem, getSearchAnalytics } from "./CommandMenu";
+
+describe("getIdNavigationItem", () => {
+  it("filters traces by an exact 32-character hex ID", () => {
+    expect(
+      getIdNavigationItem("0123456789abcdef0123456789ABCDEF", "project-1"),
+    ).toEqual({
+      type: "trace_id",
+      title: "Find trace by ID",
+      url: "/project/project-1/traces?filter=id%3Bstring%3B%3B%3D%3B0123456789abcdef0123456789ABCDEF",
+    });
+  });
+
+  it("filters observations by an exact 16-character hex ID", () => {
+    expect(getIdNavigationItem("0123456789aBCDef", "project-1")).toEqual({
+      type: "observation_id",
+      title: "Find observation by ID",
+      url: "/project/project-1/observations?filter=id%3BstringOptions%3B%3Bany%20of%3B0123456789aBCDef",
+    });
+  });
+
+  it.each([
+    ["", "project-1"],
+    ["0123456789abcde", "project-1"],
+    ["0123456789abcdefg", "project-1"],
+    ["not-a-hex-id-123", "project-1"],
+    ["0123456789abcdef", undefined],
+  ])("does not match %j in project %j", (search, projectId) => {
+    expect(getIdNavigationItem(search, projectId)).toBeNull();
+  });
+
+  it("classifies searches without retaining their raw value", () => {
+    const search = "0123456789abcdef";
+
+    expect(getSearchAnalytics(search)).toEqual({
+      queryLength: 16,
+      queryType: "observation_id",
+    });
+    expect(getSearchAnalytics(search)).not.toHaveProperty("search");
+  });
+});

--- a/web/src/features/command-k-menu/CommandMenu.clienttest.ts
+++ b/web/src/features/command-k-menu/CommandMenu.clienttest.ts
@@ -21,7 +21,7 @@ describe("getIdNavigationItem", () => {
     ).toEqual({
       type: "trace_id",
       title: "Find trace by ID",
-      url: "/project/project-1/traces?filter=traceId%3Bstring%3B%3B%3D%3B0123456789abcdef0123456789ABCDEF",
+      url: "/project/project-1/traces?filter=traceId%3Bstring%3B%3Bcontains%3B0123456789abcdef0123456789ABCDEF",
     });
   });
 

--- a/web/src/features/command-k-menu/CommandMenu.clienttest.ts
+++ b/web/src/features/command-k-menu/CommandMenu.clienttest.ts
@@ -11,11 +11,11 @@ describe("getIdNavigationItem", () => {
     });
   });
 
-  it("filters observations by an exact 16-character hex ID", () => {
+  it("filters the traces table by an exact 16-character observation ID", () => {
     expect(getIdNavigationItem("0123456789aBCDef", "project-1")).toEqual({
       type: "observation_id",
       title: "Find observation by ID",
-      url: "/project/project-1/observations?filter=id%3BstringOptions%3B%3Bany%20of%3B0123456789aBCDef",
+      url: "/project/project-1/traces?filter=id%3Bstring%3B%3Bcontains%3B0123456789aBCDef",
     });
   });
 

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -47,7 +47,7 @@ export const getIdNavigationItem = (
   const idType = getIdType(id);
 
   if (idType === "trace_id") {
-    const filter = `${isV4 ? "traceId" : "id"};string;;=;${encodeURIComponent(id)}`;
+    const filter = `${isV4 ? "traceId;string;;contains" : "id;string;;="};${encodeURIComponent(id)}`;
     return {
       type: "trace_id",
       title: "Find trace by ID",

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -20,6 +20,7 @@ import { useAccountSettingsPages } from "@/src/pages/account/settings";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { api } from "@/src/utils/api";
 import { type NavigationItem } from "@/src/components/layouts/utilities/routes";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 type IdNavigationItem = {
   type: "trace_id" | "observation_id";
@@ -37,6 +38,7 @@ const getIdType = (search: string): IdNavigationItem["type"] | null => {
 export const getIdNavigationItem = (
   search: string,
   projectId?: string,
+  isV4 = false,
 ): IdNavigationItem | null => {
   if (!projectId) return null;
 
@@ -45,7 +47,7 @@ export const getIdNavigationItem = (
   const idType = getIdType(id);
 
   if (idType === "trace_id") {
-    const filter = `id;string;;=;${encodeURIComponent(id)}`;
+    const filter = `${isV4 ? "traceId" : "id"};string;;=;${encodeURIComponent(id)}`;
     return {
       type: "trace_id",
       title: "Find trace by ID",
@@ -54,11 +56,13 @@ export const getIdNavigationItem = (
   }
 
   if (idType === "observation_id") {
-    const filter = `id;string;;contains;${encodeURIComponent(id)}`;
+    const filter = isV4
+      ? `id;string;;contains;${encodeURIComponent(id)}`
+      : `id;stringOptions;;any of;${encodeURIComponent(id)}`;
     return {
       type: "observation_id",
       title: "Find observation by ID",
-      url: `/project/${encodedProjectId}/traces?filter=${encodeURIComponent(filter)}`,
+      url: `/project/${encodedProjectId}/${isV4 ? "traces" : "observations"}?filter=${encodeURIComponent(filter)}`,
     };
   }
 
@@ -334,8 +338,13 @@ function CommandMenuComponent({
   const capture = usePostHogClientCapture();
   const router = useRouter();
   const { project } = useQueryProjectOrOrganization();
+  const { isBetaEnabled } = useV4Beta();
   const [search, setSearch] = useState("");
-  const idNavigationItem = getIdNavigationItem(search, project?.id);
+  const idNavigationItem = getIdNavigationItem(
+    search,
+    project?.id,
+    isBetaEnabled,
+  );
 
   const debouncedSearchChange = useDebounce(
     (value: string) => {
@@ -373,7 +382,9 @@ function CommandMenuComponent({
             source: "cmd_k",
           });
         }
-        setOpen(!open);
+        const nextOpen = !open;
+        setOpen(nextOpen);
+        if (!nextOpen) setSearch("");
       }
     };
     document.addEventListener("keydown", down);
@@ -381,13 +392,17 @@ function CommandMenuComponent({
   }, [capture, setOpen, open]);
 
   const handleNavigate = () => {
+    setSearch("");
     setOpen(false);
   };
 
   return (
     <CommandDialog
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setSearch("");
+      }}
       filter={(value, search, keywords) => {
         const extendValue = value + " " + keywords?.join(" ");
         const searchTerms = search.toLowerCase().split(" ");
@@ -401,6 +416,7 @@ function CommandMenuComponent({
       <CommandInput
         placeholder="Type a command or search..."
         className="border-none focus:border-none focus:ring-0 focus:ring-transparent focus:outline-hidden"
+        value={search}
         onValueChange={(value) => {
           setSearch(value);
           debouncedSearchChange(value);

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -54,11 +54,11 @@ export const getIdNavigationItem = (
   }
 
   if (idType === "observation_id") {
-    const filter = `id;stringOptions;;any of;${encodeURIComponent(id)}`;
+    const filter = `id;string;;contains;${encodeURIComponent(id)}`;
     return {
       type: "observation_id",
       title: "Find observation by ID",
-      url: `/project/${encodedProjectId}/observations?filter=${encodeURIComponent(filter)}`,
+      url: `/project/${encodedProjectId}/traces?filter=${encodeURIComponent(filter)}`,
     };
   }
 

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -8,7 +8,7 @@ import {
   CommandSeparator,
 } from "@/src/components/ui/command";
 import { useRouter } from "next/router";
-import { useEffect, memo } from "react";
+import { useEffect, memo, useState } from "react";
 import { useSession } from "next-auth/react";
 import { env } from "@/src/env.mjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -20,6 +20,55 @@ import { useAccountSettingsPages } from "@/src/pages/account/settings";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { api } from "@/src/utils/api";
 import { type NavigationItem } from "@/src/components/layouts/utilities/routes";
+
+type IdNavigationItem = {
+  type: "trace_id" | "observation_id";
+  title: string;
+  url: string;
+};
+
+const getIdType = (search: string): IdNavigationItem["type"] | null => {
+  const id = search.trim();
+  if (/^[0-9a-f]{32}$/i.test(id)) return "trace_id";
+  if (/^[0-9a-f]{16}$/i.test(id)) return "observation_id";
+  return null;
+};
+
+export const getIdNavigationItem = (
+  search: string,
+  projectId?: string,
+): IdNavigationItem | null => {
+  if (!projectId) return null;
+
+  const id = search.trim();
+  const encodedProjectId = encodeURIComponent(projectId);
+  const idType = getIdType(id);
+
+  if (idType === "trace_id") {
+    const filter = `id;string;;=;${encodeURIComponent(id)}`;
+    return {
+      type: "trace_id",
+      title: "Find trace by ID",
+      url: `/project/${encodedProjectId}/traces?filter=${encodeURIComponent(filter)}`,
+    };
+  }
+
+  if (idType === "observation_id") {
+    const filter = `id;stringOptions;;any of;${encodeURIComponent(id)}`;
+    return {
+      type: "observation_id",
+      title: "Find observation by ID",
+      url: `/project/${encodedProjectId}/observations?filter=${encodeURIComponent(filter)}`,
+    };
+  }
+
+  return null;
+};
+
+export const getSearchAnalytics = (search: string) => ({
+  queryLength: search.length,
+  queryType: getIdType(search) ?? "other",
+});
 
 function MainNavigationGroup({
   navItems,
@@ -283,12 +332,14 @@ function CommandMenuComponent({
 }) {
   const { open, setOpen } = useCommandMenu();
   const capture = usePostHogClientCapture();
+  const router = useRouter();
+  const { project } = useQueryProjectOrOrganization();
+  const [search, setSearch] = useState("");
+  const idNavigationItem = getIdNavigationItem(search, project?.id);
 
   const debouncedSearchChange = useDebounce(
     (value: string) => {
-      capture("cmd_k_menu:search_entered", {
-        search: value,
-      });
+      capture("cmd_k_menu:search_entered", getSearchAnalytics(value));
     },
     500,
     false,
@@ -350,10 +401,29 @@ function CommandMenuComponent({
       <CommandInput
         placeholder="Type a command or search..."
         className="border-none focus:border-none focus:ring-0 focus:ring-transparent focus:outline-hidden"
-        onValueChange={debouncedSearchChange}
+        onValueChange={(value) => {
+          setSearch(value);
+          debouncedSearchChange(value);
+        }}
       />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
+        {idNavigationItem ? (
+          <CommandGroup heading="Tracing">
+            <CommandItem
+              value={`${idNavigationItem.title} ${search}`}
+              onSelect={() => {
+                router.push(idNavigationItem.url);
+                capture("cmd_k_menu:navigated", {
+                  type: idNavigationItem.type,
+                });
+                handleNavigate();
+              }}
+            >
+              {idNavigationItem.title}
+            </CommandItem>
+          </CommandGroup>
+        ) : null}
         <MainNavigationGroup navItems={navItems} onNavigate={handleNavigate} />
         <ProjectsGroup onNavigate={handleNavigate} />
         <DashboardsGroup onNavigate={handleNavigate} />


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16714.preview.langfuse.com](https://pr-16714.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- Recognize exact 32-character hexadecimal trace IDs in Cmd-K and open the tracing table with the correct v3 or v4 trace-ID filter.
- Recognize exact 16-character hexadecimal observation IDs; v4 uses the unified traces table, while v3 retains the observations table.
- Clear the controlled Cmd-K query whenever the menu closes so stale hidden ID actions cannot persist.
- Replace raw Cmd-K search analytics with metadata-only query length and query type.

## Scope

Impacted package: web only. No backend, ClickHouse, schema, or generalized entity-search changes.

## Analytics

Question: how often do users search for and navigate via trace or observation IDs?

- cmd_k_menu:search_entered sends queryLength and queryType only.
- cmd_k_menu:navigated sends the selected entity type only.
- No raw search text or pasted ID is captured by these paths.

## Validation

- pnpm --filter web run test-client src/features/command-k-menu/CommandMenu.clienttest.ts — Tests 10 passed (10)
- targeted ESLint for the changed source and test — passed with zero warnings
- pnpm --filter web run typecheck — passed
- Prettier check and git diff --check — passed
- Browser: verified ID navigation and close/reopen reset behavior; the reopened input is empty and no stale action remains.

Full web lint was also attempted; it remains blocked by pre-existing unused-disable warnings in unrelated files.