### PR TITLE
chore(ci): run query-AST golden SQL tests in tests-shared

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -418,10 +418,8 @@ jobs:
   tests-shared:
     timeout-minutes: 15
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # pull-requests: write lets the golden-SQL drift step post a best-effort
-    # PR comment. It is only attempted on same-repo PRs (fork PRs get a
-    # read-only token) and its step is continue-on-error, so a missing/denied
-    # token never fails the job.
+    # Lets the drift step comment on same-repo PRs (fork tokens are read-only).
+    # That step is best-effort, so a denied token never fails the job.
     permissions:
       contents: read
       pull-requests: write
@@ -462,23 +460,17 @@ jobs:
       - name: generate prisma client
         run: pnpm --filter=shared run db:generate
       - name: run shared tests
-        # Golden-SQL tests run separately below: they need the `clickhouse`
-        # binary and are intentionally non-blocking, so exclude them here to
-        # keep the rest of the shared suite hard-failing as usual.
+        # The SQL-equivalence tests need the clickhouse binary and run
+        # non-blocking in their own step below; exclude them here so the rest
+        # of the shared suite hard-fails as usual.
         run: pnpm --filter @langfuse/shared run test -- --exclude '**/*.golden.test.ts'
-      - name: Install ClickHouse binary for golden SQL tests
-        # continue-on-error keeps the vacation-safe guarantee: if the apt repo
-        # ever hiccups or prunes the pinned version, the binary is simply
-        # absent, the golden tests below skip (their pre-existing behavior), and
-        # nothing blocks unrelated PRs.
+      - name: Install ClickHouse binary for SQL-equivalence tests
+        # `clickhouse format` (from clickhouse-common-static) normalizes SQL for
+        # the equivalence snapshots. Its output is version-specific, so pin the
+        # exact version and regenerate snapshots on any bump; keep in sync with
+        # scripts/codex/cloud_services.sh. 26.4 is the v4-recommended version.
+        # continue-on-error: a missing binary just skips the tests, never blocks.
         continue-on-error: true
-        # The query-AST golden tests normalize SQL through `clickhouse format`
-        # (the multi-call binary shipped in clickhouse-common-static; no server
-        # needed). Pin the exact version: `clickhouse format` output is
-        # version-sensitive, so the committed snapshots are coupled to it. This
-        # matches the v4-recommended ClickHouse (26.4) and the version already
-        # pinned in scripts/codex/cloud_services.sh. Bump both together and
-        # regenerate the snapshots when this changes.
         env:
           CLICKHOUSE_VERSION: 26.4.5.143
         run: |
@@ -493,23 +485,20 @@ jobs:
           sudo apt-get install --allow-downgrades -y \
             "clickhouse-common-static=${CLICKHOUSE_VERSION}"
           clickhouse --version
-      - name: run golden SQL tests (non-blocking)
+      - name: run SQL-equivalence tests (non-blocking)
         id: golden
-        # Intentionally continue-on-error: a formatter-version drift or a
-        # genuine SQL-shape change must NOT block unrelated PRs. The next step
-        # surfaces any failure as a warning (and a PR comment on same-repo PRs).
-        # Promote to a required check once the suite has proven stable.
+        # Non-blocking: a snapshot drift or an intentional SQL change must not
+        # fail the job. The next step surfaces it. Make it required once stable.
         continue-on-error: true
         run: pnpm --filter @langfuse/shared run test .golden.test
-      - name: Flag golden SQL drift
+      - name: Flag SQL-equivalence drift
         if: steps.golden.outcome == 'failure'
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          echo "::warning title=Golden SQL tests failed::Query-AST golden-SQL snapshots drifted or the tests failed. This is non-blocking. Review ${RUN_URL} — a ClickHouse \`format\` version bump needs the snapshots regenerated (pnpm --filter @langfuse/shared run test .golden.test -u)."
-      - name: Comment golden SQL drift on PR
-        # Best-effort only: same-repo PRs have a writable token; fork PRs do
-        # not, so guard on that and never fail the job on a comment error.
+          echo "::warning title=SQL-equivalence tests failed::Query-AST SQL-equivalence snapshots drifted or the tests failed. This is non-blocking. Review ${RUN_URL} — a ClickHouse \`format\` version bump needs the snapshots regenerated (pnpm --filter @langfuse/shared run test .golden.test -u)."
+      - name: Comment SQL-equivalence drift on PR
+        # Best-effort: fork PRs have read-only tokens. Never fails the job.
         if: >-
           steps.golden.outcome == 'failure' &&
           github.event_name == 'pull_request' &&
@@ -519,12 +508,12 @@ jobs:
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const marker = '<!-- golden-sql-drift -->';
+            const marker = '<!-- sql-equivalence-drift -->';
             const body = [
               marker,
-              '⚠️ **Query-AST golden-SQL tests failed** (non-blocking).',
+              '⚠️ **Query-AST SQL-equivalence tests failed** (non-blocking).',
               '',
-              'The query-AST golden-SQL snapshots drifted or the tests failed. This check does **not** block the PR.',
+              'The query-AST SQL-equivalence snapshots drifted or the tests failed. This check does **not** block the PR.',
               '',
               `- Run: ${runUrl}`,
               '- If the SQL shape changed intentionally, regenerate: `pnpm --filter @langfuse/shared run test .golden.test -u`',

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -418,6 +418,13 @@ jobs:
   tests-shared:
     timeout-minutes: 15
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # pull-requests: write lets the golden-SQL drift step post a best-effort
+    # PR comment. It is only attempted on same-repo PRs (fork PRs get a
+    # read-only token) and its step is continue-on-error, so a missing/denied
+    # token never fails the job.
+    permissions:
+      contents: read
+      pull-requests: write
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -455,7 +462,83 @@ jobs:
       - name: generate prisma client
         run: pnpm --filter=shared run db:generate
       - name: run shared tests
-        run: pnpm --filter @langfuse/shared run test
+        # Golden-SQL tests run separately below: they need the `clickhouse`
+        # binary and are intentionally non-blocking, so exclude them here to
+        # keep the rest of the shared suite hard-failing as usual.
+        run: pnpm --filter @langfuse/shared run test -- --exclude '**/*.golden.test.ts'
+      - name: Install ClickHouse binary for golden SQL tests
+        # continue-on-error keeps the vacation-safe guarantee: if the apt repo
+        # ever hiccups or prunes the pinned version, the binary is simply
+        # absent, the golden tests below skip (their pre-existing behavior), and
+        # nothing blocks unrelated PRs.
+        continue-on-error: true
+        # The query-AST golden tests normalize SQL through `clickhouse format`
+        # (the multi-call binary shipped in clickhouse-common-static; no server
+        # needed). Pin the exact version: `clickhouse format` output is
+        # version-sensitive, so the committed snapshots are coupled to it. This
+        # matches the v4-recommended ClickHouse (26.4) and the version already
+        # pinned in scripts/codex/cloud_services.sh. Bump both together and
+        # regenerate the snapshots when this changes.
+        env:
+          CLICKHOUSE_VERSION: 26.4.5.143
+        run: |
+          set -euo pipefail
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key \
+            | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/clickhouse.gpg >/dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/clickhouse.gpg] https://packages.clickhouse.com/deb stable main" \
+            | sudo tee /etc/apt/sources.list.d/clickhouse.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install --allow-downgrades -y \
+            "clickhouse-common-static=${CLICKHOUSE_VERSION}"
+          clickhouse --version
+      - name: run golden SQL tests (non-blocking)
+        id: golden
+        # Intentionally continue-on-error: a formatter-version drift or a
+        # genuine SQL-shape change must NOT block unrelated PRs. The next step
+        # surfaces any failure as a warning (and a PR comment on same-repo PRs).
+        # Promote to a required check once the suite has proven stable.
+        continue-on-error: true
+        run: pnpm --filter @langfuse/shared run test .golden.test
+      - name: Flag golden SQL drift
+        if: steps.golden.outcome == 'failure'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          echo "::warning title=Golden SQL tests failed::Query-AST golden-SQL snapshots drifted or the tests failed. This is non-blocking. Review ${RUN_URL} — a ClickHouse \`format\` version bump needs the snapshots regenerated (pnpm --filter @langfuse/shared run test .golden.test -u)."
+      - name: Comment golden SQL drift on PR
+        # Best-effort only: same-repo PRs have a writable token; fork PRs do
+        # not, so guard on that and never fail the job on a comment error.
+        if: >-
+          steps.golden.outcome == 'failure' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const marker = '<!-- golden-sql-drift -->';
+            const body = [
+              marker,
+              '⚠️ **Query-AST golden-SQL tests failed** (non-blocking).',
+              '',
+              'The query-AST golden-SQL snapshots drifted or the tests failed. This check does **not** block the PR.',
+              '',
+              `- Run: ${runUrl}`,
+              '- If the SQL shape changed intentionally, regenerate: `pnpm --filter @langfuse/shared run test .golden.test -u`',
+              '- If CI bumped the pinned ClickHouse version, regenerate against the new `clickhouse format`.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
   test-docker-build:
     name: test-docker-build (${{ matrix.component }})

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -455,17 +455,20 @@ jobs:
       - name: generate prisma client
         run: pnpm --filter=shared run db:generate
       - name: run shared tests
-        # The SQL-equivalence tests need the clickhouse binary and run
-        # non-blocking in their own step below; exclude them here so the rest
-        # of the shared suite hard-fails as usual.
-        run: pnpm --filter @langfuse/shared run test -- --exclude '**/*.golden.test.ts'
+        # The clickhouse binary isn't installed yet, so the SQL-equivalence
+        # tests skip here (they run for real in the dedicated step below); every
+        # other shared test hard-fails as usual.
+        run: pnpm --filter @langfuse/shared run test
       - name: Install ClickHouse binary for SQL-equivalence tests
         # `clickhouse format` (from clickhouse-common-static) normalizes SQL for
         # the equivalence snapshots. Its output is version-specific, so pin the
         # exact version and regenerate snapshots on any bump; keep in sync with
         # scripts/codex/cloud_services.sh. 26.4 is the v4-recommended version.
-        # continue-on-error: a missing binary just skips the tests, never blocks.
+        # continue-on-error + timeout-minutes: a missing binary OR a stalled apt
+        # mirror just skips the tests, never blocks (timeout-minutes bounds a
+        # hang, which continue-on-error alone would not).
         continue-on-error: true
+        timeout-minutes: 5
         env:
           CLICKHOUSE_VERSION: 26.4.5.143
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -418,11 +418,6 @@ jobs:
   tests-shared:
     timeout-minutes: 15
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Lets the drift step comment on same-repo PRs (fork tokens are read-only).
-    # That step is best-effort, so a denied token never fails the job.
-    permissions:
-      contents: read
-      pull-requests: write
     needs:
       - pre-job
     # pre-job only runs on push events; everywhere else it resolves as skipped
@@ -486,48 +481,12 @@ jobs:
             "clickhouse-common-static=${CLICKHOUSE_VERSION}"
           clickhouse --version
       - name: run SQL-equivalence tests (non-blocking)
-        id: golden
-        # Non-blocking: a snapshot drift or an intentional SQL change must not
-        # fail the job. The next step surfaces it. Make it required once stable.
-        continue-on-error: true
-        run: pnpm --filter @langfuse/shared run test .golden.test
-      - name: Flag SQL-equivalence drift
-        if: steps.golden.outcome == 'failure'
-        env:
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        # Non-blocking: a snapshot drift or an intentional SQL change emits a
+        # warning but must not fail the job (`|| echo` swallows the exit code).
+        # Make it a required check once the suite has proven stable.
         run: |
-          echo "::warning title=SQL-equivalence tests failed::Query-AST SQL-equivalence snapshots drifted or the tests failed. This is non-blocking. Review ${RUN_URL} — a ClickHouse \`format\` version bump needs the snapshots regenerated (pnpm --filter @langfuse/shared run test .golden.test -u)."
-      - name: Comment SQL-equivalence drift on PR
-        # Best-effort: fork PRs have read-only tokens. Never fails the job.
-        if: >-
-          steps.golden.outcome == 'failure' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const marker = '<!-- sql-equivalence-drift -->';
-            const body = [
-              marker,
-              '⚠️ **Query-AST SQL-equivalence tests failed** (non-blocking).',
-              '',
-              'The query-AST SQL-equivalence snapshots drifted or the tests failed. This check does **not** block the PR.',
-              '',
-              `- Run: ${runUrl}`,
-              '- If the SQL shape changed intentionally, regenerate: `pnpm --filter @langfuse/shared run test .golden.test -u`',
-              '- If CI bumped the pinned ClickHouse version, regenerate against the new `clickhouse format`.',
-            ].join('\n');
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          pnpm --filter @langfuse/shared run test .golden.test \
+            || echo "::warning title=SQL-equivalence tests failed::Query-AST SQL-equivalence snapshots drifted or the tests failed (non-blocking). Regenerate with: pnpm --filter @langfuse/shared run test .golden.test -u"
 
   test-docker-build:
     name: test-docker-build (${{ matrix.component }})

--- a/packages/shared/src/server/query-ast/README.md
+++ b/packages/shared/src/server/query-ast/README.md
@@ -25,3 +25,19 @@ Regenerate baselines with `-u` after an intentional SQL change:
 ```
 pnpm --filter @langfuse/shared run test src/server/query-ast -- -u
 ```
+
+## CI and the `clickhouse format` version
+
+These tests need the `clickhouse` binary (the `format` subcommand, shipped in
+`clickhouse-common-static`); without it they `describe.skip`. The `tests-shared`
+CI job installs it pinned to **26.4.5.143** — the ClickHouse version recommended
+for Langfuse v4, also pinned in `scripts/codex/cloud_services.sh`.
+
+`clickhouse format` output is version-sensitive (e.g. how `UNION ALL` branches
+are parenthesized changed between 25.x and 26.x), so the committed snapshots are
+coupled to that exact version. When bumping the CI pin, regenerate the snapshots
+against the new binary in the same PR, or the golden tests drift.
+
+The golden step is intentionally **non-blocking** in CI (`continue-on-error`): a
+drift surfaces as a warning (and a PR comment on same-repo PRs) but never blocks
+the pipeline. Promote it to a required check once it has proven stable.

--- a/packages/shared/src/server/query-ast/README.md
+++ b/packages/shared/src/server/query-ast/README.md
@@ -38,6 +38,6 @@ are parenthesized changed between 25.x and 26.x), so the committed snapshots are
 coupled to that exact version. When bumping the CI pin, regenerate the snapshots
 against the new binary in the same PR, or the golden tests drift.
 
-The golden step is intentionally **non-blocking** in CI (`continue-on-error`): a
-drift surfaces as a warning (and a PR comment on same-repo PRs) but never blocks
-the pipeline. Promote it to a required check once it has proven stable.
+The CI step is intentionally **non-blocking**: a drift surfaces as a warning
+annotation but never fails the pipeline (`|| echo "::warning::"`). Promote it to
+a required check once it has proven stable.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16745.preview.langfuse.com](https://pr-16745.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

The query-AST golden-SQL tests (`packages/shared/src/server/query-ast/environments.golden.test.ts`) `describe.skip` when the `clickhouse` binary is unavailable. The `tests-shared` CI job has no ClickHouse, so these tests **never ran in CI** — they only ever ran on machines with a local `clickhouse` binary. This installs the binary in that job so they run.

Key discovery: `clickhouse format` output is **version-sensitive** (e.g. `UNION ALL` branch parenthesization changed between 25.x and 26.x), so the committed snapshots are coupled to the exact formatter version. Verified locally: the snapshots pass on 26.4.5.143 (v4-recommended ClickHouse; already pinned in `scripts/codex/cloud_services.sh`) and fail on 25.12 — so no snapshot regeneration is needed.

Changes:
- Install `clickhouse-common-static` pinned to `26.4.5.143` in `tests-shared` (the multi-call binary provides `format`; no server needed).
- Run the golden tests in their own `continue-on-error` step so a formatter drift or intentional SQL-shape change **can never block unrelated PRs**. Failures surface as a `::warning::` annotation plus a best-effort sticky PR comment (same-repo PRs only — fork tokens are read-only).
- The binary-install step is also `continue-on-error`: an apt hiccup or a pruned version degrades to the pre-existing skip, never a block.
- The main shared-test step excludes `*.golden.test.ts` (all other tests keep hard-failing as before).
- Documented the version-pin coupling in the query-AST README.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR installs a pinned ClickHouse formatter in the shared-tests CI job and separates query-AST golden tests into a non-blocking run with warning and PR-comment reporting.

- Excludes golden tests from the blocking shared test suite.
- Installs `clickhouse-common-static` version `26.4.5.143`.
- Adds warning and sticky-comment reporting for golden-test failures.
- Documents the formatter-version coupling and snapshot update process.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The stale golden-test failure comment should be fixed before merging so resolved failures do not continue to mislead reviewers.

Failure comments are persisted per pull request, but the workflow only manages them on failed runs and leaves no path for a later successful run to clear or resolve the warning.

**Files Needing Attention:** .github/workflows/pipeline.yml
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/pipeline.yml:513-516
**Failure comment remains stale**

When a pull request's golden-SQL tests fail and then pass on a later run, the success skips comment management entirely, leaving the previous failure warning visible and misleading reviewers about the latest test state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): run query-AST golden SQL test..."](https://github.com/langfuse/langfuse/commit/af4fe88820715d3e25cea215f3e4a5a94e79252b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57837868)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->