### PR TITLE
fix(shared): don't substitute prototype-named prompt placeholders

### DIFF
--- a/packages/shared/src/utils/prompts.test.ts
+++ b/packages/shared/src/utils/prompts.test.ts
@@ -19,6 +19,21 @@ describe("compileTemplateString", () => {
       }),
     ).toBe("[object Object] ");
   });
+
+  it("preserves placeholders named like Object.prototype members when not provided", () => {
+    expect(
+      compileTemplateString(
+        "{{constructor}} {{toString}} {{hasOwnProperty}}",
+        {},
+      ),
+    ).toBe("{{constructor}} {{toString}} {{hasOwnProperty}}");
+  });
+
+  it("interpolates a provided key even if it shadows a prototype member", () => {
+    expect(compileTemplateString("{{toString}}", { toString: "ok" })).toBe(
+      "ok",
+    );
+  });
 });
 
 describe("compileEvalPrompt", () => {

--- a/packages/shared/src/utils/prompts.ts
+++ b/packages/shared/src/utils/prompts.ts
@@ -17,7 +17,11 @@ export function compileTemplateString(
 ) {
   try {
     return template.replace(/{{\s*([\w.]+)\s*}}/g, (match, key: string) => {
-      if (!(key in context)) return match;
+      // Own-property check only: `key in context` also matches inherited
+      // Object.prototype members, so a placeholder like {{constructor}} or
+      // {{toString}} that was never provided would render as the prototype
+      // method instead of being left untouched.
+      if (!Object.prototype.hasOwnProperty.call(context, key)) return match;
 
       const value = context[key];
       return value === undefined || value === null ? "" : String(value);


### PR DESCRIPTION
## Problem

`compileTemplateString` (in `@langfuse/shared`) decides whether to interpolate a `{{placeholder}}` with `key in context`. `in` also matches inherited `Object.prototype` members, so a placeholder that was **never provided** but happens to be named `constructor`, `toString`, `hasOwnProperty`, `valueOf`, etc. is replaced with the prototype method's string instead of being left intact:

```ts
compileTemplateString("{{constructor}}", {})
// -> "function Object() { [native code] }"   (expected "{{constructor}}")

compileTemplateString("Hi {{name}} {{hasOwnProperty}}", { name: "Ada" })
// -> "Hi Ada function hasOwnProperty() { [native code] }"
```

This reaches user-authored prompt templates via `compileEvalPrompt`.

## Fix

Use an own-property check (`Object.prototype.hasOwnProperty.call(context, key)`) so only keys actually present in `context` interpolate; unprovided placeholders — including prototype-named ones — are preserved, and an explicitly provided key that shadows a prototype member still works.

## Tests

Added two cases to the existing `compileTemplateString` suite in `prompts.test.ts` (prototype-named placeholders preserved; a provided shadowing key still interpolates). The first fails on `main` and passes with the fix. I verified the function against all existing + new cases directly (the monorepo `pnpm install` was too slow to run the full vitest suite in my environment); CI runs `@langfuse/shared` tests.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents prompt placeholders named after `Object.prototype` members from being substituted unless explicitly provided.

- Replaces inherited-property lookup with an own-property check in `compileTemplateString`.
- Adds coverage for preserving unprovided prototype-named placeholders and interpolating explicitly shadowed keys.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The own-property check fixes unintended prototype-member interpolation while preserving all current call paths, which construct contexts with own properties.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): don&#39;t substitute prototype-..."](https://github.com/langfuse/langfuse/commit/74dba7ccbeb8078ee03db80859a2b9cac04c3435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58158174)</sub>

<!-- /greptile_comment -->