### PR TITLE
fix(shared): preserve user text when pydantic-ai message mixes tool responses with text parts

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/pydantic-ai.test.ts
+++ b/packages/shared/src/utils/chatml/adapters/pydantic-ai.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { pydanticAIAdapter } from "./pydantic-ai";
+
+describe("pydanticAIAdapter", () => {
+  it("preserves user text when a message contains both tool responses and text parts", () => {
+    const data = [
+      {
+        role: "user",
+        parts: [
+          { type: "tool_call_response", id: "t1", result: "42" },
+          { type: "text", content: "now summarize the result" },
+        ],
+      },
+    ];
+
+    const result = pydanticAIAdapter.preprocess(data, "input", {
+      framework: "pydantic-ai",
+    });
+
+    expect(result).toEqual([
+      { role: "tool", tool_call_id: "t1", content: "42" },
+      { role: "user", content: "now summarize the result" },
+    ]);
+  });
+
+  it("handles user messages with only tool responses without extra user message", () => {
+    const data = [
+      {
+        role: "user",
+        parts: [{ type: "tool_call_response", id: "t1", result: "42" }],
+      },
+    ];
+
+    const result = pydanticAIAdapter.preprocess(data, "input", {
+      framework: "pydantic-ai",
+    });
+
+    expect(result).toEqual([
+      { role: "tool", tool_call_id: "t1", content: "42" },
+    ]);
+  });
+
+  it("handles multiple tool responses alongside user text", () => {
+    const data = [
+      {
+        role: "user",
+        parts: [
+          { type: "tool_call_response", id: "t1", result: "42" },
+          { type: "tool_call_response", id: "t2", result: "100" },
+          { type: "text", content: "compare these two numbers" },
+        ],
+      },
+    ];
+
+    const result = pydanticAIAdapter.preprocess(data, "input", {
+      framework: "pydantic-ai",
+    });
+
+    expect(result).toEqual([
+      { role: "tool", tool_call_id: "t1", content: "42" },
+      { role: "tool", tool_call_id: "t2", content: "100" },
+      { role: "user", content: "compare these two numbers" },
+    ]);
+  });
+});

--- a/packages/shared/src/utils/chatml/adapters/pydantic-ai.ts
+++ b/packages/shared/src/utils/chatml/adapters/pydantic-ai.ts
@@ -213,12 +213,23 @@ function normalizeMessage(
 
   // User message with tool responses - split into separate tool messages
   if (message.role === "user" && toolResponses.length > 0) {
-    return toolResponses.map((tr) =>
+    const messages: Record<string, unknown>[] = toolResponses.map((tr) =>
       removeNullFields({
         role: "tool",
         ...tr,
       }),
     );
+    if (text) {
+      messages.push(
+        removeNullFields({
+          role: "user",
+          content: text,
+          ...thinkingFields,
+          ...rest,
+        }),
+      );
+    }
+    return messages;
   }
 
   // Regular text message (may include thinking for assistant messages)


### PR DESCRIPTION
## Problem
In `packages/shared/src/utils/chatml/adapters/pydantic-ai.ts`, when a user message contains both `tool_call_response` parts and `text` parts (such as in PydanticAI `ModelRequest(parts=[ToolReturnPart(...), UserPromptPart("...")])`), `normalizeMessage` split the tool responses into separate `role: "tool"` messages and completely dropped the text parts.

This caused chat bubbles and trace replays into the playground to lose the user's follow-up prompt.

## Solution
- Preserved user text in `normalizeMessage` when tool responses and text parts are present by appending a trailing `role: "user"` message with the text and metadata.
- Added unit tests in `packages/shared/src/utils/chatml/adapters/pydantic-ai.test.ts` verifying single and multiple tool response splits with text preserved.

Fixes #16447

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Preserves user text when Pydantic-AI user messages contain both tool responses and text.
- Splits tool responses into individual tool messages and appends the preserved text as a user message.
- Adds tests for single and multiple tool responses and tool-only messages.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable issues identified.

The normalization change preserves the previously dropped user text while retaining existing tool-only behavior, and the added tests cover the intended output shapes.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): preserve user text when pyd..."](https://github.com/langfuse/langfuse/commit/28648d1cd66e995a2945dafe7d509322d846c86c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58308824)</sub>

<!-- /greptile_comment -->