### PR TITLE
fix(clickhouse): accept explicitly empty CLICKHOUSE_PASSWORD in migration scripts

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -34,8 +34,10 @@ if [ -z "${CLICKHOUSE_USER}" ]; then
   exit 1
 fi
 
-# Check if CLICKHOUSE_PASSWORD is set
-if [ -z "${CLICKHOUSE_PASSWORD}" ]; then
+# Check if CLICKHOUSE_PASSWORD is set. An explicitly empty value is accepted
+# to support instances whose user has no password (matches the application,
+# which validates the password as a plain string and allows "").
+if [ -z "${CLICKHOUSE_PASSWORD+x}" ]; then
   echo "Error: CLICKHOUSE_PASSWORD is not set."
   echo "Please set CLICKHOUSE_PASSWORD in your environment variables."
   exit 1

--- a/packages/shared/clickhouse/scripts/up.sh
+++ b/packages/shared/clickhouse/scripts/up.sh
@@ -24,8 +24,10 @@ if [ -z "${CLICKHOUSE_USER}" ]; then
   exit 1
 fi
 
-# Check if CLICKHOUSE_PASSWORD is set
-if [ -z "${CLICKHOUSE_PASSWORD}" ]; then
+# Check if CLICKHOUSE_PASSWORD is set. An explicitly empty value is accepted
+# to support instances whose user has no password (matches the application,
+# which validates the password as a plain string and allows "").
+if [ -z "${CLICKHOUSE_PASSWORD+x}" ]; then
   echo "Error: CLICKHOUSE_PASSWORD is not set."
   echo "Please set CLICKHOUSE_PASSWORD in your environment variables."
   exit 1


### PR DESCRIPTION
## Summary

Fixes #16730.

`up.sh` and `dev-tables.sh` currently treat an unset and explicitly empty `CLICKHOUSE_PASSWORD` the same, so migrations fail against passwordless ClickHouse instances.

The app already accepts an empty password, so this just makes the migration scripts behave the same way.

## Change

Use `[ -z "${CLICKHOUSE_PASSWORD+x}" ]` to check whether the variable is unset.

| `CLICKHOUSE_PASSWORD` | before | after |
|---|---|---|
| unset | fail | fail |
| `""` | fail | pass |
| non-empty | pass | pass |

No new config or behavior beyond allowing an explicitly empty password. An unset password still fails, so a forgotten password can't slip through. For an already passwordless server, blocking the migration doesn't add any extra protection.

## Verification

Tested locally with `clickhouse/clickhouse-server:25.12`:

- unset password → fails as before
- empty password → all 46 migrations pass
- non-empty password → all 46 migrations pass
- `bash -n` passes for both scripts