### PR TITLE
fix(api): treat prompt version metrics dimensions as numbers (v3 backport of #16746)

### DIFF
--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -406,7 +406,7 @@ export const observationsView: ViewDeclarationType = {
     promptVersion: {
       sql: "observations.prompt_version",
       alias: "promptVersion",
-      type: "string",
+      type: "number",
       description: "Version of the prompt used for the observation.",
     },
     userId: {
@@ -675,7 +675,7 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
   observationPromptVersion: {
     sql: "observations.prompt_version",
     alias: "observationPromptVersion",
-    type: "string",
+    type: "number",
     relationTable: "observations",
     description: "Version of the prompt used for the observation.",
   },
@@ -762,7 +762,7 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
   observationPromptVersion: {
     sql: "events_observations.prompt_version",
     alias: "observationPromptVersion",
-    type: "string",
+    type: "number",
     relationTable: "events_observations",
     description: "Version of the prompt used for the observation.",
   },
@@ -1186,7 +1186,7 @@ export const eventsObservationsView: ViewDeclarationType = {
     promptVersion: {
       sql: "events_observations.prompt_version",
       alias: "promptVersion",
-      type: "string",
+      type: "number",
       description: "Version of the prompt used for the observation.",
     },
     startTimeMonth: {

--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -44,6 +44,93 @@ describe("queryBuilder filter type validation", () => {
     expect(view.dimensions.value).toBeUndefined();
   });
 
+  it.each(["v1", "v2"] as const)(
+    "declares prompt version dimensions as numbers in the %s scores view",
+    (version) => {
+      const scoresView = getViewDeclaration("scores-numeric", version);
+      const observationsView = getViewDeclaration("observations", version);
+
+      expect(scoresView.dimensions.observationPromptVersion?.type).toBe(
+        "number",
+      );
+      expect(observationsView.dimensions.promptVersion?.type).toBe("number");
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "lowers a numeric observationPromptVersion filter in the %s scores view",
+    async (version) => {
+      const { query } = await buildQueryWithFilter(
+        {
+          column: "observationPromptVersion",
+          operator: "=",
+          value: 2,
+          type: "number",
+        },
+        { view: "scores-numeric" },
+        version,
+      );
+
+      expect(query).toContain("prompt_version = {numberFilter");
+      expect(query).not.toContain("position(");
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "rejects a string observationPromptVersion filter in the %s scores view",
+    async (version) => {
+      await expect(
+        buildQueryWithFilter(
+          {
+            column: "observationPromptVersion",
+            operator: "contains",
+            value: "2",
+            type: "string",
+          },
+          { view: "scores-numeric" },
+          version,
+        ),
+      ).rejects.toThrow(
+        "Filter type 'string' is not supported for dimension type 'number'",
+      );
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "selects observationPromptVersion when grouping scores in %s",
+    async (version) => {
+      const { query } = await new QueryBuilder(undefined, version).build(
+        {
+          ...baseQuery,
+          view: "scores-numeric",
+          dimensions: [{ field: "observationPromptVersion" }],
+        } as QueryType,
+        "test-project",
+      );
+
+      expect(query).toContain("prompt_version");
+      expect(query).toContain("observationPromptVersion");
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "lowers a numeric promptVersion filter in the %s observations view",
+    async (version) => {
+      const { query } = await buildQueryWithFilter(
+        {
+          column: "promptVersion",
+          operator: "=",
+          value: 3,
+          type: "number",
+        },
+        undefined,
+        version,
+      );
+
+      expect(query).toContain("prompt_version = {numberFilter");
+    },
+  );
+
   it.each([
     {
       name: "arrayOptions on scalar string dimension",

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -546,7 +546,7 @@ export class QueryBuilder {
         } else {
           clickhouseSelect = dimension.sql;
         }
-        type = "string";
+        type = dimension.type ?? "string";
         if (dimension.relationTable) {
           clickhouseTableName = dimension.relationTable;
         }

--- a/web/src/__tests__/server/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-v2-api.servertest.ts
@@ -1175,6 +1175,8 @@ describe("/api/public/v2/metrics API Endpoint", () => {
           project_id: projectId,
           name: "test-observation-for-score-v2",
           provided_model_name: "gpt-4-turbo",
+          prompt_name: "ticket-intent-router",
+          prompt_version: 2,
           start_time: Date.now() * 1000,
         }),
       ]);
@@ -1218,6 +1220,16 @@ describe("/api/public/v2/metrics API Endpoint", () => {
         "test-observation-for-score-v2",
         (row: any) => row.observationName === "test-observation-for-score-v2",
       ],
+      [
+        "observationPromptName",
+        "ticket-intent-router",
+        (row: any) => row.observationPromptName === "ticket-intent-router",
+      ],
+      [
+        "observationPromptVersion",
+        2,
+        (row: any) => Number(row.observationPromptVersion) === 2,
+      ],
     ])(
       "should support %s dimension via events table",
       async (dimensionField, expectedValue, findRowFn) => {
@@ -1251,5 +1263,91 @@ describe("/api/public/v2/metrics API Endpoint", () => {
         expect(foundRow).toBeDefined();
       },
     );
+
+    it("should filter scores-numeric by observationPromptVersion as a number", async () => {
+      const query = {
+        view: "scores-numeric",
+        dimensions: [{ field: "name" }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "name",
+            operator: "=",
+            value: "score-with-observation-v2",
+            type: "string",
+          },
+          {
+            column: "observationPromptVersion",
+            operator: "=",
+            value: 2,
+            type: "number",
+          },
+        ],
+        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+        toTimestamp: new Date().toISOString(),
+      };
+
+      const response = await makeZodVerifiedAPICall(
+        GetMetricsV1Response,
+        "GET",
+        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "score-with-observation-v2",
+          }),
+        ]),
+      );
+
+      const mismatched = await makeZodVerifiedAPICall(
+        GetMetricsV1Response,
+        "GET",
+        `/api/public/v2/metrics?query=${encodeURIComponent(
+          JSON.stringify({
+            ...query,
+            filters: [
+              query.filters[0],
+              {
+                column: "observationPromptVersion",
+                operator: "=",
+                value: 99,
+                type: "number",
+              },
+            ],
+          }),
+        )}`,
+      );
+
+      expect(mismatched.status).toBe(200);
+      expect(mismatched.body.data).toHaveLength(0);
+    });
+
+    it("rejects a string filter on observationPromptVersion", async () => {
+      const query = {
+        view: "scores-numeric",
+        dimensions: [{ field: "name" }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "observationPromptVersion",
+            operator: "=",
+            value: "2",
+            type: "string",
+          },
+        ],
+        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+        toTimestamp: new Date().toISOString(),
+      };
+
+      const response = await makeAPICall(
+        "GET",
+        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
+      );
+
+      expect(response.status).toBe(400);
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Backport of #16746 — cherry-picked with `-x`, no adaptation needed.

The metrics query data model declared `promptVersion` / `observationPromptVersion`
as `string`, but ClickHouse stores `prompt_version` as `Nullable(UInt16)`. On v3
that mismatch makes the Metrics API unable to slice by prompt version:

- `type: "number"` filters are rejected with 400
- `type: "string"` filters are accepted and silently do nothing
- `contains` compiles to `position(prompt_version, …)` over a `UInt16` and 500s

This affects the **v1** Metrics API (`/api/public/metrics`) as well as the v2
preview, so it is reachable on a default v3 install — the `observations` view's
`promptVersion` and the scores views' `observationPromptVersion` are both
declaration-driven and both were wrong.

Four declarations move to `type: "number"`, matching the table definitions.

**Filter contract change:** clients must send `type: "number"`, e.g.
`{"column":"observationPromptVersion","operator":"=","value":2,"type":"number"}`.
The previous `type: "string"` form never filtered correctly, so nothing that
worked stops working — but a client sending the ineffective string form now gets
a 400 instead of a silently unfiltered result set.

## Impacted packages

- `@langfuse/shared` (metrics data model + query builder)
- `web` (metrics v2 API tests)

## Patch identity

The applied change is line-for-line main's patch — diffing
`git show d91c904cb9` against `git diff origin/v3..HEAD` with `+++`/`---`/`@@`
headers stripped produces no differences. All four files applied cleanly.

## Verification

- `pnpm --filter @langfuse/shared run test src/features/query/server/queryBuilder.filterValidation.test.ts` — `Tests  20 passed (20)` (main reports 37 for the same file; v3's copy has fewer pre-existing cases)
- Related query suites (`filterValidation`, `intervalBucketing`, `monitors/isValidQuery`, `event-query-builder`, `events-stream-query`) — `Tests  68 passed (68)`
- `pnpm --filter web run test metrics-v2-api.servertest.ts` — `Tests  47 passed (47)`
- `pnpm --filter web run test metrics-api.servertest.ts` (v1, the default-install path) — `Tests  17 passed (17)`
- `pnpm --filter worker run test src/__tests__/monitorProcessorScalarQuery.test.ts` — `Tests  1 passed (1)`
- `pnpm run typecheck` — `Tasks:    7 successful, 7 total`
- `pnpm run lint` — `Tasks:    7 successful, 7 total`
- `pnpm run format:check` — `All matched files use Prettier code style!`

Servertests ran against a v3 dev server on a dedicated `langfuse_v3_test`
Postgres (424 applied = 424 migration dirs) and a v3 ClickHouse (37 applied
migrations), not the shared `langfuse_test` database, which has drifted to
main's schema (435 applied).

### Revert-check

Restoring both prod files to `origin/v3` and keeping the new tests:

```
Tests  8 failed | 12 passed (20)
```

with the exact pre-fix symptoms, including the `contains` case compiling
`position()` over the numeric column:

```
InvalidRequestError: Invalid filter for field 'promptVersion': Filter type 'number' is not supported for dimension type 'string'. Expected 'string' or 'stringOptions'.

WHERE position(events_observations.prompt_version, {stringFilterMJdlH: String}) > 0 …
```

Same revert at the API level (rebuilt `@langfuse/shared` dist, restarted the dev
server):

```
Tests  2 failed | 45 passed (47)

Error: API call did not return 200, returned status 400, body {"message":"Invalid filter for field 'observationPromptVersion': Filter type 'number' is not supported for dimension type 'string'. …"}
AssertionError: expected 200 to be 400   // the string filter was silently accepted
```

## What a reviewer should doubt

1. **The `queryBuilder.ts` line is inert on v3, as measured.** `type = dimension.type ?? "string"`
   changes the mapping type for every dimension that declares a non-string type —
   on v3 that is `tags` (`string[]`), `toolNames` / `calledToolNames`
   (`arrayString`), scores `value` (`number`), `booleanValue` (`boolean`), plus
   the four changed here. I generated the `WHERE` clause for all seven across
   `v1` and `v2` with and without that line: **byte-identical in every case**,
   and the 20 tests all pass with `dataModel.ts` alone. `createFilterFromFilterState`
   switches on the *request's* filter type, and nothing in `factory.ts` reads the
   mapping's `type`. I kept the line for parity with main (it is the honest
   declaration and avoids a future conflict in this file), but the `dataModel.ts`
   half is what fixes the bug. Drop it if you would rather not carry dead code.
2. **The two grouping tests pass before and after.** `selects observationPromptVersion when grouping scores`
   asserts the generated SQL mentions the column, which was already true — the
   reported symptom (grouping returns `null`) is not what those two assert. They
   came with the upstream patch; I kept them verbatim rather than strengthening
   them in a backport.
3. **The 400-instead-of-silent-no-op behaviour change.** Any v3 client currently
   sending `type: "string"` for these dimensions starts getting a 400. That is
   upstream's chosen contract and the old behaviour was wrong, but it is the one
   externally visible change here.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns prompt-version query dimensions with their numeric ClickHouse representation and adds validation and API coverage for numeric filtering. One chart compatibility workaround still treats `promptVersion` as unsupported, so chart queries continue to drop an otherwise valid active filter.

- Changes `promptVersion` and `observationPromptVersion` declarations from string to number across v1 and v2 views.
- Propagates declared dimension types into query-builder mappings.
- Adds query-builder and Metrics API tests for numeric filtering, grouping, and string-filter rejection.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The prompt-version API correction is sound, but the events chart path should be updated before merging so it does not continue dropping valid promptVersion filters.

The changed numeric declaration makes promptVersion filters valid for the observations query, while the chart compatibility layer still removes them based on the former string-type limitation, causing charts to ignore an active filter.

**Files Needing Attention:** packages/shared/src/features/query/dataModel.ts and web/src/features/chart-view/lib/chartFilterCompatibility.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/features/query/dataModel.ts:409
**Chart drops prompt-version filters**

When a user applies a numeric `promptVersion` filter in chart mode, the chart compatibility layer still excludes the dimension based on its former string type, causing the chart query to run without the active filter and display unfiltered results.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): treat prompt version metrics d..."](https://github.com/langfuse/langfuse/commit/d340842a43bd923ed6108d626788ee34d6d003d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59019923)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Analytics and query data](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/analytics-query-data.md)

<!-- /greptile_comment -->