### PR TITLE
fix(evals): classify code evaluator OOM as customer error

### DIFF
--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
@@ -193,6 +193,38 @@ describe("AwsLambdaCodeEvalDispatcher observability", () => {
     });
   });
 
+  it("classifies Lambda out-of-memory failures as evaluator memory errors", async () => {
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: {
+        send: vi.fn().mockResolvedValue({
+          StatusCode: 200,
+          FunctionError: "Unhandled",
+          Payload: Buffer.from(
+            JSON.stringify({
+              errorMessage: "Runtime exited with error: signal: killed",
+              errorType: "Runtime.OutOfMemory",
+            }),
+          ),
+          $metadata: {
+            requestId: "request-oom",
+            httpStatusCode: 200,
+            attempts: 1,
+            totalRetryDelay: 0,
+          },
+        }),
+      } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "OUT_OF_MEMORY",
+      retryable: false,
+    });
+    expectSpanAttributes({
+      "langfuse.code_eval.error.code": "OUT_OF_MEMORY",
+      "langfuse.code_eval.error.retryable": false,
+    });
+  });
+
   it("records the original Lambda FunctionError before throwing the derived user-facing error", async () => {
     const dispatcher = new AwsLambdaCodeEvalDispatcher({
       lambdaClient: {

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -429,6 +429,13 @@ function classifyLambdaFunctionError(params: {
     );
   }
 
+  if (errorType === "Runtime.OutOfMemory") {
+    return new CodeEvalDispatcherError(
+      composedMessage || "Evaluator exceeded the available memory",
+      { code: CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY, retryable: false },
+    );
+  }
+
   // Abnormal runtime exit (OOM kill, segfault, process.exit, SIGKILL).
   // Retrying never recovers from these.
   if (errorType === "Runtime.ExitError") {

--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -148,6 +148,7 @@ export const CodeEvalDispatcherErrorCode = z.enum([
   "RESULT_TOO_LARGE",
   "SOURCE_TOO_LARGE",
   "TIMEOUT",
+  "OUT_OF_MEMORY",
   "UNSUPPORTED_RUNTIME",
   "USER_CODE_ERROR",
   "LAMBDA_CONCURRENCY_LIMIT",

--- a/packages/shared/src/server/evals/codeEvalExecution.ts
+++ b/packages/shared/src/server/evals/codeEvalExecution.ts
@@ -45,6 +45,9 @@ const USER_VISIBLE_CODE_EVAL_ERROR_MESSAGE_BY_CODE: Partial<
   [CodeEvalDispatcherErrorCodes.TIMEOUT]: withCodeEvalDocs(
     "Evaluator timed out. Code-based evaluators must complete within the configured runtime limit. Long executions can be caused by network calls, which are forbidden and may never complete. Remove network calls, optimize your evaluator code, and try again.",
   ),
+  [CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY]: withCodeEvalDocs(
+    "Evaluator exceeded the available memory. Reduce memory usage in your evaluator code and try again.",
+  ),
   [CodeEvalDispatcherErrorCodes.SOURCE_TOO_LARGE]: withCodeEvalDocs(
     `Evaluator source code is too large. Code-based evaluator source code is limited to ${formatCodeEvalByteLimit(CODE_EVAL_SOURCE_MAX_BYTES)}. Shorten the evaluator code and try again.`,
   ),

--- a/worker/src/features/evaluation/evalExecutionMetrics.test.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.test.ts
@@ -108,6 +108,10 @@ describe("evaluation execution metrics", () => {
       expected: "customer_error",
     },
     {
+      code: CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY,
+      expected: "customer_error",
+    },
+    {
       code: CodeEvalDispatcherErrorCodes.LAMBDA_CONCURRENCY_LIMIT,
       expected: "platform_error",
     },

--- a/worker/src/features/evaluation/evalExecutionMetrics.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.ts
@@ -25,6 +25,7 @@ const CODE_EVAL_CUSTOMER_ERROR_CODES: ReadonlySet<string> = new Set([
   CodeEvalDispatcherErrorCodes.RESULT_TOO_LARGE,
   CodeEvalDispatcherErrorCodes.SOURCE_TOO_LARGE,
   CodeEvalDispatcherErrorCodes.TIMEOUT,
+  CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY,
   CodeEvalDispatcherErrorCodes.USER_CODE_ERROR,
 ]);
 


### PR DESCRIPTION
## Summary

Treat evaluator out-of-memory failures as customer errors instead of platform errors.

Reasoning:
- HIPAA recorded 28 terminal platform errors from 191 Node Lambda OOM attempts.
- The memory use comes from evaluator code, similar to evaluator timeouts. It should not burn the platform reliability SLO.
- A dedicated `OUT_OF_MEMORY` code keeps real Lambda invocation/configuration failures classified as platform errors.

## Changes

- Detect `Runtime.OutOfMemory` responses from AWS Lambda.
- Return a user-facing memory-limit error without retrying.
- Exclude this error from the code evaluator platform-error SLO.

## Verification

- `pnpm --filter @langfuse/shared run test awsLambdaCodeEvalDispatcher.test.ts` - 5 tests passed
- `pnpm --filter worker run test evalExecutionMetrics.test.ts` - 11 tests passed
- `pnpm run lint` - 7/7 tasks passed
- `pnpm --filter web run typecheck` - passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR classifies AWS Lambda code-evaluator out-of-memory failures as non-retryable customer errors rather than platform failures.

- Adds a dedicated `OUT_OF_MEMORY` dispatcher error code and user-facing remediation message.
- Detects Lambda `Runtime.OutOfMemory` function errors and terminates without retrying.
- Excludes evaluator OOM failures from the platform-error SLO and adds focused dispatcher and metrics tests.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with the new error code consistently classified, surfaced, measured, and tested.

The changed path converts the targeted Lambda OOM response into a terminal customer-facing error while preserving existing handling for other Lambda failures, and no concrete incompatible consumer or broken execution path was identified.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[AWS Lambda invocation] --> B{Function error type}
    B -->|Runtime.OutOfMemory| C[OUT_OF_MEMORY]
    C --> D[Non-retryable terminal evaluation error]
    D --> E[Customer error metric]
    D --> F[User-facing memory-limit message]
    B -->|Other Lambda failure| G[Existing error classification]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): classify code evaluator OOM ..."](https://github.com/langfuse/langfuse/commit/3fd17a9ba3cfec2d9cf511a5875eb97c83de0c95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59052137)</sub>

<!-- /greptile_comment -->