### PR TITLE
fix(web): Decrease error styling intensity

### DIFF
--- a/web/src/components/design-system/Badge/Badge.tsx
+++ b/web/src/components/design-system/Badge/Badge.tsx
@@ -10,8 +10,8 @@ const badgeVariants = cva(
       color: {
         primary: "bg-primary text-primary-foreground",
         neutral: "bg-tertiary text-tertiary-foreground",
-        red: "bg-light-red text-dark-red",
-        yellow: "bg-light-yellow text-dark-yellow",
+        red: "bg-light-red/60 text-dark-red/90 dark:bg-light-red/40 dark:text-dark-red/90",
+        yellow: "bg-light-yellow/80 text-dark-yellow",
         blue: "bg-light-blue text-dark-blue",
         violet: "bg-light-violet text-dark-violet",
         teal: "bg-light-teal text-dark-teal",

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -93,13 +93,14 @@ const PRETTY_JSON_VIEW_TONE_CLASSES: Record<
   { container: string; row: string; cell: string }
 > = {
   danger: {
-    container: "border-dark-red bg-light-red",
-    row: "hover:bg-light-red",
-    cell: "border-dark-red/30",
+    container:
+      "border-dark-red/30 bg-light-red/50 dark:border-dark-red/20 dark:bg-light-red/35",
+    row: "hover:bg-light-red/50 dark:hover:bg-light-red/35",
+    cell: "border-dark-red/20 dark:border-dark-red/15",
   },
   warning: {
-    container: "border-dark-yellow/40 bg-light-yellow",
-    row: "hover:bg-light-yellow",
+    container: "border-dark-yellow/40 bg-light-yellow/80",
+    row: "hover:bg-light-yellow/80",
     cell: "border-dark-yellow/20",
   },
   muted: {

--- a/web/src/features/traces/components/IOPreview/components/StatusMessageSection.tsx
+++ b/web/src/features/traces/components/IOPreview/components/StatusMessageSection.tsx
@@ -13,8 +13,9 @@ const STATUS_MESSAGE_CLASS_NAMES: Record<
   ObservationStatusMessage["level"],
   string
 > = {
-  ERROR: "border-dark-red bg-light-red",
-  WARNING: "border-dark-yellow/40 bg-light-yellow",
+  ERROR:
+    "border-dark-red/30 bg-light-red/50 dark:border-dark-red/20 dark:bg-light-red/35",
+  WARNING: "border-dark-yellow/40 bg-light-yellow/80",
   DEBUG: "border-muted-foreground/15 bg-muted/30 text-muted-foreground",
   DEFAULT: "bg-card",
 };


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16784 app preview](https://pr-16784.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR decreases the visual intensity of error and warning treatments across badges and trace status-message views.

- Adds lighter red and yellow badge backgrounds, including dark-mode-specific red styling.
- Softens danger and warning borders, backgrounds, row hover states, and cell dividers in formatted JSON views.
- Aligns unstructured trace status messages with the updated semantic styling.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete functional, accessibility, or build regression identified.

The changes are limited to supported Tailwind color-opacity utilities and preserve the existing semantic status mappings and component behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Decrease error styling intensi..."](https://github.com/langfuse/langfuse/commit/a15dc18017dd78e773582c8ebbbdcbbd04b4e35f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57928801)</sub>

<!-- /greptile_comment -->