### PR TITLE
chore(ingestion): add sdk/attributeKey/parse-failure-kind tags to metadata_dropped

### DIFF
--- a/packages/shared/src/server/ingestion/ingestionAttribution.ts
+++ b/packages/shared/src/server/ingestion/ingestionAttribution.ts
@@ -203,6 +203,42 @@ export const classifyIngestionSdkAttribution = (params: {
   return "attributed";
 };
 
+const METRIC_TAG_MAX_LENGTH = 32;
+
+/**
+ * Bounds a caller-supplied SDK value for safe use as a StatsD/Datadog metric
+ * tag. Ingestion SDK name/version come straight from request headers, so
+ * without this a caller could inject oversized or separator-bearing
+ * (`,` `|` `:` `=`) tag values and inflate metric cardinality. Strips control
+ * characters and tag separators, caps length, and falls back to "unknown".
+ */
+export const sanitizeSdkMetricTagValue = (
+  value: string | null | undefined,
+): string => {
+  if (!value) {
+    return UNKNOWN_INGESTION_SDK_VALUE;
+  }
+  const sanitized = Array.from(value)
+    .filter((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      if (codePoint <= 31 || codePoint === 127) {
+        return false;
+      }
+      return (
+        character !== "," &&
+        character !== "|" &&
+        character !== ":" &&
+        character !== "="
+      );
+    })
+    .join("")
+    .trim();
+  const bounded = Array.from(sanitized)
+    .slice(0, METRIC_TAG_MAX_LENGTH)
+    .join("");
+  return bounded || UNKNOWN_INGESTION_SDK_VALUE;
+};
+
 const sanitizeCallerAttributionValue = (
   value: string,
   maxLength: number,

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.metadataDropped.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.metadataDropped.test.ts
@@ -1,6 +1,6 @@
 /**
- * LFE-14342: `langfuse.ingestion.metadata_dropped` counter at the OTel
- * metadata drop site (`parseMetadataAttribute` drop branches).
+ * `langfuse.ingestion.metadata_dropped` counter at the OTel metadata drop
+ * site (`parseMetadataAttribute` drop branches).
  *
  * Spec under test:
  * - Counter name: langfuse.ingestion.metadata_dropped
@@ -119,7 +119,7 @@ const expectDropTags = (
   expect(tags?.sdkVersion).toBe("3.8.1");
 };
 
-describe("OTel metadata_dropped metric (LFE-14342)", () => {
+describe("OTel metadata_dropped metric", () => {
   beforeEach(() => {
     recordIncrementMock.mockClear();
   });
@@ -815,5 +815,35 @@ describe("metadata_dropped attribution tags (parse_failure kind, attributeKey)",
     const tags = singleDropTags();
     expect(tags.reason).toBe("primitive");
     expect(tags.kind).toBeUndefined();
+  });
+
+  it("sanitizes and bounds attacker-controlled sdkName/sdkVersion tags", async () => {
+    // sdkName/sdkVersion come from raw request headers; a caller must not be
+    // able to inject tag separators, control chars, or oversized values.
+    const processor = new OtelIngestionProcessor({
+      projectId: PROJECT_ID,
+      publicKey: "pk-test",
+      sdkName: "evil,name|with:sep=chars",
+      sdkVersion: `1.0\n${"x".repeat(100)}`,
+    });
+    await processor.processToIngestionEvents(
+      buildBatch([
+        {
+          key: "langfuse.observation.metadata",
+          value: { stringValue: "{bad" },
+        },
+      ]),
+    );
+
+    const tags = singleDropTags();
+    for (const key of ["sdkName", "sdkVersion"] as const) {
+      expect(tags[key]).not.toMatch(/[,|:=]/);
+      expect(tags[key].length).toBeLessThanOrEqual(32);
+      for (const character of tags[key]) {
+        const codePoint = character.codePointAt(0) ?? 0;
+        expect(codePoint).toBeGreaterThan(31);
+        expect(codePoint).not.toBe(127);
+      }
+    }
   });
 });

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.metadataDropped.test.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.metadataDropped.test.ts
@@ -6,7 +6,9 @@
  * - Counter name: langfuse.ingestion.metadata_dropped
  * - Tags: reason ∈ {non_object_top_level, parse_failure, primitive},
  *   source = otel, domain ∈ {trace, observation}, projectId (low
- *   cardinality: only projects emitting malformed metadata appear)
+ *   cardinality: only projects emitting malformed metadata appear),
+ *   attributeKey (closed set of Langfuse constants), sdkName, sdkVersion,
+ *   and — for parse_failure only — kind (value-shape sub-classification)
  * - No behavior change to what the processor returns
  * - Dotted-key metadata (langfuse.*.metadata.foo) stays increment-free
  *
@@ -112,6 +114,9 @@ const expectDropTags = (
   expect(tags).toEqual(expect.objectContaining(expected));
   // projectId is a metric tag (low cardinality) for tenant attribution.
   expect(tags?.projectId).toBe(PROJECT_ID);
+  // sdkName/sdkVersion attribute the emitting client.
+  expect(tags?.sdkName).toBe("python");
+  expect(tags?.sdkVersion).toBe("3.8.1");
 };
 
 describe("OTel metadata_dropped metric (LFE-14342)", () => {
@@ -743,5 +748,72 @@ describe("OTel reconstructed array drop telemetry", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe("metadata_dropped attribution tags (parse_failure kind, attributeKey)", () => {
+  beforeEach(() => {
+    recordIncrementMock.mockClear();
+  });
+
+  const singleDropTags = () => {
+    const calls = recordIncrementMock.mock.calls.filter(
+      ([stat]) => stat === METRIC,
+    );
+    expect(calls).toHaveLength(1);
+    return (calls[0] as [string, number, Record<string, string>])[2];
+  };
+
+  // Each value fails JSON.parse and must be sub-classified by its shape.
+  // The values are synthetic and carry no real user content.
+  const kindCases: Array<{ name: string; value: string; kind: string }> = [
+    {
+      name: "python dict repr",
+      value: "{'user': 'x', 'ok': True}",
+      kind: "python_repr",
+    },
+    { name: "bare True token", value: "True", kind: "python_repr" },
+    { name: "unquoted string", value: "in progress", kind: "unquoted_string" },
+    {
+      name: "truncated object",
+      value: '{"a":"long va',
+      kind: "truncated_json",
+    },
+    {
+      name: "loose json trailing comma",
+      value: '{"a":1,}',
+      kind: "loose_json",
+    },
+    { name: "empty string on compat key", value: "", kind: "empty" },
+  ];
+
+  for (const { name, value, kind } of kindCases) {
+    it(`classifies ${name} as kind=${kind}`, async () => {
+      // Empty is only reachable on the compat key (a falsy primary value
+      // survives the `||` fallback); non-empty values sit on the primary key.
+      const attrKey =
+        value === "" ? "langfuse.metadata" : "langfuse.observation.metadata";
+      await createProcessor().processToIngestionEvents(
+        buildBatch([{ key: attrKey, value: { stringValue: value } }]),
+      );
+
+      const tags = singleDropTags();
+      expect(tags.reason).toBe("parse_failure");
+      expect(tags.kind).toBe(kind);
+      expect(tags.attributeKey).toBe(attrKey);
+      expect(tags.sdkName).toBe("python");
+      expect(tags.sdkVersion).toBe("3.8.1");
+    });
+  }
+
+  it("omits kind for a non-parse_failure drop (primitive)", async () => {
+    await createProcessor().processToIngestionEvents(
+      buildBatch([
+        { key: "langfuse.observation.metadata", value: { intValue: 42 } },
+      ]),
+    );
+    const tags = singleDropTags();
+    expect(tags.reason).toBe("primitive");
+    expect(tags.kind).toBeUndefined();
   });
 });

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -25,6 +25,7 @@ import {
   normalizeEnvironment,
   DEFAULT_TRACE_ENVIRONMENT,
   LangfuseInternalTraceEnvironment,
+  sanitizeSdkMetricTagValue,
 } from "../";
 
 import {
@@ -3293,7 +3294,8 @@ export class OtelIngestionProcessor {
 
     // attributeKey is a closed set of Langfuse-defined attribute names
     // (never a user-supplied key); sdkName/sdkVersion attribute the emitting
-    // client; kind sub-classifies parse_failure by the value's shape. None
+    // client and are sanitized because they originate from raw request
+    // headers; kind sub-classifies parse_failure by the value's shape. None
     // of these carry the dropped value itself.
     const tags: Record<string, string> = {
       reason,
@@ -3301,8 +3303,8 @@ export class OtelIngestionProcessor {
       domain,
       projectId: this.projectId,
       attributeKey,
-      sdkName: this.sdkName,
-      sdkVersion: this.sdkVersion,
+      sdkName: sanitizeSdkMetricTagValue(this.sdkName),
+      sdkVersion: sanitizeSdkMetricTagValue(this.sdkVersion),
     };
     if (kind) {
       tags.kind = kind;
@@ -3311,10 +3313,11 @@ export class OtelIngestionProcessor {
   }
 
   // Sub-classifies a JSON.parse failure by the failing string's shape,
-  // reading only its head and tail — never parses the (possibly large)
-  // value again and never logs its content.
+  // reading only bounded head/tail windows — never re-parses or copies the
+  // (possibly multi-MB) value, and never logs its content. Slicing first
+  // keeps the trim/regex work off the full string.
   private classifyParseFailure(value: string): string {
-    const head = value.replace(/^\s+/, "").slice(0, 32);
+    const head = value.slice(0, 64).trimStart();
     if (head.length === 0) {
       return "empty";
     }
@@ -3325,7 +3328,7 @@ export class OtelIngestionProcessor {
     const first = head[0];
     if (first === "{" || first === "[") {
       const expectedClose = first === "{" ? "}" : "]";
-      const last = value.replace(/\s+$/, "").slice(-1);
+      const last = value.slice(-64).trimEnd().slice(-1);
       return last === expectedClose ? "loose_json" : "truncated_json";
     }
     return "unquoted_string";

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2510,9 +2510,11 @@ export class OtelIngestionProcessor {
     // survive the fallback and are counted by the parser itself.
     const primaryValue = attributes[metadataKeyPrefix];
     if (primaryValue !== undefined && primaryValue !== null && !primaryValue) {
+      const isString = typeof primaryValue === "string";
       this.recordMetadataDropped(
-        typeof primaryValue === "string" ? "parse_failure" : "primitive",
+        isString ? "parse_failure" : "primitive",
         { domain, attributeKey: metadataKeyPrefix, dropScope },
+        isString ? this.classifyParseFailure(primaryValue) : undefined,
       );
     }
 
@@ -3275,6 +3277,7 @@ export class OtelIngestionProcessor {
   private recordMetadataDropped(
     reason: string,
     context: MetadataDropContext,
+    kind?: string,
   ): void {
     const { domain, attributeKey, dropScope } = context;
     let seen = this.reportedMetadataDrops.get(dropScope);
@@ -3288,12 +3291,44 @@ export class OtelIngestionProcessor {
     }
     seen.add(dedupeKey);
 
-    recordIncrement("langfuse.ingestion.metadata_dropped", 1, {
+    // attributeKey is a closed set of Langfuse-defined attribute names
+    // (never a user-supplied key); sdkName/sdkVersion attribute the emitting
+    // client; kind sub-classifies parse_failure by the value's shape. None
+    // of these carry the dropped value itself.
+    const tags: Record<string, string> = {
       reason,
       source: "otel",
       domain,
       projectId: this.projectId,
-    });
+      attributeKey,
+      sdkName: this.sdkName,
+      sdkVersion: this.sdkVersion,
+    };
+    if (kind) {
+      tags.kind = kind;
+    }
+    recordIncrement("langfuse.ingestion.metadata_dropped", 1, tags);
+  }
+
+  // Sub-classifies a JSON.parse failure by the failing string's shape,
+  // reading only its head and tail — never parses the (possibly large)
+  // value again and never logs its content.
+  private classifyParseFailure(value: string): string {
+    const head = value.replace(/^\s+/, "").slice(0, 32);
+    if (head.length === 0) {
+      return "empty";
+    }
+    // Python `str(dict)` / `str(list)` — single-quoted, or bare True/False/None.
+    if (/^[{[]\s*'/.test(head) || /^(True|False|None)\b/.test(head)) {
+      return "python_repr";
+    }
+    const first = head[0];
+    if (first === "{" || first === "[") {
+      const expectedClose = first === "{" ? "}" : "]";
+      const last = value.replace(/\s+$/, "").slice(-1);
+      return last === expectedClose ? "loose_json" : "truncated_json";
+    }
+    return "unquoted_string";
   }
 
   private parseMetadataAttribute(
@@ -3313,7 +3348,11 @@ export class OtelIngestionProcessor {
         this.recordMetadataDropped("non_object_top_level", context);
         return {};
       } catch {
-        this.recordMetadataDropped("parse_failure", context);
+        this.recordMetadataDropped(
+          "parse_failure",
+          context,
+          this.classifyParseFailure(value),
+        );
         return {};
       }
     }

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -54,6 +54,7 @@ import {
   normalizeToolsForObservation,
   hasNoEvalConfigsCache,
   buildClickHouseLogComment,
+  sanitizeSdkMetricTagValue,
   type IngestionAttribution,
   type PricingTierMatchAttributes,
 } from "@langfuse/shared/src/server";
@@ -729,8 +730,8 @@ export class IngestionService {
         source: "api",
         domain: "score",
         projectId,
-        sdkName: attribution.ingestionSdkName,
-        sdkVersion: attribution.ingestionSdkVersion,
+        sdkName: sanitizeSdkMetricTagValue(attribution.ingestionSdkName),
+        sdkVersion: sanitizeSdkMetricTagValue(attribution.ingestionSdkVersion),
       });
     }
 

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -729,6 +729,8 @@ export class IngestionService {
         source: "api",
         domain: "score",
         projectId,
+        sdkName: attribution.ingestionSdkName,
+        sdkVersion: attribution.ingestionSdkVersion,
       });
     }
 

--- a/worker/src/services/IngestionService/tests/scoreValidationDroppedMetric.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/scoreValidationDroppedMetric.unit.test.ts
@@ -10,7 +10,8 @@
  *   events in the same batch are still written, unexpected errors still
  *   reject the batch (and must NOT emit the drop counter — a rejected
  *   batch is retried, not silently lost).
- * - projectId is a metric tag (low cardinality) for tenant attribution.
+ * - projectId, sdkName, sdkVersion are metric tags (low cardinality) for
+ *   tenant and client attribution.
  */
 import { expect, describe, it, vi, beforeEach } from "vitest";
 
@@ -62,6 +63,8 @@ const expectScoreDropTags = (call: unknown[]) => {
       source: "api",
       domain: "score",
       projectId: PROJECT_ID,
+      sdkName: "langfuse-test",
+      sdkVersion: "0.0.0",
     }),
   );
 };

--- a/worker/src/services/IngestionService/tests/scoreValidationDroppedMetric.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/scoreValidationDroppedMetric.unit.test.ts
@@ -1,6 +1,6 @@
 /**
- * LFE-14345: `langfuse.ingestion.metadata_dropped` counter at the score
- * validation drop site (catch in processScoreEventList).
+ * `langfuse.ingestion.metadata_dropped` counter at the score validation
+ * drop site (catch in processScoreEventList).
  *
  * Spec under test:
  * - The catch that silently filters score events on validation failure
@@ -119,7 +119,7 @@ const processScores = (
     },
   });
 
-describe("score validation drop metric (LFE-14345)", () => {
+describe("score validation drop metric", () => {
   beforeEach(() => {
     mocks.recordIncrement.mockClear();
     mocks.validateAndInflateScoreOverride = undefined;


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16850 app preview](https://pr-16850.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Follow-up to the `metadata_dropped` observability work (prior PR removed the noisy per-drop warn log and added `projectId`). Production shows 96–99.6% of drops are `parse_failure` on `langfuse.observation.metadata` — a `JSON.parse` throw whose value and error were both swallowed, so we currently can't tell *what* triggers them.

This adds three low-cardinality, PII-safe tags to `langfuse.ingestion.metadata_dropped` so the trigger becomes diagnosable without logging any customer value:

- **`sdkName` + `sdkVersion`** at both drop sites (OTel + score) — attributes the emitting client, so a bad SDK release shows up directly.
- **`attributeKey`** at the OTel site — a closed set of Langfuse-defined attribute names (`langfuse.trace.metadata`, `langfuse.observation.metadata`, `langfuse.experiment[.item].metadata`, `langfuse.metadata`). Never a user-supplied key: only the fixed-prefix parse path emits the metric; user-defined dotted keys go through a different path that never counts.
- **`kind`** (parse_failure only) — sub-classifies the failing string by shape, read from its head and tail only (no re-parse of a potentially huge value, no content):

| kind | detects | likely cause |
|---|---|---|
| `python_repr` | `{'`/`['` or `True`/`False`/`None` | Python `str(dict)` instead of `json.dumps` |
| `unquoted_string` | doesn't start like JSON | bare string sent to an object field |
| `truncated_json` | starts `{`/`[`, doesn't close | value cut off client-side |
| `loose_json` | starts/ends like JSON but throws | trailing comma / `NaN` / JS literal |
| `empty` | empty / whitespace-only | empty string on compat key |

Counts and dedup are unchanged; `kind` is absent on non-`parse_failure` reasons.

**Cardinality note for reviewers:** `sdkVersion` is the highest-cardinality tag here and multiplies with `projectId`. It's intentional (finding the culprit release is the whole point), but if metric cost is a concern we can drop `sdkVersion` from the metric and recover it from a future sampled log instead.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Tests: OTel suite gains a `kind`/`attributeKey`/`sdk` block (6 shape cases + a no-kind primitive case); both suites assert `sdkName`/`sdkVersion`.
- [x] `Tests 31 passed (31)` shared, `Tests 6 passed (6)` worker; lint + typecheck green for shared + worker (`Tasks: 7 successful, 7 total`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds SDK attribution, metadata attribute keys, and parse-failure shape classifications to metadata-drop telemetry. The new diagnostics improve drop attribution, but the SDK dimensions currently accept arbitrary client-provided values and can generate unbounded custom-metric series.
- Adds `attributeKey`, `sdkName`, and `sdkVersion` tags to OTel metadata-drop metrics.
- Adds parse-failure `kind` classification using string head and tail inspection.
- Adds SDK attribution to score-validation drop metrics.
- Extends OTel and worker metric tests for the new dimensions.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The unbounded client-controlled SDK metric dimensions should be constrained before merging to prevent custom-metric cardinality and cost growth.

Both ingestion paths now forward raw SDK attribution into DogStatsD tags, allowing each distinct caller-provided name or version to create another metadata-drop metric series.

**Files Needing Attention:** packages/shared/src/server/otel/OtelIngestionProcessor.ts; worker/src/services/IngestionService/index.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Client SDK headers] --> A[Ingestion attribution]
  A --> O[OTel metadata drop]
  A --> S[Score validation drop]
  O --> M[metadata_dropped metric]
  S --> M
  M --> D[DogStatsD series keyed by SDK tags]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:3299-3300
**SDK tags allow unbounded cardinality**

When a client varies `x-langfuse-sdk-name` or `x-langfuse-sdk-version` while submitting malformed metadata, the raw values become DogStatsD dimensions without canonicalization or length bounds, creating distinct metric series across every project, reason, domain, attribute key, and kind combination and driving custom-metric usage and billing growth. The score-drop path at `worker/src/services/IngestionService/index.ts:732-733` has the same issue.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ingestion): add sdk/attributeKey/p..."](https://github.com/langfuse/langfuse/commit/3816f7ba50956da9f72cb4717038707e93e8af23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58661058)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Trace and observation ingestion](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/trace-observation-ingestion.md)
- Knowledge Base — [Remove ECS task ARN tags from custom metrics](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/reverts/incident-mitigation_15335-20260722-dd-tags-cardinality-e585c3d.md)

<!-- /greptile_comment -->