### PR TITLE
feat(datasets): ingest media URLs during CSV import

### DIFF
--- a/packages/shared/src/server/media/mediaService.test.ts
+++ b/packages/shared/src/server/media/mediaService.test.ts
@@ -39,6 +39,7 @@ vi.mock("../s3", () => ({
 
 import { MediaAssociationOrigin } from "@prisma/client";
 
+import { LangfuseNotFoundError } from "../../errors";
 import { MediaContentType } from "../../domain/media";
 import { recordHistogram, recordIncrement } from "../instrumentation";
 import { uploadMediaForDatasetItem, uploadMediaForTrace } from "./mediaService";
@@ -223,6 +224,9 @@ describe("uploadMediaForDatasetItem", () => {
     expect(result.mediaId).toBe("n-vgG9Qb-2loPinXEdit_8");
     expect(result.sha256Hash).toEqual(expect.any(String));
     expect(mocks.uploadFile).toHaveBeenCalledTimes(1);
+    expect(mocks.datasetFindFirst.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.uploadFile.mock.invocationCallOrder[0]!,
+    );
     expect(mocks.datasetItemMediaCreateMany).toHaveBeenCalledTimes(1);
     expect(mocks.queryRaw).not.toHaveBeenCalled();
   });
@@ -251,5 +255,27 @@ describe("uploadMediaForDatasetItem", () => {
     });
     expect(mocks.uploadFile).not.toHaveBeenCalled();
     expect(mocks.datasetItemMediaCreateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not upload when the dataset is missing from the project", async () => {
+    mocks.datasetFindFirst.mockResolvedValue(null);
+
+    await expect(
+      uploadMediaForDatasetItem({
+        projectId: "project-id",
+        datasetId: "missing-dataset-id",
+        datasetItemId: "item-id",
+        field: "input",
+        contentType: MediaContentType.PNG,
+        contentBytes: CONTENT_BYTES,
+        mediaBucket: "media-bucket",
+        mediaPrefix: "media/",
+      }),
+    ).rejects.toBeInstanceOf(LangfuseNotFoundError);
+
+    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+    expect(mocks.executeRaw).not.toHaveBeenCalled();
+    expect(mocks.datasetItemMediaCreateMany).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/server/media/mediaService.test.ts
+++ b/packages/shared/src/server/media/mediaService.test.ts
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   updateMany: vi.fn(),
   update: vi.fn(),
   uploadFile: vi.fn(),
+  datasetFindFirst: vi.fn(),
+  datasetItemMediaCreateMany: vi.fn(),
 }));
 
 vi.mock("../../db", () => ({
@@ -18,6 +20,12 @@ vi.mock("../../db", () => ({
       findUnique: mocks.findUnique,
       updateMany: mocks.updateMany,
       update: mocks.update,
+    },
+    dataset: {
+      findFirst: mocks.datasetFindFirst,
+    },
+    datasetItemMedia: {
+      createMany: mocks.datasetItemMediaCreateMany,
     },
   },
 }));
@@ -33,7 +41,7 @@ import { MediaAssociationOrigin } from "@prisma/client";
 
 import { MediaContentType } from "../../domain/media";
 import { recordHistogram, recordIncrement } from "../instrumentation";
-import { uploadMediaForTrace } from "./mediaService";
+import { uploadMediaForDatasetItem, uploadMediaForTrace } from "./mediaService";
 
 const CONTENT_BYTES = Buffer.from("test-image");
 
@@ -184,5 +192,64 @@ describe("uploadMediaForTrace", () => {
     expect(mocks.queryRaw.mock.calls[0]).toContain(
       MediaAssociationOrigin.INGESTION_MEDIA_EXTRACTION,
     );
+  });
+});
+
+describe("uploadMediaForDatasetItem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.datasetFindFirst.mockResolvedValue({ id: "dataset-id" });
+    mocks.datasetItemMediaCreateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("uploads new bytes and declares a pending dataset association", async () => {
+    mocks.findUnique.mockResolvedValue(null);
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+    mocks.update.mockResolvedValue({});
+    mocks.uploadFile.mockResolvedValue(undefined);
+
+    const result = await uploadMediaForDatasetItem({
+      projectId: "project-id",
+      datasetId: "dataset-id",
+      datasetItemId: "item-id",
+      field: "input",
+      contentType: MediaContentType.PNG,
+      contentBytes: CONTENT_BYTES,
+      mediaBucket: "media-bucket",
+      mediaPrefix: "media/",
+    });
+
+    expect(result.outcome).toBe("uploaded");
+    expect(result.mediaId).toBe("n-vgG9Qb-2loPinXEdit_8");
+    expect(result.sha256Hash).toEqual(expect.any(String));
+    expect(mocks.uploadFile).toHaveBeenCalledTimes(1);
+    expect(mocks.datasetItemMediaCreateMany).toHaveBeenCalledTimes(1);
+    expect(mocks.queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("reuses existing media and still declares a pending association", async () => {
+    mocks.findUnique.mockResolvedValue({
+      id: "existing-media-id",
+      uploadHttpStatus: 200,
+      contentType: MediaContentType.PNG,
+    });
+
+    const result = await uploadMediaForDatasetItem({
+      projectId: "project-id",
+      datasetId: "dataset-id",
+      datasetItemId: "item-id",
+      field: "expectedOutput",
+      contentType: MediaContentType.PNG,
+      contentBytes: CONTENT_BYTES,
+      mediaBucket: "media-bucket",
+      mediaPrefix: "media/",
+    });
+
+    expect(result).toMatchObject({
+      mediaId: "existing-media-id",
+      outcome: "reused",
+    });
+    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.datasetItemMediaCreateMany).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/shared/src/server/media/mediaService.ts
+++ b/packages/shared/src/server/media/mediaService.ts
@@ -4,12 +4,14 @@ import { Readable } from "stream";
 import type { MediaAssociationOrigin } from "@prisma/client";
 
 import { Prisma, prisma } from "../../db";
+import type { DatasetItemMediaField } from "../../domain/dataset-items";
 import {
   getFileExtensionFromContentType,
   type MediaContentType,
   type MediaField,
 } from "../../domain/media";
 import { InternalServerError } from "../../errors";
+import { declarePendingDatasetItemMedia } from "../repositories/dataset-item-media";
 import { recordHistogram, recordIncrement } from "../instrumentation";
 import { getS3MediaStorageClient } from "../s3";
 import { summarizeS3Error } from "../services/s3SigningDiagnostics";
@@ -171,37 +173,27 @@ export type UploadMediaForTraceResult = {
   outcome: "uploaded" | "reused";
 };
 
+type StoredMediaBytesResult = {
+  mediaId: string;
+  outcome: "uploaded" | "reused";
+  sha256Hash: string;
+};
+
+export type UploadMediaForDatasetItemResult = StoredMediaBytesResult;
+
 /**
- * Persists binary media and links it to a trace or observation.
- *
- * Content is deduplicated per project by its full SHA-256 hash. For new media,
- * the link is created only after S3 upload and the media row's upload status
- * are confirmed, preventing failed uploads from leaving dangling links. This
- * function mutates PostgreSQL and media storage; it does not mutate its input
- * parameters or the caller's normalized OTEL payload.
+ * Writes media bytes to object storage and upserts the `media` row. Dedupes by
+ * project + SHA-256. Does not create trace or dataset associations.
  */
-export async function uploadMediaForTrace(params: {
+async function storeMediaBytes(params: {
   projectId: string;
-  traceId: string;
-  observationId?: string;
-  field: MediaField;
   contentType: MediaContentType;
   contentBytes: Buffer;
   mediaBucket: string;
   mediaPrefix: string;
-  origin: MediaAssociationOrigin;
-}): Promise<UploadMediaForTraceResult> {
-  const {
-    projectId,
-    traceId,
-    observationId,
-    field,
-    contentType,
-    contentBytes,
-    mediaBucket,
-    mediaPrefix,
-    origin,
-  } = params;
+}): Promise<StoredMediaBytesResult> {
+  const { projectId, contentType, contentBytes, mediaBucket, mediaPrefix } =
+    params;
   const sha256Hash = createHash("sha256").update(contentBytes).digest("base64");
   const mediaId = getMediaId(sha256Hash);
   const existingMedia = await prisma.media.findUnique({
@@ -219,15 +211,11 @@ export async function uploadMediaForTrace(params: {
       existingMedia.uploadHttpStatus === 201) &&
     existingMedia.contentType === contentType
   ) {
-    await linkMediaToTraceOrObservation({
-      projectId,
-      traceId,
-      observationId,
+    return {
       mediaId: existingMedia.id,
-      field,
-      origin,
-    });
-    return { mediaId: existingMedia.id, outcome: "reused" };
+      outcome: "reused",
+      sha256Hash,
+    };
   }
 
   const bucketPath = getMediaBucketPath({
@@ -294,15 +282,6 @@ export async function uploadMediaForTrace(params: {
     throw error;
   }
 
-  await linkMediaToTraceOrObservation({
-    projectId,
-    traceId,
-    observationId,
-    mediaId,
-    field,
-    origin,
-  });
-
   recordIncrement("langfuse.media.upload_http_status", 1, {
     status_code: 200,
   });
@@ -310,5 +289,91 @@ export async function uploadMediaForTrace(params: {
     status_code: 200,
   });
 
-  return { mediaId, outcome: "uploaded" };
+  return { mediaId, outcome: "uploaded", sha256Hash };
+}
+
+/**
+ * Persists binary media and links it to a trace or observation.
+ *
+ * Content is deduplicated per project by its full SHA-256 hash. For new media,
+ * the link is created only after S3 upload and the media row's upload status
+ * are confirmed, preventing failed uploads from leaving dangling links. This
+ * function mutates PostgreSQL and media storage; it does not mutate its input
+ * parameters or the caller's normalized OTEL payload.
+ */
+export async function uploadMediaForTrace(params: {
+  projectId: string;
+  traceId: string;
+  observationId?: string;
+  field: MediaField;
+  contentType: MediaContentType;
+  contentBytes: Buffer;
+  mediaBucket: string;
+  mediaPrefix: string;
+  origin: MediaAssociationOrigin;
+}): Promise<UploadMediaForTraceResult> {
+  const {
+    projectId,
+    traceId,
+    observationId,
+    field,
+    contentType,
+    contentBytes,
+    mediaBucket,
+    mediaPrefix,
+    origin,
+  } = params;
+
+  const stored = await storeMediaBytes({
+    projectId,
+    contentType,
+    contentBytes,
+    mediaBucket,
+    mediaPrefix,
+  });
+
+  await linkMediaToTraceOrObservation({
+    projectId,
+    traceId,
+    observationId,
+    mediaId: stored.mediaId,
+    field,
+    origin,
+  });
+
+  return { mediaId: stored.mediaId, outcome: stored.outcome };
+}
+
+/**
+ * Persists binary media and declares a pending dataset-item association that is
+ * claimed when the item is written. Dedupes by project + SHA-256 like the
+ * trace upload path.
+ */
+export async function uploadMediaForDatasetItem(params: {
+  projectId: string;
+  datasetId: string;
+  datasetItemId: string;
+  field: DatasetItemMediaField;
+  contentType: MediaContentType;
+  contentBytes: Buffer;
+  mediaBucket: string;
+  mediaPrefix: string;
+}): Promise<UploadMediaForDatasetItemResult> {
+  const stored = await storeMediaBytes({
+    projectId: params.projectId,
+    contentType: params.contentType,
+    contentBytes: params.contentBytes,
+    mediaBucket: params.mediaBucket,
+    mediaPrefix: params.mediaPrefix,
+  });
+
+  await declarePendingDatasetItemMedia({
+    projectId: params.projectId,
+    datasetId: params.datasetId,
+    datasetItemId: params.datasetItemId,
+    field: params.field,
+    mediaId: stored.mediaId,
+  });
+
+  return stored;
 }

--- a/packages/shared/src/server/media/mediaService.ts
+++ b/packages/shared/src/server/media/mediaService.ts
@@ -11,7 +11,10 @@ import {
   type MediaField,
 } from "../../domain/media";
 import { InternalServerError } from "../../errors";
-import { declarePendingDatasetItemMedia } from "../repositories/dataset-item-media";
+import {
+  assertDatasetInProject,
+  declarePendingDatasetItemMedia,
+} from "../repositories/dataset-item-media";
 import { recordHistogram, recordIncrement } from "../instrumentation";
 import { getS3MediaStorageClient } from "../s3";
 import { summarizeS3Error } from "../services/s3SigningDiagnostics";
@@ -346,8 +349,9 @@ export async function uploadMediaForTrace(params: {
 
 /**
  * Persists binary media and declares a pending dataset-item association that is
- * claimed when the item is written. Dedupes by project + SHA-256 like the
- * trace upload path.
+ * claimed when the item is written. Verifies dataset ownership before writing
+ * bytes so a rejected request cannot leave unassociated blob content. Dedupes
+ * by project + SHA-256 like the trace upload path.
  */
 export async function uploadMediaForDatasetItem(params: {
   projectId: string;
@@ -359,6 +363,11 @@ export async function uploadMediaForDatasetItem(params: {
   mediaBucket: string;
   mediaPrefix: string;
 }): Promise<UploadMediaForDatasetItemResult> {
+  await assertDatasetInProject({
+    projectId: params.projectId,
+    datasetId: params.datasetId,
+  });
+
   const stored = await storeMediaBytes({
     projectId: params.projectId,
     contentType: params.contentType,

--- a/packages/shared/src/server/repositories/dataset-item-media.ts
+++ b/packages/shared/src/server/repositories/dataset-item-media.ts
@@ -151,6 +151,26 @@ export async function markDatasetMediaUploadComplete(props: {
 }
 
 /**
+ * Throws if `datasetId` is missing, deleted, or belongs to another project.
+ * Call before persisting media bytes so a rejected request cannot leave
+ * unassociated blob content.
+ */
+export async function assertDatasetInProject(props: {
+  projectId: string;
+  datasetId: string;
+}): Promise<void> {
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: props.datasetId, projectId: props.projectId },
+    select: { id: true },
+  });
+  if (!dataset) {
+    throw new LangfuseNotFoundError(
+      `Dataset ${props.datasetId} not found in project ${props.projectId}`,
+    );
+  }
+}
+
+/**
  * Declares a pending media association at upload (a dataset_item_media row with
  * null validFrom/jsonPath/referenceString), claimed when the item is written.
  * Verifies the dataset belongs to the project; the item may not exist yet.
@@ -162,15 +182,10 @@ export async function declarePendingDatasetItemMedia(props: {
   field: DatasetItemMediaField;
   mediaId: string;
 }) {
-  const dataset = await prisma.dataset.findFirst({
-    where: { id: props.datasetId, projectId: props.projectId },
-    select: { id: true },
+  await assertDatasetInProject({
+    projectId: props.projectId,
+    datasetId: props.datasetId,
   });
-  if (!dataset) {
-    throw new LangfuseNotFoundError(
-      `Dataset ${props.datasetId} not found in project ${props.projectId}`,
-    );
-  }
 
   // createMany for skipDuplicates: redeclaring the same (item, field, media)
   // is a no-op against the pending partial unique index (create would throw,

--- a/web/src/__tests__/server/unit/ingestDatasetItemMediaFromUrl.servertest.ts
+++ b/web/src/__tests__/server/unit/ingestDatasetItemMediaFromUrl.servertest.ts
@@ -1,0 +1,89 @@
+const {
+  fetchWithSecureRedirectsMock,
+  parseOutboundUrlMock,
+  uploadMediaForDatasetItemMock,
+  validateOutboundUrlHostMock,
+} = vi.hoisted(() => ({
+  fetchWithSecureRedirectsMock: vi.fn(),
+  parseOutboundUrlMock: vi.fn((url: string) => new URL(url)),
+  uploadMediaForDatasetItemMock: vi.fn(),
+  validateOutboundUrlHostMock: vi.fn(),
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: "media-bucket",
+    LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: "media/",
+    LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH: 1_000_000_000,
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    fetchWithSecureRedirects: fetchWithSecureRedirectsMock,
+    parseOutboundUrl: parseOutboundUrlMock,
+    uploadMediaForDatasetItem: uploadMediaForDatasetItemMock,
+    validateOutboundUrlHost: validateOutboundUrlHostMock,
+  };
+});
+
+import { InvalidRequestError } from "@langfuse/shared";
+import { ingestDatasetItemMediaFromUrl } from "@/src/features/media/server/ingestDatasetItemMediaFromUrl";
+
+describe("ingestDatasetItemMediaFromUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateOutboundUrlHostMock.mockResolvedValue(undefined);
+    uploadMediaForDatasetItemMock.mockResolvedValue({
+      mediaId: "media-id",
+      outcome: "uploaded",
+      sha256Hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=",
+    });
+  });
+
+  it("uploads fetched bytes and returns a langfuse media reference", async () => {
+    fetchWithSecureRedirectsMock.mockResolvedValue({
+      response: new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    });
+
+    const result = await ingestDatasetItemMediaFromUrl({
+      projectId: "project-id",
+      datasetId: "dataset-id",
+      datasetItemId: "item-id",
+      field: "input",
+      url: "https://cdn.example.com/cat.png",
+    });
+
+    expect(result.referenceString).toBe(
+      "@@@langfuseMedia:type=image/png|id=media-id|source=bytes@@@",
+    );
+    expect(uploadMediaForDatasetItemMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-id",
+        datasetId: "dataset-id",
+        datasetItemId: "item-id",
+        field: "input",
+        contentType: "image/png",
+      }),
+    );
+  });
+
+  it("rejects http URLs", async () => {
+    await expect(
+      ingestDatasetItemMediaFromUrl({
+        projectId: "project-id",
+        datasetId: "dataset-id",
+        datasetItemId: "item-id",
+        field: "input",
+        url: "http://cdn.example.com/cat.png",
+      }),
+    ).rejects.toBeInstanceOf(InvalidRequestError);
+
+    expect(fetchWithSecureRedirectsMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/server/unit/ingestDatasetItemMediaFromUrl.servertest.ts
+++ b/web/src/__tests__/server/unit/ingestDatasetItemMediaFromUrl.servertest.ts
@@ -86,4 +86,67 @@ describe("ingestDatasetItemMediaFromUrl", () => {
 
     expect(fetchWithSecureRedirectsMock).not.toHaveBeenCalled();
   });
+
+  it("infers type from the final URL when Content-Type is missing after a redirect", async () => {
+    fetchWithSecureRedirectsMock.mockResolvedValue({
+      response: new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+      finalUrl: "https://cdn.example.com/real.webp",
+    });
+
+    await ingestDatasetItemMediaFromUrl({
+      projectId: "project-id",
+      datasetId: "dataset-id",
+      datasetItemId: "item-id",
+      field: "input",
+      url: "https://cdn.example.com/cat.png",
+    });
+
+    expect(uploadMediaForDatasetItemMock).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "image/webp" }),
+    );
+  });
+
+  it("infers type from bytes when Content-Type and final URL have no media type", async () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    ]);
+    fetchWithSecureRedirectsMock.mockResolvedValue({
+      response: new Response(pngBytes, { status: 200 }),
+      finalUrl: "https://cdn.example.com/objects/abc123",
+    });
+
+    await ingestDatasetItemMediaFromUrl({
+      projectId: "project-id",
+      datasetId: "dataset-id",
+      datasetItemId: "item-id",
+      field: "input",
+      url: "https://cdn.example.com/cat.png",
+    });
+
+    expect(uploadMediaForDatasetItemMock).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "image/png" }),
+    );
+  });
+
+  it("rejects a media-looking URL that redirects to an unsupported Content-Type", async () => {
+    fetchWithSecureRedirectsMock.mockResolvedValue({
+      response: new Response("<html>not media</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+      finalUrl: "https://cdn.example.com/landing",
+    });
+
+    await expect(
+      ingestDatasetItemMediaFromUrl({
+        projectId: "project-id",
+        datasetId: "dataset-id",
+        datasetItemId: "item-id",
+        field: "input",
+        url: "https://cdn.example.com/cat.png",
+      }),
+    ).rejects.toBeInstanceOf(InvalidRequestError);
+
+    expect(uploadMediaForDatasetItemMock).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/features/datasets/hooks/useCsvImport.ts
+++ b/web/src/features/datasets/hooks/useCsvImport.ts
@@ -2,17 +2,22 @@ import { useState } from "react";
 import { type RouterInputs, api } from "@/src/utils/api";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { MAX_FILE_SIZE_BYTES } from "@/src/features/datasets/components/UploadDatasetCsv";
-import { type BulkDatasetItemValidationError } from "@langfuse/shared";
+import {
+  type BulkDatasetItemValidationError,
+  type DatasetItemMediaField,
+} from "@langfuse/shared";
 import chunk from "lodash/chunk";
 import {
   parseCsvClient,
   parseColumns,
   buildSchemaObject,
 } from "@/src/features/datasets/lib/csv/helpers";
+import { rewriteCsvFieldMedia } from "@/src/features/datasets/lib/csv/csvMedia";
 import type {
   CsvColumnPreview,
   FieldMapping,
 } from "@/src/features/datasets/lib/csv/types";
+import { safeRandomUUID } from "@/src/utils/safe-random-uuid";
 
 const MIN_CHUNK_SIZE = 1;
 const CHUNK_START_SIZE = 50;
@@ -65,6 +70,14 @@ type UseCsvImportOptions = {
   metadata: CsvColumnPreview[];
 };
 
+type ParsedCsvItem = {
+  id: string;
+  datasetId: string;
+  input: unknown;
+  expectedOutput: unknown;
+  metadata: unknown;
+};
+
 export function useCsvImport(options: UseCsvImportOptions) {
   const [progress, setProgress] = useState<ImportProgress>({
     totalItems: 0,
@@ -78,6 +91,8 @@ export function useCsvImport(options: UseCsvImportOptions) {
   const utils = api.useUtils();
   const mutCreateManyDatasetItems =
     api.datasets.createManyDatasetItems.useMutation({});
+  const ingestItemMediaFromUrl =
+    api.datasets.ingestItemMediaFromUrl.useMutation();
 
   const execute = async (wrapSingleColumn: boolean): Promise<boolean> => {
     const { csvFile, projectId, datasetId, input, expectedOutput, metadata } =
@@ -94,8 +109,7 @@ export function useCsvImport(options: UseCsvImportOptions) {
     let processedCount = 0;
     let headerMap: Map<string, number>;
 
-    const items: RouterInputs["datasets"]["createManyDatasetItems"]["items"] =
-      [];
+    const parsedItems: ParsedCsvItem[] = [];
 
     // Prepare mappings based on field type
     const inputMapping =
@@ -183,11 +197,12 @@ export function useCsvImport(options: UseCsvImportOptions) {
                   wrapSingleColumn,
                 }) ?? undefined;
 
-              items.push({
-                input: JSON.stringify(itemInput),
-                expectedOutput: JSON.stringify(itemExpected),
-                metadata: JSON.stringify(itemMetadata),
+              parsedItems.push({
+                id: safeRandomUUID(),
                 datasetId,
+                input: itemInput,
+                expectedOutput: itemExpected,
+                metadata: itemMetadata,
               });
             } catch (error) {
               throw new Error(
@@ -197,6 +212,54 @@ export function useCsvImport(options: UseCsvImportOptions) {
           },
         },
       });
+
+      setProgress({
+        totalItems: parsedItems.length,
+        processedItems: 0,
+        status: "processing",
+      });
+
+      const urlCache = new Map<string, Promise<string>>();
+
+      const items: RouterInputs["datasets"]["createManyDatasetItems"]["items"] =
+        [];
+
+      for (const parsed of parsedItems) {
+        const convertUrl = (url: string, field: DatasetItemMediaField) => {
+          let pending = urlCache.get(url);
+          if (!pending) {
+            pending = ingestItemMediaFromUrl
+              .mutateAsync({
+                projectId,
+                datasetId,
+                datasetItemId: parsed.id,
+                field,
+                url,
+              })
+              .then((result) => result.referenceString);
+            urlCache.set(url, pending);
+          }
+          return pending;
+        };
+
+        items.push({
+          id: parsed.id,
+          datasetId,
+          input: JSON.stringify(
+            await rewriteCsvFieldMedia(parsed.input, "input", convertUrl),
+          ),
+          expectedOutput: JSON.stringify(
+            await rewriteCsvFieldMedia(
+              parsed.expectedOutput,
+              "expectedOutput",
+              convertUrl,
+            ),
+          ),
+          metadata: JSON.stringify(
+            await rewriteCsvFieldMedia(parsed.metadata, "metadata", convertUrl),
+          ),
+        });
+      }
 
       const optimalChunkSize = getOptimalChunkSize(items, CHUNK_START_SIZE);
       const chunks = chunk(items, optimalChunkSize);
@@ -254,8 +317,8 @@ export function useCsvImport(options: UseCsvImportOptions) {
     utils.datasets.invalidate();
 
     setProgress({
-      totalItems: items.length,
-      processedItems: items.length,
+      totalItems: parsedItems.length,
+      processedItems: parsedItems.length,
       status: "complete",
     });
 

--- a/web/src/features/datasets/lib/csv/csvMedia.clienttest.ts
+++ b/web/src/features/datasets/lib/csv/csvMedia.clienttest.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { rewriteCsvFieldMedia } from "./csvMedia";
+
+const IMAGE_REF =
+  "@@@langfuseMedia:type=image/png|id=cc48838a-3da8-4ca4-a007-2cf8df930e69|source=bytes@@@";
+
+describe("rewriteCsvFieldMedia", () => {
+  it("leaves langfuse media tokens and non-media strings unchanged", async () => {
+    const convertUrl = async () => "should-not-run";
+    await expect(
+      rewriteCsvFieldMedia(IMAGE_REF, "input", convertUrl),
+    ).resolves.toBe(IMAGE_REF);
+    await expect(
+      rewriteCsvFieldMedia("https://example.com/page", "input", convertUrl),
+    ).resolves.toBe("https://example.com/page");
+  });
+
+  it("converts third-party media URLs nested in JSON", async () => {
+    const rewritten = await rewriteCsvFieldMedia(
+      {
+        prompt: "describe",
+        image: "https://cdn.example.com/cat.png",
+        note: "https://example.com/page",
+      },
+      "input",
+      async (url) => `token:${url}`,
+    );
+    expect(rewritten).toEqual({
+      prompt: "describe",
+      image: "token:https://cdn.example.com/cat.png",
+      note: "https://example.com/page",
+    });
+  });
+});

--- a/web/src/features/datasets/lib/csv/csvMedia.ts
+++ b/web/src/features/datasets/lib/csv/csvMedia.ts
@@ -1,0 +1,36 @@
+import { classifyMediaValue } from "@/src/components/ui/media/mediaUtils";
+import { type DatasetItemMediaField } from "@langfuse/shared";
+
+/**
+ * Walks dataset-item JSON and replaces third-party media URLs with
+ * `@@@langfuseMedia:...@@@` tokens. Existing Langfuse tokens are left unchanged.
+ */
+export async function rewriteCsvFieldMedia(
+  value: unknown,
+  field: DatasetItemMediaField,
+  convertUrl: (url: string, field: DatasetItemMediaField) => Promise<string>,
+): Promise<unknown> {
+  if (typeof value === "string") {
+    const kind = classifyMediaValue(value)?.kind;
+    if (kind === "url") return convertUrl(value, field);
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map((entry) => rewriteCsvFieldMedia(entry, field, convertUrl)),
+    );
+  }
+
+  if (value !== null && typeof value === "object") {
+    const entries = await Promise.all(
+      Object.entries(value).map(async ([key, entry]) => [
+        key,
+        await rewriteCsvFieldMedia(entry, field, convertUrl),
+      ]),
+    );
+    return Object.fromEntries(entries);
+  }
+
+  return value;
+}

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -8,6 +8,7 @@ import { env as sharedEnv } from "@langfuse/shared/src/env";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { createMediaUploadUrl } from "@/src/features/media/server/mediaService";
+import { ingestDatasetItemMediaFromUrl } from "@/src/features/media/server/ingestDatasetItemMediaFromUrl";
 import {
   datasetItemMediaReferenceKey,
   resolveDatasetItemMediaReferences,
@@ -981,6 +982,31 @@ export const datasetRouter = createTRPCRouter({
       });
 
       return { success: true as const };
+    }),
+  ingestItemMediaFromUrl: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        datasetId: z.string(),
+        datasetItemId: z.string(),
+        field: z.enum(datasetItemMediaFields),
+        url: z.url().max(2048),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:CUD",
+      });
+
+      return ingestDatasetItemMediaFromUrl({
+        projectId: input.projectId,
+        datasetId: input.datasetId,
+        datasetItemId: input.datasetItemId,
+        field: input.field,
+        url: input.url,
+      });
     }),
   // Resolve a saved dataset item version's media from dataset_item_media.
   // The create/edit forms instead derive media from the live JSON.

--- a/web/src/features/media/server/ingestDatasetItemMediaFromUrl.ts
+++ b/web/src/features/media/server/ingestDatasetItemMediaFromUrl.ts
@@ -1,0 +1,227 @@
+import { env } from "@/src/env.mjs";
+import {
+  type DatasetItemMediaField,
+  InternalServerError,
+  InvalidRequestError,
+  isMediaContentType,
+  type MediaContentType,
+} from "@langfuse/shared";
+import {
+  fetchWithSecureRedirects,
+  parseOutboundUrl,
+  uploadMediaForDatasetItem,
+  validateOutboundUrlHost,
+  type ValidateOutboundUrlHostOptions,
+} from "@langfuse/shared/src/server";
+
+const MAX_MEDIA_URL_LENGTH = 2048;
+const MAX_REDIRECTS = 5;
+const FETCH_TIMEOUT_MS = 30_000;
+const MAX_INGEST_BYTES = 100 * 1024 * 1024;
+
+const URL_VALIDATION_OPTIONS = {
+  whitelist: { hosts: [], ips: [], ip_ranges: [] },
+  logContext: "Dataset CSV media URL",
+  shouldSkipDnsCheckForLiteralIps: true,
+} satisfies Omit<ValidateOutboundUrlHostOptions, "url">;
+
+// Matches the UI previewer's unambiguous media-URL extensions so CSV import
+// converts the same strings the item table already renders as media chips.
+const URL_EXTENSION_TO_MIME: Record<string, MediaContentType> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  avif: "image/avif",
+  tiff: "image/tiff",
+  tif: "image/tiff",
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  oga: "audio/ogg",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  flac: "audio/flac",
+  opus: "audio/opus",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  mpeg: "video/mpeg",
+};
+
+const PREVIEWABLE_TOP_LEVEL = new Set(["image", "audio", "video"]);
+
+export type IngestDatasetItemMediaFromUrlResult = {
+  referenceString: string;
+  mediaId: string;
+  contentType: MediaContentType;
+  contentLength: number;
+  sha256Hash: string;
+};
+
+function contentTypeFromMediaUrl(urlString: string): MediaContentType | null {
+  let pathname: string;
+  try {
+    pathname = new URL(urlString).pathname;
+  } catch {
+    return null;
+  }
+  const ext = pathname.split(".").pop()?.toLowerCase();
+  if (!ext || ext === pathname) return null;
+  return URL_EXTENSION_TO_MIME[ext] ?? null;
+}
+
+function normalizeContentTypeHeader(
+  header: string | null,
+): MediaContentType | null {
+  if (!header) return null;
+  const mime = header.split(";")[0]?.trim().toLowerCase();
+  if (!mime || !isMediaContentType(mime)) return null;
+  if (!PREVIEWABLE_TOP_LEVEL.has(mime.split("/")[0]!)) return null;
+  return mime;
+}
+
+async function assertSafeHttpsMediaUrl(urlString: string): Promise<void> {
+  if (urlString.length > MAX_MEDIA_URL_LENGTH) {
+    throw new InvalidRequestError("Media URL is too long");
+  }
+
+  const url = parseOutboundUrl(urlString);
+  if (url.protocol !== "https:") {
+    throw new InvalidRequestError(
+      "Only https media URLs can be imported. Convert http URLs or attach the file in the item editor.",
+    );
+  }
+
+  await validateOutboundUrlHost({
+    url,
+    ...URL_VALIDATION_OPTIONS,
+  });
+}
+
+async function readResponseBytes(response: Response): Promise<Buffer> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_INGEST_BYTES) {
+    throw new InvalidRequestError(
+      `Media file is larger than ${MAX_INGEST_BYTES} bytes`,
+    );
+  }
+
+  const body = response.body;
+  if (!body) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_INGEST_BYTES) {
+      throw new InvalidRequestError(
+        `Media file is larger than ${MAX_INGEST_BYTES} bytes`,
+      );
+    }
+    return buffer;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > MAX_INGEST_BYTES) {
+      await reader.cancel();
+      throw new InvalidRequestError(
+        `Media file is larger than ${MAX_INGEST_BYTES} bytes`,
+      );
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Fetches a third-party media URL (SSRF-checked) and stores it as project media,
+ * returning a `@@@langfuseMedia:...@@@` reference for the dataset item JSON.
+ */
+export async function ingestDatasetItemMediaFromUrl(params: {
+  projectId: string;
+  datasetId: string;
+  datasetItemId: string;
+  field: DatasetItemMediaField;
+  url: string;
+}): Promise<IngestDatasetItemMediaFromUrlResult> {
+  const uploadBucket = env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET;
+  if (!uploadBucket) {
+    throw new InternalServerError(
+      "Media upload to blob storage not enabled or no bucket configured",
+    );
+  }
+
+  await assertSafeHttpsMediaUrl(params.url);
+
+  const { response } = await fetchWithSecureRedirects(
+    params.url,
+    {
+      method: "GET",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: "image/*,audio/*,video/*" },
+    },
+    {
+      maxRedirects: MAX_REDIRECTS,
+      redirectValidation: {
+        validateUrl: async (redirectUrl) => {
+          await assertSafeHttpsMediaUrl(redirectUrl);
+        },
+        whitelist: URL_VALIDATION_OPTIONS.whitelist,
+        logContext: URL_VALIDATION_OPTIONS.logContext,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new InvalidRequestError(
+      `Failed to fetch media URL (HTTP ${response.status})`,
+    );
+  }
+
+  const contentType =
+    normalizeContentTypeHeader(response.headers.get("content-type")) ??
+    contentTypeFromMediaUrl(params.url);
+
+  if (!contentType) {
+    throw new InvalidRequestError(
+      "URL is not a supported image, audio, or video file",
+    );
+  }
+
+  const contentBytes = await readResponseBytes(response);
+  if (contentBytes.byteLength === 0) {
+    throw new InvalidRequestError("Media URL returned an empty file");
+  }
+
+  if (contentBytes.byteLength > env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH) {
+    throw new InvalidRequestError(
+      `File size must be less than ${env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH} bytes`,
+    );
+  }
+
+  const stored = await uploadMediaForDatasetItem({
+    projectId: params.projectId,
+    datasetId: params.datasetId,
+    datasetItemId: params.datasetItemId,
+    field: params.field,
+    contentType,
+    contentBytes,
+    mediaBucket: uploadBucket,
+    mediaPrefix: env.LANGFUSE_S3_MEDIA_UPLOAD_PREFIX ?? "",
+  });
+
+  return {
+    referenceString: `@@@langfuseMedia:type=${contentType}|id=${stored.mediaId}|source=bytes@@@`,
+    mediaId: stored.mediaId,
+    contentType,
+    contentLength: contentBytes.byteLength,
+    sha256Hash: stored.sha256Hash,
+  };
+}

--- a/web/src/features/media/server/ingestDatasetItemMediaFromUrl.ts
+++ b/web/src/features/media/server/ingestDatasetItemMediaFromUrl.ts
@@ -53,6 +53,20 @@ const URL_EXTENSION_TO_MIME: Record<string, MediaContentType> = {
 };
 
 const PREVIEWABLE_TOP_LEVEL = new Set(["image", "audio", "video"]);
+const GENERIC_CONTENT_TYPES = new Set(["application/octet-stream"]);
+
+// Unambiguous file signatures used when the response omits a media Content-Type
+// and the final URL has no usable extension (common after CDN redirects).
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const GIF87A_MAGIC = Buffer.from("GIF87a");
+const GIF89A_MAGIC = Buffer.from("GIF89a");
+const RIFF_MAGIC = Buffer.from("RIFF");
+const WEBP_MAGIC = Buffer.from("WEBP");
+const WAVE_MAGIC = Buffer.from("WAVE");
+const TIFF_LE_MAGIC = Buffer.from([0x49, 0x49, 0x2a, 0x00]);
+const TIFF_BE_MAGIC = Buffer.from([0x4d, 0x4d, 0x00, 0x2a]);
+const FLAC_MAGIC = Buffer.from("fLaC");
+const OGG_MAGIC = Buffer.from("OggS");
 
 export type IngestDatasetItemMediaFromUrlResult = {
   referenceString: string;
@@ -74,14 +88,70 @@ function contentTypeFromMediaUrl(urlString: string): MediaContentType | null {
   return URL_EXTENSION_TO_MIME[ext] ?? null;
 }
 
+function declaredMime(header: string | null): string | null {
+  if (!header) return null;
+  const mime = header.split(";")[0]?.trim().toLowerCase();
+  return mime || null;
+}
+
 function normalizeContentTypeHeader(
   header: string | null,
 ): MediaContentType | null {
-  if (!header) return null;
-  const mime = header.split(";")[0]?.trim().toLowerCase();
+  const mime = declaredMime(header);
   if (!mime || !isMediaContentType(mime)) return null;
   if (!PREVIEWABLE_TOP_LEVEL.has(mime.split("/")[0]!)) return null;
   return mime;
+}
+
+function startsWithMagic(bytes: Buffer, magic: Buffer): boolean {
+  return (
+    bytes.length >= magic.length &&
+    bytes.subarray(0, magic.length).equals(magic)
+  );
+}
+
+function contentTypeFromMagicBytes(bytes: Buffer): MediaContentType | null {
+  if (startsWithMagic(bytes, PNG_MAGIC)) return "image/png";
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    startsWithMagic(bytes, GIF87A_MAGIC) ||
+    startsWithMagic(bytes, GIF89A_MAGIC)
+  ) {
+    return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    startsWithMagic(bytes, RIFF_MAGIC) &&
+    bytes.subarray(8, 12).equals(WEBP_MAGIC)
+  ) {
+    return "image/webp";
+  }
+  if (bytes.length >= 2 && bytes[0] === 0x42 && bytes[1] === 0x4d) {
+    return "image/bmp";
+  }
+  if (
+    startsWithMagic(bytes, TIFF_LE_MAGIC) ||
+    startsWithMagic(bytes, TIFF_BE_MAGIC)
+  ) {
+    return "image/tiff";
+  }
+  if (
+    bytes.length >= 12 &&
+    startsWithMagic(bytes, RIFF_MAGIC) &&
+    bytes.subarray(8, 12).equals(WAVE_MAGIC)
+  ) {
+    return "audio/wav";
+  }
+  if (startsWithMagic(bytes, FLAC_MAGIC)) return "audio/flac";
+  if (startsWithMagic(bytes, OGG_MAGIC)) return "audio/ogg";
+  return null;
 }
 
 async function assertSafeHttpsMediaUrl(urlString: string): Promise<void> {
@@ -160,7 +230,7 @@ export async function ingestDatasetItemMediaFromUrl(params: {
 
   await assertSafeHttpsMediaUrl(params.url);
 
-  const { response } = await fetchWithSecureRedirects(
+  const { response, finalUrl } = await fetchWithSecureRedirects(
     params.url,
     {
       method: "GET",
@@ -185,11 +255,11 @@ export async function ingestDatasetItemMediaFromUrl(params: {
     );
   }
 
-  const contentType =
-    normalizeContentTypeHeader(response.headers.get("content-type")) ??
-    contentTypeFromMediaUrl(params.url);
-
-  if (!contentType) {
+  const contentTypeHeader = response.headers.get("content-type");
+  const headerContentType = normalizeContentTypeHeader(contentTypeHeader);
+  const mime = declaredMime(contentTypeHeader);
+  if (!headerContentType && mime && !GENERIC_CONTENT_TYPES.has(mime)) {
+    await response.body?.cancel();
     throw new InvalidRequestError(
       "URL is not a supported image, audio, or video file",
     );
@@ -203,6 +273,20 @@ export async function ingestDatasetItemMediaFromUrl(params: {
   if (contentBytes.byteLength > env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH) {
     throw new InvalidRequestError(
       `File size must be less than ${env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH} bytes`,
+    );
+  }
+
+  // Prefer the declared type, then bytes, then the *final* URL after redirects.
+  // The original request URL is not used: a media-looking path can redirect to
+  // HTML or a different encoding.
+  const contentType =
+    headerContentType ??
+    contentTypeFromMagicBytes(contentBytes) ??
+    contentTypeFromMediaUrl(finalUrl);
+
+  if (!contentType) {
+    throw new InvalidRequestError(
+      "URL is not a supported image, audio, or video file",
     );
   }
 


### PR DESCRIPTION
## What does this PR do?

Implements the first slice of [feat(datasets): support multi-modal dataset items in CSV import](https://github.com/orgs/langfuse/discussions/16477): bulk CSV import can now attach images, audio, and video by referencing third-party `https` media URLs in `input`, `expectedOutput`, and `metadata`.

During import, the client walks each parsed field and replaces media URLs (the same strings the item table already renders as media chips) with `@@@langfuseMedia:...@@@` reference tokens. The server fetches each URL with SSRF protections, stores bytes in object storage via the existing media upload path, and declares a pending dataset-item association so the item write can claim it.

**Changes**
- Add `rewriteCsvFieldMedia` to recursively scan parsed CSV JSON and convert media URLs.
- Add `ingestDatasetItemMediaFromUrl` tRPC mutation and server helper (secure outbound fetch, content-type validation, size limits).
- Add `uploadMediaForDatasetItem` in shared `mediaService`, refactoring trace uploads to share `storeMediaBytes`.
- Deduplicate repeated URLs within a single import via a per-import URL cache.

**Not in this PR** (follow-ups from the discussion)
- Base64 data URI detection and inline upload.
- Large-cell preview handling for oversized CSV cells.
- Cross-project round-trip for exported `@@@langfuseMedia:...@@@` tokens.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`npm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes

## Test plan

- [x] `uploadMediaForDatasetItem` unit tests (upload + reuse paths)
- [x] `rewriteCsvFieldMedia` client tests (nested JSON URL replacement)
- [x] `ingestDatasetItemMediaFromUrl` server unit tests (validation + happy path mocks)
- [x] Manual: import a CSV with `https` image/audio/video URLs in input/expectedOutput/metadata and confirm items render media chips in the dataset table
- [x] Manual: confirm `http` URLs are rejected with a clear error

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds recursive ingestion of HTTPS media URLs during CSV dataset imports, using secure server-side fetching and the existing object-storage media lifecycle.
- Rewrites media URLs in input, expected output, and metadata into Langfuse media references.
- Adds a project-authorized tRPC ingestion mutation with redirects, size limits, and content-type handling.
- Refactors shared media persistence for reuse by trace and dataset-item uploads.
- Deduplicates repeated URLs within one import.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until redirected responses can no longer be stored under a media type inferred from the original URL; validating datasets before upload is also advisable.

Redirect fallback can persist non-media bytes as previewable media, while invalid dataset identifiers cause durable uploads before the request is rejected.

**Files Needing Attention:** web/src/features/media/server/ingestDatasetItemMediaFromUrl.ts; packages/shared/src/server/media/mediaService.ts
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as CSV import client
    participant T as Dataset tRPC mutation
    participant U as Secure URL fetch
    participant S as Media storage
    participant D as Dataset item write
    B->>T: Ingest HTTPS media URL
    T->>U: Validate host and fetch redirects
    U-->>T: Response bytes and headers
    T->>S: Store deduplicated media bytes
    S-->>T: Media reference
    T-->>B: Langfuse media token
    B->>D: Bulk-create item containing token
    D->>D: Validate and claim media association
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/media/server/ingestDatasetItemMediaFromUrl.ts:188-190
**Redirect fallback misclassifies media**

When a media-looking URL redirects to a response without a supported `Content-Type`, this fallback infers the type from the original URL rather than the final response URL or bytes, causing non-media or differently encoded content to be stored under an incorrect type and rendered as a broken preview.

### Issue 2
packages/shared/src/server/media/mediaService.ts:362-370
**Upload precedes dataset validation**

For a deleted, nonexistent, stale, or cross-project `datasetId`, `storeMediaBytes` persists the fetched content before `declarePendingDatasetItemMedia` validates dataset ownership, so the rejected request leaves up to 100 MiB of unassociated media for retention cleanup.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(datasets): ingest media URLs during..."](https://github.com/langfuse/langfuse/commit/df2b237800c130545830a6d4bfb66220e7feb8a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57870996)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)
- Knowledge Base — [Media and blob processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/media-and-blob-processing.md)

<!-- /greptile_comment -->