### PR TITLE
fix(api): enforce historical data access limits

### DIFF
--- a/web/src/__tests__/server/experiments-public-api.servertest.ts
+++ b/web/src/__tests__/server/experiments-public-api.servertest.ts
@@ -104,6 +104,42 @@ describe("GET /api/public/experiments", () => {
   });
 
   maybeEventTables(
+    "keeps a Hobby caller's fromStartTime when it is inside the access window",
+    async () => {
+      const { auth, projectId } = await createOrgProjectAndApiKey({
+        plan: "Hobby",
+      });
+      const beforeRequestedFrom = `exp-${randomUUID()}`;
+      const insideRequestedWindow = `exp-${randomUUID()}`;
+
+      await createEventsCh([
+        createExperimentRootEvent({
+          projectId,
+          experimentId: beforeRequestedFrom,
+          startTimeMs: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        }),
+        createExperimentRootEvent({
+          projectId,
+          experimentId: insideRequestedWindow,
+          startTimeMs: Date.now() - 24 * 60 * 60 * 1000,
+        }),
+      ]);
+
+      const fromStartTime = new Date(
+        Date.now() - 7 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const res = await getExperiments(
+        `/api/public/experiments?fromStartTime=${encodeURIComponent(fromStartTime)}`,
+        auth,
+      );
+
+      const ids = res.body.data.map((experiment) => experiment.id);
+      expect(ids).toContain(insideRequestedWindow);
+      expect(ids).not.toContain(beforeRequestedFrom);
+    },
+  );
+
+  maybeEventTables(
     "lists experiment summaries with core fields by default",
     async () => {
       const { auth, projectId } = await createOrgProjectAndApiKey();

--- a/web/src/__tests__/server/observation-api.servertest.ts
+++ b/web/src/__tests__/server/observation-api.servertest.ts
@@ -5,6 +5,7 @@ import {
   createTracesCh,
   createEventsCh,
   createObservationsCh,
+  createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
 import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
 import {
@@ -77,6 +78,41 @@ const insertObservations = async (
 };
 
 describe("/api/public/observations API Endpoint", () => {
+  it("clamps Hobby observation access to the last 30 days", async () => {
+    const fixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+    const oldId = uuidv4();
+    const recentId = uuidv4();
+    await createObservationsCh([
+      createObservation({
+        id: oldId,
+        project_id: fixture.projectId,
+        trace_id: uuidv4(),
+        start_time: Date.now() - 100 * 24 * 60 * 60 * 1000,
+      }),
+      createObservation({
+        id: recentId,
+        project_id: fixture.projectId,
+        trace_id: uuidv4(),
+        start_time: Date.now() - 24 * 60 * 60 * 1000,
+      }),
+    ]);
+
+    const response = await makeZodVerifiedAPICall(
+      GetObservationsV1Response,
+      "GET",
+      "/api/public/observations",
+      undefined,
+      fixture.auth,
+    );
+
+    expect(response.body.data.map((observation) => observation.id)).toContain(
+      recentId,
+    );
+    expect(
+      response.body.data.map((observation) => observation.id),
+    ).not.toContain(oldId);
+  });
+
   // Test suite factory to run tests against both implementations
   const runTestSuite = (useEventsTable: boolean) => {
     const suiteName = useEventsTable

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -71,6 +71,43 @@ describe("/api/public/v2/observations API Endpoint", () => {
   });
 
   maybe("GET /api/public/v2/observations", () => {
+    it("clamps Hobby observation access to the last 30 days", async () => {
+      const fixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+      const oldId = randomUUID();
+      const recentId = randomUUID();
+      const createObservationAt = (id: string, timestamp: number) =>
+        createEvent({
+          id,
+          span_id: id,
+          trace_id: randomUUID(),
+          project_id: fixture.projectId,
+          name: `data-access-${id}`,
+          type: "SPAN",
+          level: "DEFAULT",
+          start_time: timestamp * 1000,
+          end_time: timestamp * 1000 + 1_000,
+        });
+      await createEventsCh([
+        createObservationAt(oldId, Date.now() - 100 * 24 * 60 * 60 * 1000),
+        createObservationAt(recentId, Date.now() - 24 * 60 * 60 * 1000),
+      ]);
+
+      const response = await makeZodVerifiedAPICall(
+        GetObservationsV2Response,
+        "GET",
+        "/api/public/v2/observations",
+        undefined,
+        fixture.auth,
+      );
+
+      expect(response.body.data.map((observation) => observation.id)).toContain(
+        recentId,
+      );
+      expect(
+        response.body.data.map((observation) => observation.id),
+      ).not.toContain(oldId);
+    });
+
     it("allows legacy v1 contains filters on IO", async () => {
       const filterParam = JSON.stringify([
         {

--- a/web/src/__tests__/server/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v1.servertest.ts
@@ -401,6 +401,45 @@ describe("/api/public/scores API Endpoint", () => {
   });
 
   describe("GET /api/public/scores", () => {
+    it("clamps Hobby score access to the last 30 days", async () => {
+      const fixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+      const oldId = v4();
+      const recentId = v4();
+      const traceId = v4();
+      await createTracesCh([
+        createTrace({
+          id: traceId,
+          project_id: fixture.projectId,
+          timestamp: Date.now() - 24 * 60 * 60 * 1000,
+        }),
+      ]);
+      await createScoresCh([
+        createTraceScore({
+          id: oldId,
+          project_id: fixture.projectId,
+          trace_id: traceId,
+          timestamp: Date.now() - 100 * 24 * 60 * 60 * 1000,
+        }),
+        createTraceScore({
+          id: recentId,
+          project_id: fixture.projectId,
+          trace_id: traceId,
+          timestamp: Date.now() - 24 * 60 * 60 * 1000,
+        }),
+      ]);
+
+      const response = await makeZodVerifiedAPICall(
+        GetScoresResponseV1,
+        "GET",
+        "/api/public/scores",
+        undefined,
+        fixture.auth,
+      );
+
+      expect(response.body.data.map((score) => score.id)).toContain(recentId);
+      expect(response.body.data.map((score) => score.id)).not.toContain(oldId);
+    });
+
     it("#6396: should correctly list 100s of scores", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
 

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -244,6 +244,45 @@ describe("/api/public/v2/scores API Endpoint", () => {
   });
 
   describe("GET /api/public/scores", () => {
+    it("clamps Hobby score access to the last 30 days", async () => {
+      const fixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+      const oldId = v4();
+      const recentId = v4();
+      const traceId = v4();
+      await createTracesCh([
+        createTrace({
+          id: traceId,
+          project_id: fixture.projectId,
+          timestamp: Date.now() - 24 * 60 * 60 * 1000,
+        }),
+      ]);
+      await createScoresCh([
+        createTraceScore({
+          id: oldId,
+          project_id: fixture.projectId,
+          trace_id: traceId,
+          timestamp: Date.now() - 100 * 24 * 60 * 60 * 1000,
+        }),
+        createTraceScore({
+          id: recentId,
+          project_id: fixture.projectId,
+          trace_id: traceId,
+          timestamp: Date.now() - 24 * 60 * 60 * 1000,
+        }),
+      ]);
+
+      const response = await makeZodVerifiedAPICall(
+        GetScoresResponseV2,
+        "GET",
+        "/api/public/v2/scores",
+        undefined,
+        fixture.auth,
+      );
+
+      expect(response.body.data.map((score) => score.id)).toContain(recentId);
+      expect(response.body.data.map((score) => score.id)).not.toContain(oldId);
+    });
+
     describe("should Filter scores", () => {
       let configId = "";
       const userId = "user-name";

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -11,6 +11,7 @@ import {
   makeZodVerifiedAPICall,
 } from "@/src/__tests__/test-utils";
 import { GetScoresResponseV3 } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
 import { v4 } from "uuid";
 
 describe("/api/public/v3/scores API Endpoint", () => {
@@ -1662,6 +1663,44 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
       expect(res.body.data.some((s) => s.id === oldId)).toBe(true);
       expect(res.body.data.some((s) => s.id === newId)).toBe(false);
+    });
+
+    it("clamps Hobby score access to the last 30 days", async () => {
+      const hobbyFixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+      const oldId = v4();
+      const recentId = v4();
+
+      try {
+        await createScoresCh([
+          createTraceScore({
+            id: oldId,
+            project_id: hobbyFixture.projectId,
+            timestamp: new Date(
+              Date.now() - 100 * 24 * 60 * 60 * 1000,
+            ).getTime(),
+          }),
+          createTraceScore({
+            id: recentId,
+            project_id: hobbyFixture.projectId,
+            timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).getTime(),
+          }),
+        ]);
+
+        const res = await makeZodVerifiedAPICall(
+          GetScoresResponseV3,
+          "GET",
+          "/api/public/v3/scores",
+          undefined,
+          hobbyFixture.auth,
+        );
+
+        expect(res.body.data.map((score) => score.id)).toContain(recentId);
+        expect(res.body.data.map((score) => score.id)).not.toContain(oldId);
+      } finally {
+        await prisma.organization.delete({
+          where: { id: hobbyFixture.orgId },
+        });
+      }
     });
 
     it("combines multiple filters with AND semantics", async () => {

--- a/web/src/__tests__/server/sessions-api.servertest.ts
+++ b/web/src/__tests__/server/sessions-api.servertest.ts
@@ -114,6 +114,48 @@ describe("/api/public/sessions API Endpoint", () => {
       );
     });
 
+    it("clamps Hobby session access to the last 30 days", async () => {
+      const hobbyFixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+      const oldSessionId = `old-session-${v4()}`;
+      const recentSessionId = `recent-session-${v4()}`;
+
+      try {
+        await prisma.traceSession.createMany({
+          data: [
+            {
+              id: oldSessionId,
+              createdAt: new Date(Date.now() - 100 * 24 * 60 * 60 * 1000),
+              projectId: hobbyFixture.projectId,
+            },
+            {
+              id: recentSessionId,
+              createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+              projectId: hobbyFixture.projectId,
+            },
+          ],
+        });
+
+        const response = await makeZodVerifiedAPICall(
+          GetSessionsV1Response,
+          "GET",
+          "/api/public/sessions",
+          undefined,
+          hobbyFixture.auth,
+        );
+
+        expect(response.body.data.map((session) => session.id)).toContain(
+          recentSessionId,
+        );
+        expect(response.body.data.map((session) => session.id)).not.toContain(
+          oldSessionId,
+        );
+      } finally {
+        await prisma.organization.delete({
+          where: { id: hobbyFixture.orgId },
+        });
+      }
+    });
+
     it("should return sessions with environment", async () => {
       const sessions = await makeZodVerifiedAPICall(
         GetSessionsV1Response,

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -2442,6 +2442,101 @@ describe("/api/public/traces API Endpoint", () => {
     }
   });
 
+  describe("data-access-days enforcement", () => {
+    it("intersects advanced timestamp filters with the Hobby access floor", async () => {
+      const fixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+      const oldTrace = createTrace({
+        id: randomUUID(),
+        project_id: fixture.projectId,
+        timestamp: Date.now() - 100 * 24 * 60 * 60 * 1000,
+      });
+      const recentTrace = createTrace({
+        id: randomUUID(),
+        project_id: fixture.projectId,
+        timestamp: Date.now() - 24 * 60 * 60 * 1000,
+      });
+      await createTracesCh([oldTrace, recentTrace]);
+
+      const filter = encodeURIComponent(
+        JSON.stringify([
+          {
+            column: "timestamp",
+            type: "datetime",
+            operator: ">=",
+            value: new Date(
+              Date.now() - 365 * 24 * 60 * 60 * 1000,
+            ).toISOString(),
+          },
+        ]),
+      );
+      const response = await makeZodVerifiedAPICall(
+        GetTracesV1Response,
+        "GET",
+        `/api/public/traces?filter=${filter}`,
+        undefined,
+        fixture.auth,
+      );
+
+      expect(response.body.data.map((trace) => trace.id)).toContain(
+        recentTrace.id,
+      );
+      expect(response.body.data.map((trace) => trace.id)).not.toContain(
+        oldTrace.id,
+      );
+    });
+
+    it("preserves stricter from and to bounds alongside advanced filters", async () => {
+      const fixture = await createOrgProjectAndApiKey({ plan: "Hobby" });
+      const beforeFrom = createTrace({
+        id: randomUUID(),
+        project_id: fixture.projectId,
+        timestamp: Date.now() - 10 * 24 * 60 * 60 * 1000,
+      });
+      const withinRange = createTrace({
+        id: randomUUID(),
+        project_id: fixture.projectId,
+        timestamp: Date.now() - 5 * 24 * 60 * 60 * 1000,
+      });
+      const afterTo = createTrace({
+        id: randomUUID(),
+        project_id: fixture.projectId,
+        timestamp: Date.now() - 24 * 60 * 60 * 1000,
+      });
+      await createTracesCh([beforeFrom, withinRange, afterTo]);
+
+      const filter = encodeURIComponent(
+        JSON.stringify([
+          {
+            column: "timestamp",
+            type: "datetime",
+            operator: ">=",
+            value: new Date(
+              Date.now() - 365 * 24 * 60 * 60 * 1000,
+            ).toISOString(),
+          },
+        ]),
+      );
+      const fromTimestamp = new Date(
+        Date.now() - 7 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const toTimestamp = new Date(
+        Date.now() - 2 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const response = await makeZodVerifiedAPICall(
+        GetTracesV1Response,
+        "GET",
+        `/api/public/traces?fromTimestamp=${fromTimestamp}&toTimestamp=${toTimestamp}&filter=${filter}`,
+        undefined,
+        fixture.auth,
+      );
+      const ids = response.body.data.map((trace) => trace.id);
+
+      expect(ids).toContain(withinRange.id);
+      expect(ids).not.toContain(beforeFrom.id);
+      expect(ids).not.toContain(afterTo.id);
+    });
+  });
+
   describe.skip("GET /api/public/traces env var controls", () => {
     const originalRejectNoDateRange =
       env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE;

--- a/web/src/__tests__/server/unit/data-access-days.servertest.ts
+++ b/web/src/__tests__/server/unit/data-access-days.servertest.ts
@@ -35,6 +35,21 @@ describe("clampToDataAccessDays", () => {
     ).toEqual(new Date("2026-07-29T12:00:00.000Z"));
   });
 
+  it.each([
+    ["cloud:hobby", "2026-08-21T12:00:00.000Z"],
+    ["cloud:core", "2026-06-28T12:00:00.000Z"],
+  ] as const)(
+    "preserves a requested timestamp inside the %s window",
+    (plan, requested) => {
+      expect(
+        clampToDataAccessDays({ plan, fromTimestamp: requested, now: NOW }),
+      ).toMatchObject({
+        effectiveFromTimestamp: new Date(requested),
+        wasClamped: false,
+      });
+    },
+  );
+
   it("preserves a timestamp exactly on the boundary", () => {
     const boundary = new Date("2026-07-29T12:00:00.000Z");
 

--- a/web/src/__tests__/server/unit/data-access-days.servertest.ts
+++ b/web/src/__tests__/server/unit/data-access-days.servertest.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
+
+const NOW = new Date("2026-08-28T12:00:00.000Z");
+
+describe("clampToDataAccessDays", () => {
+  it.each([
+    ["cloud:hobby", "2026-07-29T12:00:00.000Z"],
+    ["cloud:core", "2026-05-30T12:00:00.000Z"],
+  ] as const)(
+    "injects the data access floor for %s",
+    (plan, expectedTimestamp) => {
+      expect(
+        clampToDataAccessDays({
+          plan,
+          fromTimestamp: undefined,
+          now: NOW,
+        }),
+      ).toEqual({
+        accessFloor: new Date(expectedTimestamp),
+        effectiveFromTimestamp: new Date(expectedTimestamp),
+        wasClamped: true,
+      });
+    },
+  );
+
+  it("clamps a timestamp older than the Hobby floor", () => {
+    expect(
+      clampToDataAccessDays({
+        plan: "cloud:hobby",
+        fromTimestamp: "2026-01-01T00:00:00.000Z",
+        now: NOW,
+      }).effectiveFromTimestamp,
+    ).toEqual(new Date("2026-07-29T12:00:00.000Z"));
+  });
+
+  it("preserves a timestamp exactly on the boundary", () => {
+    const boundary = new Date("2026-07-29T12:00:00.000Z");
+
+    expect(
+      clampToDataAccessDays({
+        plan: "cloud:hobby",
+        fromTimestamp: boundary,
+        now: NOW,
+      }),
+    ).toEqual({
+      accessFloor: boundary,
+      effectiveFromTimestamp: boundary,
+      wasClamped: false,
+    });
+  });
+
+  it.each([
+    "cloud:pro",
+    "cloud:team",
+    "cloud:enterprise",
+    "oss",
+    "self-hosted:pro",
+    "self-hosted:enterprise",
+  ] as const)("leaves unlimited plan %s unchanged", (plan) => {
+    expect(
+      clampToDataAccessDays({
+        plan,
+        fromTimestamp: undefined,
+        now: NOW,
+      }),
+    ).toEqual({
+      accessFloor: undefined,
+      effectiveFromTimestamp: undefined,
+      wasClamped: false,
+    });
+  });
+
+  it("uses the existing OSS fallback for a missing plan", () => {
+    expect(
+      clampToDataAccessDays({
+        plan: null,
+        fromTimestamp: "2026-01-01T00:00:00.000Z",
+        now: NOW,
+      }),
+    ).toEqual({
+      accessFloor: undefined,
+      effectiveFromTimestamp: new Date("2026-01-01T00:00:00.000Z"),
+      wasClamped: false,
+    });
+  });
+});

--- a/web/src/features/entitlements/server/hasEntitlementLimit.ts
+++ b/web/src/features/entitlements/server/hasEntitlementLimit.ts
@@ -34,7 +34,7 @@ export const hasEntitlementLimit = (
   });
 };
 
-export const hasEntitlementLimitBasedOnPlan = ({
+const hasEntitlementLimitBasedOnPlan = ({
   plan,
   entitlementLimit,
 }: {

--- a/web/src/features/entitlements/server/hasEntitlementLimit.ts
+++ b/web/src/features/entitlements/server/hasEntitlementLimit.ts
@@ -34,7 +34,7 @@ export const hasEntitlementLimit = (
   });
 };
 
-const hasEntitlementLimitBasedOnPlan = ({
+export const hasEntitlementLimitBasedOnPlan = ({
   plan,
   entitlementLimit,
 }: {
@@ -42,6 +42,50 @@ const hasEntitlementLimitBasedOnPlan = ({
   entitlementLimit: EntitlementLimit;
 }) => {
   return entitlementAccess[plan ?? "oss"].entitlementLimits[entitlementLimit];
+};
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const clampToDataAccessDays = ({
+  plan,
+  fromTimestamp,
+  now = new Date(),
+}: {
+  plan: Plan | null;
+  fromTimestamp?: string | Date;
+  now?: Date;
+}): {
+  accessFloor?: Date;
+  effectiveFromTimestamp?: Date;
+  wasClamped: boolean;
+} => {
+  const limitDays = hasEntitlementLimitBasedOnPlan({
+    plan,
+    entitlementLimit: "data-access-days",
+  });
+  const requestedFromTimestamp = fromTimestamp
+    ? new Date(fromTimestamp)
+    : undefined;
+
+  if (limitDays === false) {
+    return {
+      accessFloor: undefined,
+      effectiveFromTimestamp: requestedFromTimestamp,
+      wasClamped: false,
+    };
+  }
+
+  const accessFloor = new Date(
+    now.getTime() - limitDays * MILLISECONDS_PER_DAY,
+  );
+  const wasClamped =
+    !requestedFromTimestamp || requestedFromTimestamp < accessFloor;
+
+  return {
+    accessFloor,
+    effectiveFromTimestamp: wasClamped ? accessFloor : requestedFromTimestamp,
+    wasClamped,
+  };
 };
 
 /**

--- a/web/src/features/mcp/server/experiments/tools/listExperimentItems.ts
+++ b/web/src/features/mcp/server/experiments/tools/listExperimentItems.ts
@@ -7,6 +7,7 @@ import {
   ListExperimentItemsBaseSchema,
   ListExperimentItemsInputSchema,
 } from "../schema";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export const [listExperimentItemsTool, handleListExperimentItems] = defineTool({
   name: "listExperimentItems",
@@ -27,9 +28,18 @@ export const [listExperimentItemsTool, handleListExperimentItems] = defineTool({
         "mcp.experiment_item_fields": input.fields.join(","),
       },
       fn: async (span) => {
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: context.plan,
+          fromTimestamp: input.fromStartTime,
+        });
         const result = await listExperimentItemsForPublicApi({
           projectId: context.projectId,
-          query: input,
+          query: {
+            ...input,
+            fromStartTime:
+              dataAccessWindow.effectiveFromTimestamp?.toISOString() ??
+              input.fromStartTime,
+          },
         });
         const parsed = GetExperimentItemsV1Response.parse(result);
 

--- a/web/src/features/mcp/server/experiments/tools/listExperiments.ts
+++ b/web/src/features/mcp/server/experiments/tools/listExperiments.ts
@@ -7,6 +7,7 @@ import {
   ListExperimentsBaseSchema,
   ListExperimentsInputSchema,
 } from "../schema";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export const [listExperimentsTool, handleListExperiments] = defineTool({
   name: "listExperiments",
@@ -27,9 +28,18 @@ export const [listExperimentsTool, handleListExperiments] = defineTool({
         "mcp.experiment_fields": input.fields.join(","),
       },
       fn: async (span) => {
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: context.plan,
+          fromTimestamp: input.fromStartTime,
+        });
         const result = await listExperimentsForPublicApi({
           projectId: context.projectId,
-          query: input,
+          query: {
+            ...input,
+            fromStartTime:
+              dataAccessWindow.effectiveFromTimestamp?.toISOString() ??
+              input.fromStartTime,
+          },
         });
         const parsed = GetExperimentsV1Response.parse(result);
 

--- a/web/src/features/mcp/server/metrics/tools/queryMetrics.ts
+++ b/web/src/features/mcp/server/metrics/tools/queryMetrics.ts
@@ -14,6 +14,7 @@ import {
 import { defineTool } from "../../../core/define-tool";
 import { McpAdvancedFilterBaseSchema } from "../../../core/filter-schema";
 import { runMcpTool } from "../../../core/run-mcp-tool";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 import { z } from "zod";
 
 const DEFAULT_ROW_LIMIT = 100;
@@ -150,9 +151,19 @@ export const [queryMetricsTool, handleQueryMetrics] = defineTool({
         "mcp.metrics_view": input.view,
       },
       fn: async () => {
-        const normalizedInput = normalizeMetricOrderByFields(
+        const normalizedInputUnclamped = normalizeMetricOrderByFields(
           normalizeMetricFilters(input),
         );
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: context.plan,
+          fromTimestamp: normalizedInputUnclamped.fromTimestamp,
+        });
+        const normalizedInput = {
+          ...normalizedInputUnclamped,
+          fromTimestamp:
+            dataAccessWindow.effectiveFromTimestamp?.toISOString() ??
+            normalizedInputUnclamped.fromTimestamp,
+        };
         const validation = validateQuery(normalizedInput, "v2");
 
         if (!validation.valid) {

--- a/web/src/features/mcp/server/observations/tools/getObservationFilterValues.ts
+++ b/web/src/features/mcp/server/observations/tools/getObservationFilterValues.ts
@@ -15,6 +15,7 @@ import {
   ObservationLimitSchema,
   type ObservationMcpFilterColumn,
 } from "../schema";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 const OBSERVATION_MCP_FILTER_VALUE_COLUMNS = [
   "name",
@@ -174,8 +175,12 @@ export const [
         "mcp.pagination_limit": input.limit,
       },
       fn: async () => {
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: context.plan,
+          fromTimestamp: input.fromStartTime,
+        });
         const startTimeFilter = buildStartTimeFilter({
-          fromStartTime: input.fromStartTime,
+          fromStartTime: dataAccessWindow.effectiveFromTimestamp?.toISOString(),
           toStartTime: input.toStartTime,
         });
 

--- a/web/src/features/mcp/server/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/server/observations/tools/listObservations.ts
@@ -29,6 +29,7 @@ import {
 } from "@/src/features/public-api/types/observations";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 import {
   ExpandMetadataKeysSchema,
   getMetadataExpansionForProjection,
@@ -382,6 +383,31 @@ export const [listObservationsTool, handleListObservations] = defineTool({
         const projectionFields = getProjectionFields(input.fields);
         const fieldGroups = getProjectionFieldGroups(projectionFields);
         assertAllowedExpensiveObservationAccess(input, projectionFields);
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: context.plan,
+          fromTimestamp: input.fromStartTime,
+        });
+        const advancedFilters = dataAccessWindow.accessFloor
+          ? [
+              ...(input.filter ?? []),
+              {
+                column: "startTime",
+                operator: ">=" as const,
+                value: dataAccessWindow.effectiveFromTimestamp!,
+                type: "datetime" as const,
+              },
+              ...(input.toStartTime
+                ? [
+                    {
+                      column: "startTime",
+                      operator: "<" as const,
+                      value: new Date(input.toStartTime),
+                      type: "datetime" as const,
+                    },
+                  ]
+                : []),
+            ]
+          : input.filter;
 
         span.setAttributes({
           "mcp.projection_fields": projectionFields.join(","),
@@ -400,10 +426,10 @@ export const [listObservationsTool, handleListObservations] = defineTool({
           environment: input.environment,
           parentObservationId: input.parentObservationId,
           isRootObservation: input.isRootObservation,
-          fromStartTime: input.fromStartTime,
+          fromStartTime: dataAccessWindow.effectiveFromTimestamp?.toISOString(),
           toStartTime: input.toStartTime,
           version: input.version,
-          advancedFilters: input.filter,
+          advancedFilters,
           cursor: input.cursor
             ? EncodedObservationsCursorV2.parse(input.cursor)
             : undefined,

--- a/web/src/features/mcp/server/scores/tools/listScores.ts
+++ b/web/src/features/mcp/server/scores/tools/listScores.ts
@@ -7,6 +7,7 @@ import {
 import { z } from "zod";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 import { listScoresV3ForPublicApi } from "@/src/features/public-api/server/scores-api-v3";
 import { EncodedScoresCursorV3 } from "@/src/features/public-api/types/scores";
 import { buildScoreSubjectUrl } from "@langfuse/shared/src/server";
@@ -159,6 +160,10 @@ export const [listScoresTool, handleListScores] = defineTool({
         "mcp.pagination_limit": input.limit,
       },
       fn: async (span) => {
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: context.plan,
+          fromTimestamp: input.fromTimestamp,
+        });
         const result = await listScoresV3ForPublicApi({
           projectId: context.projectId,
           limit: input.limit,
@@ -180,9 +185,7 @@ export const [listScoresTool, handleListScores] = defineTool({
           sessionId: input.sessionId,
           observationId: input.observationId,
           experimentId: input.experimentId,
-          fromTimestamp: input.fromTimestamp
-            ? new Date(input.fromTimestamp)
-            : undefined,
+          fromTimestamp: dataAccessWindow.effectiveFromTimestamp,
           toTimestamp: input.toTimestamp
             ? new Date(input.toTimestamp)
             : undefined,

--- a/web/src/pages/api/public/experiment-items/index.ts
+++ b/web/src/pages/api/public/experiment-items/index.ts
@@ -8,6 +8,7 @@ import {
   GetExperimentItemsV1Response,
 } from "@/src/features/public-api/types/experiments";
 import { listExperimentItemsForPublicApi } from "@/src/features/experiments/server/public";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -15,16 +16,32 @@ export default withMiddlewares({
     querySchema: GetExperimentItemsV1Query,
     responseSchema: GetExperimentItemsV1Response,
     allowInAppAgentKey: true,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true") {
         throw new LangfuseNotFoundError(
           "The experiment items API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
         );
       }
 
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: query.fromStartTime,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
+
       return listExperimentItemsForPublicApi({
         projectId: auth.scope.projectId,
-        query,
+        query: {
+          ...query,
+          fromStartTime:
+            dataAccessWindow.effectiveFromTimestamp?.toISOString() ??
+            query.fromStartTime,
+        },
       });
     },
   }),

--- a/web/src/pages/api/public/experiment-items/index.ts
+++ b/web/src/pages/api/public/experiment-items/index.ts
@@ -16,7 +16,7 @@ export default withMiddlewares({
     querySchema: GetExperimentItemsV1Query,
     responseSchema: GetExperimentItemsV1Response,
     allowInAppAgentKey: true,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       if (env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true") {
         throw new LangfuseNotFoundError(
           "The experiment items API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
@@ -27,12 +27,6 @@ export default withMiddlewares({
         plan: auth.scope.plan,
         fromTimestamp: query.fromStartTime,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
 
       return listExperimentItemsForPublicApi({
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/experiments/index.ts
+++ b/web/src/pages/api/public/experiments/index.ts
@@ -8,6 +8,7 @@ import {
   GetExperimentsV1Response,
 } from "@/src/features/public-api/types/experiments";
 import { listExperimentsForPublicApi } from "@/src/features/experiments/server/public";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -15,16 +16,32 @@ export default withMiddlewares({
     querySchema: GetExperimentsV1Query,
     responseSchema: GetExperimentsV1Response,
     allowInAppAgentKey: true,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true") {
         throw new LangfuseNotFoundError(
           "The experiments API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
         );
       }
 
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: query.fromStartTime,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
+
       return listExperimentsForPublicApi({
         projectId: auth.scope.projectId,
-        query,
+        query: {
+          ...query,
+          fromStartTime:
+            dataAccessWindow.effectiveFromTimestamp?.toISOString() ??
+            query.fromStartTime,
+        },
       });
     },
   }),

--- a/web/src/pages/api/public/experiments/index.ts
+++ b/web/src/pages/api/public/experiments/index.ts
@@ -16,7 +16,7 @@ export default withMiddlewares({
     querySchema: GetExperimentsV1Query,
     responseSchema: GetExperimentsV1Response,
     allowInAppAgentKey: true,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       if (env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true") {
         throw new LangfuseNotFoundError(
           "The experiments API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
@@ -27,12 +27,6 @@ export default withMiddlewares({
         plan: auth.scope.plan,
         fromTimestamp: query.fromStartTime,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
 
       return listExperimentsForPublicApi({
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/metrics/daily.ts
+++ b/web/src/pages/api/public/metrics/daily.ts
@@ -9,6 +9,7 @@ import {
   getDailyMetricsCount,
 } from "@/src/features/public-api/server/dailyMetrics";
 import { METRICS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -20,7 +21,18 @@ export default withMiddlewares({
     // Aggregates over the legacy traces and observations tables without an
     // events_full fallback.
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: query.fromTimestamp ?? undefined,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
+
       const filterProps = {
         projectId: auth.scope.projectId,
         page: query.page ?? undefined,
@@ -31,7 +43,7 @@ export default withMiddlewares({
         // We need to map environment to both keys to propagate the filter to all tables.
         traceEnvironment: query.environment ?? undefined,
         observationEnvironment: query.environment ?? undefined,
-        fromTimestamp: query.fromTimestamp ?? undefined,
+        fromTimestamp: dataAccessWindow.effectiveFromTimestamp?.toISOString(),
         toTimestamp: query.toTimestamp ?? undefined,
       };
 

--- a/web/src/pages/api/public/metrics/daily.ts
+++ b/web/src/pages/api/public/metrics/daily.ts
@@ -21,17 +21,11 @@ export default withMiddlewares({
     // Aggregates over the legacy traces and observations tables without an
     // events_full fallback.
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       const dataAccessWindow = clampToDataAccessDays({
         plan: auth.scope.plan,
         fromTimestamp: query.fromTimestamp ?? undefined,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
 
       const filterProps = {
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -22,19 +22,13 @@ export default withMiddlewares(
       // v1 metrics executes QueryBuilder against the legacy traces/observations
       // tables; the v2 endpoint at /api/public/v2/metrics targets events_full.
       rejectInEventsOnlyMode: true,
-      fn: async ({ query, auth, res }) => {
+      fn: async ({ query, auth }) => {
         try {
           // Extract the parsed query object
           const dataAccessWindow = clampToDataAccessDays({
             plan: auth.scope.plan,
             fromTimestamp: query.query.fromTimestamp,
           });
-          if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-            res.setHeader(
-              "X-Langfuse-Data-Access-From",
-              dataAccessWindow.accessFloor.toISOString(),
-            );
-          }
           const queryParams = {
             ...query.query,
             fromTimestamp:

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@langfuse/shared/query/server";
 import { METRICS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 export default withMiddlewares(
   {
     GET: createAuthedProjectAPIRoute({
@@ -21,10 +22,25 @@ export default withMiddlewares(
       // v1 metrics executes QueryBuilder against the legacy traces/observations
       // tables; the v2 endpoint at /api/public/v2/metrics targets events_full.
       rejectInEventsOnlyMode: true,
-      fn: async ({ query, auth }) => {
+      fn: async ({ query, auth, res }) => {
         try {
           // Extract the parsed query object
-          const queryParams = query.query;
+          const dataAccessWindow = clampToDataAccessDays({
+            plan: auth.scope.plan,
+            fromTimestamp: query.query.fromTimestamp,
+          });
+          if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+            res.setHeader(
+              "X-Langfuse-Data-Access-From",
+              dataAccessWindow.accessFloor.toISOString(),
+            );
+          }
+          const queryParams = {
+            ...query.query,
+            fromTimestamp:
+              dataAccessWindow.effectiveFromTimestamp?.toISOString() ??
+              query.query.fromTimestamp,
+          };
 
           // Log the received query for debugging
           logger.debug("Received metrics query", {

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -21,6 +21,7 @@ import {
 } from "@/src/features/public-api/server/observations";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { OBSERVATIONS_V1_DEPRECATION } from "@/src/features/public-api/server/deprecations";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares(
   {
@@ -34,7 +35,39 @@ export default withMiddlewares(
         legacyPublicApiRateLimitUpgradePaths.observationsList,
       rejectInEventsOnlyMode: true,
       deprecation: OBSERVATIONS_V1_DEPRECATION,
-      fn: async ({ query, auth }) => {
+      fn: async ({ query, auth, res }) => {
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: auth.scope.plan,
+          fromTimestamp: query.fromStartTime ?? undefined,
+        });
+        if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+          res.setHeader(
+            "X-Langfuse-Data-Access-From",
+            dataAccessWindow.accessFloor.toISOString(),
+          );
+        }
+        const advancedFilters = dataAccessWindow.accessFloor
+          ? [
+              ...(query.filter ?? []),
+              {
+                column: "startTime",
+                operator: ">=" as const,
+                value: dataAccessWindow.effectiveFromTimestamp!,
+                type: "datetime" as const,
+              },
+              ...(query.toStartTime
+                ? [
+                    {
+                      column: "startTime",
+                      operator: "<" as const,
+                      value: new Date(query.toStartTime),
+                      type: "datetime" as const,
+                    },
+                  ]
+                : []),
+            ]
+          : query.filter;
+
         const filterProps = {
           projectId: auth.scope.projectId,
           page: query.page,
@@ -46,10 +79,10 @@ export default withMiddlewares(
           type: query.type ?? undefined,
           environment: query.environment ?? undefined,
           parentObservationId: query.parentObservationId ?? undefined,
-          fromStartTime: query.fromStartTime ?? undefined,
+          fromStartTime: dataAccessWindow.effectiveFromTimestamp?.toISOString(),
           toStartTime: query.toStartTime ?? undefined,
           version: query.version ?? undefined,
-          advancedFilters: query.filter,
+          advancedFilters,
         };
 
         if (query.useEventsTable) {

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -35,17 +35,11 @@ export default withMiddlewares(
         legacyPublicApiRateLimitUpgradePaths.observationsList,
       rejectInEventsOnlyMode: true,
       deprecation: OBSERVATIONS_V1_DEPRECATION,
-      fn: async ({ query, auth, res }) => {
+      fn: async ({ query, auth }) => {
         const dataAccessWindow = clampToDataAccessDays({
           plan: auth.scope.plan,
           fromTimestamp: query.fromStartTime ?? undefined,
         });
-        if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-          res.setHeader(
-            "X-Langfuse-Data-Access-From",
-            dataAccessWindow.accessFloor.toISOString(),
-          );
-        }
         const advancedFilters = dataAccessWindow.accessFloor
           ? [
               ...(query.filter ?? []),

--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -67,18 +67,12 @@ export default withMiddlewares({
     responseSchema: GetScoresResponseV1,
     deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       const scoresApiService = new ScoresApiService("v1");
       const dataAccessWindow = clampToDataAccessDays({
         plan: auth.scope.plan,
         fromTimestamp: query.fromTimestamp ?? undefined,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
       const advancedFilters = dataAccessWindow.accessFloor
         ? [
             ...(query.filter ?? []),

--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -15,6 +15,7 @@ import {
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
 import { SCORES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
 import { randomUUID } from "crypto";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -66,8 +67,39 @@ export default withMiddlewares({
     responseSchema: GetScoresResponseV1,
     deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
       const scoresApiService = new ScoresApiService("v1");
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: query.fromTimestamp ?? undefined,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
+      const advancedFilters = dataAccessWindow.accessFloor
+        ? [
+            ...(query.filter ?? []),
+            {
+              column: "timestamp",
+              operator: ">=" as const,
+              value: dataAccessWindow.effectiveFromTimestamp!,
+              type: "datetime" as const,
+            },
+            ...(query.toTimestamp
+              ? [
+                  {
+                    column: "timestamp",
+                    operator: "<" as const,
+                    value: new Date(query.toTimestamp),
+                    type: "datetime" as const,
+                  },
+                ]
+              : []),
+          ]
+        : query.filter;
 
       const scoreParams = {
         projectId: auth.scope.projectId,
@@ -79,14 +111,14 @@ export default withMiddlewares({
         queueId: query.queueId ?? undefined,
         traceTags: query.traceTags ?? undefined,
         dataType: query.dataType ?? undefined,
-        fromTimestamp: query.fromTimestamp ?? undefined,
+        fromTimestamp: dataAccessWindow.effectiveFromTimestamp?.toISOString(),
         toTimestamp: query.toTimestamp ?? undefined,
         environment: query.environment ?? undefined,
         source: query.source ?? undefined,
         value: query.value ?? undefined,
         operator: query.operator ?? undefined,
         scoreIds: query.scoreIds ?? undefined,
-        advancedFilters: query.filter,
+        advancedFilters,
       };
       const [items, count] = await Promise.all([
         scoresApiService.generateScoresForPublicApi(scoreParams),

--- a/web/src/pages/api/public/sessions/index.ts
+++ b/web/src/pages/api/public/sessions/index.ts
@@ -7,6 +7,7 @@ import { withMiddlewares } from "@/src/features/public-api/server/withMiddleware
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { SESSIONS_DEPRECATION } from "@/src/features/public-api/server/deprecations";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -17,13 +18,25 @@ export default withMiddlewares({
     responseSchema: GetSessionsV1Response,
     rateLimitUpgradePath: legacyPublicApiRateLimitUpgradePaths.sessionsList,
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
       const { fromTimestamp, toTimestamp, limit, page, environment } = query;
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: fromTimestamp ?? undefined,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
 
       const where = {
         projectId: auth.scope.projectId,
         createdAt: {
-          ...(fromTimestamp && { gte: new Date(fromTimestamp) }),
+          ...(dataAccessWindow.effectiveFromTimestamp && {
+            gte: dataAccessWindow.effectiveFromTimestamp,
+          }),
           ...(toTimestamp && { lt: new Date(toTimestamp) }),
         },
         environment: environment

--- a/web/src/pages/api/public/sessions/index.ts
+++ b/web/src/pages/api/public/sessions/index.ts
@@ -18,18 +18,12 @@ export default withMiddlewares({
     responseSchema: GetSessionsV1Response,
     rateLimitUpgradePath: legacyPublicApiRateLimitUpgradePaths.sessionsList,
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       const { fromTimestamp, toTimestamp, limit, page, environment } = query;
       const dataAccessWindow = clampToDataAccessDays({
         plan: auth.scope.plan,
         fromTimestamp: fromTimestamp ?? undefined,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
 
       const where = {
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -33,6 +33,7 @@ import {
 import { env } from "@/src/env.mjs";
 import { legacyPublicApiRateLimitUpgradePaths } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { TRACES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares(
   {
@@ -84,7 +85,7 @@ export default withMiddlewares(
       deprecation: TRACES_DEPRECATION,
       rateLimitUpgradePath: legacyPublicApiRateLimitUpgradePaths.tracesList,
       rejectInEventsOnlyMode: true,
-      fn: async ({ query, auth }) => {
+      fn: async ({ query, auth, res }) => {
         // Api-performance controls.
         // 1. Reject if no date range and rejection is enabled
         if (
@@ -108,6 +109,41 @@ export default withMiddlewares(
             referenceDateMs - defaultDateRangeDays * 24 * 60 * 60 * 1000,
           ).toISOString();
         }
+
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: auth.scope.plan,
+          fromTimestamp: effectiveFromTimestamp,
+        });
+        effectiveFromTimestamp =
+          dataAccessWindow.effectiveFromTimestamp?.toISOString();
+        if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+          res.setHeader(
+            "X-Langfuse-Data-Access-From",
+            dataAccessWindow.accessFloor.toISOString(),
+          );
+        }
+
+        const advancedFilters = dataAccessWindow.accessFloor
+          ? [
+              ...(query.filter ?? []),
+              {
+                column: "timestamp",
+                operator: ">=" as const,
+                value: dataAccessWindow.effectiveFromTimestamp!,
+                type: "datetime" as const,
+              },
+              ...(query.toTimestamp
+                ? [
+                    {
+                      column: "timestamp",
+                      operator: "<" as const,
+                      value: new Date(query.toTimestamp),
+                      type: "datetime" as const,
+                    },
+                  ]
+                : []),
+            ]
+          : query.filter;
 
         // 3. Apply default fields if configured and no fields query param provided
         let effectiveFields = query.fields ?? undefined;
@@ -142,12 +178,12 @@ export default withMiddlewares(
           const [items, count] = await Promise.all([
             getTracesFromEventsTableForPublicApi({
               ...filterProps,
-              advancedFilters: query.filter,
+              advancedFilters,
               orderBy: query.orderBy ?? null,
             }),
             getTracesCountFromEventsTableForPublicApi({
               ...filterProps,
-              advancedFilters: query.filter,
+              advancedFilters,
             }),
           ]);
 
@@ -169,12 +205,12 @@ export default withMiddlewares(
         const [items, count] = await Promise.all([
           generateTracesForPublicApi({
             props: filterProps,
-            advancedFilters: query.filter,
+            advancedFilters,
             orderBy: query.orderBy ?? null,
           }),
           getTracesCountForPublicApi({
             props: filterProps,
-            advancedFilters: query.filter,
+            advancedFilters,
           }),
         ]);
 

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -85,7 +85,7 @@ export default withMiddlewares(
       deprecation: TRACES_DEPRECATION,
       rateLimitUpgradePath: legacyPublicApiRateLimitUpgradePaths.tracesList,
       rejectInEventsOnlyMode: true,
-      fn: async ({ query, auth, res }) => {
+      fn: async ({ query, auth }) => {
         // Api-performance controls.
         // 1. Reject if no date range and rejection is enabled
         if (
@@ -116,12 +116,6 @@ export default withMiddlewares(
         });
         effectiveFromTimestamp =
           dataAccessWindow.effectiveFromTimestamp?.toISOString();
-        if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-          res.setHeader(
-            "X-Langfuse-Data-Access-From",
-            dataAccessWindow.accessFloor.toISOString(),
-          );
-        }
 
         const advancedFilters = dataAccessWindow.accessFloor
           ? [

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -9,6 +9,7 @@ import {
 import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
 import { executeQuery } from "@langfuse/shared/query/server";
 import { validateQuery } from "@langfuse/shared/query";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 const DEFAULT_ROW_LIMIT = 100;
 
 export function isMetricsV2Available(): boolean {
@@ -24,7 +25,7 @@ export default withMiddlewares({
     rateLimitResource: "public-api-v2-metrics",
     querySchema: GetMetricsV2Query,
     responseSchema: GetMetricsV2Response,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
       if (!isMetricsV2Available()) {
         throw new LangfuseNotFoundError(
           "The metrics v2 API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
@@ -32,9 +33,26 @@ export default withMiddlewares({
       }
 
       try {
+        const dataAccessWindow = clampToDataAccessDays({
+          plan: auth.scope.plan,
+          fromTimestamp: query.query.fromTimestamp,
+        });
+        if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+          res.setHeader(
+            "X-Langfuse-Data-Access-From",
+            dataAccessWindow.accessFloor.toISOString(),
+          );
+        }
+        const effectiveQuery = {
+          ...query.query,
+          fromTimestamp:
+            dataAccessWindow.effectiveFromTimestamp?.toISOString() ??
+            query.query.fromTimestamp,
+        };
+
         // Validate query (high cardinality checks) BEFORE applying defaults
         // This ensures users must explicitly opt-in with row_limit for high cardinality queries
-        const validation = validateQuery(query.query as any, "v2");
+        const validation = validateQuery(effectiveQuery as any, "v2");
 
         if (!validation.valid) {
           throw new InvalidRequestError(validation.reason);
@@ -42,10 +60,10 @@ export default withMiddlewares({
 
         // Apply default row_limit AFTER validation
         const queryParams = {
-          ...query.query,
+          ...effectiveQuery,
           config: {
-            ...query.query.config,
-            row_limit: query.query.config?.row_limit ?? DEFAULT_ROW_LIMIT,
+            ...effectiveQuery.config,
+            row_limit: effectiveQuery.config?.row_limit ?? DEFAULT_ROW_LIMIT,
           },
         };
 

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -25,7 +25,7 @@ export default withMiddlewares({
     rateLimitResource: "public-api-v2-metrics",
     querySchema: GetMetricsV2Query,
     responseSchema: GetMetricsV2Response,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       if (!isMetricsV2Available()) {
         throw new LangfuseNotFoundError(
           "The metrics v2 API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
@@ -37,12 +37,6 @@ export default withMiddlewares({
           plan: auth.scope.plan,
           fromTimestamp: query.query.fromTimestamp,
         });
-        if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-          res.setHeader(
-            "X-Langfuse-Data-Access-From",
-            dataAccessWindow.accessFloor.toISOString(),
-          );
-        }
         const effectiveQuery = {
           ...query.query,
           fromTimestamp:

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -18,7 +18,7 @@ export default withMiddlewares({
     allowInAppAgentKey: true,
     querySchema: GetObservationsV2Query,
     responseSchema: GetObservationsV2Response,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       if (env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true") {
         throw new LangfuseNotFoundError(
           "The observations v2 API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
@@ -32,12 +32,6 @@ export default withMiddlewares({
         plan: auth.scope.plan,
         fromTimestamp: query.fromStartTime ?? undefined,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
       const advancedFilters = dataAccessWindow.accessFloor
         ? [
             ...(query.filter ?? []),

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -10,6 +10,7 @@ import {
   GetObservationsV2Response,
   encodeCursor,
 } from "@/src/features/public-api/types/observations";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -17,7 +18,7 @@ export default withMiddlewares({
     allowInAppAgentKey: true,
     querySchema: GetObservationsV2Query,
     responseSchema: GetObservationsV2Response,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true") {
         throw new LangfuseNotFoundError(
           "The observations v2 API is only available in a Langfuse v4 write mode. Learn more at: https://langfuse.com/docs/v4",
@@ -27,6 +28,37 @@ export default withMiddlewares({
       // Extract field groups and metadata expansion keys
       const fieldGroups = query.fields ?? undefined;
       const expandMetadataKeys = query.expandMetadata ?? undefined;
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: query.fromStartTime ?? undefined,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
+      const advancedFilters = dataAccessWindow.accessFloor
+        ? [
+            ...(query.filter ?? []),
+            {
+              column: "startTime",
+              operator: ">=" as const,
+              value: dataAccessWindow.effectiveFromTimestamp!,
+              type: "datetime" as const,
+            },
+            ...(query.toStartTime
+              ? [
+                  {
+                    column: "startTime",
+                    operator: "<" as const,
+                    value: new Date(query.toStartTime),
+                    type: "datetime" as const,
+                  },
+                ]
+              : []),
+          ]
+        : query.filter;
 
       const filterProps = {
         projectId: auth.scope.projectId,
@@ -41,10 +73,10 @@ export default withMiddlewares({
         environment: query.environment ?? undefined,
         parentObservationId: query.parentObservationId ?? undefined,
         isRootObservation: query.isRootObservation,
-        fromStartTime: query.fromStartTime ?? undefined,
+        fromStartTime: dataAccessWindow.effectiveFromTimestamp?.toISOString(),
         toStartTime: query.toStartTime ?? undefined,
         version: query.version ?? undefined,
-        advancedFilters: query.filter,
+        advancedFilters,
         cursor: query.cursor ?? undefined,
         fields: fieldGroups,
         expandMetadataKeys,

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
 import { SCORES_DEPRECATION } from "@/src/features/public-api/server/deprecations";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -16,7 +17,7 @@ export default withMiddlewares({
     responseSchema: GetScoresResponseV2,
     deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
       // Validate that trace filters are not used when trace field is excluded
       const requestedFields = query.fields ?? ["score", "trace"];
 
@@ -33,6 +34,38 @@ export default withMiddlewares({
         );
       }
 
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: query.fromTimestamp ?? undefined,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
+      const advancedFilters = dataAccessWindow.accessFloor
+        ? [
+            ...(query.filter ?? []),
+            {
+              column: "timestamp",
+              operator: ">=" as const,
+              value: dataAccessWindow.effectiveFromTimestamp!,
+              type: "datetime" as const,
+            },
+            ...(query.toTimestamp
+              ? [
+                  {
+                    column: "timestamp",
+                    operator: "<" as const,
+                    value: new Date(query.toTimestamp),
+                    type: "datetime" as const,
+                  },
+                ]
+              : []),
+          ]
+        : query.filter;
+
       const scoreParams = {
         projectId: auth.scope.projectId,
         page: query.page ?? undefined,
@@ -47,7 +80,7 @@ export default withMiddlewares({
         queueId: query.queueId ?? undefined,
         traceTags: query.traceTags ?? undefined,
         dataType: query.dataType ?? undefined,
-        fromTimestamp: query.fromTimestamp ?? undefined,
+        fromTimestamp: dataAccessWindow.effectiveFromTimestamp?.toISOString(),
         toTimestamp: query.toTimestamp ?? undefined,
         environment: query.environment ?? undefined,
         source: query.source ?? undefined,
@@ -55,7 +88,7 @@ export default withMiddlewares({
         operator: query.operator ?? undefined,
         scoreIds: query.scoreIds ?? undefined,
         fields: query.fields ?? undefined,
-        advancedFilters: query.filter,
+        advancedFilters,
       };
       const scoresApiService = new ScoresApiService("v2");
       const [items, count] = await Promise.all([

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -17,7 +17,7 @@ export default withMiddlewares({
     responseSchema: GetScoresResponseV2,
     deprecation: SCORES_DEPRECATION,
     rejectInEventsOnlyMode: true,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       // Validate that trace filters are not used when trace field is excluded
       const requestedFields = query.fields ?? ["score", "trace"];
 
@@ -38,12 +38,6 @@ export default withMiddlewares({
         plan: auth.scope.plan,
         fromTimestamp: query.fromTimestamp ?? undefined,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
       const advancedFilters = dataAccessWindow.accessFloor
         ? [
             ...(query.filter ?? []),

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -102,17 +102,11 @@ export default withMiddlewares({
     name: "Get Scores V3",
     querySchema: GetScoresV3Query,
     responseSchema: GetScoresResponseV3,
-    fn: async ({ query, auth, res }) => {
+    fn: async ({ query, auth }) => {
       const dataAccessWindow = clampToDataAccessDays({
         plan: auth.scope.plan,
         fromTimestamp: query.fromTimestamp,
       });
-      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
-        res.setHeader(
-          "X-Langfuse-Data-Access-From",
-          dataAccessWindow.accessFloor.toISOString(),
-        );
-      }
 
       const result = await listScoresV3ForPublicApi({
         projectId: auth.scope.projectId,

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -3,6 +3,7 @@ import { withMiddlewares } from "@/src/features/public-api/server/withMiddleware
 import { GetScoresQueryV3, GetScoresResponseV3 } from "@langfuse/shared";
 import { listScoresV3ForPublicApi } from "@/src/features/public-api/server/scores-api-v3";
 import { EncodedScoresCursorV3 } from "@/src/features/public-api/types/scores";
+import { clampToDataAccessDays } from "@/src/features/entitlements/server/hasEntitlementLimit";
 
 const GetScoresV3Query = GetScoresQueryV3.extend({
   cursor: EncodedScoresCursorV3.optional(),
@@ -101,7 +102,18 @@ export default withMiddlewares({
     name: "Get Scores V3",
     querySchema: GetScoresV3Query,
     responseSchema: GetScoresResponseV3,
-    fn: async ({ query, auth }) => {
+    fn: async ({ query, auth, res }) => {
+      const dataAccessWindow = clampToDataAccessDays({
+        plan: auth.scope.plan,
+        fromTimestamp: query.fromTimestamp,
+      });
+      if (dataAccessWindow.wasClamped && dataAccessWindow.accessFloor) {
+        res.setHeader(
+          "X-Langfuse-Data-Access-From",
+          dataAccessWindow.accessFloor.toISOString(),
+        );
+      }
+
       const result = await listScoresV3ForPublicApi({
         projectId: auth.scope.projectId,
         limit: query.limit,
@@ -122,7 +134,7 @@ export default withMiddlewares({
         sessionId: query.sessionId,
         observationId: query.observationId,
         experimentId: query.experimentId,
-        fromTimestamp: query.fromTimestamp,
+        fromTimestamp: dataAccessWindow.effectiveFromTimestamp,
         toTimestamp: query.toTimestamp,
       });
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16760 app preview](https://pr-16760.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Enforces the existing `data-access-days` entitlement on authenticated historical REST and MCP reads. Hobby organizations are limited to 30 days, Core organizations to 90 days, and unlimited plans remain unchanged.

The effective lower bound is applied silently to list, aggregate, cursor, and advanced-filter query paths. Response bodies are unchanged. There is no clamp response header.

Impacted package: `web`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Verification

- `pnpm --filter web run lint` (`Tasks: 7 successful, 7 total`)
- `pnpm --filter web run typecheck`
- `pnpm exec knip`
- Targeted server regressions: `Test Files 8 passed (8)`, `Tests 19 passed | 349 skipped (368)`
- Unit: `Test Files 1 passed (1)`, `Tests 13 passed (13)` (`data-access-days.servertest.ts`)
- Full Cursor Cloud stack startup: 6 services healthy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7591f0df-2e6a-4f76-86f9-1b9218eabcb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7591f0df-2e6a-4f76-86f9-1b9218eabcb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a shared plan-aware access-floor helper and applies it across historical list, aggregate, cursor, and advanced-filter paths in public REST and MCP APIs.
- Clamps Hobby access to 30 days and Core access to 90 days while preserving unlimited plans.
- Adds effective access-floor response headers to clamped REST requests.
- Adds regression coverage for traces, observations, sessions, scores, and helper boundary behavior.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until direct REST and MCP resource lookups enforce the same historical-access boundary as collection reads.

The new floor correctly constrains the reviewed list and cursor paths, but known IDs still reach old traces, observations, and scores through authenticated lookup handlers that apply project scope without any timestamp entitlement check.

**Files Needing Attention:** web/src/features/entitlements/server/hasEntitlementLimit.ts and direct trace, observation, and score lookup handlers
</details>


<details open><summary><h3>Security Review</h3></summary>

The enforcement remains bypassable through authenticated direct-resource reads: callers who know an old trace, observation, or score ID can retrieve it through REST or MCP without an access-floor check.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Authenticated limited-plan caller] --> B{Read path}
  B -->|List or aggregate| C[Clamp requested lower bound]
  C --> D[Apply plan access floor]
  D --> E[Only recent records returned]
  B -->|Direct resource ID| F[Project-scoped lookup]
  F --> G[Historical record returned without floor check]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/entitlements/server/hasEntitlementLimit.ts:50-83
**Direct reads bypass access floor**

When a limited-plan caller knows an old resource ID, the authenticated trace, observation, and score lookup paths return the project-scoped record without applying `clampToDataAccessDays`, exposing historical contents hidden by the newly clamped list endpoints.

**How this was verified:** The direct-read handlers query by project and resource ID without passing or checking an access-floor timestamp.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): enforce historical data access..."](https://github.com/langfuse/langfuse/commit/85200a3b5791128f7e6eafe301dfd431bab7e23f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57859656)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/authentication-and-authorization.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->