### PR TITLE
feat: add API spec previews for pull requests

### DIFF
--- a/.github/workflows/api-spec-preview.yml
+++ b/.github/workflows/api-spec-preview.yml
@@ -1,13 +1,19 @@
 name: API Spec Preview
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number for the selected branch
+        required: true
+        type: string
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
 permissions: {}
 
 concurrency:
-  group: api-spec-preview-${{ github.event.pull_request.number }}
+  group: api-spec-preview-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'api-spec' }}
 
 jobs:
@@ -15,9 +21,10 @@ jobs:
     name: Deploy API spec preview
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: >-
-      contains(github.event.pull_request.labels.*.name, 'api-spec') &&
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'api-spec') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event.action != 'labeled' || github.event.label.name == 'api-spec')
+      (github.event.action != 'labeled' || github.event.label.name == 'api-spec'))
     permissions:
       contents: read
       issues: write
@@ -63,7 +70,7 @@ jobs:
       - name: Deploy preview to Vercel
         id: publish
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           VERCEL_ORG_ID: ${{ secrets.STORYBOOK_VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.STORYBOOK_VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.STORYBOOK_VERCEL_TOKEN }}
@@ -101,8 +108,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_URL: ${{ steps.publish.outputs.url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         with:
           script: |
             const marker = "<!-- api-spec-preview -->";

--- a/.github/workflows/api-spec-preview.yml
+++ b/.github/workflows/api-spec-preview.yml
@@ -1,0 +1,142 @@
+name: API Spec Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions: {}
+
+concurrency:
+  group: api-spec-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'api-spec' }}
+
+jobs:
+  deploy:
+    name: Deploy API spec preview
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'api-spec') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'labeled' || github.event.label.name == 'api-spec')
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout API reference
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: langfuse/langfuse-api-reference
+          ref: 7affc0ed7208985f60dab27c9ad0c1751ec4d2f8
+          path: api-reference
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.22.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Export OpenAPI spec
+        run: pnpm run openapi:export
+
+      - name: Prepare API reference
+        run: |
+          set -euo pipefail
+
+          cp web/public/generated/api/openapi.yml api-reference/public/openapi.yml
+          find api-reference/public -type f -name '*.html' -exec sed -i 's|%APISPEC_DATA_URL%|/openapi.yml|g' {} \;
+
+      - name: Deploy preview to Vercel
+        id: publish
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERCEL_ORG_ID: ${{ secrets.STORYBOOK_VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.STORYBOOK_VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.STORYBOOK_VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          pnpm install -g vercel@54.7.0
+
+          set +e
+          deploy_output=$(vercel deploy api-reference --yes --scope langfuse 2>&1)
+          deploy_status=$?
+          set -e
+
+          if [ "${deploy_status}" -ne 0 ]; then
+            printf '%s\n' "${deploy_output}"
+            echo "Vercel deploy failed."
+            exit "${deploy_status}"
+          fi
+
+          preview_url=$(printf '%s\n' "${deploy_output}" | grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | tail -n 1 || true)
+
+          if [ -z "${preview_url}" ]; then
+            printf '%s\n' "${deploy_output}"
+            echo "Failed to determine Vercel preview URL."
+            exit 1
+          fi
+
+          preview_alias="pr-${PR_NUMBER}-api-spec.langfuse.vercel.app"
+          vercel alias set "${preview_url}" "${preview_alias}" --scope langfuse
+          preview_url="https://${preview_alias}"
+
+          echo "url=${preview_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview link
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_URL: ${{ steps.publish.outputs.url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = "<!-- api-spec-preview -->";
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            // The link label ends in "preview" so Linear's GitHub integration
+            // picks it up as a custom preview link on every linked Linear issue.
+            const link = `[pr-${issue_number} api spec preview](${process.env.PREVIEW_URL})`;
+            const body = `${marker}\nAPI spec preview: ${link}\n\nUpdated at: ${new Date().toISOString()}\nCommit: ${process.env.COMMIT_SHA}`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previousComment = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker),
+            );
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/api-spec-preview.yml
+++ b/.github/workflows/api-spec-preview.yml
@@ -58,7 +58,7 @@ jobs:
           set -euo pipefail
 
           cp web/public/generated/api/openapi.yml api-reference/public/openapi.yml
-          find api-reference/public -type f -name '*.html' -exec sed -i 's|%APISPEC_DATA_URL%|/openapi.yml|g' {} \;
+          sed -i 's/%APISPEC_DATA_URL%/\/openapi.yml/g' api-reference/public/index.html
 
       - name: Deploy preview to Vercel
         id: publish

--- a/.github/workflows/api-spec-preview.yml
+++ b/.github/workflows/api-spec-preview.yml
@@ -1,19 +1,14 @@
 name: API Spec Preview
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: Pull request number for the selected branch
-        required: true
-        type: string
+  workflow_dispatch: {}
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
 permissions: {}
 
 concurrency:
-  group: api-spec-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: api-spec-preview-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'api-spec' }}
 
 jobs:
@@ -30,6 +25,23 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Resolve pull request number
+        id: resolve-pr-number
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          pr_number=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/pulls" -f "head=${GITHUB_REPOSITORY%%/*}:${GITHUB_REF_NAME}" -f state=open --jq '.[0].number')
+
+          if [ -z "${pr_number}" ] || [ "${pr_number}" = "null" ]; then
+            echo "No open pull request found for branch ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout pull request
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -70,7 +82,7 @@ jobs:
       - name: Deploy preview to Vercel
         id: publish
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || steps.resolve-pr-number.outputs.pr_number }}
           VERCEL_ORG_ID: ${{ secrets.STORYBOOK_VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.STORYBOOK_VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.STORYBOOK_VERCEL_TOKEN }}
@@ -108,7 +120,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_URL: ${{ steps.publish.outputs.url }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || steps.resolve-pr-number.outputs.pr_number }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         with:
           script: |

--- a/.github/workflows/preview-autolabel.yml
+++ b/.github/workflows/preview-autolabel.yml
@@ -73,6 +73,9 @@ jobs:
               per_page: 100,
             });
             const paths = files.map((file) => file.filename);
+            const existingLabels = new Set(
+              pr.labels.map((label) => label.name),
+            );
             const labels = [];
 
             const hasApiSpecChanges = paths.some(
@@ -113,15 +116,16 @@ jobs:
 
             // Events created with GITHUB_TOKEN do not trigger workflows for
             // newly added labels. workflow_dispatch is the supported exception,
-            // so start each matching preview explicitly on the PR branch.
+            // so start each newly enabled preview explicitly on the PR branch.
+            // Existing labels already make the pull_request event run the preview.
             const dispatches = [];
-            if (hasApiSpecChanges) {
+            if (hasApiSpecChanges && !existingLabels.has("api-spec")) {
               dispatches.push({
                 workflow_id: "api-spec-preview.yml",
                 inputs: { pr_number: String(pr.number) },
               });
             }
-            if (hasStorybookChanges) {
+            if (hasStorybookChanges && !existingLabels.has("storybook")) {
               dispatches.push({ workflow_id: "storybook-preview.yml" });
             }
 

--- a/.github/workflows/preview-autolabel.yml
+++ b/.github/workflows/preview-autolabel.yml
@@ -95,7 +95,6 @@ jobs:
                 (path.startsWith("web/src/features/") &&
                   path.includes("/components/")) ||
                 path === "web/src/styles/globals.css" ||
-                path === "web/tailwind.config.ts" ||
                 /\.stories\.[^/]+$/.test(path) ||
                 path === ".github/workflows/storybook-preview.yml",
             );
@@ -120,10 +119,7 @@ jobs:
             // Existing labels already make the pull_request event run the preview.
             const dispatches = [];
             if (hasApiSpecChanges && !existingLabels.has("api-spec")) {
-              dispatches.push({
-                workflow_id: "api-spec-preview.yml",
-                inputs: { pr_number: String(pr.number) },
-              });
+              dispatches.push({ workflow_id: "api-spec-preview.yml" });
             }
             if (hasStorybookChanges && !existingLabels.has("storybook")) {
               dispatches.push({ workflow_id: "storybook-preview.yml" });

--- a/.github/workflows/preview-autolabel.yml
+++ b/.github/workflows/preview-autolabel.yml
@@ -1,20 +1,16 @@
-name: AWS preview auto-label
+name: Preview auto-labels
 
-# Auto-apply the `preview` label to same-repo PRs on open or update, so the Argo
-# CD ApplicationSet (in the infrastructure repo) picks them up and builds a
-# preview. Including synchronize recovers PRs that opened with merge conflicts:
-# GitHub skips pull_request workflows until the conflict is resolved. It also
-# reactivates a stale or manually removed preview when development resumes.
-# Anyone with write access can also apply the label by hand.
+# Auto-apply preview labels to same-repo PRs on open or update. Including
+# synchronize recovers PRs that opened with merge conflicts: GitHub skips
+# pull_request workflows until the conflict is resolved. It also reactivates a
+# stale or manually removed preview when development resumes.
 #
 # Trust boundary is WRITE access, not a per-author allowlist: opening a
-# same-repo PR requires push access, so labeling every same-repo PR is exactly
-# "auto-preview for write-access members." Fork PRs are short-circuited — they
-# can't mint an OIDC token to build anyway.
+# same-repo PR requires push access. Fork PRs are short-circuited because the
+# preview workflows do not expose deployment credentials to them.
 #
 # Uses the plain `pull_request` trigger (NOT pull_request_target): no cloud
-# credentials, no checkout, no PR-code execution — only issues.addLabels — so it
-# stays off zizmor's dangerous-triggers list.
+# credentials, no checkout, no PR-code execution - only GitHub API calls.
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -22,8 +18,8 @@ on:
 permissions: {}
 
 jobs:
-  autolabel:
-    name: Auto-label same-repo PRs
+  aws-preview:
+    name: Auto-label AWS preview
     runs-on: ubuntu-latest
     # AWS_PREVIEW_ECR_PUSH_ROLE_ARN is the feature flag: unset => preview system
     # off, so don't label.
@@ -38,9 +34,6 @@ jobs:
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
 
-            // Same-repo only: opening a same-repo PR requires push (write)
-            // access, so this is "auto-preview for write-access members." Fork
-            // PRs can't mint an OIDC token to build, so skip them.
             if (pr.head.repo.full_name !== `${owner}/${repo}`) {
               core.info("Fork PR; auto-label is limited to same-repo branches.");
               return;
@@ -53,3 +46,104 @@ jobs:
               labels: ["preview"],
             });
             core.info(`Applied 'preview' label to PR #${pr.number}.`);
+
+  related-previews:
+    name: Auto-label related previews
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    steps:
+      - name: Label related previews
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.info("Fork PR; auto-label is limited to same-repo branches.");
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const paths = files.map((file) => file.filename);
+            const labels = [];
+
+            const hasApiSpecChanges = paths.some(
+              (path) =>
+                path.startsWith("fern/apis/server/") ||
+                path === "fern/fern.config.json" ||
+                path.startsWith("web/scripts/openapi/") ||
+                path.startsWith("web/public/generated/api/") ||
+                path === ".github/workflows/api-spec-preview.yml",
+            );
+            if (hasApiSpecChanges) labels.push("api-spec");
+
+            const hasStorybookChanges = paths.some(
+              (path) =>
+                path.startsWith("web/.storybook/") ||
+                path.startsWith("web/src/components/") ||
+                (path.startsWith("web/src/features/") &&
+                  path.includes("/components/")) ||
+                path === "web/src/styles/globals.css" ||
+                path === "web/tailwind.config.ts" ||
+                /\.stories\.[^/]+$/.test(path) ||
+                path === ".github/workflows/storybook-preview.yml",
+            );
+            if (hasStorybookChanges) labels.push("storybook");
+
+            if (labels.length === 0) {
+              core.info("No API spec or Storybook preview changes detected.");
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pr.number,
+              labels,
+            });
+            core.info(`Applied ${labels.join(", ")} to PR #${pr.number}.`);
+
+            // Events created with GITHUB_TOKEN do not trigger workflows for
+            // newly added labels. workflow_dispatch is the supported exception,
+            // so start each matching preview explicitly on the PR branch.
+            const dispatches = [];
+            if (hasApiSpecChanges) {
+              dispatches.push({
+                workflow_id: "api-spec-preview.yml",
+                inputs: { pr_number: String(pr.number) },
+              });
+            }
+            if (hasStorybookChanges) {
+              dispatches.push({ workflow_id: "storybook-preview.yml" });
+            }
+
+            for (const dispatch of dispatches) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  ref: pr.head.ref,
+                  ...dispatch,
+                });
+                core.info(`Dispatched ${dispatch.workflow_id} for PR #${pr.number}.`);
+              } catch (error) {
+                // A newly added workflow cannot be dispatched until it exists
+                // on the default branch. Its own pull_request run still tests
+                // the initial change; future PRs use this dispatch path.
+                if (error.status === 404) {
+                  core.warning(
+                    `${dispatch.workflow_id} is not available on the default branch yet.`,
+                  );
+                  continue;
+                }
+                throw error;
+              }
+            }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16833 app preview](https://pr-16833.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What

- Add an `api-spec` label-gated preview workflow for same-repository PRs.
- Export and post-process the PR's OpenAPI spec.
- Render it with the exact production [`langfuse-api-reference`](https://github.com/langfuse/langfuse-api-reference) Scalar setup, pinned to a commit.
- Deploy it through the existing Storybook Vercel project and keep one preview comment updated.

## Testing

- `pnpm run openapi:export`
- Prepared the pinned API reference locally and verified it loads `/openapi.yml`.
- `actionlint` passed with the known Blacksmith runner label allowed.
- `zizmor --min-severity low .github/workflows/api-spec-preview.yml`
- Commit hooks: `Tasks: 7 successful, 7 total`

## Trade-off

The API reference checkout is pinned for safe and repeatable builds. We need to update the commit when its production configuration changes.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a same-repository, label-gated GitHub Actions workflow that exports a PR's OpenAPI specification, inserts it into a pinned copy of the production API reference, deploys it through Vercel, and creates or updates one preview comment.
- Restricts execution to same-repository pull requests carrying the `api-spec` label.
- Pins all actions, the API-reference revision, pnpm, Node.js, and the Vercel CLI.
- Uses a stable PR-specific alias and marker-based comment updates.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defect identified in the changed workflow.

The workflow confines pull-request-controlled execution to same-repository branches, does not expose deployment secrets until the deployment step, pins external components, and consistently exports, deploys, and comments the preview.
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant GA as GitHub Actions
    participant Repo as Langfuse Checkout
    participant Ref as Pinned API Reference
    participant V as Vercel
    participant GH as GitHub Comments
    PR->>GA: api-spec label / synchronize
    GA->>GA: Verify label and same-repository head
    GA->>Repo: Checkout and install dependencies
    GA->>Repo: Export OpenAPI specification
    GA->>Ref: Checkout pinned revision
    Repo->>Ref: Copy generated openapi.yml
    GA->>Ref: Configure /openapi.yml
    GA->>V: Deploy API-reference directory
    V-->>GA: Preview deployment URL
    GA->>V: Assign stable PR alias
    GA->>GH: Create or update preview comment
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add API spec previews for pull req..."](https://github.com/langfuse/langfuse/commit/0987f2591a0e1803df714f4880fc52cc9241e167) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58561852)</sub>

<!-- /greptile_comment -->