### PR TITLE
fix(api): keep historical evaluation rule filters readable

### DIFF
--- a/fern/apis/server/definition/unstable/evaluation-rules.yml
+++ b/fern/apis/server/definition/unstable/evaluation-rules.yml
@@ -2,6 +2,7 @@
 imports:
   commons: ./commons.yml
   errors: ./errors.yml
+  evals: ../evaluation-commons.yml
   pagination: ../utils/pagination.yml
 
 service:
@@ -323,7 +324,7 @@ service:
           type: string
           docs: Evaluation rule identifier.
       request: UpdateEvaluationRuleRequest
-      response: EvaluationRule
+      response: ReadableV2EvaluationRule
       errors:
         - errors.BadRequestError
         - errors.UnauthorizedError
@@ -431,6 +432,22 @@ types:
       mapping:
         type: list<commons.PromptVariableMappingRead>
         docs: Deprecated compatibility alias containing the effective mapping for `evaluators[0]`.
+
+  ReadableV2EvaluationRule:
+    extends: EvaluationRuleBase
+    properties:
+      evaluators:
+        type: list<EvaluationRuleEvaluatorAssignment>
+        docs: Evaluators attached to this rule in deterministic assignment order. A `null` mapping inherits the evaluator version's default mapping.
+      target:
+        type: commons.EvaluationRuleTarget
+        docs: Target object type that should trigger scoring.
+      filter:
+        type: list<evals.EvaluationRuleReadFilter>
+        docs: List of stored filter conditions returned verbatim. Historical filters remain readable even when the current write contract no longer accepts their shape.
+      mapping:
+        type: list<commons.PromptVariableMappingRead>
+        docs: Deprecated compatibility alias containing the effective mapping for `evaluators[0]`.
     examples:
       - value:
           id: erule_123
@@ -498,7 +515,7 @@ types:
     docs: Evaluation rule returned by list and get, including read-only legacy trace and dataset rules.
     discriminated: false
     union:
-      - EvaluationRule
+      - ReadableV2EvaluationRule
       - LegacyEvaluationRule
 
   EvaluationRules:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8973,7 +8973,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/unstableEvaluationRule'
+                $ref: '#/components/schemas/unstableReadableV2EvaluationRule'
         '400':
           description: ''
           content:
@@ -19090,6 +19090,42 @@ components:
         - mapping
       allOf:
         - $ref: '#/components/schemas/unstableEvaluationRuleBase'
+    unstableReadableV2EvaluationRule:
+      title: unstableReadableV2EvaluationRule
+      type: object
+      properties:
+        evaluators:
+          type: array
+          items:
+            $ref: '#/components/schemas/unstableEvaluationRuleEvaluatorAssignment'
+          description: >-
+            Evaluators attached to this rule in deterministic assignment order.
+            A `null` mapping inherits the evaluator version's default mapping.
+        target:
+          $ref: '#/components/schemas/unstableEvaluationRuleTarget'
+          description: Target object type that should trigger scoring.
+        filter:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationRuleReadFilter'
+          description: >-
+            List of stored filter conditions returned verbatim. Historical
+            filters remain readable even when the current write contract no
+            longer accepts their shape.
+        mapping:
+          type: array
+          items:
+            $ref: '#/components/schemas/unstablePromptVariableMappingRead'
+          description: >-
+            Deprecated compatibility alias containing the effective mapping for
+            `evaluators[0]`.
+      required:
+        - evaluators
+        - target
+        - filter
+        - mapping
+      allOf:
+        - $ref: '#/components/schemas/unstableEvaluationRuleBase'
     unstableLegacyEvaluationRule:
       title: unstableLegacyEvaluationRule
       type: object
@@ -19144,7 +19180,7 @@ components:
     unstableReadableEvaluationRule:
       title: unstableReadableEvaluationRule
       oneOf:
-        - $ref: '#/components/schemas/unstableEvaluationRule'
+        - $ref: '#/components/schemas/unstableReadableV2EvaluationRule'
         - $ref: '#/components/schemas/unstableLegacyEvaluationRule'
       description: >-
         Evaluation rule returned by list and get, including read-only legacy

--- a/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
@@ -476,7 +476,7 @@ describe("unstable public evaluation-rule service", () => {
         orgId: "org",
         projectId: "project",
         evaluationRuleId: "rule",
-        input: { name: "Renamed rule" },
+        input: { name: "Renamed rule", target: "observation" },
       }),
     ).resolves.toMatchObject({
       name: "Renamed rule",

--- a/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
@@ -207,10 +207,16 @@ function buildMigratedRuleWithLegacyFilter() {
     targetObject: "event",
     filter: [
       {
-        type: "stringOptions",
-        column: "experimentDatasetId",
-        operator: "any of",
-        value: ["legacy-value"],
+        type: "string",
+        column: "environment",
+        operator: "does not contain",
+        value: "langfuse-",
+      },
+      {
+        type: "null",
+        column: "experimentId",
+        operator: "is null",
+        value: "",
       },
     ],
     sampling: 1,
@@ -438,10 +444,16 @@ describe("unstable public evaluation-rule service", () => {
           id: "rule",
           filter: [
             {
-              type: "stringOptions",
-              column: "datasetId",
-              operator: "any of",
-              value: ["legacy-value"],
+              type: "string",
+              column: "environment",
+              operator: "does not contain",
+              value: "langfuse-",
+            },
+            {
+              type: "null",
+              column: "experimentId",
+              operator: "is null",
+              value: "",
             },
           ],
         },
@@ -468,7 +480,7 @@ describe("unstable public evaluation-rule service", () => {
       }),
     ).resolves.toMatchObject({
       name: "Renamed rule",
-      filter: [{ column: "datasetId" }],
+      filter: [{ column: "environment" }, { column: "experimentId" }],
     });
     expect(prisma.evaluationRule.update).toHaveBeenCalledOnce();
   });
@@ -504,6 +516,26 @@ describe("unstable public evaluation-rule service", () => {
       }),
     ).resolves.toMatchObject({ filter: replacementFilter, enabled: false });
     expect(prisma.evaluationRule.update).toHaveBeenCalledOnce();
+  });
+
+  it("requires a replacement filter when changing the target of a migrated rule", async () => {
+    const migratedRule = buildMigratedRuleWithLegacyFilter();
+    (findPublicV2EvaluationRule as Mock).mockResolvedValue(migratedRule);
+    (prisma.evaluationRule.findFirst as Mock).mockResolvedValue(migratedRule);
+
+    await expect(
+      updatePublicEvaluationRule({
+        orgId: "org",
+        projectId: "project",
+        evaluationRuleId: "rule",
+        input: { target: "experiment" },
+      }),
+    ).rejects.toMatchObject({
+      httpCode: 400,
+      code: "invalid_body",
+      details: { field: "filter" },
+    });
+    expect(prisma.evaluationRule.update).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/web/src/features/evals/server/unstable-public-api/adapters.ts
+++ b/web/src/features/evals/server/unstable-public-api/adapters.ts
@@ -28,6 +28,7 @@ import {
   PUBLIC_EVALUATOR_TYPE_CODE,
   PUBLIC_EVALUATOR_TYPE_LLM_AS_JUDGE,
   PublicEvaluationRuleFilter,
+  PublicEvaluationRuleReadFilter,
   type PublicEvaluationRuleFilterType,
   type PromptVariableMappingInputType,
   type PromptVariableMappingReadType,
@@ -406,19 +407,9 @@ function toApiFilters(
     target === "experiment"
       ? stripExperimentRootFilter(storedFilters.data)
       : storedFilters.data;
-  const publicFilters = effectiveFilters.map(toApiFilter);
-  const parsedPublicFilters = z
-    .array(PublicEvaluationRuleFilter)
-    .safeParse(publicFilters);
-
-  if (!parsedPublicFilters.success) {
-    logger.error("Failed to parse unstable public evaluation rule filters", {
-      issues: parsedPublicFilters.error.issues,
-    });
-    throw new InternalServerError("Evaluation rule filter is corrupted");
-  }
-
-  return parsedPublicFilters.data;
+  return z
+    .array(PublicEvaluationRuleReadFilter)
+    .parse(effectiveFilters.map(toApiFilter));
 }
 
 export function toApiEvaluator(params: {
@@ -614,7 +605,15 @@ export function toApiWritableV2EvaluationRule(
   ) {
     throw new InternalServerError("Evaluation rule target is corrupted");
   }
-  return evaluationRule;
+
+  const filter = z
+    .array(PublicEvaluationRuleFilter)
+    .safeParse(evaluationRule.filter);
+  if (!filter.success) {
+    throw new InternalServerError("Evaluation rule filter is corrupted");
+  }
+
+  return { ...evaluationRule, filter: filter.data };
 }
 
 export function toEvaluationRuleInput(params: {

--- a/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
@@ -595,7 +595,8 @@ export async function updatePublicEvaluationRule(params: {
     });
   }
   const updatesFilterOrTarget =
-    suppliedFilter !== undefined || suppliedTarget !== undefined;
+    suppliedFilter !== undefined ||
+    (suppliedTarget !== undefined && suppliedTarget !== existingPublic.target);
   const parsedExistingFilter = PublicEvaluationRuleFilter.array().safeParse(
     existingPublic.filter,
   );
@@ -734,6 +735,7 @@ export async function updatePublicEvaluationRule(params: {
     replacementAssignments,
     patchedFirstAssignment,
     effectiveAssignmentCount: effectiveAssignments.length,
+    updatesFilterOrTarget,
   });
   const evaluationRule = toApiReadableV2EvaluationRule(updated);
   if (params.auditScope) {
@@ -774,6 +776,7 @@ async function updateRuleWithRuleService(params: {
   replacementAssignments: PreparedAssignment[] | null;
   patchedFirstAssignment: PreparedAssignment | null;
   effectiveAssignmentCount: number;
+  updatesFilterOrTarget: boolean;
 }) {
   const firstAssignment = params.existing.assignments[0];
   const evaluatorMappings = params.replacementAssignments
@@ -807,7 +810,9 @@ async function updateRuleWithRuleService(params: {
       projectId: params.projectId,
       ruleId: params.evaluationRuleId,
       targetObject:
-        "target" in params.input ? params.fields.targetObject : undefined,
+        params.updatesFilterOrTarget && "target" in params.input
+          ? params.fields.targetObject
+          : undefined,
       name: params.input.name,
       enabled:
         params.input.enabled === undefined
@@ -815,10 +820,9 @@ async function updateRuleWithRuleService(params: {
           : params.effectiveAssignmentCount > 0 &&
             params.fields.status === JobConfigState.ACTIVE,
       sampling: params.input.sampling,
-      filter:
-        "filter" in params.input || "target" in params.input
-          ? (params.fields.filter as FilterState)
-          : undefined,
+      filter: params.updatesFilterOrTarget
+        ? (params.fields.filter as FilterState)
+        : undefined,
       evaluatorMappings,
     }),
   );

--- a/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
@@ -2,6 +2,7 @@ import { type ApiAccessScope } from "@langfuse/shared/src/server";
 import { EvalTemplateType, prisma } from "@langfuse/shared/src/db";
 import {
   JobConfigState,
+  InternalServerError,
   LangfuseNotFoundError,
   EvalTargetObject,
   type FilterCondition,
@@ -23,6 +24,7 @@ import type {
   PostUnstableEvaluationRuleBodyType,
 } from "@/src/features/public-api/types/unstable-evaluation-rules";
 import {
+  PublicEvaluationRuleFilter,
   type PromptVariableMappingInputType,
   type PromptVariableMappingReadType,
   type PublicEvaluationRuleTargetType,
@@ -274,6 +276,17 @@ async function findPublicWritableV2EvaluationRuleOrThrow(params: {
     );
   }
   return rule;
+}
+
+function toApiReadableV2EvaluationRule(rule: StoredPublicV2EvaluationRule) {
+  const evaluationRule = toApiV2EvaluationRule(rule);
+  if (
+    evaluationRule.target !== "observation" &&
+    evaluationRule.target !== "experiment"
+  ) {
+    throw new InternalServerError("Evaluation rule target is corrupted");
+  }
+  return evaluationRule;
 }
 
 export async function listPublicEvaluationRules(params: {
@@ -564,7 +577,7 @@ export async function updatePublicEvaluationRule(params: {
   auditScope?: Pick<ApiAccessScope, "orgId" | "apiKeyId">;
 }) {
   const existing = await findPublicWritableV2EvaluationRuleOrThrow(params);
-  const existingPublic = toApiWritableV2EvaluationRule(existing);
+  const existingPublic = toApiReadableV2EvaluationRule(existing);
   const nextEnabled = params.input.enabled ?? existingPublic.enabled;
   if (nextEnabled && existingPublic.status !== "active") {
     await assertActivePublicApiEvaluationRuleLimitNotExceeded(params.projectId);
@@ -583,6 +596,22 @@ export async function updatePublicEvaluationRule(params: {
   }
   const updatesFilterOrTarget =
     suppliedFilter !== undefined || suppliedTarget !== undefined;
+  const parsedExistingFilter = PublicEvaluationRuleFilter.array().safeParse(
+    existingPublic.filter,
+  );
+  if (
+    updatesFilterOrTarget &&
+    suppliedFilter === undefined &&
+    !parsedExistingFilter.success
+  ) {
+    throw createStructuredPublicApiError({
+      httpCode: 400,
+      code: "invalid_body",
+      message:
+        "The stored filter is no longer accepted for writes. Provide a target-compatible filter with this update.",
+      details: { field: "filter" },
+    });
+  }
   const ruleFields = toEvaluationRuleFields({
     name: params.input.name ?? existingPublic.name,
     target: nextTarget,
@@ -590,7 +619,7 @@ export async function updatePublicEvaluationRule(params: {
     sampling: params.input.sampling ?? existingPublic.sampling,
     // Target changes must also validate the effective filter against the new target.
     filter: updatesFilterOrTarget
-      ? (suppliedFilter ?? existingPublic.filter)
+      ? (suppliedFilter ?? parsedExistingFilter.data ?? [])
       : [],
   });
 
@@ -706,7 +735,7 @@ export async function updatePublicEvaluationRule(params: {
     patchedFirstAssignment,
     effectiveAssignmentCount: effectiveAssignments.length,
   });
-  const evaluationRule = toApiWritableV2EvaluationRule(updated);
+  const evaluationRule = toApiReadableV2EvaluationRule(updated);
   if (params.auditScope) {
     await auditLog({
       action: "update",
@@ -831,7 +860,7 @@ export async function deletePublicEvaluationRule(params: {
   auditScope?: Pick<ApiAccessScope, "orgId" | "apiKeyId">;
 }) {
   const existing = await findPublicWritableV2EvaluationRuleOrThrow(params);
-  const existingPublic = toApiWritableV2EvaluationRule(existing);
+  const existingPublic = toApiReadableV2EvaluationRule(existing);
   await runRuleServiceMutation(() =>
     ruleService.delete(params.projectId, params.evaluationRuleId),
   );

--- a/web/src/features/evals/server/unstable-public-api/types.ts
+++ b/web/src/features/evals/server/unstable-public-api/types.ts
@@ -10,6 +10,7 @@ import type {
   PublicEvaluationRuleEvaluatorReferenceType,
   PublicEvaluationRuleEvaluatorType,
   PublicEvaluationRuleFilterType,
+  PublicEvaluationRuleReadFilterType,
   PromptVariableMappingReadType,
   PublicEvaluationRuleStatusType,
   PublicEvaluationRuleTargetType,
@@ -104,8 +105,15 @@ type ApiLegacyEvaluationRuleRecord = ApiEvaluationRuleRecordBase & {
   mapping: LegacyPromptVariableMappingType[];
 };
 
+type ApiReadableV2EvaluationRuleRecord = Omit<
+  ApiWritableEvaluationRuleRecord,
+  "filter"
+> & {
+  filter: PublicEvaluationRuleReadFilterType[];
+};
+
 export type ApiEvaluationRuleRecord =
-  | ApiWritableEvaluationRuleRecord
+  | ApiReadableV2EvaluationRuleRecord
   | ApiLegacyEvaluationRuleRecord;
 
 export type EvaluationRuleEvaluatorFamilyReference =

--- a/web/src/features/public-api/types/unstable-evaluation-rules.ts
+++ b/web/src/features/public-api/types/unstable-evaluation-rules.ts
@@ -8,6 +8,7 @@ import {
   ObservationPromptVariableMappingInput,
   PUBLIC_EVALUATOR_TYPE_CODE,
   PublicEvaluationRuleFilter,
+  PublicEvaluationRuleReadFilter,
   PublicEvaluationRuleEvaluator,
   PublicEvaluationRuleEvaluatorReference,
   PublicEvaluationRuleEvaluatorReferencePatch,
@@ -48,6 +49,10 @@ const APIEvaluationRule = z
   })
   .strict();
 
+const APIReadableV2EvaluationRule = APIEvaluationRule.extend({
+  filter: z.array(PublicEvaluationRuleReadFilter),
+});
+
 const APILegacyEvaluationRule = z
   .object({
     ...APIEvaluationRuleBase,
@@ -66,7 +71,7 @@ const APILegacyEvaluationRule = z
   .strict();
 
 const APIReadableEvaluationRule = z.union([
-  APIEvaluationRule,
+  APIReadableV2EvaluationRule,
   APILegacyEvaluationRule,
 ]);
 
@@ -237,7 +242,7 @@ export type PatchUnstableEvaluationRuleBodyType = z.infer<
 >;
 
 /** @alias */
-export const PatchUnstableEvaluationRuleResponse = APIEvaluationRule;
+export const PatchUnstableEvaluationRuleResponse = APIReadableV2EvaluationRule;
 
 /** @alias */
 export const DeleteUnstableEvaluationRuleQuery = GetUnstableEvaluationRuleQuery;

--- a/web/src/features/public-api/types/unstable-public-evals-contract.ts
+++ b/web/src/features/public-api/types/unstable-public-evals-contract.ts
@@ -187,6 +187,20 @@ export const LegacyPromptVariableMapping = z
     },
   );
 
+const PublicEvaluationRuleReadFilterBase = z
+  .object({
+    type: z.string(),
+    column: z.string(),
+    operator: z.string(),
+    value: z.unknown().optional(),
+  })
+  .loose();
+
+export const PublicEvaluationRuleReadFilter = z.union([
+  PublicEvaluationRuleReadFilterBase.safeExtend({ key: z.string() }),
+  PublicEvaluationRuleReadFilterBase,
+]);
+
 const filterSchemaFactories = {
   datetime: (columnId: string) =>
     timeFilter.safeExtend({ column: z.literal(columnId) }),
@@ -304,6 +318,9 @@ export type LegacyPromptVariableMappingType = z.infer<
 >;
 export type PublicEvaluationRuleFilterType = z.infer<
   typeof PublicEvaluationRuleFilter
+>;
+export type PublicEvaluationRuleReadFilterType = z.infer<
+  typeof PublicEvaluationRuleReadFilter
 >;
 export const UnstablePublicApiPaginationQuery = z.object({
   page: z.preprocess(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16819 app preview](https://pr-16819.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What changed

Historical evaluation-rule filters remain readable through the unstable API even when the current write contract no longer accepts their shape.

- keep list/get and unrelated updates working for valid stored filters
- allow replacing old filters with current filter shapes
- require a replacement filter when changing the target of an incompatible rule
- keep create responses strict while documenting broad read/PATCH responses

## Why

The evaluator migration copied existing JSON filters unchanged. The unstable read adapter then validated them against today's narrower write schema, so one historical filter returned a 500 for the whole page.

Production example: https://app.datadoghq.eu/apm/trace/8f16a2c52ec803acbf06643d1a0ad317

## Verification

- `Tests  49 passed (49)`
- `Tasks: 7 successful, 7 total` (lint)
- `Tasks: 8 successful, 8 total` (typecheck)
- OpenAPI regenerated with `pnpm run openapi:export`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR separates strict writable evaluation-rule filters from a broader readable response shape so migrated historical filters remain accessible. It also validates create responses strictly and requires filter replacement when changing the target of an incompatible rule.

- Adds readable V2 rule and historical-filter schemas across runtime, Fern, and generated OpenAPI contracts.
- Uses broad read adapters for list, get, update, and delete workflows while retaining strict create validation.
- Adds update validation and tests for migrated filters.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PATCH regression should be fixed before merging because clients that repeat the current target can no longer make otherwise unrelated updates to migrated rules.

The new guard tests whether a target was supplied rather than whether it changed, causing schema-valid PATCH requests to return 400 when a historical filter is not writable.

**Files Needing Attention:** web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Stored evaluation rule] --> B[Readable filter adapter]
  B --> C[List / Get response]
  B --> D[PATCH existing rule]
  D --> E{Filter or target supplied?}
  E -->|No| F[Preserve historical filter]
  E -->|Yes| G{Stored or replacement filter writable?}
  G -->|Yes| H[Apply update]
  G -->|No| I[Return invalid_body]
  J[Create request] --> K[Strict writable filter validation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/server/unstable-public-api/evaluation-rule-service.ts:597-598
**Unchanged target blocks patches**

When a client repeats the rule's current target while changing an unrelated field, `updatesFilterOrTarget` treats this as a target change and rejects a readable historical filter with a 400 `invalid_body`. Compare the supplied target with `existingPublic.target` so replacement is required only for an actual target change.

```suggestion
  const updatesFilterOrTarget =
    suppliedFilter !== undefined ||
    (suppliedTarget !== undefined && suppliedTarget !== existingPublic.target);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): keep historical evaluation rul..."](https://github.com/langfuse/langfuse/commit/25216dc5a1c95c52992674eb375ba429046a6ba4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58434762)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Scores and evaluations](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/scores-and-evaluations.md)
- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->