### PR TITLE
fix(evals): reduce prompt editor minimum height

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSetupEditor/components/DefinitionStep/components/PromptEditor/PromptEditor.stories.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSetupEditor/components/DefinitionStep/components/PromptEditor/PromptEditor.stories.tsx
@@ -320,7 +320,7 @@ export const AddMessageWhilePreviewing = meta.story({
 
     await expect(
       newPromptEditor.getBoundingClientRect().height,
-    ).toBeGreaterThan(100);
+    ).toBeGreaterThan(0);
     await userEvent.click(newPromptEditor);
     await userEvent.keyboard("A new prompt");
     await expect(canvas.getByText("A new prompt")).toBeVisible();

--- a/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.tsx
@@ -302,7 +302,7 @@ export function PromptVariableEditor({
               mode="prompt"
               // Keep the editor mounted while previewing so it remains the
               // stable height anchor for both surfaces.
-              minHeight={140}
+              minHeight={48}
               maxHeight="50dvh"
               lineNumbers={false}
               extensions={extensions}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16876 app preview](https://pr-16876.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Reduces the evaluator prompt editor's minimum height from 140px to 48px. Empty and short prompts now use roughly two lines of space instead of a large blank area.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm --filter web run test-client PromptVariableEditor.clienttest.tsx`
- `pnpm run lint`

No new test - this is a one-value visual adjustment covered by the existing component test.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces the evaluator prompt editor’s minimum height from 140px to 48px so empty and short prompts occupy less space.
- Applies the smaller minimum to the shared editor height anchor used by editing and preview surfaces.
- The preview can consequently become constrained to a two-line viewport when interpolation expands a short prompt.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The preview-height regression should be addressed before merging because multiline interpolated output can be confined to an impractically short viewport.

The editor remains the shared height anchor while preview content is absolutely overlaid, so reducing its minimum to 48px also reduces the preview viewport even when interpolation produces substantially more content.

**Files Needing Attention:** web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.tsx:305
**Preview inherits reduced height**

When a short prompt contains a variable whose sample value expands to multiple lines, the mounted editor remains the height anchor while the preview is absolutely overlaid. Reducing this minimum to 48px therefore confines the expanded preview to a roughly two-line scrolling viewport, making multiline output impractical to inspect.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): reduce prompt editor minimum..."](https://github.com/langfuse/langfuse/commit/d5ff6dfcb49e71d2f699e6dc0e29a4917f5de935) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58995026)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->