### PR TITLE
fix(chatml): preserve all output_text segments

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -291,15 +291,16 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
     Array.isArray(normalized.content) &&
     normalized.content.length > 0
   ) {
-    const firstItem = normalized.content[0];
-    if (
-      firstItem &&
-      typeof firstItem === "object" &&
-      (firstItem as Record<string, unknown>).type === "output_text" &&
-      typeof (firstItem as Record<string, unknown>).text === "string"
-    ) {
-      // Extract just the text for simple output
-      normalized.content = (firstItem as Record<string, unknown>).text;
+    const outputTextItems = normalized.content.filter(
+      (item): item is Record<string, unknown> =>
+        Boolean(item) &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "output_text" &&
+        typeof (item as Record<string, unknown>).text === "string",
+    );
+
+    if (outputTextItems.length === normalized.content.length) {
+      normalized.content = outputTextItems.map((item) => item.text).join("");
     }
   }
 

--- a/worker/src/__tests__/chatml/adapters/openai.test.ts
+++ b/worker/src/__tests__/chatml/adapters/openai.test.ts
@@ -314,6 +314,43 @@ describe("OpenAI Adapter", () => {
 
       expect(result.data?.[0].content).toBe("Hello");
     });
+
+    it("should preserve every output_text content segment", () => {
+      const output = {
+        output: [
+          {
+            content: [
+              { type: "output_text", text: "The capital is Paris." },
+              {
+                type: "output_text",
+                text: " It is known for the Eiffel Tower.",
+              },
+            ],
+            role: "assistant",
+          },
+        ],
+      };
+
+      const result = normalizeOutput(output, { framework: "openai" });
+
+      expect(result.data?.[0].content).toBe(
+        "The capital is Paris. It is known for the Eiffel Tower.",
+      );
+    });
+
+    it("should preserve mixed content arrays", () => {
+      const content = [
+        { type: "output_text", text: "I cannot help with that." },
+        { type: "refusal", refusal: "Policy restriction" },
+      ];
+      const output = {
+        output: [{ content, role: "assistant" }],
+      };
+
+      const result = normalizeOutput(output, { framework: "openai" });
+
+      expect(result.data?.[0].content).toEqual(content);
+    });
   });
 
   describe("Responses API request format", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #16455.

The OpenAI ChatML adapter currently replaces a content array with only the first `output_text` value. Responses API messages can contain several annotated text segments, so everything after the first segment disappears from the normalized trace.

This change joins every text value when the content array consists entirely of valid `output_text` parts. Mixed arrays keep their original shape so refusal or other non-text parts are not silently discarded.

This independently revives the narrowly scoped fix from the voluntarily closed #16456; thanks to @feiiiiii5 for the earlier investigation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] I have self-reviewed the code.

## Testing

- Added regression coverage for multiple `output_text` segments.
- Added coverage proving mixed content arrays remain unchanged.
- `git diff --check` passed.
- Prettier passed for both changed files.
- The targeted Vitest run could not start locally because the workspace's first `pnpm install` hit a Windows `EPERM` rename for `next-auth`; a cached retry stalled during dependency linking. CI is expected to run the repository test matrix.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes OpenAI Responses API normalization so every valid `output_text` segment is retained while mixed content arrays remain structured.

- Replaces first-segment extraction with all-segment concatenation when every content item is valid `output_text`.
- Adds regression tests for multipart text and mixed text/refusal content.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The updated normalization preserves all text segments only for homogeneous valid output-text arrays, retains mixed arrays unchanged, and follows the concatenation behavior used by sibling adapters.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chatml): preserve all output\_text se..."](https://github.com/langfuse/langfuse/commit/c584732574b2409fc5b9d23929b5c93262d6231b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57977584)</sub>

<!-- /greptile_comment -->