### PR TITLE
test(worker): lock Mastra prompt order for cache prefixes

### DIFF
--- a/worker/src/features/in-app-agent/runtime/mastraPromptOrder.test.ts
+++ b/worker/src/features/in-app-agent/runtime/mastraPromptOrder.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Captures the provider-facing prompt Mastra 1.46 actually emits so cache
+ * breakpoints can sit on a stable prefix.
+ *
+ * Observed order on each model call:
+ *   tools (including skill / skill_read / skill_search when skills exist)
+ *   system: Agent.instructions
+ *   system: defaultOptions.system or generate({ system })
+ *   optional generate({ context }) user messages
+ *   conversation messages
+ *   processLLMRequest trailing user suffix
+ *
+ * Skill bodies stay out of the first call; only metadata is in the leading
+ * system run. generate({ instructions }) replaces the constructor
+ * instructions. generate({ context }) lands after system and before the
+ * user turn, so page/clock data must not use that channel.
+ */
+import { Agent } from "@mastra/core/agent";
+import type { Processor } from "@mastra/core/processors";
+import { createSkill } from "@mastra/core/skills";
+import { describe, expect, it } from "vitest";
+
+import { applyPromptCachePoints } from "./promptCache";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const STABLE_INSTRUCTIONS = "STABLE_INSTRUCTIONS_PREFIX";
+const SANDBOX_RESET_SYSTEM = "SANDBOX_RESET_SYSTEM";
+const PER_CALL_INSTRUCTIONS = "PER_CALL_INSTRUCTIONS_OVERRIDE";
+const PER_CALL_SYSTEM = "PER_CALL_SYSTEM_APPEND";
+const SKILL_NAME = "error-analysis";
+const SKILL_DESCRIPTION = "Use when analysing pipeline failures.";
+const SKILL_BODY = "SKILL_BODY_ERROR_ANALYSIS";
+const CONTEXT_MESSAGE = "MASTRA_CONTEXT_MESSAGE";
+const USER_TURN = "USER_TURN_HELLO";
+const PRIOR_ASSISTANT = "PRIOR_ASSISTANT_REPLY";
+const FOLLOW_UP_USER = "USER_TURN_FOLLOWUP";
+const TRAILING_TIME = '<current_time tz="UTC">2026-08-29 08:00</current_time>';
+
+type CapturedModelCall = {
+  prompt: unknown[];
+  tools: unknown;
+};
+
+class TrailingCurrentTimeProcessor implements Processor {
+  readonly id = "current-time";
+
+  processLLMRequest({ prompt }: { prompt: unknown[] }) {
+    return {
+      prompt: [
+        ...prompt,
+        {
+          role: "user" as const,
+          content: [{ type: "text" as const, text: TRAILING_TIME }],
+        },
+      ],
+    };
+  }
+}
+
+function createRecordingModel(calls: CapturedModelCall[]) {
+  const usage = {
+    inputTokens: {
+      total: 10,
+      noCache: 10,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    outputTokens: { total: 4, text: 4, reasoning: 0 },
+  };
+
+  const finishStream = () =>
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "stream-start", warnings: [] });
+        controller.enqueue({ type: "text-start", id: "text-1" });
+        controller.enqueue({
+          type: "text-delta",
+          id: "text-1",
+          delta: "ok",
+        });
+        controller.enqueue({ type: "text-end", id: "text-1" });
+        controller.enqueue({
+          type: "finish",
+          finishReason: "stop",
+          usage,
+        });
+        controller.close();
+      },
+    });
+
+  const record = (options: { prompt?: unknown; tools?: unknown }) => {
+    calls.push({
+      prompt: Array.isArray(options.prompt) ? options.prompt : [],
+      tools: options.tools,
+    });
+  };
+
+  return {
+    specificationVersion: "v3" as const,
+    provider: "test",
+    modelId: "test-model",
+    supportedUrls: {},
+    doGenerate: async (options: { prompt?: unknown; tools?: unknown }) => {
+      record(options);
+      return {
+        content: [{ type: "text", text: "ok" }],
+        finishReason: "stop" as const,
+        usage,
+        warnings: [],
+      };
+    },
+    doStream: async (options: { prompt?: unknown; tools?: unknown }) => {
+      record(options);
+      return { stream: finishStream() };
+    },
+  };
+}
+
+function messageRole(message: unknown) {
+  return isRecord(message) && typeof message.role === "string"
+    ? message.role
+    : "unknown";
+}
+
+function messageText(message: unknown): string {
+  if (!isRecord(message)) {
+    return "";
+  }
+
+  const content = message.content;
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (isRecord(part) && typeof part.text === "string") {
+        return part.text;
+      }
+      return "";
+    })
+    .join("");
+}
+
+function firstIndexContaining(prompt: unknown[], marker: string) {
+  return prompt.findIndex((message) => messageText(message).includes(marker));
+}
+
+function lastLeadingSystemIndex(prompt: unknown[]) {
+  let lastIndex = -1;
+  for (let i = 0; i < prompt.length; i++) {
+    if (messageRole(prompt[i]) !== "system") {
+      break;
+    }
+    lastIndex = i;
+  }
+  return lastIndex;
+}
+
+function toolNames(tools: unknown): string[] {
+  if (!Array.isArray(tools)) {
+    return [];
+  }
+
+  return tools.flatMap((tool) => {
+    if (!isRecord(tool)) {
+      return [];
+    }
+    if (typeof tool.name === "string") {
+      return [tool.name];
+    }
+    if (typeof tool.id === "string") {
+      return [tool.id];
+    }
+    return [];
+  });
+}
+
+function cachedPromptIndices(prompt: unknown[]) {
+  const cached = applyPromptCachePoints(prompt, "bedrock");
+  if (!Array.isArray(cached)) {
+    return [];
+  }
+
+  return cached.flatMap((message, index) => {
+    if (
+      isRecord(message) &&
+      isRecord(message.providerOptions) &&
+      isRecord(message.providerOptions.bedrock) &&
+      isRecord(message.providerOptions.bedrock.cachePoint)
+    ) {
+      return [index];
+    }
+    return [];
+  });
+}
+
+function errorAnalysisSkill() {
+  return createSkill({
+    name: SKILL_NAME,
+    description: SKILL_DESCRIPTION,
+    instructions: SKILL_BODY,
+  });
+}
+
+function createOrderAgent(params: {
+  calls: CapturedModelCall[];
+  skills?: ReturnType<typeof createSkill>[];
+  system?: string;
+}) {
+  return new Agent({
+    id: "mastra-prompt-order",
+    name: "Mastra prompt order",
+    instructions: STABLE_INSTRUCTIONS,
+    model: createRecordingModel(params.calls),
+    ...(params.skills ? { skills: params.skills } : {}),
+    inputProcessors: [new TrailingCurrentTimeProcessor()],
+    defaultOptions: {
+      maxSteps: 1,
+      ...(params.system ? { system: params.system } : {}),
+    },
+  });
+}
+
+async function captureFirstCall(
+  agent: Agent,
+  messages: Parameters<Agent["generate"]>[0],
+  options?: Parameters<Agent["generate"]>[1],
+) {
+  const result = await agent.generate(messages, {
+    maxSteps: 1,
+    ...options,
+  });
+  await result.text;
+  return result;
+}
+
+describe("Mastra model-call prompt order", () => {
+  it("places constructor instructions and defaultOptions.system before conversation, and the processLLMRequest clock last", async () => {
+    const calls: CapturedModelCall[] = [];
+    const agent = createOrderAgent({
+      calls,
+      system: SANDBOX_RESET_SYSTEM,
+    });
+
+    await captureFirstCall(agent, USER_TURN);
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt ?? [];
+    const instructionsIndex = firstIndexContaining(prompt, STABLE_INSTRUCTIONS);
+    const systemIndex = firstIndexContaining(prompt, SANDBOX_RESET_SYSTEM);
+    const userIndex = firstIndexContaining(prompt, USER_TURN);
+    const suffixIndex = firstIndexContaining(prompt, TRAILING_TIME);
+
+    expect(messageRole(prompt[instructionsIndex])).toBe("system");
+    expect(messageRole(prompt[systemIndex])).toBe("system");
+    expect(messageRole(prompt[userIndex])).toBe("user");
+    expect(messageRole(prompt[suffixIndex])).toBe("user");
+
+    expect(instructionsIndex).toBeGreaterThanOrEqual(0);
+    expect(systemIndex).toBeGreaterThan(instructionsIndex);
+    expect(userIndex).toBeGreaterThan(systemIndex);
+    expect(suffixIndex).toBe(prompt.length - 1);
+    expect(suffixIndex).toBeGreaterThan(userIndex);
+    expect(lastLeadingSystemIndex(prompt)).toBeGreaterThanOrEqual(systemIndex);
+  });
+
+  it("exposes skill metadata and skill tools on the first call without injecting the skill body", async () => {
+    const calls: CapturedModelCall[] = [];
+    const agent = createOrderAgent({
+      calls,
+      skills: [errorAnalysisSkill()],
+    });
+
+    await captureFirstCall(agent, USER_TURN);
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt ?? [];
+    const names = toolNames(calls[0]?.tools);
+    // Observed Mastra 1.46 skill tools: skill, skill_read, skill_search.
+    const skillMessageIndex = prompt.findIndex((message) => {
+      const text = messageText(message);
+      return (
+        text.includes(SKILL_NAME) ||
+        text.includes(SKILL_DESCRIPTION) ||
+        text.includes(SKILL_BODY)
+      );
+    });
+
+    expect(names).toEqual(
+      expect.arrayContaining(["skill", "skill_read", "skill_search"]),
+    );
+    expect(
+      prompt.some((message) => messageText(message).includes(SKILL_BODY)),
+    ).toBe(false);
+    expect(skillMessageIndex).toBeGreaterThanOrEqual(0);
+    expect(skillMessageIndex).toBeLessThanOrEqual(
+      lastLeadingSystemIndex(prompt),
+    );
+    expect(
+      prompt.some(
+        (message) =>
+          messageText(message).includes(SKILL_NAME) ||
+          messageText(message).includes(SKILL_DESCRIPTION),
+      ),
+    ).toBe(true);
+  });
+
+  it("places generate({ context }) after the leading system run and before the trailing clock", async () => {
+    const calls: CapturedModelCall[] = [];
+    const agent = createOrderAgent({ calls });
+
+    await captureFirstCall(agent, USER_TURN, {
+      context: [{ role: "user", content: CONTEXT_MESSAGE }],
+    });
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt ?? [];
+    const leadingSystemIndex = lastLeadingSystemIndex(prompt);
+    const contextIndex = firstIndexContaining(prompt, CONTEXT_MESSAGE);
+    const userIndex = firstIndexContaining(prompt, USER_TURN);
+    const suffixIndex = firstIndexContaining(prompt, TRAILING_TIME);
+
+    expect(contextIndex).toBeGreaterThan(leadingSystemIndex);
+    expect(contextIndex).toBeLessThan(suffixIndex);
+    expect(userIndex).toBeGreaterThan(leadingSystemIndex);
+    expect(suffixIndex).toBe(prompt.length - 1);
+    // Mastra inserts `context` immediately after the leading system run,
+    // before the persisted user turn. That would sit inside the growing
+    // conversation prefix if we used this channel for page/clock data.
+    expect(contextIndex).toBeLessThan(userIndex);
+  });
+
+  it("replaces constructor instructions when generate({ instructions }) is set", async () => {
+    const calls: CapturedModelCall[] = [];
+    const agent = createOrderAgent({ calls });
+
+    await captureFirstCall(agent, USER_TURN, {
+      instructions: PER_CALL_INSTRUCTIONS,
+    });
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt ?? [];
+    const overrideIndex = firstIndexContaining(prompt, PER_CALL_INSTRUCTIONS);
+    const stableIndex = firstIndexContaining(prompt, STABLE_INSTRUCTIONS);
+
+    expect(overrideIndex).toBeGreaterThanOrEqual(0);
+    expect(messageRole(prompt[overrideIndex])).toBe("system");
+    expect(overrideIndex).toBeLessThanOrEqual(lastLeadingSystemIndex(prompt));
+    expect(stableIndex).toBe(-1);
+  });
+
+  it("appends generate({ system }) inside the leading system run after constructor instructions", async () => {
+    const calls: CapturedModelCall[] = [];
+    const agent = createOrderAgent({ calls });
+
+    await captureFirstCall(agent, USER_TURN, {
+      system: PER_CALL_SYSTEM,
+    });
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt ?? [];
+    const instructionsIndex = firstIndexContaining(prompt, STABLE_INSTRUCTIONS);
+    const systemIndex = firstIndexContaining(prompt, PER_CALL_SYSTEM);
+    const userIndex = firstIndexContaining(prompt, USER_TURN);
+
+    expect(messageRole(prompt[systemIndex])).toBe("system");
+    expect(systemIndex).toBeGreaterThan(instructionsIndex);
+    expect(systemIndex).toBeLessThanOrEqual(lastLeadingSystemIndex(prompt));
+    expect(userIndex).toBeGreaterThan(systemIndex);
+  });
+
+  it("stamps cache checkpoints on the last leading system and last conversation message, not the trailing clock", async () => {
+    const calls: CapturedModelCall[] = [];
+    const agent = createOrderAgent({
+      calls,
+      system: SANDBOX_RESET_SYSTEM,
+    });
+
+    await captureFirstCall(agent, [
+      { role: "user", content: USER_TURN },
+      { role: "assistant", content: PRIOR_ASSISTANT },
+      { role: "user", content: FOLLOW_UP_USER },
+    ]);
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt ?? [];
+    const leadingSystemIndex = lastLeadingSystemIndex(prompt);
+    const instructionsIndex = firstIndexContaining(prompt, STABLE_INSTRUCTIONS);
+    const followUpIndex = firstIndexContaining(prompt, FOLLOW_UP_USER);
+    const suffixIndex = firstIndexContaining(prompt, TRAILING_TIME);
+    const priorUserIndex = firstIndexContaining(prompt, USER_TURN);
+    const cachedIndices = cachedPromptIndices(prompt);
+
+    expect(suffixIndex).toBe(prompt.length - 1);
+    expect(followUpIndex).toBe(suffixIndex - 1);
+    expect(instructionsIndex).toBeGreaterThanOrEqual(0);
+    expect(instructionsIndex).toBeLessThanOrEqual(leadingSystemIndex);
+    expect(messageText(prompt[leadingSystemIndex])).toContain(
+      SANDBOX_RESET_SYSTEM,
+    );
+    expect(cachedIndices).toContain(leadingSystemIndex);
+    expect(cachedIndices).toContain(followUpIndex);
+    expect(cachedIndices).toContain(priorUserIndex);
+    expect(cachedIndices).not.toContain(suffixIndex);
+  });
+});


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16808 app preview](https://pr-16808.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a worker test that drives a real Mastra 1.46 `Agent` (not the mocked constructor in `agent.test.ts`) and records the provider-facing `prompt` + `tools` on `doGenerate` / `doStream`.

That locks the message order we need for prompt-cache prefix design:

- `tools` first, including `skill` / `skill_read` / `skill_search` when skills are registered
- `Agent.instructions` as the first leading system message
- `defaultOptions.system` / `generate({ system })` as a later leading system message
- `generate({ context })` after the system run and **before** the user turn
- conversation history
- `processLLMRequest` trailing `<current_time>` user suffix last

Skill bodies stay out of the first call (metadata only). `generate({ instructions })` replaces constructor instructions. Existing `applyPromptCachePoints` still stamps the last leading system and last conversation message, and skips the trailing clock.

No production behavior change. Context-window truncation is still out of scope.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Impacted packages

- `worker`

## Verification

- `pnpm --filter worker run test mastraPromptOrder` — `Tests 6 passed (6)`
- `pnpm --filter worker run lint` — clean (`Tasks: 7 successful, 7 total` via pre-commit turbo lint)
- Skipped typecheck-all, browser, and seed: tests only, no UI or schema change

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Read the contributing guide
- Followed repo style (Prettier on the new test)
- Added tests that lock Mastra's real model-call order
- New unit tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04c8c-1c94-798f-90d5-7c8c71e46683?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04c8c-1c94-798f-90d5-7c8c71e46683&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds integration-style worker tests using a real Mastra 1.46 Agent and a recording model.
- Verifies system, context, conversation, and trailing processor message ordering.
- Verifies skill metadata/tool exposure and per-call instruction/system behavior.
- Confirms cache checkpoints exclude the trailing clock message.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only adds focused regression tests and no actionable defect was identified.

The new tests exercise the pinned Mastra Agent’s provider-facing prompt construction and existing cache-point logic without modifying runtime code.
</details>

<sub>Reviews (1): Last reviewed commit: ["test(worker): lock Mastra prompt order f..."](https://github.com/langfuse/langfuse/commit/59e6bb418238bc9d111d388ec925c994866b906e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58183924)</sub>

<!-- /greptile_comment -->