### PR TITLE
feat(experiments): filter datasets by name instead of id

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -280,15 +280,6 @@ export default function ExperimentsTable({
   showControlsInPageHeader = false,
 }: ExperimentsTableProps) {
   const router = useRouter();
-  const filterConfig = useMemo(
-    () =>
-      getExperimentsFilterConfig(
-        fixedFilter
-          .map((filter) => filter.column)
-          .filter(isExperimentsOmittableFilterColumn),
-      ),
-    [fixedFilter],
-  );
 
   const { setDetailPageList } = useDetailPageLists();
   // Selection lives in a per-mount vanilla zustand store (not useState) so a
@@ -352,6 +343,19 @@ export default function ExperimentsTable({
     projectId,
     oldFilterState,
   });
+
+  // Built after the dataset map, which its filter-state migration needs to
+  // translate a legacy dataset id into the name the facet is keyed by.
+  const filterConfig = useMemo(
+    () =>
+      getExperimentsFilterConfig(
+        fixedFilter
+          .map((filter) => filter.column)
+          .filter(isExperimentsOmittableFilterColumn),
+        datasetNameById,
+      ),
+    [fixedFilter, datasetNameById],
+  );
 
   const queryFilter = useSidebarFilterState(filterConfig, filterOptions, {
     loading: isFilterOptionsPending,

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -11,6 +11,7 @@ import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
 import { EXPERIMENTS_FIELD_REGISTRY } from "@/src/features/experiments/constants/experimentsSearchRegistry";
+import { withDatasetNamesResolved } from "@/src/features/experiments/fns/datasetNameFilter";
 import { toObservedOptions } from "@/src/features/search-bar/lib/observed-options";
 import { DEFAULT_SEARCH_TYPE } from "@/src/features/search-bar/lib/commit";
 import { useEventsSearchBar } from "@/src/features/search-bar/hooks/useEventsSearchBar";
@@ -342,7 +343,12 @@ export default function ExperimentsTable({
   const oldFilterState = inputFilterState.concat(dateRangeFilter, fixedFilter);
 
   // Fetch filter options for datasets and scores
-  const { filterOptions, isFilterOptionsPending } = useExperimentFilterOptions({
+  const {
+    filterOptions,
+    datasetIdByName,
+    datasetNameById,
+    isFilterOptionsPending,
+  } = useExperimentFilterOptions({
     projectId,
     oldFilterState,
   });
@@ -409,7 +415,12 @@ export default function ExperimentsTable({
     fixedFilter,
   );
 
-  const filterState = combinedFilterState;
+  // The one boundary where a dataset NAME becomes its id — see
+  // fns/datasetNameFilter.
+  const filterState = useMemo(
+    () => withDatasetNamesResolved(combinedFilterState, datasetIdByName),
+    [combinedFilterState, datasetIdByName],
+  );
 
   // Use the custom hook for experiments data fetching
   const { experiments, totalCount, dataUpdatedAt } = useExperimentsTableData({
@@ -557,13 +568,13 @@ export default function ExperimentsTable({
     {
       accessorKey: "datasetId",
       id: "datasetId",
-      header: getExperimentsColumnName("experimentDatasetId"),
+      header: getExperimentsColumnName("experimentDatasetName"),
       size: 150,
       cell: ({ row }) => {
         const datasetId: string | undefined = row.getValue("datasetId");
-        const datasetName = filterOptions.experimentDatasetId?.find(
-          (d) => d.value === datasetId,
-        )?.displayValue;
+        const datasetName = datasetId
+          ? datasetNameById.get(datasetId)
+          : undefined;
 
         if (!datasetId || !datasetName) {
           return undefined;

--- a/web/src/features/experiments/components/table/filter-config.ts
+++ b/web/src/features/experiments/components/table/filter-config.ts
@@ -42,8 +42,22 @@ export const experimentsTableCols: ColumnDefinition[] = [
     internal: "prompts",
     nullable: true,
   },
+  // Dataset names are unique per project, so the NAME is the canonical filter
+  // value: it survives in a URL or saved view as something readable, and the
+  // sidebar picker and the search bar can both show the same string. It is
+  // translated to `experimentDatasetId` on the way to the query (the dataset
+  // name is not a ClickHouse column) — see fns/datasetNameFilter.
   {
     name: "Dataset",
+    id: "experimentDatasetName",
+    type: "stringOptions",
+    internal: "experiment_dataset_id",
+    options: [],
+  },
+  // Still filterable so URLs and saved views written before the switch keep
+  // resolving; no longer offered as a facet.
+  {
+    name: "Dataset ID",
     id: "experimentDatasetId",
     type: "stringOptions",
     internal: "experiment_dataset_id",
@@ -141,7 +155,7 @@ export const experimentsFilterConfig: FilterConfig = {
 
   columnDefinitions: experimentsTableCols,
 
-  defaultExpanded: ["experimentDatasetId"],
+  defaultExpanded: ["experimentDatasetName"],
 
   facets: [
     {
@@ -151,8 +165,8 @@ export const experimentsFilterConfig: FilterConfig = {
     },
     {
       type: "categorical" as const,
-      column: "experimentDatasetId",
-      label: getExperimentsColumnName("experimentDatasetId"),
+      column: "experimentDatasetName",
+      label: getExperimentsColumnName("experimentDatasetName"),
     },
     {
       type: "stringKeyValue" as const,
@@ -194,7 +208,9 @@ export const experimentsFilterConfig: FilterConfig = {
   ],
 };
 
-export type ExperimentsOmittableFilterColumn = "experimentDatasetId";
+export type ExperimentsOmittableFilterColumn =
+  | "experimentDatasetId"
+  | "experimentDatasetName";
 
 export function isExperimentsOmittableFilterColumn(
   column: string,
@@ -205,5 +221,12 @@ export function isExperimentsOmittableFilterColumn(
 export function getExperimentsFilterConfig(
   omittedFilter: ExperimentsOmittableFilterColumn[] = [],
 ): FilterConfig {
-  return omitFilterFacets(experimentsFilterConfig, omittedFilter);
+  // A dataset-scoped page pins `experimentDatasetId`, but the facet it should
+  // hide is the name one that replaced it.
+  return omitFilterFacets(
+    experimentsFilterConfig,
+    omittedFilter.map((column) =>
+      column === "experimentDatasetId" ? "experimentDatasetName" : column,
+    ) as ExperimentsOmittableFilterColumn[],
+  );
 }

--- a/web/src/features/experiments/components/table/filter-config.ts
+++ b/web/src/features/experiments/components/table/filter-config.ts
@@ -1,6 +1,7 @@
 import {
   omitFilterFacets,
   type FilterConfig,
+  type FilterStateMigration,
 } from "@/src/features/filters/lib/filter-config";
 import type { ColumnDefinition } from "@langfuse/shared";
 
@@ -150,12 +151,39 @@ export const getExperimentsColumnName = (id: string): string => {
   return column.name;
 };
 
+/**
+ * Folds a legacy `experimentDatasetId` filter onto the canonical column.
+ *
+ * Both ids compile to the same ClickHouse column, and the name resolver passes
+ * a value it cannot translate straight through — so an id keeps matching. What
+ * matters is that only ONE dataset column can be present: the sidebar's facet
+ * actions replace entries by exact column name, so a leftover
+ * `experimentDatasetId` from an old link survived every interaction with the
+ * Dataset facet and was ANDed with the user's new choice, silently showing zero
+ * rows with one dataset apparently selected.
+ */
+const foldLegacyDatasetColumn: FilterStateMigration = (filters) => {
+  if (!filters.some((filter) => filter.column === "experimentDatasetId")) {
+    return filters;
+  }
+  const seen = new Set<string>();
+  return filters.flatMap((filter) => {
+    if (filter.column !== "experimentDatasetId") return [filter];
+    // Two legacy entries would fold onto one column and re-create the AND.
+    if (seen.has(filter.column)) return [];
+    seen.add(filter.column);
+    return [{ ...filter, column: "experimentDatasetName" }];
+  });
+};
+
 export const experimentsFilterConfig: FilterConfig = {
   tableName: "experiments",
 
   columnDefinitions: experimentsTableCols,
 
   defaultExpanded: ["experimentDatasetName"],
+
+  migrateFilterState: foldLegacyDatasetColumn,
 
   facets: [
     {

--- a/web/src/features/experiments/components/table/filter-config.ts
+++ b/web/src/features/experiments/components/table/filter-config.ts
@@ -162,19 +162,54 @@ export const getExperimentsColumnName = (id: string): string => {
  * Dataset facet and was ANDed with the user's new choice, silently showing zero
  * rows with one dataset apparently selected.
  */
-const foldLegacyDatasetColumn: FilterStateMigration = (filters) => {
-  if (!filters.some((filter) => filter.column === "experimentDatasetId")) {
-    return filters;
-  }
-  const seen = new Set<string>();
-  return filters.flatMap((filter) => {
-    if (filter.column !== "experimentDatasetId") return [filter];
-    // Two legacy entries would fold onto one column and re-create the AND.
-    if (seen.has(filter.column)) return [];
-    seen.add(filter.column);
-    return [{ ...filter, column: "experimentDatasetName" }];
-  });
-};
+/**
+ * Folds a legacy `experimentDatasetId` filter onto the canonical column,
+ * translating its value from the id to the dataset's NAME.
+ *
+ * Only ONE dataset column may be present: the sidebar's facet actions replace
+ * entries by exact column name, so a leftover `experimentDatasetId` from an old
+ * link survived every interaction with the Dataset facet and was ANDed with the
+ * user's new choice - one dataset apparently selected, zero rows.
+ *
+ * The value has to travel with the column. The facet's options and its display
+ * labels are keyed by name, so a folded id would render as an opaque id with no
+ * checkbox matching it. Until the id -> name map arrives the legacy filter is
+ * left exactly as it is: it names a real column, so it keeps querying correctly
+ * in the meantime, and an id with no name (a deleted dataset) stays put rather
+ * than becoming a name that resolves to nothing.
+ */
+const foldLegacyDatasetColumn =
+  (datasetNameById: ReadonlyMap<string, string>): FilterStateMigration =>
+  (filters) => {
+    if (
+      datasetNameById.size === 0 ||
+      !filters.some((filter) => filter.column === "experimentDatasetId")
+    ) {
+      return filters;
+    }
+
+    let folded = false;
+    return filters.flatMap((filter) => {
+      if (filter.column !== "experimentDatasetId") return [filter];
+      if (filter.type !== "stringOptions") return [filter];
+
+      const names = filter.value.map((id) => datasetNameById.get(id));
+      // Partial knowledge would drop a constraint, so fold all or nothing.
+      if (names.some((name) => name === undefined)) return [filter];
+      // A second legacy entry would fold onto the same column and re-create
+      // the AND this exists to remove.
+      if (folded) return [];
+      folded = true;
+
+      return [
+        {
+          ...filter,
+          column: "experimentDatasetName",
+          value: names as string[],
+        },
+      ];
+    });
+  };
 
 export const experimentsFilterConfig: FilterConfig = {
   tableName: "experiments",
@@ -182,8 +217,6 @@ export const experimentsFilterConfig: FilterConfig = {
   columnDefinitions: experimentsTableCols,
 
   defaultExpanded: ["experimentDatasetName"],
-
-  migrateFilterState: foldLegacyDatasetColumn,
 
   facets: [
     {
@@ -248,13 +281,19 @@ export function isExperimentsOmittableFilterColumn(
 
 export function getExperimentsFilterConfig(
   omittedFilter: ExperimentsOmittableFilterColumn[] = [],
+  datasetNameById: ReadonlyMap<string, string> = new Map(),
 ): FilterConfig {
   // A dataset-scoped page pins `experimentDatasetId`, but the facet it should
   // hide is the name one that replaced it.
-  return omitFilterFacets(
+  const config = omitFilterFacets(
     experimentsFilterConfig,
     omittedFilter.map((column) =>
       column === "experimentDatasetId" ? "experimentDatasetName" : column,
     ) as ExperimentsOmittableFilterColumn[],
   );
+
+  return {
+    ...config,
+    migrateFilterState: foldLegacyDatasetColumn(datasetNameById),
+  };
 }

--- a/web/src/features/experiments/constants/experimentsSearchRegistry.ts
+++ b/web/src/features/experiments/constants/experimentsSearchRegistry.ts
@@ -21,6 +21,10 @@ function facetColumns(config: FilterConfig) {
 
 const AI_CONTEXT_FIELDS = [
   { observedOptionsKey: "name", promptLabel: "name" },
+  {
+    observedOptionsKey: "experimentDatasetName",
+    promptLabel: "experimentDatasetName (dataset)",
+  },
 ] as const;
 
 /**
@@ -38,14 +42,6 @@ const AI_CONTEXT_FIELDS = [
  * surface as a bogus keyless field.
  */
 const EXCLUDED_COLUMN_IDS: ReadonlySet<string> = new Set([
-  // `experimentDatasetId` holds the dataset ID while the sidebar's picker shows
-  // the dataset NAME (`displayValue`). A text query bar can only show what the
-  // query text contains, so offering it here would put `dataset:cmtc1z…` in a
-  // pill next to a sidebar that says `legal-answer-quality`. Making the bar
-  // speak names would require the derived committed text to depend on
-  // async-loaded options, which breaks the one invariant every bar surface
-  // relies on. Dataset filtering stays in the sidebar.
-  "experimentDatasetId",
   "obs_scores_avg",
   "obs_score_categories",
   "obs_score_booleans",
@@ -65,6 +61,11 @@ const EXPERIMENT_FIELD_OVERLAY = {
     label: "Experiment name",
     description: "Experiment name",
   },
+  experimentDatasetName: {
+    aliases: ["dataset", "datasetname", "dataset_name"],
+    label: "Dataset",
+    description: "Dataset the experiment ran against",
+  },
 };
 
 export const EXPERIMENTS_FIELD_REGISTRY: FieldRegistry =
@@ -81,7 +82,11 @@ export const EXPERIMENTS_FIELD_REGISTRY: FieldRegistry =
     recentSearches: true,
     // `dataset:` takes the dataset ID, not its name — the observed-value picker
     // offers the ids, so the examples must not imply a name works.
-    searchExamples: ["name:sonnet", "-name:baseline", 'metadata."model":opus'],
+    searchExamples: [
+      "dataset:legal-answer-quality",
+      "name:sonnet",
+      'metadata."model":opus',
+    ],
     aiContextFields: AI_CONTEXT_FIELDS,
     fields: EXPERIMENT_FIELD_OVERLAY,
   });

--- a/web/src/features/experiments/fns/datasetNameFilter.clienttest.ts
+++ b/web/src/features/experiments/fns/datasetNameFilter.clienttest.ts
@@ -1,4 +1,4 @@
-import { experimentsFilterConfig } from "@/src/features/experiments/components/table/filter-config";
+import { getExperimentsFilterConfig } from "@/src/features/experiments/components/table/filter-config";
 import { describe, expect, it } from "vitest";
 import type { FilterState } from "@langfuse/shared";
 
@@ -75,48 +75,60 @@ describe("withDatasetNamesResolved", () => {
 });
 
 describe("folding the legacy dataset column", () => {
-  const migrate = experimentsFilterConfig.migrateFilterState!;
+  const nameById = new Map([
+    ["ds-legal", "legal-answer-quality"],
+    ["ds-judge", "groundedness-judge-calibration"],
+  ]);
+  const migrate = (filters: FilterState, map = nameById) =>
+    getExperimentsFilterConfig([], map).migrateFilterState!(filters);
 
-  it("moves a legacy experimentDatasetId filter onto the canonical column", () => {
-    // Left on its own column it survives every Dataset-facet interaction and is
-    // ANDed with the user's choice, so the table shows nothing.
-    expect(
-      migrate([
-        {
-          type: "stringOptions",
-          column: "experimentDatasetId",
-          operator: "any of",
-          value: ["dataset-abc"],
-        },
-      ]),
-    ).toEqual([
+  const legacy = (...ids: string[]): FilterState => [
+    {
+      type: "stringOptions",
+      column: "experimentDatasetId",
+      operator: "any of",
+      value: ids,
+    },
+  ];
+
+  it("moves the filter onto the canonical column as the dataset NAME", () => {
+    // The facet's options and labels are keyed by name, so folding the id
+    // through unchanged would show an opaque id with nothing checked.
+    expect(migrate(legacy("ds-legal"))).toEqual([
       {
         type: "stringOptions",
         column: "experimentDatasetName",
         operator: "any of",
-        value: ["dataset-abc"],
+        value: ["legal-answer-quality"],
       },
     ]);
   });
 
+  it("waits rather than folding while the id -> name map is empty", () => {
+    // The legacy column is real, so leaving it alone keeps querying correctly.
+    const filters = legacy("ds-legal");
+    expect(migrate(filters, new Map())).toBe(filters);
+  });
+
+  it("leaves an id it cannot name alone", () => {
+    // A deleted dataset must not become a name that matches nothing.
+    const filters = legacy("ds-deleted");
+    expect(migrate(filters)).toEqual(filters);
+  });
+
+  it("folds all values of an entry or none of them", () => {
+    const filters = legacy("ds-legal", "ds-deleted");
+    expect(migrate(filters)).toEqual(filters);
+  });
+
   it("cannot leave two dataset filters behind", () => {
-    const migrated = migrate([
-      {
-        type: "stringOptions",
-        column: "experimentDatasetId",
-        operator: "any of",
-        value: ["dataset-abc"],
-      },
-      {
-        type: "stringOptions",
-        column: "experimentDatasetId",
-        operator: "any of",
-        value: ["dataset-def"],
-      },
-    ]);
+    const migrated = migrate([...legacy("ds-legal"), ...legacy("ds-judge")]);
 
     expect(migrated).toHaveLength(1);
-    expect(migrated[0]).toMatchObject({ column: "experimentDatasetName" });
+    expect(migrated[0]).toMatchObject({
+      column: "experimentDatasetName",
+      value: ["legal-answer-quality"],
+    });
   });
 
   it("leaves a filter state without the legacy column untouched", () => {

--- a/web/src/features/experiments/fns/datasetNameFilter.clienttest.ts
+++ b/web/src/features/experiments/fns/datasetNameFilter.clienttest.ts
@@ -1,3 +1,4 @@
+import { experimentsFilterConfig } from "@/src/features/experiments/components/table/filter-config";
 import { describe, expect, it } from "vitest";
 import type { FilterState } from "@langfuse/shared";
 
@@ -70,5 +71,64 @@ describe("withDatasetNamesResolved", () => {
         idByName,
       )[0],
     ).toMatchObject({ value: ["ds-legal", "ds-ground"] });
+  });
+});
+
+describe("folding the legacy dataset column", () => {
+  const migrate = experimentsFilterConfig.migrateFilterState!;
+
+  it("moves a legacy experimentDatasetId filter onto the canonical column", () => {
+    // Left on its own column it survives every Dataset-facet interaction and is
+    // ANDed with the user's choice, so the table shows nothing.
+    expect(
+      migrate([
+        {
+          type: "stringOptions",
+          column: "experimentDatasetId",
+          operator: "any of",
+          value: ["dataset-abc"],
+        },
+      ]),
+    ).toEqual([
+      {
+        type: "stringOptions",
+        column: "experimentDatasetName",
+        operator: "any of",
+        value: ["dataset-abc"],
+      },
+    ]);
+  });
+
+  it("cannot leave two dataset filters behind", () => {
+    const migrated = migrate([
+      {
+        type: "stringOptions",
+        column: "experimentDatasetId",
+        operator: "any of",
+        value: ["dataset-abc"],
+      },
+      {
+        type: "stringOptions",
+        column: "experimentDatasetId",
+        operator: "any of",
+        value: ["dataset-def"],
+      },
+    ]);
+
+    expect(migrated).toHaveLength(1);
+    expect(migrated[0]).toMatchObject({ column: "experimentDatasetName" });
+  });
+
+  it("leaves a filter state without the legacy column untouched", () => {
+    const filters: FilterState = [
+      {
+        type: "stringOptions",
+        column: "experimentDatasetName",
+        operator: "any of",
+        value: ["legal-answer-quality"],
+      },
+    ];
+
+    expect(migrate(filters)).toBe(filters);
   });
 });

--- a/web/src/features/experiments/fns/datasetNameFilter.clienttest.ts
+++ b/web/src/features/experiments/fns/datasetNameFilter.clienttest.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { FilterState } from "@langfuse/shared";
+
+import { withDatasetNamesResolved } from "./datasetNameFilter";
+
+const idByName = new Map([
+  ["legal-answer-quality", "ds-legal"],
+  ["groundedness-judge-calibration", "ds-ground"],
+]);
+
+const nameFilter = (values: string[]): FilterState => [
+  {
+    column: "experimentDatasetName",
+    type: "stringOptions",
+    operator: "any of",
+    value: values,
+  },
+];
+
+describe("withDatasetNamesResolved", () => {
+  it("swaps names for ids and keeps the operator", () => {
+    expect(
+      withDatasetNamesResolved(nameFilter(["legal-answer-quality"]), idByName),
+    ).toEqual([
+      {
+        column: "experimentDatasetId",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["ds-legal"],
+      },
+    ]);
+  });
+
+  it("leaves other filters and pre-existing id filters untouched", () => {
+    const others: FilterState = [
+      {
+        column: "name",
+        type: "string",
+        operator: "contains",
+        value: "sonnet",
+      },
+      // A saved view written before the switch already carries the id column.
+      {
+        column: "experimentDatasetId",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["ds-legal"],
+      },
+    ];
+    expect(withDatasetNamesResolved(others, idByName)).toBe(others);
+  });
+
+  it("maps an unknown name to no id rather than dropping the filter", () => {
+    // Dropping it would widen the query to every dataset; an unknown dataset
+    // must return nothing.
+    const [resolved] = withDatasetNamesResolved(
+      nameFilter(["deleted-dataset"]),
+      idByName,
+    );
+    expect(resolved).toMatchObject({
+      column: "experimentDatasetId",
+      value: ["deleted-dataset"],
+    });
+  });
+
+  it("resolves each name in a multi-value selection", () => {
+    expect(
+      withDatasetNamesResolved(
+        nameFilter(["legal-answer-quality", "groundedness-judge-calibration"]),
+        idByName,
+      )[0],
+    ).toMatchObject({ value: ["ds-legal", "ds-ground"] });
+  });
+});

--- a/web/src/features/experiments/fns/datasetNameFilter.ts
+++ b/web/src/features/experiments/fns/datasetNameFilter.ts
@@ -1,0 +1,35 @@
+import type { FilterState } from "@langfuse/shared";
+
+export const DATASET_NAME_COLUMN = "experimentDatasetName";
+const DATASET_ID_COLUMN = "experimentDatasetId";
+
+/**
+ * Swaps `experimentDatasetName` filters for the equivalent
+ * `experimentDatasetId` filters on the way to the query.
+ *
+ * The dataset name is not a ClickHouse column — it lives in Postgres and
+ * reaches the client with the filter options. Keeping the NAME as the filter
+ * value is what makes a URL or saved view readable and lets the sidebar and the
+ * search bar show the same string; this is the one boundary where it becomes an
+ * id again. Names are unique per project, so the mapping is lossless.
+ *
+ * A name with no known id maps to no id rather than being dropped: an unknown
+ * dataset must return nothing, not everything.
+ */
+export function withDatasetNamesResolved(
+  filters: FilterState,
+  datasetIdByName: ReadonlyMap<string, string>,
+): FilterState {
+  if (!filters.some((filter) => filter.column === DATASET_NAME_COLUMN)) {
+    return filters;
+  }
+  return filters.map((filter) => {
+    if (filter.column !== DATASET_NAME_COLUMN) return filter;
+    if (filter.type !== "stringOptions") return filter;
+    return {
+      ...filter,
+      column: DATASET_ID_COLUMN,
+      value: filter.value.map((name) => datasetIdByName.get(name) ?? name),
+    };
+  });
+}

--- a/web/src/features/experiments/fns/datasetNameFilter.ts
+++ b/web/src/features/experiments/fns/datasetNameFilter.ts
@@ -1,6 +1,6 @@
 import type { FilterState } from "@langfuse/shared";
 
-export const DATASET_NAME_COLUMN = "experimentDatasetName";
+const DATASET_NAME_COLUMN = "experimentDatasetName";
 const DATASET_ID_COLUMN = "experimentDatasetId";
 
 /**

--- a/web/src/features/experiments/hooks/useExperimentFilterOptions.ts
+++ b/web/src/features/experiments/hooks/useExperimentFilterOptions.ts
@@ -52,18 +52,27 @@ export function useExperimentFilterOptions({
   // Dataset names are unique per project, so the name IS the filter value —
   // no displayValue indirection, which is what let the sidebar show a name
   // while the search bar and the URL showed an opaque id.
+  //
+  // Both maps are built from EVERY dataset in the project, not from the
+  // datasets the facet offers. The facet list comes from a bounded options
+  // query, so a name missing from it would fail to translate and reach the
+  // query as an id that matches nothing — a filter that silently returns no
+  // rows. Offering fewer options than we can translate is fine; the reverse is
+  // not.
   const datasetIdByName = useMemo(() => {
     const map = new Map<string, string>();
-    for (const dataset of usedDatasets ?? []) map.set(dataset.name, dataset.id);
+    for (const dataset of datasets.data ?? [])
+      map.set(dataset.name, dataset.id);
     return map;
-  }, [usedDatasets]);
+  }, [datasets.data]);
 
   /** Rows carry the dataset id; the table renders its name. */
   const datasetNameById = useMemo(() => {
     const map = new Map<string, string>();
-    for (const dataset of usedDatasets ?? []) map.set(dataset.id, dataset.name);
+    for (const dataset of datasets.data ?? [])
+      map.set(dataset.id, dataset.name);
     return map;
-  }, [usedDatasets]);
+  }, [datasets.data]);
 
   const experimentFilterOptions = useMemo(() => {
     return {

--- a/web/src/features/experiments/hooks/useExperimentFilterOptions.ts
+++ b/web/src/features/experiments/hooks/useExperimentFilterOptions.ts
@@ -41,16 +41,33 @@ export function useExperimentFilterOptions({
     startTimeFilter: startTimeFilters.length > 0 ? startTimeFilters : undefined,
   });
 
-  const experimentFilterOptions = useMemo(() => {
-    const experimentDatasetFilterOptions = datasets.data
-      ?.filter((d) => filterOptions.data?.experimentDatasetIds?.includes(d.id))
-      .map((d) => ({
-        value: d.id,
-        displayValue: d.name,
-      }));
+  const usedDatasets = useMemo(
+    () =>
+      datasets.data?.filter((d) =>
+        filterOptions.data?.experimentDatasetIds?.includes(d.id),
+      ),
+    [datasets.data, filterOptions.data],
+  );
 
+  // Dataset names are unique per project, so the name IS the filter value —
+  // no displayValue indirection, which is what let the sidebar show a name
+  // while the search bar and the URL showed an opaque id.
+  const datasetIdByName = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const dataset of usedDatasets ?? []) map.set(dataset.name, dataset.id);
+    return map;
+  }, [usedDatasets]);
+
+  /** Rows carry the dataset id; the table renders its name. */
+  const datasetNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const dataset of usedDatasets ?? []) map.set(dataset.id, dataset.name);
+    return map;
+  }, [usedDatasets]);
+
+  const experimentFilterOptions = useMemo(() => {
     return {
-      experimentDatasetId: experimentDatasetFilterOptions,
+      experimentDatasetName: usedDatasets?.map((d) => ({ value: d.name })),
       // Observation-level score options
       obs_scores_avg: filterOptions.data?.obs_scores_avg ?? undefined,
       obs_score_categories: processScoreCategories(
@@ -65,10 +82,12 @@ export function useExperimentFilterOptions({
       trace_score_booleans:
         filterOptions.data?.trace_score_booleans ?? undefined,
     };
-  }, [datasets.data, filterOptions.data]);
+  }, [usedDatasets, filterOptions.data]);
 
   return {
     filterOptions: experimentFilterOptions,
+    datasetIdByName,
+    datasetNameById,
     isFilterOptionsPending: datasets.isLoading || filterOptions.isLoading,
   };
 }

--- a/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
+++ b/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
@@ -688,11 +688,18 @@ describe("search bar invariants — experiments registry", () => {
 
   it("exposes only the sidebar facets whose columns are actually filterable", () => {
     expect(EXPERIMENTS_FIELD_REGISTRY.fields.map((f) => f.id).sort()).toEqual([
+      "experimentDatasetName",
       "name",
     ]);
-    // The dataset column holds an ID while the sidebar shows the name, so the
-    // bar would contradict it — see the registry's EXCLUDED_COLUMN_IDS note.
-    expect(EXPERIMENTS_FIELD_REGISTRY.resolveField("dataset")).toBeNull();
+    // `dataset:` filters by the readable, unique name; the id column stays
+    // filterable for old saved views but is not offered here.
+    expect(EXPERIMENTS_FIELD_REGISTRY.resolveField("dataset")).toMatchObject({
+      type: "field",
+      field: { id: "experimentDatasetName" },
+    });
+    expect(
+      EXPERIMENTS_FIELD_REGISTRY.resolveField("experimentDatasetId"),
+    ).toBeNull();
   });
 
   it("keeps score dot-paths closed until the columns are unified", () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16762 app preview](https://pr-16762.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Experiments filter by **dataset name**, not dataset id. The sidebar already
showed names; the URL, saved views and search bar carried cuids. Now everything
says `legal-answer-quality`.

> [!NOTE]
> **Second in a stack.** Base is `lfe-15470-move-experiments-to-the-filter-bar-…`
> (#16756), which adds the bar to this table. Score-facet unification follows on
> top of this one.

## Why

The two surfaces disagreed. `useExperimentFilterOptions` built dataset options as
`{ value: d.id, displayValue: d.name }`, so the sidebar's picker rendered the
name while the emitted filter carried the id. That was invisible until the search
bar arrived and had to render the filter as *text*: it offered
`dataset:cmtc1zmkv0007phmyo7xum5lr`, and typing `dataset:legal` matched nothing.

Making the bar display names while the text held ids would mean the derived
committed text depends on async-loaded filter options — a first paint showing
ids that flips to names when options land, and ids whenever they fail. That text
deriving purely from URL state is the invariant every bar surface relies on.

So instead of teaching two surfaces to translate, the **filter value itself is
now the name**.

## What

- The dataset facet is `experimentDatasetName`, whose options are plain names —
  no `displayValue` indirection.
- `fns/datasetNameFilter.ts` swaps name → id at one boundary, where the query
  payload is built. The name is not a ClickHouse column; it reaches the client
  from Postgres with the filter options, so this is the only place it can happen.
  Names are unique per project, so the mapping is lossless.
- An unknown name resolves to no id rather than being dropped — dropping it
  would widen the query to every dataset, and a deleted dataset must return
  nothing.
- `experimentDatasetId` stays filterable but is no longer offered, so existing
  links and saved views keep resolving.

<details>
<summary>Verification</summary>

Checked against a seeded project with two datasets:

- `dataset:` offers `groundedness-judge-calibration` and `legal-answer-quality`
  — names, where it previously listed cuids.
- Picking one commits as `dataset:legal-answer-quality`, writes
  `?filter=experimentDatasetName;stringOptions;;any of;legal-answer-quality`,
  and narrows 7 runs → the 5 in that dataset.
- **Backwards compat**: an old id-based permalink
  (`experimentDatasetId;…;cmtc1zmkv…`) still filters correctly — same 5 rows,
  `Filters 1` in the sidebar. The bar leaves it as a preserved skipped filter
  rather than dropping it, which is the documented no-silent-drop behaviour and
  matches how #14692 retired `trace_scores_avg`.
- The Dataset column still renders the name (it now reads an id → name map
  rather than the options' `displayValue`).

`Tasks: 7 successful, 7 total` (turbo lint) · typecheck clean ·
`Tests 306 passed (306)`, including four cases on the translation: the swap,
untouched non-dataset and pre-existing id filters, the unknown-name case, and
multi-value selections.

</details>

## Result

One readable, unique value for datasets across the sidebar, the bar, the URL and
saved views — and one boundary where it becomes an id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes dataset names the canonical experiment-filter value and translates them back to dataset IDs at the query boundary.

- Adds a name-based dataset facet and search-bar field while preserving legacy ID filters.
- Builds bidirectional dataset lookup maps for filtering and table rendering.
- Adds tests for name resolution and experiment search-field invariants.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until valid persisted dataset-name filters can resolve independently of sampled and capped facet options.

Building the translation map from restricted filter-option results can convert a valid dataset name into a nonmatching dataset ID filter and incorrectly return an empty experiment table.

**Files Needing Attention:** web/src/features/experiments/hooks/useExperimentFilterOptions.ts; web/src/features/experiments/fns/datasetNameFilter.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[URL, saved view, or picker: dataset name] --> B[datasetIdByName lookup]
  C[Sampled and capped filter options] --> B
  B -->|Found| D[experimentDatasetId filter]
  B -->|Missing| E[Name retained as ID value]
  D --> F[Experiments query]
  E --> F
  F --> G[Filtered table results]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/experiments/hooks/useExperimentFilterOptions.ts:56-58
**Lookup omits valid datasets**

When a valid dataset is omitted from the sampled, top-1000 filter-option response, this map lacks its name, so `withDatasetNamesResolved` submits the name as an `experimentDatasetId` and the experiment table incorrectly returns no matching rows. Build the translation map from the complete project dataset list rather than the restricted facet options.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(experiments): filter datasets by na..."](https://github.com/langfuse/langfuse/commit/3ca1dd340db5325b30cf74adc2ca50f0140c5ee5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57866259)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)

<!-- /greptile_comment -->