### PR TITLE
fix(in-app-agent): force reasoning for Claude ids on the OpenAI Responses path

### DIFF
--- a/worker/src/features/in-app-agent/runtime/model.ts
+++ b/worker/src/features/in-app-agent/runtime/model.ts
@@ -141,8 +141,17 @@ export function getInAppAgentReasoningProviderOptions(
         },
       };
     }
-    case "openai":
-      return resolveLangfuseAIOpenAICallFromEnv(config.baseURL).providerOptions;
+    case "openai": {
+      const call = resolveLangfuseAIOpenAICallFromEnv(config.baseURL);
+      if (
+        call.apiMode !== "responses" ||
+        !config.modelId.includes(ANTHROPIC_CLAUDE_MODEL_ID_PART)
+      ) {
+        return call.providerOptions;
+      }
+
+      return forceResponsesReasoning(call.providerOptions);
+    }
     case "bedrock":
       return getBedrockReasoningProviderOptions(config.modelId);
     default: {
@@ -157,4 +166,25 @@ function resolveLangfuseAIOpenAICallFromEnv(baseURL: string | undefined) {
     baseURL,
     useResponsesApi: env.LANGFUSE_AI_USE_RESPONSES_API,
   });
+}
+
+// @ai-sdk/openai sends `reasoning` (and requests encrypted reasoning for
+// stateless replay) only for model ids it detects as gpt/o-series reasoning
+// models. `forceReasoning` extends that to Claude ids behind a Responses
+// gateway. Forced reasoning also defaults `systemMessageMode` to `developer`;
+// pinning it to `system` keeps the system role, so the reasoning fields are
+// the only difference from the unforced request.
+function forceResponsesReasoning(
+  providerOptions: Extract<
+    ReturnType<typeof resolveLangfuseAIOpenAICallFromEnv>,
+    { apiMode: "responses" }
+  >["providerOptions"],
+) {
+  return {
+    openai: {
+      ...providerOptions.openai,
+      forceReasoning: true,
+      systemMessageMode: "system" as const,
+    },
+  };
 }

--- a/worker/src/features/in-app-agent/runtime/reasoning.test.ts
+++ b/worker/src/features/in-app-agent/runtime/reasoning.test.ts
@@ -180,6 +180,69 @@ describe("OpenAI Responses request shape", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.url).toBe("https://llm-exec.internal/v1/responses");
   });
+
+  it("requests summarized reasoning for Claude ids behind a Responses gateway", async () => {
+    // @ai-sdk/openai emits `reasoning` only for model ids on its own
+    // reasoning-model allowlist. Without `forceReasoning` a Claude id gets no
+    // `reasoning`, so a translating gateway leaves thinking at the model
+    // default (omitted display: no summary deltas, blank reasoning UI), and
+    // the request does not ask for encrypted reasoning to replay on the next
+    // tool step.
+    Object.assign(env, { LANGFUSE_AI_USE_RESPONSES_API: "true" });
+
+    const config = {
+      provider: "openai" as const,
+      modelId: "claude-opus-5",
+      titleModelId: "gpt-5.6-luna",
+      apiKey: "sk-test",
+      baseURL: "https://llm-gateway.internal/v1",
+    };
+    const { calls, fetch } = createCaptureFetch(OPENAI_RESPONSES_RESPONSE);
+    vi.stubGlobal("fetch", fetch);
+
+    const model = createInAppAgentLanguageModel({ config });
+    await model.doGenerate({
+      prompt: [
+        { role: "system" as const, content: "You are the Langfuse assistant." },
+        ...userPrompt(),
+      ],
+      providerOptions: getInAppAgentReasoningProviderOptions(config),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body.reasoning).toEqual({ summary: "auto" });
+    expect(calls[0]?.body.store).toBe(false);
+    expect(calls[0]?.body.include).toEqual(["reasoning.encrypted_content"]);
+    // `systemMessageMode: "system"` keeps the system role.
+    expect(calls[0]?.body.input).toEqual([
+      { role: "system", content: "You are the Langfuse assistant." },
+      { role: "user", content: [{ type: "input_text", text: "hi" }] },
+    ]);
+  });
+
+  it("does not force reasoning for non-Claude custom model ids", async () => {
+    Object.assign(env, { LANGFUSE_AI_USE_RESPONSES_API: "true" });
+
+    const config = {
+      provider: "openai" as const,
+      modelId: "custom-chat-model",
+      titleModelId: "custom-chat-model",
+      apiKey: "sk-test",
+      baseURL: "https://llm-gateway.internal/v1",
+    };
+    const { calls, fetch } = createCaptureFetch(OPENAI_RESPONSES_RESPONSE);
+    vi.stubGlobal("fetch", fetch);
+
+    const model = createInAppAgentLanguageModel({ config });
+    await model.doGenerate({
+      prompt: userPrompt(),
+      providerOptions: getInAppAgentReasoningProviderOptions(config),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body).not.toHaveProperty("reasoning");
+    expect(calls[0]?.body.store).toBe(false);
+  });
 });
 
 describe("Anthropic Messages request shape", () => {


### PR DESCRIPTION
## Problem

With `LANGFUSE_AI_PROVIDER=openai`, `LANGFUSE_AI_USE_RESPONSES_API=true`, and a Claude model id (a Responses gateway that translates to Anthropic), `@ai-sdk/openai` classifies the id as a non-reasoning model and drops `providerOptions.openai.reasoningSummary`. The request carries no `reasoning`, so:

- The gateway leaves thinking at the model default. On Opus 5 that is display `omitted`: reasoning items come back with an empty summary and the Assistant shows "Thinking…" then nothing.
- Nothing is emitted during the thinking phase, so a proxy with an idle read timeout (Cloudflare: 125 s) cuts the stream cleanly on a long think; the SDK reports `finishReason: other` with no error, Mastra continues into another step, and the turn is lost.
- `include: ["reasoning.encrypted_content"]` is requested only for reasoning models, so stateless replay depends on the gateway emitting encrypted content unasked.
- `reasoningEffort` would be dropped if ever set.

## Fix

Set `forceReasoning: true` on the Responses provider options when the model id contains `claude`; it is the SDK's option for reasoning models its gpt/o-series detection misses. Forced reasoning also defaults `systemMessageMode` to `developer`; pinning it to `system` keeps the system role, so the reasoning fields are the only difference from the unforced request.

GPT ids and Chat Completions are unchanged. A Claude id on the Responses path presumes a gateway that translates Responses to Anthropic Messages, which consumes `reasoning.summary`.

## Verified

Wire body for `claude-opus-5`: `reasoning: {summary: "auto"}`, `store: false`, `include: ["reasoning.encrypted_content"]`, `role: system`. Live against a translating gateway, the request yields `thinking: {type: "adaptive", display: "summarized"}`, summary deltas stream during thinking (max inter-event gap ~5 s instead of 100 s+ of silence), and a 3-step tool loop replays the encrypted reasoning.

## Tests

`reasoning.test.ts`: a Claude id on a custom Responses URL gets the forced shape (fails on `main`: `expected undefined to deeply equal { summary: 'auto' }`); a non-Claude custom id stays on the SDK's own detection.

`pnpm --filter worker run test reasoning.test.ts`: `Tests  9 passed (9)`. `pnpm --filter worker run lint` and `typecheck` clean.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables OpenAI Responses reasoning options for Claude model IDs routed through a translating gateway while preserving system-role messages.
- Adds conditional `forceReasoning` and `systemMessageMode` provider options for Claude Responses calls.
- Adds request-shape coverage for Claude and non-Claude custom model IDs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed behavior.

The new options are narrowly gated to Claude model IDs using the Responses path, preserve prior provider options, and are covered by request-shape tests for both matching and nonmatching models.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(in-app-agent): force reasoning for C..."](https://github.com/langfuse/langfuse/commit/09bc5b8e604c3c4e9dab960925197aae06184e4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58776880)</sub>

<!-- /greptile_comment -->