### PR TITLE
fix(evals): show custom model configuration

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSetupEditor/components/DefinitionStep/components/ModelSelector/ModelSelector.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSetupEditor/components/DefinitionStep/components/ModelSelector/ModelSelector.tsx
@@ -68,6 +68,10 @@ export function ModelSelector({
         onSelectCustom={state.actions.selectModel}
         onConfigureProviders={onConfigureProviders}
         onConfigureModel={() => setConfigurationOpen(true)}
+        hasModelConfiguration={
+          state.mode === "custom" &&
+          Object.keys(state.modelParams ?? {}).length > 0
+        }
         canSetProjectDefault={canSetProjectDefault}
         onSetProjectDefault={() => {
           if (selectedConfig) onSetProjectDefault(selectedConfig);

--- a/web/src/features/evals/v2/components/Evaluators/JudgeModelConfigurationDialog/JudgeModelConfigurationDialog.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/JudgeModelConfigurationDialog/JudgeModelConfigurationDialog.tsx
@@ -55,7 +55,14 @@ function JudgeModelConfigurationDialogContent({
   onSave: (model: ProjectDefaultModelConfig) => void;
 }) {
   const { modelParams, updateModelParamValue, setModelParamEnabled } =
-    useModelParams(undefined, { initialModel });
+    useModelParams(undefined, {
+      initialModel: {
+        provider: initialModel.provider,
+        adapter: initialModel.adapter,
+        model: initialModel.model,
+        ...initialModel.modelParams,
+      },
+    });
 
   return (
     <DialogContent>

--- a/web/src/features/evals/v2/components/Evaluators/JudgeModelPicker/JudgeModelPicker.stories.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/JudgeModelPicker/JudgeModelPicker.stories.tsx
@@ -86,6 +86,19 @@ export const Custom = meta.story({
   render: StatefulJudgeModelPicker,
 });
 
+export const CustomWithModelConfiguration = meta.story({
+  args: {
+    ...actions,
+    open: true,
+    mode: "custom",
+    defaultModel: { provider: "OpenAI", model: "gpt-4.1-mini" },
+    providerGroups: [["Anthropic", ["claude-sonnet-4"]]],
+    selectedModel: { provider: "Anthropic", model: "claude-sonnet-4" },
+    hasModelConfiguration: true,
+  },
+  render: StatefulJudgeModelPicker,
+});
+
 export const CustomWithoutSelection = meta.story({
   args: {
     ...actions,

--- a/web/src/features/evals/v2/components/Evaluators/JudgeModelPicker/JudgeModelPicker.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/JudgeModelPicker/JudgeModelPicker.tsx
@@ -35,6 +35,7 @@ type JudgeModelPickerCommonProps = {
   providerGroups: Array<[string, string[]]>;
   onConfigureProviders: () => void;
   onConfigureModel: () => void;
+  hasModelConfiguration?: boolean;
 };
 
 type EvaluatorJudgeModelPickerProps = JudgeModelPickerCommonProps & {
@@ -169,6 +170,7 @@ export function JudgeModelPicker(props: JudgeModelPickerProps) {
     providerGroups,
     onConfigureProviders,
     onConfigureModel,
+    hasModelConfiguration = false,
   } = props;
   const selectsProjectDefault = props.purpose === "projectDefault";
   const selectedModel = selectsProjectDefault
@@ -304,7 +306,19 @@ export function JudgeModelPicker(props: JudgeModelPickerProps) {
               onClick={() => selectAndClose(onConfigureModel)}
             >
               <Settings2 className="text-muted-foreground mr-2 h-3.5 w-3.5" />
-              Model configuration...
+              Model configuration
+              {hasModelConfiguration ? (
+                <>
+                  <span className="sr-only">Customized</span>
+                  <span
+                    aria-hidden="true"
+                    className="relative ml-auto inline-flex h-2.5 w-2.5"
+                  >
+                    <span className="bg-dark-yellow absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />
+                    <span className="bg-dark-yellow relative inline-flex h-2.5 w-2.5 rounded-full" />
+                  </span>
+                </>
+              ) : null}
             </Button>
             {!selectsProjectDefault ? (
               <Button

--- a/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorsPage.tsx
@@ -599,6 +599,10 @@ export default function EvaluatorsPage() {
                 }}
                 onConfigureProviders={projectDefaultModel.openProviderSettings}
                 onConfigureModel={() => setDefaultModelConfigurationOpen(true)}
+                hasModelConfiguration={Boolean(
+                  defaultModelConfig &&
+                  Object.keys(defaultModelConfig.modelParams).length > 0,
+                )}
               >
                 <PopoverTrigger asChild>
                   <JudgeModelPickerTrigger


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16815 app preview](https://pr-16815.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

- Preserve saved model parameters when reopening model configuration.
- Show an accessible marker when evaluator or project-default model parameters are customized.
- Add a Storybook case for the configured state.

## Test plan

- `pnpm run lint`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run test-client judgeModel.clienttest.ts`
- `pnpm --filter web run test-storybook JudgeModelPicker.stories.tsx`

## Preview test steps

1. Open Evaluators and configure custom parameters for an evaluator model.
2. Reopen the model picker and verify the configuration marker is visible.
3. Reopen model configuration and verify the saved parameters are preserved.
4. Repeat for the project default model.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores saved evaluator and project-default model parameters when reopening configuration and adds an accessible customized-state marker to the model picker.

- Flattens saved advanced parameters into the model-parameter hook’s initial state.
- Computes customized state for evaluator and project-default model configurations.
- Adds a Storybook scenario covering the configured picker state.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking reduced-motion accessibility issue in the new animated marker.

The saved-parameter initialization and customized-state calculations preserve the expected model configuration behavior, while the new decorative ping animation should be disabled for users who request reduced motion.

**Files Needing Attention:** web/src/features/evals/v2/components/Evaluators/JudgeModelPicker/JudgeModelPicker.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/components/Evaluators/JudgeModelPicker/JudgeModelPicker.tsx:317
**Ping ignores reduced motion**

The customized-state indicator unconditionally applies `animate-ping`, so it continues pulsing for users who request reduced motion and creates an avoidable accessibility issue.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): show custom model configurat..."](https://github.com/langfuse/langfuse/commit/b678971ffc6a9e13640ab33ce52fa50031aac47f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58383057)</sub>

<!-- /greptile_comment -->