### PR TITLE
fix(playground): close the tools popover before opening the tool dialog

### DIFF
--- a/web/src/features/playground/page/components/ConfigurationDropdowns.clienttest.tsx
+++ b/web/src/features/playground/page/components/ConfigurationDropdowns.clienttest.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ConfigurationDropdowns } from "./ConfigurationDropdowns";
+
+vi.mock("../context", () => ({
+  usePlaygroundContext: () => ({
+    tools: [],
+    structuredOutputSchema: null,
+    promptVariables: [],
+    messagePlaceholders: [],
+    setTools: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/usePlaygroundWindowSize", () => ({
+  usePlaygroundWindowSize: () => ({
+    containerRef: { current: null },
+    width: 640,
+    isVeryCompact: false,
+    isCompact: false,
+  }),
+}));
+
+vi.mock("@/src/hooks/useProjectIdFromURL", () => ({
+  default: () => "project-id",
+}));
+
+vi.mock("@/src/utils/api", () => {
+  const useMutation = () => ({ mutateAsync: vi.fn() });
+  return {
+    api: {
+      llmTools: {
+        getAll: { useQuery: () => ({ data: [] }) },
+        create: { useMutation },
+        update: { useMutation },
+        delete: { useMutation },
+      },
+      llmSchemas: { getAll: { useQuery: () => ({ data: [] }) } },
+      useUtils: () => ({ llmTools: { getAll: { invalidate: vi.fn() } } }),
+    },
+  };
+});
+
+// CodeMirror needs layout APIs jsdom does not provide, and the parameters
+// editor is not what these tests are about.
+vi.mock("@/src/components/editor", () => ({
+  CodeMirrorEditor: () => <div data-testid="parameters-editor" />,
+}));
+
+// cmdk observes its list container; jsdom has no ResizeObserver.
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+const openToolsPopover = () => {
+  fireEvent.click(screen.getByRole("button", { name: /tools/i }));
+};
+
+// Queried by text, not by role: an open modal dialog marks everything outside
+// it aria-hidden, so a role query cannot tell a closed popover apart from one
+// that is still mounted underneath the dialog.
+const createToolAction = () => screen.queryByText("Create new tool");
+
+const clickCreateTool = () => {
+  const action = createToolAction()?.closest("button");
+  if (!action) throw new Error("Create new tool action is not rendered");
+  fireEvent.click(action);
+};
+
+describe("ConfigurationDropdowns tools overlay lifecycle", () => {
+  it("closes the tools popover when the create tool dialog opens", () => {
+    render(<ConfigurationDropdowns />);
+
+    openToolsPopover();
+    clickCreateTool();
+
+    expect(screen.getByText("Create LLM Tool")).toBeInTheDocument();
+    // The popover must not linger underneath the dialog.
+    expect(createToolAction()).not.toBeInTheDocument();
+  });
+
+  it("reopens the tools popover when the dialog is cancelled", () => {
+    render(<ConfigurationDropdowns />);
+
+    openToolsPopover();
+    clickCreateTool();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Create LLM Tool")).not.toBeInTheDocument();
+    expect(createToolAction()).toBeInTheDocument();
+  });
+});

--- a/web/src/features/playground/page/components/ConfigurationDropdowns.tsx
+++ b/web/src/features/playground/page/components/ConfigurationDropdowns.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Badge } from "@/src/components/ui/badge";
 import { ChevronDown, Wrench, Braces, Variable } from "lucide-react";
@@ -9,13 +9,26 @@ import {
 } from "@/src/components/ui/popover";
 import { usePlaygroundContext } from "../context";
 import { usePlaygroundWindowSize } from "../hooks/usePlaygroundWindowSize";
-import { PlaygroundTools, PlaygroundToolsPopover } from "./PlaygroundTools";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import { CreateOrEditLLMToolDialog } from "./CreateOrEditLLMToolDialog";
+import {
+  PlaygroundTools,
+  PlaygroundToolsPopover,
+  usePlaygroundToolActions,
+  type ToolDialogTarget,
+} from "./PlaygroundTools";
 import {
   StructuredOutputSchemaSection,
   StructuredOutputSchemaPopover,
 } from "./StructuredOutputSchemaSection";
 import { Variables } from "./Variables";
 import { MessagePlaceholders } from "./MessagePlaceholders";
+
+type ToolDialogState = ToolDialogTarget & {
+  open: boolean;
+  /** Bumped on every open so the dialog remounts with a pristine form. */
+  instance: number;
+};
 
 export const ConfigurationDropdowns: React.FC = () => {
   const { containerRef, width, isVeryCompact, isCompact } =
@@ -26,6 +39,39 @@ export const ConfigurationDropdowns: React.FC = () => {
     promptVariables,
     messagePlaceholders,
   } = usePlaygroundContext();
+
+  const projectId = useProjectIdFromURL();
+  const { handleSelectTool, handleRemoveTool } = usePlaygroundToolActions();
+
+  const [toolsPopoverOpen, setToolsPopoverOpen] = useState(false);
+  const [toolDialog, setToolDialog] = useState<ToolDialogState>({
+    open: false,
+    instance: 0,
+  });
+  // Saving or deleting is a committed action, so we don't bounce the user back
+  // into the picker afterwards — only a cancelled dialog reopens it.
+  const toolDialogCommittedRef = useRef(false);
+
+  // The popover must close BEFORE the dialog opens: Radix unmounts
+  // PopoverContent on close, which is why the dialog is rendered as a sibling of
+  // the Popover rather than inside it (see the overlay lifecycle note in
+  // web/AGENTS.md).
+  const openToolDialog = useCallback((target: ToolDialogTarget) => {
+    toolDialogCommittedRef.current = false;
+    setToolsPopoverOpen(false);
+    setToolDialog((prev) => ({
+      ...target,
+      open: true,
+      instance: prev.instance + 1,
+    }));
+  }, []);
+
+  const handleToolDialogOpenChange = useCallback((open: boolean) => {
+    setToolDialog((prev) => ({ ...prev, open }));
+    if (!open && !toolDialogCommittedRef.current) {
+      setToolsPopoverOpen(true);
+    }
+  }, []);
 
   const toolsCount = tools.length;
   const hasSchema = structuredOutputSchema ? 1 : 0;
@@ -62,7 +108,7 @@ export const ConfigurationDropdowns: React.FC = () => {
     <div ref={containerRef} className="bg-muted/25 shrink-0 border-b px-3 py-2">
       <div className="flex items-center justify-start gap-2">
         {/* Tools Dropdown */}
-        <Popover>
+        <Popover open={toolsPopoverOpen} onOpenChange={setToolsPopoverOpen}>
           <PopoverTrigger asChild>
             <Button variant="outline" size="sm" className="h-8 gap-2">
               {getResponsiveContent("Tools", Wrench)}
@@ -87,7 +133,7 @@ export const ConfigurationDropdowns: React.FC = () => {
             </div>
             {toolsCount > 0 ? (
               <div className="mb-3">
-                <PlaygroundTools />
+                <PlaygroundTools onOpenToolDialog={openToolDialog} />
               </div>
             ) : (
               <div className="mb-3">
@@ -97,10 +143,33 @@ export const ConfigurationDropdowns: React.FC = () => {
               </div>
             )}
             <div className="border-t pt-3">
-              <PlaygroundToolsPopover />
+              <PlaygroundToolsPopover onOpenToolDialog={openToolDialog} />
             </div>
           </PopoverContent>
         </Popover>
+
+        {/* Dialog lives OUTSIDE the PopoverContent so closing the popover does
+            not unmount it (see openToolDialog). */}
+        <CreateOrEditLLMToolDialog
+          key={toolDialog.instance}
+          open={toolDialog.open}
+          onOpenChange={handleToolDialogOpenChange}
+          projectId={projectId as string}
+          existingLlmTool={toolDialog.existingLlmTool}
+          defaultValues={toolDialog.defaultValues}
+          onSave={(llmTool) => {
+            toolDialogCommittedRef.current = true;
+            handleSelectTool(llmTool);
+          }}
+          onDelete={
+            toolDialog.removeToolId
+              ? () => {
+                  toolDialogCommittedRef.current = true;
+                  handleRemoveTool(toolDialog.removeToolId as string);
+                }
+              : undefined
+          }
+        />
 
         {/* Structured Output Dropdown */}
         <Popover>

--- a/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @repo/no-abstracted-overlay-trigger */
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowUpRight } from "lucide-react";
@@ -14,7 +13,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/src/components/ui/dialog";
 import {
   Form,
@@ -43,7 +41,14 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>;
 
 type CreateOrEditLLMToolDialog = {
-  children: React.ReactNode;
+  /**
+   * Controlled open state. This dialog renders no trigger of its own: it must be
+   * mounted as a SIBLING of whatever opens it, so a dropdown/popover trigger can
+   * close before the dialog opens without unmounting it. See the overlay
+   * lifecycle note in web/AGENTS.md.
+   */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   projectId: string;
   onSave: (llmTool: LlmTool) => void;
   onDelete?: (llmTool: LlmTool) => void;
@@ -58,14 +63,12 @@ type CreateOrEditLLMToolDialog = {
 export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
   props,
 ) => {
-  const { children, projectId, onSave, existingLlmTool } = props;
+  const { open, onOpenChange, projectId, onSave, existingLlmTool } = props;
 
   const utils = api.useUtils();
   const createLlmTool = api.llmTools.create.useMutation();
   const updateLlmTool = api.llmTools.update.useMutation();
   const deleteLlmTool = api.llmTools.delete.useMutation();
-
-  const [open, setOpen] = useState(false);
 
   const form = useForm({
     resolver: zodResolver(formSchema),
@@ -118,7 +121,7 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
     await utils.llmTools.getAll.invalidate({ projectId });
 
     onSave(result);
-    setOpen(false);
+    onOpenChange(false);
   }
 
   async function handleDelete() {
@@ -132,7 +135,7 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
     props.onDelete?.(existingLlmTool);
 
     await utils.llmTools.getAll.invalidate({ projectId });
-    setOpen(false);
+    onOpenChange(false);
   }
 
   const prettifyJson = () => {
@@ -151,14 +154,8 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild onClick={(e) => e.stopPropagation()}>
-        {children}
-      </DialogTrigger>
-      <DialogContent
-        className="flex flex-col sm:min-w-128 md:min-w-160"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex flex-col sm:min-w-128 md:min-w-160">
         <DialogHeader>
           <DialogTitle>
             {existingLlmTool ? "Edit LLM Tool" : "Create LLM Tool"}
@@ -283,7 +280,7 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={() => setOpen(false)}
+                    onClick={() => onOpenChange(false)}
                   >
                     Cancel
                   </Button>

--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -7,7 +7,6 @@ import { PlusIcon, PencilIcon, MinusCircle, WrenchIcon } from "lucide-react";
 import { type LlmTool } from "@prisma/client";
 import { api } from "@/src/utils/api";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
-import { CreateOrEditLLMToolDialog } from "@/src/features/playground/page/components/CreateOrEditLLMToolDialog";
 import {
   Command,
   CommandEmpty,
@@ -20,10 +19,85 @@ import {
 
 import { type PlaygroundTool } from "@/src/features/playground/page/types";
 
-// Popover content component for use in CollapsibleSection action buttons
-export const PlaygroundToolsPopover = () => {
+/**
+ * What the create/edit tool dialog should be opened with. The dialog itself is
+ * owned by the parent that renders the Tools popover, so it survives the
+ * popover closing (see the overlay lifecycle note in web/AGENTS.md).
+ */
+export type ToolDialogTarget = {
+  existingLlmTool?: LlmTool;
+  defaultValues?: {
+    name: string;
+    description: string;
+    parameters: string;
+  };
+  /** Tool to detach from the playground when it is deleted from the project. */
+  removeToolId?: string;
+};
+
+type ToolDialogProps = {
+  onOpenToolDialog: (target: ToolDialogTarget) => void;
+};
+
+/** Attach/replace and detach helpers shared by the tool list and the picker. */
+export const usePlaygroundToolActions = () => {
   const { setTools } = usePlaygroundContext();
+
+  const handleSelectTool = useCallback(
+    (selectedLLMTool: LlmTool) => {
+      setTools((prev: PlaygroundTool[]) => {
+        let existingToolIndex = -1;
+        existingToolIndex = prev.findIndex((t) => t.id === selectedLLMTool.id);
+
+        if (existingToolIndex === -1) {
+          const unsavedToolIndexWithSameName = prev.findIndex(
+            (t) => t.name === selectedLLMTool.name,
+          );
+
+          if (unsavedToolIndexWithSameName !== -1) {
+            existingToolIndex = unsavedToolIndexWithSameName;
+          }
+        }
+
+        const newTool: PlaygroundTool = {
+          id: selectedLLMTool.id,
+          name: selectedLLMTool.name,
+          description: selectedLLMTool.description,
+          parameters: selectedLLMTool.parameters as Record<string, unknown>,
+          existingLlmTool: selectedLLMTool,
+        };
+
+        if (existingToolIndex !== -1) {
+          const newTools = [...prev];
+          newTools[existingToolIndex] = newTool;
+          return newTools;
+        }
+
+        return [...prev, newTool];
+      });
+    },
+    [setTools],
+  );
+
+  const handleRemoveTool = useCallback(
+    (toolId: string) => {
+      setTools(
+        (prev: PlaygroundTool[]) =>
+          prev.filter((t) => !(t.id === toolId)) as PlaygroundTool[],
+      );
+    },
+    [setTools],
+  );
+
+  return { handleSelectTool, handleRemoveTool };
+};
+
+// Popover content component for use in CollapsibleSection action buttons
+export const PlaygroundToolsPopover = ({
+  onOpenToolDialog,
+}: ToolDialogProps) => {
   const projectId = useProjectIdFromURL();
+  const { handleSelectTool } = usePlaygroundToolActions();
 
   const { data: savedTools = [] } = api.llmTools.getAll.useQuery(
     {
@@ -34,46 +108,6 @@ export const PlaygroundToolsPopover = () => {
       staleTime: 1000 * 60 * 5, // 5 minutes
     },
   );
-
-  const handleSelectTool = (selectedLLMTool: LlmTool) => {
-    setTools((prev: PlaygroundTool[]) => {
-      let existingToolIndex = -1;
-      existingToolIndex = prev.findIndex((t) => t.id === selectedLLMTool.id);
-
-      if (existingToolIndex === -1) {
-        const unsavedToolIndexWithSameName = prev.findIndex(
-          (t) => t.name === selectedLLMTool.name,
-        );
-
-        if (unsavedToolIndexWithSameName !== -1) {
-          existingToolIndex = unsavedToolIndexWithSameName;
-        }
-      }
-
-      const newTool: PlaygroundTool = {
-        id: selectedLLMTool.id,
-        name: selectedLLMTool.name,
-        description: selectedLLMTool.description,
-        parameters: selectedLLMTool.parameters as Record<string, unknown>,
-        existingLlmTool: selectedLLMTool,
-      };
-
-      if (existingToolIndex !== -1) {
-        const newTools = [...prev];
-        newTools[existingToolIndex] = newTool;
-        return newTools;
-      }
-
-      return [...prev, newTool];
-    });
-  };
-
-  const handleRemoveTool = (toolId: string) => {
-    setTools(
-      (prev: PlaygroundTool[]) =>
-        prev.filter((t) => !(t.id === toolId)) as PlaygroundTool[],
-    );
-  };
 
   return (
     <Command className="flex flex-col">
@@ -105,45 +139,47 @@ export const PlaygroundToolsPopover = () => {
                   </div>
                 </div>
               </div>
-              <CreateOrEditLLMToolDialog
-                projectId={projectId as string}
-                onSave={handleSelectTool}
-                onDelete={() => handleRemoveTool(tool.id)}
-                existingLlmTool={tool}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="ml-2 h-7 w-7 shrink-0"
+                aria-label={`Edit tool ${tool.name}`}
+                onClick={(e) => {
+                  // Editing must not also attach the tool via CommandItem.onSelect
+                  e.stopPropagation();
+                  onOpenToolDialog({
+                    existingLlmTool: tool,
+                    removeToolId: tool.id,
+                  });
+                }}
               >
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="ml-2 h-7 w-7 shrink-0"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <PencilIcon className="h-3.5 w-3.5" />
-                </Button>
-              </CreateOrEditLLMToolDialog>
+                <PencilIcon className="h-3.5 w-3.5" />
+              </Button>
             </CommandItem>
           ))}
         </CommandGroup>
         <CommandSeparator />
       </CommandList>
       <div className="mt-auto p-1">
-        <CreateOrEditLLMToolDialog
-          projectId={projectId as string}
-          onSave={handleSelectTool}
+        <Button
+          variant="outline"
+          size="default"
+          className="w-full"
+          onClick={() => onOpenToolDialog({})}
         >
-          <Button variant="outline" size="default" className="w-full">
-            <PlusIcon className="mr-2 h-4 w-4" />
-            Create new tool
-          </Button>
-        </CreateOrEditLLMToolDialog>
+          <PlusIcon className="mr-2 h-4 w-4" />
+          Create new tool
+        </Button>
       </div>
     </Command>
   );
 };
 
 // Main component for embedding in CollapsibleSection content
-export const PlaygroundTools = () => {
+export const PlaygroundTools = ({ onOpenToolDialog }: ToolDialogProps) => {
   const { tools, setTools } = usePlaygroundContext();
   const projectId = useProjectIdFromURL();
+  const { handleRemoveTool } = usePlaygroundToolActions();
 
   const { data: savedTools = [] } = api.llmTools.getAll.useQuery(
     {
@@ -168,6 +204,23 @@ export const PlaygroundTools = () => {
     [savedTools],
   );
 
+  const toolDialogTarget = useCallback(
+    (tool: PlaygroundTool): ToolDialogTarget => ({
+      existingLlmTool: tool.existingLlmTool,
+      // A tool that drifted from its saved version (e.g. restored from a prompt)
+      // seeds the form with the playground copy rather than the saved one.
+      defaultValues: !isToolSaved(tool)
+        ? {
+            name: tool.name,
+            description: tool.description,
+            parameters: JSON.stringify(tool.parameters, null, 2),
+          }
+        : undefined,
+      removeToolId: tool.id,
+    }),
+    [isToolSaved],
+  );
+
   useEffect(() => {
     tools.forEach((tool, index) => {
       if (!tool.existingLlmTool) {
@@ -188,46 +241,6 @@ export const PlaygroundTools = () => {
     });
   }, [savedTools, tools, setTools]);
 
-  const handleSelectTool = (selectedLLMTool: LlmTool) => {
-    setTools((prev: PlaygroundTool[]) => {
-      let existingToolIndex = -1;
-      existingToolIndex = prev.findIndex((t) => t.id === selectedLLMTool.id);
-
-      if (existingToolIndex === -1) {
-        const unsavedToolIndexWithSameName = prev.findIndex(
-          (t) => t.name === selectedLLMTool.name,
-        );
-
-        if (unsavedToolIndexWithSameName !== -1) {
-          existingToolIndex = unsavedToolIndexWithSameName;
-        }
-      }
-
-      const newTool: PlaygroundTool = {
-        id: selectedLLMTool.id,
-        name: selectedLLMTool.name,
-        description: selectedLLMTool.description,
-        parameters: selectedLLMTool.parameters as Record<string, unknown>,
-        existingLlmTool: selectedLLMTool,
-      };
-
-      if (existingToolIndex !== -1) {
-        const newTools = [...prev];
-        newTools[existingToolIndex] = newTool;
-        return newTools;
-      }
-
-      return [...prev, newTool];
-    });
-  };
-
-  const handleRemoveTool = (toolId: string) => {
-    setTools(
-      (prev: PlaygroundTool[]) =>
-        prev.filter((t) => !(t.id === toolId)) as PlaygroundTool[],
-    );
-  };
-
   return (
     <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[min(45vh,18rem)]">
       {tools.length === 0 ? (
@@ -237,60 +250,52 @@ export const PlaygroundTools = () => {
       ) : (
         <div className="space-y-1">
           {tools.map((tool) => (
-            <CreateOrEditLLMToolDialog
+            <div
               key={tool.id}
-              projectId={projectId as string}
-              onSave={handleSelectTool}
-              onDelete={() => handleRemoveTool(tool.id)}
-              existingLlmTool={tool.existingLlmTool}
-              defaultValues={
-                !isToolSaved(tool)
-                  ? {
-                      name: tool.name,
-                      description: tool.description,
-                      parameters: JSON.stringify(tool.parameters, null, 2),
-                    }
-                  : undefined
-              }
+              role="button"
+              tabIndex={0}
+              aria-label={`Edit tool ${tool.name}`}
+              className="bg-background hover:bg-accent/50 relative cursor-pointer rounded-md border p-2 pr-10 transition-colors duration-200"
+              onClick={() => onOpenToolDialog(toolDialogTarget(tool))}
+              onKeyDown={(e) => {
+                if (e.key !== "Enter" && e.key !== " ") return;
+                e.preventDefault();
+                onOpenToolDialog(toolDialogTarget(tool));
+              }}
             >
-              <div className="bg-background hover:bg-accent/50 relative cursor-pointer rounded-md border p-2 pr-10 transition-colors duration-200">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="absolute top-2 right-3 h-6 w-6 p-0"
-                  aria-label={`Remove tool ${tool.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    handleRemoveTool(tool.id);
-                  }}
-                >
-                  <MinusCircle className="h-4 w-4" />
-                </Button>
-                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-2 gap-y-1">
-                  <WrenchIcon className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
-                  <div className="min-w-0">
-                    <h3
-                      className="truncate text-sm font-bold"
-                      title={tool.name}
-                    >
-                      {tool.name}
-                    </h3>
-                    {!isToolSaved(tool) ? (
-                      <span className="bg-muted text-muted-foreground mt-1 inline-flex rounded px-1 py-0.5 text-xs">
-                        Unsaved
-                      </span>
-                    ) : null}
-                  </div>
-                  <p
-                    className="text-muted-foreground col-start-2 line-clamp-2 text-xs break-words"
-                    title={tool.description}
-                  >
-                    {tool.description}
-                  </p>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="absolute top-2 right-3 h-6 w-6 p-0"
+                aria-label={`Remove tool ${tool.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  handleRemoveTool(tool.id);
+                }}
+              >
+                <MinusCircle className="h-4 w-4" />
+              </Button>
+              <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-2 gap-y-1">
+                <WrenchIcon className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-bold" title={tool.name}>
+                    {tool.name}
+                  </h3>
+                  {!isToolSaved(tool) ? (
+                    <span className="bg-muted text-muted-foreground mt-1 inline-flex rounded px-1 py-0.5 text-xs">
+                      Unsaved
+                    </span>
+                  ) : null}
                 </div>
+                <p
+                  className="text-muted-foreground col-start-2 line-clamp-2 text-xs break-words"
+                  title={tool.description}
+                >
+                  {tool.description}
+                </p>
               </div>
-            </CreateOrEditLLMToolDialog>
+            </div>
           ))}
         </div>
       )}

--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -252,16 +252,8 @@ export const PlaygroundTools = ({ onOpenToolDialog }: ToolDialogProps) => {
           {tools.map((tool) => (
             <div
               key={tool.id}
-              role="button"
-              tabIndex={0}
-              aria-label={`Edit tool ${tool.name}`}
               className="bg-background hover:bg-accent/50 relative cursor-pointer rounded-md border p-2 pr-10 transition-colors duration-200"
               onClick={() => onOpenToolDialog(toolDialogTarget(tool))}
-              onKeyDown={(e) => {
-                if (e.key !== "Enter" && e.key !== " ") return;
-                e.preventDefault();
-                onOpenToolDialog(toolDialogTarget(tool));
-              }}
             >
               <Button
                 variant="ghost"


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #16738

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

Opening the create/edit tool dialog from the playground Tools dropdown left the dropdown open underneath the dialog. Same for the pencil (edit) icon and for clicking an attached tool card.

After the fix (before is in the issue):

https://github.com/user-attachments/assets/0abf5764-0d3e-48e0-8989-3680d50b7bac

Tests: ConfigurationDropdowns.clienttest.tsx asserts the popover is gone once the dialog opens and comes back when it is cancelled. The first case fails on main.

Not in scope: the Structured Output dropdown has the same nesting via CreateOrEditLLMSchemaDialog, but PromptModelStep also consumes it — happy to follow up.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves the playground tool dialog outside the Tools popover and introduces controlled overlay state so opening create or edit closes the popover first.
- Centralizes tool attachment and removal helpers.
- Reopens the Tools popover after cancellation but leaves it closed after save or deletion.
- Adds tests for create-dialog popover closure and cancellation.
- Adds keyboard activation to attached tool cards.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The keyboard interaction defect on attached tool cards should be fixed before merging because removing a tool can also open its edit dialog.

The new parent-card key handler receives Enter and Space events from the nested Remove button, conflating two distinct actions for keyboard users.

**Files Needing Attention:** web/src/features/playground/page/components/PlaygroundTools/index.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/playground/page/components/PlaygroundTools/index.tsx:260-264
**Remove keypress opens dialog**

When a keyboard user presses Enter or Space on the nested Remove button, its keydown event bubbles to the tool card and opens the edit dialog; Enter also removes the tool, while Space can suppress removal.

```suggestion
              onKeyDown={(e) => {
                if (e.target !== e.currentTarget) return;
                if (e.key !== "Enter" && e.key !== " ") return;
                e.preventDefault();
                onOpenToolDialog(toolDialogTarget(tool));
              }}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playground): close the tools popover..."](https://github.com/langfuse/langfuse/commit/6f821b2b65bed9709927640a3975868dc4cf64a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57836013)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->