### PR TITLE
feat(mcp): describe evaluator output definitions

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -214,7 +214,7 @@ const createLlmEvaluatorForMcpReadTest = async (
       name,
       type: "LLM_AS_JUDGE",
       prompt: "Judge {{input}} against {{output}}",
-      outputDefinition: { version: 2, ...mcpEvalOutputDefinition },
+      outputDefinition: mcpEvalOutputDefinition,
     },
     setup.context,
   )) as { id: string; name: string };

--- a/web/src/__tests__/server/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-write.servertest.ts
@@ -131,7 +131,7 @@ const createStableLlmEvaluatorForMcpWriteTest = async (
       name,
       type: "LLM_AS_JUDGE",
       prompt: "Judge {{input}} against {{output}}",
-      outputDefinition: { version: 2, ...mcpEvalOutputDefinition },
+      outputDefinition: mcpEvalOutputDefinition,
       variableMapping: [
         { templateVariable: "input", selectedColumnId: "input" },
         { templateVariable: "output", selectedColumnId: "output" },
@@ -203,7 +203,7 @@ describe("MCP Write Tools", () => {
           name: evaluator.name,
           type: "LLM_AS_JUDGE",
           prompt: "Judge {{input}} very strictly",
-          outputDefinition: { version: 2, ...mcpEvalOutputDefinition },
+          outputDefinition: mcpEvalOutputDefinition,
         },
         setup.context,
       )) as { id: string; versions: Array<{ version: number }> };

--- a/web/src/__tests__/server/unit/evaluator-input.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluator-input.servertest.ts
@@ -44,6 +44,35 @@ describe("MCP evaluator input", () => {
       type: "object",
       required: ["provider", "model"],
     });
+    expect(schema.properties?.outputDefinition).toMatchObject({
+      type: "object",
+      required: ["dataType", "reasoning", "score"],
+      properties: {
+        dataType: {
+          type: "string",
+          enum: ["NUMERIC", "CATEGORICAL", "BOOLEAN"],
+        },
+        reasoning: {
+          type: "object",
+          properties: {
+            description: { type: "string" },
+          },
+        },
+        score: {
+          type: "object",
+          properties: {
+            description: { type: "string" },
+            minValue: { type: "number" },
+            maxValue: { type: "number" },
+            categories: {
+              type: "array",
+              items: { type: "string" },
+            },
+            shouldAllowMultipleMatches: { type: "boolean" },
+          },
+        },
+      },
+    });
     expect(hasJsonSchemaComposition(schema)).toBe(false);
   });
 

--- a/web/src/features/mcp/server/evals/tools/evaluatorInput.ts
+++ b/web/src/features/mcp/server/evals/tools/evaluatorInput.ts
@@ -1,4 +1,8 @@
-import { EvalTemplateType, observationVariableMapping } from "@langfuse/shared";
+import {
+  EvalOutputDataTypeSchema,
+  EvalTemplateType,
+  observationVariableMapping,
+} from "@langfuse/shared";
 import { z } from "zod";
 import {
   CodeEvaluatorDefinitionSchema,
@@ -27,6 +31,50 @@ const McpObservationVariableMappingSchema = observationVariableMapping.extend({
   jsonSelector: z.string().optional(),
 });
 
+const McpEvalOutputDefinitionSchema = z.object({
+  dataType: EvalOutputDataTypeSchema.describe(
+    "The score type returned by the evaluator.",
+  ),
+  reasoning: z
+    .object({
+      description: z
+        .string()
+        .optional()
+        .describe("Instructions for the evaluator's reasoning output."),
+    })
+    .describe("Definition of the evaluator's textual reasoning output."),
+  score: z
+    .object({
+      description: z
+        .string()
+        .optional()
+        .describe("Instructions for the evaluator's score output."),
+      minValue: z
+        .number()
+        .optional()
+        .describe("Optional minimum score for NUMERIC evaluators."),
+      maxValue: z
+        .number()
+        .optional()
+        .describe("Optional maximum score for NUMERIC evaluators."),
+      categories: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Allowed score labels for CATEGORICAL evaluators. Provide at least two unique values.",
+        ),
+      shouldAllowMultipleMatches: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether CATEGORICAL evaluators may return multiple score labels.",
+        ),
+    })
+    .describe(
+      "Definition of the evaluator's typed score output. Type-specific fields are validated against dataType.",
+    ),
+});
+
 export const McpEvaluatorInputBase = z.object({
   name: CreateEvaluatorSchema.shape.name,
   description: CreateEvaluatorSchema.shape.description.unwrap().optional(),
@@ -35,7 +83,9 @@ export const McpEvaluatorInputBase = z.object({
   modelConfig: McpEvaluatorModelConfigSchema.optional().describe(
     "Optional custom model configuration. Omit to use the project default model.",
   ),
-  outputDefinition: z.record(z.string(), z.unknown()).optional(),
+  outputDefinition: McpEvalOutputDefinitionSchema.optional().describe(
+    "Required for LLM-as-a-judge evaluators. Defines the reasoning and score returned by the evaluator.",
+  ),
   sourceCode: CodeEvaluatorDefinitionSchema.shape.sourceCode.optional(),
   sourceCodeLanguage:
     CodeEvaluatorDefinitionSchema.shape.sourceCodeLanguage.optional(),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16816 app preview](https://pr-16816.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a structured, composition-free JSON Schema for evaluator `outputDefinition` inputs exposed by the create and update MCP tools. MCP clients now receive guidance for numeric, boolean, and categorical score configuration while the existing strict domain schema remains the runtime validation authority.

It also removes a legacy `version` key from MCP test fixtures; that key was accepted only because the former catch-all schema permitted it and was silently discarded by the service.

Impacted package: `web`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Proof of work

A live `tools/list` request against the local MCP endpoint now returns `outputDefinition` as an object with:

- required `dataType`, `reasoning`, and `score` fields
- the `NUMERIC`, `CATEGORICAL`, and `BOOLEAN` data types
- typed numeric bounds, categorical labels, and multiple-match configuration
- descriptions for each type-specific field
- no `anyOf`, `oneOf`, or `allOf` composition

## Verification

- `pnpm --filter web run test src/__tests__/server/unit/evaluator-input.servertest.ts` — `Tests 3 passed (3)`
- `pnpm --filter web run test src/__tests__/server/mcp-tools-write.servertest.ts` — `Tests 68 passed (68)`
- `pnpm --filter web run test src/__tests__/server/mcp-tools-read.servertest.ts -t "listEvaluators tool|getEvaluator tool"` — `Tests 6 passed | 168 skipped (174)`
- `pnpm --filter web run typecheck` — passed
- Commit hooks: Prettier check passed; lint `Tasks: 7 successful, 7 total`

## Checklist

- [x] The MCP schema remains free of JSON Schema unions/intersections.
- [x] Added regression coverage for all output definition fields.
- [x] No documentation update is required because this is generated MCP tool metadata.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15709](https://linear.app/clickhouse/issue/LFE-15709/better-mcp-schema-for-evaluator-definition)

<div><a href="https://cursor.com/agents/bc-b3a16177-8a07-46ab-91f8-964b23653cfb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3a16177-8a07-46ab-91f8-964b23653cfb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds composition-free MCP metadata for evaluator output definitions while preserving the strict domain schema as the runtime validator.
- Describes numeric, categorical, and boolean evaluator output configuration.
- Adds regression assertions for the generated JSON Schema structure and composition-free requirement.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The structured MCP schema accepts domain-valid evaluator output definitions, remains composition-free, and leaves strict type-specific validation on the existing runtime path.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mcp): describe evaluator output def..."](https://github.com/langfuse/langfuse/commit/6e99d011c39ea16787892f681b5b773d840d6588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58384718)</sub>

<!-- /greptile_comment -->