### PR TITLE
feat(public-api): add PATCH /api/public/models/{modelId}

### DIFF
--- a/fern/apis/server/definition/models.yml
+++ b/fern/apis/server/definition/models.yml
@@ -41,6 +41,18 @@ service:
       path-parameters:
         id: string
       response: commons.Model
+    update:
+      method: PATCH
+      docs: |
+        Partially update a model definition. Only the mutable fields are accepted:
+        `matchPattern`, `tokenizerId`, `tokenizerConfig`, `startDate`, `unit`.
+        `modelName` and pricing are not patchable; use `PUT /models/{id}` (upsert)
+        or `DELETE` + `POST /models` for those.
+      path: /models/{id}
+      path-parameters:
+        id: string
+      request: UpdateModelRequest
+      response: commons.Model
     delete:
       method: DELETE
       docs: Delete a model. Cannot delete models managed by Langfuse. You can create your own definition with the same modelName to override the definition though.
@@ -103,6 +115,23 @@ types:
           If omitted, you must provide flat prices instead (inputPrice/outputPrice/totalPrice),
           which will automatically create a single default tier named "Standard".
         type: optional<nullable<list<commons.PricingTierInput>>>
+      tokenizerId:
+        docs: Optional. Tokenizer to be applied to observations which match to this model. See docs for more details.
+        type: optional<nullable<ModelTokenizerId>>
+      tokenizerConfig:
+        docs: Optional. Configuration for the selected tokenizer. Needs to be JSON. See docs for more details.
+        type: optional<nullable<unknown>>
+  UpdateModelRequest:
+    properties:
+      matchPattern:
+        docs: "Regex pattern which matches this model definition to generation.model. Useful in case of fine-tuned models. If you want to exact match, use `(?i)^modelname$`"
+        type: optional<string>
+      startDate:
+        docs: Apply only to generations which are newer than this ISO date.
+        type: optional<nullable<datetime>>
+      unit:
+        docs: Unit used by this model.
+        type: optional<commons.ModelUsageUnit>
       tokenizerId:
         docs: Optional. Tokenizer to be applied to observations which match to this model. See docs for more details.
         type: optional<nullable<ModelTokenizerId>>

--- a/web/src/__tests__/server/model-definitions.servertest.ts
+++ b/web/src/__tests__/server/model-definitions.servertest.ts
@@ -7,6 +7,7 @@ import {
   DeleteModelV1Response,
   GetModelV1Response,
   GetModelsV1Response,
+  PatchModelV1Response,
   PostModelsV1Response,
   PutModelV1Response,
 } from "@/src/features/public-api/types/models";
@@ -664,5 +665,276 @@ describe("/models API Endpoints", () => {
       auth,
     );
     expect(modelsAfterDelete.status).toBe(200);
+  });
+
+  describe("PATCH /models/{modelId}", () => {
+    it("updates matchPattern and tokenizer on an existing project-owned model", async () => {
+      const create = await makeZodVerifiedAPICall(
+        PostModelsV1Response,
+        "POST",
+        "/api/public/models",
+        {
+          modelName: `gpt-patch-${v4()}`,
+          matchPattern: "(.*)old-pattern(.*)",
+          startDate: "2023-12-01",
+          inputPrice: 0.001,
+          outputPrice: 0.002,
+          unit: "TOKENS",
+        },
+        auth,
+      );
+      expect(create.status).toBe(200);
+
+      const patched = await makeZodVerifiedAPICall(
+        PatchModelV1Response,
+        "PATCH",
+        `/api/public/models/${create.body.id}`,
+        {
+          matchPattern: "(.*)new-pattern(.*)",
+          tokenizerId: "openai",
+          tokenizerConfig: { tokensPerMessage: 4 },
+          unit: "TOKENS",
+        },
+        auth,
+      );
+      expect(patched.status).toBe(200);
+      expect(patched.body.id).toBe(create.body.id);
+      expect(patched.body.matchPattern).toBe("(.*)new-pattern(.*)");
+      expect(patched.body.tokenizerId).toBe("openai");
+      expect(patched.body.tokenizerConfig).toEqual({ tokensPerMessage: 4 });
+      expect(patched.body.modelName).toBe(create.body.modelName);
+
+      // Audit log records the update with both before and after.
+      const audit = await prisma.auditLog.findFirst({
+        where: {
+          resourceType: "model",
+          resourceId: create.body.id,
+          action: "update",
+        },
+        orderBy: { createdAt: "desc" },
+      });
+      expect(audit).not.toBeNull();
+
+      // Cleanup
+      await makeZodVerifiedAPICall(
+        DeleteModelV1Response,
+        "DELETE",
+        `/api/public/models/${create.body.id}`,
+        undefined,
+        auth,
+      );
+    });
+
+    it("returns 404 when the model does not exist in the project", async () => {
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/models/${v4()}`,
+        { matchPattern: "(.*)x(.*)" },
+        auth,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when matchPattern is not a valid regex", async () => {
+      const create = await makeZodVerifiedAPICall(
+        PostModelsV1Response,
+        "POST",
+        "/api/public/models",
+        {
+          modelName: `gpt-patch-bad-${v4()}`,
+          matchPattern: "(.*)ok(.*)",
+          startDate: "2023-12-01",
+          inputPrice: 0.001,
+          outputPrice: 0.002,
+          unit: "TOKENS",
+        },
+        auth,
+      );
+      expect(create.status).toBe(200);
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/models/${create.body.id}`,
+        { matchPattern: "[unterminated" },
+        auth,
+      );
+      expect(res.status).toBe(400);
+
+      await makeZodVerifiedAPICall(
+        DeleteModelV1Response,
+        "DELETE",
+        `/api/public/models/${create.body.id}`,
+        undefined,
+        auth,
+      );
+    });
+
+    it("rejects modelName and pricing fields with 400", async () => {
+      const create = await makeZodVerifiedAPICall(
+        PostModelsV1Response,
+        "POST",
+        "/api/public/models",
+        {
+          modelName: `gpt-patch-strict-${v4()}`,
+          matchPattern: "(.*)ok(.*)",
+          startDate: "2023-12-01",
+          inputPrice: 0.001,
+          outputPrice: 0.002,
+          unit: "TOKENS",
+        },
+        auth,
+      );
+      expect(create.status).toBe(200);
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/models/${create.body.id}`,
+        { modelName: "renamed", inputPrice: 0.5 },
+        auth,
+      );
+      expect(res.status).toBe(400);
+
+      await makeZodVerifiedAPICall(
+        DeleteModelV1Response,
+        "DELETE",
+        `/api/public/models/${create.body.id}`,
+        undefined,
+        auth,
+      );
+    });
+
+    it("returns 400 when the body is empty", async () => {
+      const create = await makeZodVerifiedAPICall(
+        PostModelsV1Response,
+        "POST",
+        "/api/public/models",
+        {
+          modelName: `gpt-patch-empty-${v4()}`,
+          matchPattern: "(.*)ok(.*)",
+          startDate: "2023-12-01",
+          inputPrice: 0.001,
+          outputPrice: 0.002,
+          unit: "TOKENS",
+        },
+        auth,
+      );
+      expect(create.status).toBe(200);
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/models/${create.body.id}`,
+        {},
+        auth,
+      );
+      expect(res.status).toBe(400);
+
+      await makeZodVerifiedAPICall(
+        DeleteModelV1Response,
+        "DELETE",
+        `/api/public/models/${create.body.id}`,
+        undefined,
+        auth,
+      );
+    });
+
+    it("returns 404 when patching a built-in (projectId=null) model", async () => {
+      // Built-in models have projectId=null and visibleModelsWhere should
+      // not return them for project-scoped reads/updates.
+      const builtInId = v4();
+      await prisma.model.create({
+        data: {
+          id: builtInId,
+          projectId: null,
+          modelName: `built-in-${v4()}`,
+          matchPattern: "(.*)built-in(.*)",
+          unit: "TOKENS",
+        },
+      });
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/models/${builtInId}`,
+        { matchPattern: "(.*)hijack(.*)" },
+        auth,
+      );
+      expect(res.status).toBe(404);
+
+      // Cleanup
+      await prisma.model.delete({ where: { id: builtInId } });
+    });
+
+    it("returns 404 when patching a model owned by a different project (IDOR)", async () => {
+      const { auth: otherAuth, projectId: otherProjectId } =
+        await createOrgProjectAndApiKey();
+      const otherModelId = v4();
+      await prisma.model.create({
+        data: {
+          id: otherModelId,
+          projectId: otherProjectId,
+          modelName: `gpt-other-${v4()}`,
+          matchPattern: "(.*)other(.*)",
+          unit: "TOKENS",
+        },
+      });
+
+      const res = await makeAPICall(
+        "PATCH",
+        `/api/public/models/${otherModelId}`,
+        { matchPattern: "(.*)hijack(.*)" },
+        auth, // primary auth, NOT otherAuth
+      );
+      expect(res.status).toBe(404);
+
+      // Verify the model was untouched.
+      const stillThere = await prisma.model.findUnique({
+        where: { id: otherModelId },
+      });
+      expect(stillThere?.matchPattern).toBe("(.*)other(.*)");
+
+      // Cleanup
+      await prisma.model.delete({ where: { id: otherModelId } });
+      // Unused otherAuth captured so lint does not complain
+      expect(otherAuth).toBeDefined();
+    });
+
+    it("only updates the fields provided in the body", async () => {
+      const create = await makeZodVerifiedAPICall(
+        PostModelsV1Response,
+        "POST",
+        "/api/public/models",
+        {
+          modelName: `gpt-partial-${v4()}`,
+          matchPattern: "(.*)original(.*)",
+          startDate: "2023-12-01",
+          inputPrice: 0.001,
+          outputPrice: 0.002,
+          unit: "TOKENS",
+        },
+        auth,
+      );
+      expect(create.status).toBe(200);
+
+      // PATCH only `unit`. matchPattern and prices must be unchanged.
+      const patched = await makeZodVerifiedAPICall(
+        PatchModelV1Response,
+        "PATCH",
+        `/api/public/models/${create.body.id}`,
+        { unit: "CHARACTERS" },
+        auth,
+      );
+      expect(patched.status).toBe(200);
+      expect(patched.body.unit).toBe("CHARACTERS");
+      expect(patched.body.matchPattern).toBe("(.*)original(.*)");
+      expect(patched.body.inputPrice).toBe(0.001);
+      expect(patched.body.outputPrice).toBe(0.002);
+
+      await makeZodVerifiedAPICall(
+        DeleteModelV1Response,
+        "DELETE",
+        `/api/public/models/${create.body.id}`,
+        undefined,
+        auth,
+      );
+    });
   });
 });

--- a/web/src/features/models/server/publicApiModelService.ts
+++ b/web/src/features/models/server/publicApiModelService.ts
@@ -4,6 +4,7 @@ import {
   type DeleteModelV1Query,
   type GetModelV1Query,
   type GetModelsV1Query,
+  type PatchModelV1Body,
   type PostModelsV1Body,
   prismaToApiModelDefinition,
 } from "@/src/features/public-api/types/models";
@@ -54,6 +55,13 @@ type CreateModelInput = {
 type UpsertModelInput = z.infer<typeof GetModelV1Query> & {
   projectId: string;
   input: z.infer<typeof PostModelsV1Body>;
+  auditScope: ModelAuditScope;
+};
+
+type PatchModelInput = {
+  projectId: string;
+  modelId: string;
+  input: z.infer<typeof PatchModelV1Body>;
   auditScope: ModelAuditScope;
 };
 
@@ -257,6 +265,71 @@ export const createModelForApi = async ({
   }
 
   return prismaToApiModelDefinition(modelWithTiers);
+};
+
+export const updateModelForApi = async ({
+  projectId,
+  modelId,
+  input,
+  auditScope,
+}: PatchModelInput) => {
+  if (input.matchPattern !== undefined) {
+    const validRegex = await isValidPostgresRegex(input.matchPattern, prisma);
+    if (!validRegex) {
+      throw new InvalidRequestError(
+        "matchPattern is not a valid regex pattern (Postgres)",
+      );
+    }
+  }
+
+  const data: Prisma.ModelUpdateInput = {};
+  if (input.matchPattern !== undefined) data.matchPattern = input.matchPattern;
+  if (input.tokenizerId !== undefined) data.tokenizerId = input.tokenizerId;
+  if (input.tokenizerConfig !== undefined) {
+    data.tokenizerConfig =
+      input.tokenizerConfig === null ? Prisma.DbNull : input.tokenizerConfig;
+  }
+  if (input.startDate !== undefined) data.startDate = input.startDate;
+  if (input.unit !== undefined) data.unit = input.unit;
+
+  const updatedModelWithTiers = await prisma.$transaction(async (tx) => {
+    const existing = await tx.model.findFirst({
+      where: { id: modelId, projectId },
+    });
+
+    if (!existing) {
+      throw new LangfuseNotFoundError("No model with this id found.");
+    }
+
+    const updated = await tx.model.update({
+      where: { id: modelId, projectId },
+      data,
+    });
+
+    await auditLog({
+      action: "update",
+      resourceType: "model",
+      resourceId: updated.id,
+      projectId: auditScope.projectId,
+      orgId: auditScope.orgId,
+      apiKeyId: auditScope.apiKeyId,
+      before: existing,
+      after: updated,
+    });
+
+    return tx.model.findUnique({
+      where: { id: modelId, projectId },
+      include: modelPricingInclude,
+    });
+  });
+
+  await clearModelCacheForProject(projectId);
+
+  if (!updatedModelWithTiers) {
+    throw new InvalidRequestError("Failed to fetch updated model");
+  }
+
+  return prismaToApiModelDefinition(updatedModelWithTiers);
 };
 
 export const upsertModelForApi = async ({

--- a/web/src/features/public-api/types/models.ts
+++ b/web/src/features/public-api/types/models.ts
@@ -214,6 +214,40 @@ export const GetModelV1Query = z.object({
 });
 export const GetModelV1Response = APIModelDefinition.strict();
 
+// PATCH /models/{modelId}
+// Partial update of a model definition. Only the mutable matchPattern /
+// tokenizer / startDate / unit fields are accepted; modelName and pricing
+// are intentionally not patchable (modelName is a stable identity, pricing
+// is replaced via DELETE+POST or a future dedicated pricing endpoint).
+export const PatchModelV1Query = z.object({
+  modelId: z.string(),
+});
+export const PatchModelV1Body = z
+  .object({
+    matchPattern: z.string().optional(),
+    tokenizerId: z.enum(["openai", "claude"]).nullish(),
+    tokenizerConfig: jsonSchema.nullish(),
+    startDate: z.coerce.date().nullish(),
+    unit: APIModelUsageUnit.optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (
+      data.matchPattern === undefined &&
+      data.tokenizerId === undefined &&
+      data.tokenizerConfig === undefined &&
+      data.startDate === undefined &&
+      data.unit === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "At least one of matchPattern, tokenizerId, tokenizerConfig, startDate, or unit must be provided",
+      });
+    }
+  });
+export const PatchModelV1Response = APIModelDefinition.strict();
+
 // PUT /models/{modelId}
 export const PutModelV1Response = APIModelDefinition.strict();
 

--- a/web/src/pages/api/public/models/[modelId]/index.ts
+++ b/web/src/pages/api/public/models/[modelId]/index.ts
@@ -5,12 +5,16 @@ import {
   DeleteModelV1Response,
   GetModelV1Query,
   GetModelV1Response,
+  PatchModelV1Body,
+  PatchModelV1Query,
+  PatchModelV1Response,
   PostModelsV1Body,
   PutModelV1Response,
 } from "@/src/features/public-api/types/models";
 import {
   deleteModelForApi,
   getModelForApi,
+  updateModelForApi,
   upsertModelForApi,
 } from "@/src/features/models/server/publicApiModelService";
 
@@ -36,6 +40,22 @@ export default withMiddlewares({
     responseSchema: PutModelV1Response,
     fn: async ({ query, body, auth }) => {
       return await upsertModelForApi({
+        projectId: auth.scope.projectId,
+        modelId: query.modelId,
+        input: body,
+        auditScope: auth.scope,
+      });
+    },
+  }),
+
+  PATCH: createAuthedProjectAPIRoute({
+    name: "Update model",
+    isAdminApiKeyAuthAllowed: true,
+    querySchema: PatchModelV1Query,
+    bodySchema: PatchModelV1Body,
+    responseSchema: PatchModelV1Response,
+    fn: async ({ query, body, auth }) => {
+      return await updateModelForApi({
         projectId: auth.scope.projectId,
         modelId: query.modelId,
         input: body,


### PR DESCRIPTION
Fixes #16847.

## Problem

The public `/api/public/models` API exposes `GET`, `POST`, `PUT` (upsert), and `DELETE`, but there is no narrow partial update. Customers who need to fix a `matchPattern` typo, swap a tokenizer, or adjust a `startDate` currently have two options:

- Use `PUT /models/{id}` (the existing upsert), which requires sending a full `PostModelsV1Body` with all pricing fields and is documented as "create or replace".
- `DELETE` then re-`POST`, which loses the model `id`, breaks references, and produces a noisy "delete + create" audit pair.

Neither matches the natural shape of a partial update.

## Proposed solution

Add `PATCH /api/public/models/{modelId}` for the mutable fields:

- `matchPattern` (string, validated as Postgres regex)
- `tokenizerId` (`"openai" | "claude" | null`)
- `tokenizerConfig` (object | null)
- `startDate` (ISO datetime | null)
- `unit` (`TOKENS | CHARACTERS | MILLISECONDS | SECONDS | REQUESTS | IMAGES`)

Out of scope (intentional, to keep the contract small):

- `modelName` rename — the `(projectId, modelName)` uniqueness constraint means renaming is conceptually closer to "create a new model and migrate references". Use the existing `PUT` upsert for renames.
- `pricingTiers` / flat prices — replacing the pricing set is a heavier operation; use `PUT` (upsert) or `DELETE` + `POST` for now. A future PR can add a dedicated pricing endpoint if needed.

## Behavior

- 404 when the model does not exist in the caller's project (or is built-in / cross-project — IDOR-safe).
- 400 when `matchPattern` is not a valid Postgres regex.
- 400 when the body is empty (no fields provided) or contains disallowed keys (e.g. `modelName`, `inputPrice`) — Zod `.strict()` + `.superRefine()`.
- 200 with the updated `APIModelDefinition` shape on success.
- Audit log: `action: "update"`, `resourceType: "model"`, with `before` and `after`.
- `clearModelCacheForProject` runs after the transaction commits, so the new `matchPattern` / tokenizer takes effect on the next observation ingestion.

## Files

- `web/src/features/public-api/types/models.ts` — new `PatchModelV1Query`, `PatchModelV1Body`, `PatchModelV1Response` Zod schemas. Body is `.strict()` with a `superRefine` that requires at least one field.
- `web/src/features/models/server/publicApiModelService.ts` — new `updateModelForApi` mirroring the create/delete/upsert functions in the same file. Validates `matchPattern` via `isValidPostgresRegex`, finds the model scoped to `(id, projectId)` (404 on miss), runs the prisma `update` inside a ``, audits `before`/`after`, then clears the per-project model cache.
- `web/src/pages/api/public/models/[modelId]/index.ts` — wires `PATCH` into the existing `createAuthedProjectAPIRoute` handler, alongside `GET`, `PUT`, and `DELETE`.
- `fern/apis/server/definition/models.yml` — new `update:` endpoint and `UpdateModelRequest` type.

## Tests

8 new regression tests in `web/src/__tests__/server/model-definitions.servertest.ts`:

1. Happy path — updates `matchPattern`, `tokenizerId`, `tokenizerConfig`, `unit`; `modelName` is preserved; audit log records the update.
2. 404 when the model does not exist.
3. 400 when `matchPattern` is not a valid regex.
4. 400 when the body contains `modelName` or `inputPrice` (Zod strict).
5. 400 when the body is empty (no fields).
6. 404 when patching a built-in model (`projectId = null`).
7. 404 when patching a model owned by a different project (IDOR).
8. Partial update — only the provided field changes; `matchPattern`, `inputPrice`, `outputPrice` are preserved when only `unit` is patched.

## Compatibility

Additive only. No existing route or schema is changed; the new `PATCH` route is gated by the same auth middleware as the other verbs on the path.

## Risk

Minimal. The new route is a thin wrapper around the established `createModelForApi` / `deleteModelForApi` / `upsertModelForApi` pattern in the same file. Cache invalidation and audit logging are already exercised by those.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a project-scoped public endpoint for partially updating mutable model-definition fields, with strict request validation, PostgreSQL-regex validation, audit logging, and cache invalidation.
- Defines the PATCH route and request/response schemas.
- Implements transactional model updates and project ownership checks.
- Adds Fern API definitions and regression coverage for validation, tenancy, auditing, and partial-update behavior.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The model-conflict path should be fixed before merging because a valid PATCH can currently surface a database uniqueness collision as an internal server error.

Updating startDate or unit can collide with an existing model's composite unique key, and the new service neither detects that state nor translates Prisma's constraint error; the Fern request also omits its runtime non-empty constraint.

**Files Needing Attention:** web/src/features/models/server/publicApiModelService.ts, fern/apis/server/definition/models.yml
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Route as PATCH /models/{modelId}
    participant Service as updateModelForApi
    participant DB as PostgreSQL
    participant Audit
    participant Cache
    Client->>Route: PATCH mutable fields
    Route->>Route: Authenticate and validate body
    Route->>Service: projectId, modelId, input
    Service->>DB: Find project-owned model
    Service->>DB: Update model
    Service->>Audit: Record before and after
    DB-->>Service: Updated model with pricing tiers
    Service->>Cache: Clear project model cache
    Service-->>Client: 200 APIModelDefinition
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/models/server/publicApiModelService.ts:304-307
**Unique collisions return 500**

When a PATCH changes `startDate` or `unit` to a combination already used by another same-named model in the project, `tx.model.update` raises an untranslated Prisma uniqueness error, causing a 500 response instead of a validation or conflict response.

### Issue 2
fern/apis/server/definition/models.yml:121-140
**Nonempty constraint is undocumented**

Every Fern request property is optional, so generated types permit an empty update, while the route rejects that request with HTTP 400. Document the requirement that at least one mutable field must be supplied so SDK and API-reference consumers see the runtime constraint.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add PATCH /api/public/..."](https://github.com/langfuse/langfuse/commit/5e49676c7b5e48a90924b6543cd8254e9e15048b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58634254)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->