### PR TITLE
ci: fail PRs when served OpenAPI specs drift from Fern

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -145,7 +145,8 @@ langfuse/
   regressions.
 - Public API contracts in `web/src/pages/api/public/**`,
   `web/src/features/public-api/types/**`, or `fern/apis/**`: `pnpm run lint`,
-  targeted server API tests, and Fern update/regeneration.
+  targeted server API tests, Fern update/regeneration, and
+  `pnpm run openapi:check`.
 - Cross-package refactors: `pnpm run lint`, `pnpm run typecheck`, and targeted
   tests for impacted packages.
 - Client-bundle soundness: CI scans every prod web build

--- a/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
+++ b/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
@@ -389,7 +389,10 @@ packages/shared/src/features/<domain>/interfaces/api/
 
 When modifying public API types in `web/src/features/public-api/types/` or under
 `packages/shared/src/features/<domain>/interfaces/api/`, update the matching
-Fern API definitions in `fern/apis/server/definition/`.
+Fern API definitions in `fern/apis/server/definition/`. After editing Fern
+sources, run `pnpm run openapi:export` and commit `web/public/generated/**`.
+PRs that touch `fern/**` fail CI when those served specs drift
+(`pnpm run openapi:check`).
 
 **Zod to Fern Type Mapping:**
 

--- a/.github/workflows/openapi-export-check.yml
+++ b/.github/workflows/openapi-export-check.yml
@@ -1,0 +1,61 @@
+# Re-export the served OpenAPI specs and fail when web/public/generated/**
+# drifts from fern/. `fern-api export` is local (no FERN_TOKEN), so this can
+# run on fork PRs. `sdk-api-spec.yml` still owns `fern-api generate` + SDK
+# sync and stays post-merge because that path needs Fern credentials.
+name: OpenAPI Export Check
+
+on:
+  pull_request:
+    paths:
+      - "fern/**"
+      - "web/public/generated/**"
+      - "web/scripts/openapi/**"
+      - "scripts/openapi/**"
+      - ".github/workflows/openapi-export-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "fern/**"
+      - "web/public/generated/**"
+      - "web/scripts/openapi/**"
+      - "scripts/openapi/**"
+      - ".github/workflows/openapi-export-check.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: openapi-export-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-openapi-export:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Assert helper rejects drifted specs
+        run: bash scripts/openapi/assert-generated-current.test.sh
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.22.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Export OpenAPI specs and fail on drift
+        run: pnpm run openapi:check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -549,6 +549,8 @@ To export the respective `openapi.yml` files which power the online API referenc
 pnpm run openapi:export
 ```
 
+Commit the updated files under `web/public/generated/`. CI re-runs this export on PRs that touch `fern/**` or the served specs and fails if they drift (`pnpm run openapi:check`).
+
 This command also syncs standard OpenAPI `deprecated` flags and `**Deprecated:** …` description notices from the endpoint `availability` metadata in the Fern definitions.
 
 To generate the server SDKs, run:

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,css}\" --experimental-cli",
     "playwright:install": "pnpm --filter web exec playwright install chromium",
     "openapi:export": "npx fern-api export --api server web/public/generated/api/openapi.yml && pnpm --filter web exec tsx scripts/openapi/postprocess-openapi.ts && npx fern-api export --api client web/public/generated/api-client/openapi.yml && npx fern-api export --api organizations web/public/generated/organizations-api/openapi.yml",
+    "openapi:check": "pnpm run openapi:export && bash scripts/openapi/assert-generated-current.sh",
     "storybook": "pnpm --filter web run storybook",
     "test": "turbo run test",
     "release": "bash ./scripts/release-preflight.sh && dotenv -e ../.env -- release-it",

--- a/scripts/openapi/assert-generated-current.sh
+++ b/scripts/openapi/assert-generated-current.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fail when the served OpenAPI specs under web/public/generated/ differ from
+# the git tree. CI runs this after `pnpm run openapi:export` so a forgotten
+# re-export becomes a blocking, self-explaining failure.
+
+set -euo pipefail
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Must run inside a git work tree." >&2
+  exit 1
+fi
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+generated_root="web/public/generated"
+spec_paths=(
+  "$generated_root/api/openapi.yml"
+  "$generated_root/api-client/openapi.yml"
+  "$generated_root/organizations-api/openapi.yml"
+)
+
+missing=0
+for spec_path in "${spec_paths[@]}"; do
+  if [ ! -f "$spec_path" ]; then
+    echo "Missing served OpenAPI spec: $spec_path" >&2
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  echo "Re-export with: pnpm run openapi:export" >&2
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::error::Served OpenAPI spec files are missing under ${generated_root}/. Run: pnpm run openapi:export"
+  fi
+  exit 1
+fi
+
+status="$(git status --porcelain -- "$generated_root")"
+if [ -z "$status" ]; then
+  echo "Served OpenAPI specs match their Fern sources."
+  exit 0
+fi
+
+{
+  echo
+  echo "Served OpenAPI specs are out of date with their Fern sources."
+  echo "These files are what customers fetch at /generated/.../openapi.yml."
+  echo
+  echo "Re-export and commit the result:"
+  echo
+  echo "  pnpm run openapi:export"
+  echo
+  echo "Changed files:"
+  git status --porcelain -- "$generated_root"
+  echo
+  git diff --stat -- "$generated_root"
+} >&2
+
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  echo "::error::Served OpenAPI specs drifted from fern/. Run: pnpm run openapi:export"
+fi
+
+exit 1

--- a/scripts/openapi/assert-generated-current.test.sh
+++ b/scripts/openapi/assert-generated-current.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Proves the served-spec drift assertion fails on a dirty generated OpenAPI
+# file and passes when the three tracked artifacts match HEAD.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/openapi/assert-generated-current.sh"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cd "$tmpdir"
+git init -q
+git config user.name "openapi-check-test"
+git config user.email "openapi-check-test@langfuse.local"
+
+mkdir -p \
+  web/public/generated/api \
+  web/public/generated/api-client \
+  web/public/generated/organizations-api
+
+printf 'server: spec\n' > web/public/generated/api/openapi.yml
+printf 'client: spec\n' > web/public/generated/api-client/openapi.yml
+printf 'orgs: spec\n' > web/public/generated/organizations-api/openapi.yml
+
+git add web/public/generated
+git commit -q -m "seed specs"
+
+"$script"
+
+printf 'stale\n' >> web/public/generated/api/openapi.yml
+if "$script"; then
+  echo "expected assert-generated-current.sh to fail on a dirty spec" >&2
+  exit 1
+fi
+
+rm web/public/generated/api-client/openapi.yml
+if "$script"; then
+  echo "expected assert-generated-current.sh to fail when a spec is missing" >&2
+  exit 1
+fi
+
+echo "assert-generated-current.sh: ok"

--- a/web/src/features/README.md
+++ b/web/src/features/README.md
@@ -20,7 +20,7 @@ Testing
 API Reference
 
 - Add to `fern` including `docs` attributes
-- Export with `pnpm run openapi:export`, then commit the changes to the API reference
+- Export with `pnpm run openapi:export`, then commit the changes to the API reference. CI fails if the served specs under `web/public/generated/` drift from `fern/`.
 
 SDKs
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16749.preview.langfuse.com](https://pr-16749.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The OpenAPI files served at `/generated/.../openapi.yml` are git-tracked and produced only by a manual `pnpm run openapi:export`. CI never re-ran that export, so a Fern-only PR could merge with a stale customer-facing spec.

This adds a PR job on `fern/**` and `web/public/generated/**` changes that re-exports the three specs and fails if the tree is dirty. The failure message tells the author to run `pnpm run openapi:export` and commit the result.

`fern-api export` does not need `FERN_TOKEN`, so the job can run on fork PRs without secrets. SDK generation (`fern-api generate`) stays in the existing post-merge workflow.

Current `web/public/generated/**` was re-exported against `main` as part of this work and matched HEAD (no additional spec drift to commit).

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Impacted packages

- CI / repo scripts
- Contributor docs (`CONTRIBUTING.md`, public-API README, agent verification notes)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have followed the contributing guide
- CI now fails with a self-explaining message when served specs drift
- I did not change the Fern sources or the served specs themselves

## Verification

- `bash scripts/openapi/assert-generated-current.test.sh` — helper passes on a clean tree and fails on a dirty or missing spec
- `pnpm run openapi:check` — re-export of current `main` is clean (`Served OpenAPI specs match their Fern sources.`)
- Temporary Fern description change — `pnpm run openapi:check` failed and pointed at `pnpm run openapi:export` (then reverted)
- Husky pre-commit: `Tasks: 7 successful, 7 total` (turbo lint)
- Skipped full `pnpm run typecheck` — no TypeScript production changes
- Existing OpenAPI unit tests: 21 passed; the suite then failed in shared teardown (`Cannot find package '@langfuse/shared/src/server'`), which is unrelated to this CI helper
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15155](https://linear.app/clickhouse/issue/LFE-15155/nothing-in-ci-re-exports-the-served-openapi-specs-so)

<div><a href="https://cursor.com/agents/bc-93050ab2-9cb0-412c-99dd-a8a4a3cee7f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93050ab2-9cb0-412c-99dd-a8a4a3cee7f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a pull-request and main-branch workflow that re-exports three customer-facing OpenAPI specifications and rejects generated-file drift.
- Adds `openapi:check` and shell-based drift validation with a focused test harness.
- Runs the check when Fern sources, served specifications, OpenAPI scripts, or the workflow change.
- Updates contributor and agent documentation with the new export/check process.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking reproducibility and workflow-trigger coverage gaps worth addressing.

The drift assertion itself is sound, but export-toolchain-only changes can bypass the workflow and the blocking check relies on a generator executable that is not pinned in the repository.

**Files Needing Attention:** .github/workflows/openapi-export-check.yml and package.json
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  PR[Matching PR change] --> CI[OpenAPI Export Check]
  CI --> Test[Test drift helper]
  Test --> Install[Install dependencies]
  Install --> Export[Export server, client, and organizations specs]
  Export --> Postprocess[Postprocess server spec]
  Postprocess --> Status{Generated tree clean?}
  Status -->|Yes| Pass[Pass]
  Status -->|No| Fail[Fail with regeneration instructions]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/openapi-export-check.yml:9-14
**Export dependencies bypass check**

The path filter omits `package.json`, `web/package.json`, and `pnpm-lock.yaml`, even though they define the export commands and postprocessing dependencies. An export-toolchain-only change therefore skips this workflow, allowing changed or broken generation behavior to merge without validating the customer-facing specifications.

### Issue 2
package.json:42
**Generator version remains unpinned**

The blocking check delegates to `npx fern-api export`, but `fern-api` is absent from the repository dependencies and lockfile. A newly published package version or registry availability change can therefore alter or break required PR checks without any repository change.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: fail PRs when served OpenAPI specs d..."](https://github.com/langfuse/langfuse/commit/75192dd39603c7db7cf7cf4a6f09ce17bcecb0ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57840233)</sub>

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->