### PR TITLE
fix(in-app-agent): nest approval wait and tool under invoke-model

### DIFF
--- a/packages/shared/src/in-app-agent/interrupts.test.ts
+++ b/packages/shared/src/in-app-agent/interrupts.test.ts
@@ -1,0 +1,61 @@
+import { EventType } from "@ag-ui/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  attachInterruptParentModelObservationId,
+  parseInAppAgentInterruptEvent,
+} from "./interrupts";
+
+const parentModelObservationId = "parent-run-1-llm-3";
+
+const interruptEvent = {
+  type: EventType.CUSTOM,
+  name: "on_interrupt",
+  value: {
+    type: "mastra_suspend",
+    toolCallId: "tool-1",
+    toolName: "langfuse_updateDashboardWidget",
+    args: { name: "errors" },
+    runId: "parent-run-1",
+  },
+};
+
+describe("in-app agent interrupt parent model observation", () => {
+  it("stamps and parses parentModelObservationId on an interrupt event", () => {
+    const persisted = attachInterruptParentModelObservationId(
+      interruptEvent,
+      parentModelObservationId,
+    );
+
+    expect(parseInAppAgentInterruptEvent(persisted)).toEqual({
+      type: "tool_approval_request",
+      toolCallId: "tool-1",
+      toolName: "langfuse_updateDashboardWidget",
+      args: { name: "errors" },
+      runId: "parent-run-1",
+      parentModelObservationId,
+    });
+  });
+
+  it("leaves non-interrupt events and missing ids unchanged", () => {
+    expect(
+      attachInterruptParentModelObservationId(interruptEvent, undefined),
+    ).toBe(interruptEvent);
+    expect(
+      attachInterruptParentModelObservationId(
+        { type: EventType.TOOL_CALL_START, toolCallId: "tool-1" },
+        parentModelObservationId,
+      ),
+    ).toEqual({ type: EventType.TOOL_CALL_START, toolCallId: "tool-1" });
+  });
+
+  it("parses legacy interrupt events without a parent model observation", () => {
+    expect(parseInAppAgentInterruptEvent(interruptEvent)).toEqual({
+      type: "tool_approval_request",
+      toolCallId: "tool-1",
+      toolName: "langfuse_updateDashboardWidget",
+      args: { name: "errors" },
+      runId: "parent-run-1",
+    });
+  });
+});

--- a/packages/shared/src/in-app-agent/interrupts.ts
+++ b/packages/shared/src/in-app-agent/interrupts.ts
@@ -2,7 +2,7 @@ import { EventType } from "@ag-ui/core";
 import { z } from "zod";
 
 import { safeJsonParse } from "../utils/json";
-import type { InAppAgentToolApprovalRequest } from "./schema";
+import type { AgUiEvent, InAppAgentToolApprovalRequest } from "./schema";
 
 const MastraSuspendEventSchema = z.object({
   type: z.literal("mastra_suspend"),
@@ -10,6 +10,7 @@ const MastraSuspendEventSchema = z.object({
   toolName: z.string().min(1),
   args: z.unknown().optional(),
   runId: z.string().min(1),
+  parentModelObservationId: z.string().min(1).optional(),
 });
 
 /** Parses the durable interrupt event shape in browser and server runtimes. */
@@ -34,4 +35,37 @@ export function parseInAppAgentInterruptEvent(
   return interrupt.success
     ? { ...interrupt.data, type: "tool_approval_request" }
     : undefined;
+}
+
+/** Stamp the parent invoke-model id onto a persistable interrupt event. */
+export function attachInterruptParentModelObservationId(
+  event: AgUiEvent,
+  parentModelObservationId: string | undefined,
+): AgUiEvent {
+  if (
+    !parentModelObservationId ||
+    event.type !== EventType.CUSTOM ||
+    event.name !== "on_interrupt"
+  ) {
+    return event;
+  }
+
+  const value =
+    typeof event.value === "string" ? safeJsonParse(event.value) : event.value;
+
+  if (!isPlainObject(value) || value.parentModelObservationId) {
+    return event;
+  }
+
+  return {
+    ...event,
+    value: {
+      ...value,
+      parentModelObservationId,
+    },
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/shared/src/in-app-agent/schema.ts
+++ b/packages/shared/src/in-app-agent/schema.ts
@@ -224,6 +224,9 @@ export const InAppAgentToolApprovalRequestSchema = z.object({
   toolName: z.string().min(1),
   args: z.unknown().optional(),
   runId: z.string().min(1),
+  // Last invoke-model observation of the parent run, so the continuation can
+  // nest the wait span and approved tool under that generation.
+  parentModelObservationId: z.string().min(1).optional(),
 });
 
 export type InAppAgentToolApprovalRequest = z.infer<

--- a/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
+++ b/worker/src/features/in-app-agent/executeInAppAgentRun.test.ts
@@ -195,7 +195,11 @@ const textChunk = (delta: string) => ({
   delta,
 });
 
-const interruptEvent = (parentRunId: string, toolCallId = "tc-1") => ({
+const interruptEvent = (
+  parentRunId: string,
+  toolCallId = "tc-1",
+  parentModelObservationId?: string,
+) => ({
   type: "CUSTOM",
   name: "on_interrupt",
   value: {
@@ -204,6 +208,7 @@ const interruptEvent = (parentRunId: string, toolCallId = "tc-1") => ({
     toolName: "langfuse_createTextPrompt",
     args: { name: "p" },
     runId: parentRunId,
+    ...(parentModelObservationId ? { parentModelObservationId } : {}),
   },
 });
 
@@ -277,6 +282,7 @@ async function seedApprovedContinuation(opts?: {
   rootRunId?: string;
   traceStartedAt?: string;
   approvalRequestedAt?: string;
+  parentModelObservationId?: string;
 }) {
   const seeded = await seedBackgroundRun({
     alwaysAllowedTools: opts?.alwaysAllowedTools,
@@ -299,7 +305,11 @@ async function seedApprovedContinuation(opts?: {
       runId: parentRun.id,
       sequenceNumber: 1,
       type: "CUSTOM",
-      event: interruptEvent(parentRun.id) as never,
+      event: interruptEvent(
+        parentRun.id,
+        "tc-1",
+        opts?.parentModelObservationId,
+      ) as never,
     },
   });
   await prisma.inAppAgentRun.update({
@@ -395,6 +405,7 @@ describe("executeInAppAgentRun", () => {
     const rootRunId = "root-run-1";
     const traceStartedAt = "2026-08-14T10:00:00.000Z";
     const approvalRequestedAt = "2026-08-14T10:00:05.000Z";
+    const parentModelObservationId = "parent-run-1-llm-3";
     const context = [
       {
         description: "current_url",
@@ -408,6 +419,7 @@ describe("executeInAppAgentRun", () => {
       rootRunId,
       traceStartedAt,
       approvalRequestedAt,
+      parentModelObservationId,
     });
 
     scenarioRef.current = async ({ input, options }) => {
@@ -420,6 +432,9 @@ describe("executeInAppAgentRun", () => {
         traceStartedAt,
         approvalRequestedAt,
         approvalDecidedAt: run.createdAt.toISOString(),
+        approvalRequest: expect.objectContaining({
+          parentModelObservationId,
+        }),
       });
       await options.onComplete();
       await options.onFinish();

--- a/worker/src/features/in-app-agent/runtime/agent.test.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.test.ts
@@ -9,6 +9,7 @@ import {
   IN_APP_AGENT_REDIRECT_TOOL_NAME,
   IN_APP_AGENT_TOOL_APPROVAL_EVENT_NAME,
   IN_APP_AGENT_TOOL_REJECTION_ERROR_CODE,
+  parseInAppAgentInterruptEvent,
 } from "@langfuse/shared/in-app-agent";
 import { createInAppAgentToolPolicy } from "@langfuse/shared/in-app-agent/server/mcpPolicy";
 import { IN_APP_AGENT_MAX_STEPS } from "@langfuse/shared/in-app-agent/server/tunables";
@@ -148,6 +149,7 @@ const instrumentationMocks = vi.hoisted(() => {
     recordToolExecutionEnd: vi.fn(),
     recordModelCallStart: vi.fn(),
     recordModelStreamPart: vi.fn(),
+    getLastModelObservationId: vi.fn(),
     end: vi.fn(),
     endWithError: vi.fn(),
     flush: vi.fn(),
@@ -1682,6 +1684,85 @@ describe("createAgUiStream", () => {
       "requireApproval",
     );
     expect(agentTools?.langfuse_createScoreConfig?.requireApproval).toBe(true);
+  });
+
+  it("persists the parent invoke-model id on approval interrupts", async () => {
+    const { createAgUiStream } = await import("./agent");
+    const parentModelObservationId = "parent-run-1-llm-3";
+    instrumentationMocks.instrumentation.getLastModelObservationId.mockReturnValue(
+      parentModelObservationId,
+    );
+    const input = {
+      threadId: "conversation-1",
+      runId: "run-1",
+      messages: [
+        { id: "user-message-1", role: "user" as const, content: "hello" },
+      ],
+      tools: [],
+      context: [],
+      state: null,
+      forwardedProps: {},
+    };
+    adapterEvents.items = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+      {
+        type: EventType.CUSTOM,
+        name: "on_interrupt",
+        value: {
+          type: "mastra_suspend",
+          toolCallId: "tool-1",
+          toolName: "langfuse_updateDashboardWidget",
+          args: { name: "errors" },
+          runId: "run-1",
+        },
+      },
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    ];
+    const persistedEvents: AgUiEvent[] = [];
+    const langfuseClient = {
+      getPrompt: promptMocks.getPrompt,
+    } as unknown as Langfuse;
+
+    const stream = await createAgUiStream({
+      input,
+      signal: new AbortController().signal,
+      options: {
+        onEvent: (event) => {
+          persistedEvents.push(event);
+        },
+        model: testBedrockModel("test-model"),
+        langfuseMcp: {
+          url: "https://example.com/api/public/mcp",
+          publicKey: "pk",
+          secretKey: "sk",
+          toolPolicy: defaultInAppAgentToolPolicy,
+        },
+        redirectAction: { projectId: "project-1", isV4Enabled: false },
+        langfuseClient,
+        useLocalPrompt: false,
+        langfuseTracing: createTestTracingConfig(),
+      },
+    });
+    await readStream(stream);
+
+    const interrupt = persistedEvents
+      .map((event) => parseInAppAgentInterruptEvent(event))
+      .find(Boolean);
+    expect(interrupt).toEqual(
+      expect.objectContaining({
+        toolCallId: "tool-1",
+        toolName: "langfuse_updateDashboardWidget",
+        parentModelObservationId,
+      }),
+    );
   });
 
   it("executes approved tools manually and continues with tool result history", async () => {

--- a/worker/src/features/in-app-agent/runtime/agent.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.ts
@@ -11,6 +11,7 @@ import { MCPClient } from "@mastra/mcp";
 import type { Langfuse } from "langfuse";
 
 import {
+  attachInterruptParentModelObservationId,
   type AgUiEvent,
   type InAppAgentToolApprovalRequest,
 } from "@langfuse/shared/in-app-agent";
@@ -524,13 +525,17 @@ export async function createAgUiStream(params: {
         agUiEvent: AgUiEvent,
         afterPersist?: () => void | Promise<void>,
       ) => {
+        const persistedEvent = attachInterruptParentModelObservationId(
+          agUiEvent,
+          instrumentation?.getLastModelObservationId(),
+        );
         eventQueue = eventQueue
           .then(async () => {
             if (closed) {
               return;
             }
 
-            await params.options.onEvent?.(agUiEvent);
+            await params.options.onEvent?.(persistedEvent);
             await afterPersist?.();
 
             if (closed || !shouldEnqueue) {

--- a/worker/src/features/in-app-agent/runtime/instrumentation.test.ts
+++ b/worker/src/features/in-app-agent/runtime/instrumentation.test.ts
@@ -879,6 +879,96 @@ describe("InAppAgentInstrumentation", () => {
     );
   });
 
+  it("nests approval wait and continued tool under the parent invoke-model", () => {
+    const parentModelObservationId = getInAppAgentLlmCallObservationId(
+      "parent-run-1",
+      3,
+    );
+    const instrumentation = createInstrumentation({
+      forwardedProps: {
+        command: {
+          resume: {
+            approved: true,
+            rootRunId: "root-run-1",
+            approvalRequestedAt: "2026-08-14T10:00:05.000Z",
+            approvalDecidedAt: "2026-08-14T10:02:05.000Z",
+            approvalRequest: {
+              type: "tool_approval_request",
+              toolCallId: "tool-1",
+              toolName: "langfuse_updateDashboardWidget",
+              args: { name: "errors" },
+              runId: "parent-run-1",
+              parentModelObservationId,
+            },
+          },
+        },
+      },
+    });
+
+    instrumentation.recordToolCallApproval({
+      toolCallId: "tool-1",
+      status: "approved",
+    });
+    instrumentation.recordEvents([
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tool-1",
+        toolCallName: "langfuse_updateDashboardWidget",
+      },
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tool-1",
+        delta: '{"name":"errors"}',
+      },
+      {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: "tool-1",
+      },
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: "tool-1",
+        content: '{"updated":true}',
+      },
+    ]);
+    instrumentation.recordModelCallStart({
+      prompt: [{ role: "user", content: "hello" }],
+    });
+    instrumentation.recordModelStreamPart({
+      type: "finish",
+      usage: { inputTokens: 100, outputTokens: 10, totalTokens: 110 },
+    });
+
+    const parentTraceId = getInAppAgentInstrumentationTraceId("root-run-1");
+    const rootObservationId =
+      getInAppAgentInstrumentationObservationId("root-run-1");
+
+    expect(mocks.handler.langfuse.enqueue).toHaveBeenCalledWith(
+      "span-create",
+      expect.objectContaining({
+        id: `${runId}-approval-wait`,
+        traceId: parentTraceId,
+        parentObservationId: parentModelObservationId,
+        name: "waiting for user approval for tool langfuse_updateDashboardWidget",
+      }),
+    );
+    expect(mocks.handler.langfuse.enqueue).toHaveBeenCalledWith(
+      "tool-create",
+      expect.objectContaining({
+        id: "tool-1",
+        traceId: parentTraceId,
+        parentObservationId: parentModelObservationId,
+        name: "langfuse_updateDashboardWidget",
+      }),
+    );
+    expect(mocks.handler.langfuse.enqueue).toHaveBeenCalledWith(
+      "generation-create",
+      expect.objectContaining({
+        traceId: parentTraceId,
+        parentObservationId: rootObservationId,
+      }),
+    );
+  });
+
   it.each([
     { approved: true, status: "approved" as const },
     { approved: false, status: "rejected" as const },

--- a/worker/src/features/in-app-agent/runtime/instrumentation.ts
+++ b/worker/src/features/in-app-agent/runtime/instrumentation.ts
@@ -142,6 +142,7 @@ type ApprovalContinuation = {
   rootRunId: string;
   toolCallId: string;
   toolName: string;
+  parentModelObservationId?: string;
   traceStartedAt?: Date;
   approvalRequestedAt?: Date;
   approvalDecidedAt?: Date;
@@ -296,8 +297,13 @@ export class InAppAgentInstrumentation {
     // Create the root observation immediately so tool/generation children
     // emitted during the run have a parent that already exists (avoids
     // orphans that attach to the trace as siblings of the late agent).
+    this.seedApprovalContinuationParents();
     this.emitRootAgentObservation({ metadata: this.metadata });
     this.emitApprovalWaitObservation();
+  }
+
+  getLastModelObservationId(): string | undefined {
+    return this.openModelObservationId ?? this.lastModelObservationId;
   }
 
   recordEvents(events: AgUiEvent[]) {
@@ -1059,6 +1065,19 @@ export class InAppAgentInstrumentation {
     return [...priorMessages, ...this.agentRunOutputMessages];
   }
 
+  private seedApprovalContinuationParents() {
+    const continuation = this.approvalContinuation;
+    if (!continuation?.parentModelObservationId) {
+      return;
+    }
+
+    this.lastModelObservationId = continuation.parentModelObservationId;
+    this.toolCallToModelObservationId.set(
+      continuation.toolCallId,
+      continuation.parentModelObservationId,
+    );
+  }
+
   private emitApprovalWaitObservation() {
     const continuation = this.approvalContinuation;
     if (!continuation) {
@@ -1076,7 +1095,8 @@ export class InAppAgentInstrumentation {
     this.enqueueObservation("span-create", {
       id: `${this.runId}-approval-wait`,
       traceId: this.traceId,
-      parentObservationId: this.rootObservationId,
+      parentObservationId:
+        continuation.parentModelObservationId ?? this.rootObservationId,
       name: `waiting for user approval for tool ${continuation.toolName}`,
       startTime: requestedAt,
       endTime,
@@ -1118,6 +1138,9 @@ function getApprovalContinuation(
     rootRunId,
     toolCallId: approvalRequest.toolCallId,
     toolName: approvalRequest.toolName,
+    ...(approvalRequest.parentModelObservationId
+      ? { parentModelObservationId: approvalRequest.parentModelObservationId }
+      : {}),
     ...(traceStartedAt ? { traceStartedAt: new Date(traceStartedAt) } : {}),
     ...(approvalRequestedAt
       ? { approvalRequestedAt: new Date(approvalRequestedAt) }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16732.preview.langfuse.com](https://pr-16732.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Follow-up to in-app agent production OTel ingestion. Regular tool calls already nest under the `invoke-model` generation that requested them. Approval waits and the resumed tool call were still siblings of that generation because the continuation run no longer had the parent model observation id.

This stamps the last `invoke-model` id onto the persisted approval interrupt, then parents both the wait span and the continued tool observation under that generation. The next model call after resume still sits on the agent-turn root.

Independent of https://github.com/langfuse/langfuse/pull/16717 (Ask AI / title production OTel). No expected file overlap.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Packages

- `@langfuse/shared`
- `worker`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `turbo run lint` via pre-commit: `Tasks: 7 successful, 7 total`
- `pnpm --filter worker run test instrumentation.test.ts`: `Tests 32 passed (32)`
- `pnpm --filter @langfuse/shared run test interrupts.test.ts`: `Tests 3 passed (3)`
- `pnpm --filter worker run test agent.test.ts -t "approved|approval|interrupt"`: `Tests 7 passed | 33 skipped (40)`

Skipped typecheck. Skipped `executeInAppAgentRun.test.ts` because Postgres was not reachable at `localhost:5432`. Skipped browser signoff: the tree UI already nests by `parentObservationId`; this only changes the emitted parent.

## Test this

Preview: https://pr-16732.preview.langfuse.com (once the AWS preview is up)

1. Run an in-app agent turn that needs a write-tool approval (for example `langfuse_updateDashboardWidget`).
2. Open the production trace for that turn.
3. Confirm `waiting for user approval…` and the tool call are indented under the preceding `invoke-model`, the same way `bash` already is.
4. Confirm the next `invoke-model` after approval stays a sibling of the earlier model calls.

Legacy parked approvals without `parentModelObservationId` still attach to the agent-turn root.

Sandbox: same path on http://localhost:3000 after the cloud stack is up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c254e4d-adf3-4346-aa44-6d9c7809dde5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c254e4d-adf3-4346-aa44-6d9c7809dde5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR persists the requesting model observation ID with approval interrupts and restores that parent relationship when an approved tool continues in a later run.

- Extends the durable approval-request schema with an optional parent model observation ID while retaining compatibility with legacy events.
- Stamps approval interrupts with the latest model observation before persistence.
- Parents approval-wait and resumed-tool observations beneath the model generation that requested approval, while keeping subsequent model calls on the agent-turn root.
- Adds shared parsing, worker integration, and instrumentation coverage for the updated lineage.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The optional persisted field remains compatible with legacy approvals, and the continuation instrumentation uses it narrowly to restore approval-wait and approved-tool lineage while subsequent model calls retain their existing root parent.
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant M as Invoke-model generation
  participant P as Parent agent run
  participant DB as Persisted event stream
  participant C as Continuation run
  participant T as Approved tool
  M->>P: Request approval-gated tool
  P->>DB: Persist interrupt with parentModelObservationId
  Note over P,DB: Parent run waits for approval
  DB->>C: Rebuild approved continuation
  C->>M: Emit approval-wait span as child
  C->>T: Execute approved tool
  T->>M: Emit tool observation as child
  C->>C: Start next invoke-model on turn root
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): nest approval wait an..."](https://github.com/langfuse/langfuse/commit/ce3fddc2a15a5a917151e7049ed34d8e4ee196dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57807925)</sub>

**Context used:**

- Knowledge Base — [In-app agent execution](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent-execution.md)

<!-- /greptile_comment -->