### PR TITLE
feat(web): instrument filter sidebar expand usage

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -629,6 +629,8 @@ describe("DataTableControls facet ordering", () => {
       categoricalFilter("beta", "Beta", true),
     ]);
     qf.onExpandedChange = (value) => expandedChanges.push(value);
+    qf.isV4 = true;
+    captureSpy.mockClear();
     render(
       <TooltipProvider>
         <DataTableControls queryFilter={qf} />
@@ -638,6 +640,94 @@ describe("DataTableControls facet ordering", () => {
     // Nothing expanded -> the toggle offers Expand all with every column.
     fireEvent.click(screen.getByRole("button", { name: "Expand all filters" }));
     expect(expandedChanges.at(-1)).toEqual(["beta", "alpha"]);
+
+    const expandAll = captureSpy.mock.calls.filter(
+      ([event]) => event === "filters:expand_all_toggled",
+    );
+    expect(expandAll).toHaveLength(1);
+    expect(expandAll[0][1]).toMatchObject({
+      expanded: true,
+      facetCount: 2,
+      layout: "panel",
+      isV4: true,
+    });
+    // Expand-all is its own intent; it must not also emit per-facet toggles.
+    expect(
+      captureSpy.mock.calls.filter(
+        ([event]) => event === "filters:facet_toggled",
+      ),
+    ).toHaveLength(0);
+    for (const [, payload] of captureSpy.mock.calls) {
+      expect(JSON.stringify(payload ?? {})).not.toContain('"x"');
+    }
+  });
+
+  it("captures expand_all_toggled collapsed when every visible facet is open", () => {
+    const qf = queryFilter([
+      categoricalFilter("alpha", "Alpha", false),
+      categoricalFilter("beta", "Beta", true),
+    ]);
+    qf.expanded = ["alpha", "beta"];
+    qf.isV4 = false;
+    captureSpy.mockClear();
+    render(
+      <TooltipProvider>
+        <DataTableControls queryFilter={qf} />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse all filters" }),
+    );
+    const expandAll = captureSpy.mock.calls.filter(
+      ([event]) => event === "filters:expand_all_toggled",
+    );
+    expect(expandAll).toHaveLength(1);
+    expect(expandAll[0][1]).toMatchObject({
+      expanded: false,
+      facetCount: 2,
+      layout: "panel",
+      isV4: false,
+    });
+    expect(
+      captureSpy.mock.calls.filter(
+        ([event]) => event === "filters:facet_toggled",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("captures facet_toggled once when a single header is opened", () => {
+    const qf = queryFilter([
+      categoricalFilter("alpha", "Alpha", false),
+      categoricalFilter("beta", "Beta", true),
+    ]);
+    qf.isV4 = true;
+    captureSpy.mockClear();
+    render(
+      <TooltipProvider>
+        <DataTableControls queryFilter={qf} />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Alpha All" }));
+    const toggled = captureSpy.mock.calls.filter(
+      ([event]) => event === "filters:facet_toggled",
+    );
+    expect(toggled).toHaveLength(1);
+    expect(toggled[0][1]).toMatchObject({
+      column: "alpha",
+      expanded: true,
+      layout: "panel",
+      isV4: true,
+    });
+    expect(
+      captureSpy.mock.calls.filter(
+        ([event]) => event === "filters:expand_all_toggled",
+      ),
+    ).toHaveLength(0);
+    for (const [, payload] of captureSpy.mock.calls) {
+      expect(JSON.stringify(payload ?? {})).not.toContain('"x"');
+    }
   });
 
   it("shows only active facets plus an Add filter picker when active-only mode is on", () => {

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -728,7 +728,23 @@ export function DataTableControls({
         type="multiple"
         className="w-full"
         value={queryFilter.expanded}
-        onValueChange={queryFilter.onExpandedChange}
+        onValueChange={(next) => {
+          const prev = queryFilter.expanded;
+          queryFilter.onExpandedChange(next);
+          // One header click changes exactly one column. Expand-all, add
+          // filter, and AI apply call onExpandedChange directly and skip
+          // this handler, so they do not double-count as facet toggles.
+          const added = next.filter((column) => !prev.includes(column));
+          const removed = prev.filter((column) => !next.includes(column));
+          if (added.length + removed.length !== 1) return;
+          capture("filters:facet_toggled", {
+            tableName,
+            column: added[0] ?? removed[0],
+            expanded: added.length === 1,
+            layout,
+            isV4: queryFilter.isV4 ?? false,
+          });
+        }}
       >
         {/* ONE keyed child array — not two .map() slices: React can
             only match keys within the same array, so a facet crossing
@@ -1026,9 +1042,10 @@ export function DataTableControls({
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6"
-                  onClick={() =>
+                  onClick={() => {
+                    const expanded = expandedVisibleCount === 0;
                     queryFilter.onExpandedChange(
-                      expandedVisibleCount === 0
+                      expanded
                         ? [
                             ...new Set([
                               ...queryFilter.expanded,
@@ -1038,8 +1055,15 @@ export function DataTableControls({
                         : queryFilter.expanded.filter(
                             (column) => !visibleColumns.has(column),
                           ),
-                    )
-                  }
+                    );
+                    capture("filters:expand_all_toggled", {
+                      tableName,
+                      expanded,
+                      facetCount: visibleFilters.length,
+                      layout,
+                      isV4: queryFilter.isV4 ?? false,
+                    });
+                  }}
                   aria-label={
                     expandedVisibleCount === 0
                       ? "Expand all filters"

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -412,6 +412,8 @@ const events = {
     "facet_added",
     "facet_search",
     "facet_mode_switched",
+    "expand_all_toggled",
+    "facet_toggled",
     "sidebar_toggled",
     "search_submitted",
     "search_error",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16769 app preview](https://pr-16769.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

| Area | Change |
| --- | --- |
| Events | `filters:expand_all_toggled` on the header expand/collapse-all click. `filters:facet_toggled` on a single facet accordion header. |
| Props | Metadata only: `expanded`, `facetCount` or `column`, `tableName`, `layout`, `isV4`. No filter values, search text, or ids. |
| Tests | Client tests assert one event per action, no double-count with expand-all, and no raw values in payloads. |

Impacted package: `web`.

## Tracking plan

Question: which filter-sidebar chrome is used, so we can drop unused controls.

| Event | When | Props |
| --- | --- | --- |
| `filters:expand_all_toggled` | Header expand/collapse-all | `expanded`, `facetCount`, `tableName`, `layout`, `isV4` |
| `filters:facet_toggled` | One facet header | `column`, `expanded`, `tableName`, `layout`, `isV4` |

Expand-all, add-filter, and AI apply call `onExpandedChange` directly and skip the accordion handler, so they do not also emit `facet_toggled`.

Existing events already cover apply, clear, facet search, add filter, active-only, AI generate, sidebar toggle, mode switch, and operator toggle.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-reviewed.

## Verification

- `pnpm --filter web run test-client data-table-controls.clienttest.tsx` — Tests 33 passed (33)
- `pnpm run lint` (pre-commit turbo) — Tasks: 7 successful, 7 total
- Full typecheck skipped: analytics-only, no UI change
- Browser walkthrough skipped: no user-visible behavior change

A Filter sidebar usage PostHog dashboard will be created after this ships.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-216eba99-5a4a-41a6-bf31-cfe68a9973e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-216eba99-5a4a-41a6-bf31-cfe68a9973e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds PostHog instrumentation for filter-sidebar expand-all and individual facet toggles.
- Registers `filters:expand_all_toggled` and `filters:facet_toggled`.
- Captures metadata-only properties while avoiding duplicate facet events for expand-all actions.
- Adds client tests for event count, payload shape, and exclusion of raw filter values.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new event names match the typed analytics registry, the emitted payloads contain the intended metadata, and expand-all bypasses the per-facet handler to prevent double counting.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): instrument filter sidebar exp..."](https://github.com/langfuse/langfuse/commit/c944c6450080c67a86747c78c4b577ab8a0d6862) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57883238)</sub>

<!-- /greptile_comment -->