### PR TITLE
fix(api): advance unstable evaluator sunset

### DIFF
--- a/fern/apis/server/definition/unstable/evaluation-rules.yml
+++ b/fern/apis/server/definition/unstable/evaluation-rules.yml
@@ -11,7 +11,7 @@ service:
     create:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Create an evaluation rule.
 
@@ -241,7 +241,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         List evaluation rules in the authenticated project.
 
@@ -269,7 +269,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Get one evaluation rule by its identifier.
 
@@ -293,7 +293,7 @@ service:
     update:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Update an evaluation rule.
 
@@ -337,7 +337,7 @@ service:
     delete:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Delete an evaluation rule.
 

--- a/fern/apis/server/definition/unstable/evaluators.yml
+++ b/fern/apis/server/definition/unstable/evaluators.yml
@@ -11,7 +11,7 @@ service:
     create:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Create an evaluator in the authenticated project.
 
@@ -262,7 +262,7 @@ service:
     list:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         List the evaluators available to the authenticated project.
 
@@ -292,7 +292,7 @@ service:
     get:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Get one evaluator by `id`.
 
@@ -316,7 +316,7 @@ service:
     delete:
       availability:
         status: deprecated
-        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
+        message: "On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4."
       docs: |
         Delete an evaluator.
 

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8572,7 +8572,7 @@ paths:
     post:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments
         are unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -8745,7 +8745,7 @@ paths:
     get:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments
         are unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -8827,7 +8827,7 @@ paths:
     get:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments
         are unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -8901,7 +8901,7 @@ paths:
     patch:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments
         are unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -9028,7 +9028,7 @@ paths:
     delete:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluation-rules` API instead. Self-hosted deployments
         are unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -9100,7 +9100,7 @@ paths:
     post:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluators` API instead. Self-hosted deployments are
         unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -9250,7 +9250,7 @@ paths:
       deprecated: true
     get:
       description: |-
-        **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on November 16, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
+        **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated and will be removed on September 4, 2026. Use the stable `/api/public/v2/evaluators` API instead. Self-hosted deployments are unaffected by this date; the endpoint becomes unavailable when they upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade guide](https://langfuse.com/self-hosting/upgrade/upgrade-guides/upgrade-v3-to-v4).
 
         List the evaluators available to the authenticated project.
 
@@ -9325,7 +9325,7 @@ paths:
     get:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluators` API instead. Self-hosted deployments are
         unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -9398,7 +9398,7 @@ paths:
     delete:
       description: >-
         **Deprecated:** On Langfuse Cloud, this unstable endpoint is deprecated
-        and will be removed on November 16, 2026. Use the stable
+        and will be removed on September 4, 2026. Use the stable
         `/api/public/v2/evaluators` API instead. Self-hosted deployments are
         unaffected by this date; the endpoint becomes unavailable when they
         upgrade to Langfuse v4. See the [Langfuse v3 to v4 upgrade
@@ -13693,8 +13693,8 @@ components:
             $ref: '#/components/schemas/EvaluationRuleAssignment'
           description: >-
             All modern and legacy evaluation-rule assignments in
-            newest-assignment-first order, including each assigned rule ID and
-            its stored mapping.
+            newest-assignment-first order. Rule-specific mappings are exposed as
+            `variableMappingOverride`; inherited defaults are omitted.
         createdAt:
           type: string
           format: date-time

--- a/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
+++ b/web/src/__tests__/server/unit/openapi-deprecations.servertest.ts
@@ -35,6 +35,18 @@ const openApiPath = path.resolve(
 );
 
 const MESSAGE = "Use `GET /api/public/v2/observations?from=<from>` instead.";
+const UNSTABLE_EVALS_SUNSET_HUMAN = "September 4, 2026";
+const UNSTABLE_EVAL_OPERATIONS = new Set([
+  "POST /api/public/unstable/evaluators",
+  "GET /api/public/unstable/evaluators",
+  "GET /api/public/unstable/evaluators/{evaluatorId}",
+  "DELETE /api/public/unstable/evaluators/{evaluatorId}",
+  "POST /api/public/unstable/evaluation-rules",
+  "GET /api/public/unstable/evaluation-rules",
+  "GET /api/public/unstable/evaluation-rules/{evaluationRuleId}",
+  "PATCH /api/public/unstable/evaluation-rules/{evaluationRuleId}",
+  "DELETE /api/public/unstable/evaluation-rules/{evaluationRuleId}",
+]);
 
 /** Spec fixture in the shape `fern export` produces, aliased `security` included. */
 const SPEC = `openapi: 3.0.1
@@ -126,9 +138,12 @@ describe("OpenAPI deprecations", () => {
     for (const { method, endpointPath, message } of getFernDeprecatedOperations(
       definitionDirectory,
     )) {
-      expect(message, `${method.toUpperCase()} ${endpointPath}`).toContain(
-        `will be removed on ${V3_SUNSET_HUMAN}.`,
-      );
+      const operation = `${method.toUpperCase()} ${endpointPath}`;
+      const sunsetDate = UNSTABLE_EVAL_OPERATIONS.has(operation)
+        ? UNSTABLE_EVALS_SUNSET_HUMAN
+        : V3_SUNSET_HUMAN;
+
+      expect(message, operation).toContain(`will be removed on ${sunsetDate}.`);
     }
   });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16716.preview.langfuse.com](https://pr-16716.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Moves the Langfuse Cloud sunset date for the unstable evaluators and evaluation-rules APIs from November 16, 2026 to September 4, 2026. Keeps the shared v3 sunset assertion for all other deprecated endpoints while explicitly allowlisting the unstable evaluation operations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm run openapi:export` — `Synced 24 deprecated OpenAPI operations from Fern definitions.`
- `pnpm run lint` (commit hook) — `Tasks: 7 successful, 7 total`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web run test src/__tests__/server/unit/openapi-deprecations.servertest.ts` — `Tests 15 passed (15)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aebf48a3-9ca1-4c3c-93ff-bac99c9025fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aebf48a3-9ca1-4c3c-93ff-bac99c9025fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Advances the Langfuse Cloud sunset date for unstable evaluator and evaluation-rule APIs from November 16 to September 4, 2026.
- Updates deprecation messages for all nine unstable evaluator and evaluation-rule operations.
- Regenerates the public OpenAPI descriptions with the revised deadline.
- Adds operation-specific test expectations while preserving the shared v3 sunset assertion for other deprecated endpoints.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with the intended sunset date consistently represented and tested across the affected API contracts.

All affected operations are covered by the operation-specific assertion, their Fern and generated OpenAPI dates agree, and the remaining generated description delta corrects pre-existing artifact drift.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): advance unstable evaluator sun..."](https://github.com/langfuse/langfuse/commit/54ee6468d1cdd23a5bfa19019eb35be89bb267c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57581814)</sub>

<!-- /greptile_comment -->