### PR TITLE
fix(evals): guide structured evaluator output

### DIFF
--- a/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
+++ b/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
@@ -146,6 +146,8 @@ describe("createProductionEvalExecutionDeps", () => {
       schema: z.ZodType;
     };
     expect(z.toJSONSchema(modelOutput.schema)).toMatchObject({
+      description:
+        'Return only top-level "score" and "scoreExplanation". Put other requested fields inside "scoreExplanation".',
       properties: {
         scoreExplanation: { type: "string" },
         score: { type: "number" },
@@ -219,10 +221,14 @@ describe("createProductionEvalExecutionDeps", () => {
           ? Buffer.from(value).toString("base64")
           : value,
     );
-    const modelFacingSchema = z.object({
-      scoreExplanation: structuredOutputSchema.shape.reasoning,
-      score: structuredOutputSchema.shape.score,
-    });
+    const modelFacingSchema = z
+      .object({
+        scoreExplanation: structuredOutputSchema.shape.reasoning,
+        score: structuredOutputSchema.shape.score,
+      })
+      .describe(
+        'Return only top-level "score" and "scoreExplanation". Put other requested fields inside "scoreExplanation".',
+      );
     const expectedBytes =
       Buffer.byteLength(serializedProviderMessages, "utf8") +
       Buffer.byteLength(

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -25,6 +25,9 @@ type StructuredOutputSchema = z.ZodObject<{
   score: z.ZodType;
 }>;
 
+const MODEL_FACING_OUTPUT_SCHEMA_DESCRIPTION =
+  'Return only top-level "score" and "scoreExplanation". Put other requested fields inside "scoreExplanation".';
+
 /**
  * Result of fetching model configuration.
  */
@@ -246,12 +249,14 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
           adapter,
         });
 
-      // Keep the evaluator contract unchanged, but avoid exposing the
-      // overloaded `reasoning` field name to the model.
-      const modelFacingStructuredOutputSchema = z.object({
-        scoreExplanation: params.structuredOutputSchema.shape.reasoning,
-        score: params.structuredOutputSchema.shape.score,
-      });
+      // Keep the evaluator contract unchanged while the model-facing schema
+      // resolves custom output instructions into the supported fields.
+      const modelFacingStructuredOutputSchema = z
+        .object({
+          scoreExplanation: params.structuredOutputSchema.shape.reasoning,
+          score: params.structuredOutputSchema.shape.score,
+        })
+        .describe(MODEL_FACING_OUTPUT_SCHEMA_DESCRIPTION);
 
       // llmaj egress: provider-bound messages (including base64-expanded inline
       // media) plus schema, uncompressed.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16887 app preview](https://pr-16887.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- add platform-owned guidance to the model-facing evaluator output schema
- keep `score` / `scoreExplanation` as the only top-level fields when evaluator prompts request custom formats
- verify the guidance is included in the provider JSON Schema and egress accounting

## Evidence

A local Bedrock Sonnet 5 test with a conflicting evaluator prompt failed in 3/20 baseline calls. The selected description completed 20/20 calls successfully without a system message.

## Tests

- `pnpm --filter worker run test evalExecutionDeps.test.ts` - `Tests  3 passed (3)`
- `pnpm run lint` - `Tasks: 7 successful, 7 total`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds platform-owned guidance to the evaluator’s model-facing output schema so custom formatting requests remain within the supported `score` and `scoreExplanation` fields.

- Adds a root description to the Zod schema passed to model providers.
- Verifies the description appears in generated JSON Schema.
- Updates egress-accounting expectations to include the serialized guidance.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The change preserves the existing two-field evaluator output contract and consistently includes the new schema description in both model-facing serialization and tested egress accounting.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): guide structured evaluator o..."](https://github.com/langfuse/langfuse/commit/8126bca240042dce58f912a3069c4473082de889) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59037426)</sub>

<!-- /greptile_comment -->