### PR TITLE
fix(evals): align evaluator name fields

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorSetupEditor/components/NameStep/NameStep.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorSetupEditor/components/NameStep/NameStep.tsx
@@ -58,8 +58,11 @@ export function NameStep({
           />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="evaluator-description">
-            Description{" "}
+          <Label
+            htmlFor="evaluator-description"
+            className="flex items-center gap-1"
+          >
+            Description
             <span className="text-muted-foreground font-normal">
               (optional)
             </span>


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16889 app preview](https://pr-16889.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- align the name and description field labels
- keep consistent spacing between `Description` and `(optional)`

## Test plan

- `pnpm --filter web run lint`
- `git diff --check`

## Manual test

Preview: https://pr-16889.preview.langfuse.com

1. Open a project.
2. Go to **Evaluations > Evaluators**.
3. Create or edit an evaluator.
4. Confirm the **Name** and **Description** inputs start at the same height and the optional label has consistent spacing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns the evaluator Description label with the Name label and standardizes spacing before the optional marker.

- Adds flex alignment and a consistent gap to the Description label.
- Removes the explicit JSX whitespace node before “(optional)”.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change is limited to label layout classes and whitespace, preserves the label-to-control association, and follows the existing adjacent label pattern.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): align evaluator name fields"](https://github.com/langfuse/langfuse/commit/6c8391bb9b939f172a16d957109627aa3a421b6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59049334)</sub>

<!-- /greptile_comment -->