### PR TITLE
fix(worker): preserve deprecated API usage rows

### DIFF
--- a/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
+++ b/worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
@@ -330,7 +330,7 @@ describe("handleV4LegacyApiUsageJob", () => {
     expect(query).toContain(
       "topK(20)(tuple(sdk_name, sdk_version, user_agent))",
     );
-    expect(query).toContain("ANY INNER JOIN caller_candidates");
+    expect(query).toContain("ALL INNER JOIN caller_candidates");
     expect(query).toContain(
       "GROUP BY hourStart, projectId, route, sdkName, sdkVersion, userAgent, isOther",
     );

--- a/worker/src/features/v4/handleV4LegacyApiUsageJob.ts
+++ b/worker/src/features/v4/handleV4LegacyApiUsageJob.ts
@@ -230,7 +230,9 @@ bounded AS (
     classified.*,
     has(caller_candidates.caller_keys, tuple(sdk_name, sdk_version, user_agent)) AS retain_caller
   FROM classified
-  ANY INNER JOIN caller_candidates
+  -- Preserve every classified query row. caller_candidates is unique per join key,
+  -- so ALL cannot multiply matches.
+  ALL INNER JOIN caller_candidates
     ON classified.project_id = caller_candidates.project_id
     AND classified.legacy_route = caller_candidates.legacy_route
   WHERE classified.legacy_route IS NOT NULL


### PR DESCRIPTION
## What changed

- use ALL INNER JOIN when applying the bounded caller candidate set
- preserve every classified query-log row while keeping the 20-caller cap
- update the worker SQL contract test to prevent ANY strictness from returning

## Why

The right-hand caller candidate set has exactly one row per project and legacy route. ANY join strictness caused production rollups to retain one arbitrary classified query row, so repeated deprecated API calls stayed at a fractional count that the UI displayed as one. ALL preserves all classified rows without multiplying them because the right-hand join keys are unique.

## Impacted package

- worker

## Validation

- CI=true pnpm --filter worker exec vitest run src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts -t keeps one endpoint total with separate SDK and user-agent callers
  - Test Files 1 passed (1)
  - Tests 1 passed, 10 skipped (11)
- CI=true pnpm run lint
  - Tasks: 7 successful, 7 total
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes the deprecated API usage query from `ANY INNER JOIN` to `ALL INNER JOIN` and updates its SQL contract assertion. Because the candidate CTE is unique on the complete join key, the strictness change is semantically equivalent and does not establish the intended row-preservation fix.

- Changes the bounded caller join strictness.
- Updates the worker test to require the new SQL text.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the production undercount is addressed by a behavior-changing fix and validated through actual ClickHouse query execution.

The candidate CTE produces one row per complete join key, so switching between ANY and ALL cannot alter matched-row cardinality, while the mocked test verifies only the emitted keyword.

**Files Needing Attention:** worker/src/features/v4/handleV4LegacyApiUsageJob.ts and worker/src/features/v4/__tests__/handleV4LegacyApiUsageJob.test.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[classified rows] --> G[Group by project and legacy route]
  G --> U[One caller_candidates row per join key]
  C --> J[ANY or ALL inner join]
  U --> J
  J --> A[Equivalent matched classified rows]
  A --> R[Usage rollup]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/v4/handleV4LegacyApiUsageJob.ts:235
**Join strictness stays equivalent**

Because `caller_candidates` produces exactly one row per `project_id` and `legacy_route`, changing this join from `ANY` to `ALL` does not alter matched-row cardinality, leaving the reported production undercount reachable; the updated test cannot detect that outcome because it mocks the ClickHouse result and checks only the generated SQL text.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): preserve deprecated API usa..."](https://github.com/langfuse/langfuse/commit/0d995731b88144a3ff333cbc39ca1bd511668956) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57593788)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->