### PR TITLE
fix(posthog): disable product analytics in the HIPAA region

### DIFF
--- a/.agents/skills/posthog-instrumentation/SKILL.md
+++ b/.agents/skills/posthog-instrumentation/SKILL.md
@@ -57,6 +57,13 @@ should emit an event — do not skip the question silently.
   `ServerPosthog` (e.g. `cloud_signup_complete`, playground analytics) with
   event names distinct from any frontend event — keep it that way; reusing a
   name across client and server double-counts.
+- **The HIPAA region runs NO product analytics.** Both entry points gate on
+  [`productAnalyticsAvailability.ts`](../../../web/src/features/posthog-analytics/productAnalyticsAvailability.ts):
+  the browser SDK is only initialized when `getPostHogClientConfig()` returns a
+  config, and `ServerPosthog` builds no client when
+  `isProductAnalyticsAvailable()` is false. Missing env vars are NOT a gate —
+  `ServerPosthog` falls back to Langfuse's telemetry key. Never add a per-call-site
+  region list, and never construct a PostHog client that bypasses that module.
 
 ## The 6 rules (each earned the hard way on LFE-10781 / PR #14929)
 
@@ -127,8 +134,9 @@ renderer that can display customer-controlled data:
 1. **Allowlist eligible deployments.** Keep replay disabled by default and
    enable it only in explicitly approved hosted regions. A configured PostHog
    key is not proof that a deployment is eligible. In Langfuse, replay remains
-   disabled when the cloud region is absent and in the HIPAA region; cover an
-   eligible region, HIPAA, and no cloud region in config tests.
+   disabled when the cloud region is absent, and the HIPAA region initializes no
+   PostHog client at all; cover an eligible region, HIPAA, and no cloud region
+   in config tests.
 2. **Classify by data provenance, not HTML element.** Customer-controlled data
    includes trace/observation payloads, dataset items, prompts, generated
    output, evaluator/code input, identifiers, comments, names, tags, metadata,

--- a/.agents/skills/posthog-instrumentation/SKILL.md
+++ b/.agents/skills/posthog-instrumentation/SKILL.md
@@ -59,11 +59,14 @@ should emit an event — do not skip the question silently.
   name across client and server double-counts.
 - **The HIPAA region runs NO product analytics.** Both entry points gate on
   [`productAnalyticsAvailability.ts`](../../../web/src/features/posthog-analytics/productAnalyticsAvailability.ts):
-  the browser SDK is only initialized when `getPostHogClientConfig()` returns a
-  config, and `ServerPosthog` builds no client when
-  `isProductAnalyticsAvailable()` is false. Missing env vars are NOT a gate —
-  `ServerPosthog` falls back to Langfuse's telemetry key. Never add a per-call-site
-  region list, and never construct a PostHog client that bypasses that module.
+  the browser SDK (`posthog-js`) is only initialized when
+  `getPostHogClientConfig()` returns a config — `init()` itself fetches remote
+  config, so skip it rather than opting out after. The server SDK
+  (`posthog-node`, via `ServerPosthog`) is constructed as usual, then
+  `disable()`d when `isProductAnalyticsAvailable()` is false. Missing env vars
+  are NOT a gate — `ServerPosthog` falls back to Langfuse's telemetry key.
+  Never add a per-call-site region list, and never construct a PostHog client
+  that bypasses that module.
 
 ## The 6 rules (each earned the hard way on LFE-10781 / PR #14929)
 

--- a/web/src/__tests__/posthog-product-analytics-region.clienttest.ts
+++ b/web/src/__tests__/posthog-product-analytics-region.clienttest.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+/**
+ * Product-analytics region gate (browser half).
+ *
+ * The HIPAA cloud region runs no Langfuse product analytics at all, so the
+ * PostHog browser SDK must never be initialized there — not even when the
+ * deployment carries a PostHog key/host. Every other deployment keeps its
+ * current behaviour, which is what the positive cases below pin down.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { postHogInitMock } = vi.hoisted(() => ({
+  postHogInitMock: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: postHogInitMock,
+  },
+}));
+
+vi.mock("posthog-js/react", () => ({
+  PostHogProvider: vi.fn(),
+}));
+
+const importAppShell = async () => {
+  vi.resetModules();
+  await import("@/src/pages/_app");
+};
+
+// Every region that keeps product analytics, plus self-hosted (region unset).
+const ANALYTICS_ENABLED_REGIONS: (string | undefined)[] = [
+  "US",
+  "EU",
+  "JP",
+  "STAGING",
+  undefined,
+];
+
+describe("PostHog product analytics region gate", () => {
+  beforeEach(() => {
+    postHogInitMock.mockClear();
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.i.posthog.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("never initializes PostHog in the HIPAA cloud region", async () => {
+    vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", "HIPAA");
+
+    await importAppShell();
+
+    expect(postHogInitMock).not.toHaveBeenCalled();
+  });
+
+  it.each(ANALYTICS_ENABLED_REGIONS)(
+    "initializes PostHog in region %s",
+    async (region) => {
+      vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", region);
+
+      await importAppShell();
+
+      expect(postHogInitMock).toHaveBeenCalledTimes(1);
+      expect(postHogInitMock).toHaveBeenCalledWith(
+        "phc_test",
+        expect.objectContaining({ api_host: "https://eu.i.posthog.com" }),
+      );
+    },
+  );
+});

--- a/web/src/__tests__/posthog-session-replay-mask.clienttest.ts
+++ b/web/src/__tests__/posthog-session-replay-mask.clienttest.ts
@@ -42,16 +42,17 @@ describe("PostHog session replay privacy", () => {
     expect(config.disable_session_recording).toBe(false);
   });
 
-  it("disables session recording in the HIPAA cloud region", async () => {
+  // Stronger than disabling the recorder: the HIPAA region runs no product
+  // analytics at all, so there is no PostHog client to record with. The wider
+  // region gate lives in posthog-product-analytics-region.clienttest.ts.
+  it("initializes no PostHog client in the HIPAA cloud region", async () => {
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://us.i.posthog.com");
     vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", "HIPAA");
 
     await import("@/src/pages/_app");
 
-    expect(initMock).toHaveBeenCalledTimes(1);
-    const config = initMock.mock.calls[0]![1] as Partial<PostHogConfig>;
-    expect(config.disable_session_recording).toBe(true);
+    expect(initMock).not.toHaveBeenCalled();
   });
 
   it("disables session recording outside Langfuse Cloud", async () => {

--- a/web/src/__tests__/server/unit/serverPosthog.servertest.ts
+++ b/web/src/__tests__/server/unit/serverPosthog.servertest.ts
@@ -5,25 +5,35 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
  *
  * `ServerPosthog` is the single server-side entry point for Langfuse product
  * analytics (signup conversion, backend activity, self-host telemetry). In the
- * HIPAA cloud region it must never construct a PostHog client, so no capture
- * from any of those call sites can leave the deployment.
+ * HIPAA cloud region it still constructs a `posthog-node` client, then opts it
+ * out with `disable()` so capture becomes a no-op. That is enough on the
+ * server: unlike the browser SDK, disable does not phone home.
  */
 
-const { postHogConstructor, captureMock, shutdownMock, flushMock } = vi.hoisted(
-  () => ({
-    postHogConstructor: vi.fn(),
-    captureMock: vi.fn(),
-    shutdownMock: vi.fn().mockResolvedValue(undefined),
-    flushMock: vi.fn().mockResolvedValue(undefined),
-  }),
-);
+const {
+  postHogConstructor,
+  captureMock,
+  disableMock,
+  shutdownMock,
+  flushMock,
+} = vi.hoisted(() => ({
+  postHogConstructor: vi.fn(),
+  captureMock: vi.fn(),
+  disableMock: vi.fn().mockResolvedValue(undefined),
+  shutdownMock: vi.fn().mockResolvedValue(undefined),
+  flushMock: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("posthog-node", () => ({
   PostHog: class {
     constructor(...args: unknown[]) {
       postHogConstructor(...args);
     }
-    capture = captureMock;
+    capture = (...args: unknown[]) => {
+      if (disableMock.mock.calls.length > 0) return;
+      captureMock(...args);
+    };
+    disable = disableMock;
     shutdown = shutdownMock;
     flush = flushMock;
     debug = vi.fn();
@@ -46,6 +56,7 @@ describe("ServerPosthog product analytics region gate", () => {
   beforeEach(() => {
     postHogConstructor.mockClear();
     captureMock.mockClear();
+    disableMock.mockClear();
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.i.posthog.com");
   });
@@ -54,7 +65,7 @@ describe("ServerPosthog product analytics region gate", () => {
     vi.unstubAllEnvs();
   });
 
-  it("captures nothing in the HIPAA cloud region", async () => {
+  it("disables the client in the HIPAA cloud region so capture is a no-op", async () => {
     vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", "HIPAA");
 
     const posthog = await loadServerPosthog();
@@ -62,11 +73,12 @@ describe("ServerPosthog product analytics region gate", () => {
     await posthog.flush();
     await posthog.shutdown();
 
-    expect(postHogConstructor).not.toHaveBeenCalled();
+    expect(postHogConstructor).toHaveBeenCalledTimes(1);
+    expect(disableMock).toHaveBeenCalledTimes(1);
     expect(captureMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to no client in HIPAA even when telemetry defaults would apply", async () => {
+  it("still disables the HIPAA client when it is built from the telemetry fallback", async () => {
     vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", "HIPAA");
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", undefined);
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", undefined);
@@ -74,7 +86,8 @@ describe("ServerPosthog product analytics region gate", () => {
     const posthog = await loadServerPosthog();
     posthog.capture(captureArgs);
 
-    expect(postHogConstructor).not.toHaveBeenCalled();
+    expect(postHogConstructor).toHaveBeenCalledTimes(1);
+    expect(disableMock).toHaveBeenCalledTimes(1);
     expect(captureMock).not.toHaveBeenCalled();
   });
 
@@ -85,6 +98,7 @@ describe("ServerPosthog product analytics region gate", () => {
     posthog.capture(captureArgs);
 
     expect(postHogConstructor).toHaveBeenCalledTimes(1);
+    expect(disableMock).not.toHaveBeenCalled();
     expect(captureMock).toHaveBeenCalledWith(captureArgs);
   });
 });

--- a/web/src/__tests__/server/unit/serverPosthog.servertest.ts
+++ b/web/src/__tests__/server/unit/serverPosthog.servertest.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Product-analytics region gate (server half).
+ *
+ * `ServerPosthog` is the single server-side entry point for Langfuse product
+ * analytics (signup conversion, backend activity, self-host telemetry). In the
+ * HIPAA cloud region it must never construct a PostHog client, so no capture
+ * from any of those call sites can leave the deployment.
+ */
+
+const { postHogConstructor, captureMock, shutdownMock, flushMock } = vi.hoisted(
+  () => ({
+    postHogConstructor: vi.fn(),
+    captureMock: vi.fn(),
+    shutdownMock: vi.fn().mockResolvedValue(undefined),
+    flushMock: vi.fn().mockResolvedValue(undefined),
+  }),
+);
+
+vi.mock("posthog-node", () => ({
+  PostHog: class {
+    constructor(...args: unknown[]) {
+      postHogConstructor(...args);
+    }
+    capture = captureMock;
+    shutdown = shutdownMock;
+    flush = flushMock;
+    debug = vi.fn();
+  },
+}));
+
+const loadServerPosthog = async () => {
+  vi.resetModules();
+  const { ServerPosthog } =
+    await import("@/src/features/posthog-analytics/ServerPosthog");
+  return new ServerPosthog();
+};
+
+const captureArgs = {
+  distinctId: "user-1",
+  event: "backend:activity",
+} as const;
+
+describe("ServerPosthog product analytics region gate", () => {
+  beforeEach(() => {
+    postHogConstructor.mockClear();
+    captureMock.mockClear();
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.i.posthog.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("captures nothing in the HIPAA cloud region", async () => {
+    vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", "HIPAA");
+
+    const posthog = await loadServerPosthog();
+    posthog.capture(captureArgs);
+    await posthog.flush();
+    await posthog.shutdown();
+
+    expect(postHogConstructor).not.toHaveBeenCalled();
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to no client in HIPAA even when telemetry defaults would apply", async () => {
+    vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", "HIPAA");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", undefined);
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", undefined);
+
+    const posthog = await loadServerPosthog();
+    posthog.capture(captureArgs);
+
+    expect(postHogConstructor).not.toHaveBeenCalled();
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it.each([["US"], ["EU"], ["JP"]])("keeps capturing in %s", async (region) => {
+    vi.stubEnv("NEXT_PUBLIC_LANGFUSE_CLOUD_REGION", region);
+
+    const posthog = await loadServerPosthog();
+    posthog.capture(captureArgs);
+
+    expect(postHogConstructor).toHaveBeenCalledTimes(1);
+    expect(captureMock).toHaveBeenCalledWith(captureArgs);
+  });
+});

--- a/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
+++ b/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
@@ -2,7 +2,6 @@ import { env } from "@/src/env.mjs";
 import { prisma, Role } from "@langfuse/shared/src/db";
 import { logger } from "@langfuse/shared/src/server";
 import { ServerPosthog } from "@/src/features/posthog-analytics/ServerPosthog";
-import { isProductAnalyticsAvailable } from "@/src/features/posthog-analytics/productAnalyticsAvailability";
 import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
 import { getOrganizationPlanServerSide } from "@/src/features/entitlements/server/getPlan";
 import { shouldAutoEnableV4 } from "@/src/features/events/lib/v4Rollout";
@@ -284,15 +283,14 @@ export async function createProjectMembershipsOnSignup(
 
     // for conversion metric tracking in posthog: did a new user sign up?
     // Fires on all production cloud regions, including ones added in the
-    // future. STAGING/DEV are excluded to keep test signups out of conversion
-    // metrics, regions that run no product analytics (HIPAA) are excluded by
-    // isProductAnalyticsAvailable, and self-hosted deployments never emit this
-    // event as the region env is unset.
+    // future. STAGING/DEV are excluded to keep test signups out of
+    // conversion metrics, and self-hosted deployments never emit this
+    // event as the region env is unset. HIPAA still constructs ServerPosthog
+    // here; the client is opted out via disable() so the capture is a no-op.
     if (
       isNewUser &&
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
-      !["STAGING", "DEV"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) &&
-      isProductAnalyticsAvailable()
+      !["STAGING", "DEV"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
     ) {
       try {
         const posthog = new ServerPosthog();

--- a/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
+++ b/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
@@ -2,6 +2,7 @@ import { env } from "@/src/env.mjs";
 import { prisma, Role } from "@langfuse/shared/src/db";
 import { logger } from "@langfuse/shared/src/server";
 import { ServerPosthog } from "@/src/features/posthog-analytics/ServerPosthog";
+import { isProductAnalyticsAvailable } from "@/src/features/posthog-analytics/productAnalyticsAvailability";
 import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
 import { getOrganizationPlanServerSide } from "@/src/features/entitlements/server/getPlan";
 import { shouldAutoEnableV4 } from "@/src/features/events/lib/v4Rollout";
@@ -283,16 +284,15 @@ export async function createProjectMembershipsOnSignup(
 
     // for conversion metric tracking in posthog: did a new user sign up?
     // Fires on all production cloud regions, including ones added in the
-    // future. STAGING/DEV are excluded to keep test signups out of
-    // conversion metrics, HIPAA is excluded deliberately to keep product
-    // analytics off that deployment, and self-hosted deployments never emit
-    // this event as the region env is unset.
+    // future. STAGING/DEV are excluded to keep test signups out of conversion
+    // metrics, regions that run no product analytics (HIPAA) are excluded by
+    // isProductAnalyticsAvailable, and self-hosted deployments never emit this
+    // event as the region env is unset.
     if (
       isNewUser &&
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
-      !["STAGING", "DEV", "HIPAA"].includes(
-        env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-      )
+      !["STAGING", "DEV"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) &&
+      isProductAnalyticsAvailable()
     ) {
       try {
         const posthog = new ServerPosthog();

--- a/web/src/features/auth/lib/signOut.ts
+++ b/web/src/features/auth/lib/signOut.ts
@@ -1,6 +1,7 @@
 import { signOut } from "next-auth/react";
 import posthog from "posthog-js";
 import { env } from "@/src/env.mjs";
+import { isPostHogClientEnabled } from "@/src/features/posthog-analytics/productAnalyticsAvailability";
 import { clearV4BetaEnabledSentryTag } from "@/src/utils/sentryV4BetaTag";
 
 /**
@@ -19,7 +20,7 @@ export const signOutCleanly = async () => {
   // see `unauthenticated`. Drop the pageload cache here so the sign-in
   // hard load is not tagged with the previous user's v4 state.
   clearV4BetaEnabledSentryTag();
-  if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
+  if (isPostHogClientEnabled()) {
     posthog.reset();
   }
   // On preview deployments the sign-in page signs visitors back in

--- a/web/src/features/posthog-analytics/ServerPosthog.ts
+++ b/web/src/features/posthog-analytics/ServerPosthog.ts
@@ -1,4 +1,5 @@
 import { env } from "@/src/env.mjs";
+import { isProductAnalyticsAvailable } from "@/src/features/posthog-analytics/productAnalyticsAvailability";
 import { PostHog } from "posthog-node";
 
 const FALLBACK_POSTHOG_KEY = "phc_zkMwFajk8ehObUlMth0D7DtPItFnxETi3lmSvyQDrwB";
@@ -8,6 +9,13 @@ export class ServerPosthog {
   private posthog: PostHog | null;
 
   constructor() {
+    // Regions that run no product analytics get no client at all, so every
+    // capture below is a no-op regardless of the configured key.
+    if (!isProductAnalyticsAvailable()) {
+      this.posthog = null;
+      return;
+    }
+
     const telemetryEnabled = env.TELEMETRY_ENABLED !== "false";
 
     const apiKey =

--- a/web/src/features/posthog-analytics/ServerPosthog.ts
+++ b/web/src/features/posthog-analytics/ServerPosthog.ts
@@ -7,15 +7,9 @@ const FALLBACK_POSTHOG_HOST = "https://eu.posthog.com";
 
 export class ServerPosthog {
   private posthog: PostHog | null;
+  private optOut: Promise<void> | undefined;
 
   constructor() {
-    // Regions that run no product analytics get no client at all, so every
-    // capture below is a no-op regardless of the configured key.
-    if (!isProductAnalyticsAvailable()) {
-      this.posthog = null;
-      return;
-    }
-
     const telemetryEnabled = env.TELEMETRY_ENABLED !== "false";
 
     const apiKey =
@@ -28,6 +22,13 @@ export class ServerPosthog {
     if (apiKey && host) {
       this.posthog = new PostHog(apiKey, { host });
       if (process.env.NODE_ENV === "development") this.posthog.debug();
+      // Unlike the browser SDK, posthog-node disable() is a local opt-out:
+      // capture becomes a no-op and nothing is sent. HIPAA uses this instead
+      // of skipping construction. The flag flips synchronously; the promise is
+      // kept so the constructor does not float it.
+      if (!isProductAnalyticsAvailable()) {
+        this.optOut = this.posthog.disable();
+      }
     } else {
       this.posthog = null;
     }
@@ -38,6 +39,7 @@ export class ServerPosthog {
   }
 
   async shutdown() {
+    await this.optOut;
     await this.posthog?.shutdown();
   }
 

--- a/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
+++ b/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
@@ -1,12 +1,13 @@
 /**
  * The one gate for Langfuse's own PostHog product analytics.
  *
- * PostHog is disabled altogether in the HIPAA cloud region: the browser SDK is
- * never initialized and the server client is never constructed, so no pageview,
- * identify, capture, signup conversion event or backend-activity event can
- * leave that deployment. Because `ServerPosthog` falls back to Langfuse's own
- * telemetry key when no key is configured, "just don't set the env vars" is not
- * a sufficient gate — the region check has to live in code.
+ * PostHog is disabled altogether in the HIPAA cloud region. The browser SDK is
+ * never initialized (init itself phones home). The server SDK is constructed
+ * as usual, then opted out with `disable()`, which is a local no-op on
+ * `posthog-node` and does not contact PostHog. Because `ServerPosthog` falls
+ * back to Langfuse's own telemetry key when no key is configured, "just don't
+ * set the env vars" is not a sufficient gate — the region check has to live
+ * in code.
  *
  * Every PostHog call site routes through here instead of carrying its own
  * region list, so the rule stays in one place and cannot drift per surface.

--- a/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
+++ b/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
@@ -1,0 +1,66 @@
+/**
+ * The one gate for Langfuse's own PostHog product analytics.
+ *
+ * PostHog is disabled altogether in the HIPAA cloud region: the browser SDK is
+ * never initialized and the server client is never constructed, so no pageview,
+ * identify, capture, signup conversion event or backend-activity event can
+ * leave that deployment. Because `ServerPosthog` falls back to Langfuse's own
+ * telemetry key when no key is configured, "just don't set the env vars" is not
+ * a sufficient gate — the region check has to live in code.
+ *
+ * Every PostHog call site routes through here instead of carrying its own
+ * region list, so the rule stays in one place and cannot drift per surface.
+ *
+ * The region and keys are read from `process.env` rather than the validated
+ * `env` object so this module also works at module scope in the app shell,
+ * where PostHog is initialized before React renders. Next.js inlines
+ * `NEXT_PUBLIC_*` into the browser bundle at build time, and each Langfuse
+ * Cloud region builds its own image with its own
+ * `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` build arg (see web/Dockerfile), so the
+ * HIPAA bundle ships with the gate already closed.
+ */
+
+/** Cloud regions that must never run Langfuse product analytics. */
+export const PRODUCT_ANALYTICS_DISABLED_CLOUD_REGIONS = ["HIPAA"] as const;
+
+/** Whether product analytics may run in the given deployment region. */
+export const isProductAnalyticsAllowedInRegion = (
+  region: string | undefined | null,
+): boolean =>
+  region == null ||
+  !(PRODUCT_ANALYTICS_DISABLED_CLOUD_REGIONS as readonly string[]).includes(
+    region,
+  );
+
+/**
+ * Whether Langfuse product analytics may run in this deployment at all.
+ * Server-side capture paths gate on this; it says nothing about whether a
+ * PostHog key is configured.
+ */
+export const isProductAnalyticsAvailable = (): boolean =>
+  isProductAnalyticsAllowedInRegion(
+    process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+  );
+
+/**
+ * The key/host the PostHog browser SDK should be initialized with, or null when
+ * the browser SDK must stay dormant — either because no key/host pair is
+ * configured or because the region runs no product analytics.
+ */
+export const getPostHogClientConfig = (): {
+  key: string;
+  host: string;
+} | null => {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  if (!isProductAnalyticsAvailable() || !key || !host) return null;
+  return { key, host };
+};
+
+/**
+ * Whether the PostHog browser SDK is live: the deployment allows product
+ * analytics and a client key/host pair is configured. Guards the capture,
+ * identify and reset call sites that run after initialization.
+ */
+export const isPostHogClientEnabled = (): boolean =>
+  getPostHogClientConfig() !== null;

--- a/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
+++ b/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
@@ -20,11 +20,13 @@
  * HIPAA bundle ships with the gate already closed.
  */
 
-/** Cloud regions that must never run Langfuse product analytics. */
-export const PRODUCT_ANALYTICS_DISABLED_CLOUD_REGIONS = ["HIPAA"] as const;
+/**
+ * Cloud regions that must never run Langfuse product analytics. This list is the
+ * single place to change when a region joins or leaves the ban.
+ */
+const PRODUCT_ANALYTICS_DISABLED_CLOUD_REGIONS = ["HIPAA"] as const;
 
-/** Whether product analytics may run in the given deployment region. */
-export const isProductAnalyticsAllowedInRegion = (
+const isProductAnalyticsAllowedInRegion = (
   region: string | undefined | null,
 ): boolean =>
   region == null ||

--- a/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
+++ b/web/src/features/posthog-analytics/productAnalyticsAvailability.ts
@@ -1,55 +1,14 @@
-/**
- * The one gate for Langfuse's own PostHog product analytics.
- *
- * PostHog is disabled altogether in the HIPAA cloud region. The browser SDK is
- * never initialized (init itself phones home). The server SDK is constructed
- * as usual, then opted out with `disable()`, which is a local no-op on
- * `posthog-node` and does not contact PostHog. Because `ServerPosthog` falls
- * back to Langfuse's own telemetry key when no key is configured, "just don't
- * set the env vars" is not a sufficient gate — the region check has to live
- * in code.
- *
- * Every PostHog call site routes through here instead of carrying its own
- * region list, so the rule stays in one place and cannot drift per surface.
- *
- * The region and keys are read from `process.env` rather than the validated
- * `env` object so this module also works at module scope in the app shell,
- * where PostHog is initialized before React renders. Next.js inlines
- * `NEXT_PUBLIC_*` into the browser bundle at build time, and each Langfuse
- * Cloud region builds its own image with its own
- * `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` build arg (see web/Dockerfile), so the
- * HIPAA bundle ships with the gate already closed.
- */
+// PostHog product analytics are off in the HIPAA cloud region. Not setting the
+// env vars is not enough: ServerPosthog falls back to Langfuse's telemetry key.
+//
+// Read from process.env, not the validated env object, so this also works at
+// module scope in the app shell where posthog-js is initialized. Next.js inlines
+// NEXT_PUBLIC_* per region build (see web/Dockerfile).
 
-/**
- * Cloud regions that must never run Langfuse product analytics. This list is the
- * single place to change when a region joins or leaves the ban.
- */
-const PRODUCT_ANALYTICS_DISABLED_CLOUD_REGIONS = ["HIPAA"] as const;
-
-const isProductAnalyticsAllowedInRegion = (
-  region: string | undefined | null,
-): boolean =>
-  region == null ||
-  !(PRODUCT_ANALYTICS_DISABLED_CLOUD_REGIONS as readonly string[]).includes(
-    region,
-  );
-
-/**
- * Whether Langfuse product analytics may run in this deployment at all.
- * Server-side capture paths gate on this; it says nothing about whether a
- * PostHog key is configured.
- */
 export const isProductAnalyticsAvailable = (): boolean =>
-  isProductAnalyticsAllowedInRegion(
-    process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-  );
+  process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== "HIPAA";
 
-/**
- * The key/host the PostHog browser SDK should be initialized with, or null when
- * the browser SDK must stay dormant — either because no key/host pair is
- * configured or because the region runs no product analytics.
- */
+/** Key/host for posthog-js, or null when the browser SDK must not initialize. */
 export const getPostHogClientConfig = (): {
   key: string;
   host: string;
@@ -60,10 +19,5 @@ export const getPostHogClientConfig = (): {
   return { key, host };
 };
 
-/**
- * Whether the PostHog browser SDK is live: the deployment allows product
- * analytics and a client key/host pair is configured. Guards the capture,
- * identify and reset call sites that run after initialization.
- */
 export const isPostHogClientEnabled = (): boolean =>
   getPostHogClientConfig() !== null;

--- a/web/src/features/posthog-analytics/server/backendActivity.ts
+++ b/web/src/features/posthog-analytics/server/backendActivity.ts
@@ -1,6 +1,7 @@
 import { logger, redis } from "@langfuse/shared/src/server";
 
 import { env } from "@/src/env.mjs";
+import { isProductAnalyticsAvailable } from "@/src/features/posthog-analytics/productAnalyticsAvailability";
 import { ServerPosthog } from "@/src/features/posthog-analytics/ServerPosthog";
 
 const BACKEND_ACTIVITY_EVENT = "backend:activity";
@@ -97,8 +98,11 @@ export const recordBackendActivity = createBackendActivityTracker({
     serverPosthog ??= new ServerPosthog();
     serverPosthog.capture(event);
   },
+  // No region means "not Langfuse Cloud" to the tracker, which is also the
+  // right answer for a region that runs no product analytics: it then skips the
+  // Redis deduplication write as well, not just the capture.
   cloudRegion:
-    env.NODE_ENV === "production"
+    env.NODE_ENV === "production" && isProductAnalyticsAvailable()
       ? env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
       : undefined,
   now: () => new Date(),

--- a/web/src/features/posthog-analytics/server/backendActivity.ts
+++ b/web/src/features/posthog-analytics/server/backendActivity.ts
@@ -1,7 +1,6 @@
 import { logger, redis } from "@langfuse/shared/src/server";
 
 import { env } from "@/src/env.mjs";
-import { isProductAnalyticsAvailable } from "@/src/features/posthog-analytics/productAnalyticsAvailability";
 import { ServerPosthog } from "@/src/features/posthog-analytics/ServerPosthog";
 
 const BACKEND_ACTIVITY_EVENT = "backend:activity";
@@ -98,11 +97,8 @@ export const recordBackendActivity = createBackendActivityTracker({
     serverPosthog ??= new ServerPosthog();
     serverPosthog.capture(event);
   },
-  // No region means "not Langfuse Cloud" to the tracker, which is also the
-  // right answer for a region that runs no product analytics: it then skips the
-  // Redis deduplication write as well, not just the capture.
   cloudRegion:
-    env.NODE_ENV === "production" && isProductAnalyticsAvailable()
+    env.NODE_ENV === "production"
       ? env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
       : undefined,
   now: () => new Date(),

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -92,26 +92,31 @@ import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { ScoreCacheProvider } from "@/src/features/scores/contexts/ScoreCacheContext";
 import { CorrectionCacheProvider } from "@/src/features/corrections/contexts/CorrectionCacheContext";
 import { V4_BETA_ENABLED_POSTHOG_PROPERTY } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  getPostHogClientConfig,
+  isPostHogClientEnabled,
+  isProductAnalyticsAvailable,
+} from "@/src/features/posthog-analytics/productAnalyticsAvailability";
 
+// Session replay is a Langfuse Cloud feature, so self-hosted never records.
+// The product-analytics gate makes this redundant in HIPAA (PostHog is not
+// initialized there at all); it stays in the expression as defense in depth for
+// a compliance-sensitive flag.
 const isPostHogSessionRecordingEnabled =
   env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined &&
-  env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== "HIPAA";
+  isProductAnalyticsAvailable();
 
-// Check that PostHog is client-side (used to handle Next.js SSR) and that env vars are set
-if (
-  typeof window !== "undefined" &&
-  process.env.NEXT_PUBLIC_POSTHOG_KEY &&
-  process.env.NEXT_PUBLIC_POSTHOG_HOST
-) {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
+// Check that PostHog is client-side (used to handle Next.js SSR), that env vars
+// are set, and that the deployment region runs product analytics at all.
+const postHogClientConfig = getPostHogClientConfig();
+if (typeof window !== "undefined" && postHogClientConfig) {
+  posthog.init(postHogClientConfig.key, {
+    api_host: postHogClientConfig.host,
     ui_host: "https://eu.posthog.com",
     // Enable debug mode in development
     loaded: (posthog) => {
       if (process.env.NODE_ENV === "development") posthog.debug();
     },
-    // Session replay is a Langfuse Cloud feature and must stay disabled in the
-    // HIPAA region. Other PostHog analytics remain independently configured.
     disable_session_recording: !isPostHogSessionRecordingEnabled,
     session_recording: {
       maskAllInputs: true,
@@ -144,7 +149,7 @@ const MyApp: AppType<{ session: Session | null }> = ({
 
   useEffect(() => {
     // PostHog (cloud.langfuse.com)
-    if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
+    if (isPostHogClientEnabled()) {
       const handleRouteChange = () => {
         posthog.capture("$pageview");
       };
@@ -247,7 +252,7 @@ function UserTracking() {
     ) {
       lastIdentifiedUser.current = JSON.stringify(sessionUser);
       // PostHog
-      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
+      if (isPostHogClientEnabled()) {
         posthog.identify(sessionUser.id ?? undefined, {
           environment: process.env.NODE_ENV,
           email: sessionUser.email ?? undefined,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16721.preview.langfuse.com](https://pr-16721.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Turns PostHog off in the HIPAA cloud region, with a different mechanism on each SDK:

- **Browser (`posthog-js`):** never call `init()`. `init()` itself fetches remote config and sets a cookie, so opting out after init still talks to PostHog.
- **Server (`posthog-node`):** construct `ServerPosthog` as usual, then call `disable()`. On the Node SDK that is a local opt-out: capture becomes a no-op and nothing is sent.

The region list lives in `web/src/features/posthog-analytics/productAnalyticsAvailability.ts`. Missing env vars are not a gate — `ServerPosthog` falls back to Langfuse's telemetry key, so HIPAA still constructs that fallback client and immediately disables it.

Scope note: this is *our* product analytics. The customer-configurable PostHog **export** integration is untouched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `web/src/__tests__/posthog-product-analytics-region.clienttest.ts` — no `posthog.init` in HIPAA; still initialized in US/EU/JP/STAGING/self-hosted.
- `web/src/__tests__/server/unit/serverPosthog.servertest.ts` — HIPAA constructs the client, calls `disable()`, capture is a no-op (including the telemetry-key fallback); US/EU/JP keep capturing.
- Browser traffic: `init` + `opt_out_capturing_by_default` still fetched `eu-assets.i.posthog.com` and set `ph_…_posthog`; skipping `init` did neither. Server `disable()` sent 0 `/batch/` requests against a local sink.
- `pnpm run lint` → `Tasks: 7 successful, 7 total`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d656a3e-95fc-4b75-ae97-16a0a97cb5da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d656a3e-95fc-4b75-ae97-16a0a97cb5da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes product-analytics availability and disables Langfuse-owned browser and server PostHog analytics in the HIPAA region.

- Adds a shared region gate for browser configuration and server analytics availability.
- Prevents PostHog client initialization, identification, page views, signup conversion events, and backend-activity tracking in HIPAA.
- Adds client and server tests covering HIPAA and analytics-enabled regions.
- Documents the centralized HIPAA analytics policy while leaving customer-configured PostHog exports unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the browser and server analytics paths consistently disabled for the HIPAA region.

The centralized gate prevents PostHog initialization and server capture in HIPAA, null-backed server lifecycle methods remain safe no-ops, and backend-activity tracking returns before Redis deduplication or capture.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Deployment region] --> B{Product analytics available?}
    B -->|No: HIPAA| C[Do not initialize browser PostHog]
    B -->|No: HIPAA| D[Do not construct server PostHog]
    B -->|No: HIPAA| E[Skip backend-activity Redis dedup]
    B -->|Yes| F[Initialize configured browser client]
    B -->|Yes| G[Allow server analytics client]
    G --> H[Signup and backend-activity events]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(posthog): disable product analytics ..."](https://github.com/langfuse/langfuse/commit/32789e7a7eb4d6565d18c03320ac2c8ad6eb76a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57609709)</sub>

<!-- /greptile_comment -->