### PR TITLE
fix(web): drop interactive transaction from API-key audit logs

### DIFF
--- a/web/src/__tests__/server/audit-log-in-app-agent.servertest.ts
+++ b/web/src/__tests__/server/audit-log-in-app-agent.servertest.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { prisma, AuditLogRecordType } from "@langfuse/shared/src/db";
 import { createAndAddApiKeysToDb } from "@langfuse/shared/src/server/auth/apiKeys";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 
 describe("in-app agent audit logging", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("stores the creator on in-app-agent MCP keys", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     const user = await prisma.user.create({
@@ -84,6 +89,49 @@ describe("in-app agent audit logging", () => {
       type: AuditLogRecordType.API_KEY,
       apiKeyId: mcpApiKey.id,
       userId: user.id,
+    });
+  });
+
+  it("writes API-key audit logs without an interactive Prisma transaction", async () => {
+    const { orgId, projectId, publicKey } = await createOrgProjectAndApiKey();
+    const apiKey = await prisma.apiKey.findUniqueOrThrow({
+      where: { publicKey },
+      select: { id: true },
+    });
+
+    const resourceId = randomUUID();
+    const transactionSpy = vi.spyOn(prisma, "$transaction");
+
+    await auditLog({
+      action: "create",
+      resourceType: "annotationQueueItem",
+      resourceId,
+      orgId,
+      projectId,
+      apiKeyId: apiKey.id,
+    });
+
+    expect(transactionSpy).not.toHaveBeenCalled();
+
+    const persistedAuditLog = await prisma.auditLog.findFirstOrThrow({
+      where: {
+        apiKeyId: apiKey.id,
+        resourceId,
+      },
+      select: {
+        type: true,
+        apiKeyId: true,
+        userId: true,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    expect(persistedAuditLog).toEqual({
+      type: AuditLogRecordType.API_KEY,
+      apiKeyId: apiKey.id,
+      userId: null,
     });
   });
 });

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -398,7 +398,7 @@ describe("MCP public API tools", () => {
     ).resolves.toBe(assignmentAuditLogCount + 1);
 
     const auditLogCreateSpy = vi
-      .spyOn(prisma, "$transaction")
+      .spyOn(prisma.auditLog, "create")
       .mockRejectedValueOnce(new Error("audit failed"));
 
     try {

--- a/web/src/features/audit-logs/auditLog.ts
+++ b/web/src/features/audit-logs/auditLog.ts
@@ -94,28 +94,29 @@ export async function auditLog(log: AuditLog, prisma?: typeof _prisma) {
   };
 
   if ("apiKeyId" in log) {
-    await db.$transaction(async (tx) => {
-      const apiKey = await tx.apiKey.findUnique({
-        where: { id: log.apiKeyId },
-        select: {
-          isInAppAgentKey: true,
-          createdByUserId: true,
-        },
-      });
+    // Sequential find + create, not $transaction. Interactive transactions
+    // use a 5s timeout and hold a pooled connection across both awaits, so
+    // an event-loop stall can 500 public API writes that only need an audit log.
+    const apiKey = await db.apiKey.findUnique({
+      where: { id: log.apiKeyId },
+      select: {
+        isInAppAgentKey: true,
+        createdByUserId: true,
+      },
+    });
 
-      await tx.auditLog.create({
-        data: {
-          apiKeyId: log.apiKeyId,
-          userId:
-            apiKey?.isInAppAgentKey === true
-              ? (apiKey.createdByUserId ?? undefined)
-              : undefined,
-          orgId: log.orgId,
-          projectId: log.projectId,
-          type: AuditLogRecordType.API_KEY,
-          ...shared,
-        },
-      });
+    await db.auditLog.create({
+      data: {
+        apiKeyId: log.apiKeyId,
+        userId:
+          apiKey?.isInAppAgentKey === true
+            ? (apiKey.createdByUserId ?? undefined)
+            : undefined,
+        orgId: log.orgId,
+        projectId: log.projectId,
+        type: AuditLogRecordType.API_KEY,
+        ...shared,
+      },
     });
 
     return;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16748.preview.langfuse.com](https://pr-16748.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Public API mutations that write an API-key audit log (including `POST /api/public/annotation-queues/{queueId}/items`) were 500ing when a web event-loop stall lasted past Prisma's default 5s interactive transaction timeout.

The API-key branch of `auditLog()` did a `findUnique` + `create` inside `$transaction` with no need for serializable atomicity. That held a pooled connection across two awaits. This change runs the two queries sequentially so a stall cannot expire the write.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test src/__tests__/server/audit-log-in-app-agent.servertest.ts` — `Tests 3 passed (3)`
- `pnpm --filter web run test src/__tests__/server/mcp-public-api-tools.servertest.ts` — annotation-queue coverage passed (12/14; the two failures are ClickHouse `ECONNREFUSED :8123` on dataset/health routes, unrelated)
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- Targeted ESLint on the three changed files — clean

Skipped HTTP `annotation-queues-api.servertest.ts` here (needs a web server on port 3000 serving the test database). Skipped typecheck; the change is local to `auditLog()`.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Tests added that prove API-key audit writes no longer use an interactive transaction
- Targeted unit tests passed locally

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15646](https://linear.app/clickhouse/issue/LFE-15646/prod-eu-other-public-apis-error-rate)

<div><a href="https://cursor.com/agents/bc-3de40bab-4605-494c-9627-5932b083309f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3de40bab-4605-494c-9627-5932b083309f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes an unnecessary interactive Prisma transaction from API-key audit logging, preventing event-loop stalls from expiring the transaction and failing public API mutations.

- Runs the API-key lookup and audit-log insertion sequentially on the Prisma client.
- Adds coverage confirming API-key audit writes do not open an interactive transaction and preserve actor attribution.
- Updates MCP public API error-path coverage to mock the audit-log insertion directly.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The changed API-key audit path preserves its lookup and record fields while eliminating only the interactive transaction that caused timeout failures, and the updated tests cover both successful persistence and audit-write failure handling.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): drop interactive transaction f..."](https://github.com/langfuse/langfuse/commit/087361fa6ba1f88ea5f31ce06a1b3047542c616a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57840013)</sub>

<!-- /greptile_comment -->