### PR TITLE
fix(chatml): stop OpenAI adapter claiming Microsoft.Extensions.AI tool calls

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/microsoft-agent.ts
+++ b/packages/shared/src/utils/chatml/adapters/microsoft-agent.ts
@@ -295,7 +295,8 @@ export const microsoftAgentAdapter: ProviderAdapter = {
     // HINTS: Fast checks for explicit Microsoft Agent Framework indicators
     if (ctx.framework === "microsoft-agent") return true;
 
-    const scopeName = getNestedProperty(meta, "scope", "name");
+    const scopeName =
+      getNestedProperty(meta, "scope", "name") ?? meta?.["scope.name"];
     if (scopeName === "agent_framework") return true;
     if (
       typeof scopeName === "string" &&

--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -13,11 +13,30 @@ import { z } from "zod";
  * These are permissive - only validate structural markers, not full API contracts
  */
 
+// OpenAI uses parts inside content, not at message level.
+// Microsoft Agent / Gemini / OTel GenAI use top-level parts.
+function hasTopLevelParts(messages: unknown): boolean {
+  return (
+    Array.isArray(messages) &&
+    messages.some(
+      (msg) =>
+        typeof msg === "object" &&
+        msg !== null &&
+        "parts" in msg &&
+        Array.isArray((msg as Record<string, unknown>).parts),
+    )
+  );
+}
+
 // INPUT SCHEMAS (requests)
-const OpenAIInputChatCompletionsSchema = z.looseObject({
-  messages: z.array(z.any()),
-  tools: z.array(z.any()).optional(),
-});
+const OpenAIInputChatCompletionsSchema = z
+  .looseObject({
+    messages: z.array(z.any()),
+    tools: z.array(z.any()).optional(),
+  })
+  .refine((data) => !hasTopLevelParts(data.messages), {
+    message: "Messages with top-level parts are not OpenAI format",
+  });
 
 const OpenAIInputMessagesSchema = z
   .array(
@@ -25,20 +44,9 @@ const OpenAIInputMessagesSchema = z
       role: z.enum(["system", "user", "assistant", "tool", "function"]),
     }),
   )
-  .refine(
-    (data) => {
-      // Reject if any message has top-level parts (Microsoft Agent/Gemini format)
-      // OpenAI uses parts inside content, not at message level
-      return !data.some(
-        (msg) =>
-          typeof msg === "object" &&
-          msg !== null &&
-          "parts" in msg &&
-          Array.isArray((msg as Record<string, unknown>).parts),
-      );
-    },
-    { message: "Messages with top-level parts are not OpenAI format" },
-  );
+  .refine((data) => !hasTopLevelParts(data), {
+    message: "Messages with top-level parts are not OpenAI format",
+  });
 
 // Role-less Responses input item types. normalizeMessage converts the common
 // conversation items and preserves built-in tool items as JSON passthrough.

--- a/worker/src/__tests__/chatml/adapters/microsoft-agent.test.ts
+++ b/worker/src/__tests__/chatml/adapters/microsoft-agent.test.ts
@@ -48,6 +48,53 @@ describe("Microsoft Agent Framework Adapter", () => {
       ).toBe(true);
     });
 
+    it("should detect Microsoft.Extensions.AI via flattened scope.name", () => {
+      expect(
+        microsoftAgentAdapter.detect({
+          metadata: {
+            "scope.name": "Experimental.Microsoft.Extensions.AI",
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it("should claim wrapped {messages, tools} input when scope.name is flattened", () => {
+      const input = {
+        messages: [
+          {
+            role: "system",
+            parts: [{ type: "text", content: "You are helpful." }],
+          },
+          {
+            role: "user",
+            parts: [{ type: "text", content: "What's the weather?" }],
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "get_weather",
+              description: "Get the weather for a given location.",
+            },
+          },
+        ],
+      };
+      const ctx = {
+        metadata: {
+          "scope.name": "Experimental.Microsoft.Extensions.AI",
+        },
+      };
+
+      expect(selectAdapter({ ...ctx, data: input }).id).toBe("microsoft-agent");
+
+      const result = normalizeInput(input, ctx);
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("You are helpful.");
+      expect(result.data?.[1].content).toBe("What's the weather?");
+      expect(result.data?.[0].tools?.[0].name).toBe("get_weather");
+    });
+
     it("should detect Microsoft Agent format with parts array", () => {
       const input = [
         {

--- a/worker/src/__tests__/chatml/adapters/openai.test.ts
+++ b/worker/src/__tests__/chatml/adapters/openai.test.ts
@@ -82,6 +82,33 @@ describe("OpenAI Adapter", () => {
       expect(openAIAdapter.detect({ metadata: {}, data: input })).toBe(false);
     });
 
+    it("should reject top-level parts in Chat Completions {messages, tools} wrapper", () => {
+      // OTel GenAI wraps Microsoft.Extensions.AI input as {messages, tools}.
+      // That wrapper is not OpenAI Chat Completions; claiming it leaves
+      // System/User as JSON path trees of parts instead of text.
+      const input = {
+        messages: [
+          {
+            role: "system",
+            parts: [{ type: "text", content: "You are helpful." }],
+          },
+          {
+            role: "user",
+            parts: [{ type: "text", content: "Hello" }],
+          },
+        ],
+        tools: [{ type: "function", function: { name: "get_weather" } }],
+      };
+
+      expect(openAIAdapter.detect({ metadata: input })).toBe(false);
+      expect(openAIAdapter.detect({ metadata: {}, data: input })).toBe(false);
+
+      const result = normalizeInput(input);
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("You are helpful.");
+      expect(result.data?.[1].content).toBe("Hello");
+    });
+
     it("should not crash when detecting messages array with null items", () => {
       // tests for bug when detection code tried to access .type on null items
       const messagesWithNull = {


### PR DESCRIPTION
## What does this PR do?

Microsoft.Extensions.AI generations with tool definitions were claimed by the OpenAI Chat Completions detector because OTel wraps the input as `{messages, tools}`. That wrapper had no top-level-`parts` guard, so System and User rendered as JSON path trees instead of text. The same app's tool-free calls (bare message arrays) already hit the guarded schema and rendered correctly.

This change:

- Applies the existing top-level-`parts` guard to `OpenAIInputChatCompletionsSchema`, so wrapped and bare inputs agree
- Reads flattened `scope.name` in `microsoftAgentAdapter`, matching `aisdk.ts`, so `Experimental.Microsoft.Extensions.AI` still selects microsoft-agent in the trace view

Fixes #16841

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `@langfuse/shared` — ChatML OpenAI and microsoft-agent adapters
- `worker` — adapter unit tests

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Validation

- `pnpm --filter worker run test src/__tests__/chatml`: Tests 136 passed (136)
- `pnpm --filter web run test-client jumptoplayground.clienttest.ts`: Tests 21 passed (21)
- `pnpm --filter @langfuse/shared run lint` and `pnpm --filter worker run lint`: both passed
- Pre-commit `turbo run lint`: Tasks: 7 successful, 7 total
- Shared package `tsc` via `pnpm --filter @langfuse/shared run build`
- `pnpm run typecheck` run passed.


Made with [Cursor](https://cursor.com)