### PR TITLE
fix(v4): sort deprecated API callers by recency

### DIFF
--- a/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
+++ b/web/src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts
@@ -316,6 +316,54 @@ describe("project v4 migration data", () => {
     expect(result.current.apis).toEqual({ status: "loaded", count: 0 });
     expect(result.current.apiUsage).toHaveLength(1);
   });
+
+  it("orders API routes and their callers by most recent usage", () => {
+    mocks.legacyApiUsageSummaryUseQuery.mockReturnValue(
+      loadedQuery([
+        {
+          entrypoint: "publicapi: GET /api/public/sessions",
+          count: 2,
+          lastSeen: "2026-07-23T09:00:00Z",
+          callers: [
+            {
+              userAgent: "recent-sessions-caller",
+              count: 1,
+              lastSeen: "2026-07-23T09:00:00Z",
+            },
+          ],
+        },
+        {
+          entrypoint: "publicapi: GET /api/public/traces",
+          count: 11,
+          lastSeen: "2026-07-23T11:00:00Z",
+          callers: [
+            {
+              userAgent: "frequent-older-caller",
+              count: 10,
+              lastSeen: "2026-07-23T10:00:00Z",
+            },
+            {
+              userAgent: "recent-caller",
+              count: 1,
+              lastSeen: "2026-07-23T11:00:00Z",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() =>
+      useProjectV4MigrationData({ projectId: "project-1", enabled: true }),
+    );
+
+    expect(result.current.apiUsage.map((row) => row.endpoint)).toEqual([
+      "GET /api/public/traces",
+      "GET /api/public/sessions",
+    ]);
+    expect(
+      result.current.apiUsage[0]?.callers.map((caller) => caller.userAgent),
+    ).toEqual(["recent-caller", "frequent-older-caller"]);
+  });
 });
 
 describe("migration actions", () => {

--- a/web/src/features/v4-migration/hooks/useV4MigrationData.ts
+++ b/web/src/features/v4-migration/hooks/useV4MigrationData.ts
@@ -233,12 +233,14 @@ export function useProjectV4MigrationData(params: {
       endpoint: normalizeLegacyApiEntrypoint(row.entrypoint),
       count: row.count,
       lastSeen: row.lastSeen,
-      callers: row.callers ?? [
-        {
-          count: row.count,
-          lastSeen: row.lastSeen,
-        },
-      ],
+      callers: Array.from(
+        row.callers ?? [
+          {
+            count: row.count,
+            lastSeen: row.lastSeen,
+          },
+        ],
+      ).sort((left, right) => right.lastSeen.localeCompare(left.lastSeen)),
     }))
     .sort(
       (left, right) =>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16755.preview.langfuse.com](https://pr-16755.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- keep deprecated API routes ordered by their latest call
- sort each route's caller evidence by `lastSeen`, newest first
- preserve backend aggregation and caller-cap selection semantics

## Impacted packages

- `web`

## Verification

- `pnpm run lint`
- `pnpm --filter web run typecheck`
- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter web run test-client src/features/v4-migration`
- `pnpm exec dotenv -e .env.dev.example -e .env.test.example -- pnpm --filter web run test-client src/features/v4-migration/hooks/useV4MigrationData.clienttest.ts`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR orders deprecated API routes and their retained caller evidence by most recent usage while preserving backend aggregation and caller-cap selection.

- Sorts each route’s caller array by `lastSeen`, newest first.
- Adds client coverage for route-level and caller-level recency ordering.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The caller sort operates on validated, consistently formatted timestamps, preserves the backend-selected caller set, and is covered by a focused ordering test.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v4): sort deprecated API callers by ..."](https://github.com/langfuse/langfuse/commit/539f8ce7902f0278abe1e88f037317d578a69c42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57849940)</sub>

<!-- /greptile_comment -->