### PR TITLE
feat(sessions): persist header detail visibility

### DIFF
--- a/web/src/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/components/session/ModernSessionHeader.clienttest.tsx
@@ -96,7 +96,7 @@ describe("ModernSessionHeader", () => {
       {
         action: "hide",
         detailType: "traces",
-        hiddenDetailCount: 1,
+        storedHiddenDetailCount: 1,
         isV4: true,
       },
     );
@@ -126,7 +126,7 @@ describe("ModernSessionHeader", () => {
       {
         action: "show",
         detailType: "traces",
-        hiddenDetailCount: 0,
+        storedHiddenDetailCount: 0,
         isV4: true,
       },
     );

--- a/web/src/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/components/session/ModernSessionHeader.clienttest.tsx
@@ -206,17 +206,17 @@ describe("ModernSessionHeader", () => {
         name: "Show 1 hidden session details",
       }),
     );
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Hide user 4 in session header",
-      }),
-    );
+    const hideOverflowUser = screen.getByRole("button", {
+      name: "Hide user 4 in session header",
+    });
+    hideOverflowUser.focus();
+    fireEvent.click(hideOverflowUser);
 
-    expect(
-      screen.getByRole("button", {
-        name: "Show user 4 in session header",
-      }),
-    ).toBeInTheDocument();
+    const showOverflowUser = screen.getByRole("button", {
+      name: "Show user 4 in session header",
+    });
+    expect(showOverflowUser).toBeInTheDocument();
+    expect(showOverflowUser).toHaveFocus();
     expect(
       localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
     ).not.toContain(users[3]);

--- a/web/src/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/components/session/ModernSessionHeader.clienttest.tsx
@@ -191,4 +191,34 @@ describe("ModernSessionHeader", () => {
       "traces",
     ]);
   });
+
+  it("lets overflow-only users participate in visibility preferences", () => {
+    const users = [
+      "user-1@example.com",
+      "user-2@example.com",
+      "user-3@example.com",
+      "user-4@example.com",
+    ];
+    render(<ModernSessionHeader {...defaultProps} users={users} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Show 1 hidden session details",
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Hide user 4 in session header",
+      }),
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Show user 4 in session header",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
+    ).not.toContain(users[3]);
+  });
 });

--- a/web/src/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/components/session/ModernSessionHeader.clienttest.tsx
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -75,11 +74,10 @@ describe("ModernSessionHeader", () => {
     localStorage.clear();
   });
 
-  it("hides and reveals a detail while persisting the preference", async () => {
-    const user = userEvent.setup();
+  it("hides and reveals a detail while persisting the preference", () => {
     render(<ModernSessionHeader {...defaultProps} />);
 
-    await user.click(
+    fireEvent.click(
       screen.getByRole("button", {
         name: "Hide trace and span counts in session header",
       }),
@@ -103,12 +101,12 @@ describe("ModernSessionHeader", () => {
       },
     );
 
-    await user.click(
+    fireEvent.click(
       screen.getByRole("button", {
         name: "Show 1 hidden session details",
       }),
     );
-    await user.click(
+    fireEvent.click(
       screen.getByRole("button", {
         name: "Show trace and span counts in session header",
       }),
@@ -124,13 +122,11 @@ describe("ModernSessionHeader", () => {
     ).toBe(JSON.stringify([]));
   });
 
-  it("restores hidden details from project-scoped local storage", async () => {
+  it("restores hidden details from project-scoped local storage", () => {
     localStorage.setItem(
       sessionHeaderVisibilityStorageKey("project-1"),
       JSON.stringify(["traces"]),
     );
-    const user = userEvent.setup();
-
     render(<ModernSessionHeader {...defaultProps} />);
 
     expect(
@@ -138,7 +134,7 @@ describe("ModernSessionHeader", () => {
         name: "Hide trace and span counts in session header",
       }),
     ).not.toBeInTheDocument();
-    await user.click(
+    fireEvent.click(
       screen.getByRole("button", {
         name: "Show 1 hidden session details",
       }),

--- a/web/src/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/components/session/ModernSessionHeader.clienttest.tsx
@@ -172,4 +172,23 @@ describe("ModernSessionHeader", () => {
     expect(storedValue).not.toContain(userId);
     expect(JSON.parse(storedValue ?? "[]")).toHaveLength(1);
   });
+
+  it("preserves preferences for details that are temporarily unavailable", () => {
+    const storageKey = sessionHeaderVisibilityStorageKey("project-1");
+    localStorage.setItem(storageKey, JSON.stringify(["latency"]));
+    render(
+      <ModernSessionHeader {...defaultProps} traces={{ state: "loading" }} />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Hide trace and span counts in session header",
+      }),
+    );
+
+    expect(JSON.parse(localStorage.getItem(storageKey) ?? "[]")).toEqual([
+      "latency",
+      "traces",
+    ]);
+  });
 });

--- a/web/src/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/components/session/ModernSessionHeader.clienttest.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ModernSessionHeader } from "@/src/components/session/ModernSessionHeader";
+import { sessionHeaderVisibilityStorageKey } from "@/src/components/session/sessionHeaderVisibility";
+
+const capture = vi.hoisted(() => vi.fn());
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => capture,
+}));
+
+vi.mock("@/src/components/SingleLineOverflowList", () => ({
+  SingleLineOverflowList: ({
+    items,
+    additionalOverflowCount,
+    getKey,
+    renderItem,
+    renderOverflow,
+    trailingContent,
+  }: {
+    items: readonly { key: string }[];
+    additionalOverflowCount: number;
+    getKey: (item: { key: string }) => string;
+    renderItem: (item: { key: string }) => ReactNode;
+    renderOverflow: (props: {
+      hiddenItems: readonly { key: string }[];
+      overflowItemCount: number;
+    }) => ReactNode;
+    trailingContent?: ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={getKey(item)}>{renderItem(item)}</div>
+      ))}
+      {additionalOverflowCount > 0
+        ? renderOverflow({
+            hiddenItems: [],
+            overflowItemCount: additionalOverflowCount,
+          })
+        : null}
+      {trailingContent}
+    </div>
+  ),
+}));
+
+const defaultProps = {
+  projectId: "project-1",
+  countTraces: 3,
+  traces: {
+    state: "loaded" as const,
+    data: [{ latencyMs: null, observationCount: 7 }],
+  },
+  tokensIn: 0,
+  tokensOut: 0,
+  totalTokens: 0,
+  totalCost: 0.12,
+  environment: null,
+  users: [],
+  metadataJsonPaths: {
+    paths: [],
+    source: { state: "idle" as const },
+    onEditorOpenChange: vi.fn(),
+    onSave: vi.fn(),
+    onRemove: vi.fn(),
+  },
+  scores: [],
+};
+
+describe("ModernSessionHeader", () => {
+  afterEach(() => {
+    capture.mockClear();
+    localStorage.clear();
+  });
+
+  it("hides and reveals a detail while persisting the preference", async () => {
+    const user = userEvent.setup();
+    render(<ModernSessionHeader {...defaultProps} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Hide trace and span counts in session header",
+      }),
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Hide trace and span counts in session header",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
+    ).toBe(JSON.stringify(["traces"]));
+    expect(capture).toHaveBeenCalledWith(
+      "session_detail:header_detail_visibility_changed",
+      {
+        action: "hide",
+        detailType: "traces",
+        hiddenDetailCount: 1,
+        isV4: true,
+      },
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Show 1 hidden session details",
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Show trace and span counts in session header",
+      }),
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Hide trace and span counts in session header",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
+    ).toBe(JSON.stringify([]));
+  });
+
+  it("restores hidden details from project-scoped local storage", async () => {
+    localStorage.setItem(
+      sessionHeaderVisibilityStorageKey("project-1"),
+      JSON.stringify(["traces"]),
+    );
+    const user = userEvent.setup();
+
+    render(<ModernSessionHeader {...defaultProps} />);
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Hide trace and span counts in session header",
+      }),
+    ).not.toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", {
+        name: "Show 1 hidden session details",
+      }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Show trace and span counts in session header",
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/session/ModernSessionHeader.clienttest.tsx
+++ b/web/src/components/session/ModernSessionHeader.clienttest.tsx
@@ -120,6 +120,16 @@ describe("ModernSessionHeader", () => {
     expect(
       localStorage.getItem(sessionHeaderVisibilityStorageKey("project-1")),
     ).toBe(JSON.stringify([]));
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(capture).toHaveBeenLastCalledWith(
+      "session_detail:header_detail_visibility_changed",
+      {
+        action: "show",
+        detailType: "traces",
+        hiddenDetailCount: 0,
+        isV4: true,
+      },
+    );
   });
 
   it("restores hidden details from project-scoped local storage", () => {
@@ -144,5 +154,22 @@ describe("ModernSessionHeader", () => {
         name: "Show trace and span counts in session header",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("does not persist customer identifiers in dynamic detail keys", () => {
+    const userId = "customer@example.com";
+    render(<ModernSessionHeader {...defaultProps} users={[userId]} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Hide user 1 in session header",
+      }),
+    );
+
+    const storedValue = localStorage.getItem(
+      sessionHeaderVisibilityStorageKey("project-1"),
+    );
+    expect(storedValue).not.toContain(userId);
+    expect(JSON.parse(storedValue ?? "[]")).toHaveLength(1);
   });
 });

--- a/web/src/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/components/session/ModernSessionHeader.stories.tsx
@@ -3,6 +3,7 @@ import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import preview from "../../../.storybook/preview";
 import { ModernSessionHeader } from "@/src/components/session/ModernSessionHeader";
+import { sessionHeaderVisibilityStorageKey } from "@/src/components/session/sessionHeaderVisibility";
 
 const scores = [
   {
@@ -328,5 +329,60 @@ export const TestCompactsTokenCounts = meta.story({
       "title",
       "tokens 648,714 → 6,697 (Σ 655,411)",
     );
+  },
+});
+
+export const TestHidesAndRevealsDetails = meta.story({
+  name: "(Test) Hides and reveals details",
+  args: {
+    ...defaultArgs,
+    projectId: "project-header-visibility-story",
+  },
+  play: async ({ canvasElement }) => {
+    const storageKey = sessionHeaderVisibilityStorageKey(
+      "project-header-visibility-story",
+    );
+    const storedValue = JSON.stringify([]);
+    localStorage.setItem(storageKey, storedValue);
+    window.dispatchEvent(
+      new CustomEvent("localStorageChange", {
+        detail: { key: storageKey, newValue: storedValue },
+      }),
+    );
+
+    const canvas = within(canvasElement);
+    const hideTraceDetail = await canvas.findByRole("button", {
+      name: "Hide trace and span counts in session header",
+    });
+    await userEvent.hover(canvas.getByText("traces"));
+    await expect(hideTraceDetail).toBeVisible();
+    await userEvent.click(hideTraceDetail);
+    await expect(
+      canvas.queryByRole("button", {
+        name: "Hide trace and span counts in session header",
+      }),
+    ).not.toBeInTheDocument();
+    await expect(
+      JSON.parse(localStorage.getItem(storageKey) ?? "[]"),
+    ).toContain("traces");
+
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: /show \d+ hidden session details/i,
+      }),
+    );
+    const body = within(canvasElement.ownerDocument.body);
+    const showTraceDetail = await body.findByRole("button", {
+      name: "Show trace and span counts in session header",
+    });
+    await userEvent.hover(showTraceDetail);
+    await userEvent.click(showTraceDetail);
+
+    await expect(
+      canvas.getByRole("button", {
+        name: "Hide trace and span counts in session header",
+      }),
+    ).toBeInTheDocument();
+    await expect(localStorage.getItem(storageKey)).toBe(JSON.stringify([]));
   },
 });

--- a/web/src/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/components/session/ModernSessionHeader.stories.tsx
@@ -358,7 +358,7 @@ export const TestHidesAndRevealsDetails = meta.story({
       "[data-overflow-visible-item='true']",
     );
     await expect(visibleTraceDetail).toBeInTheDocument();
-    await userEvent.hover(visibleTraceDetail!);
+    hideTraceDetail.focus();
     await waitFor(() => expect(hideTraceDetail).toBeVisible());
     await userEvent.click(hideTraceDetail);
     await expect(
@@ -379,7 +379,7 @@ export const TestHidesAndRevealsDetails = meta.story({
     const showTraceDetail = await body.findByRole("button", {
       name: "Show trace and span counts in session header",
     });
-    await userEvent.hover(showTraceDetail);
+    showTraceDetail.focus();
     await waitFor(() => expect(showTraceDetail).toBeVisible());
     await userEvent.click(showTraceDetail);
 

--- a/web/src/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/components/session/ModernSessionHeader.stories.tsx
@@ -376,12 +376,15 @@ export const TestHidesAndRevealsDetails = meta.story({
       JSON.parse(localStorage.getItem(storageKey) ?? "[]"),
     ).toContain("traces");
 
-    await userEvent.click(
-      canvas.getByRole("button", {
-        name: /show \d+ hidden session details/i,
-      }),
-    );
+    const overflowButton = canvas.getByRole("button", {
+      name: /show \d+ hidden session details/i,
+    });
+    await waitFor(() => expect(overflowButton).toHaveFocus());
+    await userEvent.click(overflowButton);
     const body = within(canvasElement.ownerDocument.body);
+    const overflowSearchInput = await body.findByRole("textbox", {
+      name: "Search session details",
+    });
     const showTraceDetail = await body.findByRole("button", {
       name: "Show trace and span counts in session header",
     });
@@ -395,5 +398,13 @@ export const TestHidesAndRevealsDetails = meta.story({
       }),
     ).toBeInTheDocument();
     await expect(localStorage.getItem(storageKey)).toBe(JSON.stringify([]));
+    const metadataEditorButton = canvas.getByRole("button", {
+      name: "Add metadata JSONPath",
+    });
+    await waitFor(() =>
+      expect([overflowSearchInput, metadataEditorButton]).toContain(
+        canvasElement.ownerDocument.activeElement,
+      ),
+    );
   },
 });

--- a/web/src/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/components/session/ModernSessionHeader.stories.tsx
@@ -359,7 +359,7 @@ export const TestHidesAndRevealsDetails = meta.story({
     );
     await expect(visibleTraceDetail).toBeInTheDocument();
     await userEvent.hover(visibleTraceDetail!);
-    await expect(hideTraceDetail).toBeVisible();
+    await waitFor(() => expect(hideTraceDetail).toBeVisible());
     await userEvent.click(hideTraceDetail);
     await expect(
       canvas.queryByRole("button", {
@@ -380,6 +380,7 @@ export const TestHidesAndRevealsDetails = meta.story({
       name: "Show trace and span counts in session header",
     });
     await userEvent.hover(showTraceDetail);
+    await waitFor(() => expect(showTraceDetail).toBeVisible());
     await userEvent.click(showTraceDetail);
 
     await expect(

--- a/web/src/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/components/session/ModernSessionHeader.stories.tsx
@@ -360,6 +360,12 @@ export const TestHidesAndRevealsDetails = meta.story({
     await expect(visibleTraceDetail).toBeInTheDocument();
     hideTraceDetail.focus();
     await waitFor(() => expect(hideTraceDetail).toBeVisible());
+    await expect(
+      hideTraceDetail.getBoundingClientRect().width,
+    ).toBeGreaterThanOrEqual(24);
+    await expect(
+      hideTraceDetail.getBoundingClientRect().height,
+    ).toBeGreaterThanOrEqual(24);
     await userEvent.click(hideTraceDetail);
     await expect(
       canvas.queryByRole("button", {

--- a/web/src/components/session/ModernSessionHeader.stories.tsx
+++ b/web/src/components/session/ModernSessionHeader.stories.tsx
@@ -354,7 +354,11 @@ export const TestHidesAndRevealsDetails = meta.story({
     const hideTraceDetail = await canvas.findByRole("button", {
       name: "Hide trace and span counts in session header",
     });
-    await userEvent.hover(canvas.getByText("traces"));
+    const visibleTraceDetail = hideTraceDetail.closest(
+      "[data-overflow-visible-item='true']",
+    );
+    await expect(visibleTraceDetail).toBeInTheDocument();
+    await userEvent.hover(visibleTraceDetail!);
     await expect(hideTraceDetail).toBeVisible();
     await userEvent.click(hideTraceDetail);
     await expect(

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, type SyntheticEvent, useRef, useState } from "react";
 import { SingleLineOverflowList } from "@/src/components/SingleLineOverflowList";
 import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
 import {
+  MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS,
   parseStoredHiddenSessionHeaderDetails,
   sessionHeaderDynamicDetailKey,
   sessionHeaderVisibilityStorageKey,
@@ -576,12 +577,6 @@ export function ModernSessionHeader({
   const manuallyHiddenPills = pills.filter((pill) =>
     hiddenDetailKeySet.has(pill.key),
   );
-  const hiddenUserDetailCount = userDetails.reduce(
-    (count, detail) => count + Number(hiddenDetailKeySet.has(detail.key)),
-    0,
-  );
-  const currentlyHiddenDetailCount =
-    manuallyHiddenPills.length + hiddenUserDetailCount;
   const changeDetailVisibility = (
     detail: SessionHeaderDetail,
     isHidden: boolean,
@@ -593,15 +588,17 @@ export function ModernSessionHeader({
     setRawHiddenDetailKeys((current: unknown) => {
       const currentKeys = parseStoredHiddenSessionHeaderDetails(current);
       return isHidden
-        ? currentKeys.concat(detail.key).slice(-1_000)
+        ? currentKeys
+            .concat(detail.key)
+            .slice(-MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS)
         : currentKeys.filter((key) => key !== detail.key);
     });
     capture("session_detail:header_detail_visibility_changed", {
       action: isHidden ? "hide" : "show",
       detailType: detail.type,
-      hiddenDetailCount: Math.max(
-        currentlyHiddenDetailCount + (isHidden ? 1 : -1),
-        0,
+      storedHiddenDetailCount: Math.min(
+        Math.max(hiddenDetailKeys.length + (isHidden ? 1 : -1), 0),
+        MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS,
       ),
       isV4: true,
     });

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -1,6 +1,6 @@
 import { percentile, type ScoreDomain } from "@langfuse/shared";
 import { ArrowUpRight, Eye, EyeOff, Plus, Search, X } from "lucide-react";
-import { type ReactNode, type SyntheticEvent, useState } from "react";
+import { type ReactNode, type SyntheticEvent, useRef, useState } from "react";
 
 import { SingleLineOverflowList } from "@/src/components/SingleLineOverflowList";
 import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
@@ -82,6 +82,8 @@ type SessionHeaderDetail = {
   content: ReactNode;
 };
 
+type SessionHeaderDetailControlLocation = "header" | "overflow";
+
 const EMPTY_HIDDEN_SESSION_HEADER_DETAILS: readonly string[] = [];
 
 const ChipValue = ({ children }: { children: React.ReactNode }) => (
@@ -122,11 +124,17 @@ const UserChip = ({ projectId, user }: { projectId: string; user: string }) => (
 const SessionHeaderDetailWithVisibilityControl = ({
   detail,
   isHidden,
+  location,
   onVisibilityChange,
 }: {
   detail: SessionHeaderDetail;
   isHidden: boolean;
-  onVisibilityChange: (detail: SessionHeaderDetail, isHidden: boolean) => void;
+  location: SessionHeaderDetailControlLocation;
+  onVisibilityChange: (
+    detail: SessionHeaderDetail,
+    isHidden: boolean,
+    location: SessionHeaderDetailControlLocation,
+  ) => void;
 }) => {
   const action = isHidden ? "Show" : "Hide";
   return (
@@ -137,7 +145,7 @@ const SessionHeaderDetailWithVisibilityControl = ({
         aria-label={`${action} ${detail.visibilityLabel} in session header`}
         title={`${action} in session header`}
         className="bg-header hover:bg-muted focus-visible:ring-ring absolute right-0 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm border opacity-0 shadow-sm transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
-        onClick={() => onVisibilityChange(detail, !isHidden)}
+        onClick={() => onVisibilityChange(detail, !isHidden, location)}
       >
         {isHidden ? (
           <Eye aria-hidden="true" className="h-3 w-3" />
@@ -335,6 +343,9 @@ export function ModernSessionHeader({
   const hiddenDetailKeys =
     parseStoredHiddenSessionHeaderDetails(rawHiddenDetailKeys);
   const hiddenDetailKeySet = new Set(hiddenDetailKeys);
+  const overflowButtonRef = useRef<HTMLButtonElement>(null);
+  const metadataEditorButtonRef = useRef<HTMLButtonElement>(null);
+  const overflowSearchInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState("");
   const [visibleUserCount, setVisibleUserCount] = useState(
     SESSION_USERS_PER_PAGE,
@@ -512,16 +523,25 @@ export function ModernSessionHeader({
     });
   }
 
-  users.slice(0, INITIAL_SESSION_USERS_DISPLAY_COUNT).forEach((user, index) => {
-    pills.push({
+  const userDetails = users.map(
+    (user, index): SessionHeaderDetail => ({
       key: sessionHeaderDynamicDetailKey("user", user),
       searchText: `user ${user}`,
       visibilityLabel: `user ${index + 1}`,
       type: "user",
       content: <UserChip projectId={projectId} user={user} />,
-    });
-  });
-  const remainingUsers = users.slice(INITIAL_SESSION_USERS_DISPLAY_COUNT);
+    }),
+  );
+  const visibleUserDetails = userDetails
+    .filter((detail) => !hiddenDetailKeySet.has(detail.key))
+    .slice(0, INITIAL_SESSION_USERS_DISPLAY_COUNT);
+  visibleUserDetails.forEach((detail) => pills.push(detail));
+  const visibleUserDetailKeySet = new Set(
+    visibleUserDetails.map((detail) => detail.key),
+  );
+  const overflowUserDetails = userDetails.filter(
+    (detail) => !visibleUserDetailKeySet.has(detail.key),
+  );
 
   metadataJsonPaths.paths.forEach((path, index) => {
     const display = getConfiguredMetadataDisplay(
@@ -547,9 +567,16 @@ export function ModernSessionHeader({
   const manuallyHiddenPills = pills.filter((pill) =>
     hiddenDetailKeySet.has(pill.key),
   );
+  const hiddenUserDetailCount = userDetails.reduce(
+    (count, detail) => count + Number(hiddenDetailKeySet.has(detail.key)),
+    0,
+  );
+  const currentlyHiddenDetailCount =
+    manuallyHiddenPills.length + hiddenUserDetailCount;
   const changeDetailVisibility = (
     detail: SessionHeaderDetail,
     isHidden: boolean,
+    location: SessionHeaderDetailControlLocation,
   ) => {
     if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
 
@@ -563,10 +590,21 @@ export function ModernSessionHeader({
       action: isHidden ? "hide" : "show",
       detailType: detail.type,
       hiddenDetailCount: Math.max(
-        manuallyHiddenPills.length + (isHidden ? 1 : -1),
+        currentlyHiddenDetailCount + (isHidden ? 1 : -1),
         0,
       ),
       isV4: true,
+    });
+    window.requestAnimationFrame(() => {
+      const preferredTarget =
+        location === "overflow"
+          ? overflowSearchInputRef.current
+          : overflowButtonRef.current;
+      (
+        preferredTarget ??
+        overflowButtonRef.current ??
+        metadataEditorButtonRef.current
+      )?.focus();
     });
   };
 
@@ -575,13 +613,14 @@ export function ModernSessionHeader({
       <SingleLineOverflowList
         items={visiblePills}
         additionalOverflowCount={
-          remainingUsers.length + manuallyHiddenPills.length
+          overflowUserDetails.length + manuallyHiddenPills.length
         }
         getKey={(pill) => pill.key}
         renderItem={(pill) => (
           <SessionHeaderDetailWithVisibilityControl
             detail={pill}
             isHidden={false}
+            location="header"
             onVisibilityChange={changeDetailVisibility}
           />
         )}
@@ -594,6 +633,7 @@ export function ModernSessionHeader({
               <ModernSessionHeaderPill
                 variant="button"
                 ariaLabel="Add metadata JSONPath"
+                ref={metadataEditorButtonRef}
               >
                 <Plus className="h-3 w-3" />
               </ModernSessionHeaderPill>
@@ -622,12 +662,14 @@ export function ModernSessionHeader({
                 pill.searchText.toLocaleLowerCase().includes(normalizedSearch),
               )
             : overflowPills;
-          const filteredUsers = normalizedSearch
-            ? remainingUsers.filter((user) =>
-                user.toLocaleLowerCase().includes(normalizedSearch),
+          const filteredUserDetails = normalizedSearch
+            ? overflowUserDetails.filter((detail) =>
+                detail.searchText
+                  .toLocaleLowerCase()
+                  .includes(normalizedSearch),
               )
-            : remainingUsers;
-          const visibleUsers = filteredUsers.slice(0, visibleUserCount);
+            : overflowUserDetails;
+          const visibleUsers = filteredUserDetails.slice(0, visibleUserCount);
           const hasResults =
             filteredPills.length > 0 || visibleUsers.length > 0;
 
@@ -643,6 +685,7 @@ export function ModernSessionHeader({
                 <ModernSessionHeaderPill
                   variant="button"
                   ariaLabel={`Show ${overflowItemCount} hidden session details`}
+                  ref={overflowButtonRef}
                 >
                   +{overflowItemCount}
                 </ModernSessionHeaderPill>
@@ -655,6 +698,7 @@ export function ModernSessionHeader({
                 <div className="relative border-b p-2">
                   <Search className="text-muted-foreground absolute top-1/2 left-4 h-3.5 w-3.5 -translate-y-1/2" />
                   <Input
+                    ref={overflowSearchInputRef}
                     value={search}
                     onChange={(event) => {
                       setSearch(event.target.value);
@@ -680,7 +724,7 @@ export function ModernSessionHeader({
                     setVisibleUserCount((current) =>
                       Math.min(
                         current + SESSION_USERS_PER_PAGE,
-                        filteredUsers.length,
+                        filteredUserDetails.length,
                       ),
                     );
                   }}
@@ -692,14 +736,17 @@ export function ModernSessionHeader({
                           key={pill.key}
                           detail={pill}
                           isHidden={hiddenDetailKeySet.has(pill.key)}
+                          location="overflow"
                           onVisibilityChange={changeDetailVisibility}
                         />
                       ))}
-                      {visibleUsers.map((user) => (
-                        <UserChip
-                          key={user}
-                          projectId={projectId}
-                          user={user}
+                      {visibleUsers.map((detail) => (
+                        <SessionHeaderDetailWithVisibilityControl
+                          key={detail.key}
+                          detail={detail}
+                          isHidden={hiddenDetailKeySet.has(detail.key)}
+                          location="overflow"
+                          onVisibilityChange={changeDetailVisibility}
                         />
                       ))}
                     </>

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -130,23 +130,21 @@ const SessionHeaderDetailWithVisibilityControl = ({
 }) => {
   const action = isHidden ? "Show" : "Hide";
   return (
-    <span className="group flex items-center">
+    <span className="group relative flex items-center [@media(hover:none)]:pr-6">
       {detail.content}
-      <span className="-ml-1 inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within:ml-1 group-focus-within:w-4 group-hover:ml-1 group-hover:w-4 [@media(hover:none)]:ml-1 [@media(hover:none)]:w-4">
-        <button
-          type="button"
-          aria-label={`${action} ${detail.visibilityLabel} in session header`}
-          title={`${action} in session header`}
-          className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
-          onClick={() => onVisibilityChange(detail, !isHidden)}
-        >
-          {isHidden ? (
-            <Eye aria-hidden="true" className="h-3 w-3" />
-          ) : (
-            <EyeOff aria-hidden="true" className="h-3 w-3" />
-          )}
-        </button>
-      </span>
+      <button
+        type="button"
+        aria-label={`${action} ${detail.visibilityLabel} in session header`}
+        title={`${action} in session header`}
+        className="bg-header hover:bg-muted focus-visible:ring-ring absolute right-0 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm border opacity-0 shadow-sm transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
+        onClick={() => onVisibilityChange(detail, !isHidden)}
+      >
+        {isHidden ? (
+          <Eye aria-hidden="true" className="h-3 w-3" />
+        ) : (
+          <EyeOff aria-hidden="true" className="h-3 w-3" />
+        )}
+      </button>
     </span>
   );
 };
@@ -549,7 +547,6 @@ export function ModernSessionHeader({
   const manuallyHiddenPills = pills.filter((pill) =>
     hiddenDetailKeySet.has(pill.key),
   );
-  const availableDetailKeySet = new Set(pills.map((pill) => pill.key));
   const changeDetailVisibility = (
     detail: SessionHeaderDetail,
     isHidden: boolean,
@@ -557,12 +554,10 @@ export function ModernSessionHeader({
     if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
 
     setRawHiddenDetailKeys((current: unknown) => {
-      const availableStoredKeys = parseStoredHiddenSessionHeaderDetails(
-        current,
-      ).filter((key) => availableDetailKeySet.has(key));
+      const currentKeys = parseStoredHiddenSessionHeaderDetails(current);
       return isHidden
-        ? availableStoredKeys.concat(detail.key)
-        : availableStoredKeys.filter((key) => key !== detail.key);
+        ? currentKeys.concat(detail.key).slice(-1_000)
+        : currentKeys.filter((key) => key !== detail.key);
     });
     capture("session_detail:header_detail_visibility_changed", {
       action: isHidden ? "hide" : "show",

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -130,14 +130,14 @@ const SessionHeaderDetailWithVisibilityControl = ({
 }) => {
   const action = isHidden ? "Show" : "Hide";
   return (
-    <span className="group/detail flex items-center">
+    <span className="group flex items-center">
       {detail.content}
-      <span className="-ml-1 inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within/detail:ml-1 group-focus-within/detail:w-4 group-hover/detail:ml-1 group-hover/detail:w-4 [@media(hover:none)]:ml-1 [@media(hover:none)]:w-4">
+      <span className="-ml-1 inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within:ml-1 group-focus-within:w-4 group-hover:ml-1 group-hover:w-4 [@media(hover:none)]:ml-1 [@media(hover:none)]:w-4">
         <button
           type="button"
           aria-label={`${action} ${detail.visibilityLabel} in session header`}
           title={`${action} in session header`}
-          className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within/detail:opacity-100 group-hover/detail:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
+          className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
           onClick={() => onVisibilityChange(detail, !isHidden)}
         >
           {isHidden ? (

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -6,6 +6,7 @@ import { SingleLineOverflowList } from "@/src/components/SingleLineOverflowList"
 import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
 import {
   parseStoredHiddenSessionHeaderDetails,
+  sessionHeaderDynamicDetailKey,
   sessionHeaderVisibilityStorageKey,
 } from "@/src/components/session/sessionHeaderVisibility";
 import {
@@ -131,12 +132,12 @@ const SessionHeaderDetailWithVisibilityControl = ({
   return (
     <span className="group/detail flex items-center">
       {detail.content}
-      <span className="-ml-1 inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within/detail:ml-1 group-focus-within/detail:w-4 group-hover/detail:ml-1 group-hover/detail:w-4">
+      <span className="-ml-1 inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within/detail:ml-1 group-focus-within/detail:w-4 group-hover/detail:ml-1 group-hover/detail:w-4 [@media(hover:none)]:ml-1 [@media(hover:none)]:w-4">
         <button
           type="button"
           aria-label={`${action} ${detail.visibilityLabel} in session header`}
           title={`${action} in session header`}
-          className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within/detail:opacity-100 group-hover/detail:opacity-100 focus-visible:ring-1 focus-visible:outline-none"
+          className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within/detail:opacity-100 group-hover/detail:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
           onClick={() => onVisibilityChange(detail, !isHidden)}
         >
           {isHidden ? (
@@ -361,28 +362,6 @@ export function ModernSessionHeader({
       isV4: true,
     });
   };
-  const changeDetailVisibility = (
-    detail: SessionHeaderDetail,
-    isHidden: boolean,
-  ) => {
-    if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
-
-    setRawHiddenDetailKeys((current: unknown) => {
-      const currentKeys = parseStoredHiddenSessionHeaderDetails(current);
-      return isHidden
-        ? currentKeys.concat(detail.key)
-        : currentKeys.filter((key) => key !== detail.key);
-    });
-    capture("session_detail:header_detail_visibility_changed", {
-      action: isHidden ? "hide" : "show",
-      detailType: detail.type,
-      hiddenDetailCount: Math.max(
-        hiddenDetailKeys.length + (isHidden ? 1 : -1),
-        0,
-      ),
-      isV4: true,
-    });
-  };
   const latencies =
     traces.state === "loaded"
       ? traces.data.flatMap((trace) =>
@@ -492,7 +471,7 @@ export function ModernSessionHeader({
     ),
   });
 
-  scores.forEach((score) => {
+  scores.forEach((score, index) => {
     const value = scoreChipValue(score);
     const isFraction =
       score.dataType === "NUMERIC" &&
@@ -501,9 +480,9 @@ export function ModernSessionHeader({
       score.value >= 0 &&
       score.value <= 1;
     pills.push({
-      key: `score-${score.id}`,
+      key: sessionHeaderDynamicDetailKey("score", score.id),
       searchText: `score ${score.name} ${value}`,
-      visibilityLabel: "score",
+      visibilityLabel: `score ${index + 1}`,
       type: "score",
       content: (
         <ModernSessionHeaderPill variant="display" title={score.name}>
@@ -535,26 +514,26 @@ export function ModernSessionHeader({
     });
   }
 
-  users.slice(0, INITIAL_SESSION_USERS_DISPLAY_COUNT).forEach((user) => {
+  users.slice(0, INITIAL_SESSION_USERS_DISPLAY_COUNT).forEach((user, index) => {
     pills.push({
-      key: `user-${user}`,
+      key: sessionHeaderDynamicDetailKey("user", user),
       searchText: `user ${user}`,
-      visibilityLabel: "user",
+      visibilityLabel: `user ${index + 1}`,
       type: "user",
       content: <UserChip projectId={projectId} user={user} />,
     });
   });
   const remainingUsers = users.slice(INITIAL_SESSION_USERS_DISPLAY_COUNT);
 
-  metadataJsonPaths.paths.forEach((path) => {
+  metadataJsonPaths.paths.forEach((path, index) => {
     const display = getConfiguredMetadataDisplay(
       path,
       metadataJsonPaths.source,
     );
     pills.push({
-      key: `metadata-${path}`,
+      key: sessionHeaderDynamicDetailKey("metadata", path),
       searchText: `metadata ${display.path} ${display.label} ${display.displayValue}`,
-      visibilityLabel: "metadata",
+      visibilityLabel: `metadata ${index + 1}`,
       type: "metadata",
       content: (
         <MetadataJsonPathPill
@@ -570,6 +549,31 @@ export function ModernSessionHeader({
   const manuallyHiddenPills = pills.filter((pill) =>
     hiddenDetailKeySet.has(pill.key),
   );
+  const availableDetailKeySet = new Set(pills.map((pill) => pill.key));
+  const changeDetailVisibility = (
+    detail: SessionHeaderDetail,
+    isHidden: boolean,
+  ) => {
+    if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
+
+    setRawHiddenDetailKeys((current: unknown) => {
+      const availableStoredKeys = parseStoredHiddenSessionHeaderDetails(
+        current,
+      ).filter((key) => availableDetailKeySet.has(key));
+      return isHidden
+        ? availableStoredKeys.concat(detail.key)
+        : availableStoredKeys.filter((key) => key !== detail.key);
+    });
+    capture("session_detail:header_detail_visibility_changed", {
+      action: isHidden ? "hide" : "show",
+      detailType: detail.type,
+      hiddenDetailCount: Math.max(
+        manuallyHiddenPills.length + (isHidden ? 1 : -1),
+        0,
+      ),
+      isV4: true,
+    });
+  };
 
   return (
     <div className="bg-header border-b px-4 py-2">

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -1,9 +1,13 @@
 import { percentile, type ScoreDomain } from "@langfuse/shared";
-import { ArrowUpRight, Plus, Search, X } from "lucide-react";
+import { ArrowUpRight, Eye, EyeOff, Plus, Search, X } from "lucide-react";
 import { type ReactNode, type SyntheticEvent, useState } from "react";
 
 import { SingleLineOverflowList } from "@/src/components/SingleLineOverflowList";
 import { ModernSessionHeaderPill } from "@/src/components/session/ModernSessionHeaderPill";
+import {
+  parseStoredHiddenSessionHeaderDetails,
+  sessionHeaderVisibilityStorageKey,
+} from "@/src/components/session/sessionHeaderVisibility";
 import {
   getMetadataJsonPathLabel,
   resolveMetadataJsonPath,
@@ -22,6 +26,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/src/components/ui/popover";
+import useLocalStorage from "@/src/components/useLocalStorage";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 import {
@@ -58,6 +63,26 @@ type ModernSessionHeaderProps = {
   >;
 };
 
+type SessionHeaderDetailType =
+  | "cost"
+  | "environment"
+  | "latency"
+  | "metadata"
+  | "score"
+  | "tokens"
+  | "traces"
+  | "user";
+
+type SessionHeaderDetail = {
+  key: string;
+  searchText: string;
+  visibilityLabel: string;
+  type: SessionHeaderDetailType;
+  content: ReactNode;
+};
+
+const EMPTY_HIDDEN_SESSION_HEADER_DETAILS: readonly string[] = [];
+
 const ChipValue = ({ children }: { children: React.ReactNode }) => (
   <span className="text-foreground">{children}</span>
 );
@@ -92,6 +117,38 @@ const UserChip = ({ projectId, user }: { projectId: string; user: string }) => (
     <ArrowUpRight className="text-link h-3 w-3 shrink-0" />
   </ModernSessionHeaderPill>
 );
+
+const SessionHeaderDetailWithVisibilityControl = ({
+  detail,
+  isHidden,
+  onVisibilityChange,
+}: {
+  detail: SessionHeaderDetail;
+  isHidden: boolean;
+  onVisibilityChange: (detail: SessionHeaderDetail, isHidden: boolean) => void;
+}) => {
+  const action = isHidden ? "Show" : "Hide";
+  return (
+    <span className="group/detail flex items-center">
+      {detail.content}
+      <span className="-ml-1 inline-flex w-0 overflow-hidden transition-[width,margin] group-focus-within/detail:ml-1 group-focus-within/detail:w-4 group-hover/detail:ml-1 group-hover/detail:w-4">
+        <button
+          type="button"
+          aria-label={`${action} ${detail.visibilityLabel} in session header`}
+          title={`${action} in session header`}
+          className="hover:bg-muted focus-visible:ring-ring inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-focus-within/detail:opacity-100 group-hover/detail:opacity-100 focus-visible:ring-1 focus-visible:outline-none"
+          onClick={() => onVisibilityChange(detail, !isHidden)}
+        >
+          {isHidden ? (
+            <Eye aria-hidden="true" className="h-3 w-3" />
+          ) : (
+            <EyeOff aria-hidden="true" className="h-3 w-3" />
+          )}
+        </button>
+      </span>
+    </span>
+  );
+};
 
 const resolveAgainstSource = (
   source: FirstVisibleObservationMetadataState,
@@ -271,6 +328,14 @@ export function ModernSessionHeader({
   scores,
 }: ModernSessionHeaderProps) {
   const capture = usePostHogClientCapture();
+  const [rawHiddenDetailKeys, setRawHiddenDetailKeys] =
+    useLocalStorage<unknown>(
+      sessionHeaderVisibilityStorageKey(projectId),
+      EMPTY_HIDDEN_SESSION_HEADER_DETAILS,
+    );
+  const hiddenDetailKeys =
+    parseStoredHiddenSessionHeaderDetails(rawHiddenDetailKeys);
+  const hiddenDetailKeySet = new Set(hiddenDetailKeys);
   const [search, setSearch] = useState("");
   const [visibleUserCount, setVisibleUserCount] = useState(
     SESSION_USERS_PER_PAGE,
@@ -296,6 +361,28 @@ export function ModernSessionHeader({
       isV4: true,
     });
   };
+  const changeDetailVisibility = (
+    detail: SessionHeaderDetail,
+    isHidden: boolean,
+  ) => {
+    if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
+
+    setRawHiddenDetailKeys((current) => {
+      const currentKeys = parseStoredHiddenSessionHeaderDetails(current);
+      return isHidden
+        ? currentKeys.concat(detail.key)
+        : currentKeys.filter((key) => key !== detail.key);
+    });
+    capture("session_detail:header_detail_visibility_changed", {
+      action: isHidden ? "hide" : "show",
+      detailType: detail.type,
+      hiddenDetailCount: Math.max(
+        hiddenDetailKeys.length + (isHidden ? 1 : -1),
+        0,
+      ),
+      isV4: true,
+    });
+  };
   const latencies =
     traces.state === "loaded"
       ? traces.data.flatMap((trace) =>
@@ -311,33 +398,36 @@ export function ModernSessionHeader({
   const p50LatencyMs = latencies.length > 0 ? percentile(latencies, 0.5) : null;
   const p95LatencyMs =
     latencies.length > 0 ? percentile(latencies, 0.95) : null;
-  const pills: Array<{ key: string; searchText: string; content: ReactNode }> =
-    [
-      {
-        key: "traces",
-        searchText: `traces ${countTraces} spans ${spanCount ?? ""}`,
-        content: (
-          <ModernSessionHeaderPill variant="display">
-            <span>
-              <ChipValue>{numberFormatter(countTraces, 0)}</ChipValue> traces
-            </span>
-            {spanCount !== null ? (
-              <>
-                <ChipDot />
-                <span>
-                  <ChipValue>{numberFormatter(spanCount, 0)}</ChipValue> spans
-                </span>
-              </>
-            ) : null}
-          </ModernSessionHeaderPill>
-        ),
-      },
-    ];
+  const pills: SessionHeaderDetail[] = [
+    {
+      key: "traces",
+      searchText: `traces ${countTraces} spans ${spanCount ?? ""}`,
+      visibilityLabel: "trace and span counts",
+      type: "traces",
+      content: (
+        <ModernSessionHeaderPill variant="display">
+          <span>
+            <ChipValue>{numberFormatter(countTraces, 0)}</ChipValue> traces
+          </span>
+          {spanCount !== null ? (
+            <>
+              <ChipDot />
+              <span>
+                <ChipValue>{numberFormatter(spanCount, 0)}</ChipValue> spans
+              </span>
+            </>
+          ) : null}
+        </ModernSessionHeaderPill>
+      ),
+    },
+  ];
 
   if (p50LatencyMs !== null) {
     pills.push({
       key: "latency",
       searchText: `latency p50 ${p50LatencyMs} p95 ${p95LatencyMs ?? ""}`,
+      visibilityLabel: "latency percentiles",
+      type: "latency",
       content: (
         <ModernSessionHeaderPill variant="display">
           <span>
@@ -365,6 +455,8 @@ export function ModernSessionHeader({
     pills.push({
       key: "tokens",
       searchText: `tokens ${tokensIn} ${tokensOut} ${totalTokens}`,
+      visibilityLabel: "token usage",
+      type: "tokens",
       content: (
         <ModernSessionHeaderPill
           variant="display"
@@ -386,6 +478,8 @@ export function ModernSessionHeader({
   pills.push({
     key: "cost",
     searchText: `cost ${totalCost}`,
+    visibilityLabel: "cost",
+    type: "cost",
     content: (
       <ModernSessionHeaderPill
         variant="display"
@@ -409,6 +503,8 @@ export function ModernSessionHeader({
     pills.push({
       key: `score-${score.id}`,
       searchText: `score ${score.name} ${value}`,
+      visibilityLabel: "score",
+      type: "score",
       content: (
         <ModernSessionHeaderPill variant="display" title={score.name}>
           {isFraction ? (
@@ -427,6 +523,8 @@ export function ModernSessionHeader({
     pills.push({
       key: "environment",
       searchText: `environment env ${environment}`,
+      visibilityLabel: "environment",
+      type: "environment",
       content: (
         <ModernSessionHeaderPill variant="display">
           <span>
@@ -441,6 +539,8 @@ export function ModernSessionHeader({
     pills.push({
       key: `user-${user}`,
       searchText: `user ${user}`,
+      visibilityLabel: "user",
+      type: "user",
       content: <UserChip projectId={projectId} user={user} />,
     });
   });
@@ -454,6 +554,8 @@ export function ModernSessionHeader({
     pills.push({
       key: `metadata-${path}`,
       searchText: `metadata ${display.path} ${display.label} ${display.displayValue}`,
+      visibilityLabel: "metadata",
+      type: "metadata",
       content: (
         <MetadataJsonPathPill
           display={display}
@@ -462,14 +564,28 @@ export function ModernSessionHeader({
       ),
     });
   });
+  const visiblePills = pills.filter(
+    (pill) => !hiddenDetailKeySet.has(pill.key),
+  );
+  const manuallyHiddenPills = pills.filter((pill) =>
+    hiddenDetailKeySet.has(pill.key),
+  );
 
   return (
     <div className="bg-header border-b px-4 py-2">
       <SingleLineOverflowList
-        items={pills}
-        additionalOverflowCount={remainingUsers.length}
+        items={visiblePills}
+        additionalOverflowCount={
+          remainingUsers.length + manuallyHiddenPills.length
+        }
         getKey={(pill) => pill.key}
-        renderItem={(pill) => pill.content}
+        renderItem={(pill) => (
+          <SessionHeaderDetailWithVisibilityControl
+            detail={pill}
+            isHidden={false}
+            onVisibilityChange={changeDetailVisibility}
+          />
+        )}
         trailingContent={
           <Popover
             open={isMetadataEditorOpen}
@@ -494,11 +610,19 @@ export function ModernSessionHeader({
         }
         renderOverflow={({ hiddenItems: hiddenPills, overflowItemCount }) => {
           const normalizedSearch = search.trim().toLocaleLowerCase();
+          const overflowPillKeys = new Set(
+            hiddenPills
+              .map((pill) => pill.key)
+              .concat(manuallyHiddenPills.map((pill) => pill.key)),
+          );
+          const overflowPills = pills.filter((pill) =>
+            overflowPillKeys.has(pill.key),
+          );
           const filteredPills = normalizedSearch
-            ? hiddenPills.filter((pill) =>
+            ? overflowPills.filter((pill) =>
                 pill.searchText.toLocaleLowerCase().includes(normalizedSearch),
               )
-            : hiddenPills;
+            : overflowPills;
           const filteredUsers = normalizedSearch
             ? remainingUsers.filter((user) =>
                 user.toLocaleLowerCase().includes(normalizedSearch),
@@ -565,7 +689,12 @@ export function ModernSessionHeader({
                   {hasResults ? (
                     <>
                       {filteredPills.map((pill) => (
-                        <div key={pill.key}>{pill.content}</div>
+                        <SessionHeaderDetailWithVisibilityControl
+                          key={pill.key}
+                          detail={pill}
+                          isHidden={hiddenDetailKeySet.has(pill.key)}
+                          onVisibilityChange={changeDetailVisibility}
+                        />
                       ))}
                       {visibleUsers.map((user) => (
                         <UserChip

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -35,6 +35,7 @@ import {
   numberFormatter,
   usdFormatter,
 } from "@/src/utils/numbers";
+import { cn } from "@/src/utils/tailwind";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 type ModernSessionHeaderProps = {
@@ -134,18 +135,26 @@ const SessionHeaderDetailWithVisibilityControl = ({
     detail: SessionHeaderDetail,
     isHidden: boolean,
     location: SessionHeaderDetailControlLocation,
+    control: HTMLButtonElement,
   ) => void;
 }) => {
   const action = isHidden ? "Show" : "Hide";
   return (
-    <span className="group relative flex items-center [@media(hover:none)]:pr-6">
+    <span
+      className={cn(
+        "group relative flex items-center",
+        detail.type === "metadata" ? "pr-6" : "[@media(hover:none)]:pr-6",
+      )}
+    >
       {detail.content}
       <button
         type="button"
         aria-label={`${action} ${detail.visibilityLabel} in session header`}
         title={`${action} in session header`}
         className="bg-header hover:bg-muted focus-visible:ring-ring absolute right-0 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm border opacity-0 shadow-sm transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:ring-1 focus-visible:outline-none [@media(hover:none)]:opacity-100"
-        onClick={() => onVisibilityChange(detail, !isHidden, location)}
+        onClick={(event) =>
+          onVisibilityChange(detail, !isHidden, location, event.currentTarget)
+        }
       >
         {isHidden ? (
           <Eye aria-hidden="true" className="h-3 w-3" />
@@ -577,6 +586,7 @@ export function ModernSessionHeader({
     detail: SessionHeaderDetail,
     isHidden: boolean,
     location: SessionHeaderDetailControlLocation,
+    control: HTMLButtonElement,
   ) => {
     if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
 
@@ -596,6 +606,8 @@ export function ModernSessionHeader({
       isV4: true,
     });
     window.requestAnimationFrame(() => {
+      if (control.isConnected) return;
+
       const preferredTarget =
         location === "overflow"
           ? overflowSearchInputRef.current

--- a/web/src/components/session/ModernSessionHeader.tsx
+++ b/web/src/components/session/ModernSessionHeader.tsx
@@ -367,7 +367,7 @@ export function ModernSessionHeader({
   ) => {
     if (hiddenDetailKeySet.has(detail.key) === isHidden) return;
 
-    setRawHiddenDetailKeys((current) => {
+    setRawHiddenDetailKeys((current: unknown) => {
       const currentKeys = parseStoredHiddenSessionHeaderDetails(current);
       return isHidden
         ? currentKeys.concat(detail.key)

--- a/web/src/components/session/sessionHeaderVisibility.ts
+++ b/web/src/components/session/sessionHeaderVisibility.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
+export const MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS = 1_000;
+
 const storedHiddenSessionHeaderDetailsSchema = z
   .array(z.string().min(1).max(2_000))
-  .max(1_000)
+  .max(MAX_STORED_HIDDEN_SESSION_HEADER_DETAILS)
   .transform((keys) => Array.from(new Set(keys)));
 
 export type StoredHiddenSessionHeaderDetails = z.infer<

--- a/web/src/components/session/sessionHeaderVisibility.ts
+++ b/web/src/components/session/sessionHeaderVisibility.ts
@@ -12,6 +12,18 @@ export type StoredHiddenSessionHeaderDetails = z.infer<
 export const sessionHeaderVisibilityStorageKey = (projectId: string) =>
   `modern-session:hidden-header-details:v1:${projectId}`;
 
+export const sessionHeaderDynamicDetailKey = (
+  type: "metadata" | "score" | "user",
+  identity: string,
+) => {
+  let fingerprint = 2_166_136_261;
+  for (let index = 0; index < identity.length; index += 1) {
+    fingerprint ^= identity.charCodeAt(index);
+    fingerprint = Math.imul(fingerprint, 16_777_619);
+  }
+  return `${type}-${(fingerprint >>> 0).toString(36)}`;
+};
+
 export const parseStoredHiddenSessionHeaderDetails = (
   raw: unknown,
 ): StoredHiddenSessionHeaderDetails => {

--- a/web/src/components/session/sessionHeaderVisibility.ts
+++ b/web/src/components/session/sessionHeaderVisibility.ts
@@ -16,12 +16,14 @@ export const sessionHeaderDynamicDetailKey = (
   type: "metadata" | "score" | "user",
   identity: string,
 ) => {
-  let fingerprint = 2_166_136_261;
+  let firstFingerprint = 2_166_136_261;
+  let secondFingerprint = 2_654_435_769;
   for (let index = 0; index < identity.length; index += 1) {
-    fingerprint ^= identity.charCodeAt(index);
-    fingerprint = Math.imul(fingerprint, 16_777_619);
+    const codeUnit = identity.charCodeAt(index);
+    firstFingerprint = Math.imul(firstFingerprint ^ codeUnit, 16_777_619);
+    secondFingerprint = Math.imul(secondFingerprint ^ codeUnit, 2_246_822_519);
   }
-  return `${type}-${(fingerprint >>> 0).toString(36)}`;
+  return `${type}-${(firstFingerprint >>> 0).toString(36)}-${(secondFingerprint >>> 0).toString(36)}`;
 };
 
 export const parseStoredHiddenSessionHeaderDetails = (

--- a/web/src/components/session/sessionHeaderVisibility.ts
+++ b/web/src/components/session/sessionHeaderVisibility.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+const storedHiddenSessionHeaderDetailsSchema = z
+  .array(z.string().min(1).max(2_000))
+  .max(1_000)
+  .transform((keys) => Array.from(new Set(keys)));
+
+export type StoredHiddenSessionHeaderDetails = z.infer<
+  typeof storedHiddenSessionHeaderDetailsSchema
+>;
+
+export const sessionHeaderVisibilityStorageKey = (projectId: string) =>
+  `modern-session:hidden-header-details:v1:${projectId}`;
+
+export const parseStoredHiddenSessionHeaderDetails = (
+  raw: unknown,
+): StoredHiddenSessionHeaderDetails => {
+  const result = storedHiddenSessionHeaderDetailsSchema.safeParse(raw);
+  return result.success ? result.data : [];
+};

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -149,6 +149,7 @@ const events = {
     "inline_tools_toggled",
     "system_prompt_toggled",
     "metadata_jsonpath_config_changed",
+    "header_detail_visibility_changed",
   ],
   eval_config: [
     "new_form_submit",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16779 app preview](https://pr-16779.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds per-detail hide and reveal controls to the modern session header. Hidden details remain searchable in the existing overflow popover, all user pills (including overflow-only users) participate, and the preference is persisted per project in versioned local storage without storing raw dynamic identifiers.

The controls support hover, keyboard focus, coarse pointers, stable 24×24 targets, and focus restoration when a toggled control unmounts.

Tracking plan: measure adoption through `session_detail:header_detail_visibility_changed` with only the action, detail category, capped stored-hidden count, and v4 flag; no session values or identifiers are captured.

Impacted package: `web`.

## Proof

<a href="https://cursor.com/agents/bc-4c3007b4-aaf6-457c-a2d5-599bc0ab24d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_header_visibility_demo.mp4"><img src="https://cursor.com/artifacts/c/art-229dbc7a-9cf9-4c2b-bfb8-eaf843a26bcf" alt="session_header_visibility_demo.mp4" /></a>

The video shows hover-to-hide, the `+1` overflow state, persistence across reload, and reveal from overflow using seeded synthetic data.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-reviewed the code

## Verification

- [x] Formatting: `All matched files use Prettier code style!`
- [x] Lint: `Tasks: 7 successful, 7 total`
- [x] Client tests: `Tests 5 passed (5)`
- [x] Chromium Storybook tests: `Tests 9 passed (9)`
- [x] Web typecheck: exit 0
- [x] Source-built stack: `Cursor Cloud Langfuse stack is healthy: 6 services, web :3000, worker :3030.`
- [x] Local browser, desktop: hide → reload persistence → reveal
- [x] Local browser, ~750px: one-line header, clickable `+N`, usable hide/reveal popover, no horizontal overflow
- [x] GitHub CI: 50 terminal checks, 39 successful, 0 failed

The final preview image built successfully, but https://pr-16779.preview.langfuse.com returned `404 preview not found`, so browser signoff used the source-built sandbox instead.

## Reproduce

Data: `pnpm run seed -- session-shapes --shape agent --json`

Sandbox: http://localhost:3000/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/sessions/session-shapes-s42-agent

Preview click path once deployment is available: open [pr-16779 app preview](https://pr-16779.preview.langfuse.com) → demo project → Sessions → any modern session → hover a header pill → hide → open `+N` → reveal.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15761](https://linear.app/clickhouse/issue/LFE-15761/modern-session-allow-users-to-hide-reveal-elements-in-session-header)

<div><a href="https://cursor.com/agents/bc-4c3007b4-aaf6-457c-a2d5-599bc0ab24d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c3007b4-aaf6-457c-a2d5-599bc0ab24d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds project-scoped persistence and analytics for hiding individual details in the modern session header.
- Adds hide and reveal controls to header details and keeps hidden details accessible through the overflow popover.
- Stores validated, deduplicated hidden-detail keys in versioned local storage.
- Registers the new visibility-change analytics event and adds client coverage for persistence and restoration.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule violations identified.

The persisted state is validated and project-scoped, the production mount remounts across project changes, and the overflow merge preserves item membership and counts.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(sessions): persist header detail vi..."](https://github.com/langfuse/langfuse/commit/c10d13f5df9b825ce0b913190a705327c173be30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57922266)</sub>

<!-- /greptile_comment -->