### PR TITLE
fix: parse session `createdAt` as UTC on non-UTC servers (use `parseClickhouseUTCDateTimeFormat`)

### DIFF
--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -245,7 +245,7 @@ export const sessionRouter = createTRPCRouter({
             userIds: s.user_ids,
             countTraces: s.trace_count,
             traceTags: s.trace_tags,
-            createdAt: new Date(s.min_timestamp),
+            createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
             bookmarked:
               prismaSessionInfo.find((p) => p.id === s.session_id)
                 ?.bookmarked ?? false,
@@ -307,7 +307,7 @@ export const sessionRouter = createTRPCRouter({
             userIds: s.user_ids,
             countTraces: s.trace_count,
             traceTags: s.trace_tags,
-            createdAt: new Date(s.min_timestamp),
+            createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
             bookmarked:
               prismaSessionInfo.find((p) => p.id === s.session_id)
                 ?.bookmarked ?? false,
@@ -439,7 +439,7 @@ export const sessionRouter = createTRPCRouter({
         userIds: s.user_ids,
         countTraces: s.trace_count,
         traceTags: s.trace_tags,
-        createdAt: new Date(s.min_timestamp),
+        createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
         bookmarked:
           prismaSessionInfo.find((p) => p.id === s.session_id)?.bookmarked ??
           false,
@@ -506,7 +506,7 @@ export const sessionRouter = createTRPCRouter({
         userIds: s.user_ids,
         countTraces: s.trace_count,
         traceTags: s.trace_tags,
-        createdAt: new Date(s.min_timestamp),
+        createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
         bookmarked:
           prismaSessionInfo.find((p) => p.id === s.session_id)?.bookmarked ??
           false,


### PR DESCRIPTION
## Summary

On self-hosted deployments where the web server runs in a non-UTC timezone (e.g. bare-metal servers set to `Asia/Shanghai`), the session `createdAt` shown in the Sessions list / session detail is shifted by the UTC offset (−8h for CST), while the timestamps of the traces inside that session are displayed correctly. The data in ClickHouse is correct — only the display is off.

## Root cause

ClickHouse `DateTime64` values come back from the client as UTC wall-clock strings **without a timezone designator**, e.g. `"2026-08-28 09:00:23.390"`.

The four session list/metrics queries in `web/src/server/api/routers/sessions.ts` construct `createdAt` with:

```ts
createdAt: new Date(s.min_timestamp),
```

V8 parses date-time strings without an offset as the **process-local timezone**, so on a server running `Asia/Shanghai` the string is interpreted as Beijing time and the resulting instant is shifted by −8h. (On the standard Docker image this is masked because containers default to UTC.)

The rest of the codebase already handles this correctly via `parseClickhouseUTCDateTimeFormat` (appends `Z` before parsing) — all entity converters (`traces_converters.ts`, `observations_converters.ts`, `scores_converters.ts`, `dashboards.ts`, …) use it, and even this same file uses it in `byIdWithScoresFromEvents` for `minTimestamp`/`maxTimestamp`. These four `createdAt` call sites were simply missed.

## Reproduction

1. Self-host Langfuse from source on a host with `TZ=Asia/Shanghai` (or any non-UTC zone), e.g. `timedatectl set-timezone Asia/Shanghai`, then restart web.
2. Ingest a trace with a `session_id` at time T.
3. Sessions page shows the session `createdAt` as `T − 8h`, while the trace list shows the trace timestamp at T. Exactly 8 hours apart (offset = server TZ offset).

## Changes

Replaced the four occurrences with the existing helper (already imported in this file):

```diff
- createdAt: new Date(s.min_timestamp),
+ createdAt: parseClickhouseUTCDateTimeFormat(s.min_timestamp),
```

No behavior change on UTC servers (identical parse result), so CI and Langfuse Cloud are unaffected.

## Testing

- Existing `sessions-trpc` tests assert `createdAt: expect.any(Date)` — still satisfied.
- Verified the fix on a bare-metal `Asia/Shanghai` deployment: session `createdAt` now matches the earliest trace timestamp of the session.

## Aside (not changed in this PR)

`convertToDatasetRunMetrics` in `packages/shared/src/server/repositories/dataset-run-items-converters.ts` also uses `new Date(row.created_at)`, but it appears to be dead code (no call sites found) — mentioning it here in case maintainers want to clean it up separately.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes session timestamp interpretation on non-UTC web servers by consistently parsing four ClickHouse `min_timestamp` values as UTC.

- Replaces process-local `Date` parsing with the existing ClickHouse UTC parser.
- Applies the correction across session list, detail, and event-backed metrics mappings.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The four changed query mappings consume ClickHouse timestamp strings matching the established UTC parser contract, correcting timezone-dependent display shifts while preserving `Date` values in the tRPC responses.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: parse session createdAt as UTC on n..."](https://github.com/langfuse/langfuse/commit/6349d281aaaf6fd5f54b17ea15d2454faa66930b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57896320)</sub>

<!-- /greptile_comment -->