### PR TITLE
fix(otel): parse prompt version attributes as integers

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -594,13 +594,7 @@ export class OtelIngestionProcessor {
                       null)
                     : null,
                   promptVersion: canLinkPrompt
-                    ? (spanAttributes?.[
-                        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
-                      ] ??
-                      spanAttributes["langfuse.prompt.version"] ??
-                      this.parseLangfusePromptFromAISDK(spanAttributes)
-                        ?.version ??
-                      null)
+                    ? this.extractPromptVersion(spanAttributes)
                     : null,
 
                   modelParameters: this.extractModelParameters(
@@ -1278,12 +1272,7 @@ export class OtelIngestionProcessor {
           null)
         : null,
       promptVersion: canLinkPrompt
-        ? (attributes?.[
-            LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION
-          ] ??
-          attributes["langfuse.prompt.version"] ??
-          this.parseLangfusePromptFromAISDK(attributes)?.version ??
-          null)
+        ? this.extractPromptVersion(attributes)
         : null,
       usageDetails: isAiSdkAgentSpan
         ? {}
@@ -3495,6 +3484,25 @@ export class OtelIngestionProcessor {
       "OTEL invalid experiment item version, dropping. Expected timestamp.",
     );
     return undefined;
+  }
+
+  /**
+   * OTLP exporters may carry the prompt version as a stringValue; downstream
+   * schemas require an integer. Non-integer values become null.
+   */
+  private extractPromptVersion(
+    attributes: Record<string, unknown>,
+  ): number | null {
+    const raw =
+      attributes[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION] ??
+      attributes["langfuse.prompt.version"] ??
+      this.parseLangfusePromptFromAISDK(attributes)?.version;
+
+    if (typeof raw === "number") return Number.isInteger(raw) ? raw : null;
+    if (typeof raw === "string" && /^\d+$/.test(raw.trim())) {
+      return Number(raw);
+    }
+    return null;
   }
 
   private parseLangfusePromptFromAISDK(

--- a/packages/shared/src/server/otel/internalAiFeatureOtelWriter.test.ts
+++ b/packages/shared/src/server/otel/internalAiFeatureOtelWriter.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createIngestionEventSchema } from "../ingestion/types";
 import { buildInternalTraceEventInputs } from "../llm/internalTraceEvents";
 import {
   AI_FEATURE_OTEL_SDK_NAME,
@@ -88,6 +89,8 @@ const processedEvents = [
       endTime: new Date(END_ISO),
       model: "claude-opus",
       usageDetails: { input: 10, output: 5, total: 15 },
+      promptName: "in-app-agent-system",
+      promptVersion: 3,
     },
   },
 ];
@@ -107,9 +110,7 @@ const spanAttributeMap = (span: {
     ]),
   );
 
-const processPublishedSpans = async (sdkName = AI_FEATURE_OTEL_SDK_NAME) => {
-  const resourceSpans = getPublishedResourceSpans();
-
+const createProcessor = async (sdkName = AI_FEATURE_OTEL_SDK_NAME) => {
   const { OtelIngestionProcessor } = await vi.importActual<
     typeof import("./OtelIngestionProcessor")
   >("./OtelIngestionProcessor");
@@ -120,7 +121,22 @@ const processPublishedSpans = async (sdkName = AI_FEATURE_OTEL_SDK_NAME) => {
     sdkVersion: "unknown",
     ingestionVersion: "4",
     isLangfuseInternal: false,
-  }).processToEvent(resourceSpans);
+  });
+};
+
+const processPublishedSpans = async (sdkName = AI_FEATURE_OTEL_SDK_NAME) => {
+  const resourceSpans = getPublishedResourceSpans();
+  return (await createProcessor(sdkName)).processToEvent(resourceSpans);
+};
+
+const processPublishedIngestionEvents = async () => {
+  const resourceSpans = getPublishedResourceSpans();
+  const processor = await createProcessor();
+  vi.spyOn(
+    processor as unknown as { getSeenTracesSet: () => Promise<Set<string>> },
+    "getSeenTracesSet",
+  ).mockResolvedValue(new Set());
+  return processor.processToIngestionEvents(resourceSpans);
 };
 
 const publishFixture = async () => {
@@ -193,6 +209,8 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
       modelName: "claude-opus",
       userId: "user-1",
       sessionId: "conversation-1",
+      promptName: "in-app-agent-system",
+      promptVersion: 3,
     });
     expect(tool).toMatchObject({
       traceId: TRACE_ID,
@@ -248,24 +266,7 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
   it("does not emit named trace-create rewrites from child spans", async () => {
     await publishFixture();
 
-    const resourceSpans = getPublishedResourceSpans();
-    const { OtelIngestionProcessor } = await vi.importActual<
-      typeof import("./OtelIngestionProcessor")
-    >("./OtelIngestionProcessor");
-    const processor = new OtelIngestionProcessor({
-      projectId: "project-1",
-      publicKey: "",
-      sdkName: AI_FEATURE_OTEL_SDK_NAME,
-      sdkVersion: "unknown",
-      ingestionVersion: "4",
-      isLangfuseInternal: false,
-    });
-    vi.spyOn(
-      processor as unknown as { getSeenTracesSet: () => Promise<Set<string>> },
-      "getSeenTracesSet",
-    ).mockResolvedValue(new Set());
-
-    const events = await processor.processToIngestionEvents(resourceSpans);
+    const events = await processPublishedIngestionEvents();
     const namedTraceCreates = events.filter(
       (event) =>
         event.type === "trace-create" &&
@@ -276,6 +277,22 @@ describe("publishAiFeatureTraceViaOtelIngestion", () => {
     expect(namedTraceCreates[0]?.body).toMatchObject({
       id: TRACE_ID,
       name: "agent-turn",
+    });
+  });
+
+  it("links the generation prompt as an integer version in legacy ingestion events", async () => {
+    await publishFixture();
+
+    const events = await processPublishedIngestionEvents();
+    const generation = events.find(
+      (event) => (event.body as { id?: string }).id === `${RUN_ID}-llm-0`,
+    );
+
+    const parsed = createIngestionEventSchema(false).safeParse(generation);
+    expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+    expect(parsed.data?.body).toMatchObject({
+      promptName: "in-app-agent-system",
+      promptVersion: 3,
     });
   });
 

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4209,6 +4209,38 @@ describe("OTel Resource Span Mapping", () => {
         expect(eventInputs[0].promptVersion).toBe(1);
       });
 
+      it("should map string-encoded prompt version on generation observations", async () => {
+        const resourceSpan = buildResourceSpan([
+          {
+            key: "langfuse.observation.type",
+            value: { stringValue: "generation" },
+          },
+          {
+            key: "langfuse.observation.prompt.name",
+            value: { stringValue: "my-prompt" },
+          },
+          {
+            key: "langfuse.observation.prompt.version",
+            value: { stringValue: "3" },
+          },
+        ]);
+
+        const events = await convertOtelSpanToIngestionEvent(
+          resourceSpan,
+          new Set(),
+        );
+        const observation = events.find((e) => e.type !== "trace-create");
+        expect(observation?.type).toBe("generation-create");
+        expect(observation?.body.promptName).toBe("my-prompt");
+        expect(observation?.body.promptVersion).toBe(3);
+
+        const processor = createTestOtelProcessor();
+        const eventInputs = processor.processToEvent([resourceSpan]);
+        expect(eventInputs).toHaveLength(1);
+        expect(eventInputs[0].promptName).toBe("my-prompt");
+        expect(eventInputs[0].promptVersion).toBe(3);
+      });
+
       it("should map legacy langfuse.prompt.name attributes on generation observations", async () => {
         const resourceSpan = buildResourceSpan([
           {


### PR DESCRIPTION
## Problem

After every in-app agent run, the worker logs

```
Failed to parse otel observation for project <id> in events/otel/<...>.json: [ { "expected": "number", "code": "invalid_type", "path": ["body","promptVersion"], "message": "Invalid input: expected number, received string" } ]
```

and drops that observation from the legacy ingestion write.

The in-app agent (and the other AI features routed through `publishAiFeatureTraceViaOtelIngestion`) stamp `promptName`/`promptVersion` onto their generation events. `buildInternalTraceEventInputs` stringifies the version for the events-table contract, and the AI-feature OTel writer emits every attribute as an OTLP `stringValue`. `OtelIngestionProcessor` then copied `langfuse.observation.prompt.version` verbatim into the legacy ingestion event, whose schema requires `z.number().int()`, so the generation was rejected. Real SDKs send the attribute as an `intValue`, which is why this was never hit before the AI-feature writer started using the OTel path.

The v4 events-table path already tolerates a string here (`IngestionService.createEventRecord` calls `parseInt`/`parseUInt16`); the legacy path in the processor was the only consumer that did not.

Impact by write mode: in `events_only` the observation still lands in `events` via `processToEvent`, so this is log noise plus a skewed `langfuse.ingestion.otel.observation_count`; in `dual` the generation is silently missing from the legacy `observations` table.

## Fix

`OtelIngestionProcessor.extractPromptVersion` centralizes the existing attribute fallback chain (`langfuse.observation.prompt.version` -> `langfuse.prompt.version` -> AI SDK `langfusePrompt` metadata) and returns an integer: integral numbers pass through, numeric strings are parsed, anything else becomes `null`. Both read sites (`processToIngestionEvents` and `processToEvent`) use it, so the two paths yield the same type.

This is a shared-behavior change with one meaning for every caller rather than a new option or field. Fixing only the in-house writer (emit `intValue`) was considered, but it would special-case one attribute inside the generic stringValue conversion and leave any third-party OTLP producer that sends the version as a string with the same silent drop.

## Tests

- `web/src/__tests__/server/api/otel/otelMapping.servertest.ts`: new case in the existing `prompt linking gated to GENERATION observations` block feeds `langfuse.observation.prompt.version` as `{ stringValue: "3" }` through both `processToIngestionEvents` and `processToEvent` and asserts `3` from each. Fails before the fix with `expected '3' to be 3`.
- `packages/shared/src/server/otel/internalAiFeatureOtelWriter.test.ts`: end-to-end repro through the in-house writer. The generation fixture now carries `promptName`/`promptVersion: 3`; a new test asserts `createIngestionEventSchema` accepts the resulting legacy generation with `promptVersion: 3` (fails before the fix with the exact production Zod issue), and the existing `processToEvent` assertion now pins the same fields.

## How to verify

- `pnpm --filter web run test otelMapping.servertest.ts`
- `pnpm --filter @langfuse/shared run test src/server/otel/internalAiFeatureOtelWriter.test.ts`
- On a deployment with `LANGFUSE_IN_APP_AGENT_ENABLED=true` and the system prompt loaded, run one Assistant turn and confirm the worker no longer logs `Failed to parse otel observation ... ["body","promptVersion"]`; in `dual` mode the run's generation now appears in the legacy observations table with `prompt_name`/`prompt_version` set.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes OTel prompt-version extraction and normalizes integer-valued attributes before both ingestion paths consume them.
- Converts digit-only string versions to numbers while rejecting non-integral values.
- Applies identical prompt-version extraction to legacy and events-table mappings.
- Adds direct mapping and internal AI-feature regression coverage.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the intended prompt-version normalization covered across both ingestion paths.

The changed helper converts the affected string representation into the integer required downstream, preserves integral numeric values, and consistently returns null for unsupported forms without introducing a concrete reachable regression.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): parse prompt version attribut..."](https://github.com/langfuse/langfuse/commit/df76270dbed314a5f4ebb8e15a01c609df1a701a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58675970)</sub>

<!-- /greptile_comment -->