### PR TITLE
docs(ingestion): correct outdated handler docblock in public ingestion API

### DIFF
--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -42,20 +42,19 @@ export const config = {
 };
 
 /**
- * This handler performs multiple actions to ingest data. It is compatible with the new async workflow, but also
- * supports the old synchronous workflow which processes events in the web container.
- * Overall, the processing of each incoming request happens in three stages
+ * This handler ingests data via the async workflow:
  * 1. Validation
  *   - Check that the user has permissions
  *   - Check whether rate-limits are breached
  *   - Check that the request is well-formed
- * 2. Async Processing
+ * 2. Async Processing (in processEventBatch, also reused for the POST scores
+ *    endpoint and OTLP ingestion)
  *   - Upload each event to S3 for long-term storage and as an event cache
- *   - Add the event batch to the queue for async processing
- *   - Fallback to sync processing on errors
- * 3. Sync Processing
- * The last two stages live in a processEventBatch function which is reused for the POST scores endpoint and for
- * legacy event types.
+ *   - Add the event batch to the queue for async processing by the worker
+ *
+ * If the S3 upload fails, event processing is aborted (the request fails) so
+ * that the queue never references a missing S3 object. There is no synchronous
+ * fallback path.
  */
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## What does this PR do?

Fixes an outdated docblock on the public ingestion API handler that still describes a removed synchronous processing workflow:

> *supports the old synchronous workflow which processes events in the web container*
> *Fallback to sync processing on errors*
> *3. Sync Processing*

Current behavior in `processEventBatch`: if any S3 event upload fails, processing is aborted and the error is thrown (`Failed to upload events to blob storage, aborting event processing`) — so the ingestion queue never references a missing S3 object. There is no synchronous fallback path.

The docblock now describes the two actual stages (validation, async processing) and documents the abort-on-S3-failure behavior.

Comment-only change; no functional changes.

## How to test

Not applicable (docs-only).

## Checklist
- [ ] N/A — no code change

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the public ingestion handler’s docblock to remove the obsolete synchronous-fallback description and document abort-on-upload-failure behavior.
- Describes validation and asynchronous ingestion as the two current stages.
- Clarifies that failed object-storage uploads prevent queue submission.
- The new reference to OTLP ingestion is broader than the actual limited worker-side reuse of `processEventBatch`.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge, with a non-blocking documentation clarification needed around the limited OTLP reuse of `processEventBatch`.

The change does not affect runtime behavior, but its new OTLP wording can misdirect maintainers because OTLP requests use a separate queueing path and only some downstream trace events reach `processEventBatch`.

**Files Needing Attention:** web/src/pages/api/public/ingestion.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/pages/api/public/ingestion.ts:50-51
**Overbroad OTLP reuse description**

OTLP requests use a separate queueing path, and only a subset of downstream trace events reaches `processEventBatch`; observations and direct-write processing bypass it. Describing the function as reused for OTLP ingestion directs maintainers to the wrong implementation when debugging OTLP upload, queueing, or observation processing.

```suggestion
 * 2. Async Processing (in processEventBatch, also reused for the POST scores
 *    endpoint and some downstream OTLP trace processing)
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(ingestion): correct outdated handle..."](https://github.com/langfuse/langfuse/commit/18dd2a548fcf3e1e1cc9eba42aaf39ddac4af85d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57812593)</sub>

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->