### PR TITLE
fix(web): keep every filter-sidebar facet visible

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -829,7 +829,7 @@ describe("DataTableControls blocked facets (LFE-11040)", () => {
   });
 });
 
-describe("DataTableControls facet fold", () => {
+describe("DataTableControls facet catalog", () => {
   const categoricalFilter = (
     column: string,
     label: string,
@@ -849,32 +849,15 @@ describe("DataTableControls facet fold", () => {
     onChange: () => {},
   });
 
-  const queryFilter = (
-    filters: UIFilter[],
-    commonFacets?: string[],
-  ): QueryFilter => ({
+  const queryFilter = (filters: UIFilter[]): QueryFilter => ({
     filters,
     expanded: [],
     onExpandedChange: () => {},
     clearAll: () => {},
     isFiltered: filters.some((f) => f.isActive),
     setFilterState: () => {},
-    commonFacets,
   });
 
-  // The fold preference is session-scoped and (without a provider) shares one
-  // key across tests; the used-facet recency map is localStorage-backed the
-  // same way. (Guarded: this vitest environment lacks localStorage on some
-  // Node versions, where the hook falls back to plain state.)
-  beforeEach(() => {
-    sessionStorage.clear();
-    globalThis.localStorage?.clear?.();
-    captureSpy.mockClear();
-  });
-
-  // Config order deliberately interleaves a tail facet (Release) between the
-  // common ones, so the append-below-the-fold ordering is distinguishable
-  // from plain catalog order.
   const CATALOG = [
     categoricalFilter("environment", "Environment", false),
     categoricalFilter("release", "Release", false),
@@ -882,97 +865,15 @@ describe("DataTableControls facet fold", () => {
     categoricalFilter("version", "Version", false),
   ];
 
-  const labelOrder = (first: string, second: string) => {
-    const a = screen.getByText(first);
-    const b = screen.getByText(second);
-    return Boolean(
-      a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-  };
-
-  it("folds uncommon facets behind 'Show N more' with the real hidden count", () => {
-    render(
-      <TooltipProvider>
-        <DataTableControls
-          queryFilter={queryFilter(CATALOG, ["environment", "name"])}
-        />
-      </TooltipProvider>,
-    );
-
-    expect(screen.getByText("Environment")).toBeVisible();
-    expect(screen.getByText("Name")).toBeVisible();
-    expect(screen.getByText("Release")).not.toBeVisible();
-    expect(screen.getByText("Version")).not.toBeVisible();
-    expect(
-      screen.getByRole("button", { name: "Show 2 more" }),
-    ).toBeInTheDocument();
-  });
-
-  it("expands to the full catalog and collapses back, capturing the toggle", () => {
-    render(
-      <TooltipProvider>
-        <DataTableControls
-          queryFilter={queryFilter(CATALOG, ["environment", "name"])}
-        />
-      </TooltipProvider>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Show 2 more" }));
-    expect(screen.getByText("Release")).toBeVisible();
-    expect(screen.getByText("Version")).toBeVisible();
-    // Revealed facets APPEND below the common block — the facets already on
-    // screen keep their positions, so Release (config-ordered between
-    // Environment and Name) lands after Name, not between them.
-    expect(labelOrder("Environment", "Name")).toBe(true);
-    expect(labelOrder("Name", "Release")).toBe(true);
-    expect(labelOrder("Release", "Version")).toBe(true);
-    const toggled = captureSpy.mock.calls.filter(
-      ([event]) => event === "filters:facet_fold_toggled",
-    );
-    expect(toggled).toHaveLength(1);
-    expect(toggled[0][1]).toMatchObject({
-      expanded: true,
-      foldedCount: 2,
-      isV4: false,
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Show fewer" }));
-    expect(screen.getByText("Release")).not.toBeVisible();
-    expect(screen.getByText("Version")).not.toBeVisible();
-  });
-
-  it("never folds a facet with an active filter, even outside the common set", () => {
-    render(
-      <TooltipProvider>
-        <DataTableControls
-          queryFilter={queryFilter(
-            [
-              categoricalFilter("environment", "Environment", false),
-              categoricalFilter("name", "Name", false),
-              categoricalFilter("release", "Release", true),
-              categoricalFilter("version", "Version", false),
-            ],
-            ["environment", "name"],
-          )}
-        />
-      </TooltipProvider>,
-    );
-
-    // Active Release stays reachable; only inactive Version counts as folded.
-    expect(screen.getByText("Release")).toBeVisible();
-    expect(screen.getByText("Version")).not.toBeVisible();
-    expect(
-      screen.getByRole("button", { name: "Show 1 more" }),
-    ).toBeInTheDocument();
-  });
-
-  it("renders the full catalog with no fold control when the table declares no common set", () => {
+  it("keeps every facet visible so browser find can reach it", () => {
     render(
       <TooltipProvider>
         <DataTableControls queryFilter={queryFilter(CATALOG)} />
       </TooltipProvider>,
     );
 
+    expect(screen.getByText("Environment")).toBeVisible();
+    expect(screen.getByText("Name")).toBeVisible();
     expect(screen.getByText("Release")).toBeVisible();
     expect(screen.getByText("Version")).toBeVisible();
     expect(
@@ -980,54 +881,13 @@ describe("DataTableControls facet fold", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps a facet the user has filtered on visible after the filter clears", () => {
-    const withReleaseActive = [
-      categoricalFilter("environment", "Environment", false),
-      categoricalFilter("release", "Release", true),
-      categoricalFilter("name", "Name", false),
-      categoricalFilter("version", "Version", false),
-    ];
-    const { rerender } = render(
-      <TooltipProvider>
-        <DataTableControls
-          queryFilter={queryFilter(CATALOG, ["environment", "name"])}
-        />
-      </TooltipProvider>,
-    );
-    expect(screen.getByText("Release")).not.toBeVisible();
-
-    // A filter lands on Release: it surfaces and is recorded as used.
-    rerender(
-      <TooltipProvider>
-        <DataTableControls
-          queryFilter={queryFilter(withReleaseActive, ["environment", "name"])}
-        />
-      </TooltipProvider>,
-    );
-    expect(screen.getByText("Release")).toBeVisible();
-
-    // Clearing the filter no longer folds it away: a used facet stays
-    // visible, and the fold count only covers the never-used tail.
-    rerender(
-      <TooltipProvider>
-        <DataTableControls
-          queryFilter={queryFilter(CATALOG, ["environment", "name"])}
-        />
-      </TooltipProvider>,
-    );
-    expect(screen.getByText("Release")).toBeVisible();
-    expect(
-      screen.getByRole("button", { name: "Show 1 more" }),
-    ).toBeInTheDocument();
-  });
-
-  it("expand-all expands only the facets on screen while folded", () => {
+  it("expand-all expands every facet in the catalog", () => {
     const onExpandedChange = vi.fn();
     render(
       <TooltipProvider>
         <DataTableControls
           queryFilter={{
-            ...queryFilter(CATALOG, ["environment", "name"]),
+            ...queryFilter(CATALOG),
             onExpandedChange,
           }}
         />
@@ -1035,30 +895,12 @@ describe("DataTableControls facet fold", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Expand all filters" }));
-    // Folded tail facets must not expand: that would fire their option
-    // loads with no visible effect.
-    expect(onExpandedChange).toHaveBeenCalledWith(["environment", "name"]);
-  });
-
-  it("hides the fold control when every tail facet is promoted (nothing left to fold)", () => {
-    render(
-      <TooltipProvider>
-        <DataTableControls
-          queryFilter={queryFilter(
-            [
-              categoricalFilter("environment", "Environment", false),
-              categoricalFilter("release", "Release", true),
-            ],
-            ["environment"],
-          )}
-        />
-      </TooltipProvider>,
-    );
-
-    expect(screen.getByText("Release")).toBeVisible();
-    expect(
-      screen.queryByRole("button", { name: /Show \d+ more|Show fewer/ }),
-    ).not.toBeInTheDocument();
+    expect(onExpandedChange).toHaveBeenCalledWith([
+      "environment",
+      "release",
+      "name",
+      "version",
+    ]);
   });
 });
 

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -33,7 +33,6 @@ import {
 } from "@/src/features/filters/lib/facet-order";
 import { useMediaQuery } from "react-responsive";
 import useLocalStorage from "@/src/components/useLocalStorage";
-import useSessionStorage from "@/src/components/useSessionStorage";
 import { cn } from "@/src/utils/tailwind";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 import { Accordion } from "@/src/components/ui/accordion";
@@ -179,12 +178,6 @@ export interface QueryFilter {
   setFilterState: (filters: FilterState) => void;
   /** v3-vs-v4 analytics dimension of the surface (see useSidebarFilterState). */
   isV4?: boolean;
-  /**
-   * Curated default-visible facet set from the table's FilterConfig
-   * When present, facets outside it fold behind "Show N more";
-   * absent = the whole catalog stays visible.
-   */
-  commonFacets?: string[];
 }
 
 interface DataTableControlsProps {
@@ -267,17 +260,7 @@ export function DataTableControls({
   facetOrderRef.current = facetOrder;
   // No event = a programmatic in-list action (Add filter), which is always a
   // deliberate interaction.
-  const noteFacetInteraction = (event?: React.SyntheticEvent) => {
-    // The fold toggle never changes promotion, so it must not arm the
-    // attribution token: a dangling token would wrongly hold the order
-    // through the next external filter change (search bar, saved view).
-    if (
-      event &&
-      event.target instanceof Element &&
-      event.target.closest("[data-facet-fold-toggle]")
-    ) {
-      return;
-    }
+  const noteFacetInteraction = () => {
     facetInteractionRef.current += 1;
   };
   // Boundaries the sidebar owns itself (Clear all, AI apply): the change they
@@ -293,18 +276,6 @@ export function DataTableControls({
   const displayedFilters = showOnlyActive
     ? orderedFilters.filter(isPromoted)
     : orderedFilters;
-
-  // Fold the uncommon tail of the catalog behind "Show N more",
-  // on tables that declare a curated `commonFacets` set. Session-scoped like
-  // the per-facet expanded state: a mid-session "show all" survives
-  // navigation, a fresh session starts folded again. Active-only mode is a
-  // stricter collapse already, so the fold only applies outside it.
-  const [showAllFacets, setShowAllFacets] = useSessionStorage(
-    `${storagePrefix}-facets-show-all`,
-    false,
-  );
-  const commonFacetSet = new Set(queryFilter.commonFacets ?? []);
-  const facetFoldEnabled = commonFacetSet.size > 0 && !showOnlyActive;
 
   // Facet-NAME search over a long catalog. Two surfaces search the same names:
   // this list, and the active-only "Add filter" picker below.
@@ -335,59 +306,18 @@ export function DataTableControls({
 
   // Facet-usage recency: every facet the user has filtered on, on this table,
   // in this browser (localStorage; written by the activity effect below).
-  // Feeds the "Add filter" dropdown's ordering, and keeps used facets out of
-  // the fold — once someone filters on a facet, it stays visible for them.
+  // Feeds the "Add filter" dropdown's ordering.
   const [recentColumns, setRecentColumns] = useLocalStorage<
     Record<string, number>
   >(`${storagePrefix}-recent-facets`, EMPTY_RECENCY);
-  // Two groups, both in settled order: the top group is the curated common
-  // set, every facet this user has ever filtered on, and the SETTLED promoted
-  // block; everything else is the tail. Expanding APPENDS the tail below the
-  // top group (never interleaves it back into catalog order), so the facets
-  // already on screen keep their exact positions when the button is clicked.
-  // Group membership uses the settled promotion — not the live one — so a
-  // facet activated in place stays in place until the next settle. A
-  // live-active tail facet still never hides: when folded it renders at the
-  // end of the top group, right above the button.
-  const inTopFoldGroup = (filter: UIFilter) =>
-    commonFacetSet.has(filter.column) ||
-    recentColumns[filter.column] !== undefined ||
-    facetOrder.promoted.has(filter.column);
-  const topFoldGroup = facetFoldEnabled
-    ? displayedFilters.filter(inTopFoldGroup)
-    : displayedFilters;
-  const tailFoldGroup = facetFoldEnabled
-    ? displayedFilters.filter((filter) => !inTopFoldGroup(filter))
-    : [];
-  const foldedFacetCount = tailFoldGroup.filter(
-    (filter) => !isPromoted(filter),
-  ).length;
-  // The one render order: top group first, tail appended below — expanding
-  // the fold never interleaves the tail back into catalog order, so facets
-  // already on screen keep their exact positions. Reordering a single keyed
-  // array moves elements without remounting them.
-  const renderOrderedFilters = facetFoldEnabled
-    ? [...topFoldGroup, ...tailFoldGroup]
-    : displayedFilters;
-  const foldVisibleFilters = facetFoldEnabled
-    ? [
-        ...topFoldGroup,
-        ...(showAllFacets ? tailFoldGroup : tailFoldGroup.filter(isPromoted)),
-      ]
-    : displayedFilters;
-  // Search and fold COMPOSE: an active search suspends the fold (a match in
-  // the folded tail must be findable), otherwise the fold decides what is on
-  // screen. Either way rows are HIDDEN, never unmounted: every facet holds
+  // Search hides non-matching rows; it never unmounts them. Every facet holds
   // uncommitted local state — a typed-but-not-added text filter, a metadata
   // condition mid-build, a "show more" expansion, a debounced numeric draft —
-  // and unmounting throws all of it away with nothing said. Now that an ACTIVE
-  // facet can be hidden too, that matters more, not less: hiding is
+  // and unmounting throws all of it away with nothing said. Hiding is
   // presentation only and must never touch the filter state.
   const visibleFilters = facetSearchMatches
-    ? renderOrderedFilters.filter((filter) =>
-        facetSearchMatches.has(filter.column),
-      )
-    : foldVisibleFilters;
+    ? displayedFilters.filter((filter) => facetSearchMatches.has(filter.column))
+    : displayedFilters;
   const visibleColumns = new Set(visibleFilters.map((filter) => filter.column));
   const expandedVisibleCount = queryFilter.expanded.filter((column) =>
     visibleColumns.has(column),
@@ -570,8 +500,7 @@ export function DataTableControls({
     : visibleFilters.filter((filter) => facetOrder.promoted.has(filter.column))
         .length;
   // Anchored to the first VISIBLE catalog facet rather than to an index: rows
-  // hidden by a search or the fold stay in the list, so an index would count
-  // them.
+  // hidden by a search stay in the list, so an index would count them.
   const firstCatalogColumn = visibleFilters.find(
     (filter) => !facetOrder.promoted.has(filter.column),
   )?.column;
@@ -806,11 +735,11 @@ export function DataTableControls({
             the promoted/rest boundary would REMOUNT (wiping input
             focus and draft state) instead of moving.
 
-            Every facet renders; a search or the fold only sets `hidden`
-            on the rows they exclude. The wrapper is always present for
+            Every facet renders; a search only sets `hidden`
+            on the rows it excludes. The wrapper is always present for
             the same reason the array is single: swapping the element
             around a facet would remount it and lose its draft state. */}
-        {renderOrderedFilters.flatMap((filter) => {
+        {displayedFilters.flatMap((filter) => {
           const nodes = [];
           if (showPromotedSeparator && filter.column === firstCatalogColumn) {
             nodes.push(
@@ -841,46 +770,6 @@ export function DataTableControls({
         <p className="text-muted-foreground px-3 pt-6 text-center text-xs break-words">
           {`No filters match "${facetSearchQuery}"`}
         </p>
-      )}
-
-      {/* The fold control: the uncommon tail of the catalog sits
-          behind an accurate "Show N more"; expanding reveals every remaining
-          facet, so nothing is unreachable. Hidden while nothing is foldable
-          (e.g. every tail facet currently carries an active filter) and while
-          a search owns visibility. */}
-      {facetFoldEnabled && foldedFacetCount > 0 && !facetSearchQuery && (
-        <div className="px-2 pt-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            data-facet-fold-toggle
-            onClick={() => {
-              const next = !showAllFacets;
-              setShowAllFacets(next);
-              capture("filters:facet_fold_toggled", {
-                tableName,
-                expanded: next,
-                foldedCount: foldedFacetCount,
-                isV4: queryFilter.isV4 ?? false,
-              });
-            }}
-            // Reads like a facet header row: same muted color, size, and
-            // chevron treatment (> folded, v expanded), same left inset.
-            className="text-muted-foreground hover:text-foreground h-auto w-full justify-start gap-1.5 px-2 py-1 text-xs font-normal"
-          >
-            {showAllFacets ? (
-              <>
-                <ChevronDown className="h-3.5 w-3.5 shrink-0" />
-                Show fewer
-              </>
-            ) : (
-              <>
-                <ChevronRight className="h-3.5 w-3.5 shrink-0" />
-                Show {foldedFacetCount} more
-              </>
-            )}
-          </Button>
-        </div>
       )}
 
       {/* Active-only mode: surface the rest of the catalog behind an

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -79,30 +79,10 @@ export const observationEventsFilterConfig: FilterConfig = {
 
   defaultExpanded: ["environment", "name", "isRootObservation", "type"],
 
-  // Top 15 facets by real usage — 60 days of PostHog `filters:applied` on
-  // this table: they cover ~98% of sidebar filter applies per project on
-  // average, ~95% at the 10th percentile. The rest folds behind
-  // "Show N more".
-  commonFacets: [
-    "isRootObservation",
-    "name",
-    "type",
-    "environment",
-    "traceName",
-    "metadata",
-    "traceTags",
-    "sessionId",
-    "userId",
-    "traceId",
-    "level",
-    "providedModelName",
-    "promptName",
-    "latency",
-    "scores_avg",
-  ],
-
   migrateFilterState: migrateLegacyRootObservationFilters,
 
+  // Observation-table facet order follows real sidebar usage (PostHog
+  // `filters:applied`): the most-applied columns sit at the top.
   facets: [
     {
       type: "boolean" as const,

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -1991,9 +1991,6 @@ export function useSidebarFilterPresentation(
     // Exposed so view-layer captures (DataTableControls) carry the same
     // v3-vs-v4 dimension as the hook's own events.
     isV4: isV4Surface,
-    // The curated default-visible facet set; DataTableControls folds the
-    // rest behind "Show N more".
-    commonFacets: config.commonFacets,
   };
 }
 

--- a/web/src/features/filters/lib/filter-config.ts
+++ b/web/src/features/filters/lib/filter-config.ts
@@ -79,14 +79,6 @@ export interface FilterConfig {
   columnDefinitions: ColumnDefinition[];
   defaultExpanded?: string[];
   defaultSidebarCollapsed?: boolean;
-  /**
-   * The facets most sessions actually use (curated from PostHog
-   * `filters:applied` data). When set, the sidebar shows only
-   * these by default and folds the rest behind a "Show N more" control.
-   * A facet with an active filter is always shown regardless of this list.
-   * Unset = every facet stays visible (tables that haven't opted in).
-   */
-  commonFacets?: string[];
   facets: Facet[];
   /** Runs after display-name normalization and before filter validation. */
   migrateFilterState?: FilterStateMigration;
@@ -112,9 +104,6 @@ export function omitFilterFacets(
   return {
     ...config,
     defaultExpanded: config.defaultExpanded?.filter(
-      (column) => !omittedColumnSet.has(column),
-    ),
-    commonFacets: config.commonFacets?.filter(
       (column) => !omittedColumnSet.has(column),
     ),
     facets: config.facets.filter(

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -410,7 +410,6 @@ const events = {
     "facet_operator_toggled",
     "active_only_toggled",
     "facet_added",
-    "facet_fold_toggled",
     "facet_search",
     "facet_mode_switched",
     "sidebar_toggled",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16761.preview.langfuse.com](https://pr-16761.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

| Area | Change |
| --- | --- |
| Filter sidebar | Every facet stays in the list. The Show N more fold is gone, so browser find can reach every facet name. |
| Observation table | Usage-based facet order is unchanged. |

PostHog: dropped `filters:facet_fold_toggled` because the toggle is gone. No new event.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Targeted client tests: `pnpm --filter web run test-client src/components/table/data-table-controls.clienttest.tsx` (`Tests 32 passed (32)`)
- Pre-commit lint: `Tasks: 7 successful, 7 total`

![Observations filter sidebar showing every facet, including Latency, Prompt Name, Version, Release](https://cursor.com/artifacts/c/art-c8762900-274a-4e8c-944d-519b66d08f8a)
![Browser find highlighting the Latency facet header](https://cursor.com/artifacts/c/art-154b832a-a549-4bb5-88c4-e04121982593)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-216eba99-5a4a-41a6-bf31-cfe68a9973e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-216eba99-5a4a-41a6-bf31-cfe68a9973e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes the filter-sidebar facet fold so every facet remains rendered and searchable, while preserving the observation facet order.

- Removes the common-facet configuration and session-scoped fold state.
- Removes the fold toggle and its PostHog event.
- Updates client tests to require the complete facet catalog to remain visible and participate in Expand all.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, though Expand all should ideally batch or limit the burst of lazy facet-option requests on the events table.

The functional removal is internally consistent, but expanding the newly visible full catalog can issue roughly 18 concurrent unbatched filter-option requests from one user action.

**Files Needing Attention:** web/src/components/table/data-table-controls.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/data-table-controls.tsx:309-312
**Full catalog expands concurrently**

Expand all now adds the complete events facet catalog to `expanded`, causing approximately 18 lazy `events.filterOptions` queries to run as separate concurrent HTTP requests. Batch or limit these requests to avoid unnecessary sidebar latency and backend load from one presentation action.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep every filter-sidebar face..."](https://github.com/langfuse/langfuse/commit/ee5de17e9f449ffee150c311d188a12222ffbe71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57860188)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->