### PR TITLE
fix(billing): read the CHB checkout URL from checkoutUrl

### DIFF
--- a/web/src/__tests__/server/chbCheckoutClaim.servertest.ts
+++ b/web/src/__tests__/server/chbCheckoutClaim.servertest.ts
@@ -84,7 +84,7 @@ describe("chbBillingService checkout claim (postgres)", () => {
       data: { id: orgId, name: "CHB Claim Test Org" },
     });
     vi.mocked(clientMock.createCheckoutSession).mockResolvedValue({
-      url: "https://billing.clickhouse.test/checkout/abc",
+      checkoutUrl: "https://billing.clickhouse.test/checkout/abc",
       organizationId: chOrganizationId,
     } satisfies ChbCheckoutSession);
   });
@@ -178,7 +178,7 @@ describe("chbBillingService checkout claim (postgres)", () => {
     // CHB hands back a different org for a request that asked to reuse one:
     // sticky routing is broken, so checkout must refuse rather than clobber.
     vi.mocked(clientMock.createCheckoutSession).mockResolvedValue({
-      url: "https://billing.clickhouse.test/checkout/def",
+      checkoutUrl: "https://billing.clickhouse.test/checkout/def",
       organizationId: randomUUID(),
     } satisfies ChbCheckoutSession);
 

--- a/web/src/__tests__/server/unit/chbApiClient.servertest.ts
+++ b/web/src/__tests__/server/unit/chbApiClient.servertest.ts
@@ -218,7 +218,7 @@ describe("chbApiClient", () => {
 
       onChb(
         jsonResponse(200, {
-          url: "https://pay.example.com/c/1",
+          checkoutUrl: "https://pay.example.com/c/1",
           organizationId: CH_ORG_ID,
         }),
       );
@@ -371,6 +371,26 @@ describe("chbApiClient", () => {
       expect(bundle.scheduled).toBeUndefined();
     });
 
+    it("reads the checkout URL from CHB's checkoutUrl field", async () => {
+      onChb(
+        jsonResponse(200, {
+          organizationId: CH_ORG_ID,
+          checkoutUrl: "https://pay.example.com/c/1",
+        }),
+      );
+
+      await expect(
+        client().createCheckoutSession({
+          email: "user@example.com",
+          planCode: "LANGFUSE_PRO",
+          returnUrl: "https://cloud.langfuse.com/back",
+        }),
+      ).resolves.toEqual({
+        organizationId: CH_ORG_ID,
+        checkoutUrl: "https://pay.example.com/c/1",
+      });
+    });
+
     it("defaults the invoice list to empty when CHB omits the key", async () => {
       onChb(jsonResponse(200, {}));
 
@@ -387,7 +407,7 @@ describe("chbApiClient", () => {
       // uuid — rejecting here keeps a bad id from ever reaching the database.
       onChb(
         jsonResponse(200, {
-          url: "https://pay.example.com/c/1",
+          checkoutUrl: "https://pay.example.com/c/1",
           organizationId: "not-a-uuid",
         }),
       );

--- a/web/src/__tests__/server/unit/chbBillingService.servertest.ts
+++ b/web/src/__tests__/server/unit/chbBillingService.servertest.ts
@@ -245,7 +245,7 @@ describe("chbBillingService", () => {
 
   describe("createCheckoutSession", () => {
     const session = {
-      url: "https://pay.example.com/c/1",
+      checkoutUrl: "https://pay.example.com/c/1",
       organizationId: CH_ORG_ID,
     };
 
@@ -259,7 +259,7 @@ describe("chbBillingService", () => {
         "op-checkout",
       );
 
-      expect(url).toBe(session.url);
+      expect(url).toBe(session.checkoutUrl);
       expect(clientMock.createCheckoutSession).toHaveBeenCalledWith({
         organizationId: undefined,
         email: "user@example.com",
@@ -336,7 +336,7 @@ describe("chbBillingService", () => {
     it("refuses when a retry comes back with a different CH organization", async () => {
       withOrg({ clickhouse: { organizationId: CH_ORG_ID } });
       clientMock.createCheckoutSession.mockResolvedValue({
-        url: session.url,
+        checkoutUrl: session.checkoutUrl,
         organizationId: "11111111-2222-4333-8444-555555555555",
       });
 
@@ -356,7 +356,7 @@ describe("chbBillingService", () => {
     it("refuses to persist an id the stored schema rejects", async () => {
       withOrg(null);
       clientMock.createCheckoutSession.mockResolvedValue({
-        url: session.url,
+        checkoutUrl: session.checkoutUrl,
         organizationId: "not-a-uuid",
       });
 

--- a/web/src/ee/features/billing/server/chb/chbApiClient.ts
+++ b/web/src/ee/features/billing/server/chb/chbApiClient.ts
@@ -76,7 +76,7 @@ const ChbBundleSchema = z.object({
 export type ChbBundle = z.infer<typeof ChbBundleSchema>;
 
 const ChbCheckoutSessionSchema = z.object({
-  url: z.string(),
+  checkoutUrl: z.url(),
   // ClickHouse Organization ID — persisted on the Langfuse org right away so a
   // checkout retry recovers the same CH org instead of orphaning one.
   organizationId: z.uuid(),

--- a/web/src/ee/features/billing/server/chb/chbBillingService.ts
+++ b/web/src/ee/features/billing/server/chb/chbBillingService.ts
@@ -353,7 +353,7 @@ export class ChbBillingService {
             "ClickHouse Billing returned a different organization for this checkout",
         });
       }
-      return session.url;
+      return session.checkoutUrl;
     }
 
     // First checkout for this org: the CH organization id is the one thing
@@ -414,7 +414,7 @@ export class ChbBillingService {
       );
     });
 
-    return session.url;
+    return session.checkoutUrl;
   }
 
   async changePlan(orgId: string, newProductId: string, opId?: string) {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16800 app preview](https://pr-16800.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## TL;DR

ClickHouse Billing returns the hosted checkout link as `checkoutUrl`; our client's Zod schema demanded `url`. Every CHB checkout-session response therefore failed validation and became an opaque 500 before the user reached the payment page. This renames the field to match the wire contract.

## What CHB actually sends

```ts
schema: z.object({
  organizationId: z.uuid(),
  checkoutUrl: z.url(),
}),
```

Our `ChbCheckoutSessionSchema` had `url: z.string()` alongside the (correct) `organizationId: z.uuid()`.

## Changes

- `chbApiClient.ts`: `url: z.string()` → `checkoutUrl: z.url()`. The `z.url()` mirrors CHB's own declared type, and the value is a redirect target, so validating it as a URL is worth the extra strictness.
- `chbBillingService.ts`: both `return session.url` sites → `session.checkoutUrl` (the reuse path and the first-checkout path).
- Tests: new failing-first case in `chbApiClient.servertest.ts` that feeds CHB's real payload shape, plus the existing mock payloads updated.

## Verification

- `chbApiClient.servertest.ts` — `Tests 24 passed (24)`
- `chbBillingService.servertest.ts` — `Tests 40 passed (40)`
- `chbCheckoutClaim.servertest.ts` (Postgres) — `Tests 5 passed (5)`
- `cloudBillingRouter.servertest.ts` — `Tests 4 passed (4)`
- `pnpm run lint` — exit 0 under `--max-warnings 0`; pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` — exit 0

The new test fails against the old schema with exactly the reported error:

```
ZodError: [{ "expected": "string", "code": "invalid_type", "path": ["url"],
  "message": "Invalid input: expected string, received undefined" }]
```

## What a reviewer should doubt

`portal-sessions` still parses `{ url: z.string() }`. If CHB names that field consistently with checkout (`portalUrl`?), the billing portal is broken the same way — I did not touch it because I have no confirmed payload for that endpoint. Worth checking against the same source that produced the checkout schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Corrects the ClickHouse Billing checkout-session response contract so hosted checkout links can reach users.
- Renames the parsed response field from `url` to `checkoutUrl`.
- Validates checkout links as URLs and updates both service return paths.
- Updates existing fixtures and adds coverage for the actual response shape.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the corrected response field is used consistently throughout the checkout flow and its tests.

The client now parses CHB's declared `checkoutUrl` field, both service branches return that field, and no stale checkout-session `url` consumers remain in the repository.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): read the CHB checkout URL ..."](https://github.com/langfuse/langfuse/commit/ed3a2f66d0472bd01aa4a0feb0481f5e85d017f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57999285)</sub>

<!-- /greptile_comment -->