### PR TITLE
fix(api): treat prompt version metrics dimensions as numbers

### DIFF
--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -444,7 +444,7 @@ export const observationsView: ViewDeclarationType = {
     promptVersion: {
       sql: "observations.prompt_version",
       alias: "promptVersion",
-      type: "string",
+      type: "number",
       description: "Version of the prompt used for the observation.",
     },
     userId: {
@@ -723,7 +723,7 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
   observationPromptVersion: {
     sql: "observations.prompt_version",
     alias: "observationPromptVersion",
-    type: "string",
+    type: "number",
     relationTable: "observations",
     description: "Version of the prompt used for the observation.",
   },
@@ -810,7 +810,7 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
   observationPromptVersion: {
     sql: "events_observations.prompt_version",
     alias: "observationPromptVersion",
-    type: "string",
+    type: "number",
     relationTable: "events_observations",
     description: "Version of the prompt used for the observation.",
   },
@@ -1308,7 +1308,7 @@ export const eventsObservationsView: ViewDeclarationType = {
     promptVersion: {
       sql: "events_observations.prompt_version",
       alias: "promptVersion",
-      type: "string",
+      type: "number",
       description: "Version of the prompt used for the observation.",
     },
     startTimeMonth: {

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -46,6 +46,93 @@ describe("queryBuilder filter type validation", () => {
     expect(view.dimensions.value).toBeUndefined();
   });
 
+  it.each(["v1", "v2"] as const)(
+    "declares prompt version dimensions as numbers in the %s scores view",
+    (version) => {
+      const scoresView = getViewDeclaration("scores-numeric", version);
+      const observationsView = getViewDeclaration("observations", version);
+
+      expect(scoresView.dimensions.observationPromptVersion?.type).toBe(
+        "number",
+      );
+      expect(observationsView.dimensions.promptVersion?.type).toBe("number");
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "lowers a numeric observationPromptVersion filter in the %s scores view",
+    async (version) => {
+      const { query } = await buildQueryWithFilter(
+        {
+          column: "observationPromptVersion",
+          operator: "=",
+          value: 2,
+          type: "number",
+        },
+        { view: "scores-numeric" },
+        version,
+      );
+
+      expect(query).toContain("prompt_version = {numberFilter");
+      expect(query).not.toContain("position(");
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "rejects a string observationPromptVersion filter in the %s scores view",
+    async (version) => {
+      await expect(
+        buildQueryWithFilter(
+          {
+            column: "observationPromptVersion",
+            operator: "contains",
+            value: "2",
+            type: "string",
+          },
+          { view: "scores-numeric" },
+          version,
+        ),
+      ).rejects.toThrow(
+        "Filter type 'string' is not supported for dimension type 'number'",
+      );
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "selects observationPromptVersion when grouping scores in %s",
+    async (version) => {
+      const { query } = await new QueryBuilder(undefined, version).build(
+        {
+          ...baseQuery,
+          view: "scores-numeric",
+          dimensions: [{ field: "observationPromptVersion" }],
+        } as QueryType,
+        "test-project",
+      );
+
+      expect(query).toContain("prompt_version");
+      expect(query).toContain("observationPromptVersion");
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "lowers a numeric promptVersion filter in the %s observations view",
+    async (version) => {
+      const { query } = await buildQueryWithFilter(
+        {
+          column: "promptVersion",
+          operator: "=",
+          value: 3,
+          type: "number",
+        },
+        undefined,
+        version,
+      );
+
+      expect(query).toContain("prompt_version = {numberFilter");
+    },
+  );
+
   it.each([
     {
       name: "arrayOptions on scalar string dimension",

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -564,7 +564,7 @@ export class QueryBuilder {
         } else {
           clickhouseSelect = dimension.sql;
         }
-        type = "string";
+        type = dimension.type ?? "string";
         if (dimension.relationTable) {
           clickhouseTableName = dimension.relationTable;
         }

--- a/web/src/__tests__/server/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-v2-api.servertest.ts
@@ -1363,6 +1363,8 @@ describe("/api/public/v2/metrics API Endpoint", () => {
           project_id: projectId,
           name: "test-observation-for-score-v2",
           provided_model_name: "gpt-4-turbo",
+          prompt_name: "ticket-intent-router",
+          prompt_version: 2,
           start_time: Date.now() * 1000,
         }),
       ]);
@@ -1406,6 +1408,16 @@ describe("/api/public/v2/metrics API Endpoint", () => {
         "test-observation-for-score-v2",
         (row: any) => row.observationName === "test-observation-for-score-v2",
       ],
+      [
+        "observationPromptName",
+        "ticket-intent-router",
+        (row: any) => row.observationPromptName === "ticket-intent-router",
+      ],
+      [
+        "observationPromptVersion",
+        2,
+        (row: any) => Number(row.observationPromptVersion) === 2,
+      ],
     ])(
       "should support %s dimension via events table",
       async (dimensionField, expectedValue, findRowFn) => {
@@ -1439,5 +1451,90 @@ describe("/api/public/v2/metrics API Endpoint", () => {
         expect(foundRow).toBeDefined();
       },
     );
+
+    it("should filter scores-numeric by observationPromptVersion as a number", async () => {
+      const query = {
+        view: "scores-numeric",
+        dimensions: [{ field: "name" }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "name",
+            operator: "=",
+            value: "score-with-observation-v2",
+            type: "string",
+          },
+          {
+            column: "observationPromptVersion",
+            operator: "=",
+            value: 2,
+            type: "number",
+          },
+        ],
+        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+        toTimestamp: new Date().toISOString(),
+      };
+
+      const response = await makeZodVerifiedAPICall(
+        GetMetricsV1Response,
+        "GET",
+        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "score-with-observation-v2",
+          }),
+        ]),
+      );
+
+      const mismatched = await makeAPICall(
+        "GET",
+        `/api/public/v2/metrics?query=${encodeURIComponent(
+          JSON.stringify({
+            ...query,
+            filters: [
+              query.filters[0],
+              {
+                column: "observationPromptVersion",
+                operator: "=",
+                value: 99,
+                type: "number",
+              },
+            ],
+          }),
+        )}`,
+      );
+
+      expect(mismatched.status).toBe(200);
+      expect(mismatched.body.data ?? []).toHaveLength(0);
+    });
+
+    it("rejects a string filter on observationPromptVersion", async () => {
+      const query = {
+        view: "scores-numeric",
+        dimensions: [{ field: "name" }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "observationPromptVersion",
+            operator: "=",
+            value: "2",
+            type: "string",
+          },
+        ],
+        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+        toTimestamp: new Date().toISOString(),
+      };
+
+      const response = await makeAPICall(
+        "GET",
+        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
+      );
+
+      expect(response.status).toBe(400);
+    });
   });
 });

--- a/web/src/__tests__/server/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-v2-api.servertest.ts
@@ -1490,7 +1490,8 @@ describe("/api/public/v2/metrics API Endpoint", () => {
         ]),
       );
 
-      const mismatched = await makeAPICall(
+      const mismatched = await makeZodVerifiedAPICall(
+        GetMetricsV1Response,
         "GET",
         `/api/public/v2/metrics?query=${encodeURIComponent(
           JSON.stringify({
@@ -1509,7 +1510,7 @@ describe("/api/public/v2/metrics API Endpoint", () => {
       );
 
       expect(mismatched.status).toBe(200);
-      expect(mismatched.body.data ?? []).toHaveLength(0);
+      expect(mismatched.body.data).toHaveLength(0);
     });
 
     it("rejects a string filter on observationPromptVersion", async () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16746.preview.langfuse.com](https://pr-16746.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The metrics query data model declared `promptVersion` and `observationPromptVersion` as strings, but ClickHouse stores `prompt_version` as `Nullable(UInt16)`. That mismatch made the public Metrics API unable to slice scores by prompt version:

- Grouping by `observationPromptVersion` returned `null`
- `type: "string"` filters were accepted and silently did nothing
- `type: "number"` filters returned 400
- `contains` compiled to `position(UInt16, …)` and 500'd

This aligns those dimensions with the table definitions (already `type: "number"`) so numeric filters compile to a ClickHouse number predicate and string/`contains` filters are rejected with 400.

**Filter contract change:** clients must send `type: "number"` (for example `{"column":"observationPromptVersion","operator":"=","value":2,"type":"number"}`). The previous `type: "string"` form never filtered correctly.

Fixes #16351

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

The accepted filter type for these dimensions changes from `string` to `number`. Existing string filters were already ineffective.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Impacted packages

- `@langfuse/shared` (metrics data model + query builder)
- `web` (metrics v2 API tests)

## Verification

- `pnpm --filter @langfuse/shared run test src/features/query/server/queryBuilder.filterValidation.test.ts` — Tests 37 passed (37)
- Related query-builder suites — Tests 35 passed (35)
- Pre-commit `turbo run lint` — Tasks: 7 successful, 7 total
- First CI run: `tests-web` and `tests-shared` passed; `lint`/`web` preview build failed on `makeAPICall` defaulting to `IngestionAPIResponse` (fixed)
- Local `tsc` on web after the test typing fix produced no `metrics-v2-api` errors

## Checklist

- Self-reviewed
- Tests added for the number-filter path and the rejected string/`contains` path

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15368](https://linear.app/clickhouse/issue/LFE-15368/bug-metrics-api-scores-cannot-be-grouped-or-filtered-by)

<div><a href="https://cursor.com/agents/bc-b6e19f93-9ada-4c4c-a227-f8d8ebf1b16e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6e19f93-9ada-4c4c-a227-f8d8ebf1b16e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns prompt-version metric dimensions with their numeric ClickHouse representation and ensures relation-backed dimensions retain their declared types.
- Declares prompt-version dimensions as numbers in v1 and v2 observation and score views.
- Validates numeric filters while rejecting incompatible string filters.
- Adds query-builder and Metrics API coverage for filtering and grouping by prompt version.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the declaration, validation, and API tests consistently enforcing numeric prompt-version behavior.

The v1 and v2 declarations remain aligned, the underlying prompt-version columns are numeric, and no concrete regression or unsupported downstream contract was identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): treat prompt version metrics d..."](https://github.com/langfuse/langfuse/commit/6038a3e5ec4d93f2ba8f50fb34bdcd64dd46b9b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57839644)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Analytics and query data](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/analytics-query-data.md)
- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)
</details>


<!-- /greptile_comment -->