### PR TITLE
chore(ci): remove pnpm --legacy handling

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -62,8 +62,8 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} builder AS prod-deps
 # we only need the prod + generated prisma client plus .prisma artifacts
 # @langfuse/shared still pulls in next-auth transitively, so keep the deploy output
 # intact here instead of pruning node_modules in Docker.
-# Keep legacy deploy until the worker Docker image is verified with pnpm's default deploy implementation.
-RUN pnpm --filter worker deploy --legacy --prod /prod/worker && \
+# Scope workspace injection to deploy so regular workspace installs keep source-link semantics.
+RUN pnpm --config.inject-workspace-packages=true --filter worker deploy --prod /prod/worker && \
     builder_prisma_client_dir="$(find /app/node_modules/.pnpm -path '*/node_modules/@prisma/client' -type d | head -n 1)" && \
     deployed_prisma_client_dir="$(find /prod/worker/node_modules/.pnpm -path '*/node_modules/@prisma/client' -type d | head -n 1)" && \
     builder_prisma_runtime_dir="$(dirname "$(dirname "$builder_prisma_client_dir")")/.prisma" && \


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16874 app preview](https://pr-16874.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the worker image’s legacy pnpm deploy mode with the default deploy implementation while explicitly enabling workspace-package injection for that command.

- Removes the `--legacy` deploy flag from `worker/Dockerfile`.
- Scopes `inject-workspace-packages=true` to the production dependency deployment.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The pinned pnpm version supports the scoped workspace-injection configuration, and the worker Docker build pipeline exercises the resulting production deployment.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): remove pnpm --legacy handling"](https://github.com/langfuse/langfuse/commit/559012b947ff872483014a913baf714b25a7a6ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58991111)</sub>

<!-- /greptile_comment -->