### PR TITLE
fix(monitors): evaluate alerts with each monitor's stored filters

### DIFF
--- a/packages/shared/src/features/monitors/processor/processor.filters.test.ts
+++ b/packages/shared/src/features/monitors/processor/processor.filters.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import type { MonitorFilters } from "../types";
+import {
+  buildMonitorQuery,
+  filtersFingerprint,
+  groupMonitorsByFilters,
+} from "./processorQueryHelpers";
+
+describe("groupMonitorsByFilters", () => {
+  it("groups monitors that share the same canonical filter set", () => {
+    const envFilter = {
+      column: "environment" as const,
+      operator: "any of" as const,
+      value: ["prd"],
+      type: "stringOptions" as const,
+    };
+    const typeFilter = {
+      column: "type" as const,
+      operator: "any of" as const,
+      value: ["GENERATION"],
+      type: "stringOptions" as const,
+    };
+
+    const groups = groupMonitorsByFilters([
+      {
+        id: "m_a",
+        filters: [envFilter, typeFilter],
+      } as never,
+      {
+        id: "m_b",
+        filters: [typeFilter, envFilter],
+      } as never,
+      {
+        id: "m_c",
+        filters: [envFilter],
+      } as never,
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(
+      groups.find((g) => g.monitorIds.includes("m_a"))?.monitorIds,
+    ).toEqual(expect.arrayContaining(["m_a", "m_b"]));
+    expect(groups.find((g) => g.monitorIds.includes("m_c"))?.filters).toEqual([
+      envFilter,
+    ]);
+  });
+});
+
+describe("filtersFingerprint", () => {
+  it("is permutation-invariant for set-semantics filters", () => {
+    const a: MonitorFilters = [
+      {
+        column: "environment",
+        operator: "any of",
+        value: ["prd", "staging"],
+        type: "stringOptions",
+      },
+    ];
+    const b: MonitorFilters = [
+      {
+        column: "environment",
+        operator: "any of",
+        value: ["staging", "prd"],
+        type: "stringOptions",
+      },
+    ];
+
+    expect(filtersFingerprint(a)).toBe(filtersFingerprint(b));
+  });
+});
+
+describe("buildMonitorQuery", () => {
+  it("uses the supplied monitor filters instead of the queue event filters", () => {
+    const query = buildMonitorQuery(
+      [{ measure: "latency", aggregation: "p95" }],
+      {
+        view: "observations",
+        window: "1d",
+        runAt: new Date("2026-05-27T12:00:00.000Z"),
+        filters: [
+          {
+            column: "environment",
+            operator: "any of",
+            value: ["prd"],
+            type: "stringOptions",
+          },
+        ],
+      } as never,
+      [
+        {
+          column: "environment",
+          operator: "any of",
+          value: ["prd"],
+          type: "stringOptions",
+        },
+        {
+          column: "type",
+          operator: "any of",
+          value: ["GENERATION"],
+          type: "stringOptions",
+        },
+      ],
+    );
+
+    expect(query.filters).toEqual([
+      {
+        column: "environment",
+        operator: "any of",
+        value: ["prd"],
+        type: "stringOptions",
+      },
+      {
+        column: "type",
+        operator: "any of",
+        value: ["GENERATION"],
+        type: "stringOptions",
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/features/monitors/processor/processor.ts
+++ b/packages/shared/src/features/monitors/processor/processor.ts
@@ -15,7 +15,6 @@ import {
   type TriggerDomainWithActions,
 } from "../../../server/repositories/automation-repository";
 import { executeQuery as defaultExecuteQuery } from "../../query/server/queryExecutor";
-import type { QueryType } from "../../query/types";
 import { isValidQuery } from "../isValidQuery";
 import {
   MonitorQueueEventSchema,
@@ -36,6 +35,12 @@ import {
 } from "../types";
 import { applyStateMachine, type MonitorCompletion } from "./applyStateMachine";
 import { computeSeverity } from "./computeSeverity";
+import {
+  buildMonitorQuery,
+  groupMonitorsByFilters,
+  metricsForMonitorIds,
+  monitorMetricsForEvent,
+} from "./processorQueryHelpers";
 import { renderAlertMessage } from "./renderAlertMessage";
 
 export { monitorEvaluationOffsetMs } from "../types";
@@ -62,9 +67,9 @@ export class MonitorProcessor {
       span.setAttribute("monitors", monitors.length);
       if (monitors.length === 0) return;
 
-      const [metrics, triggers] = await Promise.all([
+      const [metricsByMonitorId, triggers] = await Promise.all([
         instrumentAsync({ name: "queryMetrics" }, () =>
-          this.queryMetrics(event),
+          this.queryMetrics(event, monitors),
         ),
         instrumentAsync({ name: "getTriggerConfigurations" }, () =>
           this.getTriggerConfigurations({
@@ -75,7 +80,13 @@ export class MonitorProcessor {
         ),
       ]);
 
-      span.setAttribute("metrics", Object.keys(metrics).length);
+      span.setAttribute(
+        "metrics",
+        Object.values(metricsByMonitorId).reduce(
+          (count, metrics) => count + Object.keys(metrics).length,
+          0,
+        ),
+      );
       span.setAttribute("triggers", triggers.length);
 
       const [completions, monitorWebhookInputs] = instrumentSync(
@@ -83,7 +94,7 @@ export class MonitorProcessor {
         () =>
           processMonitors({
             monitors,
-            metrics,
+            metricsByMonitorId,
             triggers,
             now,
             runAt: event.runAt,
@@ -136,58 +147,77 @@ export class MonitorProcessor {
     return prismaMonitors.map(monitorFromPrisma);
   }
 
-  /** queryMetrics pre-screens the batch's metrics against the v2 data model, runs the accepted ones, and returns each metric keyed by `${aggregation}_${measure}` as a number, null, or the ErrorBadQuery sentinel. */
-  private async queryMetrics(event: MonitorQueueEvent): Promise<MetricMap> {
-    const validation = isValidQuery({
-      view: event.view,
-      metrics: event.metrics,
-      filters: event.filters,
-    });
-    const metricMap: MetricMap = {};
-    for (const metric of validation.rejected) {
-      metricMap[metricKey(metric)] = ErrorBadQuery;
-    }
-    if (validation.accepted.length === 0) return metricMap;
+  /** queryMetrics pre-screens each monitor group's metrics against the v2 data model, runs the accepted ones with that monitor's stored filters, and returns each monitor's metrics keyed by `${aggregation}_${measure}` as a number, null, or the ErrorBadQuery sentinel. */
+  private async queryMetrics(
+    event: MonitorQueueEvent,
+    monitors: Monitor[],
+  ): Promise<MetricsByMonitorId> {
+    const metricsByMonitorId: MetricsByMonitorId = {};
+    const monitorMetrics = monitorMetricsForEvent(event, monitors);
+    const groups = groupMonitorsByFilters(monitors);
 
-    try {
-      const rows = await this.executeQuery(
-        event.projectId,
-        buildMonitorQuery(validation.accepted, event),
-        "v2",
-        true,
-      );
-      const row = (rows[0] ?? {}) as Record<string, unknown>;
-      for (const metric of validation.accepted) {
-        const key = metricKey(metric);
-        metricMap[key] = parseNumericValue(row[key]);
+    for (const group of groups) {
+      const metrics = metricsForMonitorIds(monitorMetrics, group.monitorIds);
+      const validation = isValidQuery({
+        view: event.view,
+        metrics,
+        filters: group.filters,
+      });
+
+      const metricMap: MetricMap = {};
+      for (const monitorId of group.monitorIds) {
+        metricsByMonitorId[monitorId] = metricMap;
       }
-      metricMap["count_count"] = parseNumericValue(row["count_count"]);
-    } catch (error) {
-      // Resource pressure is transient, not a bad query; rethrow so the monitor stays ACTIVE and the scheduler retries.
-      if (error instanceof ClickHouseResourceError) {
-        logger.warn("queryMetrics hit a ClickHouse resource limit; retrying", {
-          errorType: error.errorType,
-          projectId: event.projectId,
-          schedulerBatchId: event.schedulerBatchId.toString(),
-          monitorIds: event.monitors.map((m) => m.monitorId),
-        });
-        throw error;
-      }
-      logger.error(
-        "queryMetrics failed; flipping affected monitors to ERROR_BAD_QUERY",
-        {
-          projectId: event.projectId,
-          schedulerBatchId: event.schedulerBatchId.toString(),
-          monitorIds: event.monitors.map((m) => m.monitorId),
-          error,
-        },
-      );
-      for (const metric of validation.accepted) {
+
+      for (const metric of validation.rejected) {
         metricMap[metricKey(metric)] = ErrorBadQuery;
       }
-      metricMap["count_count"] = ErrorBadQuery;
+      if (validation.accepted.length === 0) continue;
+
+      try {
+        const rows = await this.executeQuery(
+          event.projectId,
+          buildMonitorQuery(validation.accepted, event, group.filters),
+          "v2",
+          true,
+        );
+        const row = (rows[0] ?? {}) as Record<string, unknown>;
+        for (const metric of validation.accepted) {
+          const key = metricKey(metric);
+          metricMap[key] = parseNumericValue(row[key]);
+        }
+        metricMap["count_count"] = parseNumericValue(row["count_count"]);
+      } catch (error) {
+        // Resource pressure is transient, not a bad query; rethrow so the monitor stays ACTIVE and the scheduler retries.
+        if (error instanceof ClickHouseResourceError) {
+          logger.warn(
+            "queryMetrics hit a ClickHouse resource limit; retrying",
+            {
+              errorType: error.errorType,
+              projectId: event.projectId,
+              schedulerBatchId: event.schedulerBatchId.toString(),
+              monitorIds: group.monitorIds,
+            },
+          );
+          throw error;
+        }
+        logger.error(
+          "queryMetrics failed; flipping affected monitors to ERROR_BAD_QUERY",
+          {
+            projectId: event.projectId,
+            schedulerBatchId: event.schedulerBatchId.toString(),
+            monitorIds: group.monitorIds,
+            error,
+          },
+        );
+        for (const metric of validation.accepted) {
+          metricMap[metricKey(metric)] = ErrorBadQuery;
+        }
+        metricMap["count_count"] = ErrorBadQuery;
+      }
     }
-    return metricMap;
+
+    return metricsByMonitorId;
   }
 
   private async publishWebhookInputs(
@@ -211,42 +241,6 @@ export class MonitorProcessor {
       }),
     );
   }
-}
-
-/** buildMonitorQuery converts the accepted metrics of a MonitorQueueEvent into the scalar QueryType executeQuery accepts. */
-function buildMonitorQuery(
-  acceptedMetrics: QueryType["metrics"],
-  event: MonitorQueueEvent,
-): QueryType {
-  const { fromTimestamp, toTimestamp } = evaluationWindow(
-    event.window,
-    event.runAt,
-  );
-  const metrics = dedupeMetrics([
-    ...acceptedMetrics,
-    { measure: "count", aggregation: "count" as const },
-  ]);
-  return {
-    view: event.view,
-    dimensions: [],
-    metrics,
-    filters: event.filters,
-    timeDimension: null,
-    fromTimestamp: fromTimestamp.toISOString(),
-    toTimestamp: toTimestamp.toISOString(),
-    orderBy: null,
-  };
-}
-
-/** dedupeMetrics drops duplicate metrics keyed by `${aggregation}_${measure}` so the appended row-count metric never collides with an existing count metric. */
-function dedupeMetrics(metrics: QueryType["metrics"]): QueryType["metrics"] {
-  const seen = new Set<string>();
-  return metrics.filter((m) => {
-    const key = metricKey(m);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
 }
 
 /** metricKey is the `${aggregation}_${measure}` column name a metric resolves to in the query result row. */
@@ -279,7 +273,7 @@ function parseNumericValue(raw: unknown): number | null {
 /** processMonitors evaluates every claimed monitor, collecting the completions to persist and the webhook inputs to publish. */
 function processMonitors(args: {
   monitors: Monitor[];
-  metrics: MetricMap;
+  metricsByMonitorId: MetricsByMonitorId;
   triggers: TriggerDomainWithActions[];
   now: Date;
   runAt: Date;
@@ -290,7 +284,7 @@ function processMonitors(args: {
   for (const monitor of args.monitors) {
     const [completion, inputs] = processMonitor({
       monitor,
-      metrics: args.metrics,
+      metrics: args.metricsByMonitorId[monitor.id] ?? {},
       triggers: args.triggers,
       now: args.now,
       runAt: args.runAt,
@@ -520,6 +514,9 @@ export type MetricValue = number | null | typeof ErrorBadQuery;
 
 /** MetricMap keys each metric's MetricValue by `${aggregation}_${measure}`. */
 type MetricMap = Record<string, MetricValue>;
+
+/** MetricsByMonitorId maps each claimed monitor id to its evaluated metric map. */
+type MetricsByMonitorId = Record<string, MetricMap>;
 
 /** MonitorPublisher publishes one MonitorWebhookInput onto the webhook queue. */
 export type MonitorPublisher = (input: MonitorWebhookInput) => Promise<void>;

--- a/packages/shared/src/features/monitors/processor/processorQueryHelpers.ts
+++ b/packages/shared/src/features/monitors/processor/processorQueryHelpers.ts
@@ -1,0 +1,132 @@
+import type { QueryType } from "../../query/types";
+import { sortFiltersCanonically } from "../service/helpers";
+import type { Monitor } from "../types";
+import type { MonitorQueueEvent } from "../scheduler/types";
+import { monitorEvaluationOffsetMs, windowToMs } from "../types";
+
+/** buildMonitorQuery converts the accepted metrics of a MonitorQueueEvent into the scalar QueryType executeQuery accepts. */
+export function buildMonitorQuery(
+  acceptedMetrics: QueryType["metrics"],
+  event: MonitorQueueEvent,
+  filters: Monitor["filters"],
+): QueryType {
+  const { fromTimestamp, toTimestamp } = evaluationWindow(
+    event.window,
+    event.runAt,
+  );
+  const metrics = dedupeMetrics([
+    ...acceptedMetrics,
+    { measure: "count", aggregation: "count" as const },
+  ]);
+  return {
+    view: event.view,
+    dimensions: [],
+    metrics,
+    filters,
+    timeDimension: null,
+    fromTimestamp: fromTimestamp.toISOString(),
+    toTimestamp: toTimestamp.toISOString(),
+    orderBy: null,
+  };
+}
+
+/** filtersFingerprint canonicalizes a monitor's filters for stable group-by keys. */
+export function filtersFingerprint(filters: Monitor["filters"]): string {
+  return JSON.stringify(sortFiltersCanonically(filters));
+}
+
+/** MonitorFilterGroup is one distinct filter set and the monitors that share it. */
+export type MonitorFilterGroup = {
+  filters: Monitor["filters"];
+  monitorIds: string[];
+};
+
+/** groupMonitorsByFilters buckets claimed monitors by their stored filter set so each query uses the monitor's own filters rather than the scheduler batch aggregate. */
+export function groupMonitorsByFilters(
+  monitors: Monitor[],
+): MonitorFilterGroup[] {
+  const groups = new Map<string, MonitorFilterGroup>();
+  for (const monitor of monitors) {
+    const fingerprint = filtersFingerprint(monitor.filters);
+    const existing = groups.get(fingerprint);
+    if (existing) {
+      existing.monitorIds.push(monitor.id);
+      continue;
+    }
+    groups.set(fingerprint, {
+      filters: monitor.filters,
+      monitorIds: [monitor.id],
+    });
+  }
+  return [...groups.values()];
+}
+
+/** monitorMetricsForEvent maps each claimed monitor id to the metric row it evaluates. */
+export function monitorMetricsForEvent(
+  event: MonitorQueueEvent,
+  monitors: Monitor[],
+): Map<string, Monitor["metric"]> {
+  const metricByName = new Map(
+    event.monitors.map((monitor) => [monitor.monitorId, monitor.metricName]),
+  );
+  const metricsByMonitorId = new Map<string, Monitor["metric"]>();
+  for (const monitor of monitors) {
+    const metricName = metricByName.get(monitor.id);
+    if (!metricName) continue;
+    const [aggregation, measure] = metricName.split("_", 2);
+    if (!aggregation || !measure) continue;
+    metricsByMonitorId.set(monitor.id, {
+      aggregation: aggregation as Monitor["metric"]["aggregation"],
+      measure,
+    });
+  }
+  return metricsByMonitorId;
+}
+
+/** metricsForMonitorIds dedupes the metrics needed by the monitors in one filter group. */
+export function metricsForMonitorIds(
+  monitorMetrics: Map<string, Monitor["metric"]>,
+  monitorIds: string[],
+): QueryType["metrics"] {
+  const seen = new Set<string>();
+  const metrics: QueryType["metrics"] = [];
+  for (const monitorId of monitorIds) {
+    const metric = monitorMetrics.get(monitorId);
+    if (!metric) continue;
+    const key = metricKey(metric);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    metrics.push(metric);
+  }
+  return metrics;
+}
+
+/** dedupeMetrics drops duplicate metrics keyed by `${aggregation}_${measure}` so the appended row-count metric never collides with an existing count metric. */
+function dedupeMetrics(metrics: QueryType["metrics"]): QueryType["metrics"] {
+  const seen = new Set<string>();
+  return metrics.filter((m) => {
+    const key = metricKey(m);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/** metricKey is the `${aggregation}_${measure}` column name a metric resolves to in the query result row. */
+function metricKey(metric: { measure: string; aggregation: string }): string {
+  return `${metric.aggregation}_${metric.measure}`;
+}
+
+/** evaluationWindow returns the `[runAt - window, runAt]` edges, both shifted back by monitorEvaluationOffsetMs. */
+function evaluationWindow(
+  window: MonitorQueueEvent["window"],
+  runAt: Date,
+): {
+  fromTimestamp: Date;
+  toTimestamp: Date;
+} {
+  const windowMs = Number(windowToMs(window));
+  const toTimestamp = new Date(runAt.getTime() - monitorEvaluationOffsetMs);
+  const fromTimestamp = new Date(toTimestamp.getTime() - windowMs);
+  return { fromTimestamp, toTimestamp };
+}

--- a/packages/shared/src/features/monitors/scheduler/scheduler.ts
+++ b/packages/shared/src/features/monitors/scheduler/scheduler.ts
@@ -183,7 +183,7 @@ function buildScheduleQuery({
       scheduler_batch_id,
       MAX(run_at)                  AS run_at,
       (array_agg(view))[1]         AS view,
-      (array_agg(filters))[1]      AS filters,
+      (array_agg(filters ORDER BY id))[1]      AS filters,
       (array_agg(window_ms))[1]    AS window_ms,
       array_agg(DISTINCT metric)   AS metrics,
       array_agg(

--- a/worker/src/__tests__/monitorProcessor.test.ts
+++ b/worker/src/__tests__/monitorProcessor.test.ts
@@ -47,6 +47,7 @@ type SeedOverrides = Partial<{
   status: MonitorStatus;
   view: MonitorView;
   metric: Metric;
+  filters: Prisma.InputJsonValue;
   alertThreshold: number;
   warningThreshold: number | null;
   thresholdOperator: ThresholdOperator;
@@ -148,7 +149,7 @@ async function seedMonitor(projectId: string, seed: MonitorSeed) {
       id: seed.id,
       projectId,
       view: seed.view ?? "OBSERVATIONS",
-      filters: [] as unknown as Prisma.InputJsonValue,
+      filters: (seed.filters ?? []) as unknown as Prisma.InputJsonValue,
       metric: (seed.metric ?? {
         measure: "count",
         aggregation: "count",
@@ -186,6 +187,7 @@ async function seedMonitor(projectId: string, seed: MonitorSeed) {
 function makeEvent(
   projectId: string,
   monitors: (string | { id: string; metric?: Metric })[],
+  overrides: Partial<MonitorQueueEvent> = {},
 ): MonitorQueueEvent {
   const seeds = monitors.map((m) =>
     typeof m === "string" ? { id: m, metric: undefined } : m,
@@ -217,6 +219,7 @@ function makeEvent(
         metricName: `${metric.aggregation}_${metric.measure}`,
       };
     }),
+    ...overrides,
   };
 }
 
@@ -1464,6 +1467,116 @@ describe("MonitorProcessor.process (integration)", () => {
         exp.lastCompletedAt?.toISOString() ?? null,
       );
     }
+  });
+});
+
+describe("MonitorProcessor.process per-monitor filters", () => {
+  let projectId: string;
+
+  beforeAll(async () => {
+    const org = await createOrgProjectAndApiKey();
+    projectId = org.projectId;
+  });
+
+  afterEach(async () => {
+    await prisma.monitor.deleteMany({ where: { projectId } });
+  });
+
+  it("evaluates each monitor with its stored filters even when the queue event carries a different batch filter set", async () => {
+    const envOnlyId = `m_env_${v4()}`;
+    const envAndTypeId = `m_env_type_${v4()}`;
+    const envFilter = {
+      column: "environment",
+      operator: "any of",
+      value: ["prd"],
+      type: "stringOptions",
+    };
+    const typeFilter = {
+      column: "type",
+      operator: "any of",
+      value: ["GENERATION"],
+      type: "stringOptions",
+    };
+
+    await seedMonitor(projectId, {
+      id: envOnlyId,
+      schedulerBatchId: 7n,
+      severity: MonitorSeveritySchema.enum.UNKNOWN,
+      lastPublishedAt: runAt,
+      triggerIds: ["trig_filters"],
+      filters: [envFilter],
+      metric: { measure: "latency", aggregation: "p95" },
+      alertThreshold: 500,
+    });
+    await seedMonitor(projectId, {
+      id: envAndTypeId,
+      schedulerBatchId: 7n,
+      severity: MonitorSeveritySchema.enum.UNKNOWN,
+      lastPublishedAt: runAt,
+      triggerIds: ["trig_filters"],
+      filters: [envFilter, typeFilter],
+      metric: { measure: "latency", aggregation: "p95" },
+      alertThreshold: 500,
+    });
+
+    const publish = vi.fn<MonitorPublisher>(async () => {});
+    const executeQuery: QueryExecutor = async (_projectId, query) => {
+      const hasTypeFilter = query.filters.some(
+        (filter) => filter.column === "type",
+      );
+      return [{ p95_latency: hasTypeFilter ? 49 : 900, count_count: 10 }];
+    };
+    const getTriggers: GetTriggerConfigurations = async () =>
+      [
+        {
+          id: "trig_filters",
+          filter: matchAnyAlertTrigger.filter,
+          eventActions: [],
+          automations: [{ id: "auto_filters", actionId: "act_filters" }],
+        },
+      ] as unknown as Awaited<ReturnType<GetTriggerConfigurations>>;
+
+    const processor = new MonitorProcessor(
+      prisma,
+      publish,
+      executeQuery,
+      getTriggers,
+    );
+
+    const event = makeEvent(
+      projectId,
+      [
+        { id: envOnlyId, metric: { measure: "latency", aggregation: "p95" } },
+        {
+          id: envAndTypeId,
+          metric: { measure: "latency", aggregation: "p95" },
+        },
+      ],
+      {
+        schedulerBatchId: 7n,
+        filters: [envFilter],
+        metrics: [{ measure: "latency", aggregation: "p95" }],
+      },
+    );
+
+    await processor.process(event, justAfterRunAt);
+
+    const envOnly = await prisma.monitor.findUniqueOrThrow({
+      where: { id: envOnlyId },
+    });
+    const envAndType = await prisma.monitor.findUniqueOrThrow({
+      where: { id: envAndTypeId },
+    });
+
+    expect(envOnly.severity).toBe(MonitorSeveritySchema.enum.ALERT);
+    expect(envAndType.severity).toBe(MonitorSeveritySchema.enum.OK);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0].payload).toMatchObject({
+      payload: {
+        monitorId: envOnlyId,
+        severity: MonitorSeveritySchema.enum.ALERT,
+      },
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #16630

## Problem

Alert/monitor evaluation used a single shared `event.filters` payload per scheduler batch. When monitors in the same batch had different filter sets (e.g. `environment=prd` only vs `environment=prd` + `Type=GENERATION`), every monitor was evaluated against whichever filter set the scheduler aggregated first. Live Preview used the correct per-monitor filters, so the chart looked right while notifications fired on unfiltered data.

## Solution

- Group claimed monitors by their persisted `filters` before querying ClickHouse
- Run one query per distinct filter set and evaluate each monitor against its own results
- Make scheduler filter aggregation deterministic with `array_agg(filters ORDER BY id)`

## Testing

- Added unit tests for filter grouping and query construction (`processor.filters.test.ts`)
- Added integration test case in `monitorProcessor.test.ts` for mismatched batch vs monitor filters
- All 281 monitor unit tests in `@langfuse/shared` pass locally

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes monitor processing to query each distinct persisted filter set independently, preventing monitors in one scheduler batch from sharing incorrectly filtered results.
- Groups claimed monitors by canonicalized stored filters.
- Builds and executes one ClickHouse query per filter group.
- Maps query results back to individual monitors.
- Makes scheduler filter selection deterministic and adds focused unit and integration coverage.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed behavior.

The processor consistently validates, queries, and maps metrics per persisted filter group, while preserving existing error handling and monitor state-machine behavior.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Scheduler batch event] --> B[Claim current monitors]
  B --> C[Group by persisted filters]
  C --> D1[Filter group A query]
  C --> D2[Filter group B query]
  D1 --> E[Metrics by monitor ID]
  D2 --> E
  E --> F[Evaluate each monitor]
  F --> G[Persist severity and publish notifications]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(monitors): evaluate alerts with each..."](https://github.com/langfuse/langfuse/commit/58d628bab9c3c4b1f65a4adfb0c0862c29e5d885) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57599235)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)
- Knowledge Base — [Analytics and query data](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/analytics-query-data.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)
</details>


<!-- /greptile_comment -->