### PR TITLE
fix(scores): lead score column headers with the score name

### DIFF
--- a/web/src/features/scores/hooks/useScoreColumns.clienttest.ts
+++ b/web/src/features/scores/hooks/useScoreColumns.clienttest.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { createScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
+
+const column = {
+  key: "persona_fit-api-NUMERIC",
+  name: "persona_fit",
+  source: "API",
+  dataType: "NUMERIC" as const,
+};
+
+const build = (prefix?: string) =>
+  createScoreColumns<{ scores: Record<string, unknown> }>(
+    [column],
+    "scores",
+    "aggregate",
+    prefix,
+  )[0];
+
+describe("createScoreColumns headers", () => {
+  it("leads with the score name and trails the level", () => {
+    // A score column is narrow and truncates from the right, so anything ahead
+    // of the name hides the one part that identifies the column.
+    expect(build("Trace").header).toBe("# persona_fit (api) · Trace");
+  });
+
+  it("omits the separator when there is no level", () => {
+    expect(build().header).toBe("# persona_fit (api)");
+  });
+
+  it("keeps the level out of the column id, so persisted layouts survive", () => {
+    expect(build("Trace").id).toBe("Trace-persona_fit-api-NUMERIC");
+  });
+});

--- a/web/src/features/scores/hooks/useScoreColumns.ts
+++ b/web/src/features/scores/hooks/useScoreColumns.ts
@@ -25,11 +25,14 @@ export function createScoreColumns<T extends Record<string, any>>(
   rawKey?: boolean,
 ): LangfuseColumnDef<T>[] {
   return scoreColumns.map(({ key, name, source, dataType }) => {
-    // Apply prefix to both column ID/accessor and header
     const accessorKey = prefix ? `${prefix}-${key}` : key;
-    const header = prefix
-      ? `${prefix}: ${getScoreDataTypeIcon(dataType)} ${name} (${source.toLowerCase()})`
-      : `${getScoreDataTypeIcon(dataType)} ${name} (${source.toLowerCase()})`;
+    // The score's name identifies the column, so it comes first. A score
+    // column is narrow and truncates from the right, so a leading level ate
+    // the name and left every column of a level looking alike. The level
+    // still trails the name, where the hover title and the column picker
+    // pick it up in full.
+    const label = `${getScoreDataTypeIcon(dataType)} ${name} (${source.toLowerCase()})`;
+    const header = prefix ? `${label} · ${prefix}` : label;
 
     return {
       accessorKey,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16772 app preview](https://pr-16772.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

Score column headers put the level first — `Trace: # persona_fit (api)` — and a score column is narrow enough that the truncation ate the score name. The name now comes first, with the level trailing it.

## Why

A score column is ~150px and truncates from the right, so the visible header was:

```
Trace: © judge_ver…   Trace: # persona_fit…   Trace: # verdict_dis…   Observation: # cita…
```

Every column of a level reads as `Trace: …`. The part that actually identifies the column — the score's name — is the part that gets cut, and the part that's identical across the group is the part that survives. You had to widen the column or hover to tell two score columns apart.

## What

Swap the order: `# persona_fit (api) · Trace`. Name first, level last.

Nothing else about the string changes, so the level is still there in full for the two places that have room for it — the native hover title on the header, and the column picker (both read the header string). Levels stay out of the column *id*, so persisted column visibility and order are untouched.

## Result

```
© judge_verdict (a…   # persona_fit (api…   # verdict_distance…   # citation_usable…
```

Applies wherever score columns are built — the experiments runs table (`Trace` / `Experiment`), the dataset runs table (`Run-level`), and any future level. Unprefixed score columns are unaffected.

<details>
<summary>Verification</summary>

`pnpm run lint` → `Tasks: 7 successful, 7 total`. `pnpm run typecheck` → `Tasks: 8 successful, 8 total`. New clienttest → `Tests 3 passed (3)`, covering the order, the no-level case, and the column id staying level-prefixed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Reorders score-column header labels so the score name remains visible when narrow columns truncate from the right.
- Moves optional level prefixes to the end of score-column headers.
- Preserves accessor keys and column IDs for persisted layouts.
- Adds client tests for prefixed headers, unprefixed headers, and stable IDs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The change only reorders opaque header display text; callers continue using unchanged accessor keys and IDs, and the added tests cover the intended formats.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scores): lead score column headers w..."](https://github.com/langfuse/langfuse/commit/75ed58a42702eea5a9d87884e566db4504730cf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57889896)</sub>

<!-- /greptile_comment -->