### PR TITLE
feat(in-app-agent): refuse stale sandbox runtime protocol versions (LFE-15740)

### DIFF
--- a/packages/in-app-agent-sandbox-runtime/README.md
+++ b/packages/in-app-agent-sandbox-runtime/README.md
@@ -16,7 +16,7 @@ and prevent `sudo`-based user switching at runtime.
 
 ## Endpoints:
 
-- `GET /health`
+- `GET /health` — `{ status: "ok", protocolVersion: <int> }`. The worker refuses a sandbox whose `protocolVersion` does not match `SANDBOX_RUNTIME_PROTOCOL_VERSION`.
 - `POST /sandbox`
 - `POST /aws/lambda-microvms/runtime/v1/ready`
 - `POST /aws/lambda-microvms/runtime/v1/run`

--- a/packages/in-app-agent-sandbox-runtime/src/contracts.test.ts
+++ b/packages/in-app-agent-sandbox-runtime/src/contracts.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { SandboxFileSchema, SandboxOperationSchema } from "./contracts.js";
+import {
+  SANDBOX_RUNTIME_PROTOCOL_VERSION,
+  SandboxFileSchema,
+  SandboxOperationSchema,
+} from "./contracts.js";
+
+describe("SANDBOX_RUNTIME_PROTOCOL_VERSION", () => {
+  it("is a positive integer the worker can compare against /health", () => {
+    expect(SANDBOX_RUNTIME_PROTOCOL_VERSION).toBe(1);
+  });
+});
 
 describe("SandboxOperationSchema", () => {
   it("accepts each supported sandbox operation", () => {

--- a/packages/in-app-agent-sandbox-runtime/src/contracts.ts
+++ b/packages/in-app-agent-sandbox-runtime/src/contracts.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+/** Bump when the guest HTTP contract changes. The worker refuses a sandbox whose /health protocolVersion does not match. */
+export const SANDBOX_RUNTIME_PROTOCOL_VERSION = 1;
+
 export const SandboxFileSchema = z.object({
   path: z.string(),
   content: z.string(),

--- a/packages/in-app-agent-sandbox-runtime/src/server.ts
+++ b/packages/in-app-agent-sandbox-runtime/src/server.ts
@@ -8,6 +8,7 @@ import {
 import path from "node:path";
 
 import {
+  SANDBOX_RUNTIME_PROTOCOL_VERSION,
   SandboxFileSchema,
   SandboxOperationSchema,
   type BashSandboxOperation,
@@ -109,7 +110,10 @@ async function syncToolCallFiles(toolCallFiles: unknown, requestId: string) {
 async function routeRequest(request: IncomingMessage, requestId: string) {
   if (request.method === "GET" && request.url === "/health") {
     logSandboxServer("health.ok", { requestId });
-    return { statusCode: 200, body: { status: "ok" } };
+    return {
+      statusCode: 200,
+      body: { status: "ok", protocolVersion: SANDBOX_RUNTIME_PROTOCOL_VERSION },
+    };
   }
 
   if (

--- a/packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts
+++ b/packages/in-app-agent-sandbox-runtime/tests/sandbox.test.ts
@@ -62,7 +62,10 @@ describe("sandbox runtime docker container", () => {
     { timeout: 120_000 },
     async () => {
       const health = await requestJson(baseUrl, "/health");
-      expect(health).toEqual({ status: 200, body: { status: "ok" } });
+      expect(health).toEqual({
+        status: 200,
+        body: { status: "ok", protocolVersion: 1 },
+      });
 
       const written = await requestJson(baseUrl, "/sandbox", {
         method: "POST",

--- a/worker/src/features/in-app-agent/runtime/sandbox/protocolVersion.test.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/protocolVersion.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION,
+  assertSandboxRuntimeProtocolVersion,
+  reportedSandboxRuntimeProtocolVersion,
+} from "./protocolVersion";
+
+describe("sandbox runtime protocol version", () => {
+  it("accepts a matching /health body and rejects a stale or missing version", () => {
+    expect(
+      reportedSandboxRuntimeProtocolVersion({
+        status: "ok",
+        protocolVersion: IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION,
+      }),
+    ).toBe(1);
+
+    expect(reportedSandboxRuntimeProtocolVersion({ status: "ok" })).toBe(0);
+
+    expect(() =>
+      assertSandboxRuntimeProtocolVersion({
+        status: "ok",
+        protocolVersion: IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION,
+      }),
+    ).not.toThrow();
+
+    expect(() => assertSandboxRuntimeProtocolVersion({ status: "ok" })).toThrow(
+      /Rebuild the MicroVM image/,
+    );
+  });
+});

--- a/worker/src/features/in-app-agent/runtime/sandbox/protocolVersion.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/protocolVersion.ts
@@ -1,0 +1,37 @@
+/** Must match SANDBOX_RUNTIME_PROTOCOL_VERSION in packages/in-app-agent-sandbox-runtime. */
+export const IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION = 1;
+
+export function reportedSandboxRuntimeProtocolVersion(
+  healthBody: unknown,
+): number {
+  if (
+    healthBody &&
+    typeof healthBody === "object" &&
+    "protocolVersion" in healthBody &&
+    typeof healthBody.protocolVersion === "number" &&
+    Number.isInteger(healthBody.protocolVersion)
+  ) {
+    return healthBody.protocolVersion;
+  }
+
+  return 0;
+}
+
+export function assertSandboxRuntimeProtocolVersion(healthBody: unknown): void {
+  const reported = reportedSandboxRuntimeProtocolVersion(healthBody);
+
+  if (reported !== IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION) {
+    throw new Error(
+      `Sandbox runtime protocol mismatch: image reported version ${reported}, worker expects ${IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION}. Rebuild the MicroVM image from this Langfuse version before running the Assistant sandbox.`,
+    );
+  }
+}
+
+export function isSandboxRuntimeProtocolMismatchError(
+  error: unknown,
+): error is Error {
+  return (
+    error instanceof Error &&
+    error.message.startsWith("Sandbox runtime protocol mismatch:")
+  );
+}

--- a/worker/src/features/in-app-agent/runtime/sandbox/providers/docker.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/providers/docker.ts
@@ -4,6 +4,10 @@ import type Docker from "dockerode";
 import { logger } from "@langfuse/shared/src/server";
 
 import type { SandboxFile, SandboxProvider, SandboxSession } from "../types";
+import {
+  assertSandboxRuntimeProtocolVersion,
+  isSandboxRuntimeProtocolMismatchError,
+} from "../protocolVersion";
 
 type DockerExecResult = {
   exitCode: number;
@@ -273,6 +277,7 @@ async function waitForSandboxServer(container: DockerContainer) {
         "status" in result &&
         result.status === "ok"
       ) {
+        assertSandboxRuntimeProtocolVersion(result);
         logger.debug("In-app agent docker sandbox health probe ready", {
           containerId: container.id,
           attempt,
@@ -281,6 +286,9 @@ async function waitForSandboxServer(container: DockerContainer) {
         return;
       }
     } catch (error) {
+      if (isSandboxRuntimeProtocolMismatchError(error)) {
+        throw error;
+      }
       lastError = error;
       logger.debug("In-app agent docker sandbox health probe failed", {
         containerId: container.id,

--- a/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.test.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.test.ts
@@ -84,7 +84,7 @@ describe("in-app agent lambda microvm sandbox provider", () => {
       "fetch",
       vi
         .fn<typeof fetch>()
-        .mockResolvedValue(new Response(null, { status: 200 })),
+        .mockResolvedValue(Response.json({ status: "ok", protocolVersion: 1 })),
     );
     microvmSendMock.mockImplementation(async (command: { input: unknown }) => {
       if (command.constructor.name === "RunMicrovmCommand") {
@@ -134,7 +134,7 @@ describe("in-app agent lambda microvm sandbox provider", () => {
     const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (url) => {
       const urlString = String(url);
       if (urlString.endsWith("/health")) {
-        return new Response(null, { status: 200 });
+        return Response.json({ status: "ok", protocolVersion: 1 });
       }
 
       return Response.json({ result: { content: "hello" } });
@@ -227,7 +227,7 @@ describe("in-app agent lambda microvm sandbox provider", () => {
       "fetch",
       vi
         .fn<typeof fetch>()
-        .mockResolvedValue(new Response(null, { status: 200 })),
+        .mockResolvedValue(Response.json({ status: "ok", protocolVersion: 1 })),
     );
     microvmSendMock.mockImplementation(async (command: { input: unknown }) => {
       const input = command.input as { microvmIdentifier?: string };
@@ -283,5 +283,47 @@ describe("in-app agent lambda microvm sandbox provider", () => {
         ([command]) => command.constructor.name === "ResumeMicrovmCommand",
       ),
     ).toBeUndefined();
+  });
+
+  it("rejects a sandbox whose /health protocolVersion does not match the worker", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(Response.json({ status: "ok" })),
+    );
+    microvmSendMock.mockImplementation(async (command: { input: unknown }) => {
+      if (command.constructor.name === "RunMicrovmCommand") {
+        return {
+          microvmId: "microvm-1",
+          endpoint: "https://microvm.example.com:8443",
+          state: "RUNNING",
+        };
+      }
+
+      if (command.constructor.name === "GetMicrovmCommand") {
+        return {
+          microvmId: "microvm-1",
+          endpoint: "https://microvm.example.com:8443",
+          state: "RUNNING",
+        };
+      }
+
+      if (command.constructor.name === "CreateMicrovmAuthTokenCommand") {
+        return { authToken: { "X-aws-proxy-auth": "token-1" } };
+      }
+
+      throw new Error(`Unexpected command ${command.constructor.name}`);
+    });
+
+    const { createLambdaMicrovmSandboxProvider } =
+      await import("./lambdaMicrovm");
+    const provider = createLambdaMicrovmSandboxProvider({
+      imageIdentifier: "image-1",
+      executionRoleArn: "arn:aws:iam::123456789012:role/sandbox",
+      region: "us-east-1",
+    });
+
+    await expect(
+      provider.ensureSession({ conversationId: "conversation-1" }),
+    ).rejects.toThrow(/Rebuild the MicroVM image/);
   });
 });

--- a/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts
+++ b/worker/src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.ts
@@ -19,6 +19,10 @@ import type {
   SandboxProvider,
   SandboxSession,
 } from "../types";
+import {
+  assertSandboxRuntimeProtocolVersion,
+  isSandboxRuntimeProtocolMismatchError,
+} from "../protocolVersion";
 
 const DEFAULT_AUTH_TOKEN_EXPIRATION_MINUTES = 30;
 const AUTH_TOKEN_REFRESH_BUFFER_MS = 60_000;
@@ -494,15 +498,20 @@ async function waitForBridge(params: {
         },
       );
 
-      if (response.ok) {
+      if (!response.ok) {
+        lastError = new Error(
+          (await response.text()) ||
+            `[Lambda MicroVM Sandbox] health probe failed with ${response.status}`,
+        );
+      } else {
+        const healthBody = parseSandboxHealthBody(await response.text());
+        assertSandboxRuntimeProtocolVersion(healthBody);
         return { status: "ready" };
       }
-
-      lastError = new Error(
-        (await response.text()) ||
-          `[Lambda MicroVM Sandbox] health probe failed with ${response.status}`,
-      );
     } catch (error) {
+      if (isSandboxRuntimeProtocolMismatchError(error)) {
+        throw error;
+      }
       lastError = error;
     }
 
@@ -635,4 +644,16 @@ function isMissingMicrovmError(error: unknown) {
   const statusCode = $metadata?.httpStatusCode;
 
   return name === "ResourceNotFoundException" || statusCode === 404;
+}
+
+function parseSandboxHealthBody(bodyText: string): unknown {
+  if (!bodyText) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(bodyText);
+  } catch {
+    return {};
+  }
 }

--- a/worker/src/initialize.ts
+++ b/worker/src/initialize.ts
@@ -1,9 +1,22 @@
 import { upsertDefaultModelPrices } from "./scripts/upsertDefaultModelPrices";
 import { upsertLangfuseDashboards } from "./scripts/upsertLangfuseDashboards";
-import { initializeClickhouseCompatibility } from "@langfuse/shared/src/server";
+import {
+  initializeClickhouseCompatibility,
+  logger,
+} from "@langfuse/shared/src/server";
+import { env } from "./env";
+import { IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION } from "./features/in-app-agent/runtime/sandbox/protocolVersion";
 
 export const initializeWorker = async (): Promise<void> => {
   await initializeClickhouseCompatibility();
 
   await Promise.all([upsertDefaultModelPrices(), upsertLangfuseDashboards()]);
+
+  if (env.LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER) {
+    logger.info("Assistant sandbox enabled", {
+      provider: env.LANGFUSE_IN_APP_AGENT_SANDBOX_PROVIDER,
+      expectedRuntimeProtocolVersion:
+        IN_APP_AGENT_SANDBOX_RUNTIME_PROTOCOL_VERSION,
+    });
+  }
 };


### PR DESCRIPTION
https://linear.app/clickhouse/issue/LFE-15740/refuse-stale-sandbox-runtime-protocol-versions

## Summary
- Guest `/health` now returns `protocolVersion` (`SANDBOX_RUNTIME_PROTOCOL_VERSION = 1`).
- Worker asserts that version on first contact with Docker and Lambda MicroVM sandboxes and fails immediately on mismatch, instead of retrying for 30s or surfacing as broken file/bash tools.
- Rebuild the MicroVM image from the same Langfuse version after upgrading.

Companions:
- Terraform sandbox module: https://github.com/langfuse/langfuse-terraform-aws/pull/77
- Helm Assistant values: https://github.com/langfuse/langfuse-k8s/pull/409
- Tracking: [LFE-15741](https://linear.app/clickhouse/issue/LFE-15741/add-helm-values-and-aws-terraform-module-for-the-assistant-sandbox)
- Docs follow-up after Terraform is live: https://github.com/langfuse/langfuse-docs/pull/3619

## Test plan
- [ ] `pnpm --filter @repo/in-app-agent-sandbox-runtime run test`
- [ ] `pnpm --filter worker exec vitest run src/features/in-app-agent/runtime/sandbox/protocolVersion.test.ts src/features/in-app-agent/runtime/sandbox/providers/lambdaMicrovm.test.ts`
- [ ] Confirm a health body without `protocolVersion` is treated as `0` and rejected
- [ ] Confirm a matching `protocolVersion: 1` is accepted
- [ ] Rebuild (or stop caching) the Docker sandbox image used by `docker.test.ts` so CI is not red on a stale guest