### PR TITLE
fix(shared): emit equal-sized S3 multipart parts from buffered uploader

### DIFF
--- a/packages/shared/src/server/services/BufferedStreamUploader.ts
+++ b/packages/shared/src/server/services/BufferedStreamUploader.ts
@@ -94,7 +94,12 @@ export class BufferedStreamUploader {
   private readonly stats: UploadPartStats;
 
   constructor(params: BufferedStreamUploaderParams) {
-    this.params = params;
+    // Buffer.concat rejects a non-integer length. Callers can pass
+    // MiB * 1024 * 1024 from a fractional env value (e.g. 5.1).
+    this.params = {
+      ...params,
+      partSizeBytes: Math.floor(params.partSizeBytes),
+    };
     this.stats = params.stats ?? emptyUploadPartStats();
   }
 

--- a/packages/shared/src/server/services/BufferedStreamUploader.ts
+++ b/packages/shared/src/server/services/BufferedStreamUploader.ts
@@ -118,15 +118,20 @@ export class BufferedStreamUploader {
         this.currentBuffer.push(buf);
         this.currentBufferSize += buf.byteLength;
 
-        if (this.currentBufferSize >= this.params.partSizeBytes) {
-          await this.flushBuffer();
-          if (this.errors.hasError()) break;
+        // Slice exact partSizeBytes parts and carry the remainder. Some
+        // S3-compatible endpoints reject complete-multipart when non-trailing
+        // parts differ in length.
+        while (
+          this.currentBufferSize >= this.params.partSizeBytes &&
+          !this.errors.hasError()
+        ) {
+          await this.flushExactPart();
         }
       }
 
-      // Flush remaining data
+      // Final part is the only one allowed to be smaller than partSizeBytes.
       if (this.currentBufferSize > 0 && !this.errors.hasError()) {
-        await this.flushBuffer();
+        await this.flushRemainder();
       }
 
       // Wait for all in-flight uploads to complete
@@ -168,10 +173,34 @@ export class BufferedStreamUploader {
     return this.stats;
   }
 
-  private async flushBuffer(): Promise<void> {
-    const partData = Buffer.concat(this.currentBuffer);
-    this.currentBuffer = [];
-    this.currentBufferSize = 0;
+  private async flushExactPart(): Promise<void> {
+    await this.enqueuePart(this.takeBytes(this.params.partSizeBytes));
+  }
+
+  private async flushRemainder(): Promise<void> {
+    await this.enqueuePart(this.takeBytes(this.currentBufferSize));
+  }
+
+  // Copies the first `byteLength` bytes out of currentBuffer and leaves any
+  // leftover as the new buffer. Caller must pass byteLength <= currentBufferSize.
+  private takeBytes(byteLength: number): Buffer {
+    const partData = Buffer.concat(this.currentBuffer, byteLength);
+    let remaining = byteLength;
+    while (remaining > 0) {
+      const chunk = this.currentBuffer[0];
+      if (chunk.byteLength <= remaining) {
+        remaining -= chunk.byteLength;
+        this.currentBuffer.shift();
+      } else {
+        this.currentBuffer[0] = chunk.subarray(remaining);
+        remaining = 0;
+      }
+    }
+    this.currentBufferSize -= byteLength;
+    return partData;
+  }
+
+  private async enqueuePart(partData: Buffer): Promise<void> {
     this.partNumber++;
 
     // Wait for a slot if all concurrent slots are full

--- a/worker/src/__tests__/bufferedStreamUploader.test.ts
+++ b/worker/src/__tests__/bufferedStreamUploader.test.ts
@@ -125,6 +125,46 @@ describe("BufferedStreamUploader", () => {
       expect(mock.uploadedParts[0].data.byteLength).toBe(10);
       expect(mock.uploadedParts[1].data.byteLength).toBe(5);
     });
+
+    it("should emit exact partSizeBytes for every non-final part when chunks do not divide evenly", async () => {
+      const mock = createMockStrategy();
+      const uploader = new BufferedStreamUploader({
+        ...defaultParams(mock.strategy),
+        partSizeBytes: 10,
+      });
+
+      // 7+6=13 and 3+9=12: flushing the whole buffer would emit unequal
+      // non-final parts. Slice to exact partSizeBytes instead.
+      const chunks = ["1234567", "abcdef", "xyz", "123456789"];
+      await uploader.upload(streamFrom(chunks));
+
+      expect(mock.uploadedParts).toHaveLength(3);
+      expect(mock.uploadedParts[0].data.byteLength).toBe(10);
+      expect(mock.uploadedParts[1].data.byteLength).toBe(10);
+      expect(mock.uploadedParts[2].data.byteLength).toBe(5);
+      expect(
+        Buffer.concat(mock.uploadedParts.map((p) => p.data)).toString(),
+      ).toBe(chunks.join(""));
+    });
+
+    it("should slice a single oversized chunk into exact partSizeBytes parts", async () => {
+      const mock = createMockStrategy();
+      const uploader = new BufferedStreamUploader({
+        ...defaultParams(mock.strategy),
+        partSizeBytes: 10,
+      });
+
+      const largeChunk = "a".repeat(25);
+      await uploader.upload(streamFrom([largeChunk]));
+
+      expect(mock.uploadedParts).toHaveLength(3);
+      expect(mock.uploadedParts[0].data.byteLength).toBe(10);
+      expect(mock.uploadedParts[1].data.byteLength).toBe(10);
+      expect(mock.uploadedParts[2].data.byteLength).toBe(5);
+      expect(
+        Buffer.concat(mock.uploadedParts.map((p) => p.data)).toString(),
+      ).toBe(largeChunk);
+    });
   });
 
   describe("empty stream", () => {

--- a/worker/src/__tests__/bufferedStreamUploader.test.ts
+++ b/worker/src/__tests__/bufferedStreamUploader.test.ts
@@ -147,6 +147,22 @@ describe("BufferedStreamUploader", () => {
       ).toBe(chunks.join(""));
     });
 
+    it("should coerce a fractional partSizeBytes to an integer byte length", async () => {
+      const mock = createMockStrategy();
+      const uploader = new BufferedStreamUploader({
+        ...defaultParams(mock.strategy),
+        partSizeBytes: 10.5,
+      });
+
+      // 15 bytes: floor(10.5)=10 full part + 5-byte remainder. A float
+      // part size would throw in Buffer.concat before this change.
+      await uploader.upload(streamFrom(["aaaaaaaaaa", "bbbbb"]));
+
+      expect(mock.uploadedParts).toHaveLength(2);
+      expect(mock.uploadedParts[0].data.byteLength).toBe(10);
+      expect(mock.uploadedParts[1].data.byteLength).toBe(5);
+    });
+
     it("should slice a single oversized chunk into exact partSizeBytes parts", async () => {
       const mock = createMockStrategy();
       const uploader = new BufferedStreamUploader({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16754.preview.langfuse.com](https://pr-16754.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The buffered S3 multipart uploader flushed the entire accumulated buffer whenever it crossed `partSizeBytes`. Incoming stream chunks vary in size, so non-final parts could have different lengths.

AWS S3 accepts that. Stricter S3-compatible endpoints (notably GCS XML multipart) reject completion with `InvalidPart: All non-trailing parts must have the same length`, which failed blob-storage and core-data exports on the buffered path.

This change slices exact `partSizeBytes` parts and carries the remainder forward. Only the final part may be smaller.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Code follows the style guidelines of this project
- Comments document the equal-part constraint for S3-compatible endpoints
- No documentation update required (internal uploader behavior)
- Lint passed for `@langfuse/shared` and `worker`
- Tests prove non-final parts are exactly `partSizeBytes` for uneven chunks and oversized chunks

## Impacted packages

- `@langfuse/shared` — `BufferedStreamUploader`
- `worker` — regression tests in `bufferedStreamUploader.test.ts`

## Verification

- `pnpm --filter worker run test bufferedStreamUploader.test.ts` — `Tests  42 passed (42)`
- `pnpm --filter @langfuse/shared run lint` — clean
- `pnpm --filter worker run lint` — clean
- Pre-commit `turbo run lint` — `Tasks:    7 successful, 7 total`

Skipped a targeted web test: this path is worker-only (`uploadFileBuffered` for blob-storage, batch export, and core-data S3 export). No web UI or tRPC surface changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15739](https://linear.app/clickhouse/issue/LFE-15739/buffered-s3-multipart-upload-emits-unequal-non-final-parts-invalidpart)

<div><a href="https://cursor.com/agents/bc-da1f817e-03ae-43c6-a6c6-2a748a2a75c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da1f817e-03ae-43c6-a6c6-2a748a2a75c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the buffered multipart uploader to emit uniformly sized non-final parts while retaining excess bytes for subsequent parts.
- Replaces whole-buffer flushing with exact-size slicing and a final remainder flush.
- Adds regression coverage for uneven input chunks and single oversized chunks.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The permitted non-integer multipart-size configuration can now make sufficiently large batch exports fail, so this should be fixed before merging.

The new explicit `Buffer.concat` length is reached from a configuration schema that permits fractional MiB values, and Node rejects the resulting non-integer byte length before any upload retry is scheduled.

**Files Needing Attention:** packages/shared/src/server/services/BufferedStreamUploader.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/services/BufferedStreamUploader.ts:187
**Configured length breaks concatenation**

If `BATCH_EXPORT_S3_PART_SIZE_MIB` is set to an accepted fractional value such as `5.1`, the first full-part flush passes a non-integer byte length to `Buffer.concat`, which throws `ERR_OUT_OF_RANGE` before the part enters the upload retry path and causes the buffered export to fail.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): emit equal-sized S3 multipa..."](https://github.com/langfuse/langfuse/commit/bb321ed0b4f55d3b55f32572fdf01cb28bdf8f48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57847807)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Media and blob processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/media-and-blob-processing.md)

<!-- /greptile_comment -->