### PR TITLE
fix(otel): detect third-party spans via attributes and warn on unmasked PII

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.thirdPartyMasking.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.thirdPartyMasking.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { recordIncrementMock } = vi.hoisted(() => ({
+  recordIncrementMock: vi.fn(),
+}));
+
+vi.mock("../instrumentation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../instrumentation")>();
+  return {
+    ...actual,
+    recordIncrement: recordIncrementMock,
+  };
+});
+
+vi.mock("../redis/redis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../redis/redis")>()),
+  redis: { set: vi.fn().mockResolvedValue("OK") },
+}));
+
+import {
+  OtelIngestionProcessor,
+  type ResourceSpan,
+} from "./OtelIngestionProcessor";
+
+const PROJECT_ID = "test-project-15372";
+
+const createProcessor = () =>
+  new OtelIngestionProcessor({
+    projectId: PROJECT_ID,
+    publicKey: "pk-test",
+    sdkName: "python",
+    sdkVersion: "3.8.1",
+  });
+
+type OtelAttribute = { key: string; value: Record<string, unknown> };
+
+const buildBatch = (
+  scopeName: string,
+  attributes: OtelAttribute[],
+): ResourceSpan[] => [
+  {
+    resource: {
+      attributes: [{ key: "service.name", value: { stringValue: "test-svc" } }],
+    },
+    scopeSpans: [
+      {
+        scope: {
+          name: scopeName,
+          version: "1.0.0",
+          attributes: [],
+        },
+        spans: [
+          {
+            traceId: Buffer.from("0123456789abcdef0123456789abcdef", "hex"),
+            spanId: Buffer.from("0123456789abcdef", "hex"),
+            name: "test-span",
+            kind: 1,
+            startTimeUnixNano: "1752384000000000000",
+            endTimeUnixNano: "1752384001000000000",
+            attributes: [...attributes],
+            status: {},
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const THIRD_PARTY_METRIC = "langfuse.ingestion.otel.third_party_unmasked_span";
+
+describe("OTel third-party masking gap detection (15372)", () => {
+  beforeEach(() => {
+    recordIncrementMock.mockClear();
+  });
+
+  it("wired-tracer third-party span via langfuse-sdk scope is detected and warned", async () => {
+    // This is the bug case: instrumentor reuses langfuse._otel_tracer so scope
+    // stays langfuse-sdk, but attributes are third-party PII-like without
+    // langfuse.observation.*. Before fix, isLangfuseSDKSpans=true and no warn.
+    const processor = createProcessor();
+    const batch = buildBatch("langfuse-sdk", [
+      { key: "input.value", value: { stringValue: "PII-CANARY-123" } },
+      {
+        key: "langfuse.internal.is_app_root",
+        value: { stringValue: "true" },
+      },
+    ]);
+    const events = await processor.processToIngestionEvents(batch);
+    // Should be treated as third-party: metadata should contain attributes
+    // filtered from PII keys. Wired span now preserves attributes.
+    expect(events.length).toBeGreaterThan(0);
+    // At least one event should have metadata.attributes with input.value
+    const hasFiltered = events.some(
+      (e: any) =>
+        e.metadata?.attributes && "input.value" in e.metadata.attributes,
+    );
+    // If correctly classified as third-party, filteredAttributes are kept.
+    // If misclassified as SDK, attributes would be {}.
+    expect(hasFiltered).toBe(true);
+
+    const calls = recordIncrementMock.mock.calls.filter(
+      ([stat]) => stat === THIRD_PARTY_METRIC,
+    );
+    expect(calls.length).toBe(1);
+  });
+
+  it("native SDK span with langfuse.observation.input is not warned", async () => {
+    const processor = createProcessor();
+    const batch = buildBatch("langfuse-sdk", [
+      { key: "langfuse.observation.input", value: { stringValue: "hello" } },
+      { key: "langfuse.observation.type", value: { stringValue: "span" } },
+    ]);
+    const events = await processor.processToIngestionEvents(batch);
+    expect(events.length).toBeGreaterThan(0);
+    const calls = recordIncrementMock.mock.calls.filter(
+      ([stat]) => stat === THIRD_PARTY_METRIC,
+    );
+    expect(calls.length).toBe(0);
+  });
+
+  it("empty native observation (no IO, no PII) does not warn", async () => {
+    // Native span with only internal marker, no PII-like attributes.
+    // Should not warn even though it lacks IO (false-positive guard).
+    const processor = createProcessor();
+    const batch = buildBatch("langfuse-sdk", [
+      {
+        key: "langfuse.internal.is_app_root",
+        value: { stringValue: "true" },
+      },
+      { key: "langfuse.observation.type", value: { stringValue: "span" } },
+    ]);
+    await processor.processToIngestionEvents(batch);
+    const calls = recordIncrementMock.mock.calls.filter(
+      ([stat]) => stat === THIRD_PARTY_METRIC,
+    );
+    expect(calls.length).toBe(0);
+  });
+
+  it("distinct third-party scope is also detected", async () => {
+    const processor = createProcessor();
+    const batch = buildBatch("openinference.instrumentation.agno", [
+      { key: "input.value", value: { stringValue: "PII" } },
+    ]);
+    await processor.processToIngestionEvents(batch);
+    const calls = recordIncrementMock.mock.calls.filter(
+      ([stat]) => stat === THIRD_PARTY_METRIC,
+    );
+    expect(calls.length).toBe(1);
+  });
+
+  it("caps warnings at 10 per processor", async () => {
+    const processor = createProcessor();
+    for (let i = 0; i < 15; i++) {
+      const batch = buildBatch("langfuse-sdk", [
+        { key: "input.value", value: { stringValue: `PII-${i}` } },
+      ]);
+      await processor.processToIngestionEvents(batch);
+    }
+    const calls = recordIncrementMock.mock.calls.filter(
+      ([stat]) => stat === THIRD_PARTY_METRIC,
+    );
+    expect(calls.length).toBe(10);
+  });
+});

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -272,6 +272,26 @@ export class OtelIngestionProcessor {
 
   private static readonly METADATA_DROP_WARN_CAP = 10;
   private static readonly ARRAY_ATTRIBUTE_DROP_WARN_CAP = 10;
+  private static readonly THIRD_PARTY_UNMASKED_WARN_CAP = 10;
+
+  private static readonly LANGFUSE_IO_ATTRIBUTES = new Set([
+    LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+    LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+    LangfuseOtelSpanAttributes.TRACE_INPUT,
+    LangfuseOtelSpanAttributes.TRACE_OUTPUT,
+  ]);
+
+  // PII-prone attribute keys commonly emitted by third-party instrumentors.
+  // Used for bounded warning when a third-party span carries such keys without
+  // server-side masking. This is observability only, not redaction.
+  private static readonly PII_LIKE_ATTRIBUTE_PREFIXES = [
+    "input.value",
+    "output.value",
+    "llm.",
+    "gen_ai.",
+    "traceloop.",
+    "openinference.",
+  ];
 
   private seenTraces: Set<string> = new Set();
   private reportedMetadataDrops = new WeakMap<object, Set<string>>();
@@ -280,6 +300,7 @@ export class OtelIngestionProcessor {
     ReconstructedAttributeDropReason,
     number
   >();
+  private thirdPartyUnmaskedWarnCount = 0;
   private isInitialized = false;
   private traceEventCounts = {
     shallow: 0,
@@ -310,6 +331,79 @@ export class OtelIngestionProcessor {
     this.ingestionVersion = config.ingestionVersion;
     this.isLangfuseInternal = config.isLangfuseInternal;
     this.fileKey = config.fileKey;
+  }
+
+  private hasLangfuseIOAttributes(
+    attributes: Record<string, unknown>,
+  ): boolean {
+    for (const key of OtelIngestionProcessor.LANGFUSE_IO_ATTRIBUTES) {
+      if (key in attributes) return true;
+    }
+    return false;
+  }
+
+  private hasPiiLikeAttributes(
+    attributes: Record<string, unknown>,
+  ): boolean {
+    for (const key of Object.keys(attributes)) {
+      for (const prefix of OtelIngestionProcessor.PII_LIKE_ATTRIBUTE_PREFIXES) {
+        if (key === prefix || key.startsWith(prefix)) return true;
+      }
+      // Exact match for some common keys
+      if (key === "input" || key === "output") return true;
+    }
+    return false;
+  }
+
+  /**
+   * Determines whether a span should be treated as third-party.
+   * Scope name is a hint, but when a third-party instrumentor reuses
+   * `langfuse._otel_tracer` (common via `openlit.init(tracer=langfuse._otel_tracer)`),
+   * the scope stays `langfuse-sdk` yet the span lacks Langfuse IO attributes.
+   * In that case we treat it as third-party to avoid silently dropping
+   * `filteredAttributes` and to surface the masking gap.
+   * Native SDK spans always carry `langfuse.observation.input/output` or
+   * `langfuse.trace.input/output` when they have content; empty native
+   * observations lacking those keys are conservatively treated as non-PII
+   * and will not trigger the warning (see `hasPiiLikeAttributes` gate).
+   */
+  private isThirdPartySpan(
+    attributes: Record<string, unknown>,
+    scopeName: string | undefined,
+  ): boolean {
+    const isLangfuseScope = scopeName?.startsWith("langfuse-sdk") ?? false;
+    if (!isLangfuseScope) return true;
+    // Wired-tracer case: langfuse-sdk scope but no Langfuse IO attributes.
+    return !this.hasLangfuseIOAttributes(attributes);
+  }
+
+  private maybeWarnForThirdPartyUnmasked(
+    attributes: Record<string, unknown>,
+    scopeName: string | undefined,
+  ): void {
+    if (!this.hasPiiLikeAttributes(attributes)) return;
+    if (!this.isThirdPartySpan(attributes, scopeName)) return;
+    if (
+      this.thirdPartyUnmaskedWarnCount >=
+      OtelIngestionProcessor.THIRD_PARTY_UNMASKED_WARN_CAP
+    )
+      return;
+    this.thirdPartyUnmaskedWarnCount++;
+    recordIncrement(
+      "langfuse.ingestion.otel.third_party_unmasked_span",
+      1,
+    );
+    logger.warn(
+      "OTEL third-party span contains PII-like attributes without Langfuse IO; " +
+        "SDK `mask` does not cover raw OTel span attributes - use `mask_otel_spans` or configure ingestion masking. " +
+        "See https://langfuse.com/docs/observability/features/masking",
+      {
+        scopeName: scopeName ?? "",
+        projectId: this.projectId,
+        fileKey: this.fileKey ?? "",
+        attributeKeys: Object.keys(attributes).slice(0, 20),
+      },
+    );
   }
 
   /**
@@ -409,8 +503,17 @@ export class OtelIngestionProcessor {
                     endTimeUnixNano: span.endTimeUnixNano,
                   });
 
-                const isLangfuseSDKSpans =
-                  scopeSpan.scope?.name?.startsWith("langfuse-sdk") ?? false;
+                // Detect third-party spans that reuse the Langfuse tracer but lack
+                // Langfuse IO attributes (see `isThirdPartySpan`).
+                const isThirdParty = this.isThirdPartySpan(
+                  spanAttributes,
+                  scopeSpan.scope?.name,
+                );
+                const isLangfuseSDKSpans = !isThirdParty;
+                this.maybeWarnForThirdPartyUnmasked(
+                  spanAttributes,
+                  scopeSpan.scope?.name,
+                );
 
                 // Extract metadata from different sources
                 const spanMetadata = this.extractMetadata(
@@ -968,6 +1071,18 @@ export class OtelIngestionProcessor {
   ): IngestionEventType[] {
     const events: IngestionEventType[] = [];
     const attributes = this.extractSpanAttributes(span);
+    // Refine SDK vs third-party detection per span: wired-tracer case carries
+    // langfuse-sdk scope but no Langfuse IO attributes.
+    const effectiveIsLangfuseSDKSpans = !this.isThirdPartySpan(
+      attributes,
+      scopeSpan?.scope?.name,
+    );
+    // Use refined flag for downstream metadata handling.
+    isLangfuseSDKSpans = effectiveIsLangfuseSDKSpans;
+    this.maybeWarnForThirdPartyUnmasked(
+      attributes,
+      scopeSpan?.scope?.name,
+    );
 
     const traceId = this.parseId(span.traceId?.data ?? span.traceId);
     const parentObservationId = span?.parentSpanId


### PR DESCRIPTION
## What does this PR do?

Fixes #15372

When a third-party instrumentor is wired through `langfuse._otel_tracer` (e.g. `openlit.init(tracer=langfuse._otel_tracer, ...)`), its spans inherit the `langfuse-sdk` instrumentation scope but lack `langfuse.observation.*` attributes. The previous scope-only check misclassified those spans as native SDK spans, dropping `filteredAttributes` from `metadata.attributes` and silencing any masking gap, so content the user expected to be masked could reach ingestion unmasked with no signal.

This change keeps the scope name as a fast path and uses the Langfuse IO attributes (`langfuse.observation.input/output`, `langfuse.trace.input/output`) as ground truth. A `langfuse-sdk` scope without those keys is treated as third-party, `filteredAttributes` are preserved, and a bounded warning plus metric (`langfuse.ingestion.otel.third_party_unmasked_span`, capped at 10 per processor) points to `mask_otel_spans` / ingestion masking docs. Empty native observations without PII-like keys do not warn.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refines OpenTelemetry span classification so third-party spans using the Langfuse tracer retain their attributes, and adds bounded telemetry for potentially unmasked content.

- Uses Langfuse IO attributes to distinguish native spans from third-party spans sharing the SDK scope.
- Preserves filtered third-party attributes in normalized metadata.
- Adds a warning and metric capped at ten emissions per processor.
- Adds tests for classification, warning suppression, distinct scopes, and the cap.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the warning distinguishes successfully masked data and deduplicates spans processed by both conversion pipelines.

The new signal reports successfully redacted spans as unmasked and counts each qualifying worker span twice, producing misleading telemetry and prematurely suppressing later warnings.

**Files Needing Attention:** packages/shared/src/server/otel/OtelIngestionProcessor.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Masked or raw OTLP spans] --> P[Shared processor instance]
  P --> I[processToIngestionEvents]
  P --> E[processToEvent]
  I --> W1[Warning and metric]
  E --> W2[Warning and metric]
  W1 --> C[Shared cap]
  W2 --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:380-407
**Masked spans trigger unmasked alerts**

When ingestion masking successfully redacts a third-party span while preserving keys such as `input.value` or `gen_ai.*`, this check still emits the unmasked-span metric and warning because the processor receives no masking-status flag and examines only attribute names. Operators are therefore told to configure masking even though it is already active, making the new alert unreliable.

### Issue 2
packages/shared/src/server/otel/OtelIngestionProcessor.ts:1078-1083
**Span warnings are double-counted**

The worker sends the same spans through both `processToIngestionEvents` and `processToEvent` on one processor, and each path invokes this warning without per-span deduplication. Every affected span is therefore counted twice, so the ten-warning cap is exhausted after five unique spans and later signals in the job are suppressed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): detect third-party spans via ..."](https://github.com/langfuse/langfuse/commit/3e0b56198b234cbf3645864f332afb5dd73dafab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58165334)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)

<!-- /greptile_comment -->