### PR TITLE
fix(auth): render JumpCloud sign-in button

### DIFF
--- a/web/src/__tests__/auth-sign-in-page.clienttest.tsx
+++ b/web/src/__tests__/auth-sign-in-page.clienttest.tsx
@@ -67,6 +67,7 @@ const authProviders: PageProps["authProviders"] = {
   auth0: false,
   clickhouseCloud: false,
   cognito: false,
+  jumpcloud: false,
   keycloak: false,
   workos: false,
   wordpress: false,
@@ -219,5 +220,51 @@ describe("sign-in page NextAuth error classification", () => {
 
     expect(screen.getByText("Sign in to your account")).toBeInTheDocument();
     expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sign-in page JumpCloud provider button", () => {
+  beforeEach(() => {
+    signInMock.mockReset();
+    signInMock.mockResolvedValue(undefined);
+    routerState.query = {};
+    window.localStorage.clear();
+  });
+
+  it("does not render a JumpCloud button when the provider is disabled", () => {
+    renderSignIn();
+
+    expect(
+      screen.queryByRole("button", { name: /JumpCloud/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a JumpCloud button and signs in with the jumpcloud provider", () => {
+    renderSignIn({
+      authProviders: {
+        ...authProviders,
+        jumpcloud: true,
+      },
+    });
+
+    const button = screen.getByRole("button", { name: /JumpCloud/ });
+    fireEvent.click(button);
+
+    expect(signInMock).toHaveBeenCalledWith("jumpcloud");
+  });
+
+  it("still renders JumpCloud when username/password auth is disabled", () => {
+    renderSignIn({
+      authProviders: {
+        ...authProviders,
+        credentials: false,
+        jumpcloud: true,
+      },
+    });
+
+    expect(
+      screen.getByRole("button", { name: /JumpCloud/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -36,6 +36,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   auth0: "Auth0",
   cognito: "Cognito",
   keycloak: "Keycloak",
+  jumpcloud: "JumpCloud",
   workos: "WorkOS",
   wordpress: "WordPress",
   custom: "Custom OAuth",

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -81,6 +81,7 @@ export type PageProps = {
     auth0: boolean;
     clickhouseCloud: boolean;
     cognito: boolean;
+    jumpcloud: boolean;
     keycloak:
       | {
           name: string;
@@ -158,6 +159,10 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
           env.AUTH_COGNITO_CLIENT_ID !== undefined &&
           env.AUTH_COGNITO_CLIENT_SECRET !== undefined &&
           env.AUTH_COGNITO_ISSUER !== undefined,
+        jumpcloud:
+          env.AUTH_JUMPCLOUD_CLIENT_ID !== undefined &&
+          env.AUTH_JUMPCLOUD_CLIENT_SECRET !== undefined &&
+          env.AUTH_JUMPCLOUD_ISSUER !== undefined,
         keycloak:
           env.AUTH_KEYCLOAK_CLIENT_ID !== undefined &&
           env.AUTH_KEYCLOAK_CLIENT_SECRET !== undefined &&
@@ -214,6 +219,7 @@ export const FALLBACK_AUTH_PROVIDERS: PageProps["authProviders"] = {
   auth0: false,
   clickhouseCloud: false,
   cognito: false,
+  jumpcloud: false,
   keycloak: false,
   workos: false,
   wordpress: false,
@@ -399,6 +405,17 @@ export function SSOButtons({
               loading={providerSigningIn === "cognito"}
               showLastUsedBadge={
                 hasMultipleAuthMethods && lastUsedMethod === "cognito"
+              }
+            />
+          )}
+          {authProviders.jumpcloud && (
+            <AuthProviderButton
+              icon={<TbBrandOauth className="mr-3" size={18} />}
+              label="JumpCloud"
+              onClick={() => handleSignIn("jumpcloud")}
+              loading={providerSigningIn === "jumpcloud"}
+              showLastUsedBadge={
+                hasMultipleAuthMethods && lastUsedMethod === "jumpcloud"
               }
             />
           )}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16888 app preview](https://pr-16888.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes #16854

The native JumpCloud auth provider is registered in NextAuth whenever `AUTH_JUMPCLOUD_CLIENT_ID`, `AUTH_JUMPCLOUD_CLIENT_SECRET`, and `AUTH_JUMPCLOUD_ISSUER` are set, and `/api/auth/providers` advertises it. The sign-in page rendered SSO buttons from a hardcoded provider list that omitted `jumpcloud`, so self-hosted instances had no UI entry point. Combined with `AUTH_DISABLE_USERNAME_PASSWORD=true`, the sign-in page was empty.

This adds JumpCloud to the same four touchpoints every other provider already has:

- `PageProps` type
- `getServerSideProps` gate (mirrors the registration condition in `auth.ts`)
- `FALLBACK_AUTH_PROVIDERS` default
- "Sign in with JumpCloud" button, using the already-imported `TbBrandOauth` icon

`sign-up.tsx` re-exports `getServerSideProps` and `SSOButtons` from `sign-in.tsx`, so it is covered automatically. The enterprise SSO required page now maps `jumpcloud` to a friendly label.

No change to the provider, env schema, or auth flow.

Related community PR: #16753

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run test-client src/__tests__/auth-sign-in-page.clienttest.tsx` — `Tests 13 passed (13)`
- Pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- Pre-commit `prettier --check` — All matched files use Prettier code style
- `pnpm --filter web run typecheck` — `tsc` exited 0 (`--noEmit --skipLibCheck`)

## Tracking

Reuses the existing `sign_in:button_click` event with `{ provider }`. The JumpCloud button goes through `handleSignIn("jumpcloud")`, same as Google/GitHub. Metadata-only, no raw values.

## Mandatory Tasks

- [x] Self-reviewed the code

## Test this

Preview: [pr-16888 app preview](https://pr-16888.preview.langfuse.com/auth/sign-in?autoSignIn=false)

The preview does not set JumpCloud env vars, so the button will not appear there. To reproduce:

1. Self-host with `AUTH_JUMPCLOUD_CLIENT_ID`, `AUTH_JUMPCLOUD_CLIENT_SECRET`, `AUTH_JUMPCLOUD_ISSUER`, and optionally `AUTH_DISABLE_USERNAME_PASSWORD=true`.
2. Open `/auth/sign-in`.
3. Expect a "JumpCloud" button. Clicking it starts `signIn("jumpcloud")`.

Sandbox: same path on `http://localhost:3000` after the cloud stack is up with those env vars.

Data: demo project is enough; this is the unauthenticated sign-in page.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15831](https://linear.app/clickhouse/issue/LFE-15831/bug-jumpcloud-auth-provider-has-no-sign-in-button-on-self-hosted)

<div><a href="https://cursor.com/agents/bc-2bdfc154-2517-4923-a698-ad1e62632a15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bdfc154-2517-4923-a698-ad1e62632a15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the missing JumpCloud entry point to the authentication UI and aligns its availability with the existing server-side provider configuration.

- Adds JumpCloud to sign-in page provider properties, environment gating, and fallback state.
- Renders a JumpCloud sign-in button through the shared provider flow, including loading and last-used states.
- Adds a friendly JumpCloud label to the enterprise SSO-required page.
- Adds client tests for disabled, enabled, and passwordless configurations.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The JumpCloud availability gate matches provider registration semantics, and the new button consistently uses the existing `jumpcloud` provider identifier throughout sign-in state and enterprise SSO messaging.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): render JumpCloud sign-in butt..."](https://github.com/langfuse/langfuse/commit/4d51f26417fbcd573dd785b61a834911ad440a80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59047505)</sub>

<!-- /greptile_comment -->