### PR TITLE
fix(blob-export): do not start empty history exports at Unix epoch

### DIFF
--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -507,7 +507,41 @@ describe("Blob Storage Integrations API", () => {
 
       expect(response.status).toBe(200);
       expect(response.body.exportMode).toBe("FROM_CUSTOM_DATE");
-      expect(response.body.exportStartDate).toBeDefined();
+      expect(response.body.exportStartDate).toBeInstanceOf(Date);
+
+      const project = await prisma.project.findUniqueOrThrow({
+        where: { id: testProject1Id },
+        select: { createdAt: true },
+      });
+      expect(response.body.exportStartDate!.getTime()).toBeGreaterThanOrEqual(
+        project.createdAt.getTime(),
+      );
+    });
+
+    it("clamps a custom export start date older than the project createdAt", async () => {
+      const response = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...validBlobStorageConfig,
+          projectId: testProject1Id,
+          exportMode: "FROM_CUSTOM_DATE" as const,
+          exportStartDate: "1970-01-01T00:00:00Z",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+
+      const project = await prisma.project.findUniqueOrThrow({
+        where: { id: testProject1Id },
+        select: { createdAt: true },
+      });
+      expect(response.status).toBe(200);
+      expect(response.body.exportStartDate).toBeInstanceOf(Date);
+      expect(response.body.exportStartDate!.getTime()).toBe(
+        project.createdAt.getTime(),
+      );
     });
 
     it("should store secretAccessKey encrypted in database", async () => {

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -507,15 +507,14 @@ describe("Blob Storage Integrations API", () => {
 
       expect(response.status).toBe(200);
       expect(response.body.exportMode).toBe("FROM_CUSTOM_DATE");
-      expect(response.body.exportStartDate).toBeInstanceOf(Date);
 
       const project = await prisma.project.findUniqueOrThrow({
         where: { id: testProject1Id },
         select: { createdAt: true },
       });
-      expect(response.body.exportStartDate!.getTime()).toBeGreaterThanOrEqual(
-        project.createdAt.getTime(),
-      );
+      expect(
+        new Date(String(response.body.exportStartDate)).getTime(),
+      ).toBeGreaterThanOrEqual(project.createdAt.getTime());
     });
 
     it("clamps a custom export start date older than the project createdAt", async () => {
@@ -538,8 +537,7 @@ describe("Blob Storage Integrations API", () => {
         select: { createdAt: true },
       });
       expect(response.status).toBe(200);
-      expect(response.body.exportStartDate).toBeInstanceOf(Date);
-      expect(response.body.exportStartDate!.getTime()).toBe(
+      expect(new Date(String(response.body.exportStartDate)).getTime()).toBe(
         project.createdAt.getTime(),
       );
     });

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -684,6 +684,51 @@ describe("Blob Storage Integration tRPC Router", () => {
     });
   });
 
+  describe("export start date floor", () => {
+    it("clamps a custom start date older than the project createdAt", async () => {
+      const { caller, project } = await prepare();
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportMode: "FROM_CUSTOM_DATE",
+        exportStartDate: new Date("1970-01-01T00:00:00.000Z"),
+      });
+
+      const [stored, dbProject] = await Promise.all([
+        prisma.blobStorageIntegration.findUnique({
+          where: { projectId: project.id },
+        }),
+        prisma.project.findUniqueOrThrow({
+          where: { id: project.id },
+          select: { createdAt: true },
+        }),
+      ]);
+
+      expect(stored?.exportStartDate?.getTime()).toBe(
+        dbProject.createdAt.getTime(),
+      );
+    });
+
+    it("preserves a custom start date on or after the project createdAt", async () => {
+      const { caller, project } = await prepare();
+      const customDate = new Date();
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportMode: "FROM_CUSTOM_DATE",
+        exportStartDate: customDate,
+      });
+
+      const stored = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: project.id },
+      });
+
+      expect(stored?.exportStartDate?.getTime()).toBe(customDate.getTime());
+    });
+  });
+
   describe("legacy blob export source cutoff gate", () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/web/src/__tests__/server/unit/blob-storage-export-start-date.servertest.ts
+++ b/web/src/__tests__/server/unit/blob-storage-export-start-date.servertest.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { clampExportStartDateToProjectCreatedAt } from "@/src/features/blobstorage-integration/validation";
+
+describe("clampExportStartDateToProjectCreatedAt", () => {
+  const projectCreatedAt = new Date("2024-06-01T12:00:00.000Z");
+
+  it("returns null when no start date is provided", () => {
+    expect(
+      clampExportStartDateToProjectCreatedAt(null, projectCreatedAt),
+    ).toBeNull();
+  });
+
+  it("preserves a start date on or after project createdAt", () => {
+    const start = new Date("2025-01-01T00:00:00.000Z");
+    expect(
+      clampExportStartDateToProjectCreatedAt(start, projectCreatedAt),
+    ).toEqual(start);
+  });
+
+  it("floors a start date older than project createdAt", () => {
+    expect(
+      clampExportStartDateToProjectCreatedAt(
+        new Date("1970-01-01T00:00:00.000Z"),
+        projectCreatedAt,
+      ),
+    ).toEqual(projectCreatedAt);
+  });
+});

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
@@ -205,5 +205,6 @@ describe("BlobStorageIntegrationForm export start date", () => {
       "Export Start Date",
     ) as HTMLInputElement;
     expect(input.min).toBe("2024-06-15");
+    expect(input.max).toBe(new Date().toISOString().slice(0, 10));
   });
 });

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.clienttest.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
+  BlobStorageExportMode,
   BlobStorageIntegrationFileType,
   BlobStorageIntegrationType,
   LEGACY_EXPORT_PROJECT_CUTOFF,
@@ -37,12 +38,13 @@ const ui = (
   key: string,
   initialValues: BlobStorageFormValues,
   onSubmit: (values: unknown) => void = () => {},
+  ctx: ExportSourceContext = exportSourceCtx,
 ) => (
   <TooltipProvider>
     <BlobStorageIntegrationForm
       key={key}
       initialValues={initialValues}
-      exportSourceCtx={exportSourceCtx}
+      exportSourceCtx={ctx}
       persistedExportSource={null}
       isSaving={false}
       onSubmit={onSubmit}
@@ -171,5 +173,37 @@ describe("BlobStorageIntegrationForm draft lifetime (keyed remount)", () => {
       }),
       expect.anything(),
     );
+  });
+});
+
+describe("BlobStorageIntegrationForm export start date", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.hasPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
+
+  it("custom start date picker cannot go before the project createdAt", () => {
+    const projectCreatedAt = new Date("2024-06-15T12:34:56.000Z");
+    const ctx = { ...exportSourceCtx, projectCreatedAt };
+    const initialValues = {
+      ...buildBlobStorageFormValues(undefined, ctx),
+      exportMode: BlobStorageExportMode.FROM_CUSTOM_DATE,
+    };
+
+    render(ui("p1:new", initialValues, () => {}, ctx));
+
+    const input = screen.getByLabelText(
+      "Export Start Date",
+    ) as HTMLInputElement;
+    expect(input.min).toBe("2024-06-15");
   });
 });

--- a/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
+++ b/web/src/features/blobstorage-integration/components/BlobStorageIntegrationForm.tsx
@@ -84,7 +84,10 @@ export const BlobStorageIntegrationForm = ({
         onSubmit={blobStorageForm.handleSubmit(onSubmit)}
       >
         <StorageProviderFields control={control} />
-        <ExportScheduleFields control={control} />
+        <ExportScheduleFields
+          control={control}
+          projectCreatedAt={exportSourceCtx.projectCreatedAt}
+        />
         <ExportSourceField
           control={control}
           persistedExportSource={persistedExportSource}

--- a/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
+++ b/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
@@ -25,8 +25,10 @@ import { type BlobStorageFormControl } from "@/src/features/blobstorage-integrat
 // mode requires one).
 export const ExportScheduleFields = ({
   control,
+  projectCreatedAt,
 }: {
   control: BlobStorageFormControl;
+  projectCreatedAt?: Date;
 }) => {
   const watchedExportMode = useWatch({ control, name: "exportMode" });
 
@@ -135,6 +137,11 @@ export const ExportScheduleFields = ({
               <FormControl>
                 <Input
                   type="date"
+                  min={
+                    projectCreatedAt
+                      ? projectCreatedAt.toISOString().slice(0, 10)
+                      : undefined
+                  }
                   max={(() => {
                     const t = new Date();
                     return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, "0")}-${String(t.getDate()).padStart(2, "0")}`;

--- a/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
+++ b/web/src/features/blobstorage-integration/components/ExportScheduleFields.tsx
@@ -142,10 +142,7 @@ export const ExportScheduleFields = ({
                       ? projectCreatedAt.toISOString().slice(0, 10)
                       : undefined
                   }
-                  max={(() => {
-                    const t = new Date();
-                    return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, "0")}-${String(t.getDate()).padStart(2, "0")}`;
-                  })()}
+                  max={new Date().toISOString().slice(0, 10)}
                   value={
                     field.value instanceof Date
                       ? field.value.toISOString().split("T")[0]

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -11,6 +11,7 @@ import { assertPersistedExportSourceAllowed } from "@/src/features/analytics-int
 import { encrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
 import { validateBlobStorageEndpoint } from "@langfuse/shared/src/server";
+import { clampExportStartDateToProjectCreatedAt } from "@/src/features/blobstorage-integration/validation";
 
 type UpsertBlobStorageIntegrationInput = {
   type: BlobStorageIntegrationType;
@@ -92,6 +93,14 @@ export async function upsertBlobStorageIntegration(params: {
     exportStartDate: data.exportStartDate,
   });
 
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { createdAt: true },
+  });
+  if (!project) {
+    throw new InvalidRequestError("Project not found");
+  }
+
   const writeData = {
     type: data.type,
     bucketName: data.bucketName,
@@ -104,7 +113,10 @@ export async function upsertBlobStorageIntegration(params: {
     forcePathStyle: data.forcePathStyle,
     fileType: data.fileType,
     exportMode: data.exportMode,
-    exportStartDate: resolvedExportStartDate,
+    exportStartDate: clampExportStartDateToProjectCreatedAt(
+      resolvedExportStartDate,
+      project.createdAt,
+    ),
     exportSource: data.exportSource,
     exportFieldGroups: data.exportFieldGroups,
     compressed: data.compressed ?? true,

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -12,6 +12,16 @@ export function exportStartDateNotInFuture(d: Date | null | undefined) {
 export const EXPORT_START_DATE_FUTURE_ERROR =
   "Export start date must not be in the future (27 h tolerance for timezone differences)";
 
+export function clampExportStartDateToProjectCreatedAt(
+  start: Date | null,
+  projectCreatedAt: Date,
+): Date | null {
+  if (!start) return start;
+  return start.getTime() < projectCreatedAt.getTime()
+    ? projectCreatedAt
+    : start;
+}
+
 export function validateExportFieldGroups(
   data: { exportFieldGroups: unknown[] },
   ctx: z.RefinementCtx,

--- a/worker/src/__tests__/blobExportAbortObservability.unit.test.ts
+++ b/worker/src/__tests__/blobExportAbortObservability.unit.test.ts
@@ -102,6 +102,7 @@ function baseRow() {
     compressed: false,
     lastSyncAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
     createdAt: new Date("2026-01-01T00:00:00Z"),
+    project: { createdAt: new Date("2026-01-01T00:00:00Z") },
     exportTuning: null,
   };
 }

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -1648,6 +1648,167 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         expect(content).toContain(recentTrace.id);
       }
     });
+
+    it("should skip a first FULL_HISTORY export when the project has no data instead of starting at Unix epoch", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+
+      // An old empty project is the production failure mode: clamping to
+      // createdAt alone would still walk years of empty daily windows.
+      const twoYearsAgo = new Date("2024-01-15T00:00:00.000Z");
+      await prisma.project.update({
+        where: { id: projectId },
+        data: { createdAt: twoYearsAgo },
+      });
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId,
+          secretAccessKey: encrypt(secretAccessKey),
+          region: region ? region : "auto",
+          endpoint: endpoint ? endpoint : null,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "daily",
+          exportMode: "FULL_HISTORY",
+          exportStartDate: null,
+          lastSyncAt: null,
+          compressed: false,
+        },
+      });
+
+      await handleBlobStorageIntegrationProjectJob({
+        data: { payload: { projectId } },
+      } as Job);
+
+      const updatedIntegration = await prisma.blobStorageIntegration.findUnique(
+        {
+          where: { projectId },
+        },
+      );
+
+      expect(updatedIntegration?.lastSyncAt).toBeNull();
+      expect(updatedIntegration?.nextSyncAt).not.toBeNull();
+      expect(updatedIntegration?.nextSyncAt?.getUTCFullYear()).toBeGreaterThan(
+        1971,
+      );
+
+      const files = await storageService.listFiles(s3Prefix);
+      expect(
+        files.some(
+          (f) => f.file.includes("1970-") || f.file.includes("2024-01-15"),
+        ),
+      ).toBe(false);
+    });
+
+    maybeIt(
+      "should clamp a custom start date older than the project createdAt",
+      async () => {
+        const { projectId } = await createOrgProjectAndApiKey();
+        s3Prefix = projectId;
+
+        const projectCreatedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+        await prisma.project.update({
+          where: { id: projectId },
+          data: { createdAt: projectCreatedAt },
+        });
+
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId,
+            type: BlobStorageIntegrationType.S3,
+            bucketName,
+            prefix: s3Prefix,
+            accessKeyId: minioAccessKeyId,
+            secretAccessKey: encrypt(minioAccessKeySecret),
+            region: region ? region : "auto",
+            endpoint: minioEndpoint,
+            forcePathStyle:
+              env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+            enabled: true,
+            exportFrequency: "hourly",
+            exportMode: "FROM_CUSTOM_DATE" as const,
+            exportStartDate: new Date(0),
+            lastSyncAt: null,
+            compressed: false,
+          },
+        });
+
+        await handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+        const updatedIntegration =
+          await prisma.blobStorageIntegration.findUnique({
+            where: { projectId },
+          });
+
+        expect(updatedIntegration?.lastSyncAt).toBeDefined();
+        expect(
+          updatedIntegration!.lastSyncAt!.getTime(),
+        ).toBeGreaterThanOrEqual(projectCreatedAt.getTime());
+        expect(
+          updatedIntegration!.lastSyncAt!.getUTCFullYear(),
+        ).toBeGreaterThan(1971);
+      },
+    );
+
+    maybeIt(
+      "should clamp a lastSyncAt older than the project createdAt",
+      async () => {
+        const { projectId } = await createOrgProjectAndApiKey();
+        s3Prefix = projectId;
+
+        const projectCreatedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+        await prisma.project.update({
+          where: { id: projectId },
+          data: { createdAt: projectCreatedAt },
+        });
+
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId,
+            type: BlobStorageIntegrationType.S3,
+            bucketName,
+            prefix: s3Prefix,
+            accessKeyId: minioAccessKeyId,
+            secretAccessKey: encrypt(minioAccessKeySecret),
+            region: region ? region : "auto",
+            endpoint: minioEndpoint,
+            forcePathStyle:
+              env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+            enabled: true,
+            exportFrequency: "hourly",
+            exportMode: "FULL_HISTORY",
+            exportStartDate: null,
+            lastSyncAt: new Date(0),
+            compressed: false,
+          },
+        });
+
+        await handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+        const updatedIntegration =
+          await prisma.blobStorageIntegration.findUnique({
+            where: { projectId },
+          });
+
+        expect(updatedIntegration?.lastSyncAt).toBeDefined();
+        expect(
+          updatedIntegration!.lastSyncAt!.getTime(),
+        ).toBeGreaterThanOrEqual(projectCreatedAt.getTime());
+        expect(
+          updatedIntegration!.lastSyncAt!.getUTCFullYear(),
+        ).toBeGreaterThan(1971);
+      },
+    );
   });
 
   describe("Chunked historic exports", () => {

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -730,6 +730,68 @@ describe("BlobStorageIntegrationProcessingJob", () => {
   });
 
   maybeDescribe("events table export tests", () => {
+    it("starts a first FULL_HISTORY export from events-only history instead of skipping as empty", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      const now = new Date();
+      const dataTime = now.getTime() - 90 * 60 * 1000;
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId: minioAccessKeyId,
+          secretAccessKey: encrypt(minioAccessKeySecret),
+          region: region ? region : "auto",
+          endpoint: minioEndpoint,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "hourly",
+          exportMode: "FULL_HISTORY",
+          exportStartDate: null,
+          exportSource: "EVENTS",
+          lastSyncAt: null,
+          compressed: false,
+          fileType: BlobStorageIntegrationFileType.JSONL,
+        },
+      });
+
+      await createEventsCh([
+        createEvent({
+          project_id: projectId,
+          trace_id: randomUUID(),
+          type: "GENERATION",
+          name: "Events-only history",
+          start_time: dataTime * 1000,
+          end_time: (dataTime + 5000) * 1000,
+        }),
+      ]);
+
+      await handleBlobStorageIntegrationProjectJob({
+        data: { payload: { projectId } },
+      } as Job);
+
+      const updatedIntegration = await prisma.blobStorageIntegration.findUnique(
+        {
+          where: { projectId },
+        },
+      );
+
+      expect(updatedIntegration?.lastSyncAt).not.toBeNull();
+      expect(updatedIntegration?.lastSyncAt?.getUTCFullYear()).toBeGreaterThan(
+        1971,
+      );
+
+      const files = await s3StorageService.listFiles(s3Prefix);
+      expect(files.some((f) => f.file.includes("/observations_v2/"))).toBe(
+        true,
+      );
+      expect(files.some((f) => f.file.includes("1970-"))).toBe(false);
+    });
+
     it("should export traces, generations, and scores to S3", async () => {
       // Setup
       const { projectId } = await createOrgProjectAndApiKey();

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -43,7 +43,7 @@ import { randomUUID } from "crypto";
 import {
   createObservation,
   createObservationsCh,
-  createOrgProjectAndApiKey,
+  createOrgProjectAndApiKey as createOrgProjectAndApiKeyNow,
   createTraceScore,
   createSessionScore,
   createDatasetRunScore,
@@ -69,6 +69,24 @@ import {
   LEGACY_BLOB_EXPORTER_CUTOFF,
 } from "@langfuse/shared";
 import { encrypt } from "@langfuse/shared/encryption";
+
+const PROJECT_HISTORY_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Tests often set lastSyncAt / exportStartDate in the past on a freshly
+// created project. Flooring the export start at project.createdAt would
+// otherwise clamp those windows to "now" and skip the run. Age the project
+// so the fixtures predate the export cursor.
+const createOrgProjectAndApiKey = async (
+  props?: Parameters<typeof createOrgProjectAndApiKeyNow>[0],
+) => {
+  const result = await createOrgProjectAndApiKeyNow(props);
+  const createdAt = new Date(Date.now() - PROJECT_HISTORY_MS);
+  await prisma.project.update({
+    where: { id: result.projectId },
+    data: { createdAt },
+  });
+  return { ...result, project: { ...result.project, createdAt } };
+};
 
 // Skip tests that use Azurite in Azure mode due to known Azurite limitations
 // with multipart uploads. These tests use MinIO explicitly or are skipped.

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -105,6 +105,7 @@ function baseRow(exportTuning: unknown) {
     // 2h ago so minTimestamp = lastSyncAt and we skip the ClickHouse min query.
     lastSyncAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
     createdAt: new Date("2026-01-01T00:00:00Z"),
+    project: { createdAt: new Date("2026-01-01T00:00:00Z") },
     exportTuning,
   };
 }

--- a/worker/src/features/blobstorage/exportStartTimestamp.test.ts
+++ b/worker/src/features/blobstorage/exportStartTimestamp.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { BlobStorageExportMode } from "@langfuse/shared";
+import {
+  clampBlobExportStart,
+  resolveBlobExportMinTimestamp,
+} from "./exportStartTimestamp";
+
+const NOW = new Date("2026-08-28T12:00:00.000Z");
+const PROJECT_CREATED_AT = new Date("2024-06-01T00:00:00.000Z");
+const EPOCH = new Date(0);
+
+describe("clampBlobExportStart", () => {
+  it("returns the start when it is on or after project createdAt", () => {
+    const start = new Date("2025-01-01T00:00:00.000Z");
+    expect(clampBlobExportStart(start, PROJECT_CREATED_AT)).toEqual(start);
+  });
+
+  it("floors a start older than project createdAt", () => {
+    expect(clampBlobExportStart(EPOCH, PROJECT_CREATED_AT)).toEqual(
+      PROJECT_CREATED_AT,
+    );
+  });
+});
+
+describe("resolveBlobExportMinTimestamp", () => {
+  const base = {
+    exportStartDate: null as Date | null,
+    historicalMinTimestampMs: null as number | null,
+    projectCreatedAt: PROJECT_CREATED_AT,
+    now: NOW,
+  };
+
+  it("starts a first FULL_HISTORY export at now when ClickHouse has no rows", () => {
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FULL_HISTORY,
+    });
+
+    expect(result).toEqual(NOW);
+    expect(result.getTime()).not.toBe(0);
+  });
+
+  it("does not fall back to project createdAt when an old project has no data", () => {
+    // An old empty project must skip, not walk createdAt → now empty windows.
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FULL_HISTORY,
+      projectCreatedAt: new Date("2024-01-15T00:00:00.000Z"),
+    });
+
+    expect(result).toEqual(NOW);
+  });
+
+  it("uses the ClickHouse min timestamp for FULL_HISTORY when data exists", () => {
+    const min = new Date("2025-03-01T00:00:00.000Z");
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FULL_HISTORY,
+      historicalMinTimestampMs: min.getTime(),
+    });
+
+    expect(result).toEqual(min);
+  });
+
+  it("clamps a ClickHouse min timestamp older than project createdAt", () => {
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FULL_HISTORY,
+      historicalMinTimestampMs: new Date("2020-01-01T00:00:00.000Z").getTime(),
+    });
+
+    expect(result).toEqual(PROJECT_CREATED_AT);
+  });
+
+  it("treats a zero ClickHouse min timestamp as no data and starts at now", () => {
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FULL_HISTORY,
+      historicalMinTimestampMs: 0,
+    });
+
+    expect(result).toEqual(NOW);
+  });
+
+  it("clamps a custom start date older than project createdAt", () => {
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FROM_CUSTOM_DATE,
+      exportStartDate: EPOCH,
+    });
+
+    expect(result).toEqual(PROJECT_CREATED_AT);
+  });
+
+  it("preserves a custom start date on or after project createdAt", () => {
+    const custom = new Date("2025-02-01T00:00:00.000Z");
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FROM_CUSTOM_DATE,
+      exportStartDate: custom,
+    });
+
+    expect(result).toEqual(custom);
+  });
+
+  it("clamps lastSyncAt older than project createdAt", () => {
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: EPOCH,
+      exportMode: BlobStorageExportMode.FULL_HISTORY,
+    });
+
+    expect(result).toEqual(PROJECT_CREATED_AT);
+  });
+
+  it("preserves lastSyncAt on or after project createdAt", () => {
+    const lastSyncAt = new Date("2025-07-01T00:00:00.000Z");
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt,
+      exportMode: BlobStorageExportMode.FULL_HISTORY,
+    });
+
+    expect(result).toEqual(lastSyncAt);
+  });
+
+  it("uses exportStartDate for FROM_TODAY", () => {
+    const today = new Date("2026-08-28T00:00:00.000Z");
+    const result = resolveBlobExportMinTimestamp({
+      ...base,
+      lastSyncAt: null,
+      exportMode: BlobStorageExportMode.FROM_TODAY,
+      exportStartDate: today,
+    });
+
+    expect(result).toEqual(today);
+  });
+});

--- a/worker/src/features/blobstorage/exportStartTimestamp.ts
+++ b/worker/src/features/blobstorage/exportStartTimestamp.ts
@@ -1,0 +1,59 @@
+import { BlobStorageExportMode } from "@langfuse/shared";
+
+export function clampBlobExportStart(
+  start: Date,
+  projectCreatedAt: Date,
+): Date {
+  return start.getTime() < projectCreatedAt.getTime()
+    ? projectCreatedAt
+    : start;
+}
+
+/**
+ * Resolve the inclusive lower bound of a blob-export window.
+ *
+ * A first FULL_HISTORY run with no ClickHouse rows starts at `now` so the
+ * job's empty-window check skips the run. Starting at the Unix epoch would
+ * walk tens of thousands of empty daily windows into the customer's bucket.
+ *
+ * Every source — lastSyncAt, ClickHouse min(timestamp), the no-data
+ * fallback, and a user-supplied custom date — is then floored at
+ * project.createdAt. Data cannot predate the project.
+ */
+export function resolveBlobExportMinTimestamp(params: {
+  lastSyncAt: Date | null;
+  exportMode: BlobStorageExportMode;
+  exportStartDate: Date | null;
+  historicalMinTimestampMs: number | null;
+  projectCreatedAt: Date;
+  now?: Date;
+}): Date {
+  const now = params.now ?? new Date();
+  let resolved: Date;
+
+  if (params.lastSyncAt) {
+    resolved = params.lastSyncAt;
+  } else {
+    switch (params.exportMode) {
+      case BlobStorageExportMode.FULL_HISTORY: {
+        const minTimestampMs = Number(params.historicalMinTimestampMs);
+        if (minTimestampMs && minTimestampMs > 0) {
+          resolved = new Date(minTimestampMs);
+        } else {
+          resolved = now;
+        }
+        break;
+      }
+      case BlobStorageExportMode.FROM_TODAY:
+      case BlobStorageExportMode.FROM_CUSTOM_DATE:
+        resolved = params.exportStartDate ?? now;
+        break;
+      default: {
+        const _exhaustiveCheck: never = params.exportMode;
+        throw new Error(`Invalid export mode: ${_exhaustiveCheck}`);
+      }
+    }
+  }
+
+  return clampBlobExportStart(resolved, params.projectCreatedAt);
+}

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -222,6 +222,12 @@ const getMinTimestampForExport = async (
                 SELECT min(timestamp) as ts
                 FROM scores
                 WHERE project_id = {projectId: String}
+
+                UNION ALL
+
+                SELECT min(start_time) as ts
+                FROM events_core
+                WHERE project_id = {projectId: String}
               )
               WHERE ts > 0 -- Ignore 0 results (usually empty tables)
             `,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -85,6 +85,7 @@ import {
   buildBlobExportDeprecationNotice,
   buildBlobExportDeprecationNoticeKey,
 } from "./deprecationNotice";
+import { resolveBlobExportMinTimestamp } from "./exportStartTimestamp";
 
 const BlobExportFormat = {
   JSON_RAW: "json-raw",
@@ -196,19 +197,14 @@ const getMinTimestampForExport = async (
   lastSyncAt: Date | null,
   exportMode: BlobStorageExportMode,
   exportStartDate: Date | null,
+  projectCreatedAt: Date,
 ): Promise<Date> => {
-  // If we have a lastSyncAt, use it (this is for subsequent exports)
-  if (lastSyncAt) {
-    return lastSyncAt;
-  }
+  let historicalMinTimestampMs: number | null = null;
 
-  // For first export, use the export mode to determine start date
-  switch (exportMode) {
-    case BlobStorageExportMode.FULL_HISTORY:
-      // Query ClickHouse for the actual minimum timestamp from traces, observations, and scores tables
-      try {
-        const result = await queryClickhouse<{ min_timestamp: number | null }>({
-          query: `
+  if (!lastSyncAt && exportMode === BlobStorageExportMode.FULL_HISTORY) {
+    try {
+      const result = await queryClickhouse<{ min_timestamp: number | null }>({
+        query: `
               SELECT min(toUnixTimestamp(ts)) * 1000 as min_timestamp
               FROM (
                 SELECT min(timestamp) as ts
@@ -229,43 +225,60 @@ const getMinTimestampForExport = async (
               )
               WHERE ts > 0 -- Ignore 0 results (usually empty tables)
             `,
-          params: { projectId },
-        });
+        params: { projectId },
+      });
 
-        // Extract the minimum timestamp
+      logger.info(
+        `[BLOB INTEGRATION] ClickHouse min_timestamp for project ${projectId}: ${result[0]?.min_timestamp}, type: ${typeof result[0]?.min_timestamp}`,
+      );
+      const minTimestampValue = Number(result[0]?.min_timestamp);
+
+      if (minTimestampValue && minTimestampValue > 0) {
+        historicalMinTimestampMs = minTimestampValue;
+        const date = new Date(minTimestampValue);
         logger.info(
-          `[BLOB INTEGRATION] ClickHouse min_timestamp for project ${projectId}: ${result[0]?.min_timestamp}, type: ${typeof result[0]?.min_timestamp}`,
+          `[BLOB INTEGRATION] Created Date from min_timestamp for project ${projectId}: ${date}, isValid: ${!isNaN(date.getTime())}, getTime: ${date.getTime()}`,
         );
-        const minTimestampValue = Number(result[0]?.min_timestamp);
-
-        if (minTimestampValue && minTimestampValue > 0) {
-          const date = new Date(minTimestampValue);
-          logger.info(
-            `[BLOB INTEGRATION] Created Date from min_timestamp for project ${projectId}: ${date}, isValid: ${!isNaN(date.getTime())}, getTime: ${date.getTime()}`,
-          );
-          return date;
-        }
-
-        // If no data exists, use current time as a fallback
+      } else {
         logger.info(
           `[BLOB INTEGRATION] No historical data found for project ${projectId}, using current time`,
         );
-        return new Date(0);
-      } catch (error) {
-        logger.error(
-          `[BLOB INTEGRATION] Error querying ClickHouse for minimum timestamp for project ${projectId}`,
-          error,
-        );
-        throw new Error(`Failed to fetch minimum timestamp: ${error}`);
       }
-    case BlobStorageExportMode.FROM_TODAY:
-    case BlobStorageExportMode.FROM_CUSTOM_DATE:
-      return exportStartDate || new Date(); // Use export start date or current time as fallback
-    default:
-      // eslint-disable-next-line no-case-declarations
-      const _exhaustiveCheck: never = exportMode;
-      throw new Error(`Invalid export mode: ${exportMode}`);
+    } catch (error) {
+      logger.error(
+        `[BLOB INTEGRATION] Error querying ClickHouse for minimum timestamp for project ${projectId}`,
+        error,
+      );
+      throw new Error(`Failed to fetch minimum timestamp: ${error}`);
+    }
   }
+
+  const minTimestamp = resolveBlobExportMinTimestamp({
+    lastSyncAt,
+    exportMode,
+    exportStartDate,
+    historicalMinTimestampMs,
+    projectCreatedAt,
+  });
+
+  if (minTimestamp.getTime() === projectCreatedAt.getTime()) {
+    const unclampedSource = lastSyncAt ?? exportStartDate;
+    const historicalIsBeforeFloor =
+      historicalMinTimestampMs != null &&
+      historicalMinTimestampMs > 0 &&
+      historicalMinTimestampMs < projectCreatedAt.getTime();
+    if (
+      historicalIsBeforeFloor ||
+      (unclampedSource != null &&
+        unclampedSource.getTime() < projectCreatedAt.getTime())
+    ) {
+      logger.info(
+        `[BLOB INTEGRATION] Clamping export start to project createdAt ${projectCreatedAt.toISOString()} for project ${projectId}`,
+      );
+    }
+  }
+
+  return minTimestamp;
 };
 
 /**
@@ -1196,6 +1209,11 @@ export const handleBlobStorageIntegrationProjectJob = async (
       where: {
         projectId,
       },
+      include: {
+        project: {
+          select: { createdAt: true },
+        },
+      },
     },
   );
 
@@ -1234,6 +1252,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
     blobStorageIntegration.lastSyncAt,
     blobStorageIntegration.exportMode,
     blobStorageIntegration.exportStartDate,
+    blobStorageIntegration.project.createdAt,
   );
 
   logger.info(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16787 app preview](https://pr-16787.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

A first `FULL_HISTORY` blob-storage export for a project with no ClickHouse rows used to fall through to `new Date(0)` (Unix epoch). The worker then walked daily 24h windows from 1970 to now and uploaded tens of thousands of empty Parquet files to the customer bucket.

This change:

- Starts a first `FULL_HISTORY` export at **now** when there is no data, so the existing empty-window check skips the run instead of backfilling from 1970.
- Floors every resolved start date at `project.createdAt` (`lastSyncAt`, ClickHouse `min(timestamp)`, and user-supplied custom dates).
- Includes `events_core` in that first-export min probe so events-only projects are not treated as empty.
- Clamps persisted custom start dates to the same floor in the tRPC/public-API upsert path, and sets the date picker's `min`/`max` to UTC calendar days.

Clamping `lastSyncAt` also recovers in-progress epoch backfills on the next run.

No PostHog event: this is a start-date clamp, not a new user action.

Preview: [pr-16787 app preview](https://pr-16787.preview.langfuse.com)

![Custom start date picker disables days before the project createdAt](https://cursor.com/artifacts/c/art-91c0698b-8663-44b6-96e5-cae76ac508f9)

<a href="https://cursor.com/agents/bc-54becbf6-050b-4003-858e-ac0a91eb2ffd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblob_export_date_picker_blocks_dates_before_createdAt.mp4"><img src="https://cursor.com/artifacts/c/art-e2323178-38e6-409c-ac13-e995a5052f95" alt="blob_export_date_picker_blocks_dates_before_createdAt.mp4" /></a>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `worker` — start-date resolution and first-export skip
- `web` — upsert clamp + date-picker `min`/`max`

## Verification

- `pnpm --filter worker run test exportStartTimestamp.test.ts` — 12 passed
- `pnpm --filter worker run test blobStorageIntegrationProcessing.test.ts` — 40 passed
- `pnpm --filter worker run test blobStorageTuningWiring.unit.test.ts blobExportAbortObservability.unit.test.ts` — 4 passed
- `pnpm --filter web run test blob-storage-export-start-date.servertest.ts` — 3 passed
- `pnpm --filter web run test-client BlobStorageIntegrationForm.clienttest.tsx` — 6 passed
- Pre-commit turbo lint: Tasks: 7 successful, 7 total
- Browser: custom date picker `min` is the project createdAt day; earlier calendar days are disabled

## Test this

1. Open **Settings → Integrations → Blob Storage**.
2. Set export mode to **Custom date**.
3. Confirm the date picker cannot go before the project's creation day.
4. Saving a custom date of 1970 via API should persist `project.createdAt`, not the epoch.

Sandbox: same path on `http://localhost:3000` after the cloud stack is up. Demo project is enough.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Code follows the style guidelines of this project
- Tests cover the no-data `FULL_HISTORY` skip, events-only first export, `createdAt` floor, and custom-date clamp

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15762](https://linear.app/clickhouse/issue/LFE-15762/blob-storage-export-starts-at-unix-epoch-1970-for-projects-with-no)

<div><a href="https://cursor.com/agents/bc-54becbf6-050b-4003-858e-ac0a91eb2ffd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54becbf6-050b-4003-858e-ac0a91eb2ffd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents empty first-time FULL_HISTORY blob exports from starting at Unix epoch and floors export cursors and custom dates at project creation.
- Resolves empty-history exports to the current time so the worker skips the empty window.
- Clamps worker and persisted web/API start dates to project.createdAt.
- Adds a project-creation minimum to the custom-date picker and expands worker, API, tRPC, and unit coverage.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until first-time EVENTS exports account for event-table history instead of repeatedly treating populated projects as empty.

The new now fallback combines with a historical-minimum query that excludes events_core, causing reachable event-only FULL_HISTORY integrations to skip forever without advancing their cursor.

**Files Needing Attention:** worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts; worker/src/features/blobstorage/exportStartTimestamp.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Scheduled blob export] --> B{lastSyncAt exists?}
  B -->|Yes| C[Clamp cursor to project.createdAt]
  B -->|No, FULL_HISTORY| D[Query historical minimum]
  D --> E{Minimum found?}
  E -->|Yes| F[Clamp minimum to project.createdAt]
  E -->|No| G[Resolve start to now]
  C --> H[Build bounded export window]
  F --> H
  G --> H
  H --> I{Window non-empty?}
  I -->|No| J[Schedule next run]
  I -->|Yes| K[Export selected tables]
  K --> L[Write manifest and advance cursor]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:207-227
**Event history is treated empty**

When a first `FULL_HISTORY` export uses the `EVENTS` source on an events-only deployment and the project has tracing events but no scores, this query finds no minimum because it excludes the events table. The new `now` fallback then skips every run without advancing `lastSyncAt`, so the project's historical events are never exported.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(blob-export): age fixture projects ..."](https://github.com/langfuse/langfuse/commit/834b462f9e267737c8dd7bcaacc5c7b5d030d891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57933807)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Media and blob processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/media-and-blob-processing.md)

<!-- /greptile_comment -->