### PR TITLE
refactor(web): Extend text table columns

### DIFF
--- a/web/src/components/design-system/table/columns/createTextTableColumn.stories.tsx
+++ b/web/src/components/design-system/table/columns/createTextTableColumn.stories.tsx
@@ -8,6 +8,8 @@ import { createTextTableColumn } from "./createTextTableColumn";
 
 type Row = {
   name: string | null;
+  count: number | null;
+  isCountLoading?: boolean;
 };
 
 const columns = [
@@ -15,6 +17,14 @@ const columns = [
     id: "name",
     accessorFn: (row) => row.name,
     header: "Text",
+  }),
+  createTextTableColumn<Row, number>({
+    accessorKey: "count",
+    header: "Mapped text",
+    mapValue: (value, { row }) =>
+      row.original.isCountLoading
+        ? { type: "loading" }
+        : value?.toLocaleString(),
   }),
 ];
 
@@ -42,7 +52,7 @@ export const Default = meta.story({
     data: {
       isLoading: false,
       isError: false,
-      data: [{ name: "Production generation" }],
+      data: [{ name: "Production generation", count: 1200 }],
     },
   },
 });
@@ -53,7 +63,20 @@ export const EmptyValue = meta.story({
     data: {
       isLoading: false,
       isError: false,
-      data: [{ name: null }],
+      data: [{ name: null, count: null }],
+    },
+  },
+});
+
+export const MappedValueLoading = meta.story({
+  name: "Mapped Value Loading",
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [
+        { name: "Production generation", count: null, isCountLoading: true },
+      ],
     },
   },
 });

--- a/web/src/components/design-system/table/columns/createTextTableColumn.tsx
+++ b/web/src/components/design-system/table/columns/createTextTableColumn.tsx
@@ -1,4 +1,4 @@
-import { type RowData } from "@tanstack/react-table";
+import { type CellContext, type RowData } from "@tanstack/react-table";
 
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
@@ -6,12 +6,37 @@ import {
   type TableColumnOptions,
 } from "./utils/createTableColumn";
 
-export function createTextTableColumn<TData extends RowData>(
-  options: TableColumnOptions<TData, string>,
-) {
-  return createTableColumn<TData, string>({
+type TextValueMapper<TData extends RowData, TValue> = (
+  value: TValue | null | undefined,
+  context: CellContext<TData, TValue | null | undefined>,
+) => string | { type: "loading" } | undefined;
+
+type TextTableColumnOptions<TData extends RowData, TValue> = TableColumnOptions<
+  TData,
+  TValue
+> & {
+  className?: string;
+} & ([TValue] extends [string]
+    ? { mapValue?: TextValueMapper<TData, TValue> }
+    : { mapValue: TextValueMapper<TData, TValue> });
+
+export function createTextTableColumn<TData extends RowData, TValue = string>({
+  className,
+  mapValue,
+  ...options
+}: TextTableColumnOptions<TData, TValue>) {
+  const loadingCell = <Skeleton className="h-4 w-1/2" />;
+
+  return createTableColumn<TData, TValue>({
     ...options,
-    loadingCell: <Skeleton className="h-4 w-1/2" />,
-    renderCell: (value) => value ?? null,
+    loadingCell,
+    renderCell: (value, context) => {
+      const text = mapValue ? mapValue(value, context) : value;
+
+      if (text === null || text === undefined) return null;
+      if (typeof text !== "string") return loadingCell;
+
+      return className ? <span className={className}>{text}</span> : text;
+    },
   });
 }

--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -21,7 +21,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { Skeleton } from "@/src/components/ui/skeleton";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { LangfuseIcon } from "@/src/components/design-system/LangfuseIcon/LangfuseIcon";
 import { useRouter } from "next/router";
 import { PriceUnitSelector } from "@/src/features/models/components/PriceUnitSelector";
@@ -198,16 +198,15 @@ export default function ModelTable({ projectId }: { projectId: string }) {
       },
       enableHiding: true,
     },
-    {
+    createTextTableColumn<ModelTableRow>({
       accessorKey: "tokenizerId",
-      id: "tokenizerId",
       header: "Tokenizer",
       headerTooltip: {
         description: modelConfigDescriptions.tokenizerId,
       },
       enableHiding: true,
       size: 120,
-    },
+    }),
     createIOTableColumn<ModelTableRow>({
       accessorKey: "config",
       header: "Tokenizer Configuration",
@@ -219,8 +218,8 @@ export default function ModelTable({ projectId }: { projectId: string }) {
       getCell: (value) => value || undefined,
       singleLine: rowHeight === "s",
     }),
-    {
-      accessorKey: "lastUsed",
+    createTextTableColumn<ModelTableRow>({
+      accessorFn: () => undefined,
       id: "lastUsed",
       header: "Last used",
       headerTooltip: {
@@ -228,12 +227,11 @@ export default function ModelTable({ projectId }: { projectId: string }) {
       },
       enableHiding: true,
       size: 120,
-      cell: ({ row }) => {
-        if (!lastUsed.data) return <Skeleton className="h-4 w-20" />;
-        const value = lastUsed.data[row.original.modelId];
-        return value?.toLocaleString() ?? "";
+      mapValue: (_, { row }) => {
+        if (!lastUsed.data) return { type: "loading" };
+        return lastUsed.data[row.original.modelId]?.toLocaleString() ?? "";
       },
-    },
+    }),
     {
       accessorKey: "actions",
       header: "Actions",

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -21,6 +21,7 @@ import { Archive, Edit, MoreVertical, PlusIcon } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   DropdownMenu,
@@ -99,12 +100,11 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
   const totalCount = configs.data?.totalCount ?? null;
 
   const columns: LangfuseColumnDef<ScoreConfigTableRow>[] = [
-    {
+    createTextTableColumn<ScoreConfigTableRow>({
       accessorKey: "name",
-      id: "name",
       header: "Name",
       enableHiding: true,
-    },
+    }),
     {
       accessorKey: "dataType",
       id: "dataType",

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -9,6 +9,7 @@ import { createBadgeTableColumn } from "@/src/components/design-system/table/col
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createTagsTableColumn } from "@/src/components/design-system/table/columns/createTagsTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
@@ -764,25 +765,20 @@ export default function TracesTable({
       },
       enableHiding: true,
     },
-    {
+    createTextTableColumn<TracesTableRow, number>({
       accessorKey: "latency",
-      id: "latency",
       header: "Latency",
       size: 100,
-      // add seconds to the end of the latency
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: TracesTableRow["latency"] = row.getValue("latency");
-        if (isMetricPending(row.original.id)) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return value !== undefined ? (
-          <span className="text-nowrap">{formatIntervalSeconds(value)}</span>
-        ) : undefined;
-      },
+      className: "text-nowrap",
+      mapValue: (value, { row }) =>
+        isMetricPending(row.original.id)
+          ? { type: "loading" }
+          : value === null || value === undefined
+            ? undefined
+            : formatIntervalSeconds(value),
       enableHiding: true,
       enableSorting,
-    },
+    }),
 
     {
       accessorKey: "tokens",

--- a/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
+++ b/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
@@ -15,6 +15,7 @@ import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 import { BatchExportTableName } from "@langfuse/shared";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
 // Both endpoints return the same shape
 type AuditLogRow = RouterOutputs["auditLogs"]["all"]["data"][number];
@@ -106,18 +107,18 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
         return null;
       },
     },
-    {
+    createTextTableColumn<AuditLogRow>({
       accessorKey: "resourceType",
       header: "Resource Type",
-    },
-    {
+    }),
+    createTextTableColumn<AuditLogRow>({
       accessorKey: "resourceId",
       header: "Resource ID",
-    },
-    {
+    }),
+    createTextTableColumn<AuditLogRow>({
       accessorKey: "action",
       header: "Action",
-    },
+    }),
     createIOTableColumn<AuditLogRow>({
       accessorKey: "before",
       header: "Before",

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import Link from "next/link";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { DeleteAnnotationQueueButton } from "@/src/features/annotation-queues/components/DeleteAnnotationQueueButton";
@@ -76,13 +77,12 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
         return undefined;
       },
     }),
-    {
+    createTextTableColumn<RowData>({
       accessorKey: "description",
       header: "Description",
-      id: "description",
       enableHiding: true,
       size: 200,
-    },
+    }),
     createNumberTableColumn<RowData>({
       accessorKey: "countCompletedItems",
       header: "Completed Items",

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -8,6 +8,7 @@ import { createStatusTableColumn } from "@/src/components/design-system/table/co
 import Page from "@/src/components/layouts/page";
 import { Button } from "@/src/components/ui/button";
 import { RotateCcw } from "lucide-react";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
 export default function BackgroundMigrationsTable() {
   const backgroundMigrations = api.backgroundMigrations.all.useQuery();
@@ -54,13 +55,12 @@ export default function BackgroundMigrationsTable() {
       enableColumnFilter: false,
       header: "Failed Reason",
     },
-    {
+    createTextTableColumn<BackgroundMigration, BackgroundMigration["state"]>({
       accessorKey: "state",
-      id: "state",
       enableColumnFilter: false,
       header: "State",
-      cell: (row) => JSON.stringify(row.getValue()),
-    },
+      mapValue: (value) => JSON.stringify(value),
+    }),
     {
       id: "actions",
       header: "Actions",

--- a/web/src/features/batch-actions/components/BatchActionsTable.tsx
+++ b/web/src/features/batch-actions/components/BatchActionsTable.tsx
@@ -14,6 +14,7 @@ import {
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createUserTableColumn } from "@/src/components/design-system/table/columns/createUserTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { BatchActionStatus } from "@langfuse/shared";
 
 type BatchActionRow = {
@@ -46,20 +47,16 @@ export function BatchActionsTable(props: { projectId: string }) {
   });
 
   const columns: LangfuseColumnDef<BatchActionRow>[] = [
-    {
+    createTextTableColumn<BatchActionRow>({
       accessorKey: "actionType",
-      id: "actionType",
       header: "Action Type",
       size: 200,
-      cell: ({ row }) => {
-        const actionType = row.getValue("actionType") as string;
-        const formattedType = actionType
-          .split("-")
+      mapValue: (value) =>
+        value
+          ?.split("-")
           .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(" ");
-        return <span>{formattedType}</span>;
-      },
-    },
+          .join(" "),
+    }),
     {
       accessorKey: "tableName",
       id: "tableName",

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -47,6 +47,7 @@ import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { CompareViewAdapter } from "@/src/features/scores/adapters";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import {
   Dialog,
   DialogContent,
@@ -417,18 +418,12 @@ export function DatasetRunsTable(props: {
         };
       },
     }),
-    {
+    createTextTableColumn<DatasetRunRowData>({
       accessorKey: "description",
       header: "Description",
-      id: "description",
       size: 300,
       enableHiding: true,
-      cell: ({ row }) => {
-        const description: DatasetRunRowData["description"] =
-          row.getValue("description");
-        return description;
-      },
-    },
+    }),
     {
       accessorKey: "countRunItems",
       header: "Run Items",

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -24,6 +24,7 @@ import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createFolderKeyTableColumn } from "@/src/components/design-system/table/columns/createFolderKeyTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import { useTableViewManager } from "@/src/components/table/table-view-presets/hooks/useTableViewManager";
 import { useFolderPagination } from "@/src/features/folders/hooks/useFolderPagination";
@@ -341,18 +342,12 @@ export function DatasetsTable(props: { projectId: string }) {
         };
       },
     }),
-    {
+    createTextTableColumn<DatasetTableRow>({
       accessorKey: "description",
       header: "Description",
-      id: "description",
       enableHiding: true,
       size: 200,
-      cell: ({ row }) => {
-        const description: DatasetTableRow["description"] =
-          row.getValue("description");
-        return description;
-      },
-    },
+    }),
     {
       accessorKey: "countItems",
       header: "Items",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -44,6 +44,7 @@ import { createItemBadgeTableColumn } from "@/src/components/design-system/table
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createIOTableColumn } from "@/src/components/design-system/table/columns/createIOTableColumn";
 import { createTagsTableColumn } from "@/src/components/design-system/table/columns/createTagsTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
 import { cn } from "@/src/utils/tailwind";
@@ -1279,50 +1280,26 @@ export default function ObservationsEventsTable({
         ) : null;
       },
       columns: [
-        {
-          accessorKey: "inputCost",
+        createTextTableColumn<EventsTableRow>({
+          accessorFn: (row) =>
+            formatObservationCost(row.cost.inputCost, row.type),
           id: "inputCost",
           header: getEventsColumnName("inputCost"),
           size: 120,
-          loadingCell: <Skeleton className="h-4 w-1/2" />,
-          cell: ({ row }) => {
-            const value = row.getValue("cost") as {
-              inputCost: number | undefined;
-              outputCost: number | undefined;
-            };
-
-            return (
-              <span>
-                {formatObservationCost(value.inputCost, row.original.type)}
-              </span>
-            );
-          },
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
-        {
-          accessorKey: "outputCost",
+        }),
+        createTextTableColumn<EventsTableRow>({
+          accessorFn: (row) =>
+            formatObservationCost(row.cost.outputCost, row.type),
           id: "outputCost",
           header: getEventsColumnName("outputCost"),
           size: 120,
-          loadingCell: <Skeleton className="h-4 w-1/2" />,
-          cell: ({ row }) => {
-            const value = row.getValue("cost") as {
-              inputCost: number | undefined;
-              outputCost: number | undefined;
-            };
-
-            return (
-              <span>
-                {formatObservationCost(value.outputCost, row.original.type)}
-              </span>
-            );
-          },
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
+        }),
       ] satisfies LangfuseColumnDef<EventsTableRow>[],
     },
     createNumberTableColumn<EventsTableRow>({

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -32,6 +32,7 @@ import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
 import { useMemo } from "react";
 import { TableHeaderControls } from "@/src/components/table/table-header-controls";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
 export type PromptVersionTableRow = {
   version: number;
@@ -302,9 +303,8 @@ export default function PromptVersionTable({
         ) : null;
       },
     },
-    {
+    createTextTableColumn<PromptVersionTableRow>({
       accessorKey: "lastUsed",
-      id: "lastUsed",
       header: "Last used",
       enableHiding: true,
       size: 150,
@@ -312,17 +312,11 @@ export default function PromptVersionTable({
         description:
           "This is calculated based on the selected date range, not the full usage history.",
       },
-      cell: ({ row }) => {
-        const value: number | undefined | null = row.getValue("lastUsed");
-        if (!promptMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
-        return !!value ? <span>{value}</span> : undefined;
-      },
-    },
-    {
+      mapValue: (value) =>
+        promptMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
+    createTextTableColumn<PromptVersionTableRow>({
       accessorKey: "firstUsed",
-      id: "firstUsed",
       header: "First used",
       size: 150,
       enableHiding: true,
@@ -330,14 +324,9 @@ export default function PromptVersionTable({
         description:
           "This is calculated based on the selected date range, not the full usage history.",
       },
-      cell: ({ row }) => {
-        const value: number | undefined | null = row.getValue("firstUsed");
-        if (!promptMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
-        return !!value ? <span>{value}</span> : undefined;
-      },
-    },
+      mapValue: (value) =>
+        promptMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
   ];
 
   const [columnVisibility, setColumnVisibilityState] =

--- a/web/src/pages/project/[projectId]/users/index.tsx
+++ b/web/src/pages/project/[projectId]/users/index.tsx
@@ -9,9 +9,9 @@ import {
 } from "use-query-params";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { DataTable } from "@/src/components/table/data-table";
-import { Skeleton } from "@/src/components/ui/skeleton";
 import { createBadgeTableColumn } from "@/src/components/design-system/table/columns/createBadgeTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
@@ -318,39 +318,27 @@ const UsersTable = ({
       size: 150,
       enableHiding: true,
     }),
-    {
+    createTextTableColumn<RowData>({
       accessorKey: "firstEvent",
       header: "First Event",
       headerTooltip: {
         description: "The earliest trace recorded for this user.",
       },
       size: 150,
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: RowData["firstEvent"] = row.getValue("firstEvent");
-        if (!userMetrics.isSuccess) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return typeof value === "string" ? value : undefined;
-      },
-    },
-    {
+      mapValue: (value) =>
+        userMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
+    createTextTableColumn<RowData>({
       accessorKey: "lastEvent",
       header: "Last Event",
       headerTooltip: {
         description: "The latest trace recorded for this user.",
       },
       size: 150,
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: RowData["lastEvent"] = row.getValue("lastEvent");
-        if (!userMetrics.isSuccess) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return typeof value === "string" ? value : undefined;
-      },
-    },
-    {
+      mapValue: (value) =>
+        userMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
+    createTextTableColumn<RowData>({
       accessorKey: "totalEvents",
       header: "Total Events",
       headerTooltip: {
@@ -359,16 +347,10 @@ const UsersTable = ({
         href: "https://langfuse.com/docs/observability/data-model",
       },
       size: 120,
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: RowData["totalEvents"] = row.getValue("totalEvents");
-        if (!userMetrics.isSuccess) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return typeof value === "string" ? value : undefined;
-      },
-    },
-    {
+      mapValue: (value) =>
+        userMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
+    createTextTableColumn<RowData>({
       accessorKey: "totalTokens",
       header: "Total Tokens",
       headerTooltip: {
@@ -377,16 +359,10 @@ const UsersTable = ({
         href: "https://langfuse.com/docs/model-usage-and-cost",
       },
       size: 120,
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: RowData["totalTokens"] = row.getValue("totalTokens");
-        if (!userMetrics.isSuccess) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return typeof value === "string" ? value : undefined;
-      },
-    },
-    {
+      mapValue: (value) =>
+        userMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
+    createTextTableColumn<RowData>({
       accessorKey: "totalCost",
       header: "Total Cost",
       headerTooltip: {
@@ -394,15 +370,9 @@ const UsersTable = ({
         href: "https://langfuse.com/docs/model-usage-and-cost",
       },
       size: 120,
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: RowData["totalCost"] = row.getValue("totalCost");
-        if (!userMetrics.isSuccess) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return typeof value === "string" ? value : undefined;
-      },
-    },
+      mapValue: (value) =>
+        userMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
   ];
 
   return (


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16824 app preview](https://pr-16824.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends the shared text-column factory to support mapped values, loading states, and optional text styling, then adopts it across several tables.
- Adds generic value mapping and reusable loading rendering to `createTextTableColumn`.
- Migrates plain text and asynchronously populated cells to the shared helper.
- Adds Storybook coverage for mapped numeric text and mapped loading states.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The shared helper preserves migrated column identities, supports the mapped value types used by callers, and retains existing loading and server-side sorting behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): extend text table columns"](https://github.com/langfuse/langfuse/commit/1b78833739a7470fe5cf98370750523e4eb110e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58520199)</sub>

<!-- /greptile_comment -->