### PR TITLE
ci(preview): close the legacy-record gaps left by the shared environment

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -349,6 +349,8 @@ jobs:
           PREVIEW_SHA: ${{ needs.meta.outputs.commit_sha }}
           PREVIEW_HOST: ${{ needs.meta.outputs.preview_host }}
           PREVIEW_TASK: preview-pr-${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LEGACY_ENVIRONMENT: pr-${{ github.event.pull_request.number }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -359,10 +361,40 @@ jobs:
             const environment = "PR Preview";
             const task = process.env.PREVIEW_TASK;
 
-            const previousDeployments = await github.paginate(
-              github.rest.repos.listDeployments,
-              { owner, repo, environment, task, per_page: 100 },
-            );
+            // The job `if` gates on the EVENT payload's state, which is a
+            // snapshot from when the build started — a PR closed during the
+            // build still reads `open` there. Re-check live, or this records a
+            // deployment Argo will never serve and nothing will ever reap
+            // (preview-deactivate already fired on close; the stale sweep only
+            // scans open PRs).
+            const { data: livePr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            if (livePr.state !== "open") {
+              core.info(`PR closed during the build; not recording a deployment.`);
+              return;
+            }
+
+            // TRANSITIONAL (drop with the sibling query in
+            // preview-deactivate.yml): also retire the pre-migration `pr-<n>`
+            // record, else a rebuild leaves it active alongside the new one.
+            const previousDeployments = [
+              ...(await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                environment,
+                task,
+                per_page: 100,
+              })),
+              ...(await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                environment: process.env.LEGACY_ENVIRONMENT,
+                per_page: 100,
+              })),
+            ];
 
             const { data: deployment } = await github.rest.repos.createDeployment({
               owner,

--- a/.github/workflows/preview-stale-cleanup.yml
+++ b/.github/workflows/preview-stale-cleanup.yml
@@ -81,6 +81,7 @@ jobs:
             // (5xx, secondary rate limit, PR locked/closed since pulls.list)
             // would skip every remaining stale PR and the summary.
             let failures = 0;
+            let deploymentFailures = 0;
             for (const pr of stale) {
               const ageDays = ((Date.now() - new Date(pr.updated_at).getTime()) / 86400000).toFixed(1);
               core.info(`PR #${pr.number} stale ${ageDays}d (updated ${pr.updated_at}) — ${pr.html_url}`);
@@ -115,15 +116,34 @@ jobs:
                   // preview-build.yml and preview-deactivate.yml, or
                   // listDeployments matches nothing and dead records pile up.
                   const task = `preview-pr-${pr.number}`;
-                  const deployments = await github.paginate(
-                    github.rest.repos.listDeployments,
-                    { owner, repo, environment: "PR Preview", task, per_page: 100 },
-                  );
+                  // TRANSITIONAL (drop with the sibling queries in
+                  // preview-build.yml / preview-deactivate.yml): a reaped PR
+                  // leaves the labeled set, so no later sweep revisits it — if
+                  // its pre-migration `pr-<n>` record is not retired here it
+                  // stays active until the PR eventually closes.
+                  const deployments = [
+                    ...(await github.paginate(github.rest.repos.listDeployments, {
+                      owner,
+                      repo,
+                      environment: "PR Preview",
+                      task,
+                      per_page: 100,
+                    })),
+                    ...(await github.paginate(github.rest.repos.listDeployments, {
+                      owner,
+                      repo,
+                      environment: `pr-${pr.number}`,
+                      per_page: 100,
+                    })),
+                  ];
                   // Isolate per deployment, like the sibling loops in
                   // preview-build.yml / preview-deactivate.yml: one transient
-                  // 5xx must not skip this PR's remaining records. Not counted
-                  // as a reap failure — the label removal above is the teardown,
-                  // and it already succeeded.
+                  // 5xx must not skip this PR's remaining records. Counted
+                  // separately from the reap counter — the label removal above
+                  // is the teardown and it succeeded, but a leftover record has
+                  // no retry path (this PR is now unlabeled, and a
+                  // GITHUB_TOKEN label removal cannot fire the `unlabeled`
+                  // workflow), so it must not pass silently.
                   for (const deployment of deployments) {
                     try {
                       await github.rest.repos.createDeploymentStatus({
@@ -138,6 +158,7 @@ jobs:
                         deployment_id: deployment.id,
                       });
                     } catch (e) {
+                      deploymentFailures++;
                       core.warning(
                         `PR #${pr.number} deployment ${deployment.id}: ${e.message} — continuing`,
                       );
@@ -153,9 +174,15 @@ jobs:
             core.notice(
               `${dryRun ? "[dry-run] " : ""}${stale.length} stale preview(s) `
               + `(threshold ${staleDays}d) out of ${labeled.length} labeled`
-              + `${failures ? `; ${failures} failed (see warnings)` : ""}.`
+              + `${failures ? `; ${failures} failed (see warnings)` : ""}`
+              + `${deploymentFailures ? `; ${deploymentFailures} deployment record(s) left behind` : ""}.`
             );
             // Surface partial failure as a failed run so it isn't silently green.
-            if (failures) {
-              core.setFailed(`${failures} of ${stale.length} stale preview(s) could not be reaped.`);
+            // Deployment-record failures count too: the reap itself succeeded,
+            // but nothing will retry the leftover record before PR close.
+            if (failures || deploymentFailures) {
+              core.setFailed(
+                `${failures} of ${stale.length} stale preview(s) could not be reaped; `
+                + `${deploymentFailures} deployment record(s) could not be deleted.`
+              );
             }


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16834 app preview](https://pr-16834.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

Follow-ups from bot review of the v3 backport (#16832). All three apply to `main` too — the asymmetry is identical on both branches — so fixing `main` first and mirroring into #16832 keeps the two from drifting again.

## Summary

- **The `state == 'open'` gate was ineffective for its main case.** It reads the *event payload*, a snapshot from when the build started, so a PR closed during a five-minute build still passes it. `preview-deactivate` has already fired by then and the stale sweep only scans open PRs, so the recorded deployment is never reaped and keeps advertising a dead URL. The record step now re-checks live PR state and bails if closed.
- **The transitional `pr-<n>` lookup existed only in `preview-deactivate`.** Consequences: on rebuild, `preview-build` left the pre-migration record active alongside the new one; and a stale-reaped PR kept an active legacy record until it eventually closed, since a reaped PR leaves the labeled set and no later sweep revisits it. All three sites now query both environments.
- **Stale-cleanup's per-deployment failures now surface.** They get their own counter and fail the run rather than only warning.

## Major Decisions

- **Separate counter rather than folding into the reap counter.** A failed record deletion is not a failed reap — the label removal, which is the actual teardown, succeeded. But it can't pass silently either: the PR is now unlabeled and a `GITHUB_TOKEN` label removal cannot fire the `unlabeled` workflow, so there is no retry path before close. Hence a distinct `deploymentFailures`, reported in the notice and in `setFailed`.
- **Env vars over `context.issue.number`** for the new PR-derived values, matching the convention already used in these files.

## Review Focus

- **The live-state re-check adds an API call and an early `return` to the record step.** Worth confirming the `return` placement is right: it happens before `createDeployment`, so a closed PR gets no record and no previous-record cleanup — which is correct, since `preview-deactivate` owns cleanup on close.
- **Three sites must stay in agreement** on the environment/task pair and the transitional query. They are now consistent; the transitional branches should be dropped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR rechecks live PR state before recording preview deployments, extends build and stale cleanup to retire legacy deployment records, and surfaces partial deletion failures.
- Adds live-state validation to avoid recording previews for PRs closed during a build.
- Reconciles both shared and legacy deployment environments.
- Tracks deployment-record cleanup failures separately from stale-preview reap failures.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until deployment creation is coordinated with close cleanup and each stale-cleanup query can preserve and process the other query's successful results.

A close can still interleave between the new state check and deployment creation, permanently orphaning an active record, while failure of the added legacy cleanup query can prevent deletion of already-fetched shared records after the PR becomes ineligible for retries.

**Files Needing Attention:** .github/workflows/preview-build.yml, .github/workflows/preview-stale-cleanup.yml
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant B as Preview build
  participant G as GitHub API
  participant D as Preview deactivate
  participant S as Stale cleanup
  B->>G: Read live PR state
  G-->>B: open
  D->>G: List deployments on close
  G-->>D: Existing records
  D->>G: Delete listed records
  B->>G: Create deployment
  Note over B,G: A close between state read and creation can leave the new record active
  S->>G: Remove preview label
  S->>G: Query shared deployments
  S->>G: Query legacy deployments
  Note over S,G: Failure of either query prevents processing both result sets
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/preview-build.yml:375-378
**Close race orphans deployment**

If a PR closes after the live-state check but before `createDeployment`, close cleanup can finish its deployment query first, causing the subsequently created deployment to remain active permanently because stale cleanup only revisits open, labeled PRs.

### Issue 2
.github/workflows/preview-stale-cleanup.yml:124-138
**Query failure discards cleanup results**

When the new legacy query fails after the shared-environment query succeeds, the combined array construction rejects before the deletion loop, causing the fetched shared deployment records to remain active after label removal has excluded the PR from future stale sweeps.

### Issue 3
.github/workflows/preview-build.yml:391-396
**Lookup failure blocks preview publication**

If either new GitHub API lookup encounters a transient service or rate-limit error, the unguarded request aborts before `createDeployment` and the later pin step is skipped, leaving a successfully built preview without a deployment entry or pinned URL until someone manually reruns the workflow.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(preview): close the legacy-record gap..."](https://github.com/langfuse/langfuse/commit/fcc7d61c2b07550628fe519f78ea9647fb554b4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58561933)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->