### PR TITLE
fix(worker): harden analytics export URL checks and host logging

### DIFF
--- a/worker/src/__tests__/analyticsIntegrationLogRedaction.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationLogRedaction.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Credential redaction at the log sink for the analytics exporters.
+ *
+ * A configured host can carry credentials, and the log line fires exactly
+ * when that URL was rejected — including when it was rejected for carrying
+ * them. Assertions walk Error objects (name/message/stack/cause) rather
+ * than JSON.stringify-ing the call array: JSON.stringify renders an Error
+ * as {}, and the Mixpanel sender passes the raw error as a second argument.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_HOST;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IPS;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IP_SEGMENTS;
+});
+
+const PASSWORD = "hunter2";
+const CREDENTIALED_HOST = `http://exporter:${PASSWORD}@10.0.0.1`;
+
+const h = vi.hoisted(() => {
+  const calls: unknown[][] = [];
+  const record =
+    (level: string) =>
+    (...args: unknown[]) => {
+      calls.push([level, ...args]);
+    };
+  const logger = {
+    error: vi.fn(record("error")),
+    warn: vi.fn(record("warn")),
+    info: vi.fn(record("info")),
+    debug: vi.fn(record("debug")),
+  };
+  const noRows = () => (async function* () {})();
+  const oneRow = () =>
+    (async function* () {
+      yield { langfuse_id: "row-1" };
+    })();
+  const integration = {
+    projectId: "project-1",
+    enabled: true,
+    exportSource: "TRACES_OBSERVATIONS",
+    posthogHostName: "http://exporter:hunter2@10.0.0.1/",
+    encryptedPosthogApiKey: "enc",
+    lastSyncAt: new Date("2024-01-01"),
+    project: { name: "Test Project", createdAt: new Date("2023-01-01") },
+  };
+  const posthogIntegrationUpdate = vi.fn();
+  const posthogIntegrationUpdateMany = vi.fn(async () => ({ count: 1 }));
+  const dispatchProjectNotification = vi.fn(async () => {});
+  return {
+    calls,
+    logger,
+    noRows,
+    oneRow,
+    integration,
+    posthogIntegrationUpdate,
+    posthogIntegrationUpdateMany,
+    dispatchProjectNotification,
+  };
+});
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    posthogIntegration: {
+      findFirst: vi.fn(async () => h.integration),
+      update: h.posthogIntegrationUpdate,
+      updateMany: h.posthogIntegrationUpdateMany,
+    },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    logger: h.logger,
+    getCurrentSpan: vi.fn(() => undefined),
+    recordIncrement: vi.fn(),
+    dispatchProjectNotification: h.dispatchProjectNotification,
+    getTracesForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+    getGenerationsForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+    getScoresForAnalyticsIntegrations: vi.fn(() => h.oneRow()),
+    getEventsForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+  };
+});
+
+vi.mock("../features/posthog/transformers", () => {
+  const payload = () => ({
+    distinctId: "p",
+    event: "langfuse",
+    properties: {},
+  });
+  return {
+    transformTraceForPostHog: vi.fn(payload),
+    transformGenerationForPostHog: vi.fn(payload),
+    transformScoreForPostHog: vi.fn(payload),
+    transformEventForPostHog: vi.fn(payload),
+  };
+});
+
+vi.mock("@langfuse/shared/encryption", () => ({
+  decrypt: vi.fn(() => "phc_decrypted"),
+}));
+
+vi.mock("../env", () => ({
+  env: {
+    LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
+    LANGFUSE_POSTHOG_FLUSH_DELAY_MS: 0,
+    LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: 0,
+    LANGFUSE_MIXPANEL_TIMEOUT_MS: 3_000,
+  },
+  v4WritesToLegacyTables: () => true,
+  v4WritesToEventsTable: () => false,
+}));
+
+import { handlePostHogIntegrationProjectJob } from "../features/posthog/handlePostHogIntegrationProjectJob";
+import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
+import type { MixpanelEvent } from "../features/mixpanel/transformers";
+
+function everythingLogged(): string {
+  const parts: string[] = [];
+
+  const visit = (value: unknown, depth: number): void => {
+    if (value == null || depth > 6) return;
+
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      parts.push(String(value));
+      return;
+    }
+    if (value instanceof Error) {
+      parts.push(value.name, value.message, String(value.stack ?? ""));
+      visit((value as Error & { cause?: unknown }).cause, depth + 1);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((entry) => visit(entry, depth + 1));
+      return;
+    }
+    if (typeof value === "object") {
+      Object.values(value as Record<string, unknown>).forEach((entry) =>
+        visit(entry, depth + 1),
+      );
+    }
+  };
+
+  h.calls.forEach((call) => call.forEach((arg) => visit(arg, 0)));
+  return parts.join("\n");
+}
+
+describe("analytics export credential redaction at the log sink", () => {
+  beforeEach(() => {
+    h.calls.length = 0;
+  });
+
+  it("never writes a configured password to any log level (PostHog)", async () => {
+    await handlePostHogIntegrationProjectJob({
+      data: { id: "job-1", payload: { projectId: "project-1" } },
+      attemptsMade: 0,
+    } as never);
+
+    const logged = everythingLogged();
+
+    expect(h.calls.length).toBeGreaterThan(0);
+    expect(logged).toContain("10.0.0.1");
+    expect(logged).not.toContain(PASSWORD);
+  }, 10_000);
+
+  it("never writes a configured password to any log level (Mixpanel)", async () => {
+    const client = new MixpanelClient({
+      projectToken: "t",
+      region: "api",
+      baseUrl: CREDENTIALED_HOST,
+    });
+    client.addEvent({
+      event: "trace",
+      properties: { token: "t", distinct_id: "1", $insert_id: 1 },
+    } as unknown as MixpanelEvent);
+
+    await expect(client.flush()).rejects.toThrow();
+
+    const logged = everythingLogged();
+
+    expect(h.calls.length).toBeGreaterThan(0);
+    expect(logged).toMatch(/credentials|not allowed/i);
+    expect(logged).not.toContain(PASSWORD);
+  }, 10_000);
+});

--- a/worker/src/__tests__/analyticsIntegrationOutboundUrlAllowlist.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationOutboundUrlAllowlist.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Allowlisted counterpart to analyticsIntegrationOutboundUrlNegative.test.ts.
+ *
+ * That file proves an empty allowlist permits no internal target. This one
+ * proves the other half: when a self-hosted operator allowlists a host, the
+ * Mixpanel export still delivers. Needs LANGFUSE_WEBHOOK_WHITELISTED_HOST
+ * set before shared's env module is parsed, so it lives in its own file.
+ *
+ * Analytics exports share the webhook allowlist on purpose: allowing a host
+ * for webhook delivery also allows exports to it.
+ */
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.LANGFUSE_WEBHOOK_WHITELISTED_HOST = "localhost";
+});
+
+vi.mock("../env", () => ({
+  env: {
+    LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
+    LANGFUSE_POSTHOG_FLUSH_DELAY_MS: 0,
+    LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: 0,
+    LANGFUSE_MIXPANEL_TIMEOUT_MS: 10_000,
+  },
+  v4WritesToLegacyTables: () => true,
+  v4WritesToEventsTable: () => false,
+}));
+
+import { whitelistFromEnv } from "@langfuse/shared/src/server";
+import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
+import type { MixpanelEvent } from "../features/mixpanel/transformers";
+
+const openServers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    openServers
+      .splice(0)
+      .map((s) => new Promise<void>((r) => s.close(() => r()))),
+  );
+});
+
+async function startRecordingServer() {
+  const received: Array<{ encoding?: string; bytes: number }> = [];
+  const server = createServer((req, res) => {
+    let bytes = 0;
+    req.on("data", (chunk) => {
+      bytes += chunk.length;
+    });
+    req.on("end", () => {
+      received.push({
+        encoding: req.headers["content-encoding"] as string | undefined,
+        bytes,
+      });
+      res.end("{}");
+    });
+  });
+  openServers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { received, port: (server.address() as AddressInfo).port };
+}
+
+describe("allowlisted outbound destination", () => {
+  it("reads the operator allowlist through the accessor production uses", () => {
+    expect(whitelistFromEnv().hosts).toContain("localhost");
+  });
+
+  it("delivers a gzipped Mixpanel batch to an allowlisted host", async () => {
+    const { received, port } = await startRecordingServer();
+
+    const client = new MixpanelClient({
+      projectToken: "t",
+      region: "api",
+      baseUrl: `http://localhost:${port}`,
+    });
+    client.addEvent({
+      event: "trace",
+      properties: { token: "t", distinct_id: "1", $insert_id: 1 },
+    } as unknown as MixpanelEvent);
+
+    await client.flush();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].encoding).toBe("gzip");
+    expect(received[0].bytes).toBeGreaterThan(0);
+    expect(client.getSerializedBytes()).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/worker/src/__tests__/analyticsIntegrationOutboundUrlNegative.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationOutboundUrlNegative.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Mandated negative coverage for PostHog and Mixpanel outbound URLs:
+ * loopback literals, cloud metadata, RFC1918, a hostname that resolves
+ * internally, embedded credentials, and a non-HTTP scheme.
+ *
+ * Unlike analyticsIntegrationSsrfPinning.test.ts, validateWebhookURL is
+ * not mocked: these cases prove the URL-level defenses.
+ *
+ * Empty allowlist is the premise. vitest loads ../.env, and a developer
+ * who allowlists localhost for webhook testing would otherwise turn the
+ * hostname cases into mystery failures.
+ */
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isUnrecoverableError } from "../errors/UnrecoverableError";
+
+vi.hoisted(() => {
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_HOST;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IPS;
+  delete process.env.LANGFUSE_WEBHOOK_WHITELISTED_IP_SEGMENTS;
+});
+
+const openServers: Server[] = [];
+
+async function startLoopbackServer(onRequest: () => void) {
+  const server = createServer((_req, res) => {
+    onRequest();
+    res.end("{}");
+  });
+  openServers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return (server.address() as AddressInfo).port;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    openServers
+      .splice(0)
+      .map((s) => new Promise<void>((r) => s.close(() => r()))),
+  );
+});
+
+const h = vi.hoisted(() => {
+  const posthogIntegrationUpdate = vi.fn();
+  const posthogIntegrationUpdateMany = vi.fn(async () => ({ count: 1 }));
+  const recordIncrement = vi.fn();
+  const dispatchProjectNotification = vi.fn(async () => {});
+  const oneRow = () =>
+    (async function* () {
+      yield { langfuse_id: "row-1" };
+    })();
+  const noRows = () => (async function* () {})();
+  const integration = () => ({
+    projectId: "project-1",
+    enabled: true,
+    exportSource: "TRACES_OBSERVATIONS",
+    posthogHostName: "http://placeholder.invalid",
+    encryptedPosthogApiKey: "enc",
+    lastSyncAt: new Date("2024-01-01"),
+    project: { name: "Test Project", createdAt: new Date("2023-01-01") },
+  });
+  const db = { integration: integration() as Record<string, unknown> };
+  return {
+    posthogIntegrationUpdate,
+    posthogIntegrationUpdateMany,
+    recordIncrement,
+    dispatchProjectNotification,
+    oneRow,
+    noRows,
+    integration,
+    db,
+  };
+});
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    posthogIntegration: {
+      findFirst: vi.fn(async () => h.db.integration),
+      update: h.posthogIntegrationUpdate,
+      updateMany: h.posthogIntegrationUpdateMany,
+    },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getCurrentSpan: vi.fn(() => undefined),
+    recordIncrement: h.recordIncrement,
+    dispatchProjectNotification: h.dispatchProjectNotification,
+    getTracesForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+    getGenerationsForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+    getScoresForAnalyticsIntegrations: vi.fn(() => h.oneRow()),
+    getEventsForAnalyticsIntegrations: vi.fn(() => h.noRows()),
+  };
+});
+
+vi.mock("../features/posthog/transformers", () => {
+  const payload = () => ({
+    distinctId: "p",
+    event: "langfuse",
+    properties: {},
+  });
+  return {
+    transformTraceForPostHog: vi.fn(payload),
+    transformGenerationForPostHog: vi.fn(payload),
+    transformScoreForPostHog: vi.fn(payload),
+    transformEventForPostHog: vi.fn(payload),
+  };
+});
+
+vi.mock("@langfuse/shared/encryption", () => ({
+  decrypt: vi.fn(() => "phc_decrypted"),
+}));
+
+vi.mock("../env", () => ({
+  env: {
+    LANGFUSE_MIGRATION_V4_WRITE_MODE: "legacy",
+    LANGFUSE_POSTHOG_FLUSH_DELAY_MS: 0,
+    LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: 0,
+    LANGFUSE_MIXPANEL_TIMEOUT_MS: 3_000,
+  },
+  v4WritesToLegacyTables: () => true,
+  v4WritesToEventsTable: () => false,
+}));
+
+import { whitelistFromEnv } from "@langfuse/shared/src/server";
+import { handlePostHogIntegrationProjectJob } from "../features/posthog/handlePostHogIntegrationProjectJob";
+import { MixpanelClient } from "../features/mixpanel/mixpanelClient";
+import type { MixpanelEvent } from "../features/mixpanel/transformers";
+
+function makeJob() {
+  return {
+    data: { id: "job-1", payload: { projectId: "project-1" } },
+    attemptsMade: 0,
+  } as unknown as Parameters<typeof handlePostHogIntegrationProjectJob>[0];
+}
+
+function causeChainIncludes(error: unknown, needle: string): boolean {
+  let current: any = error;
+  for (let depth = 0; depth < 6 && current; depth++) {
+    if (typeof current.message === "string" && current.message.includes(needle))
+      return true;
+    current = current.cause;
+  }
+  return false;
+}
+
+const BLOCKED_DESTINATIONS: Array<[label: string, url: string]> = [
+  ["loopback literal", "http://127.0.0.1/"],
+  ["IPv6 loopback literal", "http://[::1]/"],
+  ["cloud metadata literal", "http://169.254.169.254/"],
+  ["RFC1918 literal", "http://10.0.0.5/"],
+  ["hostname resolving to loopback", "http://localhost/"],
+];
+
+const CREDENTIALED_URL = "http://exporter:hunter2@127.0.0.1/";
+
+describe("negative-suite premise", () => {
+  it("runs with a genuinely empty allowlist", () => {
+    expect(whitelistFromEnv()).toEqual({ hosts: [], ips: [], ip_ranges: [] });
+  });
+});
+
+describe("PostHog export — blocked outbound destinations are rejected", () => {
+  beforeEach(() => {
+    h.posthogIntegrationUpdate.mockClear();
+    h.posthogIntegrationUpdateMany.mockClear();
+    h.recordIncrement.mockClear();
+    h.dispatchProjectNotification.mockClear();
+    h.db.integration = h.integration();
+  });
+
+  it.each(BLOCKED_DESTINATIONS)(
+    "rejects %s, disables the integration, and does not advance the sync cursor",
+    async (_label, url) => {
+      h.db.integration.posthogHostName = url;
+
+      // Customer-config faults disable and resolve rather than throw, so a
+      // blocked host must not light the Failures monitor.
+      await expect(
+        handlePostHogIntegrationProjectJob(makeJob()),
+      ).resolves.toBeUndefined();
+
+      expect(h.posthogIntegrationUpdateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { enabled: false } }),
+      );
+      expect(h.posthogIntegrationUpdate).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ lastSyncAt: expect.anything() }),
+        }),
+      );
+    },
+  );
+
+  it("rejects a URL with embedded credentials without leaking the password", async () => {
+    h.db.integration.posthogHostName = CREDENTIALED_URL;
+
+    await expect(
+      handlePostHogIntegrationProjectJob(makeJob()),
+    ).resolves.toBeUndefined();
+
+    expect(h.posthogIntegrationUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { enabled: false } }),
+    );
+    const persisted = h.posthogIntegrationUpdate.mock.calls.flatMap((call) =>
+      JSON.stringify(call),
+    );
+    expect(persisted.join("\n")).not.toContain("hunter2");
+  });
+});
+
+describe("Mixpanel export — blocked outbound destinations are rejected", () => {
+  const addOneEvent = (client: MixpanelClient) =>
+    client.addEvent({
+      event: "trace",
+      properties: { token: "t", distinct_id: "1", $insert_id: 1 },
+    } as unknown as MixpanelEvent);
+
+  it("does not send to a loopback literal that is actually listening", async () => {
+    let requestCount = 0;
+    const port = await startLoopbackServer(() => {
+      requestCount++;
+    });
+
+    const client = new MixpanelClient({
+      projectToken: "t",
+      region: "api",
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+    addOneEvent(client);
+
+    let thrown: unknown;
+    try {
+      await client.flush();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(requestCount).toBe(0);
+    expect(thrown).toBeDefined();
+    expect(isUnrecoverableError(thrown)).toBe(true);
+  }, 10_000);
+
+  it.each(BLOCKED_DESTINATIONS)(
+    "refuses %s as a terminal SSRF block",
+    async (_label, url) => {
+      const client = new MixpanelClient({
+        projectToken: "t",
+        region: "api",
+        baseUrl: url.replace(/\/$/, ""),
+      });
+      addOneEvent(client);
+
+      let thrown: unknown;
+      try {
+        await client.flush();
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(isUnrecoverableError(thrown)).toBe(true);
+      expect(causeChainIncludes(thrown, "Blocked")).toBe(true);
+    },
+    10_000,
+  );
+
+  it("rejects a URL with embedded credentials without leaking the password", async () => {
+    const client = new MixpanelClient({
+      projectToken: "t",
+      region: "api",
+      baseUrl: CREDENTIALED_URL.replace(/\/$/, ""),
+    });
+    addOneEvent(client);
+
+    let thrown: unknown;
+    try {
+      await client.flush();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(String((thrown as Error).message)).not.toContain("hunter2");
+  }, 10_000);
+
+  it("refuses a non-HTTP(S) destination scheme", async () => {
+    const client = new MixpanelClient({
+      projectToken: "t",
+      region: "api",
+      baseUrl: "ftp://10.0.0.1",
+    });
+    addOneEvent(client);
+
+    await expect(client.flush()).rejects.toThrow(/HTTP and HTTPS/);
+  }, 10_000);
+});

--- a/worker/src/__tests__/analyticsIntegrationUrlValidation.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationUrlValidation.test.ts
@@ -90,7 +90,7 @@ describe("hostnameForLog", () => {
     ).toBe("posthog.example.com");
   });
 
-  it("marks an unparseable value instead of throwing", () => {
-    expect(hostnameForLog("not a url")).toBe("<unparseable>");
+  it("marks an unparsable value instead of throwing", () => {
+    expect(hostnameForLog("not a url")).toBe("<unparsable>");
   });
 });

--- a/worker/src/__tests__/analyticsIntegrationUrlValidation.test.ts
+++ b/worker/src/__tests__/analyticsIntegrationUrlValidation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Use-time URL check for analytics exporters: IP literals, embedded
+ * credentials, and non-HTTP schemes. Named hosts are left to connect-time
+ * pinning (see analyticsIntegrationSsrfPinning.test.ts).
+ *
+ * Passes an empty allowlist explicitly so a developer-local webhook
+ * allowlist cannot make these assertions vacuous.
+ */
+import { describe, expect, it } from "vitest";
+import { OutboundUrlValidationError } from "@langfuse/shared/src/server";
+import {
+  hostnameForLog,
+  validateAnalyticsIntegrationUrl,
+} from "../features/analyticsIntegrationEgress";
+
+const EMPTY_ALLOWLIST = { hosts: [], ips: [], ip_ranges: [] };
+
+const blockedIpLiterals: Array<[string, string]> = [
+  ["loopback literal", "http://127.0.0.1/"],
+  ["IPv6 loopback literal", "http://[::1]/"],
+  ["cloud metadata literal", "http://169.254.169.254/"],
+  ["RFC1918 literal", "http://10.0.0.5/"],
+];
+
+describe("validateAnalyticsIntegrationUrl", () => {
+  it.each(blockedIpLiterals)("rejects a %s", (_label, url) => {
+    expect(() =>
+      validateAnalyticsIntegrationUrl(url, EMPTY_ALLOWLIST),
+    ).toThrowError(OutboundUrlValidationError);
+    try {
+      validateAnalyticsIntegrationUrl(url, EMPTY_ALLOWLIST);
+    } catch (error) {
+      expect((error as OutboundUrlValidationError).code).toBe("blocked-ip");
+    }
+  });
+
+  it("rejects embedded credentials without echoing the password", () => {
+    expect(() =>
+      validateAnalyticsIntegrationUrl(
+        "http://exporter:hunter2@127.0.0.1/",
+        EMPTY_ALLOWLIST,
+      ),
+    ).toThrowError(OutboundUrlValidationError);
+
+    try {
+      validateAnalyticsIntegrationUrl(
+        "http://exporter:hunter2@127.0.0.1/",
+        EMPTY_ALLOWLIST,
+      );
+    } catch (error) {
+      expect((error as OutboundUrlValidationError).code).toBe(
+        "url-credentials-not-allowed",
+      );
+      expect(String((error as Error).message)).not.toContain("hunter2");
+    }
+  });
+
+  it("rejects a non-HTTP(S) scheme", () => {
+    expect(() =>
+      validateAnalyticsIntegrationUrl("ftp://10.0.0.1/", EMPTY_ALLOWLIST),
+    ).toThrowError(OutboundUrlValidationError);
+    try {
+      validateAnalyticsIntegrationUrl("ftp://10.0.0.1/", EMPTY_ALLOWLIST);
+    } catch (error) {
+      expect((error as OutboundUrlValidationError).code).toBe(
+        "protocol-not-allowed",
+      );
+    }
+  });
+
+  it("does not DNS-check a named host (connect-time pinning owns that)", () => {
+    expect(() =>
+      validateAnalyticsIntegrationUrl(
+        "https://api.mixpanel.com/import?strict=1",
+        EMPTY_ALLOWLIST,
+      ),
+    ).not.toThrow();
+    // localhost is a name, not a literal; this check must not pretend to
+    // have blocked it, or a later connect-time regression could hide here.
+    expect(() =>
+      validateAnalyticsIntegrationUrl("http://localhost/", EMPTY_ALLOWLIST),
+    ).not.toThrow();
+  });
+});
+
+describe("hostnameForLog", () => {
+  it("returns only the hostname from a credentialed URL", () => {
+    expect(
+      hostnameForLog("http://admin:hunter2@posthog.example.com/batch"),
+    ).toBe("posthog.example.com");
+  });
+
+  it("marks an unparseable value instead of throwing", () => {
+    expect(hostnameForLog("not a url")).toBe("<unparseable>");
+  });
+});

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -57,7 +57,7 @@ export function hostnameForLog(configuredUrl: string): string {
   try {
     return new URL(configuredUrl).hostname || "<no hostname>";
   } catch {
-    return "<unparseable>";
+    return "<unparsable>";
   }
 }
 

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -1,8 +1,13 @@
 import {
+  isIPAddress,
   logger,
+  OutboundUrlValidationError,
+  parseOutboundUrl,
   redactUrlCredentials,
+  validateOutboundResolvedIp,
   validateWebhookURL,
   whitelistFromEnv,
+  type OutboundUrlValidationWhitelist,
   type RedirectOptions,
 } from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../errors/UnrecoverableError";
@@ -34,6 +39,79 @@ export const buildAnalyticsRedirectOptions = (
     logContext,
   },
 });
+
+/**
+ * Hostname of a configured URL, for log lines and notifications.
+ *
+ * Never log the configured URL itself: it can carry credentials
+ * (`http://user:pass@host`), and the rejection path fires exactly when the
+ * URL was refused — including when it was refused for carrying them. The
+ * hostname component cannot contain userinfo.
+ *
+ * Uses `new URL` rather than `parseOutboundUrl` deliberately: this is
+ * redaction, not validation, and `parseOutboundUrl` refuses a credentialed
+ * URL outright, so it cannot extract a safe hostname from the case that
+ * matters most.
+ */
+export function hostnameForLog(configuredUrl: string): string {
+  try {
+    return new URL(configuredUrl).hostname || "<no hostname>";
+  } catch {
+    return "<unparseable>";
+  }
+}
+
+/**
+ * Use-time destination check for the analytics exporters. Covers exactly what
+ * the connect-time DNS lookup hook structurally cannot see, and nothing more:
+ *
+ *  - IP-literal hosts. Node skips DNS for a literal, so the connect-time
+ *    lookup never fires and the address reaches the socket unchecked.
+ *    `fetchWithSecureRedirects` validates Location targets, not the initial
+ *    URL. Without this check, any region/baseUrl that yields an IP literal
+ *    (e.g. `http://169.254.169.254/`) would receive the exported events and
+ *    the Authorization header.
+ *  - String-level faults no network check can catch: embedded credentials,
+ *    bad encoding, a non-HTTP(S) scheme.
+ *
+ * DNS-named hosts are deliberately not policed here. The connect-time lookup
+ * re-validates every IP the name actually resolves to, at connect, which is
+ * strictly stronger than a string pre-check.
+ *
+ * Not routed through `validateWebhookURL`: that wrapper also imposes the
+ * webhook surface's port policy (80/443 only), which the exporters do not
+ * have. Ports stay unrestricted because host/IP policy, not the port, is
+ * what confines this egress. Redirect targets keep the stricter default.
+ *
+ * Uses the webhook allowlist on purpose: allowing a host for webhook
+ * delivery also allows analytics exports to it. Splitting the lists is a
+ * separate operator-facing change.
+ */
+export function validateAnalyticsIntegrationUrl(
+  urlString: string,
+  whitelist: OutboundUrlValidationWhitelist = whitelistFromEnv(),
+): void {
+  // parseOutboundUrl (not new URL) so embedded credentials and bad encoding
+  // are refused without echoing the URL — undici's own guard echoes it,
+  // which would put the password in worker logs.
+  const url = parseOutboundUrl(urlString);
+
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new OutboundUrlValidationError(
+      "protocol-not-allowed",
+      `Only HTTP and HTTPS protocols are allowed for analytics integration exports, got ${url.protocol}`,
+    );
+  }
+
+  if (!isIPAddress(url.hostname)) return;
+
+  validateOutboundResolvedIp({
+    hostname: url.hostname,
+    ip: url.hostname,
+    whitelist,
+    logContext: "Analytics integration",
+  });
+}
 
 /**
  * A serialization-safe stand-in for the validation error. The original holds the

--- a/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationProjectJob.ts
@@ -51,6 +51,12 @@ type MixpanelExecutionConfig = {
   minTimestamp: Date;
   maxTimestamp: Date;
   decryptedMixpanelProjectToken: string;
+  // Plain string at use time. The Mixpanel settings dropdown is currently the
+  // only input that can set this (`api` | `api-eu` | `api-in`). If that ever
+  // becomes free-form, `validateAnalyticsIntegrationUrl` (called from the
+  // Mixpanel sender) is the remaining guard against IP-literal, credentialed,
+  // and non-HTTP destinations — the connect-time DNS hook never fires for a
+  // literal.
   mixpanelRegion: string;
   // First attempt uses ClickHouse `auto` join algorithm. We only fall back to
   // `grace_hash` (slower, but spills to disk) on retries so an OOM on the first

--- a/worker/src/features/mixpanel/mixpanelClient.test.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.test.ts
@@ -17,6 +17,10 @@ vi.mock("../analyticsIntegrationEgress", () => ({
     redirectValidation: { validateUrl: () => {} },
   }),
   rethrowIfOutboundValidationFailure: () => undefined,
+  // No-op: this suite is Mixpanel HTTP error handling, not URL policy.
+  // Real IP-literal / credential / scheme coverage lives in
+  // analyticsIntegrationOutboundUrlNegative.test.ts.
+  validateAnalyticsIntegrationUrl: () => undefined,
 }));
 
 vi.mock("../../env", () => ({

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -4,14 +4,22 @@ import { env } from "../../env";
 import {
   buildAnalyticsRedirectOptions,
   rethrowIfOutboundValidationFailure,
+  validateAnalyticsIntegrationUrl,
 } from "../analyticsIntegrationEgress";
 import type { MixpanelEvent } from "./transformers";
 
 type MixpanelClientConfig = {
   projectToken: string;
   /**
-   * Mixpanel region subdomain (e.g., "api", "api-eu", "api-in")
-   * Validated at API layer via MIXPANEL_REGIONS in web/src/features/mixpanel-integration/types.ts
+   * Mixpanel region subdomain (e.g., "api", "api-eu", "api-in").
+   *
+   * The save-time dropdown (`MIXPANEL_REGIONS`) is the only thing that
+   * currently keeps this from being a free-form host. The worker treats it
+   * as a plain string and interpolates it into `https://<region>.mixpanel.com`.
+   * If that dropdown is ever widened (custom host, raw IP, free-form region),
+   * `validateAnalyticsIntegrationUrl` is the use-time check that still
+   * refuses IP literals, embedded credentials, and non-HTTP schemes — the
+   * connect-time DNS hook never fires for a literal, so it cannot cover those.
    */
   region: string;
   /**
@@ -94,6 +102,11 @@ export class MixpanelClient {
     }, env.LANGFUSE_MIXPANEL_TIMEOUT_MS);
 
     try {
+      // Covers what the connect-time lookup cannot see (IP literals, embedded
+      // credentials, non-HTTP schemes). Named hosts are left to connect-time
+      // pinning, which is strictly stronger than a DNS pre-check.
+      validateAnalyticsIntegrationUrl(url);
+
       // Re-resolve and re-validate the destination IP at socket connect time: a
       // host that validated as public can rebind to a private/loopback address
       // before the socket opens (TOCTOU). Redirect targets are re-validated

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -16,6 +16,7 @@ import {
 } from "@langfuse/shared/src/server";
 import {
   buildAnalyticsRedirectOptions,
+  hostnameForLog,
   rethrowIfOutboundValidationFailure,
 } from "../analyticsIntegrationEgress";
 import {
@@ -291,7 +292,7 @@ export const handlePostHogIntegrationProjectJob = async (
       await validateWebhookURL(postHogIntegration.posthogHostName);
     } catch (error) {
       logger.error(
-        `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,
+        `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${hostnameForLog(postHogIntegration.posthogHostName)}. Error: ${error instanceof Error ? error.message : String(error)}`,
       );
       throw new Error(
         `Invalid PostHog hostname for project ${projectId}: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -517,7 +518,7 @@ export const handlePostHogIntegrationProjectJob = async (
     await notifyPostHogExportFailed(
       projectId,
       postHogIntegration.project.name,
-      postHogIntegration.posthogHostName,
+      hostnameForLog(postHogIntegration.posthogHostName),
     );
     return;
   }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16743.preview.langfuse.com](https://pr-16743.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Closes three dormant safety gaps on the PostHog / Mixpanel export path. None of them were reachable through the current UI (Mixpanel region is a fixed dropdown; PostHog save-time validation already rejects credentialed URLs), but they would open if those guards were ever widened.

1. **Mixpanel IP literals / credentialed / non-HTTP URLs.** Connect-time SSRF pinning only runs when Node looks up a hostname. A destination written as a raw IP (e.g. `http://169.254.169.254/`) skips DNS, so the lookup hook never fires. This adds a DNS-free check on the finished URL before send (`validateAnalyticsIntegrationUrl`), covering IP literals, embedded passwords, and non-HTTP schemes. Named hosts stay on connect-time pinning, which is strictly stronger.

2. **PostHog host logging.** The rejection path logged the configured host verbatim. A URL like `http://admin:hunter2@posthog.example.com` would have copied the password into log storage. That log line (and the disable notification label) now use only the hostname.

3. **Negative tests** for loopback, cloud metadata, RFC1918, a hostname that resolves internally, embedded credentials, non-HTTP schemes, log-sink redaction, and the allowlisted success path.

Analytics exports still share the webhook allowlist; that is an accepted operator-facing choice, not changed here. PostHog SDK retry timing on a blocked send is also left at the default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `worker`

## Verification

- `pnpm --filter worker run lint` — `Tasks: 7 successful, 7 total` (pre-commit turbo lint)
- `pnpm --filter worker run typecheck` — `tsc --noEmit` exit 0
- `pnpm --filter worker run test src/__tests__/analyticsIntegrationUrlValidation.test.ts src/__tests__/analyticsIntegrationOutboundUrlNegative.test.ts src/__tests__/analyticsIntegrationLogRedaction.test.ts src/__tests__/analyticsIntegrationOutboundUrlAllowlist.test.ts src/__tests__/analyticsIntegrationSsrfPinning.test.ts` — `Tests 41 passed (41)`
- `pnpm --filter worker run test src/__tests__/posthogIntegrationProjectJob.test.ts src/__tests__/mixpanelIntegrationProjectJob.test.ts src/features/integrations/customerFaultClassification.test.ts` — `Tests 112 passed (112)`

Skipped web tests and browser signoff: this is worker-only egress/logging, no UI change.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- My code follows the style guidelines of this project (`pnpm run format`)
- I have commented the Mixpanel region / URL-check contract so a future free-form region cannot miss it
- I have added tests that prove the blocked destinations fail and that passwords do not reach the log sink
- New and existing unit tests pass locally with my changes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15286](https://linear.app/clickhouse/issue/LFE-15286/analytics-export-dormant-egress-safety-gaps-only-act-if-the-listed)

<div><a href="https://cursor.com/agents/bc-4fb28622-81ef-4a93-8794-279702a5568e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fb28622-81ef-4a93-8794-279702a5568e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens analytics-export destination handling and removes configured PostHog credentials from rejection logs and notifications.

- Adds use-time validation for Mixpanel IP literals, embedded credentials, malformed URLs, and unsupported protocols.
- Logs and reports only the parsed PostHog hostname on configuration failures.
- Adds negative, allowlist, and credential-redaction coverage for analytics egress.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable changed-code defects identified.

The new validation blocks unsafe literal destinations before Mixpanel sends, preserves connect-time checks for named hosts, and removes configured PostHog credentials from the changed logging and notification paths.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Analytics export batch] --> B[Parse destination URL]
  B --> C{HTTP or HTTPS?}
  C -- No --> D[Terminal validation failure]
  C -- Yes --> E{IP literal?}
  E -- Yes --> F[Validate IP against outbound policy]
  E -- No --> G[Connect-time DNS resolution and IP validation]
  F --> H[Secure fetch with redirect validation]
  G --> H
  H --> I{Delivery succeeds?}
  I -- Yes --> J[Complete export and advance sync cursor]
  I -- No --> K[Classify and handle failure]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): harden analytics export URL..."](https://github.com/langfuse/langfuse/commit/957ec4add463dd5ebc6db49f6a38d8553b83dbd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57837076)</sub>

**Context used:**

- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)

<!-- /greptile_comment -->