### PR TITLE
feat(web): reframe migration headline around the compatibility deadline

### DIFF
--- a/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.clienttest.tsx
+++ b/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.clienttest.tsx
@@ -1,16 +1,21 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MobileRightDrawer } from "@/src/components/layouts/app-layout/right-drawer/MobileRightDrawer";
+
+const mocks = vi.hoisted(() => ({
+  supportOpen: true,
+  migrationOpen: false,
+}));
 
 vi.mock("@/src/features/support-chat/SupportDrawerProvider", () => ({
   useSupportDrawer: () => ({
-    open: true,
+    open: mocks.supportOpen,
     setOpen: vi.fn(),
   }),
 }));
 
 vi.mock("@/src/features/v4-migration/V4MigrationPanelProvider", () => ({
   useV4MigrationPanel: () => ({
-    open: false,
+    open: mocks.migrationOpen,
     setOpen: vi.fn(),
   }),
 }));
@@ -21,6 +26,10 @@ vi.mock("@/src/features/support-chat/SupportDrawer", () => ({
 
 vi.mock("@/src/features/v4-migration/V4MigrationPanel", () => ({
   V4MigrationPanel: () => null,
+}));
+
+vi.mock("@/src/features/v4-migration/V4MigrationContent", () => ({
+  useV4MigrationTitle: () => "Ensure compatibility after November 16",
 }));
 
 function mountOverlayRoot() {
@@ -43,6 +52,8 @@ function mountOverlayRoot() {
 
 describe("MobileRightDrawer", () => {
   beforeEach(() => {
+    mocks.supportOpen = true;
+    mocks.migrationOpen = false;
     mountOverlayRoot();
   });
 
@@ -60,5 +71,20 @@ describe("MobileRightDrawer", () => {
     const drawer = document.querySelector("#support-drawer");
     expect(drawer).not.toBeNull();
     expect(drawer?.className).not.toContain("min-h-screen-with-banner");
+  });
+
+  it("includes the compatibility deadline in the accessible migration title", () => {
+    mocks.supportOpen = false;
+    mocks.migrationOpen = true;
+
+    render(
+      <MobileRightDrawer>
+        <div>page</div>
+      </MobileRightDrawer>,
+    );
+
+    expect(
+      screen.getByText("Ensure compatibility after November 16"),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx
+++ b/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx
@@ -64,10 +64,10 @@ export function MobileRightDrawer({ children }: PropsWithChildren) {
               <div className="bg-muted h-2 w-20 rounded-full" />
             </div>
             {/* sr-only for screen readers and accessibility */}
-            <DrawerTitle className="sr-only">Upgrade to v4</DrawerTitle>
+            <DrawerTitle className="sr-only">Ensure compatibility</DrawerTitle>
             <DrawerDescription className="sr-only">
-              Information about migrating to Langfuse v4 and upcoming
-              deprecations.
+              Action items to keep your integrations compatible with Langfuse v4
+              and upcoming deprecations.
             </DrawerDescription>
           </DrawerHeader>
           <V4MigrationPanel

--- a/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx
+++ b/web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx
@@ -10,11 +10,13 @@ import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvi
 import { SupportDrawer } from "@/src/features/support-chat/SupportDrawer";
 import { useV4MigrationPanel } from "@/src/features/v4-migration/V4MigrationPanelProvider";
 import { V4MigrationPanel } from "@/src/features/v4-migration/V4MigrationPanel";
+import { useV4MigrationTitle } from "@/src/features/v4-migration/V4MigrationContent";
 
 export function MobileRightDrawer({ children }: PropsWithChildren) {
   const { open: supportOpen, setOpen: setSupportOpen } = useSupportDrawer();
   const { open: migrationOpen, setOpen: setMigrationOpen } =
     useV4MigrationPanel();
+  const migrationTitle = useV4MigrationTitle();
 
   return (
     <>
@@ -64,7 +66,7 @@ export function MobileRightDrawer({ children }: PropsWithChildren) {
               <div className="bg-muted h-2 w-20 rounded-full" />
             </div>
             {/* sr-only for screen readers and accessibility */}
-            <DrawerTitle className="sr-only">Ensure compatibility</DrawerTitle>
+            <DrawerTitle className="sr-only">{migrationTitle}</DrawerTitle>
             <DrawerDescription className="sr-only">
               Action items to keep your integrations compatible with Langfuse v4
               and upcoming deprecations.

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1345,7 +1345,7 @@ describe("V4MigrationHeaderContent", () => {
 
     expect(screen.getByText("Ensure compatibility")).toBeInTheDocument();
     expect(screen.getByText(/features may stop working/)).toHaveTextContent(
-      "Some features may stop working if you don't update integrations before your administrator disables the legacy mode.",
+      "Some features may stop working if you don't update integrations before the legacy mode is disabled.",
     );
     expect(screen.queryByText(/November 16/)).not.toBeInTheDocument();
     expect(

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1345,7 +1345,7 @@ describe("V4MigrationHeaderContent", () => {
 
     expect(screen.getByText("Ensure compatibility")).toBeInTheDocument();
     expect(screen.getByText(/features may stop working/)).toHaveTextContent(
-      "Some features may stop working if you don't update integrations before the legacy mode is disabled.",
+      "Some features may stop working if you don't update integrations before your administrator disables the legacy mode.",
     );
     expect(screen.queryByText(/November 16/)).not.toBeInTheDocument();
     expect(

--- a/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.clienttest.tsx
@@ -1264,6 +1264,7 @@ describe("V4MigrationDetailsContent", () => {
 
 describe("V4MigrationHeaderContent", () => {
   beforeEach(() => {
+    mocks.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "US";
     mocks.migrationData.evals = { status: "loaded", count: 0 };
     mocks.migrationData.experiments = {
       status: "loaded",
@@ -1283,13 +1284,18 @@ describe("V4MigrationHeaderContent", () => {
     );
   });
 
-  it("uses the project-independent upgrade title and requested description", () => {
+  it("uses the project-independent compatibility title and requested description", () => {
     render(<V4MigrationHeaderContent readiness="action-needed" />);
 
-    expect(screen.getByText("Upgrade to v4")).toBeInTheDocument();
+    // The title stays off the version number: the app shell already shows a v4
+    // build, so a "upgrade to v4" headline read as a contradiction.
+    expect(
+      screen.getByText("Ensure compatibility after November 16"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Upgrade to v4")).not.toBeInTheDocument();
     expect(screen.queryByText(/Project 1/)).not.toBeInTheDocument();
     expect(screen.getByText(/Langfuse v4 is live/)).toHaveTextContent(
-      "Langfuse v4 is live: a re-architecture of our data model and database tables. It is up to 165× more performant in UI and on APIs. It also enables new features such as full-text search, a new filter search bar, alerts, code evaluators, and the Langfuse Assistant. Complete the action items below to switch this project over. See docs.",
+      "Langfuse v4 is live: a re-architecture of our data model and database tables. It is up to 165× more performant in UI and on APIs. It also enables new features such as full-text search, a new filter search bar, alerts, code evaluators, and the Langfuse Assistant. Complete the action items below to avoid disruption. See docs.",
     );
     expect(
       screen.getByRole("link", { name: "full-text search" }),
@@ -1323,7 +1329,7 @@ describe("V4MigrationHeaderContent", () => {
     expect(
       screen.getByText(/some features may stop working/),
     ).toHaveTextContent(
-      "After November 16, 2026 some features may stop working without a v4 upgrade.",
+      "After November 16, 2026 some features may stop working if you don't update integrations.",
     );
     expect(
       screen.getByRole("link", { name: "November 16, 2026" }),
@@ -1337,10 +1343,11 @@ describe("V4MigrationHeaderContent", () => {
 
     render(<V4MigrationHeaderContent readiness="action-needed" />);
 
+    expect(screen.getByText("Ensure compatibility")).toBeInTheDocument();
     expect(screen.getByText(/features may stop working/)).toHaveTextContent(
-      "Some features may stop working without an upgrade once your administrator disables the legacy mode.",
+      "Some features may stop working if you don't update integrations before your administrator disables the legacy mode.",
     );
-    expect(screen.queryByText(/November 16, 2026/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/November 16/)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "November 16, 2026" }),
     ).not.toBeInTheDocument();
@@ -1350,7 +1357,9 @@ describe("V4MigrationHeaderContent", () => {
     // The modal host floats the dialog's fallback close button over the
     // body's top-right corner; without the gutter it overlaps the title.
     render(<V4MigrationHeaderContent titleRowClassName="pr-6" />);
-    expect(screen.getByText("Upgrade to v4").parentElement).toHaveClass("pr-6");
+    expect(
+      screen.getByText("Ensure compatibility after November 16").parentElement,
+    ).toHaveClass("pr-6");
   });
 
   it("keeps the pitch but drops the action ask for ready or unresolved projects", () => {

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1228,7 +1228,7 @@ export function V4MigrationDeadlineNote() {
     return (
       <p>
         Some features may stop working if you don&apos;t update integrations
-        before the legacy mode is disabled.
+        before your administrator disables the legacy mode.
       </p>
     );
   }

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -1228,7 +1228,7 @@ export function V4MigrationDeadlineNote() {
     return (
       <p>
         Some features may stop working if you don&apos;t update integrations
-        before your administrator disables the legacy mode.
+        before the legacy mode is disabled.
       </p>
     );
   }

--- a/web/src/features/v4-migration/V4MigrationContent.tsx
+++ b/web/src/features/v4-migration/V4MigrationContent.tsx
@@ -79,6 +79,8 @@ const V4_DOCS_URL = "https://langfuse.com/docs/v4";
 const V4_TIMELINE_URL = `${V4_DOCS_URL}#timeline`;
 // Consumed by the status page deadline copy.
 export const V4_MIGRATION_DEADLINE = "November 16, 2026";
+// Headline form of the deadline; the year is noise in a title.
+const V4_MIGRATION_DEADLINE_SHORT = "November 16";
 const SDK_UPGRADE_URL =
   "https://langfuse.com/docs/observability/sdk/upgrade-path";
 const OTEL_V4_MIGRATION_URL =
@@ -1207,14 +1209,26 @@ export function V4MigrationDocsLink() {
   );
 }
 
+/**
+ * Headline for the migration surfaces. It names the compatibility deadline
+ * rather than a version: the app shell already shows a v4 build number, so a
+ * "upgrade to v4" title reads as a contradiction to users whose integrations,
+ * not their deployment, are the thing left to update.
+ */
+export function useV4MigrationTitle(): string {
+  return useHasV4MigrationDeadline()
+    ? `Ensure compatibility after ${V4_MIGRATION_DEADLINE_SHORT}`
+    : "Ensure compatibility";
+}
+
 export function V4MigrationDeadlineNote() {
   const hasDeadline = useHasV4MigrationDeadline();
 
   if (!hasDeadline) {
     return (
       <p>
-        Some features may stop working without an upgrade once your
-        administrator disables the legacy mode.
+        Some features may stop working if you don&apos;t update integrations
+        before your administrator disables the legacy mode.
       </p>
     );
   }
@@ -1228,7 +1242,7 @@ export function V4MigrationDeadlineNote() {
       >
         {V4_MIGRATION_DEADLINE}
       </ExternalLink>{" "}
-      some features may stop working without a v4 upgrade.
+      some features may stop working if you don&apos;t update integrations.
     </p>
   );
 }
@@ -1248,6 +1262,7 @@ export function V4MigrationHeaderContent({
   readiness?: ProjectMigrationReadiness;
 }) {
   const actionNeeded = readiness === "action-needed";
+  const title = useV4MigrationTitle();
 
   return (
     <>
@@ -1257,7 +1272,7 @@ export function V4MigrationHeaderContent({
           titleRowClassName,
         )}
       >
-        <p className="min-w-0 text-lg font-bold">Upgrade to v4</p>
+        <p className="min-w-0 text-lg font-bold">{title}</p>
       </div>
       <div className="text-muted-foreground flex flex-col gap-2 text-sm leading-relaxed">
         <p>
@@ -1300,7 +1315,7 @@ export function V4MigrationHeaderContent({
           </ExternalLink>
           .
           {actionNeeded
-            ? " Complete the action items below to switch this project over."
+            ? " Complete the action items below to avoid disruption."
             : ""}{" "}
           <V4MigrationDocsLink />
         </p>

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -318,10 +318,10 @@ describe("V4MigrationStatusPage", () => {
     render(<V4MigrationStatusPage />);
 
     expect(
-      screen.getByText("once your administrator disables the legacy mode"),
+      screen.getByText("once the legacy mode is disabled"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Once your administrator disables the legacy mode"),
+      screen.getByText("Once the legacy mode is disabled"),
     ).toBeInTheDocument();
     expect(screen.queryByText(/on November 16, 2026/)).not.toBeInTheDocument();
     expect(screen.queryByText(/On November 16, 2026/)).not.toBeInTheDocument();
@@ -335,7 +335,7 @@ describe("V4MigrationStatusPage", () => {
 
     expect(
       screen.getByText(
-        /The features powering the legacy v3 UI will be sunset once your administrator disables the legacy mode\./,
+        /The features powering the legacy v3 UI will be sunset once the legacy mode is disabled\./,
       ),
     ).toBeInTheDocument();
   });

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -318,10 +318,10 @@ describe("V4MigrationStatusPage", () => {
     render(<V4MigrationStatusPage />);
 
     expect(
-      screen.getByText("once the legacy mode is disabled"),
+      screen.getByText("once your administrator disables the legacy mode"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Once the legacy mode is disabled"),
+      screen.getByText("Once your administrator disables the legacy mode"),
     ).toBeInTheDocument();
     expect(screen.queryByText(/on November 16, 2026/)).not.toBeInTheDocument();
     expect(screen.queryByText(/On November 16, 2026/)).not.toBeInTheDocument();
@@ -335,7 +335,7 @@ describe("V4MigrationStatusPage", () => {
 
     expect(
       screen.getByText(
-        /The features powering the legacy v3 UI will be sunset once the legacy mode is disabled\./,
+        /The features powering the legacy v3 UI will be sunset once your administrator disables the legacy mode\./,
       ),
     ).toBeInTheDocument();
   });

--- a/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.clienttest.tsx
@@ -86,10 +86,14 @@ vi.mock("@/src/features/v4-migration/V4MigrationContent", () => ({
   ),
   V4MigrationDeadlineNote: () => (
     <p>
-      After November 16, 2026 some features may stop working without a v4
-      upgrade.
+      After November 16, 2026 some features may stop working if you don&apos;t
+      update integrations.
     </p>
   ),
+  useV4MigrationTitle: () =>
+    mocks.hasDeadline
+      ? "Ensure compatibility after November 16"
+      : "Ensure compatibility",
 }));
 
 vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
@@ -232,7 +236,9 @@ describe("V4MigrationStatusPage", () => {
   it("opens the summary card with a link to the v4 docs", () => {
     render(<V4MigrationStatusPage />);
 
-    expect(screen.getByText("Upgrade to v4")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ensure compatibility after November 16"),
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "See docs." })).toHaveAttribute(
       "href",
       "https://langfuse.com/docs/v4",

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -16,6 +16,7 @@ import {
 import {
   useCopyMigrationPrompt,
   useHasV4MigrationDeadline,
+  useV4MigrationTitle,
   V4MigrationDeadlineNote,
   V4MigrationDocsLink,
   V4_MIGRATION_DEADLINE,
@@ -476,6 +477,7 @@ function V4MigrationStatusPageContent() {
   const session = useSession();
   const handleCopyPrompt = useCopyMigrationPrompt();
   const hasDeadline = useHasV4MigrationDeadline();
+  const title = useV4MigrationTitle();
 
   const orgs: V4MigrationOrganization[] =
     session.data?.user?.organizations?.map((org) => ({
@@ -627,11 +629,11 @@ function V4MigrationStatusPageContent() {
     >
       <div className="flex flex-col gap-6 pt-2 pb-24">
         <Card className="flex min-w-0 flex-col gap-2.5 p-6">
-          <p className="text-base font-bold">Upgrade to v4</p>
+          <p className="text-base font-bold">{title}</p>
           <div className="text-muted-foreground flex flex-col gap-2 text-sm leading-relaxed">
             <p>
               {actionNeededProjects > 0
-                ? "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. Complete the action items on each project below to switch over. "
+                ? "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. Complete the action items on each project below to avoid disruption. "
                 : "Langfuse v4 is here: real-time ingestion and up to 165× faster queries. "}
               <V4MigrationDocsLink />
             </p>

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -539,7 +539,7 @@ function V4MigrationStatusPageContent() {
           <span className="underline">
             {hasDeadline
               ? `on ${V4_MIGRATION_DEADLINE}`
-              : "once your administrator disables the legacy mode"}
+              : "once the legacy mode is disabled"}
           </span>
           . They keep running until then, but we&apos;re no longer fixing bugs
           in them.
@@ -570,7 +570,7 @@ function V4MigrationStatusPageContent() {
           <span className="underline">
             {hasDeadline
               ? `On ${V4_MIGRATION_DEADLINE}`
-              : "Once your administrator disables the legacy mode"}
+              : "Once the legacy mode is disabled"}
           </span>
           , old SDKs stop sending data, and the{" "}
           <FaqLink href={API_REFERENCE_URL}>
@@ -722,7 +722,7 @@ function SwitchBackSection() {
             The features powering the legacy v3 UI will be sunset{" "}
             {hasDeadline
               ? `on ${V4_MIGRATION_DEADLINE}`
-              : "once your administrator disables the legacy mode"}
+              : "once the legacy mode is disabled"}
             . We strongly recommend switching to the latest UI (v4) before then.
           </p>
         )}

--- a/web/src/features/v4-migration/V4MigrationStatusPage.tsx
+++ b/web/src/features/v4-migration/V4MigrationStatusPage.tsx
@@ -539,7 +539,7 @@ function V4MigrationStatusPageContent() {
           <span className="underline">
             {hasDeadline
               ? `on ${V4_MIGRATION_DEADLINE}`
-              : "once the legacy mode is disabled"}
+              : "once your administrator disables the legacy mode"}
           </span>
           . They keep running until then, but we&apos;re no longer fixing bugs
           in them.
@@ -570,7 +570,7 @@ function V4MigrationStatusPageContent() {
           <span className="underline">
             {hasDeadline
               ? `On ${V4_MIGRATION_DEADLINE}`
-              : "Once the legacy mode is disabled"}
+              : "Once your administrator disables the legacy mode"}
           </span>
           , old SDKs stop sending data, and the{" "}
           <FaqLink href={API_REFERENCE_URL}>
@@ -722,7 +722,7 @@ function SwitchBackSection() {
             The features powering the legacy v3 UI will be sunset{" "}
             {hasDeadline
               ? `on ${V4_MIGRATION_DEADLINE}`
-              : "once the legacy mode is disabled"}
+              : "once your administrator disables the legacy mode"}
             . We strongly recommend switching to the latest UI (v4) before then.
           </p>
         )}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16776 app preview](https://pr-16776.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The migration sidebar told users to "Upgrade to v4" while the app shell right above it already showed a `v4.x` build number, so people who were already on v4 read the panel as a contradiction. The headline now names the deadline instead of a version, and the body frames the work as avoiding disruption by updating integrations.

Copy changes (sidebar panel header, shared with the account-level migration status card):

| | Before | After |
| --- | --- | --- |
| Headline (Cloud) | Upgrade to v4 | Ensure compatibility after November 16 |
| Headline (self-hosted) | Upgrade to v4 | Ensure compatibility |
| Action ask | Complete the action items below to switch this project over. | Complete the action items below to avoid disruption. |
| Deadline note (Cloud) | After November 16, 2026 some features may stop working without a v4 upgrade. | After November 16, 2026 some features may stop working if you don't update integrations. |
| Deadline note (self-hosted) | Some features may stop working without an upgrade once your administrator disables the legacy mode. | Some features may stop working if you don't update integrations before your administrator disables the legacy mode. |

The headline lives in one place (`useV4MigrationTitle`) so the sidebar panel, the mobile drawer's screen-reader title, and the account-level status card cannot drift apart. The self-hosted variant drops the date because that date is a Langfuse Cloud commitment; a self-hosted deployment keeps its legacy surfaces until its own operator moves the write mode off `dual`.

## Proof

Sidebar panel header, before and after:

![Migration sidebar header before and after the copy change](https://cursor.com/artifacts/c/art-0a813560-65cb-4894-bded-280ff773f22c)

The same header in the running app, next to the `v4.23.0` version badge that caused the confusion:

![Migration panel open in the app with the new headline while the sidebar shows v4.23.0](https://cursor.com/artifacts/c/art-4565a663-4506-445d-871f-6e43ab325de1)

Account-level migration status page (`/v4-migration`) carries the same headline:

![Migration status page summary card with the new headline](https://cursor.com/artifacts/c/art-def29ffe-c026-4f82-9f79-74c4ad4996e9)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## How to test

Preview: `pr-16776.preview.langfuse.com`

1. Open a project that still has migration action items and click **Action required** in the left sidebar (the migration panel opens on the right).
2. The panel header should read **Ensure compatibility after November 16**, the pitch paragraph should end with "Complete the action items below to avoid disruption.", and the note below it should read "After November 16, 2026 some features may stop working if you don't update integrations."
3. Visit `/v4-migration` (account-level **Migration status**): the summary card carries the same headline and the same "avoid disruption" ask.

## Checks

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` — clean
- `pnpm --filter web run test-client src/features/v4-migration/ src/components/layouts/app-layout/right-drawer/` — `Tests 151 passed (151)`. Reverting only the production copy fails the four updated assertions (`Tests 4 failed | 59 passed`), so the tests pin the new strings.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15758](https://linear.app/clickhouse/issue/LFE-15758/update-v4-migration-sidebar-messaging)

<div><a href="https://cursor.com/agents/bc-87ea2155-9998-4208-9d31-36b964673012?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87ea2155-9998-4208-9d31-36b964673012&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reframes the v4 migration messaging around integration compatibility and the Cloud deadline rather than asking users to upgrade to v4.
- Adds a shared deployment-aware migration title for project and account-level migration surfaces.
- Updates deadline and action-item copy for Cloud and self-hosted deployments.
- Updates client tests to assert the revised messaging.
- Leaves the mobile drawer's accessible title hard-coded rather than sharing the Cloud-specific headline.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking accessibility inconsistency in the mobile Cloud drawer title.

The visible migration panel correctly uses the new deployment-aware headline, but the mobile drawer's screen-reader title bypasses that helper and omits the Cloud deadline.

**Files Needing Attention:** web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/layouts/app-layout/right-drawer/MobileRightDrawer.tsx:67
**Accessible title bypasses deadline**

On Langfuse Cloud, the visible panel uses `useV4MigrationTitle()` and says “Ensure compatibility after November 16,” while this hard-coded `DrawerTitle` announces only “Ensure compatibility.” This leaves screen-reader users without the deadline included in the visible headline.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): reframe migration headline ar..."](https://github.com/langfuse/langfuse/commit/7ae96096183b0889e56573c9c08888b03ee22689) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57911343)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->