### PR TITLE
docs(agents): tighten code-comment and subagent guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -9,8 +9,7 @@ evaluating, and debugging AI applications.
 - Keep changes scoped and avoid unrelated refactors.
 - Delegate exploratory or noisy work — broad code search, multi-file
   investigation, log or test-output trawls — to a subagent so the
-  intermediate tool output stays out of the main context. This isn't
-  automatic; ask for it explicitly when it applies.
+  intermediate tool output stays out of the main context.
 - For bug fixes, first write the smallest failing test that proves the reported
   behavior and confirm it fails against the buggy behavior before changing
   production code. Add another test only when it exercises a distinct adapter,

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -7,6 +7,10 @@ evaluating, and debugging AI applications.
 
 - Read the minimal local context required for the task.
 - Keep changes scoped and avoid unrelated refactors.
+- Delegate exploratory or noisy work — broad code search, multi-file
+  investigation, log or test-output trawls — to a subagent so the
+  intermediate tool output stays out of the main context. This isn't
+  automatic; ask for it explicitly when it applies.
 - For bug fixes, first write the smallest failing test that proves the reported
   behavior and confirm it fails against the buggy behavior before changing
   production code. Add another test only when it exercises a distinct adapter,
@@ -37,6 +41,10 @@ evaluating, and debugging AI applications.
   commit messages, PR titles and descriptions, or changelog entries. They mean
   nothing to OSS readers. Describe the problem on its own terms; a
   ticket-prefixed branch name is the one place the identifier belongs.
+- Code comments document behavior for future readers, not the reasoning
+  behind the current change. Do not reference PR/review history ("changed X
+  to Y", "now also handles", "per review", "was previously") or describe
+  code that no longer exists.
 - Never commit secrets or credentials. Keep `.env*.example` files in
   sync with required env vars.
 - Human handoff: assume the reader does not remember the ticket. Lead with
@@ -48,8 +56,6 @@ evaluating, and debugging AI applications.
   the seed command or sandbox URL (`http://localhost:3000`) to reproduce
   the data. Attach proof of the fix (screenshot, short video, or
   before/after). Humans can ask for more detail.
-- After opening a PR, leave a short last comment on what a reviewer should
-  doubt — the curious, questionable parts — not a changelog.
 - Open PRs as reviewable, not as drafts, unless a human asks for a draft.
 - When Claude, Greptile, or Codex (`chatgpt-codex-connector[bot]`) review
   comments appear on a PR you own: do not reply. Keep each thread open
@@ -120,6 +126,8 @@ langfuse/
 - Use Linear's git branch name (`lfe-XXXX-short-title`). Never create a
   `cursor/` branch, even if a Cursor Cloud prompt suggests that prefix.
   Repo guidance wins.
+- After opening a PR, leave a short last comment on what a reviewer should
+  doubt — the curious, questionable parts — not a changelog.
 
 ## Local Data Inspection
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16741.preview.langfuse.com](https://pr-16741.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Three small changes to `.agents/AGENTS.md`:

- Adds a rule that code comments should document behavior for future readers, not PR-relative context ("changed X to Y", "per review") or references to code that no longer exists — mirrors the existing local `check-comments` PostToolUse hook's rubric.
- Recommends delegating exploratory/noisy work (broad search, multi-file investigation, log trawls) to a subagent to keep the main context clean, and notes this isn't automatic.
- Moves the "leave a short last PR comment on what a reviewer should doubt" rule from the general "How To Work" section into "Cursor Cloud specific instructions", since it's scoped to that workflow.

## Type of change

- [x] Documentation update

## Checklist

- [x] `pnpm run agents:sync` and `pnpm run agents:check` run clean
- [x] `pnpm run lint` passes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR tightens contributor guidance for durable code comments and explicit delegation of noisy exploratory work, while moving the reviewer-doubt handoff rule into the Cursor Cloud-specific section.
- Adds guidance to delegate broad searches, multi-file investigations, and output trawls to subagents.
- Prohibits code comments that preserve PR-relative history or describe removed behavior.
- Limits the final reviewer-doubt PR comment requirement to Cursor Cloud workflows.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The changes only clarify agent workflow and comment-writing guidance, and the relocated instruction retains its intended wording under the narrower Cursor Cloud scope.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): tighten code-comment and s..."](https://github.com/langfuse/langfuse/commit/db9c7b78cc9fa29b19d31c645961c7e1475721b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57835866)</sub>

<!-- /greptile_comment -->