### PR TITLE
refactor(web): Extend number table columns

### DIFF
--- a/web/src/components/design-system/table/columns/createNumberTableColumn.stories.tsx
+++ b/web/src/components/design-system/table/columns/createNumberTableColumn.stories.tsx
@@ -11,6 +11,7 @@ type Row = {
   isNumberLoading?: boolean;
   outputTokens: number;
   latency: number | null;
+  suffix?: string;
 };
 
 function NumberTableColumnStory({
@@ -29,8 +30,8 @@ function NumberTableColumnStory({
         row.latency ? row.outputTokens / row.latency : null,
       header: "Number",
       emptyValue,
-      formatter: (value) =>
-        numberFormatter(value, fractionDigits, fractionDigits),
+      formatter: (value, { row }) =>
+        `${numberFormatter(value, fractionDigits, fractionDigits)}${row.original.suffix ?? ""}`,
       getValue: (value, { row }) => {
         if (row.original.isNumberLoading) return { type: "loading" };
         if (value === null || value === undefined) return undefined;
@@ -76,6 +77,18 @@ export const Integer = meta.story({
       isLoading: false,
       isError: false,
       data: [{ outputTokens: 2468, latency: 2 }],
+    },
+  },
+});
+
+export const ContextualFormatting = meta.story({
+  name: "Contextual Formatting",
+  args: {
+    fractionDigits: 0,
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ outputTokens: 2468, latency: 2, suffix: " tokens/s" }],
     },
   },
 });

--- a/web/src/components/design-system/table/columns/createNumberTableColumn.tsx
+++ b/web/src/components/design-system/table/columns/createNumberTableColumn.tsx
@@ -7,36 +7,53 @@ import {
   type TableColumnOptions,
 } from "./utils/createTableColumn";
 
-export function createNumberTableColumn<TData extends RowData>({
+export function createNumberTableColumn<
+  TData extends RowData,
+  TValue extends number | bigint = number,
+>({
   emptyValue,
-  formatter = numberFormatter,
+  formatter,
   getValue,
   ...options
-}: TableColumnOptions<TData, number> & {
+}: TableColumnOptions<TData, TValue> & {
   emptyValue?: string;
-  formatter?: (value: number) => string;
+  formatter?: (
+    value: TValue,
+    context: CellContext<TData, TValue | null | undefined>,
+  ) => string;
   getValue?: (
-    value: number | null | undefined,
-    context: CellContext<TData, number | null | undefined>,
-  ) => number | { type: "loading" } | undefined;
+    value: TValue | null | undefined,
+    context: CellContext<TData, TValue | null | undefined>,
+  ) => TValue | { type: "loading" } | undefined;
 }) {
-  return createTableColumn<TData, number>({
+  const loadingCell = <Skeleton className="h-4 w-1/2" />;
+
+  return createTableColumn<TData, TValue>({
     ...options,
-    loadingCell: <Skeleton className="h-4 w-1/2" />,
+    loadingCell,
     renderCell: (value, context) => {
       if (!getValue) {
         if (value === null || value === undefined) return emptyValue ?? null;
-        return <span>{formatter(value)}</span>;
+        return (
+          <span>{formatter?.(value, context) ?? numberFormatter(value)}</span>
+        );
       }
 
       const resolvedValue = getValue(value, context);
 
       if (resolvedValue === undefined) return emptyValue ?? null;
-      if (typeof resolvedValue !== "number") {
-        return <Skeleton className="h-4 w-1/2" />;
-      }
+      if (
+        typeof resolvedValue !== "number" &&
+        typeof resolvedValue !== "bigint"
+      )
+        return loadingCell;
 
-      return <span>{formatter(resolvedValue)}</span>;
+      return (
+        <span>
+          {formatter?.(resolvedValue, context) ??
+            numberFormatter(resolvedValue)}
+        </span>
+      );
     },
   });
 }

--- a/web/src/components/table/DataTable.stories.tsx
+++ b/web/src/components/table/DataTable.stories.tsx
@@ -1051,7 +1051,7 @@ function buildGroupedColumns(
         accessorFn: (row) => row.totalCost.toNumber(),
         header: "Cost (USD)",
         size: 110,
-        formatter: usdFormatter,
+        formatter: (value) => usdFormatter(value),
       }),
       createNumberTableColumn<TraceRow>({
         id: "totalTokensGrouped",

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1134,50 +1134,30 @@ export default function ObservationsTable({
         ) : null;
       },
       columns: [
-        {
-          accessorKey: "inputCost",
+        createNumberTableColumn<ObservationsTableRow>({
+          accessorFn: (row) => row.cost.inputCost,
           id: "inputCost",
           header: "Input Cost",
           size: 120,
-          loadingCell: <Skeleton className="h-4 w-1/2" />,
-          cell: ({ row }) => {
-            const value: {
-              inputCost: number | undefined;
-              outputCost: number | undefined;
-            } = row.getValue("cost");
-
-            return (
-              <span>
-                {formatObservationCost(value.inputCost, row.original.type)}
-              </span>
-            );
-          },
+          emptyValue: "-",
+          formatter: (value, { row }) =>
+            formatObservationCost(value, row.original.type),
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
-        {
-          accessorKey: "outputCost",
+        }),
+        createNumberTableColumn<ObservationsTableRow>({
+          accessorFn: (row) => row.cost.outputCost,
           id: "outputCost",
           header: "Output Cost",
           size: 120,
-          loadingCell: <Skeleton className="h-4 w-1/2" />,
-          cell: ({ row }) => {
-            const value: {
-              inputCost: number | undefined;
-              outputCost: number | undefined;
-            } = row.getValue("cost");
-
-            return (
-              <span>
-                {formatObservationCost(value.outputCost, row.original.type)}
-              </span>
-            );
-          },
+          emptyValue: "-",
+          formatter: (value, { row }) =>
+            formatObservationCost(value, row.original.type),
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
+        }),
       ] satisfies LangfuseColumnDef<ObservationsTableRow>[],
     },
   ];

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -527,7 +527,7 @@ export default function SessionsTable({
       header: "Duration",
       size: 130,
       enableHiding: true,
-      formatter: formatIntervalSeconds,
+      formatter: (value) => formatIntervalSeconds(value),
       getValue: (value) => {
         if (!sessionMetrics.isSuccess) return { type: "loading" };
         if (!value) return undefined;
@@ -594,7 +594,7 @@ export default function SessionsTable({
       enableHiding: true,
       defaultHidden: true,
       enableSorting: true,
-      formatter: usdFormatter,
+      formatter: (value) => usdFormatter(value),
       getValue: (value) => {
         if (!sessionMetrics.isSuccess) return { type: "loading" };
         if (!value) return undefined;
@@ -610,7 +610,7 @@ export default function SessionsTable({
       enableHiding: true,
       enableSorting: true,
       defaultHidden: true,
-      formatter: usdFormatter,
+      formatter: (value) => usdFormatter(value),
       getValue: (value) => {
         if (!sessionMetrics.isSuccess) return { type: "loading" };
         if (!value) return undefined;
@@ -625,7 +625,7 @@ export default function SessionsTable({
       size: 110,
       enableHiding: true,
       enableSorting: true,
-      formatter: usdFormatter,
+      formatter: (value) => usdFormatter(value),
       getValue: (value) => {
         if (!sessionMetrics.isSuccess) return { type: "loading" };
         if (!value) return undefined;

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -998,9 +998,8 @@ export default function TracesTable({
       enableHiding: true,
       enableSorting,
     },
-    {
+    createNumberTableColumn<TracesTableRow, bigint>({
       accessorKey: "observationCount",
-      id: "observationCount",
       header: "Observations",
       size: 120,
       headerTooltip: {
@@ -1008,16 +1007,10 @@ export default function TracesTable({
       },
       enableHiding: true,
       defaultHidden: true,
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: TracesTableRow["observationCount"] =
-          row.getValue("observationCount");
-        if (isMetricPending(row.original.id)) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return <span>{numberFormatter(value, 0)}</span>;
-      },
-    },
+      formatter: (value) => numberFormatter(value, 0),
+      getValue: (value, { row }) =>
+        isMetricPending(row.original.id) ? { type: "loading" } : (value ?? 0n),
+    }),
     {
       accessorKey: "level",
       id: "level",
@@ -1136,7 +1129,7 @@ export default function TracesTable({
           header: "Input Cost",
           size: 100,
           emptyValue: "-",
-          formatter: usdFormatter,
+          formatter: (value) => usdFormatter(value),
           getValue: (value, { row }) => {
             if (isMetricPending(row.original.id)) return { type: "loading" };
             return value ?? undefined;
@@ -1151,7 +1144,7 @@ export default function TracesTable({
           header: "Output Cost",
           size: 100,
           emptyValue: "-",
-          formatter: usdFormatter,
+          formatter: (value) => usdFormatter(value),
           getValue: (value, { row }) => {
             if (isMetricPending(row.original.id)) return { type: "loading" };
             return value ?? undefined;
@@ -1174,57 +1167,48 @@ export default function TracesTable({
         ) : null;
       },
       columns: [
-        {
-          accessorKey: "inputTokens",
+        createNumberTableColumn<TracesTableRow, bigint>({
+          accessorFn: (row) => row.usage.inputUsage,
           id: "inputTokens",
           header: "Input Tokens",
           size: 110,
-          loadingCell: <Skeleton className="h-4 w-1/2" />,
-          cell: ({ row }) => {
-            const value: TracesTableRow["usage"] = row.getValue("usage");
-            if (isMetricPending(row.original.id)) {
-              return <Skeleton className="h-4 w-1/2" />;
-            }
-            return <span>{numberFormatter(value.inputUsage, 0)}</span>;
-          },
+          formatter: (value) => numberFormatter(value, 0),
+          getValue: (value, { row }) =>
+            isMetricPending(row.original.id)
+              ? { type: "loading" }
+              : (value ?? 0n),
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
-        {
-          accessorKey: "outputTokens",
+        }),
+        createNumberTableColumn<TracesTableRow, bigint>({
+          accessorFn: (row) => row.usage.outputUsage,
           id: "outputTokens",
           header: "Output Tokens",
           size: 110,
-          loadingCell: <Skeleton className="h-4 w-1/2" />,
-          cell: ({ row }) => {
-            const value: TracesTableRow["usage"] = row.getValue("usage");
-            if (isMetricPending(row.original.id)) {
-              return <Skeleton className="h-4 w-1/2" />;
-            }
-            return <span>{numberFormatter(value.outputUsage, 0)}</span>;
-          },
+          formatter: (value) => numberFormatter(value, 0),
+          getValue: (value, { row }) =>
+            isMetricPending(row.original.id)
+              ? { type: "loading" }
+              : (value ?? 0n),
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
-        {
-          accessorKey: "totalTokens",
+        }),
+        createNumberTableColumn<TracesTableRow, bigint>({
+          accessorFn: (row) => row.usage.totalUsage,
           id: "totalTokens",
           header: "Total Tokens",
           size: 110,
-          loadingCell: <Skeleton className="h-4 w-1/2" />,
-          cell: ({ row }) => {
-            const value: TracesTableRow["usage"] = row.getValue("usage");
-            if (isMetricPending(row.original.id)) {
-              return <Skeleton className="h-4 w-1/2" />;
-            }
-            return <span>{numberFormatter(value.totalUsage, 0)}</span>;
-          },
+          formatter: (value) => numberFormatter(value, 0),
+          getValue: (value, { row }) =>
+            isMetricPending(row.original.id)
+              ? { type: "loading" }
+              : (value ?? 0n),
           enableHiding: true,
           defaultHidden: true,
           enableSorting,
-        },
+        }),
       ] satisfies LangfuseColumnDef<TracesTableRow>[],
     },
     ...(hideControls

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -88,14 +88,14 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
       header: "Completed Items",
       enableHiding: true,
       size: 90,
-      formatter: String,
+      formatter: (value) => String(value),
     }),
     createNumberTableColumn<RowData>({
       accessorKey: "countPendingItems",
       header: "Pending Items",
       enableHiding: true,
       size: 90,
-      formatter: String,
+      formatter: (value) => String(value),
     }),
     {
       accessorKey: "scoreConfigs",

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -47,6 +47,7 @@ import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { CompareViewAdapter } from "@/src/features/scores/adapters";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import {
   Dialog,
@@ -75,10 +76,10 @@ export type DatasetRunRowData = {
   id: string;
   name: string;
   createdAt: Date;
-  countRunItems: string;
+  countRunItems: bigint;
   avgLatency: number | undefined;
-  avgTotalCost: string | undefined;
-  totalCost: string | undefined;
+  avgTotalCost: number | undefined;
+  totalCost: number | undefined;
   // scores holds grouped column with individual scores
   runItemScores?: ScoreAggregate | undefined;
   runScores?: ScoreAggregate | undefined;
@@ -424,62 +425,50 @@ export function DatasetRunsTable(props: {
       size: 300,
       enableHiding: true,
     }),
-    {
+    createNumberTableColumn<DatasetRunRowData, bigint>({
       accessorKey: "countRunItems",
       header: "Run Items",
-      id: "countRunItems",
       size: 90,
       enableHiding: true,
-      cell: ({ row }) => {
-        const countRunItems: DatasetRunRowData["countRunItems"] =
-          row.getValue("countRunItems");
-        if (countRunItems === undefined || runsMetrics.isPending)
-          return <Skeleton className="h-3 w-1/2" />;
-        return <>{countRunItems}</>;
-      },
-    },
-    {
+      formatter: (value) => String(value),
+      getValue: (value) =>
+        value === null || value === undefined || runsMetrics.isPending
+          ? { type: "loading" }
+          : value,
+    }),
+    createNumberTableColumn<DatasetRunRowData>({
       accessorKey: "avgLatency",
       header: "Latency (avg)",
-      id: "avgLatency",
       size: 120,
       enableHiding: true,
-      cell: ({ row }) => {
-        const avgLatency: DatasetRunRowData["avgLatency"] =
-          row.getValue("avgLatency");
-        if (avgLatency === undefined || runsMetrics.isPending)
-          return <Skeleton className="h-3 w-1/2" />;
-        return <>{formatIntervalSeconds(avgLatency)}</>;
-      },
-    },
-    {
+      formatter: (value) => formatIntervalSeconds(value),
+      getValue: (value) =>
+        value === null || value === undefined || runsMetrics.isPending
+          ? { type: "loading" }
+          : value,
+    }),
+    createNumberTableColumn<DatasetRunRowData>({
       accessorKey: "avgTotalCost",
       header: "Trace Cost (avg)",
-      id: "avgTotalCost",
       size: 130,
       enableHiding: true,
-      cell: ({ row }) => {
-        const avgTotalCost: DatasetRunRowData["avgTotalCost"] =
-          row.getValue("avgTotalCost");
-        if (!avgTotalCost || runsMetrics.isPending)
-          return <Skeleton className="h-3 w-1/2" />;
-        return <>{avgTotalCost}</>;
-      },
-    },
-    {
+      formatter: (value) => usdFormatter(value),
+      getValue: (value) =>
+        value === null || value === undefined || runsMetrics.isPending
+          ? { type: "loading" }
+          : value,
+    }),
+    createNumberTableColumn<DatasetRunRowData>({
       accessorKey: "totalCost",
       header: "Trace Cost (sum)",
-      id: "totalCost",
       size: 130,
       enableHiding: true,
-      cell: ({ row }) => {
-        const totalCost: DatasetRunRowData["totalCost"] =
-          row.getValue("totalCost");
-        if (!totalCost || runsMetrics.isPending)
-          return <Skeleton className="h-3 w-1/2" />;
-        return <>{totalCost}</>;
-      },
-    },
+      formatter: (value) => usdFormatter(value),
+      getValue: (value) =>
+        value === null || value === undefined || runsMetrics.isPending
+          ? { type: "loading" }
+          : value,
+    }),
     {
       accessorKey: "runScores",
       header: "Run-Level Scores",
@@ -555,14 +544,10 @@ export function DatasetRunsTable(props: {
       id: item.id,
       name: item.name,
       createdAt: item.createdAt,
-      countRunItems: item.countRunItems?.toString() ?? "0",
+      countRunItems: BigInt(item.countRunItems ?? 0),
       avgLatency: item.avgLatency ?? 0,
-      avgTotalCost: item.avgTotalCost
-        ? usdFormatter(item.avgTotalCost.toNumber())
-        : usdFormatter(0),
-      totalCost: item.totalCost
-        ? usdFormatter(item.totalCost.toNumber())
-        : usdFormatter(0),
+      avgTotalCost: item.avgTotalCost?.toNumber() ?? 0,
+      totalCost: item.totalCost?.toNumber() ?? 0,
       runItemScores: item.scores,
       runScores: item.runScores
         ? addPrefixToScoreKeys(item.runScores, "Run-level")

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -392,7 +392,7 @@ export default function EvalsTemplateTable({
       header: "Usage Count",
       enableHiding: true,
       size: 80,
-      formatter: String,
+      formatter: (value) => String(value),
       getValue: (value) => {
         return value || undefined;
       },
@@ -402,7 +402,7 @@ export default function EvalsTemplateTable({
       header: "Latest Version",
       enableHiding: true,
       size: 80,
-      formatter: String,
+      formatter: (value) => String(value),
     }),
     columnHelper.accessor("id", {
       header: "Id",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1363,7 +1363,7 @@ export default function ObservationsEventsTable({
           id: "tokensPerSecond",
           header: "Tokens per second",
           size: 200,
-          formatter: String,
+          formatter: (value) => String(value),
           defaultHidden: true,
           enableHiding: true,
           enableSorting,

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -9,6 +9,7 @@ import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { type RouterOutput } from "@/src/utils/types";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
@@ -32,7 +33,6 @@ import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
 import { useMemo } from "react";
 import { TableHeaderControls } from "@/src/components/table/table-header-controls";
-import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
 export type PromptVersionTableRow = {
   version: number;
@@ -228,7 +228,7 @@ export default function PromptVersionTable({
       header: "Median input tokens",
       size: 160,
       enableHiding: true,
-      formatter: String,
+      formatter: (value) => String(value),
       getValue: (value) => {
         if (!promptMetrics.isSuccess) return { type: "loading" };
         if (!value) return undefined;
@@ -241,7 +241,7 @@ export default function PromptVersionTable({
       header: "Median output tokens",
       size: 170,
       enableHiding: true,
-      formatter: String,
+      formatter: (value) => String(value),
       getValue: (value) => {
         if (!promptMetrics.isSuccess) return { type: "loading" };
         if (!value) return undefined;
@@ -253,7 +253,7 @@ export default function PromptVersionTable({
       accessorKey: "medianCost",
       header: "Median cost",
       size: 120,
-      formatter: usdFormatter,
+      formatter: (value) => usdFormatter(value),
       getValue: (value) => {
         if (!promptMetrics.isSuccess) return { type: "loading" };
         if (!value) return undefined;
@@ -262,23 +262,15 @@ export default function PromptVersionTable({
       },
       enableHiding: true,
     }),
-    {
+    createNumberTableColumn<PromptVersionTableRow, bigint>({
       accessorKey: "generationCount",
-      id: "generationCount",
       header: "Generations count",
       size: 150,
       enableHiding: true,
-      cell: ({ row }) => {
-        const value: bigint | undefined | null =
-          row.getValue("generationCount");
-        if (!promptMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
-        return value === undefined || value === null ? null : (
-          <span>{numberFormatter(value, 0)}</span>
-        );
-      },
-    },
+      formatter: (value) => numberFormatter(value, 0),
+      getValue: (value) =>
+        promptMetrics.isSuccess ? (value ?? undefined) : { type: "loading" },
+    }),
     {
       accessorKey: "traceScores",
       header: "Trace Scores",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16826 app preview](https://pr-16826.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands the shared number-table column helper to support bigint values and row-aware formatters, then migrates numeric cells across trace, observation, dataset, prompt, and related tables.
- Adds contextual formatter callbacks and bigint rendering to `createNumberTableColumn`.
- Standardizes loading, empty-value, and numeric formatting behavior across table implementations.
- Converts dataset-run metrics to raw numeric values before presentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete regressions identified in the changed numeric table paths.

The generalized helper remains compatible with the inspected formatter and value contracts, and the migrated tables preserve their prior loading, empty, and zero-value presentation behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): extend number table colum..."](https://github.com/langfuse/langfuse/commit/25ea74329d67d8077afcec899d9c5bbc6bc86b0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58520581)</sub>

<!-- /greptile_comment -->