### PR TITLE
fix(chatml): reject top-level parts in OpenAI chat-completions detection

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -13,11 +13,26 @@ import { z } from "zod";
  * These are permissive - only validate structural markers, not full API contracts
  */
 
+// Reject if any message has top-level parts (Microsoft Agent/Gemini format)
+// OpenAI uses parts inside content, not at message level
+const hasNoTopLevelParts = (messages: unknown[]) =>
+  !messages.some(
+    (msg) =>
+      typeof msg === "object" &&
+      msg !== null &&
+      "parts" in msg &&
+      Array.isArray((msg as Record<string, unknown>).parts),
+  );
+
 // INPUT SCHEMAS (requests)
-const OpenAIInputChatCompletionsSchema = z.looseObject({
-  messages: z.array(z.any()),
-  tools: z.array(z.any()).optional(),
-});
+const OpenAIInputChatCompletionsSchema = z
+  .looseObject({
+    messages: z.array(z.any()),
+    tools: z.array(z.any()).optional(),
+  })
+  .refine((data) => hasNoTopLevelParts(data.messages), {
+    message: "Messages with top-level parts are not OpenAI format",
+  });
 
 const OpenAIInputMessagesSchema = z
   .array(
@@ -25,20 +40,9 @@ const OpenAIInputMessagesSchema = z
       role: z.enum(["system", "user", "assistant", "tool", "function"]),
     }),
   )
-  .refine(
-    (data) => {
-      // Reject if any message has top-level parts (Microsoft Agent/Gemini format)
-      // OpenAI uses parts inside content, not at message level
-      return !data.some(
-        (msg) =>
-          typeof msg === "object" &&
-          msg !== null &&
-          "parts" in msg &&
-          Array.isArray((msg as Record<string, unknown>).parts),
-      );
-    },
-    { message: "Messages with top-level parts are not OpenAI format" },
-  );
+  .refine((data) => hasNoTopLevelParts(data), {
+    message: "Messages with top-level parts are not OpenAI format",
+  });
 
 // Role-less Responses input item types. normalizeMessage converts the common
 // conversation items and preserves built-in tool items as JSON passthrough.

--- a/worker/src/__tests__/chatml/adapters/openai.test.ts
+++ b/worker/src/__tests__/chatml/adapters/openai.test.ts
@@ -80,6 +80,14 @@ describe("OpenAI Adapter", () => {
 
       // Should also reject when passed as data
       expect(openAIAdapter.detect({ metadata: {}, data: input })).toBe(false);
+
+      // Should also reject when wrapped with tool definitions as
+      // {messages, tools}, matching the bare-array rejection above
+      const wrappedInput = { messages: input, tools: [{ type: "function" }] };
+      expect(openAIAdapter.detect({ metadata: wrappedInput })).toBe(false);
+      expect(openAIAdapter.detect({ metadata: {}, data: wrappedInput })).toBe(
+        false,
+      );
     });
 
     it("should not crash when detecting messages array with null items", () => {


### PR DESCRIPTION
## Problem

Fixes #16841.

For a .NET app instrumented with `Microsoft.Extensions.AI`, generations render inconsistently in the trace view depending on whether the call had tools available. Messages arrive in the OTel GenAI shape, `{role, parts: [{type: "text", content: "..."}]}`.

`packages/shared/src/utils/chatml/adapters/openai.ts` defines two input schemas. `OpenAIInputMessagesSchema` (the bare-array shape) carries a `.refine` that rejects messages with top-level `parts`, commented *"Reject if any message has top-level parts (Microsoft Agent/Gemini format)"*. `OpenAIInputChatCompletionsSchema` (the `{messages, tools}` wrapped shape) had no such guard.

`detect()` tries the unguarded schema first. When tool definitions are present, the OTel ingestion wraps the input as `{messages, tools}`, which matched the unguarded schema, so `openAIAdapter` claimed the span and the adapter that flattens `parts` correctly (e.g. Microsoft Agent) never ran. With no tools, the input stayed a bare array, hit the guarded schema, was rejected, and fell through correctly. So the intended guard was bypassed for exactly the calls that needed it.

## Fix

Apply the same top-level-`parts` guard to `OpenAIInputChatCompletionsSchema`, so the wrapped and bare forms agree. Extracted the shared predicate (`hasNoTopLevelParts`) so both schemas can't drift again.

## Test

Extended the existing `should reject Microsoft Agent format with top-level parts` test in `worker/src/__tests__/chatml/adapters/openai.test.ts` to also cover the `{messages, tools}` wrapped shape.

Confirmed the new assertions fail without the fix:

```
$ git checkout HEAD~1 -- packages/shared/src/utils/chatml/adapters/openai.ts
$ pnpm --filter worker run test openai.test.ts
 FAIL  src/__tests__/chatml/adapters/openai.test.ts > OpenAI Adapter > detection > should reject Microsoft Agent format with top-level parts
AssertionError: expected true to be false // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 26 passed (27)
$ git checkout HEAD -- packages/shared/src/utils/chatml/adapters/openai.ts
```

And pass with the fix:

```
$ pnpm --filter worker run test openai.test.ts
 ✓ src/__tests__/chatml/adapters/openai.test.ts (27 tests) 23ms
 Test Files  1 passed (1)
      Tests  27 passed (27)
```

Full chatml adapter suite (`pnpm --filter worker run test chatml`): 99 passed. (`integration.test.ts` fails both before and after this change in this sandbox due to missing `CLICKHOUSE_*`/`LANGFUSE_S3_*` env vars — unrelated to this fix.)

`pnpm --filter @langfuse/shared run lint`, `pnpm --filter worker run lint`, and `pnpm --filter @langfuse/shared run typecheck` all pass clean.

## Scope

This PR only applies the existing `parts` guard consistently between the two OpenAI input schemas. The issue's secondary suggestion — having `microsoftAgentAdapter` also read a flattened `meta["scope.name"]` hint — is a separate, independent improvement and is left out to keep this change minimal.

## AI assistance disclosure

This PR was authored by an autonomous Claude Code agent.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes OpenAI chat-completions detection consistently reject Microsoft Agent/Gemini messages containing top-level `parts`.

- Extracts the existing top-level-parts predicate for reuse by both OpenAI input schemas.
- Applies the guard to wrapped `{messages, tools}` input.
- Adds detection coverage for wrapped input supplied through metadata and data.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the wrapped and bare OpenAI detection paths now applying the same format guard.

The extracted predicate preserves the prior bare-array behavior and closes the wrapped-input detection gap, while the added tests exercise both metadata and data paths.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chatml): reject top-level parts in O..."](https://github.com/langfuse/langfuse/commit/12ac11eff13a2cbfb959301cf5f35d7a251b8f13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58604778)</sub>

<!-- /greptile_comment -->