### PR TITLE
feat(shared): count ClickHouse query outcomes for read SLIs

### DIFF
--- a/packages/shared/src/server/clickhouse/queryOutcome.test.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CLICKHOUSE_QUERY_OUTCOME_METRIC,
+  CLICKHOUSE_RESOURCE_ERROR_OUTCOMES,
+  clickHouseQueryOutcomeRouteLabel,
+  recordClickHouseQueryOutcome,
+} from "./queryOutcome";
+
+const recordIncrement = vi.fn();
+
+vi.mock("../instrumentation", () => ({
+  recordIncrement: (...args: unknown[]) => recordIncrement(...args),
+}));
+
+describe("ClickHouse query outcome metric", () => {
+  beforeEach(() => {
+    recordIncrement.mockClear();
+  });
+
+  describe("route labels", () => {
+    it.each([
+      ["GET /api/public/v2/observations", "get_/api/public/v2/observations"],
+      ["GET /api/public/v2/metrics", "get_/api/public/v2/metrics"],
+      ["GET /api/public/v3/scores", "get_/api/public/v3/scores"],
+    ])("labels %s as the APM resource name", (route, expected) => {
+      expect(clickHouseQueryOutcomeRouteLabel(route)).toBe(expected);
+    });
+
+    it("normalizes a trailing slash before matching", () => {
+      expect(
+        clickHouseQueryOutcomeRouteLabel("GET /api/public/v3/scores/"),
+      ).toBe("get_/api/public/v3/scores");
+    });
+
+    // The route tag is derived from the request path, so caller-controlled
+    // segments would otherwise become unbounded metric tag values.
+    it.each([
+      "GET /api/public/traces/123e4567-e89b-12d3-a456-426614174000",
+      "GET /api/public/v2/prompts/dashboard.status_headline.low.de",
+      "GET /api/public/v2/observations/some-observation-id",
+      "HEAD /api/public/v2/observations",
+      "POST /api/public/v2/metrics",
+    ])("counts %s under the catch-all label", (route) => {
+      expect(clickHouseQueryOutcomeRouteLabel(route)).toBe("other");
+    });
+
+    it.each([undefined, "", "   ", "no-method-separator"])(
+      "falls back to the catch-all label for %s",
+      (route) => {
+        expect(clickHouseQueryOutcomeRouteLabel(route)).toBe("other");
+      },
+    );
+  });
+
+  it("maps every ClickHouse resource error type to an outcome", () => {
+    expect(CLICKHOUSE_RESOURCE_ERROR_OUTCOMES).toEqual({
+      TIMEOUT: "timeout",
+      MEMORY_LIMIT: "memory_limit",
+      OVERCOMMIT: "overcommit",
+    });
+  });
+
+  it("emits the outcome with bounded tags", () => {
+    recordClickHouseQueryOutcome("timeout", {
+      tag_schema_version: "1",
+      surface: "publicapi",
+      route: "GET /api/public/v2/observations",
+      projectId: "project-1",
+      sdkName: "python",
+      sdkVersion: "3.12.0",
+      userAgent: "python-httpx/0.28.1",
+    });
+
+    expect(recordIncrement).toHaveBeenCalledTimes(1);
+    expect(recordIncrement).toHaveBeenCalledWith(
+      CLICKHOUSE_QUERY_OUTCOME_METRIC,
+      1,
+      {
+        outcome: "timeout",
+        surface: "publicapi",
+        route: "get_/api/public/v2/observations",
+      },
+    );
+  });
+
+  it("keeps unknown surfaces and unlabelled routes queryable", () => {
+    recordClickHouseQueryOutcome("success", {
+      tag_schema_version: "1",
+      surface: "unknown",
+    });
+
+    expect(recordIncrement).toHaveBeenCalledWith(
+      CLICKHOUSE_QUERY_OUTCOME_METRIC,
+      1,
+      { outcome: "success", surface: "unknown", route: "other" },
+    );
+  });
+});

--- a/packages/shared/src/server/clickhouse/queryOutcome.ts
+++ b/packages/shared/src/server/clickhouse/queryOutcome.ts
@@ -1,0 +1,86 @@
+import { recordIncrement } from "../instrumentation";
+import { type NormalizedClickHouseQueryTags } from "./queryTags";
+
+/**
+ * Terminal outcome of one logical ClickHouse query, counted once per query
+ * after retries are exhausted.
+ *
+ * Resource limits surface to public API callers as HTTP 422 and to tRPC
+ * callers as UNPROCESSABLE_CONTENT, so status-code-derived signals cannot
+ * distinguish them from a caller's malformed request. This metric is the
+ * signal that can: it is emitted where the resource error is classified.
+ */
+export const CLICKHOUSE_QUERY_OUTCOME_METRIC =
+  "langfuse.clickhouse.query.outcome";
+
+export type ClickHouseQueryOutcome =
+  | "success"
+  | "timeout"
+  | "memory_limit"
+  | "overcommit"
+  | "error";
+
+/**
+ * Maps `ClickHouseResourceError.errorType` onto outcomes. Keyed by the error
+ * type literals rather than importing the type, so this module keeps no
+ * dependency on the query paths that call it. Indexing it with `errorType`
+ * makes the compiler reject a new error type that is not mapped here.
+ */
+export const CLICKHOUSE_RESOURCE_ERROR_OUTCOMES = {
+  TIMEOUT: "timeout",
+  MEMORY_LIMIT: "memory_limit",
+  OVERCOMMIT: "overcommit",
+} as const satisfies Record<string, ClickHouseQueryOutcome>;
+
+/**
+ * Routes whose outcomes are reported under their own `route` tag. Everything
+ * else is counted under `other`.
+ *
+ * `route` on the query tags is derived from the request path, so it carries
+ * caller-controlled segments (trace ids, prompt names) and is unbounded. Metric
+ * tags must be bounded, so only explicitly listed routes get a label. Add a
+ * route here when it gains an SLO.
+ */
+const LABELLED_ROUTES = new Set([
+  "GET /api/public/v2/observations",
+  "GET /api/public/v2/metrics",
+  "GET /api/public/v3/scores",
+]);
+
+const OTHER_ROUTE_LABEL = "other";
+
+/**
+ * Renders a route as a Datadog tag value, matching the `resource_name`
+ * convention APM uses for the same route (`get_/api/public/v2/metrics`), so
+ * SLO and dashboard queries can filter both signals the same way. Datadog tag
+ * values cannot contain spaces, so the method is folded in with an underscore.
+ */
+export function clickHouseQueryOutcomeRouteLabel(route?: string): string {
+  if (!route) return OTHER_ROUTE_LABEL;
+
+  const collapsed = route.trim();
+  const separatorIndex = collapsed.indexOf(" ");
+  if (separatorIndex === -1) return OTHER_ROUTE_LABEL;
+
+  const method = collapsed.slice(0, separatorIndex);
+  const path = collapsed.slice(separatorIndex + 1);
+  const normalizedPath =
+    path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+
+  if (!LABELLED_ROUTES.has(`${method} ${normalizedPath}`)) {
+    return OTHER_ROUTE_LABEL;
+  }
+
+  return `${method.toLowerCase()}_${normalizedPath}`;
+}
+
+export function recordClickHouseQueryOutcome(
+  outcome: ClickHouseQueryOutcome,
+  tags: NormalizedClickHouseQueryTags,
+): void {
+  recordIncrement(CLICKHOUSE_QUERY_OUTCOME_METRIC, 1, {
+    outcome,
+    surface: tags.surface,
+    route: clickHouseQueryOutcomeRouteLabel(tags.route),
+  });
+}

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -31,6 +31,10 @@ import {
   type ClickHouseQueryTags,
   type NormalizedClickHouseQueryTags,
 } from "../clickhouse/queryTags";
+import {
+  CLICKHOUSE_RESOURCE_ERROR_OUTCOMES,
+  recordClickHouseQueryOutcome,
+} from "../clickhouse/queryOutcome";
 
 /**
  * Re-exported so callers can build `Array(Tuple(...))` query parameters without
@@ -685,7 +689,7 @@ export async function queryClickhouse<T>(
     async (span) => {
       setSpanQueryAttributes(span, opts.query);
 
-      return await backOff(
+      const rows = await backOff(
         async () => {
           const res = await sendClickhouseQuery({
             ...opts,
@@ -732,11 +736,21 @@ export async function queryClickhouse<T>(
           maxDelay: 100,
         },
       ).catch((error) => {
-        throw ClickHouseResourceError.wrapIfResourceError(
+        const wrapped = ClickHouseResourceError.wrapIfResourceError(
           error as Error,
           normalizedTags,
         );
+        recordClickHouseQueryOutcome(
+          wrapped instanceof ClickHouseResourceError
+            ? CLICKHOUSE_RESOURCE_ERROR_OUTCOMES[wrapped.errorType]
+            : "error",
+          normalizedTags,
+        );
+        throw wrapped;
       });
+
+      recordClickHouseQueryOutcome("success", normalizedTags);
+      return rows;
     },
   );
 }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16777 app preview](https://pr-16777.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Problem

ClickHouse resource limits (timeout, memory limit, overcommit) are mapped to HTTP **422** for public API callers and `UNPROCESSABLE_CONTENT` for tRPC callers, and logged at `warn`. Datadog therefore leaves those spans with `status: ok` and an empty `error` block, so `trace.http.server.errors` counts none of them.

The result is that our most common read failure is invisible to any availability signal derived from status codes:

- `GET /api/public/traces` in prod-EU over the 7d to 2026-08-28: **1 × 500** against **22,976 logged query timeouts**. A "99.9% of requests return without a 5xx" SLO scores that endpoint at 99.998%, while roughly one in seven eligible requests fails after a 30-second wait.
- The 422 is shared with genuine client validation errors, so status code alone cannot separate "your request was malformed" from "we gave up after 30 seconds".

The structured signal already exists — `ClickHouse resource limit exceeded` logs carry `errorType` and `tags.{route,surface,projectId,sdkName}` under `tag_schema_version: 1` — but only as a log, so it cannot back an SLO.

## Change

Count the terminal outcome of each logical ClickHouse query in `queryClickhouse`, where the resource error is already classified. One metric, `langfuse.clickhouse.query.outcome`, covers every calling surface from one place.

- `outcome`: `success` | `timeout` | `memory_limit` | `overcommit` | `error`
- `surface`: the existing normalized query surface (`publicapi`, `trpc`, `worker`, `mcp`, `unknown`)
- `route`: only for routes explicitly listed as bounded; everything else counts under `other`

Emitted **once per logical query, after retries** — placed after `backOff` resolves or rejects, so a retried query contributes one sample, not one per attempt.

### On the route tag

`route` on the query tags is derived from the request path, so it carries caller-controlled segments — concrete trace ids, arbitrary prompt names. That is fine for a log field and unusable as a metric tag. Only routes on an explicit allowlist get a label; the rest are counted under `other`. Labels are rendered in the same form APM uses for the same route (`get_/api/public/v2/metrics`), so SLO and dashboard queries can filter both signals identically.

Seeded with the three current-generation tracing reads that are getting SLOs: `GET /api/public/v2/observations`, `GET /api/public/v2/metrics`, `GET /api/public/v3/scores`. Add a route here when it gains an SLO.

`projectId`, `sdkName`, `sdkVersion` and `userAgent` are deliberately **not** on the metric. They stay on the log, where cardinality is free.

## Scope

Instruments `queryClickhouse` only. All three endpoints in scope reach ClickHouse through it, and its success point is unambiguous. The streaming paths (`queryClickhouseStream`, `queryClickhouseStreamRawText`, `queryClickhouseWithProgress`) are deliberately left out: a consumer can abandon a generator early, so "success" there is not well defined and would produce a wrong denominator. Worth revisiting when a streaming endpoint needs its own SLO.

## Consumer

Terraform SLOs: langfuse/infrastructure#1309. Nothing reads the metric until that merges, so this is safe to ship first — and should be, so a baseline exists before thresholds are set.

## Verification

- `pnpm --filter @langfuse/shared run test queryOutcome` — `Tests  16 passed (16)`
- `pnpm run typecheck` — `Tasks:    8 successful, 8 total`
- `pnpm run lint` — `Tasks:    7 successful, 7 total`
- Adjacent shared suites (`queryTracking`, `blobStorageExportWindow`, `traces-ui-table-service`) pass unchanged.

Not verified locally: the ClickHouse integration suites live in `web` servertests and `worker`, not in `@langfuse/shared` (which has no CH global setup), so those run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a bounded-cardinality ClickHouse query outcome metric emitted once after retries complete.

- Classifies successful queries, generic errors, timeouts, memory-limit failures, and overcommit failures.
- Normalizes three SLO-backed public API routes while grouping all other routes under `other`.
- Adds unit coverage for route normalization, resource-error mapping, and emitted metric tags.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security failures identified.

The metric is emitted once after retries, current resource-error types are fully mapped, and caller-controlled route values are constrained to an explicit allowlist or catch-all label.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[queryClickhouse] --> B[Execute with retries]
    B -->|Resolved| C[Record success outcome]
    C --> D[Return rows]
    B -->|Rejected| E[Wrap resource error]
    E --> F{Resource limit?}
    F -->|Yes| G[Record timeout, memory_limit, or overcommit]
    F -->|No| H[Record generic error]
    G --> I[Throw wrapped error]
    H --> I
    C --> J[Bound surface and route tags]
    G --> J
    H --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(shared): count ClickHouse query out..."](https://github.com/langfuse/langfuse/commit/ca76bce4af14246ff2f01671a9aced6676c4ff6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57919479)</sub>

<!-- /greptile_comment -->