### PR TITLE
ci(preview): share one GitHub environment for PR preview deployments (v3 backport of #15494)

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -4,8 +4,8 @@ name: AWS preview build
 # The Argo CD ApplicationSet in the infrastructure repo deploys whichever image
 # tag exists for a labeled PR; this workflow only builds and pushes, then posts
 # the preview URL on the PR — as the marker-tagged status comment and as a
-# native GitHub deployment (the "View deployment" button), so the URL is
-# findable without scrolling the timeline.
+# native GitHub deployment (the "View deployment" button). All PR deployments
+# share one GitHub environment; Argo CD still owns the real preview lifecycle.
 #
 # The two images are independent artifacts pushed to two independent ECR repos
 # under the same tag, with no ordering dependency between them. They therefore
@@ -19,24 +19,33 @@ name: AWS preview build
 #
 # Builds every SAME-REPO PR on open/update (write access is the gate — opening a
 # same-repo PR requires push access). It deliberately does NOT trigger on the
-# `preview` label: the auto-labeler applies that label with the default
-# GITHUB_TOKEN, and GitHub does not start workflow runs from GITHUB_TOKEN-applied
-# events (anti-recursion), so a `labeled` trigger would never fire for
-# auto-labeled PRs. The label is only the Argo *deploy* filter (infra repo), and
-# the deploy allowlist lives in the ApplicationSet — not here. Fork PRs are
-# excluded (the head.repo check below) and can't mint an OIDC token anyway
+# `preview` label applied by the auto-labeler: GitHub does not start workflow
+# runs from GITHUB_TOKEN-applied events (anti-recursion), while the PR's `open`
+# event already starts the build. A manually re-added `preview` label does
+# trigger a build so its deleted native deployment record is recreated. The
+# label is the Argo *deploy* filter (infra repo), and the deploy allowlist lives
+# in the ApplicationSet — not here. Fork PRs are excluded (the head.repo check
+# below) and can't mint an OIDC token anyway
 # (public repo, read-only token); the ECR-push role's trust is scoped to
 # sub=repo:langfuse/langfuse:pull_request AND ref=refs/pull/* (GitHub OIDC has no
 # event_name claim), so pull_request_target / review — which carry the base
 # branch ref — cannot assume it either.
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions: {}
 
 concurrency:
-  group: preview-build-${{ github.event.pull_request.number }}
+  # The group is claimed at queue time, before the job `if`s, so an unrelated
+  # `labeled` run would cancel a live build and then skip every job. Only
+  # building runs join `preview-build-<n>`, which preview-deactivate.yml matches
+  # verbatim to cancel on close; the rest get a throwaway per-run group.
+  group: >-
+    ${{ (github.event.pull_request.state == 'open'
+         && (github.event.action != 'labeled' || github.event.label.name == 'preview'))
+        && format('preview-build-{0}', github.event.pull_request.number)
+        || format('preview-build-noop-{0}', github.run_id) }}
   cancel-in-progress: true
 
 jobs:
@@ -45,14 +54,17 @@ jobs:
   # place. Lightweight: no build context, only the base-branch composite action.
   meta:
     name: Resolve tags and mark building
-    # Any SAME-REPO PR (= write access) builds on open/update. No label gate here:
-    # the auto-labeler's GITHUB_TOKEN-applied label can't trigger this workflow,
-    # and the label is the Argo deploy filter, not the build trigger. Fork PRs are
-    # excluded (head.repo check) and can't mint OIDC anyway.
+    # Any SAME-REPO PR (= write access) builds on open/update; a manual label
+    # event is accepted only for `preview`, to recreate a deployment after
+    # teardown. Fork PRs are excluded and can't mint OIDC anyway.
     # AWS_PREVIEW_ECR_PUSH_ROLE_ARN doubles as the feature flag: unset => no-op.
+    # `labeled` (unlike the other three) also fires on closed/merged PRs, which
+    # Argo never deploys — so gate on state or a build there records a dead URL.
     if: >-
       vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.state == 'open' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -139,7 +151,9 @@ jobs:
     needs: meta
     if: >-
       vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.state == 'open' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -239,13 +253,15 @@ jobs:
     if: >-
       always() &&
       vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.state == 'open' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      # createDeployment/createDeploymentStatus for the native "View deployment"
-      # button on the PR (see "Record GitHub deployment" below).
+      # Create the native "View deployment" entry and retire the previous
+      # deployment for this PR after an update.
       deployments: write
     steps:
       - name: Checkout base local actions
@@ -285,42 +301,51 @@ jobs:
 
             Synthetic preview data only. Never add production data to public accounts.
 
-      # Record a native GitHub deployment for the preview, so the PR shows
-      # "deployed to pr-<n>" with a "View deployment" button in the timeline /
-      # merge box, and the environment appears on the repo's Deployments page.
-      # Inline step (not the base-checkout composite action): it needs no shared
-      # logic, and inline steps run from the PR's own workflow file.
+      # GitHub environments are durable configuration objects, so all PRs share
+      # one `PR Preview` environment instead of creating an unbounded `pr-<n>`
+      # environment per PR. The PR-specific task lets cleanup query only this
+      # PR's deployments while the immutable SHA remains the deployment ref.
       #
-      # `state: success` mirrors the 🟢 comment's semantics — images pushed,
-      # Argo CD rolling out; the URL is usually live minutes later. Like the
-      # comment, it cannot see the infra-repo deploy allowlist, so for a
-      # non-allowlisted author the deployment records but the URL 404s (same
-      # caveat as the comment's debug-guide link). `auto_inactive` retires the
-      # previous SHA's deployment on every new push; the preview-deactivate
-      # workflow retires the last one when the PR closes.
+      # A new deployment is made successful before the prior deployment is
+      # retired, so a cleanup/API failure cannot remove the PR's last working
+      # "View deployment" link.
       - name: Record GitHub deployment
         if: needs.build.result == 'success'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_SHA: ${{ needs.meta.outputs.commit_sha }}
           PREVIEW_HOST: ${{ needs.meta.outputs.preview_host }}
-          PREVIEW_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
+          PREVIEW_TASK: preview-pr-${{ github.event.pull_request.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const environment = process.env.PREVIEW_ENVIRONMENT;
+            // Environment + task are a literal contract with
+            // preview-deactivate.yml and preview-stale-cleanup.yml: if they
+            // drift, listDeployments silently matches nothing and dead records
+            // pile up.
+            const environment = "PR Preview";
+            const task = process.env.PREVIEW_TASK;
+
+            const previousDeployments = await github.paginate(
+              github.rest.repos.listDeployments,
+              { owner, repo, environment, task, per_page: 100 },
+            );
 
             const { data: deployment } = await github.rest.repos.createDeployment({
               owner,
               repo,
               ref: process.env.PREVIEW_SHA,
               environment,
+              task,
               // The images are the deployable; don't gate on commit statuses
               // (this very workflow is one of them) and never let GitHub
               // auto-merge base into the ref.
               required_contexts: [],
               auto_merge: false,
-              transient_environment: true,
+              // The shared GitHub environment is durable even though each
+              // underlying Argo preview and deployment record is temporary.
+              transient_environment: false,
+              production_environment: false,
               description: `Langfuse PR preview at https://${process.env.PREVIEW_HOST}`,
             });
             // required_contexts: [] makes a non-201 unrepresentable in practice,
@@ -338,9 +363,34 @@ jobs:
               state: "success",
               environment_url: `https://${process.env.PREVIEW_HOST}`,
               log_url: `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`,
-              auto_inactive: true,
+              // Other PRs share this environment and must remain active.
+              auto_inactive: false,
             });
-            core.info(`Recorded deployment ${deployment.id} for ${environment}.`);
+            core.info(`Recorded deployment ${deployment.id} for ${task}.`);
+
+            let failures = 0;
+            for (const previous of previousDeployments) {
+              try {
+                await github.rest.repos.createDeploymentStatus({
+                  owner,
+                  repo,
+                  deployment_id: previous.id,
+                  state: "inactive",
+                });
+                await github.rest.repos.deleteDeployment({
+                  owner,
+                  repo,
+                  deployment_id: previous.id,
+                });
+              } catch (e) {
+                failures++;
+                core.warning(`Previous deployment ${previous.id}: ${e.message} — continuing`);
+              }
+            }
+            core.info(`Deleted ${previousDeployments.length - failures} of ${previousDeployments.length} previous deployment(s) for ${task}.`);
+            if (failures) {
+              core.setFailed(`${failures} of ${previousDeployments.length} previous deployment(s) could not be deleted.`);
+            }
 
       # Two distinct failure paths, each keyed on `== 'failure'` (NOT
       # `!= 'success'`): that keeps them from firing on `cancelled` (a

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -316,6 +316,8 @@ jobs:
           PREVIEW_SHA: ${{ needs.meta.outputs.commit_sha }}
           PREVIEW_HOST: ${{ needs.meta.outputs.preview_host }}
           PREVIEW_TASK: preview-pr-${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LEGACY_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -326,10 +328,40 @@ jobs:
             const environment = "PR Preview";
             const task = process.env.PREVIEW_TASK;
 
-            const previousDeployments = await github.paginate(
-              github.rest.repos.listDeployments,
-              { owner, repo, environment, task, per_page: 100 },
-            );
+            // The job `if` gates on the EVENT payload's state, which is a
+            // snapshot from when the build started — a PR closed during the
+            // build still reads `open` there. Re-check live, or this records a
+            // deployment Argo will never serve and nothing will ever reap
+            // (preview-deactivate already fired on close; the stale sweep only
+            // scans open PRs).
+            const { data: livePr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            if (livePr.state !== "open") {
+              core.info(`PR closed during the build; not recording a deployment.`);
+              return;
+            }
+
+            // TRANSITIONAL (drop with the sibling query in
+            // preview-deactivate.yml): also retire the pre-migration `pr-<n>`
+            // record, else a rebuild leaves it active alongside the new one.
+            const previousDeployments = [
+              ...(await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                environment,
+                task,
+                per_page: 100,
+              })),
+              ...(await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                environment: process.env.LEGACY_ENVIRONMENT,
+                per_page: 100,
+              })),
+            ];
 
             const { data: deployment } = await github.rest.repos.createDeployment({
               owner,

--- a/.github/workflows/preview-deactivate.yml
+++ b/.github/workflows/preview-deactivate.yml
@@ -1,53 +1,80 @@
-name: AWS preview deactivate
+name: AWS preview deployment cleanup
 
-# Mark the PR's GitHub deployments (environment pr-<n>, recorded by
-# preview-build's "Record GitHub deployment" step) inactive when the PR closes.
-# Closing/merging is what tears the preview down — the Argo CD ApplicationSet
-# only generates Applications for OPEN labeled PRs — so without this the PR and
-# the repo's Deployments page keep advertising an "Active" environment whose
-# URL is gone.
+# Closing/merging is what tears the real preview down: the Argo CD
+# ApplicationSet only generates Applications for OPEN labeled PRs. This
+# workflow separately removes the PR's native GitHub deployment records from
+# the shared `PR Preview` environment so GitHub does not advertise a dead URL.
 #
-# Deactivation only: GITHUB_TOKEN cannot delete environments (that needs repo
-# administration permission), and inactive deployments are the standard way
-# GitHub renders retired preview environments.
-#
-# Safe trigger: plain `pull_request: closed` with no checkout, no PR-code
-# execution, no cloud credentials — only deployment-status mutations — so it
-# stays off zizmor's dangerous-triggers list.
+# Safe triggers: plain `pull_request` close / label removal with no checkout,
+# no PR-code execution, and no cloud credentials. It only mutates deployment
+# records, so it stays off zizmor's dangerous-triggers list.
 on:
   pull_request:
-    types: [closed]
+    types: [closed, unlabeled]
 
 permissions: {}
 
+concurrency:
+  # Same queue-time reason as preview-build.yml: only runs that clean up join
+  # its `preview-build-<n>` group (verbatim match = cancel-on-close), so an
+  # unrelated `unlabeled` event can't kill a live build. That cancel only
+  # narrows the notify race; the real guard is `needs.build.result == 'success'`
+  # on preview-build's deployment step.
+  group: >-
+    ${{ (github.event.action == 'closed' || github.event.label.name == 'preview')
+        && format('preview-build-{0}', github.event.pull_request.number)
+        || format('preview-cleanup-noop-{0}', github.run_id) }}
+  cancel-in-progress: true
+
 jobs:
-  deactivate:
-    name: Mark preview deployments inactive
+  cleanup:
+    name: Delete preview deployment records
     runs-on: ubuntu-latest
     # AWS_PREVIEW_ECR_PUSH_ROLE_ARN is the preview-system feature flag (same
     # gate as preview-build / preview-autolabel): unset => system off, no
     # deployments were ever recorded.
-    if: vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != ''
+    if: >-
+      vars.AWS_PREVIEW_ECR_PUSH_ROLE_ARN != '' &&
+      (github.event.action == 'closed' || github.event.label.name == 'preview')
     permissions:
       deployments: write
     steps:
-      - name: Deactivate pr-<n> deployments
+      - name: Retire and delete PR deployments
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PREVIEW_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
+          PREVIEW_TASK: preview-pr-${{ github.event.pull_request.number }}
+          LEGACY_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const environment = process.env.PREVIEW_ENVIRONMENT;
+            // Environment + task must stay byte-identical to preview-build.yml
+            // and preview-stale-cleanup.yml, or listDeployments matches nothing
+            // and this logs success while dead records pile up.
+            const task = process.env.PREVIEW_TASK;
 
-            const deployments = await github.paginate(github.rest.repos.listDeployments, {
-              owner,
-              repo,
-              environment,
-              per_page: 100,
-            });
+            // TRANSITIONAL (drop once every v3 PR opened before this landed
+            // has closed): v3 PRs predating the shared environment recorded into
+            // a per-PR `pr-<n>` environment under the default `deploy` task,
+            // which the query above cannot see — so without this their
+            // still-active record would advertise a dead URL forever.
+            // Omitting `task` matches every task in that environment.
+            const deployments = [
+              ...(await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                environment: "PR Preview",
+                task,
+                per_page: 100,
+              })),
+              ...(await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                environment: process.env.LEGACY_ENVIRONMENT,
+                per_page: 100,
+              })),
+            ];
             if (deployments.length === 0) {
-              core.info(`No deployments recorded for ${environment}; nothing to deactivate.`);
+              core.info(`No deployments recorded for ${task}; nothing to delete.`);
               return;
             }
 
@@ -63,12 +90,17 @@ jobs:
                   deployment_id: deployment.id,
                   state: "inactive",
                 });
+                await github.rest.repos.deleteDeployment({
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                });
               } catch (e) {
                 failures++;
                 core.warning(`Deployment ${deployment.id}: ${e.message} — continuing`);
               }
             }
-            core.info(`Marked ${deployments.length - failures} of ${deployments.length} deployment(s) for ${environment} inactive.`);
+            core.info(`Deleted ${deployments.length - failures} of ${deployments.length} deployment(s) for ${task}.`);
             if (failures) {
-              core.setFailed(`${failures} of ${deployments.length} deployment(s) could not be deactivated.`);
+              core.setFailed(`${failures} of ${deployments.length} deployment(s) could not be deleted.`);
             }

--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -1,11 +1,11 @@
 name: AWS preview stale cleanup
 
 # Reap stale PR preview environments by removing the `preview` label from open
-# PRs with no activity for STALE_DAYS. Label removal is the ONLY action: the
-# Argo CD ApplicationSet in the infrastructure repo polls labeled open PRs, so
-# dropping the label makes it stop generating the Application, and its
-# resources-finalizer cascade-deletes the namespace, PVCs, and DNS. Re-adding
-# the label redeploys.
+# PRs with no activity for STALE_DAYS. Label removal drives the real teardown:
+# the Argo CD ApplicationSet in the infrastructure repo polls labeled open PRs,
+# so dropping the label makes it stop generating the Application, and its
+# resources-finalizer cascade-deletes the namespace, PVCs, and DNS. The PR's
+# native GitHub deployment records are retired separately in this workflow.
 #
 # "Activity" = GitHub's PR updated_at (commits, comments, reviews, label edits).
 # The auto-labeler applies `preview` on open, which bumps updated_at, so a
@@ -46,9 +46,8 @@ jobs:
       # (NOT issues), even though they go through the issues REST endpoints —
       # same pattern as preview-autolabel / preview-build. Also covers pulls.list.
       pull-requests: write
-      # Mark the reaped preview's GitHub deployments (environment pr-<n>,
-      # recorded by preview-build) inactive alongside the label removal, so the
-      # PR stops advertising an "Active" environment whose URL is gone.
+      # Retire and delete the reaped PR's records from the shared GitHub
+      # `PR Preview` environment.
       deployments: write
     steps:
       - name: Reap stale previews
@@ -112,23 +111,37 @@ jobs:
                       + `(last update ${pr.updated_at}). Re-add the \`${label}\` label to redeploy.`,
                   });
 
-                  // Retire the PR's GitHub deployments along with the preview
-                  // itself, so the PR stops showing an "Active" environment.
-                  // Re-adding the label redeploys, and the next build records a
-                  // fresh deployment.
-                  const deployments = await github.paginate(github.rest.repos.listDeployments, {
-                    owner,
-                    repo,
-                    environment: `pr-${pr.number}`,
-                    per_page: 100,
-                  });
+                  // Environment + task must stay byte-identical to
+                  // preview-build.yml and preview-deactivate.yml, or
+                  // listDeployments matches nothing and dead records pile up.
+                  const task = `preview-pr-${pr.number}`;
+                  const deployments = await github.paginate(
+                    github.rest.repos.listDeployments,
+                    { owner, repo, environment: "PR Preview", task, per_page: 100 },
+                  );
+                  // Isolate per deployment, like the sibling loops in
+                  // preview-build.yml / preview-deactivate.yml: one transient
+                  // 5xx must not skip this PR's remaining records. Not counted
+                  // as a reap failure — the label removal above is the teardown,
+                  // and it already succeeded.
                   for (const deployment of deployments) {
-                    await github.rest.repos.createDeploymentStatus({
-                      owner,
-                      repo,
-                      deployment_id: deployment.id,
-                      state: "inactive",
-                    });
+                    try {
+                      await github.rest.repos.createDeploymentStatus({
+                        owner,
+                        repo,
+                        deployment_id: deployment.id,
+                        state: "inactive",
+                      });
+                      await github.rest.repos.deleteDeployment({
+                        owner,
+                        repo,
+                        deployment_id: deployment.id,
+                      });
+                    } catch (e) {
+                      core.warning(
+                        `PR #${pr.number} deployment ${deployment.id}: ${e.message} — continuing`,
+                      );
+                    }
                   }
                 }
               } catch (e) {

--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -81,6 +81,7 @@ jobs:
             // (5xx, secondary rate limit, PR locked/closed since pulls.list)
             // would skip every remaining stale PR and the summary.
             let failures = 0;
+            let deploymentFailures = 0;
             for (const pr of stale) {
               const ageDays = ((Date.now() - new Date(pr.updated_at).getTime()) / 86400000).toFixed(1);
               core.info(`PR #${pr.number} stale ${ageDays}d (updated ${pr.updated_at}) — ${pr.html_url}`);
@@ -115,15 +116,34 @@ jobs:
                   // preview-build.yml and preview-deactivate.yml, or
                   // listDeployments matches nothing and dead records pile up.
                   const task = `preview-pr-${pr.number}`;
-                  const deployments = await github.paginate(
-                    github.rest.repos.listDeployments,
-                    { owner, repo, environment: "PR Preview", task, per_page: 100 },
-                  );
+                  // TRANSITIONAL (drop with the sibling queries in
+                  // preview-build.yml / preview-deactivate.yml): a reaped PR
+                  // leaves the labeled set, so no later sweep revisits it — if
+                  // its pre-migration `pr-<n>` record is not retired here it
+                  // stays active until the PR eventually closes.
+                  const deployments = [
+                    ...(await github.paginate(github.rest.repos.listDeployments, {
+                      owner,
+                      repo,
+                      environment: "PR Preview",
+                      task,
+                      per_page: 100,
+                    })),
+                    ...(await github.paginate(github.rest.repos.listDeployments, {
+                      owner,
+                      repo,
+                      environment: `pr-${pr.number}`,
+                      per_page: 100,
+                    })),
+                  ];
                   // Isolate per deployment, like the sibling loops in
                   // preview-build.yml / preview-deactivate.yml: one transient
-                  // 5xx must not skip this PR's remaining records. Not counted
-                  // as a reap failure — the label removal above is the teardown,
-                  // and it already succeeded.
+                  // 5xx must not skip this PR's remaining records. Counted
+                  // separately from the reap counter — the label removal above
+                  // is the teardown and it succeeded, but a leftover record has
+                  // no retry path (this PR is now unlabeled, and a
+                  // GITHUB_TOKEN label removal cannot fire the `unlabeled`
+                  // workflow), so it must not pass silently.
                   for (const deployment of deployments) {
                     try {
                       await github.rest.repos.createDeploymentStatus({
@@ -138,6 +158,7 @@ jobs:
                         deployment_id: deployment.id,
                       });
                     } catch (e) {
+                      deploymentFailures++;
                       core.warning(
                         `PR #${pr.number} deployment ${deployment.id}: ${e.message} — continuing`,
                       );
@@ -153,9 +174,15 @@ jobs:
             core.notice(
               `${dryRun ? "[dry-run] " : ""}${stale.length} stale preview(s) `
               + `(threshold ${staleDays}d) out of ${labeled.length} labeled`
-              + `${failures ? `; ${failures} failed (see warnings)` : ""}.`
+              + `${failures ? `; ${failures} failed (see warnings)` : ""}`
+              + `${deploymentFailures ? `; ${deploymentFailures} deployment record(s) left behind` : ""}.`
             );
             // Surface partial failure as a failed run so it isn't silently green.
-            if (failures) {
-              core.setFailed(`${failures} of ${stale.length} stale preview(s) could not be reaped.`);
+            // Deployment-record failures count too: the reap itself succeeded,
+            // but nothing will retry the leftover record before PR close.
+            if (failures || deploymentFailures) {
+              core.setFailed(
+                `${failures} of ${stale.length} stale preview(s) could not be reaped; `
+                + `${deploymentFailures} deployment record(s) could not be deleted.`
+              );
             }


### PR DESCRIPTION
Backport of #15494 to `v3`.

## Summary

- `v3` forked at `cd2ea11fe` (2026-07-23), four days before #15494 landed on `main`, and nothing on `v3` has touched the preview workflows since. So every PR based on `v3` still records its preview into a durable per-PR `pr-<n>` GitHub environment.
- This is **not self-limiting**. `pull_request` runs the workflow file from the PR head, not the merge ref — so a v3 PR executes v3's copy of the workflow regardless of what `main` says. `v3` is actively maintained (latest commit is a security backport), so each new v3 PR mints another environment that no workflow can ever reap, since `GITHUB_TOKEN` cannot delete environments. 25 such environments had accumulated and were cleaned up by hand; without this backport they simply come back.
- Brings over the shared `PR Preview` environment keyed by a per-PR deployment task, deletion of records on close, the `pull_request.state == 'open'` gate on the `labeled` trigger, and the scoped concurrency groups.

## Major Decisions

- **Targeted backport, not a full sync.** `v3` is missing 8 commits touching these files; only #15494 concerns the environment leak. The other seven are unrelated preview features (Linear link labels #16759, demo auto sign-in #15579, PR top strip #15580, URL pinning #15588, both Blacksmith runner switches, one dep bump). Keeping the diff to the leak minimises blast radius on a release branch.
- **Applied unchanged except one comment.** The transitional legacy-query comment on `main` reads "added 2026-07-27"; here the cutoff is v3-relative, so it now says "drop once every v3 PR opened before this landed has closed". Code is identical to `main`.

## Review Focus

- **Shared environment across base branches.** v3 and main PRs will both write into `PR Preview`. This is safe because the deployment task is `preview-pr-<n>` and PR numbers are repo-global, so records cannot collide across base branches — but it is the one cross-branch interaction worth a second opinion.
- **Concurrency group strings must stay byte-identical** between `preview-build.yml` and `preview-deactivate.yml` (`format('preview-build-{0}', github.event.pull_request.number)`), or cancel-on-close silently stops working. Verified identical on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport moves PR previews into one durable GitHub environment, scopes records by a per-PR deployment task, and deletes deployment records when previews are replaced or deactivated.
- Adds label-aware preview build triggers and per-PR concurrency groups.
- Replaces per-PR environments with the shared `PR Preview` environment.
- Deletes current and legacy deployment records on close, label removal, and stale-preview cleanup.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until close-time cleanup reliably prevents or catches deployments created by an in-flight notify step after cleanup takes its snapshot.

The new cancellation coordination narrows teardown races but does not synchronize deployment creation with cleanup, allowing an active deployment for a closed preview to survive.

**Files Needing Attention:** .github/workflows/preview-deactivate.yml and .github/workflows/preview-build.yml
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant B as Preview build
  participant G as GitHub Deployments
  participant C as Close cleanup
  B->>B: Image build succeeds
  C->>B: Request cancellation
  C->>G: List PR deployments
  G-->>C: Existing records
  C->>G: Delete listed records
  B->>G: Create successful deployment
  Note over G: Late deployment remains active
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/preview-deactivate.yml:23-26
**Cleanup misses late deployments**

If cancellation overlaps an already-running notify step after the image build succeeds, cleanup takes its one-time deployment snapshot before that step creates its deployment. The new deployment is therefore never deleted and remains active with a dead View deployment URL after the preview closes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(preview): share one GitHub environmen..."](https://github.com/langfuse/langfuse/commit/ddeb4b4fd1ba5b04e23422f0f1dcdedd38610a1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58552451)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->