### PR TITLE
fix(web): `MarkdownViewer` styling issues around bullet-points

### DIFF
--- a/web/src/components/ui/MarkdownViewer.clienttest.tsx
+++ b/web/src/components/ui/MarkdownViewer.clienttest.tsx
@@ -95,9 +95,8 @@ describe("MarkdownView ordered lists", () => {
 
 describe("MarkdownView list item layout", () => {
   // A list item that also contains a nested list has a block sibling
-  // (`ul`/`ol`) after the label. `list-inside` then paints the marker on its
-  // own line above the bold header. `list-outside` keeps the marker beside
-  // the first line of the item.
+  // after the label. Markers use list-outside and matching left padding
+  // so they sit in the gutter beside the first line.
   it("places nested bullet markers outside the item content box", () => {
     const { container } = renderMarkdown(NESTED_BULLET_MARKDOWN);
 
@@ -118,7 +117,10 @@ describe("MarkdownView list item layout", () => {
     ]);
 
     for (const item of topItems) {
-      expect(item.querySelector(":scope > ul")).not.toBeNull();
+      const nested = item.querySelector(":scope > ul");
+      expect(nested).not.toBeNull();
+      expect(nested?.className).toContain("pl-6");
+      expect(item.className).not.toContain("[&>ul]:pl-4");
     }
   });
 
@@ -135,7 +137,10 @@ describe("MarkdownView list item layout", () => {
     expect(topItems).toHaveLength(2);
 
     for (const item of topItems) {
-      expect(item.querySelector(":scope > ol")).not.toBeNull();
+      const nested = item.querySelector(":scope > ol");
+      expect(nested).not.toBeNull();
+      expect(nested?.className).toContain("pl-6");
+      expect(item.className).not.toContain("[&>ol]:pl-4");
     }
   });
 

--- a/web/src/components/ui/MarkdownViewer.clienttest.tsx
+++ b/web/src/components/ui/MarkdownViewer.clienttest.tsx
@@ -61,11 +61,91 @@ describe("MarkdownView link rendering", () => {
   });
 });
 
+const NESTED_BULLET_MARKDOWN = `Langfuse is an open-source observability and analytics tool for LLM applications.
+
+In practical terms, it helps you:
+
+- **Track and debug LLM calls**
+  - Log prompts, model responses, latency, errors, and metadata
+- **Evaluate quality**
+  - Run evaluations on outputs (automatic metrics or human feedback)
+- **Monitor in production**
+  - Dashboards for usage, cost, latency, and failure rates`;
+
+const NESTED_ORDERED_MARKDOWN = `Steps:
+
+1. **Prepare the dataset**
+   1. Collect traces
+   2. Label outcomes
+2. **Run the eval**
+   1. Score outputs`;
+
+const directChildren = (parent: Element, tagName: string) =>
+  Array.from(parent.children).filter(
+    (child) => child.tagName === tagName.toUpperCase(),
+  );
+
 describe("MarkdownView ordered lists", () => {
   it("preserves an explicit ordered-list start number", () => {
     const { container } = renderMarkdown("2.");
 
     expect(container.querySelector("ol")?.getAttribute("start")).toBe("2");
+  });
+});
+
+describe("MarkdownView list item layout", () => {
+  // A list item that also contains a nested list has a block sibling
+  // (`ul`/`ol`) after the label. `list-inside` then paints the marker on its
+  // own line above the bold header. `list-outside` keeps the marker beside
+  // the first line of the item.
+  it("places nested bullet markers outside the item content box", () => {
+    const { container } = renderMarkdown(NESTED_BULLET_MARKDOWN);
+
+    const topList = container.querySelector("ul");
+    expect(topList).not.toBeNull();
+    expect(topList?.className).toContain("list-outside");
+    expect(topList?.className).not.toContain("list-inside");
+    expect(topList?.className).toContain("pl-6");
+
+    const topItems = directChildren(topList!, "li");
+    expect(topItems).toHaveLength(3);
+    expect(
+      topItems.map((item) => item.querySelector("strong")?.textContent),
+    ).toEqual([
+      "Track and debug LLM calls",
+      "Evaluate quality",
+      "Monitor in production",
+    ]);
+
+    for (const item of topItems) {
+      expect(item.querySelector(":scope > ul")).not.toBeNull();
+    }
+  });
+
+  it("places nested numbered-list markers outside the item content box", () => {
+    const { container } = renderMarkdown(NESTED_ORDERED_MARKDOWN);
+
+    const topList = container.querySelector("ol");
+    expect(topList).not.toBeNull();
+    expect(topList?.className).toContain("list-outside");
+    expect(topList?.className).not.toContain("list-inside");
+    expect(topList?.className).toContain("pl-6");
+
+    const topItems = directChildren(topList!, "li");
+    expect(topItems).toHaveLength(2);
+
+    for (const item of topItems) {
+      expect(item.querySelector(":scope > ol")).not.toBeNull();
+    }
+  });
+
+  it("does not emit an empty trailing list item for a nested bullet list", () => {
+    const { container } = renderMarkdown(NESTED_BULLET_MARKDOWN);
+    const topItems = directChildren(container.querySelector("ul")!, "li");
+
+    expect(
+      topItems.every((item) => (item.textContent ?? "").trim().length > 0),
+    ).toBe(true);
   });
 });
 

--- a/web/src/components/ui/MarkdownViewer.stories.tsx
+++ b/web/src/components/ui/MarkdownViewer.stories.tsx
@@ -1,0 +1,154 @@
+import preview from "../../../.storybook/preview";
+import { MarkdownView } from "./MarkdownViewer";
+
+const meta = preview.meta({
+  component: MarkdownView,
+  args: {
+    title: "assistant",
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    markdown:
+      "Langfuse is an **open-source** observability tool for LLM apps. Use `trace.generation()` to record a model call.",
+  },
+});
+
+export const NestedLists = meta.story({
+  args: {
+    markdown: `In practical terms, it helps you:
+
+- **Track and debug LLM calls**
+  - Log prompts, model responses, latency, errors, and metadata
+- **Evaluate quality**
+  - Run evaluations on outputs (automatic metrics or human feedback)
+- **Monitor in production**
+  - Dashboards for usage, cost, latency, and failure rates`,
+  },
+});
+
+export const TightLists = meta.story({
+  args: {
+    markdown: `Simple bullets stay on one line:
+
+- First item
+- Second item
+- Third item with **bold** and \`inline code\``,
+  },
+});
+
+export const OrderedLists = meta.story({
+  args: {
+    markdown: `Numbered steps:
+
+1. Collect traces
+2. Label outcomes
+3. Run the eval
+
+Resume a later list:
+
+10. Double-digit markers need gutter space
+11. Next item
+12. Last item`,
+  },
+});
+
+export const NestedOrderedLists = meta.story({
+  args: {
+    markdown: `Steps:
+
+1. **Prepare the dataset**
+   1. Collect traces
+   2. Label outcomes
+2. **Run the eval**
+   1. Score outputs
+   2. Compare baselines`,
+  },
+});
+
+export const Headings = meta.story({
+  args: {
+    markdown: `# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+
+Paragraph after headings.`,
+  },
+});
+
+export const CodeBlocks = meta.story({
+  args: {
+    markdown: `Wrap a model call:
+
+\`\`\`typescript
+const generation = trace.generation({
+  name: "support-answer",
+  model: "example-model",
+});
+\`\`\`
+
+Inline code looks like \`trace.id\`.`,
+  },
+});
+
+export const Table = meta.story({
+  args: {
+    markdown: `| Metric | Value |
+| --- | --- |
+| Latency | 842ms |
+| Tokens | 1,204 |
+| Cost | $0.012 |`,
+  },
+});
+
+export const Blockquote = meta.story({
+  args: {
+    markdown: `> Prefer traces over logs when debugging a single request.
+>
+> Keep the observation tree intact.`,
+  },
+});
+
+export const TaskList = meta.story({
+  args: {
+    markdown: `- [x] Record the generation
+- [x] Attach scores
+- [ ] Share the trace`,
+  },
+});
+
+export const Links = meta.story({
+  args: {
+    markdown:
+      "See the [tracing docs](https://langfuse.com/docs) or an unsafe [script](javascript:alert(1)).",
+  },
+});
+
+export const MixedContent = meta.story({
+  args: {
+    markdown: `## How to debug a slow trace
+
+1. Open the generation
+2. Compare **input** and **output**
+3. Check the table:
+
+| Field | Expected |
+| --- | --- |
+| model | example-model |
+| stream | true |
+
+Then wrap the call:
+
+\`\`\`ts
+trace.generation({ name: "answer" });
+\`\`\`
+
+- Nested follow-ups
+  - Re-run with a tighter prompt
+  - Compare cost`,
+  },
+});

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -315,11 +315,14 @@ const markdownComponents: NonNullable<Options["components"]> = {
   ul({ children }) {
     if (isChecklist(children)) return <ul className="list-none">{children}</ul>;
 
-    return <ul className="list-inside list-disc">{children}</ul>;
+    // list-outside keeps the marker beside the first line even when the
+    // item also contains a nested list (a block sibling). list-inside
+    // puts that marker on its own line above the label.
+    return <ul className="list-outside list-disc pl-6">{children}</ul>;
   },
   ol({ children, start }) {
     return (
-      <ol start={start} className="list-inside list-decimal">
+      <ol start={start} className="list-outside list-decimal pl-6">
         {children}
       </ol>
     );

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -315,9 +315,8 @@ const markdownComponents: NonNullable<Options["components"]> = {
   ul({ children }) {
     if (isChecklist(children)) return <ul className="list-none">{children}</ul>;
 
-    // list-outside keeps the marker beside the first line even when the
-    // item also contains a nested list (a block sibling). list-inside
-    // puts that marker on its own line above the label.
+    // Nested items contain a block list after the label. list-outside
+    // plus left padding keeps the marker in the gutter beside that line.
     return <ul className="list-outside list-disc pl-6">{children}</ul>;
   },
   ol({ children, start }) {
@@ -328,11 +327,7 @@ const markdownComponents: NonNullable<Options["components"]> = {
     );
   },
   li({ children }) {
-    return (
-      <li className="mt-1 [&>ol]:pl-4 [&>ul]:pl-4">
-        {transformListItemChildren(children)}
-      </li>
-    );
+    return <li className="mt-1">{transformListItemChildren(children)}</li>;
   },
   pre({ children }) {
     return <pre className="rounded p-2">{children}</pre>;

--- a/web/src/features/traces/components/IOPreview/IOPreviewPretty.stories.tsx
+++ b/web/src/features/traces/components/IOPreview/IOPreviewPretty.stories.tsx
@@ -85,6 +85,32 @@ generation.end({ output: "Your response" });
   },
 });
 
+export const NestedMarkdownLists = meta.story({
+  args: {
+    input: {
+      messages: [
+        {
+          role: "user",
+          content: "What is Langfuse useful for?",
+        },
+      ],
+    },
+    output: {
+      role: "assistant",
+      content: `Langfuse is an open-source observability and analytics tool for LLM applications.
+
+In practical terms, it helps you:
+
+- **Track and debug LLM calls**
+  - Log prompts, model responses, latency, errors, and metadata
+- **Evaluate quality**
+  - Run evaluations on outputs (automatic metrics or human feedback)
+- **Monitor in production**
+  - Dashboards for usage, cost, latency, and failure rates`,
+    },
+  },
+});
+
 export const ToolCall = meta.story({
   args: {
     input: {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16879 app preview](https://pr-16879.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

In the formatted IO view, nested markdown lists put the top-level bullet or number on its own line above the bold label. Nested items (plain text only) rendered correctly.

Root cause: `ul`/`ol` used `list-inside`. A list item that also contains a nested list has a block sibling after the label, so the browser paints the marker on an empty first line.

This switches lists to `list-outside` with `pl-6` so the marker stays beside the first line. `pl-6` is enough for two-digit ordered numbers that used to clip with `pl-4`. Nested lists keep that same gutter; the parent `li` no longer overrides it.

Impacted packages: `web`

Verification:
- `pnpm --filter web run test-client src/components/ui/MarkdownViewer.clienttest.tsx` — Tests 13 passed (13)
- `pnpm run lint` via pre-commit turbo — Tasks: 7 successful, 7 total
- Skipped worker/shared tests: renderer-only web change
- Storybook `MarkdownViewer` stories for nested/tight/ordered lists, headings, code, tables, quotes, tasks, links, and mixed content

![Assistant formatted view with nested list markers beside their labels](https://cursor.com/artifacts/c/art-bd112641-1519-4308-86f7-1292623acebd)
<a href="https://cursor.com/agents/bc-a33606fe-242c-4e15-9bfb-34d3f7b3df26/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fformatted-view-nested-list-markers.mp4"><img src="https://cursor.com/artifacts/c/art-e92c9632-947a-4f54-aa29-9943070dc213" alt="formatted-view-nested-list-markers.mp4" /></a>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Tests cover nested bullets, nested numbered lists, and no empty trailing item
- Storybook: `MarkdownViewer` (lists, headings, code, tables, quotes, tasks, links, mixed)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-8484](https://linear.app/clickhouse/issue/LFE-8484/bugui-bullet-points-are-not-rendered-correctly-in-formatted-view)

<div><a href="https://cursor.com/agents/bc-a33606fe-242c-4e15-9bfb-34d3f7b3df26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a33606fe-242c-4e15-9bfb-34d3f7b3df26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects nested Markdown list-marker alignment in formatted IO views.
- Replaces inside list markers with outside markers and reserves marker space using left padding.
- Adds client tests for nested bullet and ordered lists, including protection against empty trailing items.
- Adds a Storybook example for visually checking nested Markdown lists.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

The list-style change preserves ordered-list start values and checklist handling while the added padding and outside markers directly address the nested-list alignment defect.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): keep formatted-view list marker..."](https://github.com/langfuse/langfuse/commit/9e488543736eab2f2b8ad961372c990662d79bc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59007944)</sub>

<!-- /greptile_comment -->