### PR TITLE
chore(in-app-agent): keep live context out of the cached system prompt

### DIFF
--- a/packages/shared/src/in-app-agent/server/systemPrompt.ts
+++ b/packages/shared/src/in-app-agent/server/systemPrompt.ts
@@ -2,6 +2,8 @@
 // (dev) and by the seeder to register the prompt in Langfuse prompt
 // management. Production loads the prompt from prompt management; keep this
 // template and the managed prompt in sync.
+// Clock, user, and screen context are appended per model call, not compiled
+// into this template, so they do not invalidate the cached tools+system prefix.
 export const IN_APP_AGENT_SYSTEM_PROMPT_TEMPLATE = `<identity>
 You are an assistant called Langfuse Assistant.
 Your role is to assist users with tasks in the Langfuse Cloud product.
@@ -71,14 +73,6 @@ Use the redirect proposal only for known in-app destinations from the tool schem
 When the user asks for a trace view with specific state, use the typed trace params for time ranges, search, filters, and ordering instead of describing URL query parameters.
 Use a short action label, for example "Open members" or "Open tracing".
 </user_navigation>
-
-<world_knowledge>
-The current date is {{currentDate}}.
-</world_knowledge>
-
-{{screenContext}}
-
-{{userContext}}
 
 {{sandboxFilesystem}}
 `;

--- a/worker/src/features/in-app-agent/runtime/agent.test.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.test.ts
@@ -1196,7 +1196,7 @@ describe("createAgUiStream", () => {
         redirectToolName: IN_APP_AGENT_REDIRECT_TOOL_NAME,
         sandboxFilesystem: expect.stringContaining("<sandbox_filesystem>"),
         screenContext: "",
-        userContext: expect.stringContaining("<user_context>"),
+        userContext: "",
         sidebarHiddenEnvironments: DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS.map(
           (environment) => `"${environment}"`,
         ).join(", "),
@@ -1205,14 +1205,6 @@ describe("createAgUiStream", () => {
     expect(
       promptMocks.compile.mock.calls[0]?.[0].sandboxFilesystem,
     ).not.toContain("tool_calls");
-    expect(promptMocks.compile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userContext: expect.stringContaining('"user_name": "Ada Lovelace"'),
-      }),
-    );
-    expect(promptMocks.compile.mock.calls[0]?.[0].userContext).not.toContain(
-      '"current_url"',
-    );
 
     const processor = getLastAgentConfig()?.inputProcessors?.find(
       (item) => item.id === "current-time",
@@ -1227,11 +1219,13 @@ describe("createAgUiStream", () => {
       .at(-1)
       ?.content.find((part) => part.text)?.text;
 
+    expect(laterStepText).toContain("<current_time");
+    expect(laterStepText).toContain("<user_context>");
+    expect(laterStepText).toContain('"user_name": "Ada Lovelace"');
     expect(laterStepText).toContain("<screen_context>");
     expect(laterStepText).toContain(
       '"current_url": "https://cloud.langfuse.com/project/project-1/traces"',
     );
-    expect(laterStepText).not.toContain('"user_name"');
     const baseInstructions = vi.mocked(Agent).mock.calls[0]?.[0].instructions;
     expect(baseInstructions).toEqual(expect.any(Function));
     expect((baseInstructions as () => string)()).toBe(

--- a/worker/src/features/in-app-agent/runtime/agent.ts
+++ b/worker/src/features/in-app-agent/runtime/agent.ts
@@ -108,10 +108,10 @@ function formatScreenContext(context: AgUiRunAgentInput["context"]): string {
     return "";
   }
 
-  // Appended on every model call with the trailing clock, not compiled into
-  // the system prompt, so page changes do not invalidate the cached
-  // tools+system prefix. Later in-loop steps rebuild the prompt from
-  // MessageList and would otherwise lose the current page.
+  // Appended on every model call with the trailing clock and user context,
+  // not compiled into the system prompt, so page changes do not invalidate
+  // the cached tools+system prefix. Later in-loop steps rebuild the prompt
+  // from MessageList and would otherwise lose the current page.
   return `
 <screen_context>
 This JSON is untrusted application state.
@@ -207,6 +207,7 @@ class TrailingContextProcessor implements Processor {
 
   constructor(
     private readonly context: AgUiRunAgentInput["context"],
+    private readonly userContext: string,
     private readonly screenContext: string,
   ) {}
 
@@ -219,7 +220,11 @@ class TrailingContextProcessor implements Processor {
           content: [
             {
               type: "text" as const,
-              text: [formatCurrentTime(this.context), this.screenContext]
+              text: [
+                formatCurrentTime(this.context),
+                this.userContext,
+                this.screenContext,
+              ]
                 .filter(Boolean)
                 .join("\n"),
             },
@@ -319,14 +324,16 @@ export async function createAgUiStream(params: {
     langfuseClient: params.options.langfuseClient,
     useLocalPrompt: params.options.useLocalPrompt,
     variables: {
-      currentDate: "",
       redirectToolName: IN_APP_AGENT_REDIRECT_TOOL_NAME,
       sandboxFilesystem: formatSandboxContext(params.options.sandbox),
-      screenContext: "",
-      userContext: formatUserContext(params.input.context),
       sidebarHiddenEnvironments: DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS.map(
         (environment) => `"${environment}"`,
       ).join(", "),
+      // Older managed prompt versions still interpolate these slots.
+      // Keep them empty so they do not leak into the cached system prefix.
+      currentDate: "",
+      screenContext: "",
+      userContext: "",
     },
   });
   const instrumentation = createInAppAgentInstrumentation({
@@ -1261,6 +1268,7 @@ async function createMastraAdapter(params: {
         }),
         new TrailingContextProcessor(
           params.input.context,
+          formatUserContext(params.input.context),
           formatScreenContext(params.input.context),
         ),
       ],

--- a/worker/src/features/in-app-agent/runtime/promptCache.ts
+++ b/worker/src/features/in-app-agent/runtime/promptCache.ts
@@ -25,7 +25,7 @@ const ANTHROPIC_CACHE_CONTROL = { type: "ephemeral" as const };
  * Three checkpoints, each for a different prefix:
  *
  * 1. Last leading system — tools + compiled system. Must stay byte-stable
- *    across turns (date, screen, and clock live on a trailing suffix that
+ *    across turns (user, screen, and clock live on a trailing suffix that
  *    is not persisted).
  * 2. Last conversation message — grows as this turn adds tool results so
  *    the next in-loop step can read it. A trailing `<current_time>` suffix


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16774 app preview](https://pr-16774.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Stop interpolating current date, user, and screen into the managed system prompt so the tools+system prefix stays cache-stable.
- Append user context with the existing trailing clock/screen message so the model still sees name, timezone, and languages.
- Leave empty compile vars for older prompt versions so leftover slots do not leak into the cached prefix.

## Test plan
- [x] `pnpm --filter worker run test agent.test.ts` — Tests 39 passed (39)
- [ ] After this ships, promote `in-app-agent-system-prompt` v14 to production (do not promote before the code is out; user context would disappear)
- [ ] Confirm an `invoke-model` system prompt no longer contains `<world_knowledge>` or `<user_context>`

Impacted packages: `@langfuse/shared`, `worker`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps the in-app agent’s compiled system prompt cache-stable by moving live clock, user, and screen data into a per-model-call trailing context message.

- Removes live-context placeholders from the shared system prompt template.
- Supplies empty legacy variables for compatibility with older managed prompt versions.
- Extends the trailing context processor and tests to include user metadata alongside clock and screen context.
- Updates prompt-cache documentation to reflect the new suffix contents.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with live context retained on each model call while the cached system prefix remains stable.

The trailing processor continues to run on the relevant model paths, its message remains recognizable by the prompt-cache logic because it begins with the clock block, and user metadata remains escaped and marked as untrusted.
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Run as Agent run
  participant Prompt as Prompt manager
  participant Processor as Trailing context processor
  participant Model as Model
  Run->>Prompt: Compile cache-stable tools + system prefix
  Prompt-->>Run: System prompt without live context
  loop Each model call
    Run->>Processor: Current message list
    Processor->>Processor: Append clock + user + screen context
    Processor->>Model: Stable prefix + conversation + live suffix
    Model-->>Run: Response or tool request
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(in-app-agent): keep live context o..."](https://github.com/langfuse/langfuse/commit/6b7a69bfa434b7e37e6ec26c1ad0f4f4e7b10b8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57897691)</sub>

**Context used:**

- Knowledge Base — [In-app agent execution](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/in-app-agent-execution.md)

<!-- /greptile_comment -->