### PR TITLE
fix: allow empty ClickHouse passwords

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -35,7 +35,7 @@ if [ -z "${CLICKHOUSE_USER}" ]; then
 fi
 
 # Check if CLICKHOUSE_PASSWORD is set
-if [ -z "${CLICKHOUSE_PASSWORD}" ]; then
+if [ -z "${CLICKHOUSE_PASSWORD+x}" ]; then
   echo "Error: CLICKHOUSE_PASSWORD is not set."
   echo "Please set CLICKHOUSE_PASSWORD in your environment variables."
   exit 1

--- a/packages/shared/clickhouse/scripts/up.sh
+++ b/packages/shared/clickhouse/scripts/up.sh
@@ -25,7 +25,7 @@ if [ -z "${CLICKHOUSE_USER}" ]; then
 fi
 
 # Check if CLICKHOUSE_PASSWORD is set
-if [ -z "${CLICKHOUSE_PASSWORD}" ]; then
+if [ -z "${CLICKHOUSE_PASSWORD+x}" ]; then
   echo "Error: CLICKHOUSE_PASSWORD is not set."
   echo "Please set CLICKHOUSE_PASSWORD in your environment variables."
   exit 1


### PR DESCRIPTION
## Summary

Fixes #16730.

The ClickHouse migration scripts rejected an explicitly empty `CLICKHOUSE_PASSWORD`, even though an empty password is valid for the default ClickHouse user and the application configuration accepts it. This prevented self-hosted installations using passwordless ClickHouse from running migrations.

## Changes

- Update the password presence checks in `up.sh` and `dev-tables.sh` to distinguish an unset variable from an explicitly empty value.
- Keep the existing failure behavior when the variable is unset.

This is a shell-only compatibility fix. Non-empty passwords behave as before, and no API, database schema, or migration format changes are introduced.

## Validation

- `bash -n packages/shared/clickhouse/scripts/up.sh` — passed.
- `bash -n packages/shared/clickhouse/scripts/dev-tables.sh` — passed.
- Git Bash isolated harness — passed for unset, empty, and non-empty `CLICKHOUSE_PASSWORD` values in both scripts, using fake `migrate` and `clickhouse` commands.
- `git diff --check` — passed.

The full pnpm/ClickHouse integration suite was not run because it requires the repository's Docker services, ClickHouse client, migration tooling, and test environment. The focused shell validation does not require external services.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the ClickHouse migration and development-table scripts to distinguish an unset password from an explicitly empty password.
- Allows passwordless ClickHouse configurations to proceed.
- Preserves the existing error when `CLICKHOUSE_PASSWORD` is unset.
- Applies the same Bash parameter-expansion check consistently in both scripts.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The Bash expansion correctly distinguishes unset from empty values, and both downstream ClickHouse command paths support receiving an empty password.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow empty ClickHouse passwords"](https://github.com/langfuse/langfuse/commit/b6973967eff73bc78d8ed0310570e75f9f854b1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58309995)</sub>

<!-- /greptile_comment -->