### PR TITLE
fix(evals): polish editor search panel

### DIFF
--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -14,7 +14,7 @@ import {
   StateEffect,
   StateField,
 } from "@codemirror/state";
-import { SearchQuery, search, setSearchQuery } from "@codemirror/search";
+import { SearchQuery, setSearchQuery } from "@codemirror/search";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter, type Diagnostic } from "@codemirror/lint";
 import { useTheme } from "next-themes";
@@ -37,6 +37,7 @@ import { lightTheme } from "@/src/components/editor/light-theme";
 import { darkTheme } from "@/src/components/editor/dark-theme";
 import { autoScrollOnSelectionDrag } from "@/src/components/editor/autoScrollOnSelectionDrag";
 import { createJsonMagicPasteExtension } from "@/src/components/editor/jsonMagicPaste";
+import { codeMirrorSearchPanel } from "@/src/constants/codeMirrorSearchPanel";
 
 // Custom language mode for prompts that highlights mustache variables and prompt dependency tags
 const promptLanguage = StreamLanguage.define({
@@ -478,7 +479,7 @@ export function CodeMirrorEditor({
       // mouseup capture listeners registering on every drag.
       ...(editable ? [autoScrollOnSelectionDrag()] : []),
       searchHighlightingSupport,
-      search(),
+      codeMirrorSearchPanel,
       // RTL/bidi support - must be early for proper line decoration
       ...bidiSupport,
       // Remove outline if field is focussed

--- a/web/src/constants/codeMirrorSearchPanel.ts
+++ b/web/src/constants/codeMirrorSearchPanel.ts
@@ -1,0 +1,141 @@
+import { search } from "@codemirror/search";
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@uiw/react-codemirror";
+
+const searchPanelTheme = EditorView.theme({
+  ".cm-panels-top": {
+    borderBottom: "1px solid hsl(var(--border))",
+  },
+  ".cm-panel.cm-search": {
+    position: "relative",
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: "4px",
+    padding: "6px 40px 6px 8px",
+    backgroundColor: "hsl(var(--secondary))",
+    color: "hsl(var(--secondary-foreground))",
+    fontFamily: "var(--font-sans)",
+    fontSize: "var(--text-sm)",
+  },
+  ".cm-panel.cm-search br": {
+    display: "none",
+  },
+  ".cm-panel.cm-search input[name=search], .cm-panel.cm-search input[name=replace]":
+    {
+      boxSizing: "border-box",
+      width: "min(220px, 100%)",
+      height: "32px",
+      margin: "0",
+      border: "1px solid hsl(var(--input))",
+      borderRadius: "6px",
+      backgroundColor: "hsl(var(--background))",
+      color: "hsl(var(--foreground))",
+      padding: "4px 8px",
+      fontFamily: "var(--font-sans)",
+      fontSize: "var(--text-sm)",
+      outline: "none",
+    },
+  ".cm-panel.cm-search input[name=search]:focus, .cm-panel.cm-search input[name=replace]:focus":
+    {
+      borderColor: "hsl(var(--ring))",
+    },
+  ".cm-panel.cm-search button": {
+    boxSizing: "border-box",
+    height: "32px",
+    margin: "0",
+    border: "1px solid hsl(var(--border-contrast))",
+    borderRadius: "6px",
+    backgroundColor: "hsl(var(--background))",
+    backgroundImage: "none",
+    color: "hsl(var(--foreground))",
+    padding: "0 12px",
+    fontFamily: "var(--font-sans)",
+    fontSize: "var(--text-sm)",
+    lineHeight: "30px",
+    textTransform: "capitalize",
+    cursor: "pointer",
+  },
+  ".cm-panel.cm-search button:hover": {
+    backgroundColor: "hsl(var(--accent))",
+    color: "hsl(var(--accent-foreground))",
+  },
+  ".cm-panel.cm-search button:focus-visible": {
+    outline: "2px solid hsl(var(--ring))",
+    outlineOffset: "2px",
+  },
+  ".cm-panel.cm-search button:disabled": {
+    cursor: "not-allowed",
+    opacity: "0.5",
+  },
+  ".cm-panel.cm-search label": {
+    display: "inline-flex",
+    height: "32px",
+    alignItems: "center",
+    gap: "4px",
+    margin: "0",
+    borderRadius: "6px",
+    color: "hsl(var(--muted-foreground))",
+    padding: "0 4px",
+    fontFamily: "var(--font-sans)",
+    fontSize: "var(--text-xs)",
+    whiteSpace: "nowrap",
+    cursor: "pointer",
+  },
+  ".cm-panel.cm-search label:hover": {
+    backgroundColor: "hsl(var(--accent))",
+    color: "hsl(var(--accent-foreground))",
+  },
+  ".cm-panel.cm-search label:has(input:checked)": {
+    backgroundColor: "hsl(var(--accent))",
+    color: "hsl(var(--accent-foreground))",
+  },
+  ".cm-panel.cm-search input[type=checkbox]": {
+    boxSizing: "border-box",
+    display: "inline-flex",
+    width: "16px",
+    height: "16px",
+    flexShrink: "0",
+    alignItems: "center",
+    justifyContent: "center",
+    margin: "0",
+    appearance: "none",
+    border: "1px solid hsl(var(--control-border))",
+    borderRadius: "4px",
+    backgroundColor: "transparent",
+    outline: "none",
+    cursor: "pointer",
+  },
+  ".cm-panel.cm-search input[type=checkbox]:checked": {
+    borderColor: "hsl(var(--control-fill))",
+    backgroundColor: "hsl(var(--control-fill))",
+  },
+  ".cm-panel.cm-search input[type=checkbox]:checked::after": {
+    width: "12px",
+    height: "12px",
+    backgroundColor: "hsl(var(--primary-foreground))",
+    content: "''",
+    maskImage:
+      "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M20 6 9 17l-5-5' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E\")",
+    maskPosition: "center",
+    maskRepeat: "no-repeat",
+    maskSize: "contain",
+  },
+  ".cm-panel.cm-search button[name=close]": {
+    position: "absolute",
+    top: "6px",
+    right: "8px",
+    width: "32px",
+    borderColor: "transparent",
+    backgroundColor: "transparent",
+    padding: "0",
+    fontSize: "16px",
+    lineHeight: "30px",
+  },
+});
+
+/** Shared top-mounted search panel for prompt and code editors. */
+export const codeMirrorSearchPanel: Extension = [
+  search({ top: true }),
+  searchPanelTheme,
+];

--- a/web/src/constants/codeMirrorSearchPanel.ts
+++ b/web/src/constants/codeMirrorSearchPanel.ts
@@ -86,10 +86,6 @@ const searchPanelTheme = EditorView.theme({
     backgroundColor: "hsl(var(--accent))",
     color: "hsl(var(--accent-foreground))",
   },
-  ".cm-panel.cm-search label:has(input:checked)": {
-    backgroundColor: "hsl(var(--accent))",
-    color: "hsl(var(--accent-foreground))",
-  },
   ".cm-panel.cm-search input[type=checkbox]": {
     boxSizing: "border-box",
     display: "inline-flex",

--- a/web/src/constants/codeMirrorSearchPanel.ts
+++ b/web/src/constants/codeMirrorSearchPanel.ts
@@ -1,6 +1,34 @@
 import { search } from "@codemirror/search";
 import type { Extension } from "@codemirror/state";
-import { EditorView } from "@uiw/react-codemirror";
+import { EditorView, ViewPlugin } from "@uiw/react-codemirror";
+
+const KEYBOARD_NAVIGATION_CLASS = "cm-keyboard-navigation";
+
+const keyboardNavigation = ViewPlugin.fromClass(
+  class {
+    constructor(readonly view: EditorView) {
+      view.dom.addEventListener("keydown", this.handleKeyDown, true);
+      view.dom.addEventListener("mousedown", this.handleMouseDown, true);
+    }
+
+    private readonly handleKeyDown = () => {
+      this.view.dom.classList.add(KEYBOARD_NAVIGATION_CLASS);
+    };
+
+    private readonly handleMouseDown = () => {
+      this.view.dom.classList.remove(KEYBOARD_NAVIGATION_CLASS);
+    };
+
+    destroy() {
+      this.view.dom.removeEventListener("keydown", this.handleKeyDown, true);
+      this.view.dom.removeEventListener(
+        "mousedown",
+        this.handleMouseDown,
+        true,
+      );
+    }
+  },
+);
 
 const searchPanelTheme = EditorView.theme({
   ".cm-panels-top": {
@@ -102,6 +130,10 @@ const searchPanelTheme = EditorView.theme({
     outline: "none",
     cursor: "pointer",
   },
+  "&.cm-keyboard-navigation .cm-panel.cm-search input[type=checkbox]:focus": {
+    outline: "2px solid hsl(var(--ring))",
+    outlineOffset: "2px",
+  },
   ".cm-panel.cm-search input[type=checkbox]:checked": {
     borderColor: "hsl(var(--control-fill))",
     backgroundColor: "hsl(var(--control-fill))",
@@ -133,5 +165,6 @@ const searchPanelTheme = EditorView.theme({
 /** Shared top-mounted search panel for prompt and code editors. */
 export const codeMirrorSearchPanel: Extension = [
   search({ top: true }),
+  keyboardNavigation,
   searchPanelTheme,
 ];

--- a/web/src/features/evals/components/code-eval-template-form-body.clienttest.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.clienttest.tsx
@@ -40,6 +40,32 @@ describe("CodeEvalTemplateFormBody", () => {
     vi.clearAllMocks();
   });
 
+  it("opens the search panel above the code editor", async () => {
+    const { container } = render(
+      <CodeEvalTemplateFormBody
+        sourceCode="return JSON.stringify(ctx)"
+        sourceCodeLanguage="TYPESCRIPT"
+        onSourceCodeChange={vi.fn()}
+        editable
+        validationResult={null}
+        ctxSample={null}
+      />,
+      { wrapper: TestTooltipProvider },
+    );
+
+    const editorContent = container.querySelector<HTMLElement>(".cm-content");
+    expect(editorContent).not.toBeNull();
+    fireEvent.keyDown(editorContent!, {
+      key: "f",
+      code: "KeyF",
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector(".cm-panels-top .cm-search")).toBeTruthy();
+    });
+  });
+
   it("blocks evaluator source from PostHog session recordings", () => {
     const { container } = render(
       <CodeEvalTemplateFormBody

--- a/web/src/features/evals/components/code-eval-template-form-body.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.tsx
@@ -33,6 +33,7 @@ import {
 import { darkTheme } from "@/src/components/editor/dark-theme";
 import { lightTheme } from "@/src/components/editor/light-theme";
 import { autoScrollOnSelectionDrag } from "@/src/components/editor/autoScrollOnSelectionDrag";
+import { codeMirrorSearchPanel } from "@/src/constants/codeMirrorSearchPanel";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import {
   getCodeEvalHoverDocs,
@@ -376,6 +377,7 @@ export function CodeEvalTemplateFormBody({
         : []),
       EditorView.lineWrapping,
       codeMirrorLayoutTheme,
+      codeMirrorSearchPanel,
     ],
     [
       codeEvalCompletionExtension,

--- a/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.clienttest.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.clienttest.tsx
@@ -24,6 +24,36 @@ describe("PromptVariableEditor", () => {
     });
   });
 
+  it("uses a checkbox focus affordance only during keyboard navigation", async () => {
+    const { container } = render(
+      <PromptVariableEditor value="Search me" onChange={vi.fn()} />,
+    );
+
+    const editorContent = container.querySelector<HTMLElement>(".cm-content");
+    const editor = container.querySelector<HTMLElement>(".cm-editor");
+    expect(editorContent).not.toBeNull();
+    expect(editor).not.toBeNull();
+
+    fireEvent.keyDown(editorContent!, {
+      key: "f",
+      code: "KeyF",
+      ctrlKey: true,
+    });
+    const checkbox = await waitFor(() => {
+      const element = container.querySelector<HTMLInputElement>(
+        '.cm-search input[type="checkbox"]',
+      );
+      expect(element).not.toBeNull();
+      return element!;
+    });
+
+    expect(editor).toHaveClass("cm-keyboard-navigation");
+    fireEvent.mouseDown(checkbox);
+    expect(editor).not.toHaveClass("cm-keyboard-navigation");
+    fireEvent.keyDown(checkbox, { key: "Tab", code: "Tab" });
+    expect(editor).toHaveClass("cm-keyboard-navigation");
+  });
+
   it("keeps the interpolated preview aligned and theme-aware", () => {
     const { container } = render(
       <PromptVariableEditor

--- a/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.clienttest.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.clienttest.tsx
@@ -1,8 +1,29 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 
 import { PromptVariableEditor } from "./PromptVariableEditor";
 
 describe("PromptVariableEditor", () => {
+  it("opens the search panel above the prompt editor", async () => {
+    const { container } = render(
+      <PromptVariableEditor
+        value="Return only valid JSON"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const editorContent = container.querySelector<HTMLElement>(".cm-content");
+    expect(editorContent).not.toBeNull();
+    fireEvent.keyDown(editorContent!, {
+      key: "f",
+      code: "KeyF",
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector(".cm-panels-top .cm-search")).toBeTruthy();
+    });
+  });
+
   it("keeps the interpolated preview aligned and theme-aware", () => {
     const { container } = render(
       <PromptVariableEditor

--- a/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.stories.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Judges/PromptVariableEditor/PromptVariableEditor.stories.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, MoreVertical } from "lucide-react";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
@@ -188,5 +188,40 @@ export const ReadOnly = meta.story({
     variableStatus: { output: { status: "valid" } },
     variableMappings: { output: "Observation output" },
     readOnly: true,
+  },
+});
+
+export const SearchPanel = meta.story({
+  name: "(Test) Search Panel",
+  args: {
+    value:
+      "Return only valid JSON. Do not add markdown or an explanation around the JSON object.",
+    onChange: fn(),
+    showPreviewToggle: true,
+    previewEnabled: false,
+    onPreviewEnabledChange: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const editor = canvasElement.querySelector<HTMLElement>(".cm-content");
+    if (!editor) throw new Error("Prompt editor not found");
+
+    await userEvent.click(editor);
+    const isMac = /Mac|iPhone|iPad/.test(navigator.platform);
+    editor.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "f",
+        code: "KeyF",
+        metaKey: isMac,
+        ctrlKey: !isMac,
+        bubbles: true,
+      }),
+    );
+
+    const findInput = await canvas.findByRole("textbox", { name: "Find" });
+    await userEvent.type(findInput, "JSON");
+    await expect(
+      canvasElement.querySelector(".cm-panels-top .cm-search"),
+    ).toBeInTheDocument();
   },
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16886 app preview](https://pr-16886.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Polishes the built-in find / replace panel in prompt and code evaluator editors.

Key changes:
- move the panel to the top of both editors
- align inputs, buttons, hover states, and checkboxes with our design system
- keep the shared CodeMirror configuration in a top-level constant
- add a PromptVariableEditor story that opens the search panel

## Test plan

- `pnpm --filter web run test-client code-eval-template-form-body.clienttest.tsx PromptVariableEditor.clienttest.tsx` - 7 tests passed
- `pnpm --filter web run test-storybook PromptVariableEditor.stories.tsx` - 8 tests passed
- `pnpm run lint` - 7 tasks successful

## Browser verification

Preview: https://pr-16886.preview.langfuse.com

1. Open Evaluations and create or edit an LLM-as-a-Judge evaluator.
2. Focus a prompt message and press Cmd/Ctrl+F.
3. Confirm the styled panel opens above the prompt and search / replace works.
4. Open a code evaluator and repeat the same check.

Browser verification is left open as requested.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces a shared, top-mounted CodeMirror search-panel extension with design-system styling and applies it to prompt and code-evaluator editors.

- Replaces the default search extension in both editor implementations.
- Adds client tests that verify the panel opens above each editor.
- Adds an interactive PromptVariableEditor story covering search-panel behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The shared search extension remains scoped through each CodeMirror editor state, the required theme tokens are defined, and the changed editor integrations preserve their existing behavior while moving and restyling the panel.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): polish editor search panel"](https://github.com/langfuse/langfuse/commit/f4cbdcd37c186e077697dc75cae91676ef098c7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59031728)</sub>

<!-- /greptile_comment -->