### PR TITLE
security(worker): redact credentials from rejected PostHog host logs (v3 backport of #16743)

### DIFF
--- a/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
+++ b/worker/src/__tests__/posthogIntegrationProjectJob.test.ts
@@ -99,6 +99,8 @@ vi.mock("../env", () => ({
 
 // Import after mocks are registered.
 import { handlePostHogIntegrationProjectJob } from "../features/posthog/handlePostHogIntegrationProjectJob";
+import { logger, validateWebhookURL } from "@langfuse/shared/src/server";
+import { hostnameForLog } from "../features/analyticsIntegrationEgress";
 import { env } from "../env";
 
 function makeJob() {
@@ -213,5 +215,56 @@ describe("handlePostHogIntegrationProjectJob legacy-mode enriched guard (LFE-110
 
     expect(h.getEvents).toHaveBeenCalledTimes(1);
     expect(h.posthogIntegrationUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// A configured PostHog host can carry credentials, and the rejection log line
+// fires exactly when that URL was refused — including when it was refused for
+// carrying them. Only the hostname may reach the log sink.
+describe("handlePostHogIntegrationProjectJob invalid-hostname logging", () => {
+  const PASSWORD = "hunter2";
+  const CREDENTIALED_HOST = `http://exporter:${PASSWORD}@10.0.0.1/`;
+
+  beforeEach(() => {
+    h.db.integration = {
+      ...h.defaultIntegration(),
+      posthogHostName: CREDENTIALED_HOST,
+    };
+    (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "legacy";
+    vi.mocked(logger.error).mockClear();
+  });
+
+  it("logs the hostname only, never the configured password", async () => {
+    vi.mocked(validateWebhookURL).mockRejectedValueOnce(
+      new Error(
+        "URL credentials are not allowed. Use authentication headers instead.",
+      ),
+    );
+
+    await expect(handlePostHogIntegrationProjectJob(makeJob())).rejects.toThrow(
+      /Invalid PostHog hostname/,
+    );
+
+    const logged = vi
+      .mocked(logger.error)
+      .mock.calls.flat()
+      .map((arg) => String(arg))
+      .join("\n");
+
+    expect(vi.mocked(logger.error)).toHaveBeenCalledTimes(1);
+    expect(logged).toContain("10.0.0.1");
+    expect(logged).not.toContain(PASSWORD);
+  });
+});
+
+describe("hostnameForLog", () => {
+  it("returns only the hostname from a credentialed URL", () => {
+    expect(
+      hostnameForLog("http://admin:hunter2@posthog.example.com/batch"),
+    ).toBe("posthog.example.com");
+  });
+
+  it("marks an unparsable value instead of throwing", () => {
+    expect(hostnameForLog("not a url")).toBe("<unparsable>");
   });
 });

--- a/worker/src/features/analyticsIntegrationEgress.ts
+++ b/worker/src/features/analyticsIntegrationEgress.ts
@@ -1,0 +1,20 @@
+/**
+ * Hostname of a configured URL, for log lines.
+ *
+ * Never log the configured URL itself: it can carry credentials
+ * (`http://user:pass@host`), and the rejection path fires exactly when the
+ * URL was refused — including when it was refused for carrying them. The
+ * hostname component cannot contain userinfo.
+ *
+ * Uses `new URL` rather than `parseOutboundUrl` deliberately: this is
+ * redaction, not validation, and `parseOutboundUrl` refuses a credentialed
+ * URL outright, so it cannot extract a safe hostname from the case that
+ * matters most.
+ */
+export function hostnameForLog(configuredUrl: string): string {
+  try {
+    return new URL(configuredUrl).hostname || "<no hostname>";
+  } catch {
+    return "<unparsable>";
+  }
+}

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -17,6 +17,7 @@ import {
   transformEventForPostHog,
   transformScoreForPostHog,
 } from "./transformers";
+import { hostnameForLog } from "../analyticsIntegrationEgress";
 import { decrypt } from "@langfuse/shared/encryption";
 import { PostHog } from "posthog-node";
 import { recordExportVolume } from "../../services/exportVolumeMetric";
@@ -316,7 +317,7 @@ export const handlePostHogIntegrationProjectJob = async (
     await validateWebhookURL(postHogIntegration.posthogHostName);
   } catch (error) {
     logger.error(
-      `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,
+      `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${hostnameForLog(postHogIntegration.posthogHostName)}. Error: ${error instanceof Error ? error.message : String(error)}`,
     );
     throw new Error(
       `Invalid PostHog hostname for project ${projectId}: ${error instanceof Error ? error.message : "Unknown error"}`,


### PR DESCRIPTION
## What does this PR do?

Backport of the PostHog host-logging half of #16743.

When `validateWebhookURL` rejects a configured PostHog host, the worker logs
that host verbatim:

```
[POSTHOG] PostHog integration for project <id> has invalid hostname: http://exporter:hunter2@10.0.0.1/. Error: URL credentials are not allowed. Use authentication headers instead.
```

A host written as `http://admin:hunter2@posthog.example.com` therefore copies
the password into log storage — and this log line fires *exactly* when the URL
was refused, including when it was refused for carrying credentials
(`parseOutboundUrl` rejects userinfo, which is one of the paths into this
`catch`). The thrown error is already safe: it only interpolates
`error.message`, and no validator message echoes the URL.

The fix logs only the hostname component, which cannot contain userinfo.

## What was adapted for v3

#16743 bundled three things. Only one of them exists on v3:

| Upstream change | On v3 |
| --- | --- |
| PostHog rejection-log host redaction | **backported here** |
| `validateAnalyticsIntegrationUrl` use-time check for the Mixpanel sender (IP literals, credentials, non-HTTP schemes) | not backported — out of scope for this fix, and v3's Mixpanel client has no connect-time pinning for it to complement |
| Redacting the host passed to `notifyPostHogExportFailed` | not applicable — v3 has no export-failure notification path (`notifyPostHogExportFailed` does not exist) |

`hostnameForLog` is added at the same module path main uses
(`worker/src/features/analyticsIntegrationEgress.ts`) so the rest of that
module can be backported later without a move. On v3 the file holds only this
one helper, which needs no imports.

## Impacted packages

- `worker`

## Verification

Tests were added to the closest existing suite
(`worker/src/__tests__/posthogIntegrationProjectJob.test.ts`) rather than a new
file, since it already mocks `logger` and `validateWebhookURL`.

- `pnpm --filter worker run test src/__tests__/posthogIntegrationProjectJob.test.ts src/__tests__/mixpanelIntegrationProjectJob.test.ts src/__tests__/posthogExportVolume.test.ts src/__tests__/mixpanelExportVolume.test.ts src/__tests__/scoresAnalyticsIntegrationEnrichment.test.ts` — `Tests  23 passed (23)`
- `pnpm run typecheck` — `Tasks:    7 successful, 7 total`
- `pnpm run lint` — `Tasks:    7 successful, 7 total`
- `pnpm run format:check` — `All matched files use Prettier code style!`

### Revert-check

Restoring only `handlePostHogIntegrationProjectJob.ts` to `origin/v3` (helper
and tests kept) makes the new test fail with the leak in plain sight, so it is
proving the fix rather than asserting current behaviour:

```
FAIL  src/__tests__/posthogIntegrationProjectJob.test.ts > handlePostHogIntegrationProjectJob invalid-hostname logging > logs the hostname only, never the configured password
AssertionError: expected '[POSTHOG] PostHog integration for pro…' not to contain 'hunter2'

Expected: "hunter2"
Received: "[POSTHOG] PostHog integration for project project-1 has invalid hostname: http://exporter:hunter2@10.0.0.1/. Error: URL credentials are not allowed. Use authentication headers instead."

 Tests  1 failed | 8 passed (9)
```

The two `hostnameForLog` unit cases still pass under that revert, which is
expected — they do not touch the handler.

No web or browser signoff: worker-only logging change, no UI surface.

## What a reviewer should doubt

1. **Reachability.** Save-time validation already rejects credentialed PostHog
   hosts, so a leaking row has to predate that guard (or arrive by a path that
   skips it). This is a defence-in-depth fix on a log line, not a live leak I
   can point at in production.
2. **Scoping the backport to one of three changes.** The Mixpanel use-time
   check is deliberately excluded — it is a separate dormant-gap fix, and
   porting it means porting `validateAnalyticsIntegrationUrl` plus the
   connect-time pinning story it complements. Say the word if you want it in
   the same PR.
3. **A single-function module.** `analyticsIntegrationEgress.ts` exists on v3
   only to hold `hostnameForLog`. That is a bet on future backports of the same
   file; inlining the helper in the handler would be smaller today.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This worker-only backport prevents rejected PostHog URLs from exposing embedded credentials in logs.
- Adds `hostnameForLog`, which safely extracts only the URL hostname and falls back for invalid values.
- Uses the helper when logging PostHog host-validation failures.
- Adds handler-level and helper-level regression coverage for credentialed and unparsable URLs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the credential-redaction path correctly implemented and covered by focused tests.

The changed log argument cannot include URL userinfo, malformed inputs are handled without throwing, and validator error messages do not echo the configured URL.
</details>

<sub>Reviews (1): Last reviewed commit: ["security(worker): redact credentials fro..."](https://github.com/langfuse/langfuse/commit/c713a06ff2c89dd08d856b2c58b756aae27eec5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59019878)</sub>

<!-- /greptile_comment -->