### PR TITLE
fix(experiments): show dataset-run-item API runs in Experiments views

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -18,12 +18,16 @@ import {
   queryClickhouse,
 } from "./clickhouse";
 import { convertDatasetRunItemClickhouseToDomain } from "./dataset-run-items-converters";
-import { DatasetRunItemRecord } from "./definitions";
+import {
+  DatasetRunItemRecord,
+  type DatasetRunItemRecordInsertType,
+} from "./definitions";
 import { env } from "../../env";
 import { commandClickhouse } from "./clickhouse";
 import Decimal from "decimal.js";
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import {
+  clickhouseClient,
   convertDateToClickhouseDateTime,
   type PreferredClickhouseService,
 } from "../clickhouse/client";
@@ -1208,4 +1212,18 @@ export const getDatasetRunItemCountsByProjectInCreationInterval = async ({
     projectId: row.project_id,
     count: Number(row.count),
   }));
+};
+
+export const insertDatasetRunItems = async (
+  records: DatasetRunItemRecordInsertType[],
+): Promise<void> => {
+  if (records.length === 0) {
+    return;
+  }
+
+  await clickhouseClient().insert({
+    table: "dataset_run_items_rmt",
+    format: "JSONEachRow",
+    values: records,
+  });
 };

--- a/packages/shared/src/server/repositories/experiment-event-enrichment.ts
+++ b/packages/shared/src/server/repositories/experiment-event-enrichment.ts
@@ -112,18 +112,123 @@ const serializeExpectedOutput = (value: unknown): string => {
 const toStringArray = (values: Array<string | null | undefined>): string[] =>
   values.map((value) => value ?? "");
 
+type TraceSpanRef = {
+  span_id: string;
+  parent_span_id: string;
+  event_ts: string;
+};
+
+const fetchLatestTraceSpans = async (
+  projectId: string,
+  traceId: string,
+): Promise<TraceSpanRef[]> => {
+  return queryClickhouse<TraceSpanRef>({
+    query: `
+      SELECT
+        span_id,
+        coalesce(parent_span_id, '') AS parent_span_id,
+        event_ts
+      FROM events_full
+      WHERE project_id = {projectId: String}
+        AND trace_id = {traceId: String}
+        AND is_deleted = 0
+      ORDER BY event_ts DESC
+      LIMIT 1 BY span_id
+      LIMIT {maxSpans: UInt32}
+    `,
+    params: {
+      projectId,
+      traceId,
+      maxSpans: MAX_SPANS_PER_TRACE,
+    },
+    tags: {
+      route: "experiment-event-enrichment.fetch-spans",
+      projectId,
+    },
+  });
+};
+
+const collectSubtreeSpanIds = (
+  rootSpanId: string,
+  spans: TraceSpanRef[],
+): string[] => {
+  const childMap = new Map<string, string[]>();
+  const known = new Set<string>();
+  for (const span of spans) {
+    known.add(span.span_id);
+    const siblings = childMap.get(span.parent_span_id);
+    if (siblings) {
+      siblings.push(span.span_id);
+    } else {
+      childMap.set(span.parent_span_id, [span.span_id]);
+    }
+  }
+  if (!known.has(rootSpanId)) {
+    return [];
+  }
+
+  const result: string[] = [];
+  const queue = [rootSpanId];
+  const visited = new Set<string>();
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    result.push(current);
+    const children = childMap.get(current);
+    if (children) {
+      queue.push(...children);
+    }
+  }
+  return result;
+};
+
+const pickTraceRootSpanId = (
+  spans: TraceSpanRef[],
+  traceId: string,
+): string | null => {
+  const syntheticRootId = `t-${traceId}`;
+  const sorted = [...spans].sort((left, right) => {
+    const rank = (span: TraceSpanRef) =>
+      span.parent_span_id === "" || span.span_id === syntheticRootId ? 0 : 1;
+    const rankDiff = rank(left) - rank(right);
+    if (rankDiff !== 0) {
+      return rankDiff;
+    }
+    if (left.event_ts === right.event_ts) {
+      return 0;
+    }
+    return left.event_ts < right.event_ts ? 1 : -1;
+  });
+  return sorted[0]?.span_id ?? null;
+};
+
 /**
- * Re-inserts the latest copy of every span in a trace into events_full with
+ * Re-inserts the latest copy of the linked spans into events_full with
  * experiment_* columns populated. Experiments list and item views only return
  * rows where experiment_id != ''.
+ *
+ * When rootSpanId is set, only that span and its descendants are stamped so
+ * sibling observations on the same trace keep their own experiment item.
+ * Otherwise the whole trace is stamped.
  *
  * Uses an append-only ReplacingMergeTree insert (newer event_ts wins).
  */
 export const stampExperimentAttributesOnTraceEvents = async (
   input: ExperimentEventEnrichmentInput,
 ): Promise<{ stamped: boolean }> => {
-  const rootSpanId = await resolveExperimentItemRootSpanId(input);
-  if (!rootSpanId) {
+  const linkedRootSpanId = input.rootSpanId || undefined;
+  const spans = await fetchLatestTraceSpans(input.projectId, input.traceId);
+  const spanIds = linkedRootSpanId
+    ? collectSubtreeSpanIds(linkedRootSpanId, spans)
+    : spans.map((span) => span.span_id);
+  const rootSpanId = linkedRootSpanId
+    ? linkedRootSpanId
+    : pickTraceRootSpanId(spans, input.traceId);
+
+  if (!rootSpanId || spanIds.length === 0) {
     logger.info(
       "No events found to stamp with experiment attributes; the link will stay invisible until events exist",
       {
@@ -188,6 +293,7 @@ export const stampExperimentAttributesOnTraceEvents = async (
       FROM events_full
       WHERE project_id = {projectId: String}
         AND trace_id = {traceId: String}
+        AND span_id IN {spanIds: Array(String)}
         AND is_deleted = 0
       ORDER BY event_ts DESC
       LIMIT 1 BY span_id
@@ -214,6 +320,7 @@ export const stampExperimentAttributesOnTraceEvents = async (
         experimentItemMetadata.values,
       ),
       rootSpanId,
+      spanIds,
       maxSpans: MAX_SPANS_PER_TRACE,
     },
     tags: {
@@ -223,36 +330,4 @@ export const stampExperimentAttributesOnTraceEvents = async (
   });
 
   return { stamped: true };
-};
-
-const resolveExperimentItemRootSpanId = async (
-  input: ExperimentEventEnrichmentInput,
-): Promise<string | null> => {
-  if (input.rootSpanId) {
-    return input.rootSpanId;
-  }
-
-  const rows = await queryClickhouse<{ span_id: string }>({
-    query: `
-      SELECT span_id
-      FROM events_full
-      WHERE project_id = {projectId: String}
-        AND trace_id = {traceId: String}
-        AND is_deleted = 0
-      ORDER BY
-        if(parent_span_id = '' OR span_id = concat('t-', {traceId: String}), 0, 1) ASC,
-        event_ts DESC
-      LIMIT 1
-    `,
-    params: {
-      projectId: input.projectId,
-      traceId: input.traceId,
-    },
-    tags: {
-      route: "experiment-event-enrichment.resolve-root",
-      projectId: input.projectId,
-    },
-  });
-
-  return rows[0]?.span_id ?? null;
 };

--- a/packages/shared/src/server/repositories/experiment-event-enrichment.ts
+++ b/packages/shared/src/server/repositories/experiment-event-enrichment.ts
@@ -1,0 +1,258 @@
+import { flattenJsonToPathArrays } from "../otel/utils";
+import { convertDateToClickhouseDateTime } from "../clickhouse/client";
+import { commandClickhouse, queryClickhouse } from "./clickhouse";
+import { logger } from "../logger";
+
+const MAX_SPANS_PER_TRACE = 50_000;
+
+const EVENTS_FULL_INSERT_COLUMNS = [
+  "project_id",
+  "trace_id",
+  "span_id",
+  "parent_span_id",
+  "start_time",
+  "end_time",
+  "name",
+  "type",
+  "environment",
+  "version",
+  "release",
+  "trace_name",
+  "user_id",
+  "session_id",
+  "tags",
+  "level",
+  "status_message",
+  "completion_start_time",
+  "is_app_root",
+  "bookmarked",
+  "public",
+  "prompt_id",
+  "prompt_name",
+  "prompt_version",
+  "model_id",
+  "provided_model_name",
+  "model_parameters",
+  "provided_usage_details",
+  "usage_details",
+  "provided_cost_details",
+  "cost_details",
+  "usage_pricing_tier_id",
+  "usage_pricing_tier_name",
+  "tool_definitions",
+  "tool_calls",
+  "tool_call_names",
+  "input",
+  "output",
+  "metadata_names",
+  "metadata_values",
+  "experiment_id",
+  "experiment_name",
+  "experiment_metadata_names",
+  "experiment_metadata_values",
+  "experiment_description",
+  "experiment_dataset_id",
+  "experiment_item_id",
+  "experiment_item_version",
+  "experiment_item_expected_output",
+  "experiment_item_metadata_names",
+  "experiment_item_metadata_values",
+  "experiment_item_root_span_id",
+  "source",
+  "service_name",
+  "service_version",
+  "scope_name",
+  "scope_version",
+  "telemetry_sdk_language",
+  "telemetry_sdk_name",
+  "telemetry_sdk_version",
+  "ingestion_api_key",
+  "ingestion_sdk_name",
+  "ingestion_sdk_version",
+  "blob_storage_file_path",
+  "event_bytes",
+  "created_at",
+  "updated_at",
+  "event_ts",
+  "is_deleted",
+] as const;
+
+export type ExperimentEventEnrichmentInput = {
+  projectId: string;
+  traceId: string;
+  rootSpanId?: string | null;
+  experimentId: string;
+  experimentName: string;
+  experimentDescription?: string | null;
+  experimentDatasetId: string;
+  experimentItemId: string;
+  experimentItemVersion?: Date | null;
+  experimentItemExpectedOutput?: unknown;
+  experimentMetadata?: unknown;
+  experimentItemMetadata?: unknown;
+};
+
+const asJsonObjectRecord = (value: unknown): Record<string, unknown> => {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+};
+
+const serializeExpectedOutput = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value);
+};
+
+const toStringArray = (values: Array<string | null | undefined>): string[] =>
+  values.map((value) => value ?? "");
+
+/**
+ * Re-inserts the latest copy of every span in a trace into events_full with
+ * experiment_* columns populated. Experiments list and item views only return
+ * rows where experiment_id != ''.
+ *
+ * Uses an append-only ReplacingMergeTree insert (newer event_ts wins).
+ */
+export const stampExperimentAttributesOnTraceEvents = async (
+  input: ExperimentEventEnrichmentInput,
+): Promise<{ stamped: boolean }> => {
+  const rootSpanId = await resolveExperimentItemRootSpanId(input);
+  if (!rootSpanId) {
+    logger.info(
+      "No events found to stamp with experiment attributes; the link will stay invisible until events exist",
+      {
+        projectId: input.projectId,
+        traceId: input.traceId,
+        experimentId: input.experimentId,
+      },
+    );
+    return { stamped: false };
+  }
+
+  const experimentMetadata = flattenJsonToPathArrays(
+    asJsonObjectRecord(input.experimentMetadata),
+  );
+  const experimentItemMetadata = flattenJsonToPathArrays(
+    asJsonObjectRecord(input.experimentItemMetadata),
+  );
+
+  const insertColumns = EVENTS_FULL_INSERT_COLUMNS.join(",\n    ");
+  const selectColumns = EVENTS_FULL_INSERT_COLUMNS.map((column) => {
+    switch (column) {
+      case "experiment_id":
+        return "{experimentId: String} AS experiment_id";
+      case "experiment_name":
+        return "{experimentName: String} AS experiment_name";
+      case "experiment_metadata_names":
+        return "{experimentMetadataNames: Array(String)} AS experiment_metadata_names";
+      case "experiment_metadata_values":
+        return "{experimentMetadataValues: Array(String)} AS experiment_metadata_values";
+      case "experiment_description":
+        return "{experimentDescription: String} AS experiment_description";
+      case "experiment_dataset_id":
+        return "{experimentDatasetId: String} AS experiment_dataset_id";
+      case "experiment_item_id":
+        return "{experimentItemId: String} AS experiment_item_id";
+      case "experiment_item_version":
+        return "{experimentItemVersion: Nullable(DateTime64(3))} AS experiment_item_version";
+      case "experiment_item_expected_output":
+        return "{experimentItemExpectedOutput: String} AS experiment_item_expected_output";
+      case "experiment_item_metadata_names":
+        return "{experimentItemMetadataNames: Array(String)} AS experiment_item_metadata_names";
+      case "experiment_item_metadata_values":
+        return "{experimentItemMetadataValues: Array(String)} AS experiment_item_metadata_values";
+      case "experiment_item_root_span_id":
+        return "{rootSpanId: String} AS experiment_item_root_span_id";
+      case "updated_at":
+        return "now64(6) AS updated_at";
+      case "event_ts":
+        return "now64(6) AS event_ts";
+      default:
+        return column;
+    }
+  }).join(",\n    ");
+
+  await commandClickhouse({
+    query: `
+      INSERT INTO events_full (
+        ${insertColumns}
+      )
+      SELECT
+        ${selectColumns}
+      FROM events_full
+      WHERE project_id = {projectId: String}
+        AND trace_id = {traceId: String}
+        AND is_deleted = 0
+      ORDER BY event_ts DESC
+      LIMIT 1 BY span_id
+      LIMIT {maxSpans: UInt32}
+    `,
+    params: {
+      projectId: input.projectId,
+      traceId: input.traceId,
+      experimentId: input.experimentId,
+      experimentName: input.experimentName,
+      experimentDescription: input.experimentDescription ?? "",
+      experimentDatasetId: input.experimentDatasetId,
+      experimentItemId: input.experimentItemId,
+      experimentItemVersion: input.experimentItemVersion
+        ? convertDateToClickhouseDateTime(input.experimentItemVersion)
+        : null,
+      experimentItemExpectedOutput: serializeExpectedOutput(
+        input.experimentItemExpectedOutput,
+      ),
+      experimentMetadataNames: experimentMetadata.names,
+      experimentMetadataValues: toStringArray(experimentMetadata.values),
+      experimentItemMetadataNames: experimentItemMetadata.names,
+      experimentItemMetadataValues: toStringArray(
+        experimentItemMetadata.values,
+      ),
+      rootSpanId,
+      maxSpans: MAX_SPANS_PER_TRACE,
+    },
+    tags: {
+      route: "experiment-event-enrichment",
+      projectId: input.projectId,
+    },
+  });
+
+  return { stamped: true };
+};
+
+const resolveExperimentItemRootSpanId = async (
+  input: ExperimentEventEnrichmentInput,
+): Promise<string | null> => {
+  if (input.rootSpanId) {
+    return input.rootSpanId;
+  }
+
+  const rows = await queryClickhouse<{ span_id: string }>({
+    query: `
+      SELECT span_id
+      FROM events_full
+      WHERE project_id = {projectId: String}
+        AND trace_id = {traceId: String}
+        AND is_deleted = 0
+      ORDER BY
+        if(parent_span_id = '' OR span_id = concat('t-', {traceId: String}), 0, 1) ASC,
+        event_ts DESC
+      LIMIT 1
+    `,
+    params: {
+      projectId: input.projectId,
+      traceId: input.traceId,
+    },
+    tags: {
+      route: "experiment-event-enrichment.resolve-root",
+      projectId: input.projectId,
+    },
+  });
+
+  return rows[0]?.span_id ?? null;
+};

--- a/packages/shared/src/server/repositories/index.ts
+++ b/packages/shared/src/server/repositories/index.ts
@@ -24,6 +24,8 @@ export * from "./dataset-item-media";
 export * from "./comments";
 export * from "./experiments";
 export * from "./job-executions";
+export * from "./experiment-event-enrichment";
+export * from "./job-executions";
 export * from "./daily-metrics";
 export * from "./dataset-runs";
 export * from "./score-configs";

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -46,6 +46,7 @@ import {
   createDatasetItem,
   getDatasetItems,
   getExperimentsFromEvents,
+  queryClickhouse,
 } from "@langfuse/shared/src/server";
 import waitForExpect from "wait-for-expect";
 
@@ -1286,6 +1287,65 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       description: "observation-only harness",
       datasetId,
       itemCount: 1,
+    });
+  });
+
+  it("events_only persists a dataset run item for catch-up when events are not stampable", async () => {
+    const datasetId = v4();
+    await prisma.dataset.create({
+      data: {
+        id: datasetId,
+        name: "events-only-catch-up-dataset",
+        projectId,
+      },
+    });
+    const itemResult = await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { prompt: "hello" },
+      expectedOutput: { answer: "world" },
+      validateOpts: { normalizeUndefinedToNull: true },
+    });
+    if (!itemResult.success) throw new Error(itemResult.message);
+
+    const missingTraceId = v4();
+    const runName = "events-only-catch-up-run";
+    const helperAuth = { scope: { projectId } } as any;
+    const runItem = await buildStableDatasetRunItemResponseEventsOnly({
+      auth: helperAuth,
+      body: {
+        datasetItemId: itemResult.datasetItem.id,
+        traceId: missingTraceId,
+        runName,
+        runDescription: "pending events",
+        metadata: { runner: "custom" },
+      } as any,
+    });
+
+    expect(runItem.traceId).toBe(missingTraceId);
+
+    const rows = await queryClickhouse<{
+      id: string;
+      dataset_run_id: string;
+      trace_id: string;
+      dataset_item_id: string;
+    }>({
+      query: `
+        SELECT id, dataset_run_id, trace_id, dataset_item_id
+        FROM dataset_run_items_rmt
+        WHERE project_id = {projectId: String}
+          AND id = {id: String}
+        ORDER BY event_ts DESC
+        LIMIT 1
+      `,
+      params: { projectId, id: runItem.id },
+    });
+
+    expect(rows[0]).toMatchObject({
+      id: runItem.id,
+      dataset_run_id: runItem.datasetRunId,
+      trace_id: missingTraceId,
+      dataset_item_id: itemResult.datasetItem.id,
     });
   });
 

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -1228,6 +1228,67 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
   });
 
+  it("events_only stamps when only observationId is provided", async () => {
+    const datasetId = v4();
+    await prisma.dataset.create({
+      data: { id: datasetId, name: "events-only-obs-stamp-dataset", projectId },
+    });
+    const itemResult = await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { prompt: "hello" },
+      expectedOutput: { answer: "world" },
+      validateOpts: { normalizeUndefinedToNull: true },
+    });
+    if (!itemResult.success) throw new Error(itemResult.message);
+
+    const spanId = v4();
+    const eventTraceId = v4();
+    const startTimeMs = Date.now();
+    await createEventsCh([
+      createEvent({
+        id: spanId,
+        span_id: spanId,
+        trace_id: eventTraceId,
+        project_id: projectId,
+        name: "harness-generation",
+        type: "GENERATION",
+        environment: "staging",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 25) * 1000,
+      }),
+    ]);
+
+    const runName = "events-only-obs-stamp-run";
+    const helperAuth = { scope: { projectId } } as any;
+    const runItem = await buildStableDatasetRunItemResponseEventsOnly({
+      auth: helperAuth,
+      body: {
+        datasetItemId: itemResult.datasetItem.id,
+        observationId: spanId,
+        runName,
+        runDescription: "observation-only harness",
+      } as any,
+    });
+
+    expect(runItem.traceId).toBe(eventTraceId);
+
+    const experiments = await getExperimentsFromEvents({
+      projectId,
+      filter: [],
+      limit: 1000,
+      page: 0,
+    });
+    const experiment = experiments.find((e) => e.id === runItem.datasetRunId);
+    expect(experiment).toMatchObject({
+      id: runItem.datasetRunId,
+      name: runName,
+      description: "observation-only harness",
+      datasetId,
+      itemCount: 1,
+    });
+  });
+
   it("GET /api/public/datasets/{datasetName}/runs", async () => {
     // create multiple runs
     await makeZodVerifiedAPICall(

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -35,6 +35,8 @@ import {
   createObservationsCh,
   createTrace,
   createTracesCh,
+  createEvent,
+  createEventsCh,
   createOrgProjectAndApiKey,
   getDatasetRunItemsByDatasetIdCh,
   createDatasetRunItemsCh,
@@ -43,6 +45,7 @@ import {
   createDatasetItemFilterState,
   createDatasetItem,
   getDatasetItems,
+  getExperimentsFromEvents,
 } from "@langfuse/shared/src/server";
 import waitForExpect from "wait-for-expect";
 
@@ -1162,6 +1165,67 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
         body: { datasetItemId: "does-not-exist", traceId, runName } as any,
       }),
     ).rejects.toThrow("Dataset item not found");
+  });
+
+  it("events_only stamps experiment attributes so the run appears in experiments queries", async () => {
+    const datasetId = v4();
+    await prisma.dataset.create({
+      data: { id: datasetId, name: "events-only-stamp-dataset", projectId },
+    });
+    const itemResult = await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { prompt: "hello" },
+      expectedOutput: { answer: "world" },
+      validateOpts: { normalizeUndefinedToNull: true },
+    });
+    if (!itemResult.success) throw new Error(itemResult.message);
+
+    const spanId = v4();
+    const eventTraceId = v4();
+    const startTimeMs = Date.now();
+    await createEventsCh([
+      createEvent({
+        id: spanId,
+        span_id: spanId,
+        trace_id: eventTraceId,
+        project_id: projectId,
+        name: "harness-generation",
+        type: "GENERATION",
+        environment: "staging",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 25) * 1000,
+      }),
+    ]);
+
+    const runName = "events-only-stamp-run";
+    const helperAuth = { scope: { projectId } } as any;
+    const runItem = await buildStableDatasetRunItemResponseEventsOnly({
+      auth: helperAuth,
+      body: {
+        datasetItemId: itemResult.datasetItem.id,
+        traceId: eventTraceId,
+        observationId: spanId,
+        runName,
+        runDescription: "custom harness",
+        metadata: { runner: "custom" },
+      } as any,
+    });
+
+    const experiments = await getExperimentsFromEvents({
+      projectId,
+      filter: [],
+      limit: 1000,
+      page: 0,
+    });
+    const experiment = experiments.find((e) => e.id === runItem.datasetRunId);
+    expect(experiment).toMatchObject({
+      id: runItem.datasetRunId,
+      name: runName,
+      description: "custom harness",
+      datasetId,
+      itemCount: 1,
+    });
   });
 
   it("GET /api/public/datasets/{datasetName}/runs", async () => {

--- a/web/src/__tests__/server/experiments-public-api.servertest.ts
+++ b/web/src/__tests__/server/experiments-public-api.servertest.ts
@@ -12,7 +12,15 @@ import {
   makeZodVerifiedAPICall,
 } from "@/src/__tests__/test-utils";
 import { env } from "@/src/env.mjs";
-import { GetExperimentsV1Response } from "@/src/features/public-api/types/experiments";
+import {
+  GetExperimentItemsV1Response,
+  GetExperimentsV1Response,
+} from "@/src/features/public-api/types/experiments";
+import {
+  PostDatasetItemsV1Response,
+  PostDatasetRunItemsV1Response,
+  PostDatasetsV1Response,
+} from "@/src/features/public-api/types/datasets";
 
 const getExperiments = (url: string, auth: string) =>
   makeZodVerifiedAPICall(GetExperimentsV1Response, "GET", url, undefined, auth);
@@ -381,4 +389,107 @@ describe("GET /api/public/experiment-items", () => {
 
     expect(res.status).toBe(400);
   });
+});
+
+describe("POST /api/public/dataset-run-items experiment visibility", () => {
+  maybeEventTables(
+    "makes a run created without langfuse.experiment.* span attributes visible in GET /experiments",
+    async () => {
+      const { auth, projectId } = await createOrgProjectAndApiKey();
+      const datasetName = `dataset-run-item-harness-${randomUUID()}`;
+      const runName = `harness-run-${randomUUID()}`;
+      const startTimeMs = Date.now();
+      const spanId = randomUUID();
+      const traceId = randomUUID();
+
+      const dataset = await makeZodVerifiedAPICall(
+        PostDatasetsV1Response,
+        "POST",
+        "/api/public/datasets",
+        { name: datasetName },
+        auth,
+      );
+
+      const datasetItem = await makeZodVerifiedAPICall(
+        PostDatasetItemsV1Response,
+        "POST",
+        "/api/public/dataset-items",
+        {
+          datasetName,
+          input: { prompt: "hello" },
+          expectedOutput: { answer: "world" },
+          metadata: { suite: "harness" },
+        },
+        auth,
+      );
+
+      await createEventsCh([
+        createEvent({
+          id: spanId,
+          span_id: spanId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "harness-generation",
+          type: "GENERATION",
+          environment: "default",
+          start_time: startTimeMs * 1000,
+          end_time: (startTimeMs + 50) * 1000,
+        }),
+      ]);
+
+      const runItem = await makeZodVerifiedAPICall(
+        PostDatasetRunItemsV1Response,
+        "POST",
+        "/api/public/dataset-run-items",
+        {
+          datasetItemId: datasetItem.body.id,
+          traceId,
+          observationId: spanId,
+          runName,
+          runDescription: "created by a custom eval harness",
+          metadata: { runner: "custom" },
+        },
+        auth,
+      );
+
+      const fromStartTime = new Date(startTimeMs - 1_000).toISOString();
+      const experimentsRes = await getExperiments(
+        `/api/public/experiments?fromStartTime=${encodeURIComponent(fromStartTime)}&datasetId=${dataset.body.id}`,
+        auth,
+      );
+
+      expect(experimentsRes.status).toBe(200);
+      const experiment = experimentsRes.body.data.find(
+        (item) => item.id === runItem.body.datasetRunId,
+      );
+      expect(experiment).toMatchObject({
+        id: runItem.body.datasetRunId,
+        name: runName,
+        description: "created by a custom eval harness",
+        datasetId: dataset.body.id,
+        itemCount: 1,
+      });
+
+      const itemsRes = await makeZodVerifiedAPICall(
+        GetExperimentItemsV1Response,
+        "GET",
+        `/api/public/experiment-items?fromStartTime=${encodeURIComponent(fromStartTime)}&experimentId=${runItem.body.datasetRunId}`,
+        undefined,
+        auth,
+      );
+
+      expect(itemsRes.status).toBe(200);
+      expect(itemsRes.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: spanId,
+            traceId,
+            experimentId: runItem.body.datasetRunId,
+            experimentName: runName,
+            experimentItemId: datasetItem.body.id,
+          }),
+        ]),
+      );
+    },
+  );
 });

--- a/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-repository.servertest.ts
@@ -13,6 +13,7 @@ import {
   createTraceScore,
   createDatasetRunScore,
   createScoresCh,
+  stampExperimentAttributesOnTraceEvents,
 } from "@langfuse/shared/src/server";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -38,6 +39,65 @@ describe("Clickhouse Experiment Repository Test", () => {
       });
 
       expect(count).toBe(0);
+    });
+
+    it("should list a run after stamping experiment attributes onto existing events", async () => {
+      const experimentId = randomUUID();
+      const experimentName = "harness-run-" + randomUUID();
+      const datasetId = randomUUID();
+      const itemId = randomUUID();
+      const spanId = randomUUID();
+      const traceId = randomUUID();
+      const startTime = Date.now();
+
+      await createEventsCh([
+        createEvent({
+          id: spanId,
+          span_id: spanId,
+          project_id: projectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "harness-generation",
+          environment: "default",
+          start_time: startTime * 1000,
+          end_time: (startTime + 50) * 1000,
+        }),
+      ]);
+
+      const before = await getExperimentsFromEvents({
+        projectId,
+        filter: [],
+        limit: 1000,
+        page: 0,
+      });
+      expect(before.find((e) => e.id === experimentId)).toBeUndefined();
+
+      const stamped = await stampExperimentAttributesOnTraceEvents({
+        projectId,
+        traceId,
+        rootSpanId: spanId,
+        experimentId,
+        experimentName,
+        experimentDescription: "custom eval harness",
+        experimentDatasetId: datasetId,
+        experimentItemId: itemId,
+      });
+      expect(stamped).toEqual({ stamped: true });
+
+      const after = await getExperimentsFromEvents({
+        projectId,
+        filter: [],
+        limit: 1000,
+        page: 0,
+      });
+      const experiment = after.find((e) => e.id === experimentId);
+      expect(experiment).toMatchObject({
+        id: experimentId,
+        name: experimentName,
+        description: "custom eval harness",
+        datasetId,
+        itemCount: 1,
+      });
     });
 
     it("should return experiment count and latest start time per dataset", async () => {

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -51,6 +51,7 @@ import {
   getDatasetItems,
   getDatasetItemsCount,
   getObservationById,
+  getObservationByIdFromEventsTable,
   logger,
   processEventBatch,
   stampExperimentAttributesOnTraceEvents,
@@ -849,14 +850,35 @@ export const buildStableDatasetRunItemResponseEventsOnly = async ({
   });
   const createdAt = body.createdAt ? new Date(body.createdAt) : new Date();
 
+  let traceId = body.traceId ?? "";
+  if (!traceId && body.observationId) {
+    try {
+      const observation = await getObservationByIdFromEventsTable({
+        id: body.observationId,
+        projectId,
+        fetchWithInputOutput: false,
+      });
+      traceId = observation.traceId ?? "";
+    } catch (error) {
+      if (!(error instanceof LangfuseNotFoundError)) {
+        logger.error(
+          "Failed to resolve observation for events_only dataset run item",
+          {
+            error,
+            projectId,
+            observationId: body.observationId,
+          },
+        );
+      }
+    }
+  }
+
   const datasetRunItem: APIDatasetRunItem = {
     id: v4(),
     datasetRunId: experimentId,
     datasetRunName: body.runName,
     datasetItemId: datasetItem.id,
-    // events_only skips the observation→trace lookup; echo whatever the caller
-    // provided (the body schema requires traceId or observationId).
-    traceId: body.traceId ?? "",
+    traceId,
     observationId: body.observationId ?? null,
     createdAt,
     updatedAt: createdAt,

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -53,6 +53,7 @@ import {
   getObservationById,
   logger,
   processEventBatch,
+  stampExperimentAttributesOnTraceEvents,
   type AuthHeaderValidVerificationResultIngestion,
   upsertDatasetItem,
 } from "@langfuse/shared/src/server";
@@ -158,6 +159,56 @@ const resolveMetadata = (metadata: JSONValue): Record<string, unknown> => {
     return metadata as Record<string, unknown>;
   }
   return { metadata };
+};
+
+const stampExperimentAttributesOnTraceEventsFromRunItem = async ({
+  projectId,
+  traceId,
+  observationId,
+  experimentId,
+  experimentName,
+  experimentDescription,
+  experimentMetadata,
+  datasetItem,
+}: {
+  projectId: string;
+  traceId: string;
+  observationId?: string | null;
+  experimentId: string;
+  experimentName: string;
+  experimentDescription?: string | null;
+  experimentMetadata?: unknown;
+  datasetItem: {
+    id: string;
+    datasetId: string;
+    validFrom: Date;
+    expectedOutput?: unknown;
+    metadata?: unknown;
+  };
+}) => {
+  try {
+    await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId,
+      rootSpanId: observationId,
+      experimentId,
+      experimentName,
+      experimentDescription,
+      experimentDatasetId: datasetItem.datasetId,
+      experimentItemId: datasetItem.id,
+      experimentItemVersion: datasetItem.validFrom,
+      experimentItemExpectedOutput: datasetItem.expectedOutput,
+      experimentMetadata,
+      experimentItemMetadata: datasetItem.metadata,
+    });
+  } catch (error) {
+    logger.error("Failed to stamp experiment attributes onto events", {
+      error,
+      projectId,
+      traceId,
+      experimentId,
+    });
+  }
 };
 
 const getDatasetByNameOrThrow = async ({
@@ -758,15 +809,15 @@ export const createStableExperimentId = ({
 /**
  * events_only deployments no longer write dataset run items into the legacy
  * dataset_run_items ClickHouse table, so the full createDatasetRunItemForApi
- * flow has nothing to persist. The experiment runner still calls POST
+ * flow has nothing to persist there. The experiment runner still calls POST
  * /dataset-run-items per item and expects a dataset run id it can reuse as the
  * experiment id across the whole run, so we resolve the item's dataset and
  * return a stable experiment id derived from (projectId, datasetId, runName).
  *
- * In v4 the trace ↔ experiment link is established through OTel experiment span
- * attributes instead, so beyond the dataset-item lookup (needed for datasetId
- * and to 404 on genuinely missing items) we skip every legacy side effect:
- * the observation→trace lookup, ClickHouse ingestion, and the eval enqueue.
+ * The trace ↔ experiment link is written onto existing events_full rows by
+ * stamping experiment_* columns. Beyond the dataset-item lookup we skip the
+ * observation→trace lookup, ClickHouse dataset_run_items ingest, and the eval
+ * enqueue.
  */
 export const buildStableDatasetRunItemResponseEventsOnly = async ({
   body,
@@ -810,6 +861,19 @@ export const buildStableDatasetRunItemResponseEventsOnly = async ({
     createdAt,
     updatedAt: createdAt,
   };
+
+  if (datasetRunItem.traceId) {
+    await stampExperimentAttributesOnTraceEventsFromRunItem({
+      projectId,
+      traceId: datasetRunItem.traceId,
+      observationId: body.observationId,
+      experimentId,
+      experimentName: body.runName,
+      experimentDescription: body.runDescription,
+      experimentMetadata: body.metadata,
+      datasetItem,
+    });
+  }
 
   return datasetRunItem;
 };
@@ -948,6 +1012,17 @@ export const createDatasetRunItemForApi = async ({
     datasetItemValidFrom: datasetItem.validFrom,
     traceId: finalTraceId,
     observationId: observationId ?? undefined,
+  });
+
+  await stampExperimentAttributesOnTraceEventsFromRunItem({
+    projectId,
+    traceId: finalTraceId,
+    observationId,
+    experimentId: run.id,
+    experimentName: run.name,
+    experimentDescription: run.description,
+    experimentMetadata: metadata,
+    datasetItem,
   });
 
   return PostDatasetRunItemsV1Response.parse(datasetRunItem);

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -52,6 +52,7 @@ import {
   getDatasetItemsCount,
   getObservationById,
   getObservationByIdFromEventsTable,
+  insertDatasetRunItems,
   logger,
   processEventBatch,
   stampExperimentAttributesOnTraceEvents,
@@ -162,6 +163,28 @@ const resolveMetadata = (metadata: JSONValue): Record<string, unknown> => {
   return { metadata };
 };
 
+const toMetadataStringRecord = (value: unknown): Record<string, string> => {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return { metadata: String(value) };
+  }
+  if (Array.isArray(value)) {
+    return { metadata: JSON.stringify(value) };
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        typeof entry === "string" ? entry : JSON.stringify(entry ?? null),
+      ]),
+    );
+  }
+  return {};
+};
+
 const stampExperimentAttributesOnTraceEventsFromRunItem = async ({
   projectId,
   traceId,
@@ -186,9 +209,9 @@ const stampExperimentAttributesOnTraceEventsFromRunItem = async ({
     expectedOutput?: unknown;
     metadata?: unknown;
   };
-}) => {
+}): Promise<boolean> => {
   try {
-    await stampExperimentAttributesOnTraceEvents({
+    const { stamped } = await stampExperimentAttributesOnTraceEvents({
       projectId,
       traceId,
       rootSpanId: observationId,
@@ -202,8 +225,78 @@ const stampExperimentAttributesOnTraceEventsFromRunItem = async ({
       experimentMetadata,
       experimentItemMetadata: datasetItem.metadata,
     });
+    return stamped;
   } catch (error) {
     logger.error("Failed to stamp experiment attributes onto events", {
+      error,
+      projectId,
+      traceId,
+      experimentId,
+    });
+    return false;
+  }
+};
+
+const persistDatasetRunItemForCatchUp = async ({
+  id,
+  projectId,
+  traceId,
+  observationId,
+  experimentId,
+  experimentName,
+  experimentDescription,
+  experimentMetadata,
+  datasetItem,
+  createdAt,
+}: {
+  id: string;
+  projectId: string;
+  traceId: string;
+  observationId?: string | null;
+  experimentId: string;
+  experimentName: string;
+  experimentDescription?: string | null;
+  experimentMetadata?: unknown;
+  datasetItem: {
+    id: string;
+    datasetId: string;
+    validFrom: Date;
+    input?: unknown;
+    expectedOutput?: unknown;
+    metadata?: unknown;
+  };
+  createdAt: Date;
+}) => {
+  const timestamp = createdAt.getTime();
+  try {
+    await insertDatasetRunItems([
+      {
+        id,
+        project_id: projectId,
+        dataset_run_id: experimentId,
+        dataset_item_id: datasetItem.id,
+        dataset_id: datasetItem.datasetId,
+        trace_id: traceId,
+        observation_id: observationId ?? null,
+        error: null,
+        created_at: timestamp,
+        updated_at: timestamp,
+        event_ts: timestamp,
+        is_deleted: 0,
+        dataset_run_name: experimentName,
+        dataset_run_description: experimentDescription ?? null,
+        dataset_run_metadata: toMetadataStringRecord(experimentMetadata),
+        dataset_run_created_at: timestamp,
+        dataset_item_version: datasetItem.validFrom.getTime(),
+        dataset_item_input: JSON.stringify(datasetItem.input ?? null),
+        dataset_item_expected_output: JSON.stringify(
+          datasetItem.expectedOutput ?? null,
+        ),
+        dataset_item_metadata: toMetadataStringRecord(datasetItem.metadata),
+      },
+    ]);
+  } catch (error) {
+    logger.error("Failed to persist dataset run item for experiment catch-up", {
       error,
       projectId,
       traceId,
@@ -816,9 +909,11 @@ export const createStableExperimentId = ({
  * return a stable experiment id derived from (projectId, datasetId, runName).
  *
  * The trace ↔ experiment link is written onto existing events_full rows by
- * stamping experiment_* columns. Beyond the dataset-item lookup we skip the
- * observation→trace lookup, ClickHouse dataset_run_items ingest, and the eval
- * enqueue.
+ * stamping experiment_* columns. If that stamp cannot complete (events not
+ * in events_full yet, or ClickHouse error), a dataset_run_items_rmt row is
+ * persisted so worker catch-up can retry once events exist. Postgres dataset
+ * runs, eval enqueue, and observation→trace lookup via the routing wrapper
+ * are still skipped.
  */
 export const buildStableDatasetRunItemResponseEventsOnly = async ({
   body,
@@ -885,7 +980,7 @@ export const buildStableDatasetRunItemResponseEventsOnly = async ({
   };
 
   if (datasetRunItem.traceId) {
-    await stampExperimentAttributesOnTraceEventsFromRunItem({
+    const stamped = await stampExperimentAttributesOnTraceEventsFromRunItem({
       projectId,
       traceId: datasetRunItem.traceId,
       observationId: body.observationId,
@@ -895,6 +990,20 @@ export const buildStableDatasetRunItemResponseEventsOnly = async ({
       experimentMetadata: body.metadata,
       datasetItem,
     });
+    if (!stamped) {
+      await persistDatasetRunItemForCatchUp({
+        id: datasetRunItem.id,
+        projectId,
+        traceId: datasetRunItem.traceId,
+        observationId: body.observationId,
+        experimentId,
+        experimentName: body.runName,
+        experimentDescription: body.runDescription,
+        experimentMetadata: body.metadata,
+        datasetItem,
+        createdAt,
+      });
+    }
   }
 
   return datasetRunItem;

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -22,10 +22,9 @@ export default withMiddlewares({
     rateLimitResource: "datasets",
     // Writes a dataset-run-item event into the legacy dataset_run_items
     // ClickHouse table. events_only deployments no longer populate that table,
-    // so instead of writing anything we return a stable experiment id (== the
+    // so instead of writing a DRI we return a stable experiment id (== the
     // dataset run id) derived deterministically from (projectId, datasetId,
-    // runName). The trace ↔ experiment link is established through OTel
-    // experiment span attributes on ingestion instead.
+    // runName) and stamp experiment_* columns onto the linked trace's events.
     fn: async ({ body, auth, res }) => {
       if (env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only") {
         return await buildStableDatasetRunItemResponseEventsOnly({

--- a/worker/src/__tests__/experimentBackfillCatchUp.test.ts
+++ b/worker/src/__tests__/experimentBackfillCatchUp.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type TestContext,
+} from "vitest";
+import {
+  createDatasetRunItem,
+  createDatasetRunItemsCh,
+  createEvent,
+  createEventsCh,
+  createOrgProjectAndApiKey,
+  queryClickhouse,
+  redis,
+} from "@langfuse/shared/src/server";
+import {
+  EXPERIMENT_CATCH_UP_CURSOR_KEY,
+  getUnenrichedDatasetRunItemsBeforeCursor,
+  stampUnenrichedDatasetRunItemsBeforeCursor,
+} from "../features/eventPropagation/handleExperimentBackfill";
+import { skipUnlessClickhouseTablesExist } from "./helpers/clickhouseTables";
+
+describe("experiment backfill catch-up", () => {
+  beforeEach(async () => {
+    if (!redis) throw new Error("Redis not initialized");
+    await redis.del(EXPERIMENT_CATCH_UP_CURSOR_KEY);
+  });
+
+  afterEach(async () => {
+    await redis?.del(EXPERIMENT_CATCH_UP_CURSOR_KEY);
+  });
+
+  it("advances past unstampable rows so later experiments are still enriched", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, [
+      "events_full",
+      "events_core",
+      "dataset_run_items_rmt",
+    ]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+    const lastRun = new Date();
+    // Sit just after the 90-day lookback so these rows are the oldest in the
+    // catch-up window and win ORDER BY created_at ASC against leftover test data.
+    const lookbackStartMs = lastRun.getTime() - 90 * 24 * 60 * 60 * 1000;
+    const poisonCreatedAt = lookbackStartMs + 60_000;
+    const goodCreatedAt = poisonCreatedAt + 60_000;
+
+    const poisonTraceId = randomUUID();
+    const poisonPresentSpanId = randomUUID();
+    const missingObservationId = randomUUID();
+    const goodTraceId = randomUUID();
+    const goodSpanId = randomUUID();
+    const poisonDriId = randomUUID();
+    const goodDriId = randomUUID();
+    const goodExperimentId = randomUUID();
+    const startTimeMs = Date.now();
+
+    await createEventsCh([
+      createEvent({
+        id: poisonPresentSpanId,
+        span_id: poisonPresentSpanId,
+        trace_id: poisonTraceId,
+        project_id: projectId,
+        name: "unrelated-span",
+        type: "SPAN",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 10) * 1000,
+      }),
+      createEvent({
+        id: goodSpanId,
+        span_id: goodSpanId,
+        trace_id: goodTraceId,
+        project_id: projectId,
+        name: "good-item",
+        type: "GENERATION",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 20) * 1000,
+      }),
+    ]);
+
+    await createDatasetRunItemsCh([
+      createDatasetRunItem({
+        id: poisonDriId,
+        project_id: projectId,
+        trace_id: poisonTraceId,
+        observation_id: missingObservationId,
+        dataset_run_id: randomUUID(),
+        dataset_item_id: randomUUID(),
+        created_at: poisonCreatedAt,
+      }),
+      createDatasetRunItem({
+        id: goodDriId,
+        project_id: projectId,
+        trace_id: goodTraceId,
+        observation_id: goodSpanId,
+        dataset_run_id: goodExperimentId,
+        dataset_item_id: randomUUID(),
+        created_at: goodCreatedAt,
+      }),
+    ]);
+
+    const before = await getUnenrichedDatasetRunItemsBeforeCursor(lastRun, 10);
+    expect(before.map((row) => row.id)).toEqual(
+      expect.arrayContaining([poisonDriId, goodDriId]),
+    );
+    expect(before.find((row) => row.id === goodDriId)).toMatchObject({
+      project_id: projectId,
+      trace_id: goodTraceId,
+      observation_id: goodSpanId,
+    });
+    expect(
+      before.find((row) => row.id === poisonDriId)?.created_at,
+    ).toBeTruthy();
+
+    await stampUnenrichedDatasetRunItemsBeforeCursor(lastRun);
+
+    const remaining = await getUnenrichedDatasetRunItemsBeforeCursor(
+      lastRun,
+      10,
+    );
+    expect(remaining.map((row) => row.id)).not.toContain(poisonDriId);
+
+    const rows = await queryClickhouse<{
+      span_id: string;
+      experiment_id: string;
+    }>({
+      query: `
+        SELECT span_id, experiment_id
+        FROM events_full
+        WHERE project_id = {projectId: String}
+          AND span_id = {spanId: String}
+          AND is_deleted = 0
+        ORDER BY event_ts DESC
+        LIMIT 1
+      `,
+      params: { projectId, spanId: goodSpanId },
+    });
+    expect(rows[0]?.experiment_id).toBe(goodExperimentId);
+  });
+});

--- a/worker/src/__tests__/experimentBackfillCatchUp.test.ts
+++ b/worker/src/__tests__/experimentBackfillCatchUp.test.ts
@@ -6,6 +6,7 @@ import {
   expect,
   it,
   type TestContext,
+  vi,
 } from "vitest";
 import {
   createDatasetRunItem,
@@ -15,7 +16,19 @@ import {
   createOrgProjectAndApiKey,
   queryClickhouse,
   redis,
+  stampExperimentAttributesOnTraceEvents,
 } from "@langfuse/shared/src/server";
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return {
+    ...actual,
+    stampExperimentAttributesOnTraceEvents: vi.fn((input) =>
+      actual.stampExperimentAttributesOnTraceEvents(input),
+    ),
+  };
+});
 import {
   EXPERIMENT_CATCH_UP_CURSOR_KEY,
   getUnenrichedDatasetRunItemsBeforeCursor,
@@ -139,5 +152,106 @@ describe("experiment backfill catch-up", () => {
       params: { projectId, spanId: goodSpanId },
     });
     expect(rows[0]?.experiment_id).toBe(goodExperimentId);
+  });
+
+  it("does not advance the catch-up cursor past a dataset run item whose stamp throws", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, [
+      "events_full",
+      "events_core",
+      "dataset_run_items_rmt",
+    ]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+    const lastRun = new Date();
+    const lookbackStartMs = lastRun.getTime() - 90 * 24 * 60 * 60 * 1000;
+    const throwCreatedAt = lookbackStartMs + 60_000;
+    const laterCreatedAt = throwCreatedAt + 60_000;
+
+    const throwTraceId = randomUUID();
+    const throwSpanId = randomUUID();
+    const laterTraceId = randomUUID();
+    const laterSpanId = randomUUID();
+    const throwDriId = randomUUID();
+    const laterDriId = randomUUID();
+    const throwExperimentId = randomUUID();
+    const laterExperimentId = randomUUID();
+    const startTimeMs = Date.now();
+
+    vi.mocked(stampExperimentAttributesOnTraceEvents).mockImplementation(
+      async (input) => {
+        if (input.experimentId === throwExperimentId) {
+          throw new Error("simulated clickhouse failure");
+        }
+        const { stampExperimentAttributesOnTraceEvents: actualStamp } =
+          await vi.importActual<typeof import("@langfuse/shared/src/server")>(
+            "@langfuse/shared/src/server",
+          );
+        return actualStamp(input);
+      },
+    );
+
+    try {
+      await createEventsCh([
+        createEvent({
+          id: throwSpanId,
+          span_id: throwSpanId,
+          trace_id: throwTraceId,
+          project_id: projectId,
+          name: "throw-item",
+          type: "GENERATION",
+          start_time: startTimeMs * 1000,
+          end_time: (startTimeMs + 10) * 1000,
+        }),
+        createEvent({
+          id: laterSpanId,
+          span_id: laterSpanId,
+          trace_id: laterTraceId,
+          project_id: projectId,
+          name: "later-item",
+          type: "GENERATION",
+          start_time: startTimeMs * 1000,
+          end_time: (startTimeMs + 20) * 1000,
+        }),
+      ]);
+
+      await createDatasetRunItemsCh([
+        createDatasetRunItem({
+          id: throwDriId,
+          project_id: projectId,
+          trace_id: throwTraceId,
+          observation_id: throwSpanId,
+          dataset_run_id: throwExperimentId,
+          dataset_item_id: randomUUID(),
+          created_at: throwCreatedAt,
+        }),
+        createDatasetRunItem({
+          id: laterDriId,
+          project_id: projectId,
+          trace_id: laterTraceId,
+          observation_id: laterSpanId,
+          dataset_run_id: laterExperimentId,
+          dataset_item_id: randomUUID(),
+          created_at: laterCreatedAt,
+        }),
+      ]);
+
+      await stampUnenrichedDatasetRunItemsBeforeCursor(lastRun);
+
+      const remaining = await getUnenrichedDatasetRunItemsBeforeCursor(
+        lastRun,
+        10,
+      );
+      expect(remaining.map((row) => row.id)).toContain(throwDriId);
+    } finally {
+      vi.mocked(stampExperimentAttributesOnTraceEvents).mockImplementation(
+        async (input) => {
+          const { stampExperimentAttributesOnTraceEvents: actualStamp } =
+            await vi.importActual<typeof import("@langfuse/shared/src/server")>(
+              "@langfuse/shared/src/server",
+            );
+          return actualStamp(input);
+        },
+      );
+    }
   });
 });

--- a/worker/src/__tests__/experimentEventEnrichment.test.ts
+++ b/worker/src/__tests__/experimentEventEnrichment.test.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, type TestContext } from "vitest";
+import {
+  createEvent,
+  createEventsCh,
+  createOrgProjectAndApiKey,
+  queryClickhouse,
+  stampExperimentAttributesOnTraceEvents,
+} from "@langfuse/shared/src/server";
+import { skipUnlessClickhouseTablesExist } from "./helpers/clickhouseTables";
+
+describe("stampExperimentAttributesOnTraceEvents", () => {
+  it("stamps experiment columns onto events that were ingested without them", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, ["events_full", "events_core"]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+    const spanId = randomUUID();
+    const childSpanId = randomUUID();
+    const traceId = randomUUID();
+    const experimentId = randomUUID();
+    const experimentItemId = randomUUID();
+    const startTimeMs = Date.now();
+
+    await createEventsCh([
+      createEvent({
+        id: spanId,
+        span_id: spanId,
+        parent_span_id: "",
+        trace_id: traceId,
+        project_id: projectId,
+        name: "harness-root",
+        type: "SPAN",
+        environment: "production",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 80) * 1000,
+      }),
+      createEvent({
+        id: childSpanId,
+        span_id: childSpanId,
+        parent_span_id: spanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "harness-child",
+        type: "GENERATION",
+        environment: "production",
+        start_time: (startTimeMs + 10) * 1000,
+        end_time: (startTimeMs + 70) * 1000,
+      }),
+    ]);
+
+    const result = await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId,
+      rootSpanId: spanId,
+      experimentId,
+      experimentName: "harness-run",
+      experimentDescription: "custom eval harness",
+      experimentDatasetId: "dataset-1",
+      experimentItemId,
+      experimentItemExpectedOutput: { answer: 42 },
+      experimentMetadata: { runner: "custom" },
+      experimentItemMetadata: { case: "n1" },
+    });
+
+    expect(result).toEqual({ stamped: true });
+
+    const rows = await queryClickhouse<{
+      span_id: string;
+      experiment_id: string;
+      experiment_name: string;
+      experiment_description: string;
+      experiment_dataset_id: string;
+      experiment_item_id: string;
+      experiment_item_root_span_id: string;
+      experiment_item_expected_output: string;
+      environment: string;
+    }>({
+      query: `
+        SELECT
+          span_id,
+          experiment_id,
+          experiment_name,
+          experiment_description,
+          experiment_dataset_id,
+          experiment_item_id,
+          experiment_item_root_span_id,
+          experiment_item_expected_output,
+          environment
+        FROM events_full
+        WHERE project_id = {projectId: String}
+          AND trace_id = {traceId: String}
+          AND is_deleted = 0
+        ORDER BY event_ts DESC
+        LIMIT 1 BY span_id
+      `,
+      params: { projectId, traceId },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          span_id: spanId,
+          experiment_id: experimentId,
+          experiment_name: "harness-run",
+          experiment_description: "custom eval harness",
+          experiment_dataset_id: "dataset-1",
+          experiment_item_id: experimentItemId,
+          experiment_item_root_span_id: spanId,
+          experiment_item_expected_output: JSON.stringify({ answer: 42 }),
+          environment: "production",
+        }),
+        expect.objectContaining({
+          span_id: childSpanId,
+          experiment_id: experimentId,
+          experiment_item_root_span_id: spanId,
+          environment: "production",
+        }),
+      ]),
+    );
+  });
+
+  it("returns stamped false when the trace has no events", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, ["events_full"]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const result = await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId: randomUUID(),
+      experimentId: randomUUID(),
+      experimentName: "missing-trace",
+      experimentDatasetId: "dataset-1",
+      experimentItemId: randomUUID(),
+    });
+
+    expect(result).toEqual({ stamped: false });
+  });
+});

--- a/worker/src/__tests__/experimentEventEnrichment.test.ts
+++ b/worker/src/__tests__/experimentEventEnrichment.test.ts
@@ -136,4 +136,164 @@ describe("stampExperimentAttributesOnTraceEvents", () => {
 
     expect(result).toEqual({ stamped: false });
   });
+
+  it("returns stamped false when the linked observation span is missing", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, ["events_full"]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+    const traceId = randomUUID();
+    const presentSpanId = randomUUID();
+    const startTimeMs = Date.now();
+
+    await createEventsCh([
+      createEvent({
+        id: presentSpanId,
+        span_id: presentSpanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "present",
+        type: "SPAN",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 10) * 1000,
+      }),
+    ]);
+
+    const result = await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId,
+      rootSpanId: randomUUID(),
+      experimentId: randomUUID(),
+      experimentName: "missing-observation",
+      experimentDatasetId: "dataset-1",
+      experimentItemId: randomUUID(),
+    });
+
+    expect(result).toEqual({ stamped: false });
+  });
+
+  it("stamps only the linked observation subtree so sibling items keep their identity", async (ctx: TestContext) => {
+    await skipUnlessClickhouseTablesExist(ctx, ["events_full"]);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+    const traceId = randomUUID();
+    const rootSpanId = randomUUID();
+    const itemASpanId = randomUUID();
+    const itemAChildId = randomUUID();
+    const itemBSpanId = randomUUID();
+    const experimentA = randomUUID();
+    const experimentItemA = randomUUID();
+    const experimentB = randomUUID();
+    const experimentItemB = randomUUID();
+    const startTimeMs = Date.now();
+
+    await createEventsCh([
+      createEvent({
+        id: rootSpanId,
+        span_id: rootSpanId,
+        parent_span_id: "",
+        trace_id: traceId,
+        project_id: projectId,
+        name: "trace-root",
+        type: "SPAN",
+        start_time: startTimeMs * 1000,
+        end_time: (startTimeMs + 100) * 1000,
+      }),
+      createEvent({
+        id: itemASpanId,
+        span_id: itemASpanId,
+        parent_span_id: rootSpanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "item-a",
+        type: "SPAN",
+        start_time: (startTimeMs + 1) * 1000,
+        end_time: (startTimeMs + 40) * 1000,
+      }),
+      createEvent({
+        id: itemAChildId,
+        span_id: itemAChildId,
+        parent_span_id: itemASpanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "item-a-child",
+        type: "GENERATION",
+        start_time: (startTimeMs + 2) * 1000,
+        end_time: (startTimeMs + 30) * 1000,
+      }),
+      createEvent({
+        id: itemBSpanId,
+        span_id: itemBSpanId,
+        parent_span_id: rootSpanId,
+        trace_id: traceId,
+        project_id: projectId,
+        name: "item-b",
+        type: "GENERATION",
+        start_time: (startTimeMs + 50) * 1000,
+        end_time: (startTimeMs + 90) * 1000,
+      }),
+    ]);
+
+    await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId,
+      rootSpanId: itemASpanId,
+      experimentId: experimentA,
+      experimentName: "run-a",
+      experimentDatasetId: "dataset-1",
+      experimentItemId: experimentItemA,
+    });
+    await stampExperimentAttributesOnTraceEvents({
+      projectId,
+      traceId,
+      rootSpanId: itemBSpanId,
+      experimentId: experimentB,
+      experimentName: "run-b",
+      experimentDatasetId: "dataset-1",
+      experimentItemId: experimentItemB,
+    });
+
+    const rows = await queryClickhouse<{
+      span_id: string;
+      experiment_id: string;
+      experiment_item_id: string;
+      experiment_item_root_span_id: string;
+    }>({
+      query: `
+        SELECT
+          span_id,
+          experiment_id,
+          experiment_item_id,
+          experiment_item_root_span_id
+        FROM events_full
+        WHERE project_id = {projectId: String}
+          AND trace_id = {traceId: String}
+          AND is_deleted = 0
+        ORDER BY event_ts DESC
+        LIMIT 1 BY span_id
+      `,
+      params: { projectId, traceId },
+    });
+
+    const bySpan = Object.fromEntries(rows.map((row) => [row.span_id, row]));
+    expect(bySpan[itemASpanId]).toMatchObject({
+      experiment_id: experimentA,
+      experiment_item_id: experimentItemA,
+      experiment_item_root_span_id: itemASpanId,
+    });
+    expect(bySpan[itemAChildId]).toMatchObject({
+      experiment_id: experimentA,
+      experiment_item_id: experimentItemA,
+      experiment_item_root_span_id: itemASpanId,
+    });
+    expect(bySpan[itemBSpanId]).toMatchObject({
+      experiment_id: experimentB,
+      experiment_item_id: experimentItemB,
+      experiment_item_root_span_id: itemBSpanId,
+    });
+    expect(bySpan[rootSpanId]).toMatchObject({
+      experiment_id: "",
+      experiment_item_id: "",
+      experiment_item_root_span_id: "",
+    });
+  });
 });

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -14,8 +14,25 @@ import { ClickhouseWriter, TableName } from "../../services/ClickhouseWriter";
 import { chunk } from "lodash";
 import { updateLastRunStartedAt } from "./handleEventPropagationJob";
 
+const DATASET_RUN_ITEM_SELECT = `
+      dri.id AS id,
+      dri.project_id AS project_id,
+      dri.trace_id AS trace_id,
+      dri.observation_id AS observation_id,
+      dri.dataset_run_id AS dataset_run_id,
+      dri.dataset_run_name AS dataset_run_name,
+      dri.dataset_run_description AS dataset_run_description,
+      dri.dataset_run_metadata AS dataset_run_metadata,
+      dri.dataset_id AS dataset_id,
+      dri.dataset_item_version AS dataset_item_version,
+      dri.dataset_item_id AS dataset_item_id,
+      dri.dataset_item_expected_output AS dataset_item_expected_output,
+      dri.dataset_item_metadata AS dataset_item_metadata,
+      toString(dri.created_at) AS created_at`;
 const EXPERIMENT_BACKFILL_TIMESTAMP_KEY =
   "langfuse:event-propagation:experiment-backfill:last-run";
+export const EXPERIMENT_CATCH_UP_CURSOR_KEY =
+  "langfuse:event-propagation:experiment-backfill:catch-up-cursor";
 const EXPERIMENT_BACKFILL_LOCK_KEY = "langfuse:experiment-backfill:lock";
 const LOCK_TTL_SECONDS = 300; // 5 minutes
 const UNENRICHED_EVENTS_LOOKBACK_DAYS = 90;
@@ -134,27 +151,19 @@ async function getDatasetRunItemsSinceLastRun(
     )
 
     SELECT
-      dri.id,
-      dri.project_id,
-      dri.trace_id,
-      dri.observation_id,
-      dri.dataset_run_id,
-      dri.dataset_run_name,
-      dri.dataset_run_description,
-      dri.dataset_run_metadata,
-      dri.dataset_id,
-      dri.dataset_item_version,
-      dri.dataset_item_id,
-      dri.dataset_item_expected_output,
-      dri.dataset_item_metadata,
-      dri.created_at
+      ${DATASET_RUN_ITEM_SELECT}
     FROM dataset_run_items_rmt AS dri
-    -- Traces already in events_core still need a stamp when experiment_id is
-    -- empty (dataset-run-item created without langfuse.experiment.* attributes).
+    -- Observation-level DRIs are enriched when that span is stamped; a sibling
+    -- item on the same trace must still be picked up. Trace-level DRIs are
+    -- enriched when any span on the trace has experiment_id.
     LEFT ANTI JOIN events_core AS ec
       ON dri.project_id = ec.project_id
       AND dri.trace_id = ec.trace_id
       AND ec.experiment_id != ''
+      AND (
+        coalesce(dri.observation_id, '') = ''
+        OR ec.span_id = dri.observation_id
+      )
     WHERE dri.created_at > {lastRun: DateTime64(3)}
       AND dri.created_at <= {upperBound: DateTime64(3)}
       AND (dri.project_id, dri.trace_id) IN (SELECT project_id, trace_id FROM candidate_dris)
@@ -180,35 +189,80 @@ async function getDatasetRunItemsSinceLastRun(
   return rows;
 }
 
+type CatchUpCursor = { createdAt: string; id: string };
+
+const readCatchUpCursor = async (): Promise<CatchUpCursor | null> => {
+  if (!redis) {
+    return null;
+  }
+  const raw = await redis.get(EXPERIMENT_CATCH_UP_CURSOR_KEY);
+  if (!raw) {
+    return null;
+  }
+  const sep = raw.indexOf("|");
+  if (sep <= 0 || sep === raw.length - 1) {
+    return null;
+  }
+  return { createdAt: raw.slice(0, sep), id: raw.slice(sep + 1) };
+};
+
+const toCatchUpCursorDateTime = (value: string | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/.test(value)) {
+    return value;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return convertDateToClickhouseDateTime(parsed);
+};
+
+const writeCatchUpCursor = async (item: DatasetRunItem): Promise<void> => {
+  if (!redis) {
+    logger.warn(
+      "[EXPERIMENT BACKFILL] Redis not available, cannot advance catch-up cursor",
+    );
+    return;
+  }
+  const createdAt = toCatchUpCursorDateTime(item.created_at);
+  if (!createdAt) {
+    logger.error(
+      "[EXPERIMENT BACKFILL] Cannot advance catch-up cursor without created_at",
+      { id: item.id },
+    );
+    return;
+  }
+  try {
+    await redis.set(EXPERIMENT_CATCH_UP_CURSOR_KEY, `${createdAt}|${item.id}`);
+  } catch (error) {
+    logger.error(
+      "[EXPERIMENT BACKFILL] Failed to update catch-up cursor",
+      error,
+    );
+  }
+};
+
 /**
  * Dataset-run-items older than the incremental cursor whose traces exist in
  * events_core without experiment_id. Those traces are already ingested, so the
  * observations-copy path never sees them.
  */
-async function getUnenrichedDatasetRunItemsBeforeCursor(
+export async function getUnenrichedDatasetRunItemsBeforeCursor(
   lastRun: Date,
   limit: number,
 ): Promise<DatasetRunItem[]> {
   const lookbackStart = new Date(
     lastRun.getTime() - UNENRICHED_EVENTS_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
   );
+  const cursor = await readCatchUpCursor();
+  const lookbackStartCh = convertDateToClickhouseDateTime(lookbackStart);
 
   const query = `
     SELECT
-      dri.id,
-      dri.project_id,
-      dri.trace_id,
-      dri.observation_id,
-      dri.dataset_run_id,
-      dri.dataset_run_name,
-      dri.dataset_run_description,
-      dri.dataset_run_metadata,
-      dri.dataset_id,
-      dri.dataset_item_version,
-      dri.dataset_item_id,
-      dri.dataset_item_expected_output,
-      dri.dataset_item_metadata,
-      dri.created_at
+      ${DATASET_RUN_ITEM_SELECT}
     FROM dataset_run_items_rmt AS dri
     LEFT SEMI JOIN events_core AS present
       ON present.project_id = dri.project_id
@@ -217,9 +271,17 @@ async function getUnenrichedDatasetRunItemsBeforeCursor(
       ON enriched.project_id = dri.project_id
       AND enriched.trace_id = dri.trace_id
       AND enriched.experiment_id != ''
+      AND (
+        coalesce(dri.observation_id, '') = ''
+        OR enriched.span_id = dri.observation_id
+      )
     WHERE dri.created_at > {lookbackStart: DateTime64(3)}
       AND dri.created_at <= {lastRun: DateTime64(3)}
-    ORDER BY dri.created_at ASC
+      AND (
+        {hasCursor: UInt8} = 0
+        OR (dri.created_at, dri.id) > ({cursorAt: DateTime64(3)}, {cursorId: String})
+      )
+    ORDER BY dri.created_at ASC, dri.id ASC
     LIMIT 1 BY dri.project_id, dri.trace_id, coalesce(dri.observation_id, '')
     LIMIT {limit: UInt32}
   `;
@@ -227,8 +289,11 @@ async function getUnenrichedDatasetRunItemsBeforeCursor(
   const rows = await queryClickhouse<DatasetRunItem>({
     query,
     params: {
-      lookbackStart: convertDateToClickhouseDateTime(lookbackStart),
+      lookbackStart: lookbackStartCh,
       lastRun: convertDateToClickhouseDateTime(lastRun),
+      hasCursor: cursor ? 1 : 0,
+      cursorAt: cursor?.createdAt ?? lookbackStartCh,
+      cursorId: cursor?.id ?? "",
       limit,
     },
     clickhouseConfigs: {
@@ -249,7 +314,7 @@ const stampDatasetRunItemOntoEvents = async (
   const { stamped } = await stampExperimentAttributesOnTraceEvents({
     projectId: dri.project_id,
     traceId: dri.trace_id,
-    rootSpanId: dri.observation_id,
+    rootSpanId: dri.observation_id || null,
     experimentId: dri.dataset_run_id,
     experimentName: dri.dataset_run_name,
     experimentDescription: dri.dataset_run_description,
@@ -265,38 +330,52 @@ const stampDatasetRunItemOntoEvents = async (
   return stamped;
 };
 
-const stampUnenrichedDatasetRunItemsBeforeCursor = async (
+export const stampUnenrichedDatasetRunItemsBeforeCursor = async (
   lastRun: Date,
 ): Promise<void> => {
   const excludeProjectIds =
     env.LANGFUSE_EXPERIMENT_BACKFILL_EXCLUDE_PROJECT_IDS;
-  const catchUpItems = await getUnenrichedDatasetRunItemsBeforeCursor(
-    lastRun,
-    env.LANGFUSE_DATASET_RUN_BACKFILL_CHUNK_SIZE,
-  );
-  const toStamp =
-    excludeProjectIds && excludeProjectIds.length > 0
-      ? catchUpItems.filter(
-          (dri) => !excludeProjectIds.includes(dri.project_id),
-        )
-      : catchUpItems;
+  const chunkSize = env.LANGFUSE_DATASET_RUN_BACKFILL_CHUNK_SIZE;
 
-  if (toStamp.length === 0) {
-    return;
-  }
+  while (true) {
+    const catchUpItems = await getUnenrichedDatasetRunItemsBeforeCursor(
+      lastRun,
+      chunkSize,
+    );
+    if (catchUpItems.length === 0) {
+      return;
+    }
 
-  logger.info(
-    `[EXPERIMENT BACKFILL] Stamping ${toStamp.length} historically skipped dataset run items`,
-  );
+    const toStamp =
+      excludeProjectIds && excludeProjectIds.length > 0
+        ? catchUpItems.filter(
+            (dri) => !excludeProjectIds.includes(dri.project_id),
+          )
+        : catchUpItems;
 
-  for (const dri of toStamp) {
-    try {
-      await stampDatasetRunItemOntoEvents(dri);
-    } catch (error) {
-      logger.error(
-        `[EXPERIMENT BACKFILL] Failed to stamp historically skipped DRI ${dri.id}`,
-        error,
+    if (toStamp.length > 0) {
+      logger.info(
+        `[EXPERIMENT BACKFILL] Stamping ${toStamp.length} historically skipped dataset run items`,
       );
+
+      for (const dri of toStamp) {
+        try {
+          await stampDatasetRunItemOntoEvents(dri);
+        } catch (error) {
+          logger.error(
+            `[EXPERIMENT BACKFILL] Failed to stamp historically skipped DRI ${dri.id}`,
+            error,
+          );
+        }
+      }
+    }
+
+    const lastItem = catchUpItems[catchUpItems.length - 1];
+    await writeCatchUpCursor(lastItem);
+    await updateLastRunStartedAt();
+
+    if (catchUpItems.length < chunkSize) {
+      return;
     }
   }
 };

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -5,6 +5,7 @@ import {
   convertDateToClickhouseDateTime,
   flattenJsonToPathArrays,
   recordGauge,
+  stampExperimentAttributesOnTraceEvents,
   UNKNOWN_INGESTION_SDK_VALUE,
   type EventRecordInsertType,
 } from "@langfuse/shared/src/server";
@@ -17,6 +18,7 @@ const EXPERIMENT_BACKFILL_TIMESTAMP_KEY =
   "langfuse:event-propagation:experiment-backfill:last-run";
 const EXPERIMENT_BACKFILL_LOCK_KEY = "langfuse:experiment-backfill:lock";
 const LOCK_TTL_SECONDS = 300; // 5 minutes
+const UNENRICHED_EVENTS_LOOKBACK_DAYS = 90;
 
 export interface DatasetRunItem {
   id: string;
@@ -147,9 +149,12 @@ async function getDatasetRunItemsSinceLastRun(
       dri.dataset_item_metadata,
       dri.created_at
     FROM dataset_run_items_rmt AS dri
+    -- Traces already in events_core still need a stamp when experiment_id is
+    -- empty (dataset-run-item created without langfuse.experiment.* attributes).
     LEFT ANTI JOIN events_core AS ec
       ON dri.project_id = ec.project_id
       AND dri.trace_id = ec.trace_id
+      AND ec.experiment_id != ''
     WHERE dri.created_at > {lastRun: DateTime64(3)}
       AND dri.created_at <= {upperBound: DateTime64(3)}
       AND (dri.project_id, dri.trace_id) IN (SELECT project_id, trace_id FROM candidate_dris)
@@ -174,6 +179,127 @@ async function getDatasetRunItemsSinceLastRun(
 
   return rows;
 }
+
+/**
+ * Dataset-run-items older than the incremental cursor whose traces exist in
+ * events_core without experiment_id. Those traces are already ingested, so the
+ * observations-copy path never sees them.
+ */
+async function getUnenrichedDatasetRunItemsBeforeCursor(
+  lastRun: Date,
+  limit: number,
+): Promise<DatasetRunItem[]> {
+  const lookbackStart = new Date(
+    lastRun.getTime() - UNENRICHED_EVENTS_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+  );
+
+  const query = `
+    SELECT
+      dri.id,
+      dri.project_id,
+      dri.trace_id,
+      dri.observation_id,
+      dri.dataset_run_id,
+      dri.dataset_run_name,
+      dri.dataset_run_description,
+      dri.dataset_run_metadata,
+      dri.dataset_id,
+      dri.dataset_item_version,
+      dri.dataset_item_id,
+      dri.dataset_item_expected_output,
+      dri.dataset_item_metadata,
+      dri.created_at
+    FROM dataset_run_items_rmt AS dri
+    LEFT SEMI JOIN events_core AS present
+      ON present.project_id = dri.project_id
+      AND present.trace_id = dri.trace_id
+    LEFT ANTI JOIN events_core AS enriched
+      ON enriched.project_id = dri.project_id
+      AND enriched.trace_id = dri.trace_id
+      AND enriched.experiment_id != ''
+    WHERE dri.created_at > {lookbackStart: DateTime64(3)}
+      AND dri.created_at <= {lastRun: DateTime64(3)}
+    ORDER BY dri.created_at ASC
+    LIMIT 1 BY dri.project_id, dri.trace_id, coalesce(dri.observation_id, '')
+    LIMIT {limit: UInt32}
+  `;
+
+  const rows = await queryClickhouse<DatasetRunItem>({
+    query,
+    params: {
+      lookbackStart: convertDateToClickhouseDateTime(lookbackStart),
+      lastRun: convertDateToClickhouseDateTime(lastRun),
+      limit,
+    },
+    clickhouseConfigs: {
+      request_timeout: 120000,
+    },
+  });
+
+  logger.info(
+    `[EXPERIMENT BACKFILL] Found ${rows.length} unenriched dataset run items before ${lastRun.toISOString()}`,
+  );
+
+  return rows;
+}
+
+const stampDatasetRunItemOntoEvents = async (
+  dri: DatasetRunItem,
+): Promise<boolean> => {
+  const { stamped } = await stampExperimentAttributesOnTraceEvents({
+    projectId: dri.project_id,
+    traceId: dri.trace_id,
+    rootSpanId: dri.observation_id,
+    experimentId: dri.dataset_run_id,
+    experimentName: dri.dataset_run_name,
+    experimentDescription: dri.dataset_run_description,
+    experimentDatasetId: dri.dataset_id,
+    experimentItemId: dri.dataset_item_id,
+    experimentItemVersion: dri.dataset_item_version
+      ? new Date(dri.dataset_item_version)
+      : null,
+    experimentItemExpectedOutput: dri.dataset_item_expected_output,
+    experimentMetadata: dri.dataset_run_metadata,
+    experimentItemMetadata: dri.dataset_item_metadata,
+  });
+  return stamped;
+};
+
+const stampUnenrichedDatasetRunItemsBeforeCursor = async (
+  lastRun: Date,
+): Promise<void> => {
+  const excludeProjectIds =
+    env.LANGFUSE_EXPERIMENT_BACKFILL_EXCLUDE_PROJECT_IDS;
+  const catchUpItems = await getUnenrichedDatasetRunItemsBeforeCursor(
+    lastRun,
+    env.LANGFUSE_DATASET_RUN_BACKFILL_CHUNK_SIZE,
+  );
+  const toStamp =
+    excludeProjectIds && excludeProjectIds.length > 0
+      ? catchUpItems.filter(
+          (dri) => !excludeProjectIds.includes(dri.project_id),
+        )
+      : catchUpItems;
+
+  if (toStamp.length === 0) {
+    return;
+  }
+
+  logger.info(
+    `[EXPERIMENT BACKFILL] Stamping ${toStamp.length} historically skipped dataset run items`,
+  );
+
+  for (const dri of toStamp) {
+    try {
+      await stampDatasetRunItemOntoEvents(dri);
+    } catch (error) {
+      logger.error(
+        `[EXPERIMENT BACKFILL] Failed to stamp historically skipped DRI ${dri.id}`,
+        error,
+      );
+    }
+  }
+};
 
 /**
  * Fetch observations that belong to traces referenced by dataset run items.
@@ -912,6 +1038,7 @@ async function processExperimentBackfill(
       "[EXPERIMENT BACKFILL] No dataset run items to process, advancing cursor",
     );
     await updateBackfillTimestamp(upperBound);
+    await stampUnenrichedDatasetRunItemsBeforeCursor(lastRun);
     return;
   }
 
@@ -935,9 +1062,35 @@ async function processExperimentBackfill(
     // backfill would let the heartbeat go stale and trip the stuck health check.
     await updateLastRunStartedAt();
 
-    // Extract project and trace IDs for this chunk
-    const projectIds = [...new Set(driChunk.map((dri) => dri.project_id))];
-    const traceIds = [...new Set(driChunk.map((dri) => dri.trace_id))];
+    const unstamped: DatasetRunItem[] = [];
+    for (const dri of driChunk) {
+      try {
+        const stamped = await stampDatasetRunItemOntoEvents(dri);
+        if (!stamped) {
+          unstamped.push(dri);
+        }
+      } catch (error) {
+        logger.error(
+          `[EXPERIMENT BACKFILL] Failed to stamp events for DRI ${dri.id}`,
+          error,
+        );
+        unstamped.push(dri);
+      }
+    }
+
+    if (unstamped.length === 0) {
+      const lastItemInChunk = driChunk[driChunk.length - 1];
+      const chunkCursor =
+        i === chunks.length - 1
+          ? upperBound
+          : new Date(lastItemInChunk.created_at);
+      await updateBackfillTimestamp(chunkCursor);
+      continue;
+    }
+
+    // Extract project and trace IDs for traces that are not yet in events
+    const projectIds = [...new Set(unstamped.map((dri) => dri.project_id))];
+    const traceIds = [...new Set(unstamped.map((dri) => dri.trace_id))];
 
     // Fetch observations and traces
     const [observations, traces] = await Promise.all([
@@ -975,8 +1128,7 @@ async function processExperimentBackfill(
     const allEnrichedSpans: EnrichedSpan[] = [];
     const processedSpanIds = new Set<string>();
 
-    for (const dri of driChunk) {
-      // Find the root span (either observation or trace)
+    for (const dri of unstamped) {
       const rootSpanId = dri.observation_id || `t-${dri.trace_id}`;
       const rootSpanKey = spanScopedKey(
         dri.project_id,
@@ -1054,4 +1206,6 @@ async function processExperimentBackfill(
   logger.info(
     `[EXPERIMENT BACKFILL] Completed backfill process for ${datasetRunItems.length} items`,
   );
+
+  await stampUnenrichedDatasetRunItemsBeforeCursor(lastRun);
 }

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -357,24 +357,36 @@ export const stampUnenrichedDatasetRunItemsBeforeCursor = async (
       logger.info(
         `[EXPERIMENT BACKFILL] Stamping ${toStamp.length} historically skipped dataset run items`,
       );
+    }
 
-      for (const dri of toStamp) {
-        try {
-          await stampDatasetRunItemOntoEvents(dri);
-        } catch (error) {
-          logger.error(
-            `[EXPERIMENT BACKFILL] Failed to stamp historically skipped DRI ${dri.id}`,
-            error,
-          );
-        }
+    let lastAdvanced: DatasetRunItem | undefined;
+    let stampFailed = false;
+
+    for (const dri of catchUpItems) {
+      if (excludeProjectIds?.includes(dri.project_id)) {
+        lastAdvanced = dri;
+        continue;
+      }
+
+      try {
+        await stampDatasetRunItemOntoEvents(dri);
+        lastAdvanced = dri;
+      } catch (error) {
+        logger.error(
+          `[EXPERIMENT BACKFILL] Failed to stamp historically skipped DRI ${dri.id}`,
+          error,
+        );
+        stampFailed = true;
+        break;
       }
     }
 
-    const lastItem = catchUpItems[catchUpItems.length - 1];
-    await writeCatchUpCursor(lastItem);
+    if (lastAdvanced) {
+      await writeCatchUpCursor(lastAdvanced);
+    }
     await updateLastRunStartedAt();
 
-    if (catchUpItems.length < chunkSize) {
+    if (stampFailed || catchUpItems.length < chunkSize) {
       return;
     }
   }


### PR DESCRIPTION
## Summary
- Dataset runs created via `POST /api/public/dataset-run-items` (custom eval harnesses that never set `langfuse.experiment.*` span attributes) were still returned by the datasets API, but missing from Experiments views and `GET /api/public/experiments`.
- POST now stamps `experiment_*` columns onto the linked observation subtree (or the whole trace when no observation is given). Observation-only requests resolve the observation to its trace first.
- If events-only stamping cannot complete (events not in `events_full` yet, or ClickHouse error), a `dataset_run_items_rmt` row is persisted so worker catch-up can retry. The catch-up cursor advances past unstampable missing-observation rows, but does not skip items whose stamp throws.
- The experiment backfill no longer skips traces already in `events_core` unless they already have `experiment_id`, and it catch-up stamps historically skipped dataset-run-items (90-day lookback). The reserved `sdk-experiment` environment is not required.

Fixes #16835

## Test plan
- [x] `pnpm --filter worker run test experimentEventEnrichment.test.ts experimentBackfillCatchUp.test.ts` — 6 passed (stamp, subtree isolation, missing observation, catch-up poison pill, throw does not skip cursor)
- [x] `pnpm --filter web run test datasets-api.servertest.ts -t events_only` — 4 passed (stable id, stamp, observation-only, persist DRI when events are missing)
- [x] Lint on shared, worker, and web
- [ ] Preview: dataset Experiments tab and `/experiments/results?baseline={runId}` for a run created only via `POST /dataset-run-items` (no `langfuse.experiment.*` attributes)


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes dataset-run-item API runs visible in event-backed Experiments by stamping experiment attributes onto linked event rows and adding worker catch-up processing.

- Adds shared ClickHouse stamping and catch-up persistence helpers.
- Resolves observation-only requests to traces and stamps API-created run items.
- Extends incremental and historical worker backfill behavior.
- Adds server and worker coverage for visibility, subtree isolation, and cursor handling.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not safe to merge until observation-resolution failures, partial-trace stamping, and shared-trace experiment identities are handled without permanently dropping experiment results.

The new success and catch-up paths can report successful run-item creation while leaving no durable retry, permanently omit late spans from experiment aggregation, and suppress distinct experiments that share a trace or observation.

**Files Needing Attention:** web/src/features/datasets/server/publicDatasetService.ts, packages/shared/src/server/repositories/experiment-event-enrichment.ts, worker/src/features/eventPropagation/handleExperimentBackfill.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[POST dataset-run-item] --> B{Trace ID available?}
  B -->|Observation only| C[Resolve observation in events_full]
  C --> B
  B -->|Yes| D[Snapshot linked spans]
  D --> E[Stamp experiment fields]
  E --> F{Stamp complete?}
  F -->|No| G[Persist dataset_run_items_rmt row]
  G --> H[Worker catch-up]
  H --> D
  F -->|Yes| I[Experiments queries]
  B -->|No| J[Success without durable retry]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/datasets/server/publicDatasetService.ts:957-968
**Failed resolution drops retry**

When an observation-only request arrives before its observation is available in `events_full`, or its lookup fails, this catch block leaves `traceId` empty. The subsequent guard skips both stamping and catch-up persistence, so the API returns success but the run remains permanently absent from Experiments.

### Issue 2
packages/shared/src/server/repositories/experiment-event-enrichment.ts:223-229
**Partial snapshots appear complete**

When a trace-level run item is posted after only part of its trace has reached `events_full`, this snapshot is stamped and reported as successful. No retry row is retained, so later descendants remain unstamped and are excluded from experiment output, cost, and latency aggregation.

### Issue 3
worker/src/features/eventPropagation/handleExperimentBackfill.ts:270-285
**Catch-up conflates experiment identities**

When different experiments reference the same trace or observation, `LIMIT 1 BY` selects only one run item and the anti-join treats any stamped experiment as sufficient. Only one experiment identity wins, leaving the other run absent from Experiments or attributing the shared span to the wrong experiment.

### Issue 4
worker/src/__tests__/experimentBackfillCatchUp.test.ts:22-24
**Mock imports occur inside callbacks**

The new mock loads modules inside this callback and repeats the pattern in two mock implementations. Move these imports to module scope to follow the repository rule and avoid repeated asynchronous module loading during mock execution.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): retry failed stamps wi..."](https://github.com/langfuse/langfuse/commit/b2886577850d2d69e5eb7907a20d3bf6ea101a0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58757957)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)
- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)
- Knowledge Base — [Integration delivery and notifications](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/integration-delivery-and-notifications.md)
</details>


<!-- /greptile_comment -->