### PR TITLE
ci(preview): label preview links so Linear surfaces them on issues

### DIFF
--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -45,6 +45,13 @@ Pushing updates it; closing the PR tears it down.
   shared seed identity is `demo@langfuse.com` / `password`, with API keys
   `pk-lf-1234567890` / `sk-lf-1234567890` — shared and synthetic, so never
   treat a preview as private.
+- **Open it from Linear** — on any Linear issue linked to the PR, the preview
+  sits behind the issue's **Preview** shortcut. Linear builds that shortcut by
+  parsing the PR description and bot comments for markdown links whose label
+  ends in "preview", so both preview surfaces label their link that way
+  (`pr-<N> app preview`, `pr-<N> storybook preview`) — keep that suffix when
+  editing either comment, or the shortcut disappears. A bare URL is not
+  matched.
 - **Know where you are** — every preview page shows a top strip linking back
   to the PR, with the author and when the preview content last changed.
 - **Update** — push to the PR; it rebuilds and rolls to the new image (~5 min,

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -297,6 +297,13 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/actions
 
+      # The URL is a markdown link whose label ends in "preview" so Linear's
+      # GitHub integration picks it up as a custom preview link and offers it
+      # on every linked Linear issue. Linear parses PR descriptions and
+      # comments (author or bot) for markdown links labelled "... preview";
+      # a bare URL or a label ending in the hostname is not matched. The
+      # pinned description block below uses the same label and URL, so Linear
+      # shows one entry rather than two.
       - name: Mark preview image pushed
         if: needs.build.result == 'success'
         uses: ./.github/actions/preview-comment
@@ -308,7 +315,7 @@ jobs:
             Argo CD is rolling it out — the environment is usually ready within a
             few minutes of this comment.
 
-            **URL:** https://${{ needs.meta.outputs.preview_host }} (signs you in automatically; opt out with `/auth/sign-in?autoSignIn=false`)
+            **URL:** [pr-${{ github.event.pull_request.number }} app preview](https://${{ needs.meta.outputs.preview_host }}) (signs you in automatically; opt out with `/auth/sign-in?autoSignIn=false`)
             **Login:** `${{ needs.meta.outputs.login_email }}` / `${{ needs.meta.outputs.login_password }}`
             **API keys:** `${{ needs.meta.outputs.public_key }}` / `${{ needs.meta.outputs.secret_key }}`
             **Commit:** ${{ needs.meta.outputs.commit_sha }}
@@ -442,10 +449,13 @@ jobs:
             const host = process.env.PREVIEW_HOST;
 
             // Exactly one bold line, by request — the markdown link is needed
-            // because a schemeless hostname does not auto-link.
+            // because a schemeless hostname does not auto-link. Its label ends
+            // in "preview" so Linear's GitHub integration picks the line up as
+            // a custom preview link on every linked Linear issue; the label and
+            // URL match the status comment's, so Linear shows one entry.
             const block = [
               START,
-              `🟡 **Live preview: [${host}](https://${host})**`,
+              `🟡 **Live preview: [pr-${pull_number} app preview](https://${host})**`,
               END,
               "",
               "",

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -124,9 +124,14 @@ jobs:
         with:
           script: |
             const marker = "<!-- storybook-preview -->";
-            const body = `${marker}\nStorybook preview: ${process.env.PREVIEW_URL}\n\nUpdated at: ${new Date().toISOString()}\nCommit: ${process.env.COMMIT_SHA}`;
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
+            // The link label ends in "preview" so Linear's GitHub integration
+            // picks it up as a custom preview link on every linked Linear
+            // issue; a bare URL is not matched. The AWS app preview comment
+            // uses the same shape, so a linked issue offers both.
+            const link = `[pr-${issue_number} storybook preview](${process.env.PREVIEW_URL})`;
+            const body = `${marker}\nStorybook preview: ${link}\n\nUpdated at: ${new Date().toISOString()}\nCommit: ${process.env.COMMIT_SHA}`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16759 app preview](https://pr-16759.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A Linear issue linked to a PR shows a **Preview** shortcut, but ours never appeared.

Linear's GitHub integration builds that shortcut by parsing the PR description and bot comments for **markdown links whose label ends in "preview"** ([docs](https://linear.app/docs/github)). None of our three preview surfaces matched:

| Surface | Before | Matched? |
|---|---|---|
| AWS preview status comment | `**URL:** https://pr-N.preview.langfuse.com` | no — bare URL |
| Pinned PR description block | `[pr-N.preview.langfuse.com](https://…)` | no — label ends in `.com` |
| Storybook comment | `Storybook preview: https://…vercel.app` | no — bare URL |

The GitHub `PR Preview` deployment record drives GitHub's own **View deployment** button; Linear does not read it.

## Change

Label all three links so Linear parses them:

- App preview: `[pr-<N> app preview](https://pr-<N>.preview.langfuse.com)` in both the status comment and the pinned description block, using an **identical label and URL** so a linked issue lists one app entry rather than two.
- Storybook: `[pr-<N> storybook preview](…)`.
- `langfuse-previews` skill documents the "label must end in preview" contract, so a future edit to either comment does not silently remove the shortcut.

No trigger, permission, or job-graph changes.

## Verification

Ran the shipped script blocks (extracted from the workflow YAML, executed against stubbed `github`/`context`/`core`) and matched the rendered text against Linear's rule:

```
=== AWS preview status comment ===
**URL:** [pr-16800 app preview](https://pr-16800.preview.langfuse.com) (signs you in automatically; …)
RESULT: PASS — Linear entry name="pr-16800 app preview" url=https://pr-16800.preview.langfuse.com

=== Pinned PR description block ===
🟡 **Live preview: [pr-16800 app preview](https://pr-16800.preview.langfuse.com)**
RESULT: PASS — Linear entry name="pr-16800 app preview" url=https://pr-16800.preview.langfuse.com

=== Storybook preview comment ===
Storybook preview: [pr-16800 storybook preview](https://pr-16800-storybook.langfuse.vercel.app)
RESULT: PASS — Linear entry name="pr-16800 storybook preview" url=https://pr-16800-storybook.langfuse.vercel.app

=== Dedupe check (comment vs pinned description) ===
RESULT: PASS — identical label + URL

=== Negative control (formats before this change) ===
not detected (as expected): **URL:** https://pr-16800.preview.langfuse.com …
not detected (as expected): 🟡 **Live preview: [pr-16800.preview.langfuse.com](https://…)**
not detected (as expected): Storybook preview: https://pr-16800-storybook.langfuse.vercel.app

ALL CHECKS PASSED
```

The pin script also stays idempotent: a second build leaves exactly one pin block.

Other checks:

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `prettier --check` — `All matched files use Prettier code style!`
- `zizmor --min-severity low` on both workflows — `No findings to report. Good job! (7 suppressed)`
- `pnpm run agents:check` — clean after `agents:sync` (no repo diff)

**This PR is its own end-to-end test:** its own AWS preview build posts the new comment and pin, so the rendered result is visible on this PR.

## How to confirm on a Linear issue

Link any Linear issue to a PR built after this merges (branch name or `Fixes LFE-1234`). The issue's **Preview** shortcut should offer `pr-<N> app preview`, plus `pr-<N> storybook preview` when Storybook deploys.

The shortcut only leads to a live app if the PR author is on the Argo CD deploy allowlist (`author` selector in `k8s/preview/bootstrap/applicationset.yaml`, `langfuse/infrastructure`) and the preview is awake (Mon–Fri 08:00–24:00 Europe/Berlin). This PR fixes link *detection*, not deploy access.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-518dc0d6-ffe7-4d0b-baa8-2370d25e1ac8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-518dc0d6-ffe7-4d0b-baa8-2370d25e1ac8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates all app and Storybook preview surfaces to use consistently labelled Markdown links that Linear can discover, and documents the required label suffix.
- Labels AWS preview links consistently in both the status comment and pinned PR-description block.
- Labels the Storybook deployment URL with the PR number and `storybook preview` suffix.
- Documents Linear preview-link discovery conventions in the preview skill.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The changed templates receive validated workflow values, the two app-preview surfaces produce identical labels and destinations, and marker-based comment updates remain unaffected.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(preview): label preview links so Line..."](https://github.com/langfuse/langfuse/commit/8a3b0f11d7a8b15e86347f842654e0cbdd6b8658) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57857656)</sub>

<!-- /greptile_comment -->