### PR TITLE
feat(web): persist environment-filter selection in the URL

### DIFF
--- a/web/src/hooks/useEnvironmentFilter.clienttest.tsx
+++ b/web/src/hooks/useEnvironmentFilter.clienttest.tsx
@@ -1,0 +1,266 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+
+// Mock the use-query-params library. The mock provides a controllable
+// queryParamStore map that the hook reads from / writes to, mirroring the
+// pattern used by useSidebarFilterState.clienttest.tsx for the same
+// library.
+const queryParamStore = new Map<string, string | undefined>();
+
+vi.mock("use-query-params", () => ({
+  useQueryParam: (key: string) => {
+    const initial = queryParamStore.has(key)
+      ? queryParamStore.get(key)
+      : undefined;
+    const [value, setValue] = React.useState<string | undefined>(initial);
+    const setQueryValue = React.useCallback(
+      (next: string | undefined) => {
+        setValue(next);
+        if (next === undefined || next === "") {
+          queryParamStore.delete(key);
+        } else {
+          queryParamStore.set(key, next);
+        }
+      },
+      [key],
+    );
+    return [value, setQueryValue];
+  },
+  StringParam: {},
+}));
+
+// Mock useRouter. isReady defaults to true so the hook treats the URL as
+// authoritative in tests; individual tests can flip it via setRouterReady.
+let routerIsReady = true;
+vi.mock("next/router", () => ({
+  useRouter: () => ({ isReady: routerIsReady }),
+}));
+
+import { useEnvironmentFilter } from "@/src/hooks/useEnvironmentFilter";
+
+const PROJECT = "test-project";
+const PROJECT_KEY = `langfuse-environment-visibility-${PROJECT}`;
+
+describe("useEnvironmentFilter", () => {
+  beforeEach(() => {
+    queryParamStore.clear();
+    localStorage.clear();
+    routerIsReady = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to localStorage + default visibility when URL has no envs", () => {
+    localStorage.setItem(
+      PROJECT_KEY,
+      JSON.stringify({ default: true, langfuse: false, prod: true }),
+    );
+
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["default", "langfuse", "prod"], PROJECT),
+    );
+
+    // "langfuse-*" is hidden by default; "default" and "prod" explicitly true.
+    expect(result.current.selectedEnvironments.sort()).toEqual([
+      "default",
+      "prod",
+    ]);
+  });
+
+  it("URL is authoritative when present: hides a localStorage-visible env", () => {
+    localStorage.setItem(
+      PROJECT_KEY,
+      JSON.stringify({ prod: true, staging: true }),
+    );
+    queryParamStore.set("environments", "prod");
+
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["prod", "staging"], PROJECT),
+    );
+
+    // URL says only "prod" — localStorage's "staging" is overridden.
+    expect(result.current.selectedEnvironments).toEqual(["prod"]);
+  });
+
+  it("URL is authoritative when present: shows a localStorage-hidden env", () => {
+    localStorage.setItem(
+      PROJECT_KEY,
+      JSON.stringify({ prod: true, staging: false }),
+    );
+    queryParamStore.set("environments", "prod,staging");
+
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["prod", "staging"], PROJECT),
+    );
+
+    expect(result.current.selectedEnvironments.sort()).toEqual([
+      "prod",
+      "staging",
+    ]);
+  });
+
+  it("URL entry referencing a deleted env is silently filtered out", () => {
+    queryParamStore.set("environments", "prod,deleted-env");
+
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["prod"], PROJECT),
+    );
+
+    // "deleted-env" is not in availableEnvironments — it should not surface.
+    expect(result.current.selectedEnvironments).toEqual(["prod"]);
+  });
+
+  it("empty URL string is treated as no URL (localStorage fallback)", () => {
+    queryParamStore.set("environments", "");
+    localStorage.setItem(
+      PROJECT_KEY,
+      JSON.stringify({ prod: true, staging: false }),
+    );
+
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["prod", "staging"], PROJECT),
+    );
+
+    // Empty URL = fall back to localStorage.
+    expect(result.current.selectedEnvironments).toEqual(["prod"]);
+  });
+
+  it("setSelectedEnvironments writes URL-encoded values to both URL and localStorage", () => {
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["prod", "us,east-1", "staging"], PROJECT),
+    );
+
+    act(() => {
+      result.current.setSelectedEnvironments(["prod", "us,east-1"]);
+    });
+
+    // Comma-bearing env names get URL-encoded so they round-trip intact.
+    expect(queryParamStore.get("environments")).toBe("prod,us%2Ceast-1");
+    const stored = JSON.parse(localStorage.getItem(PROJECT_KEY) ?? "{}");
+    expect(stored).toEqual({
+      prod: true,
+      "us,east-1": true,
+      staging: false,
+    });
+  });
+
+  it("setSelectedEnvironments([]) removes the URL param and writes empty map", () => {
+    queryParamStore.set("environments", "prod");
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["prod", "staging"], PROJECT),
+    );
+
+    act(() => {
+      result.current.setSelectedEnvironments([]);
+    });
+
+    expect(queryParamStore.has("environments")).toBe(false);
+    const stored = JSON.parse(localStorage.getItem(PROJECT_KEY) ?? "{}");
+    expect(stored).toEqual({ prod: false, staging: false });
+  });
+
+  it("setSelectedEnvironments is a no-op when the selection is unchanged", () => {
+    queryParamStore.set("environments", "prod,staging");
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(["prod", "staging"], PROJECT),
+    );
+
+    // First call: nothing has changed yet — should be a no-op.
+    act(() => {
+      result.current.setSelectedEnvironments(["prod", "staging"]);
+    });
+
+    // URL param should be exactly what we set it to (no extra history push).
+    expect(queryParamStore.get("environments")).toBe("prod,staging");
+  });
+
+  it("setSelectedEnvironments does NOT erase localStorage when availableEnvironments is empty", () => {
+    localStorage.setItem(
+      PROJECT_KEY,
+      JSON.stringify({ prod: true, staging: true }),
+    );
+    const { result } = renderHook(() => useEnvironmentFilter([], PROJECT));
+
+    act(() => {
+      result.current.setSelectedEnvironments(["prod"]);
+    });
+
+    // localStorage must be untouched — writing against [] would have
+    // erased the previous map.
+    const stored = JSON.parse(localStorage.getItem(PROJECT_KEY) ?? "{}");
+    expect(stored).toEqual({ prod: true, staging: true });
+  });
+
+  it("default visibility (langfuse-* hidden) still applies when URL is absent", () => {
+    const { result } = renderHook(() =>
+      useEnvironmentFilter(
+        ["default", "langfuse-cloud", "langfuse-internal"],
+        PROJECT,
+      ),
+    );
+
+    // All envs first seen: defaults apply. "langfuse-*" prefixed envs hidden.
+    expect(result.current.selectedEnvironments).toEqual(["default"]);
+  });
+
+  it("does not pollute localStorage with defaults when URL is present", () => {
+    queryParamStore.set("environments", "prod");
+    renderHook(() => useEnvironmentFilter(["prod"], PROJECT));
+
+    // localStorage should remain empty — URL is authoritative, so the
+    // "initialize new env with default" useEffect did not run.
+    expect(localStorage.getItem(PROJECT_KEY)).toBeNull();
+  });
+
+  it("newly-discovered env does not become visible when URL is present", () => {
+    queryParamStore.set("environments", "prod");
+
+    // Start with a single env (matches the URL).
+    const { result, rerender } = renderHook(
+      ({ available }: { available: string[] }) =>
+        useEnvironmentFilter(available, PROJECT),
+      { initialProps: { available: ["prod"] } },
+    );
+
+    expect(result.current.selectedEnvironments).toEqual(["prod"]);
+
+    // The project now exposes a second env. URL is authoritative, so
+    // "staging" must NOT be auto-selected.
+    rerender({ available: ["prod", "staging"] });
+
+    expect(result.current.selectedEnvironments).toEqual(["prod"]);
+    // localStorage should not have been written either.
+    expect(localStorage.getItem(PROJECT_KEY)).toBeNull();
+  });
+
+  it("falls back to localStorage until router.isReady (hydration gap)", () => {
+    localStorage.setItem(
+      PROJECT_KEY,
+      JSON.stringify({ prod: true, staging: false }),
+    );
+    queryParamStore.set("environments", "prod,staging");
+
+    // Simulate pre-hydration: useQueryParam has the URL value, but the
+    // router is not ready yet. The hook should defer to localStorage to
+    // avoid a one-frame flash of the wrong filter.
+    routerIsReady = false;
+    const { result, rerender } = renderHook(() =>
+      useEnvironmentFilter(["prod", "staging"], PROJECT),
+    );
+
+    // localStorage says only "prod" is visible.
+    expect(result.current.selectedEnvironments).toEqual(["prod"]);
+
+    // After hydration the URL becomes authoritative.
+    routerIsReady = true;
+    rerender();
+
+    expect(result.current.selectedEnvironments.sort()).toEqual([
+      "prod",
+      "staging",
+    ]);
+  });
+});

--- a/web/src/hooks/useEnvironmentFilter.tsx
+++ b/web/src/hooks/useEnvironmentFilter.tsx
@@ -1,12 +1,11 @@
 import useLocalStorage from "@/src/components/useLocalStorage";
-import { useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
+import { useRouter } from "next/router";
+import { useQueryParam, StringParam } from "use-query-params";
 
 interface EnvironmentVisibility {
   [key: string]: boolean; // environment name -> isVisible
 }
-
-// TODO: Add the environment selection to the query params to persist the environment filter when sharing links.
-// See useDashboardDateRange for an example of this.
 
 export function convertSelectedEnvironmentsToFilter(
   environmentColumns: string[],
@@ -35,32 +34,124 @@ export function useEnvironmentFilter(
       {},
     );
 
+  // URL is the shareable source of truth when present; the localStorage map
+  // is the per-browser fallback. Pattern matches useDashboardDateRange and
+  // useGlobalDateRange, the established way other Langfuse surfaces plumb
+  // URL state.
+  const [urlEnvironments, setUrlEnvironments] = useQueryParam(
+    "environments",
+    StringParam,
+  );
+
+  // Pages Router: useQueryParam returns `undefined` until the router is
+  // ready (post-hydration). On the first render, treat the URL as not-yet-
+  // known and fall back to the localStorage map, then re-derive on the next
+  // render when router.isReady flips. This avoids a one-frame flash where
+  // the user's URL-driven selection is briefly replaced by their local
+  // pick on shared links.
+  const router = useRouter();
+  const urlIsReady = router.isReady;
+
   const getDefaultVisibility = (env: string) => !env.startsWith("langfuse-");
 
-  const visibleEnvironments = (availableEnvironments || []).filter((env) => {
-    return visibilityMap[env] ?? getDefaultVisibility(env);
-  });
+  // When the URL carries an explicit (non-empty) list AND the router is
+  // ready, that is the source of truth. Empty / missing / not-ready URL
+  // falls back to the localStorage map and the existing "langfuse-* hidden
+  // by default" rule.
+  //
+  // Each entry is URL-encoded so an environment name containing a literal
+  // comma (unlikely but not schema-forbidden) round-trips intact.
+  const urlSelection = useMemo(() => {
+    if (!urlIsReady) return null;
+    if (typeof urlEnvironments !== "string" || urlEnvironments.length === 0) {
+      return null;
+    }
+    const parsed = urlEnvironments
+      .split(",")
+      .map((s) => {
+        try {
+          return decodeURIComponent(s.trim());
+        } catch {
+          return s.trim();
+        }
+      })
+      .filter((s) => s.length > 0);
+    return parsed.length > 0 ? parsed : null;
+  }, [urlEnvironments, urlIsReady]);
 
-  const handleSetVisibilityMap = (environments: string[]) => {
-    const selectedSet = new Set(environments);
+  const visibleEnvironments = useMemo(() => {
+    if (urlSelection !== null) {
+      // URL is authoritative. Filter against availableEnvironments so a
+      // stale URL referencing a deleted environment does not surface it.
+      const set = new Set(urlSelection);
+      return (availableEnvironments || []).filter((env) => set.has(env));
+    }
+    return (availableEnvironments || []).filter((env) => {
+      return visibilityMap[env] ?? getDefaultVisibility(env);
+    });
+  }, [urlSelection, availableEnvironments, visibilityMap]);
 
-    const map = (availableEnvironments || []).reduce((acc, env) => {
-      acc[env] = selectedSet.has(env);
-      return acc;
-    }, {} as EnvironmentVisibility);
-    setVisibilityMap(map);
-  };
+  const handleSetVisibilityMap = useCallback(
+    (environments: string[]) => {
+      const selectedSet = new Set(environments);
 
-  // Initialize or update visibility map when available environments change
+      // No-op when the selection has not actually changed. useQueryParam
+      // does not deduplicate internally and would otherwise push a duplicate
+      // history entry per call.
+      const previous = visibleEnvironments;
+      if (
+        previous.length === environments.length &&
+        previous.every((env) => selectedSet.has(env))
+      ) {
+        return;
+      }
+
+      // URL: write the explicit list, or remove the param entirely when the
+      // selection is empty (cleaner shareable URL).
+      if (environments.length === 0) {
+        setUrlEnvironments(undefined);
+      } else {
+        setUrlEnvironments(
+          environments.map((e) => encodeURIComponent(e)).join(","),
+        );
+      }
+
+      // Bail on the localStorage write when the available-envs list has not
+      // yet resolved. Writing against an empty list would erase the user's
+      // previous per-env map (selectedSet has only the new env, reduce has
+      // no keys, setVisibilityMap({}) — the previous map is lost).
+      if (!availableEnvironments || availableEnvironments.length === 0) {
+        return;
+      }
+
+      // localStorage: keep the per-env visibility map so a navigation away
+      // from this page without the URL still shows the user's last pick.
+      const map = availableEnvironments.reduce((acc, env) => {
+        acc[env] = selectedSet.has(env);
+        return acc;
+      }, {} as EnvironmentVisibility);
+      setVisibilityMap(map);
+    },
+    [
+      availableEnvironments,
+      visibleEnvironments,
+      setUrlEnvironments,
+      setVisibilityMap,
+    ],
+  );
+
+  // Initialize or update the localStorage map when available environments
+  // change. Only runs when the URL is NOT authoritative — when the URL
+  // carries an explicit list, that list is the source of truth and adding
+  // a new env should default to "not selected" until the user adds it.
   useEffect(() => {
-    if (!availableEnvironments) return;
+    if (!availableEnvironments || availableEnvironments.length === 0) return;
+    if (urlSelection !== null) return;
 
-    // Create updated map with new environments
     const updatedMap = { ...visibilityMap };
     let hasChanges = false;
 
     availableEnvironments.forEach((env) => {
-      // If environment doesn't exist in map, set default visibility
       // Environments prefixed with "langfuse-" are deselected by default
       if (updatedMap[env] === undefined) {
         updatedMap[env] = getDefaultVisibility(env);
@@ -68,11 +159,10 @@ export function useEnvironmentFilter(
       }
     });
 
-    // Only update state if there were changes
     if (hasChanges) {
       setVisibilityMap(updatedMap);
     }
-  }, [availableEnvironments, visibilityMap, setVisibilityMap]);
+  }, [availableEnvironments, visibilityMap, urlSelection, setVisibilityMap]);
 
   return {
     selectedEnvironments: visibleEnvironments,


### PR DESCRIPTION
Fixes #16868.

## Problem

`useEnvironmentFilter` (used by the project home, dashboards, and users pages) stored the per-user "visible environments" map only in `localStorage`. A user who filters down to two environments, copies the URL, and shares it with a colleague sees those two environments — the colleague opens the same URL and sees the project's default set (everything except `langfuse-*`).

The TODO at `web/src/hooks/useEnvironmentFilter.tsx:8` called this out:

```ts
// TODO: Add the environment selection to the query params to persist the environment filter when sharing links.
// See useDashboardDateRange for an example of this.
```

## Proposed solution

Add a `?environments=foo,bar` URL param that mirrors the per-user selection when present; the localStorage map remains the per-browser fallback. Pattern follows the established `useDashboardDateRange` / `useGlobalDateRange` URL-state hooks already in the app.

## Behavior

- `?environments=foo,bar` is the source of truth when present and non-empty. The listed envs are the visible set; the localStorage map is ignored.
- `?environments` empty, absent, or the router pre-hydration: fall back to the localStorage map and the existing `langfuse-*` hidden-by-default rule. The pre-hydration fallback avoids a one-frame flash on shared links.
- `setSelectedEnvironments([...])` writes the URL (comma-separated, each name URL-encoded) and the localStorage map. Writing `[]` removes the URL param. The write is a no-op when the selection has not changed.
- The setter bails on the localStorage write when the available-envs list has not yet resolved (otherwise the previous per-env map would be wiped against an empty list).
- The "initialize new env with default visibility" useEffect no longer runs when the URL is authoritative, so a newly-discovered env does not silently become visible.

## Files

- `web/src/hooks/useEnvironmentFilter.tsx` — read `?environments` via `useQueryParam`; treat as source of truth when present and non-empty; fall back to localStorage + the existing `langfuse-*` hidden-by-default rule. The setter short-circuits when the selection is unchanged and bails on the localStorage write when the available-envs list has not yet resolved. Each env name is URL-encoded.
- `web/src/hooks/useEnvironmentFilter.clienttest.tsx` — 13 regression cases: URL-authoritative read, localStorage fallback, hydration gap, dual write, empty-list removes the URL param, comma-in-name encoding, no-op short-circuit, empty-available guard, deleted-env URL entries filtered, and newly-discovered env not auto-selected when URL is present.

## Compatibility

- The hook signature is unchanged. The three call sites (`/[projectId]`, `/[projectId]/dashboards/[dashboardId]`, `/[projectId]/users`) need no caller-side changes.
- `convertSelectedEnvironmentsToFilter` is unchanged: an empty selection still maps to "no filter / show all" for the table, the pre-existing behavior.

## Risk

Minimal. The hook is the only writer and reader of the URL param on these three pages. The worst case — a stale URL referencing a deleted env — is handled by intersecting with `availableEnvironments`, so a user sees one fewer environment than the URL lists, not a crash.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes environment-filter selections shareable by mirroring them into an `environments` URL parameter while retaining localStorage as a fallback.
- Adds URL parsing, serialization, hydration handling, and synchronization to `useEnvironmentFilter`.
- Adds client tests covering URL precedence, localStorage fallback, encoding, empty selections, unresolved options, and newly discovered environments.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The explicit empty-selection state must be represented distinctly in the URL before merging so shared links preserve the sender’s effective environment filter.

Clearing every environment removes the new query parameter, and a recipient consequently falls back to browser-local or default visibility instead of reproducing the sender’s show-all state.

**Files Needing Attention:** web/src/hooks/useEnvironmentFilter.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read environments query parameter] --> B{Router ready and value non-empty?}
  B -->|Yes| C[Decode and intersect with available environments]
  B -->|No| D[Use localStorage and default visibility]
  E[User changes selection] --> F{Selection empty?}
  F -->|No| G[Write explicit URL value]
  F -->|Yes| H[Remove URL parameter]
  G --> I[Update localStorage visibility map]
  H --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/hooks/useEnvironmentFilter.tsx:110-112
**Empty selection loses URL state**

When a user clears all environments, this branch removes the `environments` parameter, so a shared or freshly loaded URL falls back to localStorage or default visibility instead of preserving the sender's explicit show-all selection.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): persist environment-filter se..."](https://github.com/langfuse/langfuse/commit/bb537558477f74ff06b9cf345f93734a251c9d69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58952060)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->