### PR TITLE
fix(experiments): show dataset-run-item API runs in Experiments views

### DIFF
--- a/packages/shared/src/server/repositories/experiment-event-enrichment.ts
+++ b/packages/shared/src/server/repositories/experiment-event-enrichment.ts
@@ -1,0 +1,258 @@
+import { flattenJsonToPathArrays } from "../otel/utils";
+import { convertDateToClickhouseDateTime } from "../clickhouse/client";
+import { commandClickhouse, queryClickhouse } from "./clickhouse";
+import { logger } from "../logger";
+
+const MAX_SPANS_PER_TRACE = 50_000;
+
+const EVENTS_FULL_INSERT_COLUMNS = [
+  "project_id",
+  "trace_id",
+  "span_id",
+  "parent_span_id",
+  "start_time",
+  "end_time",
+  "name",
+  "type",
+  "environment",
+  "version",
+  "release",
+  "trace_name",
+  "user_id",
+  "session_id",
+  "tags",
+  "level",
+  "status_message",
+  "completion_start_time",
+  "is_app_root",
+  "bookmarked",
+  "public",
+  "prompt_id",
+  "prompt_name",
+  "prompt_version",
+  "model_id",
+  "provided_model_name",
+  "model_parameters",
+  "provided_usage_details",
+  "usage_details",
+  "provided_cost_details",
+  "cost_details",
+  "usage_pricing_tier_id",
+  "usage_pricing_tier_name",
+  "tool_definitions",
+  "tool_calls",
+  "tool_call_names",
+  "input",
+  "output",
+  "metadata_names",
+  "metadata_values",
+  "experiment_id",
+  "experiment_name",
+  "experiment_metadata_names",
+  "experiment_metadata_values",
+  "experiment_description",
+  "experiment_dataset_id",
+  "experiment_item_id",
+  "experiment_item_version",
+  "experiment_item_expected_output",
+  "experiment_item_metadata_names",
+  "experiment_item_metadata_values",
+  "experiment_item_root_span_id",
+  "source",
+  "service_name",
+  "service_version",
+  "scope_name",
+  "scope_version",
+  "telemetry_sdk_language",
+  "telemetry_sdk_name",
+  "telemetry_sdk_version",
+  "ingestion_api_key",
+  "ingestion_sdk_name",
+  "ingestion_sdk_version",
+  "blob_storage_file_path",
+  "event_bytes",
+  "created_at",
+  "updated_at",
+  "event_ts",
+  "is_deleted",
+] as const;
+
+export type ExperimentEventEnrichmentInput = {
+  projectId: string;
+  traceId: string;
+  rootSpanId?: string | null;
+  experimentId: string;
+  experimentName: string;
+  experimentDescription?: string | null;
+  experimentDatasetId: string;
+  experimentItemId: string;
+  experimentItemVersion?: Date | null;
+  experimentItemExpectedOutput?: unknown;
+  experimentMetadata?: unknown;
+  experimentItemMetadata?: unknown;
+};
+
+const asJsonObjectRecord = (value: unknown): Record<string, unknown> => {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+};
+
+const serializeExpectedOutput = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value);
+};
+
+const toStringArray = (values: Array<string | null | undefined>): string[] =>
+  values.map((value) => value ?? "");
+
+/**
+ * Re-inserts the latest copy of every span in a trace into events_full with
+ * experiment_* columns populated. Experiments list and item views only return
+ * rows where experiment_id != ''.
+ *
+ * Uses an append-only ReplacingMergeTree insert (newer event_ts wins).
+ */
+export const stampExperimentAttributesOnTraceEvents = async (
+  input: ExperimentEventEnrichmentInput,
+): Promise<{ stamped: boolean }> => {
+  const rootSpanId = await resolveExperimentItemRootSpanId(input);
+  if (!rootSpanId) {
+    logger.info(
+      "No events found to stamp with experiment attributes; the link will stay invisible until events exist",
+      {
+        projectId: input.projectId,
+        traceId: input.traceId,
+        experimentId: input.experimentId,
+      },
+    );
+    return { stamped: false };
+  }
+
+  const experimentMetadata = flattenJsonToPathArrays(
+    asJsonObjectRecord(input.experimentMetadata),
+  );
+  const experimentItemMetadata = flattenJsonToPathArrays(
+    asJsonObjectRecord(input.experimentItemMetadata),
+  );
+
+  const insertColumns = EVENTS_FULL_INSERT_COLUMNS.join(",\n    ");
+  const selectColumns = EVENTS_FULL_INSERT_COLUMNS.map((column) => {
+    switch (column) {
+      case "experiment_id":
+        return "{experimentId: String} AS experiment_id";
+      case "experiment_name":
+        return "{experimentName: String} AS experiment_name";
+      case "experiment_metadata_names":
+        return "{experimentMetadataNames: Array(String)} AS experiment_metadata_names";
+      case "experiment_metadata_values":
+        return "{experimentMetadataValues: Array(String)} AS experiment_metadata_values";
+      case "experiment_description":
+        return "{experimentDescription: String} AS experiment_description";
+      case "experiment_dataset_id":
+        return "{experimentDatasetId: String} AS experiment_dataset_id";
+      case "experiment_item_id":
+        return "{experimentItemId: String} AS experiment_item_id";
+      case "experiment_item_version":
+        return "{experimentItemVersion: Nullable(DateTime64(3))} AS experiment_item_version";
+      case "experiment_item_expected_output":
+        return "{experimentItemExpectedOutput: String} AS experiment_item_expected_output";
+      case "experiment_item_metadata_names":
+        return "{experimentItemMetadataNames: Array(String)} AS experiment_item_metadata_names";
+      case "experiment_item_metadata_values":
+        return "{experimentItemMetadataValues: Array(String)} AS experiment_item_metadata_values";
+      case "experiment_item_root_span_id":
+        return "{rootSpanId: String} AS experiment_item_root_span_id";
+      case "updated_at":
+        return "now64(6) AS updated_at";
+      case "event_ts":
+        return "now64(6) AS event_ts";
+      default:
+        return column;
+    }
+  }).join(",\n    ");
+
+  await commandClickhouse({
+    query: `
+      INSERT INTO events_full (
+        ${insertColumns}
+      )
+      SELECT
+        ${selectColumns}
+      FROM events_full
+      WHERE project_id = {projectId: String}
+        AND trace_id = {traceId: String}
+        AND is_deleted = 0
+      ORDER BY event_ts DESC
+      LIMIT 1 BY span_id
+      LIMIT {maxSpans: UInt32}
+    `,
+    params: {
+      projectId: input.projectId,
+      traceId: input.traceId,
+      experimentId: input.experimentId,
+      experimentName: input.experimentName,
+      experimentDescription: input.experimentDescription ?? "",
+      experimentDatasetId: input.experimentDatasetId,
+      experimentItemId: input.experimentItemId,
+      experimentItemVersion: input.experimentItemVersion
+        ? convertDateToClickhouseDateTime(input.experimentItemVersion)
+        : null,
+      experimentItemExpectedOutput: serializeExpectedOutput(
+        input.experimentItemExpectedOutput,
+      ),
+      experimentMetadataNames: experimentMetadata.names,
+      experimentMetadataValues: toStringArray(experimentMetadata.values),
+      experimentItemMetadataNames: experimentItemMetadata.names,
+      experimentItemMetadataValues: toStringArray(
+        experimentItemMetadata.values,
+      ),
+      rootSpanId,
+      maxSpans: MAX_SPANS_PER_TRACE,
+    },
+    tags: {
+      route: "experiment-event-enrichment",
+      projectId: input.projectId,
+    },
+  });
+
+  return { stamped: true };
+};
+
+const resolveExperimentItemRootSpanId = async (
+  input: ExperimentEventEnrichmentInput,
+): Promise<string | null> => {
+  if (input.rootSpanId) {
+    return input.rootSpanId;
+  }
+
+  const rows = await queryClickhouse<{ span_id: string }>({
+    query: `
+      SELECT span_id
+      FROM events_full
+      WHERE project_id = {projectId: String}
+        AND trace_id = {traceId: String}
+        AND is_deleted = 0
+      ORDER BY
+        if(parent_span_id = '' OR span_id = concat('t-', {traceId: String}), 0, 1) ASC,
+        event_ts DESC
+      LIMIT 1
+    `,
+    params: {
+      projectId: input.projectId,
+      traceId: input.traceId,
+    },
+    tags: {
+      route: "experiment-event-enrichment.resolve-root",
+      projectId: input.projectId,
+    },
+  });
+
+  return rows[0]?.span_id ?? null;
+};

--- a/packages/shared/src/server/repositories/index.ts
+++ b/packages/shared/src/server/repositories/index.ts
@@ -24,6 +24,8 @@ export * from "./dataset-item-media";
 export * from "./comments";
 export * from "./experiments";
 export * from "./job-executions";
+export * from "./experiment-event-enrichment";
+export * from "./job-executions";
 export * from "./daily-metrics";
 export * from "./dataset-runs";
 export * from "./score-configs";

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -35,6 +35,8 @@ import {
   createObservationsCh,
   createTrace,
   createTracesCh,
+  createEvent,
+  createEventsCh,
   createOrgProjectAndApiKey,
   getDatasetRunItemsByDatasetIdCh,
   createDatasetRunItemsCh,
@@ -43,6 +45,7 @@ import {
   createDatasetItemFilterState,
   createDatasetItem,
   getDatasetItems,
+  getExperimentsFromEvents,
 } from "@langfuse/shared/src/server";
 import waitForExpect from "wait-for-expect";
 
@@ -1162,6 +1165,67 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
         body: { datasetItemId: "does-not-exist", traceId, runName } as any,
       }),
     ).rejects.toThrow("Dataset item not found");
+  });
+
+  it("events_only stamps experiment attributes so the run appears in experiments queries", async () => {
+    const datasetId = v4();
+    await prisma.dataset.create({
+      data: { id: datasetId, name: "events-only-stamp-dataset", projectId },
+    });
+    const itemResult = await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { prompt: "hello" },
+      expectedOutput: { answer: "world" },
+      validateOpts: { normalizeUndefinedToNull: true },
+    });
+    if (!itemResult.success) throw new Error(itemResult.message);
+
+    const spanId = v4();
+    const eventTraceId = v4();
+    const startTimeMs = Date.now();
+    await createEventsCh([
+      createEvent({
+        id: spanId,
+        span_id: spanId,
+        trace_id: eventTraceId,
+        project_id: projectId,
+        name: "harness-generation",
+        type: "GENERATION",
+        environment: "staging",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 25) * 1000,
+      }),
+    ]);
+
+    const runName = "events-only-stamp-run";
+    const helperAuth = { scope: { projectId } } as any;
+    const runItem = await buildStableDatasetRunItemResponseEventsOnly({
+      auth: helperAuth,
+      body: {
+        datasetItemId: itemResult.datasetItem.id,
+        traceId: eventTraceId,
+        observationId: spanId,
+        runName,
+        runDescription: "custom harness",
+        metadata: { runner: "custom" },
+      } as any,
+    });
+
+    const experiments = await getExperimentsFromEvents({
+      projectId,
+      filter: [],
+      limit: 1000,
+      page: 0,
+    });
+    const experiment = experiments.find((e) => e.id === runItem.datasetRunId);
+    expect(experiment).toMatchObject({
+      id: runItem.datasetRunId,
+      name: runName,
+      description: "custom harness",
+      datasetId,
+      itemCount: 1,
+    });
   });
 
   it("GET /api/public/datasets/{datasetName}/runs", async () => {

--- a/web/src/__tests__/server/experiments-public-api.servertest.ts
+++ b/web/src/__tests__/server/experiments-public-api.servertest.ts
@@ -12,7 +12,15 @@ import {
   makeZodVerifiedAPICall,
 } from "@/src/__tests__/test-utils";
 import { env } from "@/src/env.mjs";
-import { GetExperimentsV1Response } from "@/src/features/public-api/types/experiments";
+import {
+  GetExperimentItemsV1Response,
+  GetExperimentsV1Response,
+} from "@/src/features/public-api/types/experiments";
+import {
+  PostDatasetItemsV1Response,
+  PostDatasetRunItemsV1Response,
+  PostDatasetsV1Response,
+} from "@/src/features/public-api/types/datasets";
 
 const getExperiments = (url: string, auth: string) =>
   makeZodVerifiedAPICall(GetExperimentsV1Response, "GET", url, undefined, auth);
@@ -381,4 +389,107 @@ describe("GET /api/public/experiment-items", () => {
 
     expect(res.status).toBe(400);
   });
+});
+
+describe("POST /api/public/dataset-run-items experiment visibility", () => {
+  maybeEventTables(
+    "makes a run created without langfuse.experiment.* span attributes visible in GET /experiments",
+    async () => {
+      const { auth, projectId } = await createOrgProjectAndApiKey();
+      const datasetName = `dataset-run-item-harness-${randomUUID()}`;
+      const runName = `harness-run-${randomUUID()}`;
+      const startTimeMs = Date.now();
+      const spanId = randomUUID();
+      const traceId = randomUUID();
+
+      const dataset = await makeZodVerifiedAPICall(
+        PostDatasetsV1Response,
+        "POST",
+        "/api/public/datasets",
+        { name: datasetName },
+        auth,
+      );
+
+      const datasetItem = await makeZodVerifiedAPICall(
+        PostDatasetItemsV1Response,
+        "POST",
+        "/api/public/dataset-items",
+        {
+          datasetName,
+          input: { prompt: "hello" },
+          expectedOutput: { answer: "world" },
+          metadata: { suite: "harness" },
+        },
+        auth,
+      );
+
+      await createEventsCh([
+        createEvent({
+          id: spanId,
+          span_id: spanId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "harness-generation",
+          type: "GENERATION",
+          environment: "default",
+          start_time: startTimeMs * 1000,
+          end_time: (startTimeMs + 50) * 1000,
+        }),
+      ]);
+
+      const runItem = await makeZodVerifiedAPICall(
+        PostDatasetRunItemsV1Response,
+        "POST",
+        "/api/public/dataset-run-items",
+        {
+          datasetItemId: datasetItem.body.id,
+          traceId,
+          observationId: spanId,
+          runName,
+          runDescription: "created by a custom eval harness",
+          metadata: { runner: "custom" },
+        },
+        auth,
+      );
+
+      const fromStartTime = new Date(startTimeMs - 1_000).toISOString();
+      const experimentsRes = await getExperiments(
+        `/api/public/experiments?fromStartTime=${encodeURIComponent(fromStartTime)}&datasetId=${dataset.body.id}`,
+        auth,
+      );
+
+      expect(experimentsRes.status).toBe(200);
+      const experiment = experimentsRes.body.data.find(
+        (item) => item.id === runItem.body.datasetRunId,
+      );
+      expect(experiment).toMatchObject({
+        id: runItem.body.datasetRunId,
+        name: runName,
+        description: "created by a custom eval harness",
+        datasetId: dataset.body.id,
+        itemCount: 1,
+      });
+
+      const itemsRes = await makeZodVerifiedAPICall(
+        GetExperimentItemsV1Response,
+        "GET",
+        `/api/public/experiment-items?fromStartTime=${encodeURIComponent(fromStartTime)}&experimentId=${runItem.body.datasetRunId}`,
+        undefined,
+        auth,
+      );
+
+      expect(itemsRes.status).toBe(200);
+      expect(itemsRes.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: spanId,
+            traceId,
+            experimentId: runItem.body.datasetRunId,
+            experimentName: runName,
+            experimentItemId: datasetItem.body.id,
+          }),
+        ]),
+      );
+    },
+  );
 });

--- a/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
@@ -13,6 +13,7 @@ import {
   createTraceScore,
   createDatasetRunScore,
   createScoresCh,
+  stampExperimentAttributesOnTraceEvents,
 } from "@langfuse/shared/src/server";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -38,6 +39,65 @@ describe("Clickhouse Experiment Repository Test", () => {
       });
 
       expect(count).toBe(0);
+    });
+
+    it("should list a run after stamping experiment attributes onto existing events", async () => {
+      const experimentId = randomUUID();
+      const experimentName = "harness-run-" + randomUUID();
+      const datasetId = randomUUID();
+      const itemId = randomUUID();
+      const spanId = randomUUID();
+      const traceId = randomUUID();
+      const startTime = Date.now();
+
+      await createEventsCh([
+        createEvent({
+          id: spanId,
+          span_id: spanId,
+          project_id: projectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "harness-generation",
+          environment: "default",
+          start_time: startTime * 1000,
+          end_time: (startTime + 50) * 1000,
+        }),
+      ]);
+
+      const before = await getExperimentsFromEvents({
+        projectId,
+        filter: [],
+        limit: 1000,
+        page: 0,
+      });
+      expect(before.find((e) => e.id === experimentId)).toBeUndefined();
+
+      const stamped = await stampExperimentAttributesOnTraceEvents({
+        projectId,
+        traceId,
+        rootSpanId: spanId,
+        experimentId,
+        experimentName,
+        experimentDescription: "custom eval harness",
+        experimentDatasetId: datasetId,
+        experimentItemId: itemId,
+      });
+      expect(stamped).toEqual({ stamped: true });
+
+      const after = await getExperimentsFromEvents({
+        projectId,
+        filter: [],
+        limit: 1000,
+        page: 0,
+      });
+      const experiment = after.find((e) => e.id === experimentId);
+      expect(experiment).toMatchObject({
+        id: experimentId,
+        name: experimentName,
+        description: "custom eval harness",
+        datasetId,
+        itemCount: 1,
+      });
     });
 
     it("should return experiment count and latest start time per dataset", async () => {

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -53,6 +53,7 @@ import {
   getObservationById,
   logger,
   processEventBatch,
+  stampExperimentAttributesOnTraceEvents,
   type AuthHeaderValidVerificationResultIngestion,
   upsertDatasetItem,
 } from "@langfuse/shared/src/server";
@@ -158,6 +159,56 @@ const resolveMetadata = (metadata: JSONValue): Record<string, unknown> => {
     return metadata as Record<string, unknown>;
   }
   return { metadata };
+};
+
+const stampExperimentAttributesOnTraceEventsFromRunItem = async ({
+  projectId,
+  traceId,
+  observationId,
+  experimentId,
+  experimentName,
+  experimentDescription,
+  experimentMetadata,
+  datasetItem,
+}: {
+  projectId: string;
+  traceId: string;
+  observationId?: string | null;
+  experimentId: string;
+  experimentName: string;
+  experimentDescription?: string | null;
+  experimentMetadata?: unknown;
+  datasetItem: {
+    id: string;
+    datasetId: string;
+    validFrom: Date;
+    expectedOutput?: unknown;
+    metadata?: unknown;
+  };
+}) => {
+  try {
+    await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId,
+      rootSpanId: observationId,
+      experimentId,
+      experimentName,
+      experimentDescription,
+      experimentDatasetId: datasetItem.datasetId,
+      experimentItemId: datasetItem.id,
+      experimentItemVersion: datasetItem.validFrom,
+      experimentItemExpectedOutput: datasetItem.expectedOutput,
+      experimentMetadata,
+      experimentItemMetadata: datasetItem.metadata,
+    });
+  } catch (error) {
+    logger.error("Failed to stamp experiment attributes onto events", {
+      error,
+      projectId,
+      traceId,
+      experimentId,
+    });
+  }
 };
 
 const getDatasetByNameOrThrow = async ({
@@ -758,15 +809,15 @@ export const createStableExperimentId = ({
 /**
  * events_only deployments no longer write dataset run items into the legacy
  * dataset_run_items ClickHouse table, so the full createDatasetRunItemForApi
- * flow has nothing to persist. The experiment runner still calls POST
+ * flow has nothing to persist there. The experiment runner still calls POST
  * /dataset-run-items per item and expects a dataset run id it can reuse as the
  * experiment id across the whole run, so we resolve the item's dataset and
  * return a stable experiment id derived from (projectId, datasetId, runName).
  *
- * In v4 the trace ↔ experiment link is established through OTel experiment span
- * attributes instead, so beyond the dataset-item lookup (needed for datasetId
- * and to 404 on genuinely missing items) we skip every legacy side effect:
- * the observation→trace lookup, ClickHouse ingestion, and the eval enqueue.
+ * The trace ↔ experiment link is written onto existing events_full rows by
+ * stamping experiment_* columns. Beyond the dataset-item lookup we skip the
+ * observation→trace lookup, ClickHouse dataset_run_items ingest, and the eval
+ * enqueue.
  */
 export const buildStableDatasetRunItemResponseEventsOnly = async ({
   body,
@@ -810,6 +861,19 @@ export const buildStableDatasetRunItemResponseEventsOnly = async ({
     createdAt,
     updatedAt: createdAt,
   };
+
+  if (datasetRunItem.traceId) {
+    await stampExperimentAttributesOnTraceEventsFromRunItem({
+      projectId,
+      traceId: datasetRunItem.traceId,
+      observationId: body.observationId,
+      experimentId,
+      experimentName: body.runName,
+      experimentDescription: body.runDescription,
+      experimentMetadata: body.metadata,
+      datasetItem,
+    });
+  }
 
   return datasetRunItem;
 };
@@ -948,6 +1012,17 @@ export const createDatasetRunItemForApi = async ({
     datasetItemValidFrom: datasetItem.validFrom,
     traceId: finalTraceId,
     observationId: observationId ?? undefined,
+  });
+
+  await stampExperimentAttributesOnTraceEventsFromRunItem({
+    projectId,
+    traceId: finalTraceId,
+    observationId,
+    experimentId: run.id,
+    experimentName: run.name,
+    experimentDescription: run.description,
+    experimentMetadata: metadata,
+    datasetItem,
   });
 
   return PostDatasetRunItemsV1Response.parse(datasetRunItem);

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -22,10 +22,9 @@ export default withMiddlewares({
     rateLimitResource: "datasets",
     // Writes a dataset-run-item event into the legacy dataset_run_items
     // ClickHouse table. events_only deployments no longer populate that table,
-    // so instead of writing anything we return a stable experiment id (== the
+    // so instead of writing a DRI we return a stable experiment id (== the
     // dataset run id) derived deterministically from (projectId, datasetId,
-    // runName). The trace ↔ experiment link is established through OTel
-    // experiment span attributes on ingestion instead.
+    // runName) and stamp experiment_* columns onto the linked trace's events.
     fn: async ({ body, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only") {
         return await buildStableDatasetRunItemResponseEventsOnly({

--- a/worker/src/__tests__/experimentEventEnrichment.test.ts
+++ b/worker/src/__tests__/experimentEventEnrichment.test.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, type TestContext } from "vitest";
+import {
+  createEvent,
+  createEventsCh,
+  createOrgProjectAndApiKey,
+  queryClickhouse,
+  stampExperimentAttributesOnTraceEvents,
+} from "@langfuse/shared/src/server";
+import { skipUnlessClickhouseTablesExist } from "./helpers/clickhouseTables";
+
+describe("stampExperimentAttributesOnTraceEvents", () => {
+  it("stamps experiment columns onto events that were ingested without them", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, ["events_full", "events_core"]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+    const spanId = randomUUID();
+    const childSpanId = randomUUID();
+    const traceId = randomUUID();
+    const experimentId = randomUUID();
+    const experimentItemId = randomUUID();
+    const startTimeMs = Date.now();
+
+    await createEventsCh([
+      createEvent({
+        id: spanId,
+        span_id: spanId,
+        parent_span_id: "",
+        trace_id: traceId,
+        project_id: projectId,
+        name: "harness-root",
+        type: "SPAN",
+        environment: "production",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 80) * 1000,
+      }),
+      createEvent({
+        id: childSpanId,
+        span_id: childSpanId,
+        parent_span_id: spanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "harness-child",
+        type: "GENERATION",
+        environment: "production",
+        start_time: (startTimeMs + 10) * 1000,
+        end_time: (startTimeMs + 70) * 1000,
+      }),
+    ]);
+
+    const result = await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId,
+      rootSpanId: spanId,
+      experimentId,
+      experimentName: "harness-run",
+      experimentDescription: "custom eval harness",
+      experimentDatasetId: "dataset-1",
+      experimentItemId,
+      experimentItemExpectedOutput: { answer: 42 },
+      experimentMetadata: { runner: "custom" },
+      experimentItemMetadata: { case: "n1" },
+    });
+
+    expect(result).toEqual({ stamped: true });
+
+    const rows = await queryClickhouse<{
+      span_id: string;
+      experiment_id: string;
+      experiment_name: string;
+      experiment_description: string;
+      experiment_dataset_id: string;
+      experiment_item_id: string;
+      experiment_item_root_span_id: string;
+      experiment_item_expected_output: string;
+      environment: string;
+    }>({
+      query: `
+        SELECT
+          span_id,
+          experiment_id,
+          experiment_name,
+          experiment_description,
+          experiment_dataset_id,
+          experiment_item_id,
+          experiment_item_root_span_id,
+          experiment_item_expected_output,
+          environment
+        FROM events_full
+        WHERE project_id = {projectId: String}
+          AND trace_id = {traceId: String}
+          AND is_deleted = 0
+        ORDER BY event_ts DESC
+        LIMIT 1 BY span_id
+      `,
+      params: { projectId, traceId },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          span_id: spanId,
+          experiment_id: experimentId,
+          experiment_name: "harness-run",
+          experiment_description: "custom eval harness",
+          experiment_dataset_id: "dataset-1",
+          experiment_item_id: experimentItemId,
+          experiment_item_root_span_id: spanId,
+          experiment_item_expected_output: JSON.stringify({ answer: 42 }),
+          environment: "production",
+        }),
+        expect.objectContaining({
+          span_id: childSpanId,
+          experiment_id: experimentId,
+          experiment_item_root_span_id: spanId,
+          environment: "production",
+        }),
+      ]),
+    );
+  });
+
+  it("returns stamped false when the trace has no events", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, ["events_full"]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const result = await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId: randomUUID(),
+      experimentId: randomUUID(),
+      experimentName: "missing-trace",
+      experimentDatasetId: "dataset-1",
+      experimentItemId: randomUUID(),
+    });
+
+    expect(result).toEqual({ stamped: false });
+  });
+});

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -5,6 +5,7 @@ import {
   convertDateToClickhouseDateTime,
   flattenJsonToPathArrays,
   recordGauge,
+  stampExperimentAttributesOnTraceEvents,
   UNKNOWN_INGESTION_SDK_VALUE,
   type EventRecordInsertType,
 } from "@langfuse/shared/src/server";
@@ -17,6 +18,7 @@ const EXPERIMENT_BACKFILL_TIMESTAMP_KEY =
   "langfuse:event-propagation:experiment-backfill:last-run";
 const EXPERIMENT_BACKFILL_LOCK_KEY = "langfuse:experiment-backfill:lock";
 const LOCK_TTL_SECONDS = 300; // 5 minutes
+const UNENRICHED_EVENTS_LOOKBACK_DAYS = 90;
 
 export interface DatasetRunItem {
   id: string;
@@ -147,9 +149,12 @@ async function getDatasetRunItemsSinceLastRun(
       dri.dataset_item_metadata,
       dri.created_at
     FROM dataset_run_items_rmt AS dri
+    -- Traces already in events_core still need a stamp when experiment_id is
+    -- empty (dataset-run-item created without langfuse.experiment.* attributes).
     LEFT ANTI JOIN events_core AS ec
       ON dri.project_id = ec.project_id
       AND dri.trace_id = ec.trace_id
+      AND ec.experiment_id != ''
     WHERE dri.created_at > {lastRun: DateTime64(3)}
       AND dri.created_at <= {upperBound: DateTime64(3)}
       AND (dri.project_id, dri.trace_id) IN (SELECT project_id, trace_id FROM candidate_dris)
@@ -174,6 +179,127 @@ async function getDatasetRunItemsSinceLastRun(
 
   return rows;
 }
+
+/**
+ * Dataset-run-items older than the incremental cursor whose traces exist in
+ * events_core without experiment_id. Those traces are already ingested, so the
+ * observations-copy path never sees them.
+ */
+async function getUnenrichedDatasetRunItemsBeforeCursor(
+  lastRun: Date,
+  limit: number,
+): Promise<DatasetRunItem[]> {
+  const lookbackStart = new Date(
+    lastRun.getTime() - UNENRICHED_EVENTS_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+  );
+
+  const query = `
+    SELECT
+      dri.id,
+      dri.project_id,
+      dri.trace_id,
+      dri.observation_id,
+      dri.dataset_run_id,
+      dri.dataset_run_name,
+      dri.dataset_run_description,
+      dri.dataset_run_metadata,
+      dri.dataset_id,
+      dri.dataset_item_version,
+      dri.dataset_item_id,
+      dri.dataset_item_expected_output,
+      dri.dataset_item_metadata,
+      dri.created_at
+    FROM dataset_run_items_rmt AS dri
+    LEFT SEMI JOIN events_core AS present
+      ON present.project_id = dri.project_id
+      AND present.trace_id = dri.trace_id
+    LEFT ANTI JOIN events_core AS enriched
+      ON enriched.project_id = dri.project_id
+      AND enriched.trace_id = dri.trace_id
+      AND enriched.experiment_id != ''
+    WHERE dri.created_at > {lookbackStart: DateTime64(3)}
+      AND dri.created_at <= {lastRun: DateTime64(3)}
+    ORDER BY dri.created_at ASC
+    LIMIT 1 BY dri.project_id, dri.trace_id, coalesce(dri.observation_id, '')
+    LIMIT {limit: UInt32}
+  `;
+
+  const rows = await queryClickhouse<DatasetRunItem>({
+    query,
+    params: {
+      lookbackStart: convertDateToClickhouseDateTime(lookbackStart),
+      lastRun: convertDateToClickhouseDateTime(lastRun),
+      limit,
+    },
+    clickhouseConfigs: {
+      request_timeout: 120000,
+    },
+  });
+
+  logger.info(
+    `[EXPERIMENT BACKFILL] Found ${rows.length} unenriched dataset run items before ${lastRun.toISOString()}`,
+  );
+
+  return rows;
+}
+
+const stampDatasetRunItemOntoEvents = async (
+  dri: DatasetRunItem,
+): Promise<boolean> => {
+  const { stamped } = await stampExperimentAttributesOnTraceEvents({
+    projectId: dri.project_id,
+    traceId: dri.trace_id,
+    rootSpanId: dri.observation_id,
+    experimentId: dri.dataset_run_id,
+    experimentName: dri.dataset_run_name,
+    experimentDescription: dri.dataset_run_description,
+    experimentDatasetId: dri.dataset_id,
+    experimentItemId: dri.dataset_item_id,
+    experimentItemVersion: dri.dataset_item_version
+      ? new Date(dri.dataset_item_version)
+      : null,
+    experimentItemExpectedOutput: dri.dataset_item_expected_output,
+    experimentMetadata: dri.dataset_run_metadata,
+    experimentItemMetadata: dri.dataset_item_metadata,
+  });
+  return stamped;
+};
+
+const stampUnenrichedDatasetRunItemsBeforeCursor = async (
+  lastRun: Date,
+): Promise<void> => {
+  const excludeProjectIds =
+    env.LANGFUSE_EXPERIMENT_BACKFILL_EXCLUDE_PROJECT_IDS;
+  const catchUpItems = await getUnenrichedDatasetRunItemsBeforeCursor(
+    lastRun,
+    env.LANGFUSE_DATASET_RUN_BACKFILL_CHUNK_SIZE,
+  );
+  const toStamp =
+    excludeProjectIds && excludeProjectIds.length > 0
+      ? catchUpItems.filter(
+          (dri) => !excludeProjectIds.includes(dri.project_id),
+        )
+      : catchUpItems;
+
+  if (toStamp.length === 0) {
+    return;
+  }
+
+  logger.info(
+    `[EXPERIMENT BACKFILL] Stamping ${toStamp.length} historically skipped dataset run items`,
+  );
+
+  for (const dri of toStamp) {
+    try {
+      await stampDatasetRunItemOntoEvents(dri);
+    } catch (error) {
+      logger.error(
+        `[EXPERIMENT BACKFILL] Failed to stamp historically skipped DRI ${dri.id}`,
+        error,
+      );
+    }
+  }
+};
 
 /**
  * Fetch observations that belong to traces referenced by dataset run items.
@@ -912,6 +1038,7 @@ async function processExperimentBackfill(
       "[EXPERIMENT BACKFILL] No dataset run items to process, advancing cursor",
     );
     await updateBackfillTimestamp(upperBound);
+    await stampUnenrichedDatasetRunItemsBeforeCursor(lastRun);
     return;
   }
 
@@ -935,9 +1062,35 @@ async function processExperimentBackfill(
     // backfill would let the heartbeat go stale and trip the stuck health check.
     await updateLastRunStartedAt();
 
-    // Extract project and trace IDs for this chunk
-    const projectIds = [...new Set(driChunk.map((dri) => dri.project_id))];
-    const traceIds = [...new Set(driChunk.map((dri) => dri.trace_id))];
+    const unstamped: DatasetRunItem[] = [];
+    for (const dri of driChunk) {
+      try {
+        const stamped = await stampDatasetRunItemOntoEvents(dri);
+        if (!stamped) {
+          unstamped.push(dri);
+        }
+      } catch (error) {
+        logger.error(
+          `[EXPERIMENT BACKFILL] Failed to stamp events for DRI ${dri.id}`,
+          error,
+        );
+        unstamped.push(dri);
+      }
+    }
+
+    if (unstamped.length === 0) {
+      const lastItemInChunk = driChunk[driChunk.length - 1];
+      const chunkCursor =
+        i === chunks.length - 1
+          ? upperBound
+          : new Date(lastItemInChunk.created_at);
+      await updateBackfillTimestamp(chunkCursor);
+      continue;
+    }
+
+    // Extract project and trace IDs for traces that are not yet in events
+    const projectIds = [...new Set(unstamped.map((dri) => dri.project_id))];
+    const traceIds = [...new Set(unstamped.map((dri) => dri.trace_id))];
 
     // Fetch observations and traces
     const [observations, traces] = await Promise.all([
@@ -975,8 +1128,7 @@ async function processExperimentBackfill(
     const allEnrichedSpans: EnrichedSpan[] = [];
     const processedSpanIds = new Set<string>();
 
-    for (const dri of driChunk) {
-      // Find the root span (either observation or trace)
+    for (const dri of unstamped) {
       const rootSpanId = dri.observation_id || `t-${dri.trace_id}`;
       const rootSpanKey = spanScopedKey(
         dri.project_id,
@@ -1054,4 +1206,6 @@ async function processExperimentBackfill(
   logger.info(
     `[EXPERIMENT BACKFILL] Completed backfill process for ${datasetRunItems.length} items`,
   );
+
+  await stampUnenrichedDatasetRunItemsBeforeCursor(lastRun);
 }


### PR DESCRIPTION
## Summary
- Dataset runs created via `POST /api/public/dataset-run-items` (custom eval harnesses that skip `langfuse.experiment.*` span attributes) were returned by the datasets API but missing from Experiments views and `GET /api/public/experiments`.
- POST now stamps `experiment_*` columns onto the linked trace’s existing events, so those runs show up without requiring the reserved `sdk-experiment` environment.
- The experiment backfill no longer skips traces already in `events_core` unless they already have `experiment_id`, and it catch-up stamps historically skipped dataset-run-items (90-day lookback).

## Test plan
- [x] `pnpm --filter worker run test experimentEventEnrichment` — 2 passed
- [x] `pnpm --filter web run test experiment-repository.servertest` — 26 passed (includes stamp → list)
- [x] `events_only stamps experiment attributes so the run appears in experiments queries` in `datasets-api.servertest.ts` — passed
- [ ] `pnpm --filter web run test experiments-public-api.servertest` with `pnpm run dev:web` (HTTP POST then `GET /api/public/experiments`; skipped locally because nothing was on `:3000`)
- [ ] Preview: dataset Experiments tab and `/experiments/results?baseline={runId}` for a run created only via `POST /dataset-run-items` (no `langfuse.experiment.*` attributes)


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stamps experiment metadata onto existing trace events so dataset-run-item API runs appear in event-backed experiment views, and extends the worker backfill to recover historically skipped links.
- Adds a shared ClickHouse event-enrichment operation.
- Invokes enrichment from both public dataset-run-item creation paths.
- Expands incremental and historical worker backfill behavior.
- Adds repository, worker, and public API coverage for trace-linked runs.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

This PR should not merge until observation-only requests, shared-trace item isolation, and durable historical catch-up progress are corrected.

Valid observation-only requests can still return without enrichment, per-item stamping can replace sibling item identities across a shared trace, and failed leading backfill rows can indefinitely prevent later historical records from being processed.

**Files Needing Attention:** packages/shared/src/server/repositories/experiment-event-enrichment.ts, web/src/features/datasets/server/publicDatasetService.ts, worker/src/features/eventPropagation/handleExperimentBackfill.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[POST dataset-run-item] --> B{Write mode}
  B -->|events only| C[Build stable experiment ID]
  B -->|legacy or dual| D[Persist dataset run item]
  C --> E[Stamp existing trace events]
  D --> E
  F[Scheduled experiment backfill] --> G[Find unenriched run items]
  G --> E
  E --> H[(events_full)]
  H --> I[(events_core)]
  I --> J[Experiments list and item views]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/server/publicDatasetService.ts:865
**Observation-only runs skip enrichment**

When a valid events-only request supplies `observationId` without `traceId`, this guard bypasses stamping because the helper never resolves the observation to its trace, causing the API to report success while the run remains absent from experiment lists and result views.

### Issue 2
packages/shared/src/server/repositories/experiment-event-enrichment.ts:186-194
**Trace-wide stamping overwrites items**

When two dataset run items link to different observations in one trace, each call stamps every span rather than the linked observation subtree, so the later event version replaces the earlier item and experiment identity and produces missing or incorrectly attributed experiment items, counts, and comparisons.

### Issue 3
worker/src/features/eventPropagation/handleExperimentBackfill.ts:2254-2255
**Failed rows block catch-up**

If the historical backlog exceeds one chunk and an early row cannot be stamped because its trace events are absent, the fixed ordered query selects that row again without advancing a catch-up cursor, causing later eligible experiments to remain invisible indefinitely.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): show dataset-run-item ..."](https://github.com/langfuse/langfuse/commit/5b07700098e2b3d94320be34152f6edb1dfbb412) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58711905)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)
- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)

<!-- /greptile_comment -->