### PR TITLE
fix(otel): denormalize AI-feature child trace names for cost filters

### DIFF
--- a/packages/shared/src/server/llm/ai-sdk/telemetry.ts
+++ b/packages/shared/src/server/llm/ai-sdk/telemetry.ts
@@ -23,8 +23,10 @@ import type { TelemetryOptions } from "ai";
 import { stringifyValue } from "../../../utils/stringChecks";
 import { traceException } from "../../instrumentation";
 import { logger } from "../../logger";
-import { LangfuseOtelSpanAttributes } from "../../otel/attributes";
-import { AI_FEATURE_OTEL_SDK_NAME } from "../../otel/internalAiFeatureOtelWriter";
+import {
+  AI_FEATURE_OTEL_SDK_NAME,
+  LangfuseOtelSpanAttributes,
+} from "../../otel/attributes";
 import { publishInternalOtelSpans } from "../../otel/internalTraceOtelWriter";
 import type { InternalTraceExperimentContext } from "../internalTraceEvents";
 import type { TraceSinkParams } from "../types";

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -27,7 +27,10 @@ import {
   LangfuseInternalTraceEnvironment,
 } from "../";
 
-import { LangfuseOtelSpanAttributes } from "./attributes";
+import {
+  AI_FEATURE_OTEL_SDK_NAME,
+  LangfuseOtelSpanAttributes,
+} from "./attributes";
 import { ObservationTypeMapperRegistry } from "./ObservationTypeMapper";
 import { env } from "../../env";
 import { OtelIngestionQueue } from "../redis/otelIngestionQueue";
@@ -383,7 +386,7 @@ export class OtelIngestionProcessor {
           return [];
         }
 
-        return resourceSpans
+        const events = resourceSpans
           .filter((r) => Boolean(r))
           .flatMap((resourceSpan) => {
             const resourceAttributes =
@@ -672,6 +675,12 @@ export class OtelIngestionProcessor {
 
             return events;
           });
+
+        if (this.sdkName === AI_FEATURE_OTEL_SDK_NAME) {
+          this.denormalizeAiFeatureChildTraceNames(events);
+        }
+
+        return events;
       } catch (error) {
         logger.error("Error processing OTEL spans to events:", {
           error,
@@ -681,6 +690,45 @@ export class OtelIngestionProcessor {
         throw error;
       }
     });
+  }
+
+  /**
+   * Copy the wrapping root's observation.traceName onto sibling events in the
+   * same batch that omitted langfuse.trace.name. That OTEL attribute is a
+   * trace-update signal; filling the events-table field keeps cost-by-trace-name
+   * filters working without rewriting the trace.
+   */
+  private denormalizeAiFeatureChildTraceNames(
+    events: Array<{
+      traceId?: string;
+      traceName?: string | null;
+      parentSpanId?: string | null;
+      isAppRoot?: boolean;
+    }>,
+  ): void {
+    const traceNameByTraceId = new Map<string, string>();
+
+    for (const event of events) {
+      if (!event.traceId || !event.traceName) {
+        continue;
+      }
+
+      const isRoot = !event.parentSpanId || event.isAppRoot === true;
+      if (isRoot) {
+        traceNameByTraceId.set(event.traceId, event.traceName);
+      }
+    }
+
+    for (const event of events) {
+      if (event.traceName || !event.traceId) {
+        continue;
+      }
+
+      const traceName = traceNameByTraceId.get(event.traceId);
+      if (traceName !== undefined) {
+        event.traceName = traceName;
+      }
+    }
   }
 
   /**

--- a/packages/shared/src/server/otel/attributes.ts
+++ b/packages/shared/src/server/otel/attributes.ts
@@ -52,3 +52,6 @@ export enum LangfuseOtelSpanAttributes {
   EXPERIMENT_ITEM_ROOT_OBSERVATION_ID = "langfuse.experiment.item.root_observation_id",
   EXPERIMENT_ITEM_EXPECTED_OUTPUT = "langfuse.experiment.item.expected_output",
 }
+
+/** SDK name for internally published AI-feature product traces. */
+export const AI_FEATURE_OTEL_SDK_NAME = "langfuse-internal-ai-features";

--- a/packages/shared/src/server/otel/internalAiFeatureOtelWriter.test.ts
+++ b/packages/shared/src/server/otel/internalAiFeatureOtelWriter.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildInternalTraceEventInputs } from "../llm/internalTraceEvents";
+import { LangfuseOtelSpanAttributes } from "./attributes";
 import {
   AI_FEATURE_OTEL_SDK_NAME,
   publishAiFeatureTraceViaOtelIngestion,
@@ -91,9 +92,23 @@ const processedEvents = [
   },
 ];
 
-const processPublishedSpans = async () => {
+const getPublishedResourceSpans = () => {
   expect(publishToOtelIngestionQueue).toHaveBeenCalledTimes(1);
-  const resourceSpans = publishToOtelIngestionQueue.mock.calls[0][0];
+  return publishToOtelIngestionQueue.mock.calls[0][0];
+};
+
+const spanAttributeMap = (span: {
+  attributes?: Array<{ key: string; value: { stringValue?: string } }>;
+}) =>
+  Object.fromEntries(
+    (span.attributes ?? []).map((attribute) => [
+      attribute.key,
+      attribute.value.stringValue,
+    ]),
+  );
+
+const processPublishedSpans = async (sdkName = AI_FEATURE_OTEL_SDK_NAME) => {
+  const resourceSpans = getPublishedResourceSpans();
 
   const { OtelIngestionProcessor } = await vi.importActual<
     typeof import("./OtelIngestionProcessor")
@@ -101,11 +116,24 @@ const processPublishedSpans = async () => {
   return new OtelIngestionProcessor({
     projectId: "project-1",
     publicKey: "",
-    sdkName: AI_FEATURE_OTEL_SDK_NAME,
+    sdkName,
     sdkVersion: "unknown",
     ingestionVersion: "4",
     isLangfuseInternal: false,
   }).processToEvent(resourceSpans);
+};
+
+const publishFixture = async () => {
+  const { eventInputs } = buildInternalTraceEventInputs({
+    processedEvents,
+    traceId: TRACE_ID,
+    projectId: "project-1",
+  });
+
+  await publishAiFeatureTraceViaOtelIngestion({
+    projectId: "project-1",
+    eventInputs,
+  });
 };
 
 beforeEach(() => {
@@ -114,16 +142,7 @@ beforeEach(() => {
 
 describe("publishAiFeatureTraceViaOtelIngestion", () => {
   it("preserves agent and tool observation types from SDK event types", async () => {
-    const { eventInputs } = buildInternalTraceEventInputs({
-      processedEvents,
-      traceId: TRACE_ID,
-      projectId: "project-1",
-    });
-
-    await publishAiFeatureTraceViaOtelIngestion({
-      projectId: "project-1",
-      eventInputs,
-    });
+    await publishFixture();
 
     expect(processorConstructor).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -147,6 +166,7 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
       traceId: TRACE_ID,
       parentSpanId: null,
       name: "agent-turn",
+      traceName: "agent-turn",
       type: "SPAN",
       environment: "production",
       userId: "user-1",
@@ -159,6 +179,7 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
       traceId: TRACE_ID,
       parentSpanId: TRACE_ID,
       name: "agent-turn",
+      traceName: "agent-turn",
       type: "AGENT",
       environment: "production",
     });
@@ -166,6 +187,7 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
       traceId: TRACE_ID,
       parentSpanId: RUN_ID,
       name: "invoke-model",
+      traceName: "agent-turn",
       type: "GENERATION",
       environment: "production",
       modelName: "claude-opus",
@@ -176,6 +198,7 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
       traceId: TRACE_ID,
       parentSpanId: RUN_ID,
       name: "langfuse_listPrompts",
+      traceName: "agent-turn",
       type: "TOOL",
       environment: "production",
       userId: "user-1",
@@ -185,6 +208,74 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
       input: 10,
       output: 5,
       total: 15,
+    });
+  });
+
+  it("keeps langfuse.trace.name on the wrapping root only", async () => {
+    await publishFixture();
+
+    const spans = getPublishedResourceSpans().flatMap((resourceSpan: any) =>
+      resourceSpan.scopeSpans.flatMap((scopeSpan: any) => scopeSpan.spans),
+    );
+    const root = spans.find((span: any) => !span.parentSpanId);
+    const children = spans.filter((span: any) => span.parentSpanId);
+
+    expect(spanAttributeMap(root)[LangfuseOtelSpanAttributes.TRACE_NAME]).toBe(
+      "agent-turn",
+    );
+    expect(children).toHaveLength(3);
+    for (const child of children) {
+      expect(
+        spanAttributeMap(child)[LangfuseOtelSpanAttributes.TRACE_NAME],
+      ).toBe(undefined);
+    }
+  });
+
+  it("does not copy the batch-root traceName onto children for other SDK names", async () => {
+    await publishFixture();
+
+    const events = await processPublishedSpans("langfuse-internal-otel-writer");
+    const wrappingRoot = events.find((event) => event.spanId === TRACE_ID);
+    const generation = events.find(
+      (event) => event.spanId === `${RUN_ID}-llm-0`,
+    );
+
+    expect(wrappingRoot?.traceName).toBe("agent-turn");
+    expect(generation?.name).toBe("invoke-model");
+    expect(generation?.traceName).toBeNull();
+  });
+
+  it("does not emit named trace-create rewrites from child spans", async () => {
+    await publishFixture();
+
+    const resourceSpans = getPublishedResourceSpans();
+    const { OtelIngestionProcessor } = await vi.importActual<
+      typeof import("./OtelIngestionProcessor")
+    >("./OtelIngestionProcessor");
+    const processor = new OtelIngestionProcessor({
+      projectId: "project-1",
+      publicKey: "",
+      sdkName: AI_FEATURE_OTEL_SDK_NAME,
+      sdkVersion: "unknown",
+      ingestionVersion: "4",
+      isLangfuseInternal: false,
+    });
+    vi.spyOn(
+      processor as unknown as { getSeenTracesSet: () => Promise<Set<string>> },
+      "getSeenTracesSet",
+    ).mockResolvedValue(new Set());
+
+    const events = await processor.processToIngestionEvents(resourceSpans);
+    const namedTraceCreates = events.filter(
+      (event) =>
+        event.type === "trace-create" &&
+        Boolean((event.body as { name?: string }).name),
+    );
+
+    expect(namedTraceCreates).toHaveLength(1);
+    expect(namedTraceCreates[0]?.body).toMatchObject({
+      id: TRACE_ID,
+      name: "agent-turn",
     });
   });
 

--- a/packages/shared/src/server/otel/internalAiFeatureOtelWriter.test.ts
+++ b/packages/shared/src/server/otel/internalAiFeatureOtelWriter.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildInternalTraceEventInputs } from "../llm/internalTraceEvents";
-import { LangfuseOtelSpanAttributes } from "./attributes";
 import {
   AI_FEATURE_OTEL_SDK_NAME,
-  publishAiFeatureTraceViaOtelIngestion,
-} from "./internalAiFeatureOtelWriter";
+  LangfuseOtelSpanAttributes,
+} from "./attributes";
+import { publishAiFeatureTraceViaOtelIngestion } from "./internalAiFeatureOtelWriter";
 
 const publishToOtelIngestionQueue = vi.fn().mockResolvedValue(undefined);
 const processorConstructor = vi.fn();

--- a/packages/shared/src/server/otel/internalAiFeatureOtelWriter.ts
+++ b/packages/shared/src/server/otel/internalAiFeatureOtelWriter.ts
@@ -4,8 +4,9 @@ import {
   internalTraceEventToOtelAttributes,
   publishOtelResourceSpans,
 } from "./internalTraceOtelWriter";
+import { AI_FEATURE_OTEL_SDK_NAME } from "./attributes";
 
-export const AI_FEATURE_OTEL_SDK_NAME = "langfuse-internal-ai-features";
+export { AI_FEATURE_OTEL_SDK_NAME };
 const AI_FEATURE_OTEL_SCOPE = "langfuse-ai-features-writer";
 const AI_FEATURE_SERVICE_NAME = "langfuse-ai-features";
 

--- a/packages/shared/src/server/otel/internalAiFeatureOtelWriter.ts
+++ b/packages/shared/src/server/otel/internalAiFeatureOtelWriter.ts
@@ -1,12 +1,11 @@
 import type { InternalTraceEventInput } from "../llm/internalTraceEvents";
 import { type ResourceSpan } from "./OtelIngestionProcessor";
+import { AI_FEATURE_OTEL_SDK_NAME } from "./attributes";
 import {
   internalTraceEventToOtelAttributes,
   publishOtelResourceSpans,
 } from "./internalTraceOtelWriter";
-import { AI_FEATURE_OTEL_SDK_NAME } from "./attributes";
 
-export { AI_FEATURE_OTEL_SDK_NAME };
 const AI_FEATURE_OTEL_SCOPE = "langfuse-ai-features-writer";
 const AI_FEATURE_SERVICE_NAME = "langfuse-ai-features";
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16793 app preview](https://pr-16793.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

AI-feature OTel batches only set `langfuse.trace.name` on the wrapping root. Child generations (`invoke-model`) therefore landed with `traceName: null`, so metrics filtered by `traceName = agent-turn` under-reported spend.

This copies the batch-root `traceName` onto sibling events in `processToEvent` when the processor SDK name is `langfuse-internal-ai-features`. It does **not** emit `langfuse.trace.name` on children. That attribute is a trace-update signal (`hasTraceUpdates`) and would rewrite the trace on the legacy `processToIngestionEvents` path.

Historical OTel-ingested Assistant rows stay unnamed. Only new traces get the denormalized field.

Impacted package: `@langfuse/shared`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Code follows the style guidelines of this project (`pnpm run format` via pre-commit)
- Tests prove child `observation.traceName` is filled after `processToEvent`, published OTLP still omits `langfuse.trace.name` on children, and other SDK names are unchanged
- `pnpm --filter @langfuse/shared run test internalAiFeatureOtelWriter.test.ts internalTraceOtelWriter.test.ts OtelIngestionProcessor.modelParameters.test.ts OtelIngestionProcessor.metadataDropped.test.ts` — Tests 37 passed (37)
- `pnpm --filter @langfuse/shared run lint` — no warnings
- Pre-commit `turbo run lint` — Tasks: 7 successful, 7 total

## Test this

Preview: `https://pr-<N>.preview.langfuse.com` (after the preview is up)

1. In a demo project, run an in-app agent turn that calls a model.
2. Open Traces / Observations and confirm child `invoke-model` rows share `traceName = agent-turn` with the wrapping root.
3. Run metrics filtered by `traceName = agent-turn` and confirm invoke-model cost is included.

Sandbox: same path on `http://localhost:3000` after the cloud stack is up. Data: demo project / a live agent turn is enough; historical unnamed rows will not change.

Skipped: browser UI signoff — this is an ingestion-field fill, not a UI change. Proof is the writer + processor tests above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ad34f6d-ae33-4973-bbc0-67e1717f1cf9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ad34f6d-ae33-4973-bbc0-67e1717f1cf9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR denormalizes the wrapping AI-feature trace name onto child observation events so trace-name cost filters include their spend, while retaining the root-only OTLP trace-update attribute.

- Centralizes the internal AI-feature SDK-name constant.
- Applies trace-name propagation only to events attributed to the AI-feature SDK.
- Adds coverage for child denormalization, unchanged behavior for other SDKs, and avoidance of child trace-create rewrites.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The AI-feature publisher keeps each root and its children in one ingestion payload, preserves the exact SDK attribution used by the new gate, and the added tests cover both denormalization and avoidance of trace-update side effects.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[AI-feature trace events] --> B[OTLP resource spans]
    B --> C[Single ingestion queue job]
    C --> D[processToEvent]
    D --> E{AI-feature SDK?}
    E -- Yes --> F[Find named wrapping root by trace ID]
    F --> G[Copy traceName to unnamed child observations]
    E -- No --> H[Leave observation traceName unchanged]
    G --> I[Persist normalized events]
    H --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): denormalize AI-feature child ..."](https://github.com/langfuse/langfuse/commit/efca59aa1daae984cd6ecd07f1f8b6860760a6db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57954671)</sub>

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->