### PR TITLE
fix(dashboards): avoid duplicate ARRAY JOIN aliases for usage and cost type

### DIFF
--- a/packages/shared/src/features/query/server/queryBuilder.pairExpand.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.pairExpand.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { QueryType } from "../types";
+import { QueryBuilder } from "./queryBuilder";
+
+// QueryBuilder.build checks the OTEL FINAL optimization before compiling SQL.
+// Mock it so these stay unit-level and do not need ClickHouse.
+vi.mock("../../../server/queries/clickhouse-sql/query-options", () => ({
+  shouldSkipObservationsFinal: vi.fn().mockResolvedValue(false),
+}));
+
+const usageByTypeTimeseries = {
+  view: "observations",
+  dimensions: [{ field: "usageType" }],
+  metrics: [{ measure: "usageByType", aggregation: "sum" }],
+  filters: [],
+  timeDimension: { granularity: "day" },
+  fromTimestamp: "2025-01-01T00:00:00.000Z",
+  toTimestamp: "2025-01-08T00:00:00.000Z",
+  orderBy: null,
+} as QueryType;
+
+const costByTypeQuery = {
+  view: "observations",
+  dimensions: [{ field: "costType" }],
+  metrics: [{ measure: "costByType", aggregation: "sum" }],
+  filters: [],
+  timeDimension: null,
+  fromTimestamp: "2025-01-01T00:00:00.000Z",
+  toTimestamp: "2025-01-08T00:00:00.000Z",
+  orderBy: null,
+} as QueryType;
+
+describe("queryBuilder pairExpand ARRAY JOIN aliases", () => {
+  it("does not re-alias usageType in a single-level usageByType timeseries", async () => {
+    // Dashboard ModelUsageChart (v2) compiles this shape. ClickHouse rejects
+    // `usageType AS usageType` in the same SELECT as `ARRAY JOIN … AS usageType`.
+    const { query } = await new QueryBuilder(undefined, "v2").build(
+      usageByTypeTimeseries,
+      "test-project",
+      true,
+    );
+
+    expect(query).toContain("ARRAY JOIN");
+    expect(query).toMatch(/mapKeys\([^)]*usage_details\) AS usageType/);
+    expect(query).not.toMatch(/usageType\s+as\s+usageType/i);
+    expect(query).toMatch(/sum\(usage_value\)\s+as\s+sum_usageByType/i);
+  });
+
+  it("does not re-alias costType in the two-level inner SELECT", async () => {
+    const { query } = await new QueryBuilder(undefined, "v2").build(
+      costByTypeQuery,
+      "test-project",
+      false,
+    );
+
+    expect(query).toContain("ARRAY JOIN");
+    expect(query).toMatch(/mapKeys\([^)]*cost_details\) AS costType/);
+    expect(query).not.toMatch(/costType\s+as\s+costType/i);
+  });
+});

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -873,6 +873,15 @@ export class QueryBuilder {
     return `ARRAY JOIN\n  ${d.sql} AS ${d.alias ?? d.sql},\n  ${d.pairExpand!.valuesSql} AS ${d.pairExpand!.valueAlias}`;
   }
 
+  /**
+   * ARRAY JOIN already binds the pairExpand key (`mapKeys(...) AS costType`).
+   * Selecting `costType AS costType` in the same query makes ClickHouse throw
+   * "Duplicate alias in ARRAY JOIN".
+   */
+  private pairExpandKeyColumn(dimension: AppliedDimensionType): string {
+    return dimension.alias ?? dimension.sql;
+  }
+
   private buildWhereClause(
     filterList: FilterList,
     parameters: Record<string, unknown>,
@@ -1047,7 +1056,7 @@ export class QueryBuilder {
           // Note: the paired value column (e.g. cost_value) is NOT in GROUP BY and IS
           // wrapped in any() in buildInnerMetricsPart, so the outer query can re-aggregate it.
           if (dimension.pairExpand) {
-            return `${dimension.alias} as ${dimension.alias ?? dimension.sql}`;
+            return this.pairExpandKeyColumn(dimension);
           }
           // Explode array dimensions using arrayJoin
           if (dimension.explodeArray) {
@@ -1141,9 +1150,10 @@ export class QueryBuilder {
     // Add regular dimensions
     if (appliedDimensions.length > 0) {
       dimensions += `${appliedDimensions
-        .map(
-          (dimension) =>
-            `${dimension.alias ?? dimension.sql} as ${dimension.alias || dimension.sql}`,
+        .map((dimension) =>
+          dimension.pairExpand
+            ? this.pairExpandKeyColumn(dimension)
+            : `${dimension.alias ?? dimension.sql} as ${dimension.alias || dimension.sql}`,
         )
         .join(",\n")},`;
     }
@@ -1338,8 +1348,7 @@ export class QueryBuilder {
         appliedDimensions
           .map((d) => {
             if (d.pairExpand) {
-              // Bare reference — already projected by the ARRAY JOIN clause
-              return `${d.alias} as ${d.alias ?? d.sql}`;
+              return this.pairExpandKeyColumn(d);
             }
             if (d.explodeArray) {
               return `arrayJoin(${d.sql}) as ${d.alias ?? d.sql}`;

--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -4074,6 +4074,9 @@ describe("queryBuilder", () => {
       expect(sql.indexOf("ARRAY JOIN")).toBeLessThan(sql.indexOf("WHERE"));
       // No inline arrayJoin() function call — must use clause form
       expect(sql).not.toMatch(/arrayJoin\(mapKeys/);
+      // ARRAY JOIN already aliases the key; re-emitting `costType AS costType`
+      // makes ClickHouse throw "Duplicate alias in ARRAY JOIN".
+      expect(sql).not.toMatch(/costType\s+as\s+costType/i);
     });
 
     maybeItWithEventsTable(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16750.preview.langfuse.com](https://pr-16750.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

ClickHouse rejects dashboard usage-by-type / cost-by-type queries with `Duplicate alias in ARRAY JOIN: usageType` (and the `costType` equivalent).

`ARRAY JOIN mapKeys(...) AS usageType` already binds that alias. The query builder then re-emitted `usageType AS usageType` in SELECT, which ClickHouse treats as a second alias of the same name. This PR emits the pair-expand key as a bare column in SELECT instead.

Fixes #16655

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `@langfuse/shared` (query builder)
- `web` (existing pairExpand SQL assertion)

## Verification

- `pnpm --filter @langfuse/shared run test queryBuilder.pairExpand.test.ts` — `Tests 2 passed (2)`
- `pnpm --filter @langfuse/shared run test queryBuilder` — `Tests 43 passed (43)`
- `pnpm --filter @langfuse/shared run lint` — passed after building `@repo/eslint-plugin`
- `pnpm --filter @langfuse/shared run typecheck` — passed
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`

Skipped ClickHouse/web integration tests and worker tests: this environment cannot talk to Docker, and the worker does not use this query builder. The regression is SQL generation; the new unit tests assert the compiled query no longer re-aliases the ARRAY JOIN key on both the single-level (dashboard) and two-level paths.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Tests cover the reported dashboard `usageByType` timeseries SQL and the two-level inner SELECT path

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15675](https://linear.app/clickhouse/issue/LFE-15675/bug-duplicate-alias-in-array-join-for-usagetypecosttype-on-dashboard)

<div><a href="https://cursor.com/agents/bc-6857516e-1a5f-4236-8f8a-a45b232a4aa3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6857516e-1a5f-4236-8f8a-a45b232a4aa3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes ClickHouse dashboard queries for usage-by-type and cost-by-type by projecting ARRAY JOIN keys without redundantly re-aliasing them.

- Centralizes pair-expand key projection in a helper used by single-level and two-level query paths.
- Adds focused regression coverage for usage and cost query generation.
- Extends the existing web assertion to reject duplicate aliases.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed projections remaining aligned with every current pair-expand declaration and query grouping path.

The two existing pair-expand dimensions always define aliases matching their ARRAY JOIN bindings, and all changed SELECT paths now reference those bound names consistently without changing the output-column contract.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): avoid duplicate ARRAY J..."](https://github.com/langfuse/langfuse/commit/70ca80b2317a5265bb72c8a9d94c1d8732898209) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57840498)</sub>

**Context used:**

- Knowledge Base — [Analytics and query data](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/analytics-query-data.md)
- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)

<!-- /greptile_comment -->