### PR TITLE
feat(evals): track judge prompt metadata

### DIFF
--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getEvaluatorCreationAnalyticsProperties } from "./getEvaluatorCreationAnalyticsProperties";
+import {
+  getEvaluatorCreationAnalyticsProperties,
+  getJudgePromptAnalyticsProperties,
+} from "./getEvaluatorCreationAnalyticsProperties";
 
 describe("getEvaluatorCreationAnalyticsProperties", () => {
   it("reports all evaluator creation attributes", () => {
@@ -13,6 +16,11 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
           hasCustomModelParams: true,
           scoreType: "CATEGORICAL",
         },
+        promptMessages: [
+          { role: "system" },
+          { role: "user" },
+          { role: "user" },
+        ],
         variableMapping: [
           {
             templateVariable: "question",
@@ -39,6 +47,8 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
       usesDefaultModel: false,
       hasCustomModelParams: true,
       scoreType: "CATEGORICAL",
+      promptMessageCount: 3,
+      promptMessageRoles: ["system", "user"],
       hasNarrowedVariableMapping: false,
       variableMappingSources: ["input", "output"],
     });
@@ -54,6 +64,20 @@ describe("getEvaluatorCreationAnalyticsProperties", () => {
       isCustomTemplate: false,
       isFromScratch: true,
       sourceCodeLanguage: "PYTHON",
+    });
+  });
+
+  it("reports judge prompt shape without prompt content", () => {
+    expect(
+      getJudgePromptAnalyticsProperties([
+        { role: "system" },
+        { role: "assistant" },
+        { role: "user" },
+        { role: "assistant" },
+      ]),
+    ).toEqual({
+      promptMessageCount: 4,
+      promptMessageRoles: ["system", "assistant", "user"],
     });
   });
 });

--- a/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
+++ b/web/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.ts
@@ -1,4 +1,5 @@
 import type {
+  EvaluatorPromptMessage,
   EvalTemplateSourceCodeLanguage,
   EvalTemplateType,
 } from "@langfuse/shared";
@@ -9,12 +10,22 @@ export type EvaluatorCreationSource =
   | { type: "custom" }
   | { type: "scratch" };
 
+export function getJudgePromptAnalyticsProperties(
+  promptMessages: Array<Pick<EvaluatorPromptMessage, "role">>,
+) {
+  return {
+    promptMessageCount: promptMessages.length,
+    promptMessageRoles: [...new Set(promptMessages.map(({ role }) => role))],
+  };
+}
+
 export function getEvaluatorCreationAnalyticsProperties({
   evaluatorType,
   creationSource,
   evaluatorConfig,
   sourceCodeLanguage,
   variableMapping,
+  promptMessages,
 }: {
   evaluatorType: EvalTemplateType;
   creationSource: EvaluatorCreationSource;
@@ -29,6 +40,7 @@ export function getEvaluatorCreationAnalyticsProperties({
     selectedColumnId: string | null;
     jsonSelector?: string | null;
   }>;
+  promptMessages?: Array<Pick<EvaluatorPromptMessage, "role">>;
 }) {
   const configProperties = evaluatorConfig
     ? {
@@ -52,6 +64,9 @@ export function getEvaluatorCreationAnalyticsProperties({
         ],
       }
     : {};
+  const promptProperties = promptMessages
+    ? getJudgePromptAnalyticsProperties(promptMessages)
+    : {};
 
   if (creationSource.type === "managed") {
     return {
@@ -61,6 +76,7 @@ export function getEvaluatorCreationAnalyticsProperties({
       isFromScratch: false,
       ...configProperties,
       ...variableMappingProperties,
+      ...promptProperties,
       ...(sourceCodeLanguage ? { sourceCodeLanguage } : {}),
     };
   }
@@ -71,6 +87,7 @@ export function getEvaluatorCreationAnalyticsProperties({
     isFromScratch: creationSource.type === "scratch",
     ...configProperties,
     ...variableMappingProperties,
+    ...promptProperties,
     ...(sourceCodeLanguage ? { sourceCodeLanguage } : {}),
   };
 }

--- a/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
@@ -54,6 +54,7 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { useCodeEvalSourceValidation } from "@/src/features/evals/hooks/useCodeEvalSourceValidation";
 import {
   getEvaluatorCreationAnalyticsProperties,
+  getJudgePromptAnalyticsProperties,
   type EvaluatorCreationSource,
 } from "@/src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties";
 
@@ -476,7 +477,12 @@ export function EvaluatorSetupPage(
           description,
           definition,
         });
-        capture("evaluators:update", { evaluatorType: state.type });
+        capture("evaluators:update", {
+          evaluatorType: state.type,
+          ...(definition.type === "LLM_AS_JUDGE"
+            ? getJudgePromptAnalyticsProperties(definition.promptMessages)
+            : {}),
+        });
         showSuccessToast({
           title: "Evaluator saved",
           description: "Your evaluator changes are saved.",
@@ -504,6 +510,10 @@ export function EvaluatorSetupPage(
           variableMapping:
             definition.type === "LLM_AS_JUDGE"
               ? definition.variableMapping
+              : undefined,
+          promptMessages:
+            definition.type === "LLM_AS_JUDGE"
+              ? definition.promptMessages
               : undefined,
           evaluatorConfig:
             state.type === "LLM_AS_JUDGE"


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16880 app preview](https://pr-16880.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds metadata-only PostHog properties to successful judge create and update events:

- `promptMessageCount`: number of configured prompt messages
- `promptMessageRoles`: deduplicated role enums used by those messages

Prompt content is never captured. Gallery selection events remain unchanged because no configured prompt exists at that intent seam.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-reviewed the scoped analytics changes.

## Verification

- `pnpm --filter web run test-client "src/features/evals/v2/fns/evaluators/getEvaluatorCreationAnalyticsProperties.clienttest.ts"` — `Tests 2 passed (2)`
- Pre-commit repository lint — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` — exited successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3b5e358-1572-444b-bf20-9cf9a7f23247?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3b5e358-1572-444b-bf20-9cf9a7f23247&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds metadata-only prompt shape properties to successful LLM-as-a-judge creation and update analytics events.

- Reports the configured prompt-message count.
- Reports deduplicated message roles without capturing prompt content.
- Adds focused coverage for creation properties and role deduplication.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed analytics paths.

The new helper derives metadata from validated prompt-message roles, does not capture message content, and is applied only to successful LLM-as-a-judge create and update events.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): track judge prompt metadata"](https://github.com/langfuse/langfuse/commit/ad4457046def4cd08dbd56944d00ed53417578a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59008383)</sub>

<!-- /greptile_comment -->