### PR TITLE
docs(ai-gateway): add V1 RFC

### DIFF
--- a/specs/llm-gateway-rfc.md
+++ b/specs/llm-gateway-rfc.md
@@ -8,14 +8,14 @@
 
 Langfuse will ship a BYOK AI Gateway that lets Claude Code, Codex, and general OpenAI or Anthropic applications use Langfuse as their LLM API base URL. The gateway executes requests with organization-managed LLM credentials, streams the result back to the client, and records usage, cost, latency, and optionally request/response content in Langfuse without client-side hooks.
 
-V1 launches on Langfuse Cloud. The same container and contracts ship for self-hosting as a fast follow.
+V1 launches on Langfuse Cloud and self-hosted at the same time. Both deployment models use the same container and contracts.
 
 V1 includes:
 
-- Anthropic Messages, OpenAI Chat Completions, OpenAI Responses, and their native auxiliary endpoints used by Claude Code and Codex.
-- OpenAI and Anthropic BYOK connections.
+- Anthropic Messages, OpenAI Chat Completions, OpenAI Responses, Claude Code's native Bedrock and Vertex protocols, and their required auxiliary endpoints.
+- OpenAI, Anthropic, Bedrock, and Vertex BYOK connections.
 - Native protocol passthrough when the client and upstream protocols match. Incompatible client/upstream protocol pairs are rejected before provider dispatch.
-- Gateway virtual keys, deterministic model-to-connection resolution, and automatic Langfuse telemetry.
+- Gateway virtual keys, deterministic protocol-to-connection resolution, and automatic Langfuse telemetry.
 
 V1 does not include cross-provider protocol translation, inference resale, multiple routing candidates, fallbacks, gateway retries, rate limits, spend limits, or guardrails.
 
@@ -23,57 +23,51 @@ V1 does not include cross-provider protocol translation, inference resale, multi
 
 Langfuse currently observes coding agents through client-side hooks. This works for individuals but is difficult to deploy and govern across organizations with hundreds of developers. A gateway gives platform teams one centrally managed integration point for tracing, cost attribution, credentials, and future runtime policy.
 
-Cross-provider translation would strengthen that value proposition by letting Codex use Anthropic models or Claude Code use OpenAI models without changing their wire protocol. However, OpenAI Responses and Anthropic Messages are not equivalent contracts. Translation introduces state, tool-lifecycle, streaming, media, and provider-owned artifact semantics whose failures can be silent and agent-breaking. V1 therefore prioritizes reliable native execution and treats translation as a separate interoperability product with its own compatibility contract and release criteria.
+Cross-provider translation would strengthen that value proposition by letting Codex use Anthropic models or Claude Code use OpenAI models without changing their wire protocol. However, OpenAI Responses and Anthropic Messages are not equivalent contracts. Translation introduces state, tool-lifecycle, streaming, media, and provider-owned artifact semantics whose failures can be silent and agent-breaking. V1 therefore prioritizes reliable native execution. Translation will only be reconsidered if strong measured demand justifies a separate compatibility product and its permanent maintenance burden.
 
 ## Product Scope
 
-### Public endpoints
+### Public protocol namespaces
 
-| Endpoint | V1 support |
+Each native protocol has an explicit namespace. The namespace determines the upstream wire contract and response format without inspecting headers or negotiating a schema.
+
+| Namespace and endpoint family | V1 support |
 | --- | --- |
-| `POST /v1/messages` | Required: Anthropic Messages and Claude Code |
-| `POST /v1/messages/count_tokens` | Native Anthropic pass-through; optional to Claude Code |
-| `POST /v1/chat/completions` | Required: native OpenAI |
-| `POST /v1/responses` | Required: native OpenAI |
-| `POST /v1/responses/compact` | Required for native OpenAI/Codex |
-| `GET /v1/models` | Required: authenticated gateway-owned catalog |
+| `POST /anthropic/v1/messages` | Native Anthropic Messages and Claude Code |
+| `POST /anthropic/v1/messages/count_tokens` | Native Anthropic token counting |
+| `GET /anthropic/v1/models` | Native Anthropic model discovery through the selected connection |
+| `POST /openai/v1/chat/completions` | Native OpenAI Chat Completions |
+| `POST /openai/v1/responses` | Native OpenAI Responses |
+| `POST /openai/v1/responses/compact` | Native OpenAI response compaction for Codex |
+| `GET /openai/v1/models` | Native OpenAI model discovery through the selected connection |
+| `/bedrock/...` | Claude Code's native Bedrock InvokeModel, streaming, and token-counting paths |
+| `/vertex/...` | Claude Code's native Vertex `rawPredict`, streaming, and token-counting paths |
+
+Clients configure the namespace as part of their base URL. The tradeoff is that Langfuse exposes provider-specific base URLs instead of one universal URL; this is acceptable because V1 does not route or translate between protocols, and the namespace makes response/error/model-discovery formats unambiguous. A future unified root API may be added as an alias or separate routing product without breaking these native endpoints.
 
 ### Protocol matrix
 
-The requested model deterministically selects one upstream adapter and LLM Connection. V1 only executes matching client and upstream protocols.
+The protocol namespace deterministically selects one upstream adapter and LLM Connection. V1 only executes matching client and upstream protocols.
 
-| Client protocol | OpenAI upstream | Anthropic upstream |
+| Client protocol | Upstream adapter | Behavior |
 | --- | --- | --- |
-| Anthropic Messages | Not supported | Native passthrough |
-| OpenAI Chat Completions | Native passthrough | Not supported |
-| OpenAI Responses | Native passthrough | Not supported |
+| Anthropic Messages | Anthropic | Native HTTP/SSE passthrough |
+| OpenAI Chat Completions | OpenAI | Native HTTP/SSE passthrough |
+| OpenAI Responses | OpenAI | Native HTTP/semantic-event passthrough |
+| Claude Code Bedrock | Bedrock | Native InvokeModel HTTP/AWS event-stream passthrough |
+| Claude Code Vertex | Vertex | Native `rawPredict` HTTP/SSE passthrough |
 
-An incompatible model/protocol pair returns a clear client error before provider dispatch. The gateway never silently translates, drops, or approximates provider-specific semantics in V1.
+An unavailable or incompatible protocol namespace returns a clear client error before provider dispatch. The gateway never silently translates, drops, or approximates provider-specific semantics in V1. Bedrock and Vertex support means accepting Claude Code's native provider protocols; it does not mean translating `/anthropic/v1/messages` into those protocols.
 
 ### Model discovery
 
-`GET /v1/models` always returns one OpenAI-compatible list:
+Model discovery is namespaced and upstream-authoritative:
 
-```json
-{
-  "object": "list",
-  "data": [
-    {
-      "id": "claude-sonnet-4-5",
-      "object": "model",
-      "created": 0,
-      "owned_by": "anthropic",
-      "display_name": "Claude Sonnet 4.5"
-    }
-  ]
-}
-```
+- `/anthropic/v1/models` forwards to the selected Anthropic connection and returns its native response unchanged.
+- `/openai/v1/models` forwards to the selected OpenAI connection and returns its native response unchanged.
+- Claude Code does not use model discovery for its native Bedrock or Vertex protocols.
 
-The [Claude Code gateway contract](https://code.claude.com/docs/en/llm-gateway-protocol#request-and-response) reads `data[].id` and optional `data[].display_name`, so this shape supports both OpenAI clients and Claude Code without switching response schemas based on a header. It is not full Anthropic Models API compatibility. If that becomes necessary, add an explicit `/anthropic` protocol namespace rather than changing the representation of the root endpoint.
-
-The endpoint requires a Gateway virtual key and returns only models enabled for that key's organization and resolved project policy. The list is generated from Langfuse configuration and never fetched synchronously from an upstream provider. A listed model maps to exactly one upstream adapter and connection, and unlisted models are rejected. This is deterministic destination selection, not routing: there is no candidate set, policy evaluation, or fallback.
-
-Claude Code only discovers IDs containing `claude` or `anthropic`. Because V1 does not translate Messages to OpenAI, the catalog must not make an OpenAI destination appear Messages-compatible by assigning it a Claude-like alias.
+Langfuse does not maintain, merge, normalize, or enforce a gateway model catalog in V1. The selected connection determines which models are available, and the provider remains responsible for accepting or rejecting the request's native model identifier. The discovery path is authenticated and uses the same connection resolution as inference. It is not cached initially; a short response cache may be added later if upstream latency or rate limits require it.
 
 ## Architecture
 
@@ -82,8 +76,8 @@ flowchart LR
     C["Claude Code, Codex, or application"] -->|"native API request"| G["Rust AI Gateway"]
     G -->|"cache miss: resolve"| W["Langfuse Web control plane"]
     W --> P[("Postgres and existing auth/config")]
-    G -->|"native request"| O["OpenAI or Anthropic"]
-    O -->|"JSON or SSE"| G
+    G -->|"native request"| O["OpenAI, Anthropic, Bedrock, or Vertex"]
+    O -->|"native response stream"| G
     G -->|"native response"| C
     G -.->|"batched telemetry and media"| W
     W -.-> I["Existing Langfuse ingestion"]
@@ -108,19 +102,18 @@ Clients cannot submit or override a project ID. Changing the organization defaul
 
 ### LLM Connections and destinations
 
-LLM Connections become organization-level resources. For V1, an administrator explicitly selects one default connection for each upstream adapter, initially OpenAI and Anthropic. The design must later allow multiple candidates and fallbacks without changing the connection resource, but V1 always resolves one destination.
+LLM Connections become organization-level resources. For V1, an administrator explicitly selects one default connection for each enabled upstream adapter: OpenAI, Anthropic, Bedrock, and Vertex. The selection contract may later return multiple candidates for routing or fallback, but V1 always resolves exactly one connection.
 
-The model catalog records which adapter owns each model. A request resolves:
+A request resolves without consulting a model catalog:
 
 ```text
-Gateway virtual key + ingress protocol + model
+Gateway virtual key + protocol namespace
   -> organization and project
-  -> upstream adapter
   -> one default LLM Connection
-  -> native execution
+  -> native execution with the request's model unchanged
 ```
 
-Official OpenAI and Anthropic origins are supported first. Custom base URLs require save-time, use-time, connection-time, DNS, and redirect validation plus strict credential stripping. They only enter V1 if that security work is completed for both Cloud and self-hosted deployments.
+Official provider origins and custom LLM Connection base URLs are supported. Custom origins require the Rust equivalent of Langfuse's secure LLM fetch boundary: scheme and URL checks when saved and used, DNS/IP validation when connecting, validation of every redirect, and strict credential/header stripping. Cloud blocks private, loopback, link-local, and metadata destinations. Self-hosters may explicitly allow private destination ranges needed for their own inference infrastructure.
 
 ### Telemetry policy
 
@@ -129,14 +122,14 @@ An organization chooses one gateway telemetry mode:
 | Mode | Customer telemetry |
 | --- | --- |
 | `full` | Input, output, tools, media references, metadata, usage, and cost |
-| `metadata` | Model, status, timing, attribution, usage, and cost; no content |
+| `usage` | Model, status, timing, attribution, usage, and cost; no content |
 | `none` | No customer request trace or cost record |
 
-`full` is the default. `none` does not disable content-free service health, security, and capacity telemetry. Rate or spend enforcement may later require at least metadata mode.
+`full` is the default. `none` does not disable content-free service health, security, and capacity telemetry. Rate or spend enforcement may later require at least `usage` mode.
 
-## Cached Resolution and Internal Authentication
+## Cached Resolution and Gateway-to-Web Authentication
 
-The gateway must not call Web for every inference request. It caches a resolved execution configuration in memory by a fingerprint of the Gateway virtual key, ingress protocol, and model.
+The gateway must not call Web for every inference request. It caches a resolved execution configuration in memory by a keyed fingerprint of the Gateway virtual key and protocol namespace.
 
 ```mermaid
 sequenceDiagram
@@ -151,7 +144,7 @@ sequenceDiagram
     else Cache miss or hard expiry
         Gateway->>Web: Resolve service token + virtual key
         Web-->>Gateway: Destination, telemetry policy, sealed context
-        Gateway->>Gateway: Cache for at most 5 minutes
+        Gateway->>Gateway: Cache for at most 60 seconds
     end
     Gateway->>Provider: Execute once
     Provider-->>Gateway: Response stream
@@ -159,7 +152,7 @@ sequenceDiagram
     Gateway-->>Web: Batched telemetry + sealed context
 ```
 
-### Internal authentication envelope
+### Service authentication envelope
 
 Gateway-to-Web requests use the standard `Authorization` header so proxies and observability systems are most likely to redact it. The credentials use one deliberately simple, versioned encoding:
 
@@ -173,37 +166,43 @@ Telemetry and media submissions replace `key` with the sealed context:
 Authorization: Langfuse-Gateway <base64url({"v":1,"service":"...","context":"..."})>
 ```
 
-The envelope avoids custom authorization-parameter parsing while keeping both credentials in one redacted header. Web validates the shared gateway service token before authenticating the customer key or opening the context. The header must not be logged and is stripped before upstream execution.
+The fields have one meaning at every endpoint:
 
-`Langfuse-Gateway` distinguishes this private service exchange from ordinary customer `Bearer` authentication. Parsing is one scheme split, one bounded base64url decode, and strict JSON-schema validation. Base64url is encoding, not protection; HTTPS and the two credentials provide the security. Implementations reject oversized envelopes, unsupported versions, unknown or duplicate fields, and invalid combinations. Web, Gateway, and the self-hosting guide must explicitly suppress the full `Authorization` field from logs because arbitrary proxies cannot be assumed to do so.
+- `service` is the shared Gateway-to-Web service token.
+- `key` is the caller-provided Gateway virtual key used to resolve an execution configuration.
+- `context` is Web's sealed execution and ingestion context, used instead of `key` for telemetry and media.
 
-The shared service token supports current/next rotation and is distributed through Secrets Manager on Cloud or one shared Kubernetes Secret for self-hosting. The internal endpoints are also private at the network layer.
+Web validates the shared gateway service token before authenticating the customer key or opening the context. The header must not be logged and is stripped before upstream execution.
+
+`Langfuse-Gateway` distinguishes this service exchange from ordinary customer `Bearer` authentication. Base64url is encoding, not protection; HTTPS and the two credentials provide the security. Web, Gateway, and the self-hosting guide must suppress the full `Authorization` field from logs.
+
+The shared service token supports current/next rotation and is distributed through Secrets Manager on Cloud or one shared Kubernetes Secret for self-hosting. Resolution, telemetry ingestion, and media upload are public authenticated Langfuse endpoints in V1; no private-network connectivity is required.
 
 ### Execution configuration and sealed context
 
 On a cache miss, Web returns:
 
 - Organization, project, key, and attribution identifiers.
-- Ingress and upstream protocols plus the resolved native model.
-- One connection ID, official origin, safe headers, and provider credential.
+- Ingress and upstream protocols.
+- One connection ID, upstream origin, safe headers, and provider credential.
 - Telemetry mode.
 - A cache hard-expiry timestamp.
 - An opaque sealed execution context.
 
-The provider credential exists only in gateway memory and is held in a secret-safe type. The cache key uses a keyed cryptographic digest of the Gateway virtual key and is never logged. The default hard cache TTL is five minutes, matching Langfuse's current API-key cache window. An expired entry is never used; resolution failure without a valid entry fails closed. This makes five minutes the explicit maximum propagation window for revocation or configuration changes in V1.
+The provider credential exists only in gateway memory and is held in a secret-safe type. The cache key uses a keyed cryptographic digest of the Gateway virtual key and is never logged. The hard cache TTL is at most 60 seconds and is not sliding. An expired entry is never used; resolution failure without a valid entry fails closed. This makes 60 seconds the explicit maximum propagation window for revocation or configuration changes in V1. The control plane may cache underlying data longer because it has explicit invalidation; the gateway does not.
 
-The sealed context is reusable across all requests using that cached execution configuration. It binds the organization, project, Gateway virtual-key ID, connection, protocols, model, telemetry mode, issued time, and expiry. It intentionally does **not** contain a request ID or provider credential. Each inference request generates its own `gateway_request_id`, returned as `x-langfuse-gateway-request-id` and included in telemetry.
+The sealed context is reusable across all requests using that cached execution configuration. It contains a version, organization ID, project ID, Gateway virtual-key ID and attribution, selected connection ID, ingress/upstream protocols and adapter, telemetry mode, issued time, and expiry. It intentionally does **not** contain a request ID, model, or provider credential. Each inference request generates its own `gateway_request_id`, returned as `x-langfuse-gateway-request-id` and included in telemetry.
 
-Web seals the context with a Web-only authenticated-encryption key. The gateway treats it as opaque. A longer context lifetime, initially 24 hours, authorizes only delayed telemetry/media delivery; it can never authorize a new inference request or extend the five-minute execution-config cache. There is no grant table, Redis record, refresh flow, or JWKS subsystem.
+Web seals the context with a Web-only authenticated-encryption key. The gateway treats it as opaque. A longer context lifetime, initially 24 hours, authorizes only delayed telemetry/media delivery; it can never authorize a new inference request or extend the 60-second execution-config cache. There is no grant table, Redis record, refresh flow, or JWKS subsystem.
 
 ## Data Plane
 
 ### Request lifecycle
 
-1. **Classify and bound:** Select the ingress protocol, normalize the client credential, reject an invalid method/content type or declared oversize body, and read the body once under a hard byte limit.
-2. **Authenticate and resolve:** Extract the model, load or refresh the cached execution configuration, and use the catalog's single adapter/connection mapping. No client-controlled origin, connection, or project is accepted.
-3. **Protect:** Apply the native protocol's minimal boundary checks plus header and media policy. Reject an incompatible client/upstream protocol pair.
-4. **Prepare:** Preserve the native body and apply only the resolved origin, model placement, provider authentication, and safe header adjustments required by the upstream transport.
+1. **Classify and bound:** Select the ingress protocol from the namespace, normalize the client credential, reject an invalid method/content type or declared oversize body, and stream or read the body under a hard byte limit.
+2. **Authenticate and resolve:** Load or refresh the cached execution configuration for the key and protocol namespace. No client-controlled origin, connection, or project is accepted.
+3. **Protect:** Enforce gateway-owned limits, header policy, protocol/connection compatibility, and custom-origin security. The upstream provider validates its native schema, model, media formats, and capabilities.
+4. **Prepare:** Preserve the native body and model identifier unchanged. Apply only the resolved origin, provider authentication, and safe header adjustments. Native Bedrock and Vertex transports place the unchanged model in their provider-required path.
 5. **Execute once:** Replace client authentication with the provider credential and perform one upstream request. Inference POSTs receive zero gateway retries.
 6. **Relay and observe:** Stream native response bytes with backpressure and cancellation. Telemetry observes the same stream and never becomes a second consumer.
 7. **Finalize:** Enqueue bounded telemetry/media work. Failures after provider dispatch fail open and never corrupt an otherwise healthy client response.
@@ -214,9 +213,9 @@ Gateway-generated errors use the client's native error envelope. Provider-native
 
 Native calls bypass a universal prompt representation. The gateway parses only what resolution, boundary enforcement, and telemetry require; it does not reconstruct provider requests or response events when the semantic protocol already matches.
 
-Native Anthropic execution preserves the evolving, non-credential `anthropic-*` headers and body fields as an open set. Upstream headers are reconstructed: customer/provider credentials, cookies, forwarding and hop-by-hop headers are always removed, and sensitive headers are never followed across origins. The gateway does not fetch prompt-supplied media URLs; it validates inline media type and bytes and passes supported sources to the provider.
+Native Anthropic execution preserves the evolving, non-credential `anthropic-*` headers and body fields as an open set. Upstream headers are reconstructed: customer/provider credentials, cookies, forwarding and hop-by-hop headers are always removed, and sensitive headers are never followed across origins. The gateway does not fetch prompt-supplied media URLs. Inline media remains part of the native body, and the provider validates its type and contents.
 
-Transport adaptation is distinct from cross-provider protocol translation. A future adapter may change authentication, URL/model placement, or event framing while preserving the provider's semantic schema—for example, Anthropic Messages on Bedrock or Vertex. Such an adapter requires its own provider conformance work but does not imply OpenAI-to-Anthropic translation.
+Transport adaptation is distinct from cross-provider protocol translation. The Bedrock and Vertex adapters accept Claude Code's native provider request paths and framing, change authentication and safe transport details as required, and preserve the provider's semantic schema. They do not accept the Anthropic namespace and convert it to another provider protocol.
 
 ### Why translation is excluded from V1
 
@@ -229,15 +228,13 @@ Translation is feasible for a constrained subset, but it is a continuously maint
 
 The dangerous failures are not limited to obvious request rejection. A translated stream can appear successful while losing a tool result, changing a stop reason, enabling a disabled tool, or breaking reasoning continuity. Those failures are difficult to detect from gateway health metrics and directly affect agent correctness and safety.
 
-V1 therefore supports Claude Code with Anthropic destinations and Codex/OpenAI clients with OpenAI-compatible destinations. Codex-to-Claude and Claude-Code-to-OpenAI remain valuable fast-follow use cases, but they require a separate RFC defining one named compatibility profile, explicit rejections, conversation/provider pinning, direct pairwise adapters, translator version telemetry, and real-client multi-turn conformance tests.
-
-This decision is about sequencing, not rejecting interoperability. The likely first post-V1 profile is OpenAI Responses to Anthropic Messages for Codex, limited initially to complete stateless history, text/images, custom function tools/results, and streaming/non-streaming execution. Stateful Responses, hosted tools, provider file IDs, encrypted reasoning translation, and cross-provider fallback after a conversation starts would be rejected.
+V1 therefore supports each client through its native provider protocol and does not schedule cross-provider translation as a fast follow. Langfuse will reconsider translation only if strong measured user demand justifies the permanent compatibility maintenance and scope expansion. Any translation work requires a separate RFC with an explicit compatibility profile, rejection rules, translator-version telemetry, and real-client multi-turn conformance tests.
 
 ## Telemetry and Media
 
 The gateway builds one Langfuse generation per provider execution, including project/key attribution, protocol pair, model and connection, timing and time-to-first-token, provider request ID, terminal outcome, usage/cache usage, and cost inputs. Claude Code session and agent headers may be recorded for grouping but are never treated as user identity. Content inclusion follows the resolved telemetry mode and explicit byte bounds.
 
-Telemetry is accumulated into timeout-or-size bounded batches and submitted to a private gateway ingestion endpoint. Web validates the sealed context, derives the project, and reuses the existing S3/queue/OTLP ingestion path. Media uses a corresponding private upload endpoint. The gateway does not receive storage or queue credentials.
+Telemetry is accumulated into timeout-or-size bounded OTLP batches and submitted to Langfuse's regular public OTLP ingestion endpoint. That endpoint validates the sealed context, derives the project and attribution, and reuses the existing ingestion path. Media uses the regular public media upload endpoint with the same context. The gateway does not receive storage or queue credentials.
 
 V1 does not add a separate ClickHouse gateway-logs table. Langfuse traces/generations remain the customer-facing request record; Datadog metrics and sanitized service logs cover operational health. A separate durable execution ledger should only be introduced when spend enforcement, settlement, or audit guarantees require semantics that best-effort observability cannot provide.
 
@@ -247,11 +244,11 @@ V1 does not add a separate ClickHouse gateway-logs table. Langfuse traces/genera
 
 Deploy `ai-gateway` as an independently scalable Rust ECS/Fargate service in every existing regional environment. Reuse the regional VPC, private subnets, NAT egress, ALB/WAF, Secrets Manager, deployment pipeline, and monitoring foundations while giving the gateway dedicated tasks, target group, security group, IAM roles, and autoscaling.
 
-The public edge uses a gateway hostname and streaming-safe idle/drain settings. Gateway-to-Web resolution, telemetry, and media endpoints are private. Scale primarily on active streams, with CPU, memory, bytes in flight, connection rate, and telemetry-queue pressure as guardrails. Deployments require readiness, graceful draining, a maximum stream duration, and progressive regional rollout.
+The public edge uses a gateway hostname and streaming-safe idle/drain settings. Gateway-to-Web resolution, telemetry, and media use public authenticated Web endpoints; private routing may be added later as transparent defense-in-depth. Scale primarily on active streams, with CPU, memory, bytes in flight, connection rate, and telemetry-queue pressure as guardrails. Deployments require readiness, graceful draining, a maximum stream duration, and progressive regional rollout.
 
-### Self-hosted fast follow
+### Self-hosted
 
-Ship the same image as an optional first-class Helm component, not a Web sidecar. Enabling the component should automatically create its Deployment and Service, connect it to the in-cluster Web Service, and share a generated or operator-provided gateway service token.
+Ship the same image at V1 launch as an optional first-class Helm component, not a Web sidecar. Enabling the component should automatically create its Deployment and Service, connect it to Web, and share a generated or operator-provided gateway service token.
 
 Operators configure only enablement, public ingress/TLS, and optionally an existing Secret. The chart exposes replicas, resources, probes, PDB, topology, graceful termination, and HPA/KEDA settings without requiring direct database, cache, object-store, or queue configuration for the gateway.
 
@@ -266,30 +263,22 @@ Operators configure only enablement, public ingress/TLS, and optionally an exist
 
 ## Delivery Milestones
 
-1. **Contracts and runtime:** Rust service skeleton, internal resolve/cache contract, sealed context, bounded telemetry endpoint, native fixtures, and streaming/load qualification.
-2. **Claude Code to Anthropic:** Messages, count tokens, model discovery, native streaming, keys/connections, tracing, cost, and real Claude Code conformance.
-3. **OpenAI native:** Chat Completions, Responses, compact, model discovery, OpenAI SDK and Codex conformance.
-4. **Cloud qualification:** Dedicated edge configuration, security review, stream-aware autoscaling, graceful deployments, SLOs, and progressive regional rollout.
-5. **Self-hosted:** First-class Helm packaging, secret wiring, networking guidance, and the same conformance suite.
+1. **Control-plane readiness:** Gateway virtual keys and permissions, project selection, organization-level LLM Connections, one explicit default connection per protocol namespace, the 60-second resolution contract, shared service authentication, and sealed execution contexts.
+2. **Data-plane readiness:** Rust gateway, native OpenAI/Anthropic/Bedrock/Vertex transports, upstream model discovery, secure custom origins, streaming/backpressure/cancellation, bounded OTLP/media publication, and protocol conformance/load tests.
+3. **Cloud readiness:** Regional ECS/Fargate service, public ALB/WAF edge, Secrets Manager wiring, stream-aware autoscaling, graceful draining, observability, SLOs, and progressive rollout.
+4. **Self-hosted readiness:** The same release image, first-class Helm component, service-token wiring, ingress/TLS configuration, custom-origin controls, operational documentation, and the same conformance suite.
 
-These workstreams can proceed mostly independently once the resolve contract, protocol types, terminal outcomes, and telemetry facts are fixed: control-plane keys/permissions, LLM Connections/model catalog, authority/cache endpoints, native protocol adapters, telemetry/media ingestion, Cloud deployment, Helm packaging, and conformance/load testing.
-
-Cross-provider translation is a post-V1 milestone with a separate compatibility RFC and launch gate; it is not on the critical path for the milestones above.
+These tracks can proceed mostly independently once the resolution response, protocol identifiers, sealed-context contents, terminal outcomes, and telemetry facts are fixed. V1 launches only when all four tracks are ready.
 
 ## Launch Gates
 
-- Real Claude Code and Codex sessions, including tools, media, cancellation, long sessions, and model discovery.
-- OpenAI and Anthropic TypeScript/Python SDK conformance for native paths.
+- Real Claude Code and Codex sessions, including tools, media, cancellation, long sessions, and applicable model discovery.
+- OpenAI and Anthropic TypeScript/Python SDK conformance for native paths, plus Claude Code conformance for Anthropic, Bedrock, and Vertex.
 - Golden native request/response/error fixtures and exact SSE pass-through behavior.
-- Strict negative tests for incompatible client protocol and destination combinations.
+- Strict negative tests for incompatible protocol namespaces and connection combinations.
 - Credential/header leak, tenant isolation, revocation-window, SSRF, redirect, and custom-origin tests.
 - Long-lived stream, slow-client, disconnect, deployment-drain, Web outage, provider failure, and telemetry saturation tests.
 - Measured gateway overhead and capacity on production-like multi-core containers.
-
-## Open Questions
-
-- Are custom public HTTPS LLM Connection base URLs included in V1 after the required transport-security spike, or deferred?
-- Are near-native Bedrock Messages and Vertex Messages transport adapters included in V1 after provider conformance, or deferred?
 
 ## References
 
@@ -299,6 +288,7 @@ Cross-provider translation is a post-V1 milestone with a separate compatibility 
 - [Anthropic Messages](https://platform.claude.com/docs/en/api/messages/create)
 - [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming)
 - [Anthropic token counting](https://platform.claude.com/docs/en/api/messages/count_tokens)
+- [Anthropic Models](https://platform.claude.com/docs/en/api/models/list)
 - [OpenAI Chat Completions](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create)
 - [OpenAI Responses](https://developers.openai.com/api/reference/resources/responses/methods/create)
 - [OpenAI Responses streaming events](https://developers.openai.com/api/reference/resources/responses/streaming-events)

--- a/specs/llm-gateway-rfc.md
+++ b/specs/llm-gateway-rfc.md
@@ -1,0 +1,338 @@
+# RFC: Langfuse AI Gateway V1
+
+- Status: Draft
+- Linear: [LFE-15204](https://linear.app/clickhouse/issue/LFE-15204/ai-gateway-v1-scope)
+- Last updated: 2026-09-01
+
+## Decision
+
+Langfuse will ship a BYOK AI Gateway that lets Claude Code, Codex, and general OpenAI or Anthropic applications use Langfuse as their LLM API base URL. The gateway executes requests with organization-managed LLM credentials, streams the result back to the client, and records usage, cost, latency, and optionally request/response content in Langfuse without client-side hooks.
+
+V1 launches on Langfuse Cloud. The same container and contracts ship for self-hosting as a fast follow.
+
+V1 includes:
+
+- Anthropic Messages, OpenAI Chat Completions, OpenAI Responses, and their native auxiliary endpoints used by Claude Code and Codex.
+- OpenAI and Anthropic BYOK connections.
+- Native protocol passthrough when the client and upstream protocols match.
+- A bounded OpenAI-to-Anthropic protocol bridge for Chat Completions and Responses.
+- Gateway virtual keys, deterministic model-to-connection resolution, and automatic Langfuse telemetry.
+
+V1 does not include inference resale, multiple routing candidates, fallbacks, gateway retries, rate limits, spend limits, or guardrails.
+
+## Context
+
+Langfuse currently observes coding agents through client-side hooks. This works for individuals but is difficult to deploy and govern across organizations with hundreds of developers. A gateway gives platform teams one centrally managed integration point for tracing, cost attribution, credentials, and future runtime policy.
+
+Provider translation materially strengthens that value proposition: OpenAI applications and Codex can use an Anthropic model without changing their wire protocol. The same bridge architecture enables Claude Code to use OpenAI models as a fast follow. Research across LiteLLM, Bifrost, Portkey, Helicone, and smaller Rust gateways shows that the common coding-agent subset is feasible to translate, but universal lossless translation is not. V1 therefore defines an explicit compatibility profile and rejects unsupported semantics instead of silently dropping them.
+
+## Product Scope
+
+### Public endpoints
+
+| Endpoint | V1 support |
+| --- | --- |
+| `POST /v1/messages` | Required: Anthropic Messages and Claude Code |
+| `POST /v1/messages/count_tokens` | Native Anthropic pass-through; optional to Claude Code |
+| `POST /v1/chat/completions` | Required: native OpenAI and translation to Anthropic |
+| `POST /v1/responses` | Required: native OpenAI and translation to Anthropic |
+| `POST /v1/responses/compact` | Required for native OpenAI/Codex; translated compaction requires a separate conformance decision |
+| `GET /v1/models` | Required: authenticated gateway-owned catalog |
+
+### Protocol matrix
+
+The requested model deterministically selects one upstream adapter and LLM Connection. Matching pairs use native passthrough; supported mismatches use the protocol bridge.
+
+| Client protocol | OpenAI upstream | Anthropic upstream |
+| --- | --- | --- |
+| Anthropic Messages | Fast follow | Native passthrough |
+| OpenAI Chat Completions | Native passthrough | Request to Messages; response back to Chat |
+| OpenAI Responses | Native passthrough | Request to Messages; response back to Responses |
+
+Translation is a V1 launch requirement, not a claim that every provider-specific extension is portable. Chat Completions and Responses to Anthropic must pass their documented compatibility profile before V1 launches. Auxiliary behavior such as Responses compaction is evaluated separately before a specific client/model combination is advertised. Anthropic Messages to OpenAI is a fast follow.
+
+### Model discovery
+
+`GET /v1/models` always returns one OpenAI-compatible list:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "claude-sonnet-4-5",
+      "object": "model",
+      "created": 0,
+      "owned_by": "anthropic",
+      "display_name": "Claude Sonnet 4.5"
+    }
+  ]
+}
+```
+
+The [Claude Code gateway contract](https://code.claude.com/docs/en/llm-gateway-protocol#request-and-response) reads `data[].id` and optional `data[].display_name`, so this shape supports both OpenAI clients and Claude Code without switching response schemas based on a header. It is not full Anthropic Models API compatibility. If that becomes necessary, add an explicit `/anthropic` protocol namespace rather than changing the representation of the root endpoint.
+
+The endpoint requires a Gateway virtual key and returns only models enabled for that key's organization and resolved project policy. The list is generated from Langfuse configuration and never fetched synchronously from an upstream provider. A listed model maps to exactly one upstream adapter and connection, and unlisted models are rejected. This is deterministic destination selection, not routing: there is no candidate set, policy evaluation, or fallback.
+
+Claude Code only discovers IDs containing `claude` or `anthropic`. An OpenAI-backed model intended for its picker therefore needs an explicit compatible gateway alias; otherwise administrators configure that model directly in Claude Code.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    C["Claude Code, Codex, or application"] -->|"native API request"| G["Rust AI Gateway"]
+    G -->|"cache miss: resolve"| W["Langfuse Web control plane"]
+    W --> P[("Postgres and existing auth/config")]
+    G -->|"native or translated request"| O["OpenAI or Anthropic"]
+    O -->|"JSON or SSE"| G
+    G -->|"native or translated response"| C
+    G -.->|"batched telemetry and media"| W
+    W -.-> I["Existing Langfuse ingestion"]
+```
+
+The gateway is a separate stateless Rust service built with Axum, Tokio, Hyper/Reqwest, Serde, Bytes, Rustls, and OpenTelemetry. It has no direct Postgres, Redis, ClickHouse, S3, or queue credentials. Langfuse Web remains the authority for authentication, project selection, LLM Connections, and ingestion.
+
+## Control Plane
+
+### Gateway virtual keys
+
+A **Gateway virtual key** is a Langfuse-issued credential accepted only by the gateway. It is named, reveal-once, attributable, expirable, rotatable, revocable, and authorized with an explicit `gateway:invoke` permission preset.
+
+Only organization administrators create Gateway virtual keys in V1. The implementation extends the authorization and key lifecycle planned in the [granular API permissions RFC](https://linear.app/clickhouse/document/rfc-granular-api-permissions-a-unified-authorization-core-for-langfuse-04e83c1c436b); the gateway must not create a parallel permissions system.
+
+Each execution maps to exactly one Langfuse project. Project selection is:
+
+1. A project override fixed when the key is created, if the organization permits it.
+2. Otherwise, the organization's current default gateway project.
+
+Clients cannot submit or override a project ID. Changing the organization default affects executions after their cached configuration expires.
+
+### LLM Connections and destinations
+
+LLM Connections become organization-level resources. For V1, an administrator explicitly selects one default connection for each upstream adapter, initially OpenAI and Anthropic. The design must later allow multiple candidates and fallbacks without changing the connection resource, but V1 always resolves one destination.
+
+The model catalog records which adapter owns each model. A request resolves:
+
+```text
+Gateway virtual key + ingress protocol + model
+  -> organization and project
+  -> upstream adapter
+  -> one default LLM Connection
+  -> native or translated execution
+```
+
+Official OpenAI and Anthropic origins are supported first. Custom base URLs require save-time, use-time, connection-time, DNS, and redirect validation plus strict credential stripping. They only enter V1 if that security work is completed for both Cloud and self-hosted deployments.
+
+### Telemetry policy
+
+An organization chooses one gateway telemetry mode:
+
+| Mode | Customer telemetry |
+| --- | --- |
+| `full` | Input, output, tools, media references, metadata, usage, and cost |
+| `metadata` | Model, status, timing, attribution, usage, and cost; no content |
+| `none` | No customer request trace or cost record |
+
+`full` is the default. `none` does not disable content-free service health, security, and capacity telemetry. Rate or spend enforcement may later require at least metadata mode.
+
+## Cached Resolution and Internal Authentication
+
+The gateway must not call Web for every inference request. It caches a resolved execution configuration in memory by a fingerprint of the Gateway virtual key, ingress protocol, and model.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Web
+    participant Provider
+
+    Client->>Gateway: Request and Gateway virtual key
+    alt Valid execution config in memory
+        Gateway->>Gateway: Reuse configuration
+    else Cache miss or hard expiry
+        Gateway->>Web: Resolve service token + virtual key
+        Web-->>Gateway: Destination, telemetry policy, sealed context
+        Gateway->>Gateway: Cache for at most 5 minutes
+    end
+    Gateway->>Provider: Execute once
+    Provider-->>Gateway: Response stream
+    Gateway-->>Client: Forward stream
+    Gateway-->>Web: Batched telemetry + sealed context
+```
+
+### Internal authentication envelope
+
+Gateway-to-Web requests use the standard `Authorization` header so proxies and observability systems are most likely to redact it. The credentials use one deliberately simple, versioned encoding:
+
+```http
+Authorization: Langfuse-Gateway <base64url({"v":1,"service":"...","key":"..."})>
+```
+
+Telemetry and media submissions replace `key` with the sealed context:
+
+```http
+Authorization: Langfuse-Gateway <base64url({"v":1,"service":"...","context":"..."})>
+```
+
+The envelope avoids custom authorization-parameter parsing while keeping both credentials in one redacted header. Web validates the shared gateway service token before authenticating the customer key or opening the context. The header must not be logged and is stripped before upstream execution.
+
+`Langfuse-Gateway` distinguishes this private service exchange from ordinary customer `Bearer` authentication. Parsing is one scheme split, one bounded base64url decode, and strict JSON-schema validation. Base64url is encoding, not protection; HTTPS and the two credentials provide the security. Implementations reject oversized envelopes, unsupported versions, unknown or duplicate fields, and invalid combinations. Web, Gateway, and the self-hosting guide must explicitly suppress the full `Authorization` field from logs because arbitrary proxies cannot be assumed to do so.
+
+The shared service token supports current/next rotation and is distributed through Secrets Manager on Cloud or one shared Kubernetes Secret for self-hosting. The internal endpoints are also private at the network layer.
+
+### Execution configuration and sealed context
+
+On a cache miss, Web returns:
+
+- Organization, project, key, and attribution identifiers.
+- Ingress and upstream protocols plus the resolved native model.
+- One connection ID, official origin, safe headers, and provider credential.
+- Telemetry mode.
+- A cache hard-expiry timestamp.
+- An opaque sealed execution context.
+
+The provider credential exists only in gateway memory and is held in a secret-safe type. The cache key uses a keyed cryptographic digest of the Gateway virtual key and is never logged. The default hard cache TTL is five minutes, matching Langfuse's current API-key cache window. An expired entry is never used; resolution failure without a valid entry fails closed. This makes five minutes the explicit maximum propagation window for revocation or configuration changes in V1.
+
+The sealed context is reusable across all requests using that cached execution configuration. It binds the organization, project, Gateway virtual-key ID, connection, protocols, model, telemetry mode, issued time, and expiry. It intentionally does **not** contain a request ID or provider credential. Each inference request generates its own `gateway_request_id`, returned as `x-langfuse-gateway-request-id` and included in telemetry.
+
+Web seals the context with a Web-only authenticated-encryption key. The gateway treats it as opaque. A longer context lifetime, initially 24 hours, authorizes only delayed telemetry/media delivery; it can never authorize a new inference request or extend the five-minute execution-config cache. There is no grant table, Redis record, refresh flow, or JWKS subsystem.
+
+## Data Plane
+
+### Request lifecycle
+
+1. **Classify and bound:** Select the ingress protocol, normalize the client credential, reject an invalid method/content type or declared oversize body, and read the body once under a hard byte limit.
+2. **Authenticate and resolve:** Extract the model, load or refresh the cached execution configuration, and use the catalog's single adapter/connection mapping. No client-controlled origin, connection, or project is accepted.
+3. **Protect:** Apply the native path's minimal boundary checks or the translated path's stricter compatibility validation, plus header and media policy.
+4. **Prepare:** Use raw native passthrough when protocols match. Otherwise validate against the translation compatibility profile and transform into the upstream protocol.
+5. **Execute once:** Replace client authentication with the provider credential and perform one upstream request. Inference POSTs receive zero gateway retries.
+6. **Relay and observe:** Stream with backpressure and cancellation. Native streams remain byte passthrough; translated streams use a stateful semantic-event converter. Telemetry observes the same stream and never becomes a second consumer.
+7. **Finalize:** Enqueue bounded telemetry/media work. Failures after provider dispatch fail open and never corrupt an otherwise healthy client response.
+
+Gateway-generated errors use the client's native error envelope. Provider-native responses are preserved on passthrough paths. Translated provider errors are mapped conservatively while retaining the provider request ID.
+
+### Protocol bridge
+
+Translation is only invoked when ingress and upstream protocols differ. It uses narrow owned wire types and a loss-aware internal representation; that internal representation is not a public API.
+
+The initial compatibility profile covers:
+
+- System/developer instructions and user/assistant text.
+- URL and base64 images.
+- Function tools, tool choice, parallel tool calls, and tool results.
+- Core generation limits and sampling parameters where semantics match.
+- Non-streaming responses.
+- Streaming text, tool-input deltas, stop reasons, usage/cache usage, and errors.
+- Interrupted streams and client cancellation.
+
+The bridge must reject unsupported fields with a client-native `400`. It must never silently discard data or fabricate provider-specific opaque values. Initial non-goals include audio, PDFs/documents, citations, provider-hosted tools, MCP server tools, computer use, multiple choices, stateful Responses references, and exact cross-provider reasoning/thinking fidelity. Real Claude Code or Codex fixtures may promote a capability into the profile before that client/model combination is advertised.
+
+Native Anthropic execution preserves the evolving, non-credential `anthropic-*` headers and body fields as an open set. Upstream headers are reconstructed: customer/provider credentials, cookies, forwarding and hop-by-hop headers are always removed, and sensitive headers are never followed across origins. The gateway does not fetch prompt-supplied media URLs; it validates inline media type and bytes and passes supported sources to the provider. On a translated request, an unsupported capability returns the stable client-native rejection required for the client to disable or surface that capability; it is not quietly removed. This behavior is part of the real-client conformance suite.
+
+Streaming conversion is a state machine, not a rewrite of arbitrary network chunks:
+
+```text
+provider bytes
+  -> SSE framing
+  -> provider semantic event
+  -> per-request translation state
+  -> client semantic event(s)
+  -> SSE encoding
+```
+
+This is necessary because Anthropic content blocks and OpenAI Responses/Chat events have different start, index, delta, usage, and terminal-event rules.
+
+### Why we own the bridge
+
+- LiteLLM's mature Python implementation demonstrates broad mapping coverage, but its current Rust Chat-to-Anthropic path deliberately rejects streaming and non-text content and falls back to Python.
+- Bifrost demonstrates the right capability-aware internal representation and stateful streaming architecture, but its Anthropic adapters and regression corpus also show that universal translation is a large maintenance surface.
+- Smaller Rust gateways demonstrate that the coding-agent matrix is feasible, but several silently drop reasoning or unknown content and are not suitable as production dependencies.
+
+We should use these projects as behavioral references, not add a gateway SDK to the hot path. Langfuse owns its protocol types, loss policy, stream state machines, and conformance fixtures. Native calls continue to avoid translation entirely.
+
+## Telemetry and Media
+
+The gateway builds one Langfuse generation per provider execution, including project/key attribution, protocol pair, model and connection, timing and time-to-first-token, provider request ID, terminal outcome, usage/cache usage, and cost inputs. Claude Code session and agent headers may be recorded for grouping but are never treated as user identity. Content inclusion follows the resolved telemetry mode and explicit byte bounds.
+
+Telemetry is accumulated into timeout-or-size bounded batches and submitted to a private gateway ingestion endpoint. Web validates the sealed context, derives the project, and reuses the existing S3/queue/OTLP ingestion path. Media uses a corresponding private upload endpoint. The gateway does not receive storage or queue credentials.
+
+V1 does not add a separate ClickHouse gateway-logs table. Langfuse traces/generations remain the customer-facing request record; Datadog metrics and sanitized service logs cover operational health. A separate durable execution ledger should only be introduced when spend enforcement, settlement, or audit guarantees require semantics that best-effort observability cannot provide.
+
+## Deployment and Reliability
+
+### Langfuse Cloud
+
+Deploy `ai-gateway` as an independently scalable Rust ECS/Fargate service in every existing regional environment. Reuse the regional VPC, private subnets, NAT egress, ALB/WAF, Secrets Manager, deployment pipeline, and monitoring foundations while giving the gateway dedicated tasks, target group, security group, IAM roles, and autoscaling.
+
+The public edge uses a gateway hostname and streaming-safe idle/drain settings. Gateway-to-Web resolution, telemetry, and media endpoints are private. Scale primarily on active streams, with CPU, memory, bytes in flight, connection rate, and telemetry-queue pressure as guardrails. Deployments require readiness, graceful draining, a maximum stream duration, and progressive regional rollout.
+
+### Self-hosted fast follow
+
+Ship the same image as an optional first-class Helm component, not a Web sidecar. Enabling the component should automatically create its Deployment and Service, connect it to the in-cluster Web Service, and share a generated or operator-provided gateway service token.
+
+Operators configure only enablement, public ingress/TLS, and optionally an existing Secret. The chart exposes replicas, resources, probes, PDB, topology, graceful termination, and HPA/KEDA settings without requiring direct database, cache, object-store, or queue configuration for the gateway.
+
+## Failure Semantics
+
+- Authentication, expired-cache resolution, destination selection, and translation validation fail closed before provider dispatch.
+- Inference POSTs are never retried by the gateway.
+- Provider status/errors are passed through or translated into the client-native envelope.
+- After provider dispatch, telemetry and media failures fail open.
+- Capture, batches, queues, and per-request translation state are byte- and count-bounded.
+- Saturation sheds new work or telemetry according to explicit limits; it never permits unbounded memory growth.
+
+## Delivery Milestones
+
+1. **Contracts and runtime:** Rust service skeleton, internal resolve/cache contract, sealed context, bounded telemetry endpoint, native fixtures, and streaming/load qualification.
+2. **Claude Code to Anthropic:** Messages, count tokens, model discovery, native streaming, keys/connections, tracing, cost, and real Claude Code conformance.
+3. **OpenAI native:** Chat Completions, Responses, compact, model discovery, OpenAI SDK and Codex conformance.
+4. **Protocol bridge:** Chat Completions and Responses to Anthropic, capability gates, translation/state-machine fixtures, and an advertised client/model compatibility matrix. Anthropic-to-OpenAI translation follows after V1.
+5. **Cloud qualification:** Dedicated edge configuration, security review, stream-aware autoscaling, graceful deployments, SLOs, and progressive regional rollout.
+6. **Self-hosted:** First-class Helm packaging, secret wiring, networking guidance, and the same conformance suite.
+
+These workstreams can proceed mostly independently once the resolve contract, protocol types, terminal outcomes, and telemetry facts are fixed: control-plane keys/permissions, LLM Connections/model catalog, authority/cache endpoints, native protocol adapters, translation adapters, telemetry/media ingestion, Cloud deployment, Helm packaging, and conformance/load testing.
+
+## Launch Gates
+
+- Real Claude Code and Codex sessions, including tools, media, cancellation, long sessions, and model discovery.
+- OpenAI and Anthropic TypeScript/Python SDK conformance for native paths.
+- Golden request/response/error fixtures and exact translated SSE event ordering.
+- Strict negative tests for every unsupported translation feature.
+- Credential/header leak, tenant isolation, revocation-window, SSRF, redirect, and custom-origin tests.
+- Long-lived stream, slow-client, disconnect, deployment-drain, Web outage, provider failure, and telemetry saturation tests.
+- Measured gateway overhead and capacity on production-like multi-core containers.
+
+## Open Questions
+
+- Which reasoning/thinking continuity subset is required before Codex-to-Anthropic or Claude-Code-to-OpenAI translation can be advertised?
+- What exact translated compaction behavior is required before Codex-to-Anthropic can be advertised for long sessions?
+- Are custom public HTTPS LLM Connection base URLs included in V1 after the required transport-security spike, or deferred?
+
+## References
+
+### Native clients and protocols
+
+- [Claude Code LLM gateway protocol](https://code.claude.com/docs/en/llm-gateway-protocol)
+- [Anthropic Messages](https://platform.claude.com/docs/en/api/messages/create)
+- [Anthropic streaming](https://platform.claude.com/docs/en/build-with-claude/streaming)
+- [Anthropic token counting](https://platform.claude.com/docs/en/api/messages/count_tokens)
+- [OpenAI Chat Completions](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create)
+- [OpenAI Responses](https://developers.openai.com/api/reference/resources/responses/methods/create)
+- [OpenAI Responses streaming events](https://developers.openai.com/api/reference/resources/responses/streaming-events)
+- [OpenAI Models](https://developers.openai.com/api/reference/resources/models/methods/list)
+
+### Translation references
+
+- [LiteLLM Anthropic passthrough architecture](https://github.com/BerriAI/litellm/blob/litellm_internal_staging/litellm/llms/anthropic/experimental_pass_through/architecture.md)
+- [LiteLLM Rust translation acceptance boundary](https://github.com/BerriAI/litellm/blob/litellm_internal_staging/litellm-rust/crates/core/src/chat_completions/transformation.rs)
+- [LiteLLM Rust migration](https://github.com/BerriAI/litellm/issues/31263)
+- [Bifrost Anthropic integration](https://github.com/maximhq/bifrost/blob/dev/transports/bifrost-http/integrations/anthropic.go)
+- [Bifrost Anthropic Responses adapter](https://github.com/maximhq/bifrost/blob/dev/core/providers/anthropic/responses.go)
+- [Portkey Anthropic Chat adapter](https://github.com/Portkey-AI/gateway/blob/main/src/providers/anthropic/chatComplete.ts)
+- [Helicone Rust protocol mappers](https://github.com/Helicone/ai-gateway/tree/main/ai-gateway/src/middleware/mapper)
+
+### Deployment and standards
+
+- [Langfuse Kubernetes Helm deployment](https://langfuse.com/self-hosting/deployment/kubernetes-helm)
+- [HTTP authentication schemes](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2)
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/)

--- a/specs/llm-gateway-rfc.md
+++ b/specs/llm-gateway-rfc.md
@@ -14,17 +14,16 @@ V1 includes:
 
 - Anthropic Messages, OpenAI Chat Completions, OpenAI Responses, and their native auxiliary endpoints used by Claude Code and Codex.
 - OpenAI and Anthropic BYOK connections.
-- Native protocol passthrough when the client and upstream protocols match.
-- A bounded OpenAI-to-Anthropic protocol bridge for Chat Completions and Responses.
+- Native protocol passthrough when the client and upstream protocols match. Incompatible client/upstream protocol pairs are rejected before provider dispatch.
 - Gateway virtual keys, deterministic model-to-connection resolution, and automatic Langfuse telemetry.
 
-V1 does not include inference resale, multiple routing candidates, fallbacks, gateway retries, rate limits, spend limits, or guardrails.
+V1 does not include cross-provider protocol translation, inference resale, multiple routing candidates, fallbacks, gateway retries, rate limits, spend limits, or guardrails.
 
 ## Context
 
 Langfuse currently observes coding agents through client-side hooks. This works for individuals but is difficult to deploy and govern across organizations with hundreds of developers. A gateway gives platform teams one centrally managed integration point for tracing, cost attribution, credentials, and future runtime policy.
 
-Provider translation materially strengthens that value proposition: OpenAI applications and Codex can use an Anthropic model without changing their wire protocol. The same bridge architecture enables Claude Code to use OpenAI models as a fast follow. Research across LiteLLM, Bifrost, Portkey, Helicone, and smaller Rust gateways shows that the common coding-agent subset is feasible to translate, but universal lossless translation is not. V1 therefore defines an explicit compatibility profile and rejects unsupported semantics instead of silently dropping them.
+Cross-provider translation would strengthen that value proposition by letting Codex use Anthropic models or Claude Code use OpenAI models without changing their wire protocol. However, OpenAI Responses and Anthropic Messages are not equivalent contracts. Translation introduces state, tool-lifecycle, streaming, media, and provider-owned artifact semantics whose failures can be silent and agent-breaking. V1 therefore prioritizes reliable native execution and treats translation as a separate interoperability product with its own compatibility contract and release criteria.
 
 ## Product Scope
 
@@ -34,22 +33,22 @@ Provider translation materially strengthens that value proposition: OpenAI appli
 | --- | --- |
 | `POST /v1/messages` | Required: Anthropic Messages and Claude Code |
 | `POST /v1/messages/count_tokens` | Native Anthropic pass-through; optional to Claude Code |
-| `POST /v1/chat/completions` | Required: native OpenAI and translation to Anthropic |
-| `POST /v1/responses` | Required: native OpenAI and translation to Anthropic |
-| `POST /v1/responses/compact` | Required for native OpenAI/Codex; translated compaction requires a separate conformance decision |
+| `POST /v1/chat/completions` | Required: native OpenAI |
+| `POST /v1/responses` | Required: native OpenAI |
+| `POST /v1/responses/compact` | Required for native OpenAI/Codex |
 | `GET /v1/models` | Required: authenticated gateway-owned catalog |
 
 ### Protocol matrix
 
-The requested model deterministically selects one upstream adapter and LLM Connection. Matching pairs use native passthrough; supported mismatches use the protocol bridge.
+The requested model deterministically selects one upstream adapter and LLM Connection. V1 only executes matching client and upstream protocols.
 
 | Client protocol | OpenAI upstream | Anthropic upstream |
 | --- | --- | --- |
-| Anthropic Messages | Fast follow | Native passthrough |
-| OpenAI Chat Completions | Native passthrough | Request to Messages; response back to Chat |
-| OpenAI Responses | Native passthrough | Request to Messages; response back to Responses |
+| Anthropic Messages | Not supported | Native passthrough |
+| OpenAI Chat Completions | Native passthrough | Not supported |
+| OpenAI Responses | Native passthrough | Not supported |
 
-Translation is a V1 launch requirement, not a claim that every provider-specific extension is portable. Chat Completions and Responses to Anthropic must pass their documented compatibility profile before V1 launches. Auxiliary behavior such as Responses compaction is evaluated separately before a specific client/model combination is advertised. Anthropic Messages to OpenAI is a fast follow.
+An incompatible model/protocol pair returns a clear client error before provider dispatch. The gateway never silently translates, drops, or approximates provider-specific semantics in V1.
 
 ### Model discovery
 
@@ -74,7 +73,7 @@ The [Claude Code gateway contract](https://code.claude.com/docs/en/llm-gateway-p
 
 The endpoint requires a Gateway virtual key and returns only models enabled for that key's organization and resolved project policy. The list is generated from Langfuse configuration and never fetched synchronously from an upstream provider. A listed model maps to exactly one upstream adapter and connection, and unlisted models are rejected. This is deterministic destination selection, not routing: there is no candidate set, policy evaluation, or fallback.
 
-Claude Code only discovers IDs containing `claude` or `anthropic`. An OpenAI-backed model intended for its picker therefore needs an explicit compatible gateway alias; otherwise administrators configure that model directly in Claude Code.
+Claude Code only discovers IDs containing `claude` or `anthropic`. Because V1 does not translate Messages to OpenAI, the catalog must not make an OpenAI destination appear Messages-compatible by assigning it a Claude-like alias.
 
 ## Architecture
 
@@ -83,9 +82,9 @@ flowchart LR
     C["Claude Code, Codex, or application"] -->|"native API request"| G["Rust AI Gateway"]
     G -->|"cache miss: resolve"| W["Langfuse Web control plane"]
     W --> P[("Postgres and existing auth/config")]
-    G -->|"native or translated request"| O["OpenAI or Anthropic"]
+    G -->|"native request"| O["OpenAI or Anthropic"]
     O -->|"JSON or SSE"| G
-    G -->|"native or translated response"| C
+    G -->|"native response"| C
     G -.->|"batched telemetry and media"| W
     W -.-> I["Existing Langfuse ingestion"]
 ```
@@ -118,7 +117,7 @@ Gateway virtual key + ingress protocol + model
   -> organization and project
   -> upstream adapter
   -> one default LLM Connection
-  -> native or translated execution
+  -> native execution
 ```
 
 Official OpenAI and Anthropic origins are supported first. Custom base URLs require save-time, use-time, connection-time, DNS, and redirect validation plus strict credential stripping. They only enter V1 if that security work is completed for both Cloud and self-hosted deployments.
@@ -203,52 +202,36 @@ Web seals the context with a Web-only authenticated-encryption key. The gateway 
 
 1. **Classify and bound:** Select the ingress protocol, normalize the client credential, reject an invalid method/content type or declared oversize body, and read the body once under a hard byte limit.
 2. **Authenticate and resolve:** Extract the model, load or refresh the cached execution configuration, and use the catalog's single adapter/connection mapping. No client-controlled origin, connection, or project is accepted.
-3. **Protect:** Apply the native path's minimal boundary checks or the translated path's stricter compatibility validation, plus header and media policy.
-4. **Prepare:** Use raw native passthrough when protocols match. Otherwise validate against the translation compatibility profile and transform into the upstream protocol.
+3. **Protect:** Apply the native protocol's minimal boundary checks plus header and media policy. Reject an incompatible client/upstream protocol pair.
+4. **Prepare:** Preserve the native body and apply only the resolved origin, model placement, provider authentication, and safe header adjustments required by the upstream transport.
 5. **Execute once:** Replace client authentication with the provider credential and perform one upstream request. Inference POSTs receive zero gateway retries.
-6. **Relay and observe:** Stream with backpressure and cancellation. Native streams remain byte passthrough; translated streams use a stateful semantic-event converter. Telemetry observes the same stream and never becomes a second consumer.
+6. **Relay and observe:** Stream native response bytes with backpressure and cancellation. Telemetry observes the same stream and never becomes a second consumer.
 7. **Finalize:** Enqueue bounded telemetry/media work. Failures after provider dispatch fail open and never corrupt an otherwise healthy client response.
 
-Gateway-generated errors use the client's native error envelope. Provider-native responses are preserved on passthrough paths. Translated provider errors are mapped conservatively while retaining the provider request ID.
+Gateway-generated errors use the client's native error envelope. Provider-native statuses, errors, response bodies, and SSE events are preserved.
 
-### Protocol bridge
+### Native protocol handling
 
-Translation is only invoked when ingress and upstream protocols differ. It uses narrow owned wire types and a loss-aware internal representation; that internal representation is not a public API.
+Native calls bypass a universal prompt representation. The gateway parses only what resolution, boundary enforcement, and telemetry require; it does not reconstruct provider requests or response events when the semantic protocol already matches.
 
-The initial compatibility profile covers:
+Native Anthropic execution preserves the evolving, non-credential `anthropic-*` headers and body fields as an open set. Upstream headers are reconstructed: customer/provider credentials, cookies, forwarding and hop-by-hop headers are always removed, and sensitive headers are never followed across origins. The gateway does not fetch prompt-supplied media URLs; it validates inline media type and bytes and passes supported sources to the provider.
 
-- System/developer instructions and user/assistant text.
-- URL and base64 images.
-- Function tools, tool choice, parallel tool calls, and tool results.
-- Core generation limits and sampling parameters where semantics match.
-- Non-streaming responses.
-- Streaming text, tool-input deltas, stop reasons, usage/cache usage, and errors.
-- Interrupted streams and client cancellation.
+Transport adaptation is distinct from cross-provider protocol translation. A future adapter may change authentication, URL/model placement, or event framing while preserving the provider's semantic schema—for example, Anthropic Messages on Bedrock or Vertex. Such an adapter requires its own provider conformance work but does not imply OpenAI-to-Anthropic translation.
 
-The bridge must reject unsupported fields with a client-native `400`. It must never silently discard data or fabricate provider-specific opaque values. Initial non-goals include audio, PDFs/documents, citations, provider-hosted tools, MCP server tools, computer use, multiple choices, stateful Responses references, and exact cross-provider reasoning/thinking fidelity. Real Claude Code or Codex fixtures may promote a capability into the profile before that client/model combination is advertised.
+### Why translation is excluded from V1
 
-Native Anthropic execution preserves the evolving, non-credential `anthropic-*` headers and body fields as an open set. Upstream headers are reconstructed: customer/provider credentials, cookies, forwarding and hop-by-hop headers are always removed, and sensitive headers are never followed across origins. The gateway does not fetch prompt-supplied media URLs; it validates inline media type and bytes and passes supported sources to the provider. On a translated request, an unsupported capability returns the stable client-native rejection required for the client to disable or surface that capability; it is not quietly removed. This behavior is part of the real-client conformance suite.
+Translation is feasible for a constrained subset, but it is a continuously maintained compatibility product rather than gateway plumbing:
 
-Streaming conversion is a state machine, not a rewrite of arbitrary network chunks:
+- **Stateful continuation:** Responses can refer only to `previous_response_id` or a stored conversation, while Messages expects complete history. Correct support requires gateway-owned state and reconstruction; LiteLLM has failed second tool turns when those identities diverged ([LiteLLM #26167](https://github.com/BerriAI/litellm/issues/26167)).
+- **Agent tool semantics:** Parallel tool calls and results have different grouping, ordering, choice, and terminal rules. Incorrect translation can return a provider `400`, silently enable disabled tools, or end a successful-looking stream before the agent executes its tool ([LiteLLM #23105](https://github.com/BerriAI/litellm/issues/23105), [LiteLLM #32505](https://github.com/BerriAI/litellm/issues/32505), [Bifrost #6123](https://github.com/maximhq/bifrost/issues/6123)).
+- **Provider-owned artifacts:** Encrypted reasoning, thinking signatures, hosted tools, file IDs, prompt-cache controls, background execution, and conversation resources do not have lossless cross-provider representations.
+- **Streaming and multimodal breadth:** Every request field, response item, nested media location, SSE transition, provider/model capability, and client release expands the conformance matrix. OSS gateways with substantial adapter suites still regress on new server tools and heterogeneous stream items ([Bifrost #4780](https://github.com/maximhq/bifrost/issues/4780), [Bifrost #4713](https://github.com/maximhq/bifrost/issues/4713)).
 
-```text
-provider bytes
-  -> SSE framing
-  -> provider semantic event
-  -> per-request translation state
-  -> client semantic event(s)
-  -> SSE encoding
-```
+The dangerous failures are not limited to obvious request rejection. A translated stream can appear successful while losing a tool result, changing a stop reason, enabling a disabled tool, or breaking reasoning continuity. Those failures are difficult to detect from gateway health metrics and directly affect agent correctness and safety.
 
-This is necessary because Anthropic content blocks and OpenAI Responses/Chat events have different start, index, delta, usage, and terminal-event rules.
+V1 therefore supports Claude Code with Anthropic destinations and Codex/OpenAI clients with OpenAI-compatible destinations. Codex-to-Claude and Claude-Code-to-OpenAI remain valuable fast-follow use cases, but they require a separate RFC defining one named compatibility profile, explicit rejections, conversation/provider pinning, direct pairwise adapters, translator version telemetry, and real-client multi-turn conformance tests.
 
-### Why we own the bridge
-
-- LiteLLM's mature Python implementation demonstrates broad mapping coverage, but its current Rust Chat-to-Anthropic path deliberately rejects streaming and non-text content and falls back to Python.
-- Bifrost demonstrates the right capability-aware internal representation and stateful streaming architecture, but its Anthropic adapters and regression corpus also show that universal translation is a large maintenance surface.
-- Smaller Rust gateways demonstrate that the coding-agent matrix is feasible, but several silently drop reasoning or unknown content and are not suitable as production dependencies.
-
-We should use these projects as behavioral references, not add a gateway SDK to the hot path. Langfuse owns its protocol types, loss policy, stream state machines, and conformance fixtures. Native calls continue to avoid translation entirely.
+This decision is about sequencing, not rejecting interoperability. The likely first post-V1 profile is OpenAI Responses to Anthropic Messages for Codex, limited initially to complete stateless history, text/images, custom function tools/results, and streaming/non-streaming execution. Stateful Responses, hosted tools, provider file IDs, encrypted reasoning translation, and cross-provider fallback after a conversation starts would be rejected.
 
 ## Telemetry and Media
 
@@ -274,11 +257,11 @@ Operators configure only enablement, public ingress/TLS, and optionally an exist
 
 ## Failure Semantics
 
-- Authentication, expired-cache resolution, destination selection, and translation validation fail closed before provider dispatch.
+- Authentication, expired-cache resolution, destination selection, protocol matching, and boundary validation fail closed before provider dispatch.
 - Inference POSTs are never retried by the gateway.
-- Provider status/errors are passed through or translated into the client-native envelope.
+- Provider statuses and errors are passed through unchanged.
 - After provider dispatch, telemetry and media failures fail open.
-- Capture, batches, queues, and per-request translation state are byte- and count-bounded.
+- Capture, batches, and queues are byte- and count-bounded.
 - Saturation sheds new work or telemetry according to explicit limits; it never permits unbounded memory growth.
 
 ## Delivery Milestones
@@ -286,27 +269,27 @@ Operators configure only enablement, public ingress/TLS, and optionally an exist
 1. **Contracts and runtime:** Rust service skeleton, internal resolve/cache contract, sealed context, bounded telemetry endpoint, native fixtures, and streaming/load qualification.
 2. **Claude Code to Anthropic:** Messages, count tokens, model discovery, native streaming, keys/connections, tracing, cost, and real Claude Code conformance.
 3. **OpenAI native:** Chat Completions, Responses, compact, model discovery, OpenAI SDK and Codex conformance.
-4. **Protocol bridge:** Chat Completions and Responses to Anthropic, capability gates, translation/state-machine fixtures, and an advertised client/model compatibility matrix. Anthropic-to-OpenAI translation follows after V1.
-5. **Cloud qualification:** Dedicated edge configuration, security review, stream-aware autoscaling, graceful deployments, SLOs, and progressive regional rollout.
-6. **Self-hosted:** First-class Helm packaging, secret wiring, networking guidance, and the same conformance suite.
+4. **Cloud qualification:** Dedicated edge configuration, security review, stream-aware autoscaling, graceful deployments, SLOs, and progressive regional rollout.
+5. **Self-hosted:** First-class Helm packaging, secret wiring, networking guidance, and the same conformance suite.
 
-These workstreams can proceed mostly independently once the resolve contract, protocol types, terminal outcomes, and telemetry facts are fixed: control-plane keys/permissions, LLM Connections/model catalog, authority/cache endpoints, native protocol adapters, translation adapters, telemetry/media ingestion, Cloud deployment, Helm packaging, and conformance/load testing.
+These workstreams can proceed mostly independently once the resolve contract, protocol types, terminal outcomes, and telemetry facts are fixed: control-plane keys/permissions, LLM Connections/model catalog, authority/cache endpoints, native protocol adapters, telemetry/media ingestion, Cloud deployment, Helm packaging, and conformance/load testing.
+
+Cross-provider translation is a post-V1 milestone with a separate compatibility RFC and launch gate; it is not on the critical path for the milestones above.
 
 ## Launch Gates
 
 - Real Claude Code and Codex sessions, including tools, media, cancellation, long sessions, and model discovery.
 - OpenAI and Anthropic TypeScript/Python SDK conformance for native paths.
-- Golden request/response/error fixtures and exact translated SSE event ordering.
-- Strict negative tests for every unsupported translation feature.
+- Golden native request/response/error fixtures and exact SSE pass-through behavior.
+- Strict negative tests for incompatible client protocol and destination combinations.
 - Credential/header leak, tenant isolation, revocation-window, SSRF, redirect, and custom-origin tests.
 - Long-lived stream, slow-client, disconnect, deployment-drain, Web outage, provider failure, and telemetry saturation tests.
 - Measured gateway overhead and capacity on production-like multi-core containers.
 
 ## Open Questions
 
-- Which reasoning/thinking continuity subset is required before Codex-to-Anthropic or Claude-Code-to-OpenAI translation can be advertised?
-- What exact translated compaction behavior is required before Codex-to-Anthropic can be advertised for long sessions?
 - Are custom public HTTPS LLM Connection base URLs included in V1 after the required transport-security spike, or deferred?
+- Are near-native Bedrock Messages and Vertex Messages transport adapters included in V1 after provider conformance, or deferred?
 
 ## References
 
@@ -321,15 +304,14 @@ These workstreams can proceed mostly independently once the resolve contract, pr
 - [OpenAI Responses streaming events](https://developers.openai.com/api/reference/resources/responses/streaming-events)
 - [OpenAI Models](https://developers.openai.com/api/reference/resources/models/methods/list)
 
-### Translation references
+### Translation decision evidence
 
-- [LiteLLM Anthropic passthrough architecture](https://github.com/BerriAI/litellm/blob/litellm_internal_staging/litellm/llms/anthropic/experimental_pass_through/architecture.md)
-- [LiteLLM Rust translation acceptance boundary](https://github.com/BerriAI/litellm/blob/litellm_internal_staging/litellm-rust/crates/core/src/chat_completions/transformation.rs)
-- [LiteLLM Rust migration](https://github.com/BerriAI/litellm/issues/31263)
-- [Bifrost Anthropic integration](https://github.com/maximhq/bifrost/blob/dev/transports/bifrost-http/integrations/anthropic.go)
-- [Bifrost Anthropic Responses adapter](https://github.com/maximhq/bifrost/blob/dev/core/providers/anthropic/responses.go)
-- [Portkey Anthropic Chat adapter](https://github.com/Portkey-AI/gateway/blob/main/src/providers/anthropic/chatComplete.ts)
-- [Helicone Rust protocol mappers](https://github.com/Helicone/ai-gateway/tree/main/ai-gateway/src/middleware/mapper)
+- [LiteLLM stateful Responses tool-turn failure](https://github.com/BerriAI/litellm/issues/26167)
+- [LiteLLM Responses-to-Vertex tool-result ordering failure](https://github.com/BerriAI/litellm/issues/23105)
+- [LiteLLM tool-choice semantic failures](https://github.com/BerriAI/litellm/issues/32505)
+- [Bifrost incorrect translated stream termination](https://github.com/maximhq/bifrost/issues/6123)
+- [Bifrost missing hosted-tool stream handling](https://github.com/maximhq/bifrost/issues/4780)
+- [Bifrost heterogeneous tool stream failure](https://github.com/maximhq/bifrost/issues/4713)
 
 ### Deployment and standards
 

--- a/specs/llm-gateway-rfc.md
+++ b/specs/llm-gateway-rfc.md
@@ -1,73 +1,62 @@
 # RFC: Langfuse AI Gateway V1
 
 - Status: Draft
-- Linear: [LFE-15204](https://linear.app/clickhouse/issue/LFE-15204/ai-gateway-v1-scope)
-- Last updated: 2026-09-01
+- Last updated: 2026-09-02
 
 ## Decision
 
-Langfuse will ship a BYOK AI Gateway that lets Claude Code, Codex, and general OpenAI or Anthropic applications use Langfuse as their LLM API base URL. The gateway executes requests with organization-managed LLM credentials, streams the result back to the client, and records usage, cost, latency, and optionally request/response content in Langfuse without client-side hooks.
+Langfuse will ship a BYOK AI Gateway that lets Claude Code, Codex, and general OpenAI or Anthropic applications use Langfuse as their LLM API base URL. The gateway executes requests with organization-managed provider credentials, streams native responses back to clients, and records usage, cost, latency, and optionally request and response content without client-side hooks.
 
-V1 launches on Langfuse Cloud and self-hosted at the same time. Both deployment models use the same container and contracts.
+V1 launches on Langfuse Cloud and self-hosted at the same time. Both deployment models use the same Rust service and contracts.
 
 V1 includes:
 
-- Anthropic Messages, OpenAI Chat Completions, OpenAI Responses, Claude Code's native Bedrock and Vertex protocols, and their required auxiliary endpoints.
-- OpenAI, Anthropic, Bedrock, and Vertex BYOK connections.
-- Native protocol passthrough when the client and upstream protocols match. Incompatible client/upstream protocol pairs are rejected before provider dispatch.
-- Gateway virtual keys, deterministic protocol-to-connection resolution, and automatic Langfuse telemetry.
+- Native Anthropic Messages, token counting, and model discovery.
+- Native OpenAI Chat Completions, Responses, response compaction, and model discovery.
+- Organization-owned BYOK connections from an explicit provider registry.
+- Gateway virtual keys, deterministic namespace-to-connection resolution, and automatic Langfuse telemetry.
 
-V1 does not include cross-provider protocol translation, inference resale, multiple routing candidates, fallbacks, gateway retries, rate limits, spend limits, or guardrails.
+V1 does not include cross-provider translation, arbitrary custom origins, inference resale, routing, fallback, retries, rate limits, spend limits, or guardrails. Bedrock and Vertex support are follow-ups because their authentication and streaming transports are materially different.
 
 ## Context
 
 Langfuse currently observes coding agents through client-side hooks. This works for individuals but is difficult to deploy and govern across organizations with hundreds of developers. A gateway gives platform teams one centrally managed integration point for tracing, cost attribution, credentials, and future runtime policy.
 
-Cross-provider translation would strengthen that value proposition by letting Codex use Anthropic models or Claude Code use OpenAI models without changing their wire protocol. However, OpenAI Responses and Anthropic Messages are not equivalent contracts. Translation introduces state, tool-lifecycle, streaming, media, and provider-owned artifact semantics whose failures can be silent and agent-breaking. V1 therefore prioritizes reliable native execution. Translation will only be reconsidered if strong measured demand justifies a separate compatibility product and its permanent maintenance burden.
+Cross-provider translation would strengthen that value proposition, but OpenAI Responses and Anthropic Messages are not equivalent contracts. Translation introduces state, tool-lifecycle, streaming, media, and provider-owned artifact semantics whose failures can be silent and agent-breaking. Langfuse will reconsider it only if measured demand justifies a separate compatibility product and its permanent maintenance burden.
 
 ## Product Scope
 
-### Public protocol namespaces
+### Public API namespaces
 
-Each native protocol has an explicit namespace. The namespace determines the upstream wire contract and response format without inspecting headers or negotiating a schema.
+Clients select a native API namespace as part of their base URL. One organization connection powers every endpoint within that namespace:
 
-| Namespace and endpoint family | V1 support |
-| --- | --- |
-| `POST /anthropic/v1/messages` | Native Anthropic Messages and Claude Code |
-| `POST /anthropic/v1/messages/count_tokens` | Native Anthropic token counting |
-| `GET /anthropic/v1/models` | Native Anthropic model discovery through the selected connection |
-| `POST /openai/v1/chat/completions` | Native OpenAI Chat Completions |
-| `POST /openai/v1/responses` | Native OpenAI Responses |
-| `POST /openai/v1/responses/compact` | Native OpenAI response compaction for Codex |
-| `GET /openai/v1/models` | Native OpenAI model discovery through the selected connection |
-| `/bedrock/...` | Claude Code's native Bedrock InvokeModel, streaming, and token-counting paths |
-| `/vertex/...` | Claude Code's native Vertex `rawPredict`, streaming, and token-counting paths |
-
-Clients configure the namespace as part of their base URL. The tradeoff is that Langfuse exposes provider-specific base URLs instead of one universal URL; this is acceptable because V1 does not route or translate between protocols, and the namespace makes response/error/model-discovery formats unambiguous. A future unified root API may be added as an alias or separate routing product without breaking these native endpoints.
-
-### Protocol matrix
-
-The protocol namespace deterministically selects one upstream adapter and LLM Connection. V1 only executes matching client and upstream protocols.
-
-| Client protocol | Upstream adapter | Behavior |
+| Namespace | V1 endpoints | Selected connection |
 | --- | --- | --- |
-| Anthropic Messages | Anthropic | Native HTTP/SSE passthrough |
-| OpenAI Chat Completions | OpenAI | Native HTTP/SSE passthrough |
-| OpenAI Responses | OpenAI | Native HTTP/semantic-event passthrough |
-| Claude Code Bedrock | Bedrock | Native InvokeModel HTTP/AWS event-stream passthrough |
-| Claude Code Vertex | Vertex | Native `rawPredict` HTTP/SSE passthrough |
+| `/anthropic/v1` | `POST /messages`, `POST /messages/count_tokens`, `GET /models` | One connection compatible with the complete Anthropic namespace |
+| `/openai/v1` | `POST /chat/completions`, `POST /responses`, `POST /responses/compact`, `GET /models` | One connection compatible with the complete OpenAI namespace |
 
-An unavailable or incompatible protocol namespace returns a clear client error before provider dispatch. The gateway never silently translates, drops, or approximates provider-specific semantics in V1. Bedrock and Vertex support means accepting Claude Code's native provider protocols; it does not mean translating `/anthropic/v1/messages` into those protocols.
+The gateway does not bind individual endpoints independently. Chat Completions, Responses, and model discovery therefore cannot unexpectedly use different credentials, providers, model catalogs, or data regions.
+
+Requests and streams remain provider-native. The gateway preserves unknown fields, forwards the requested model unchanged, and does not normalize calls through a universal prompt schema.
+
+### Controlled provider registry
+
+Gateway connections are created from provider types explicitly supported by Langfuse, initially OpenAI, Anthropic, and OpenRouter. Each provider definition owns its credential fields, official origins, authentication behavior, supported API namespaces, and request construction. Administrators cannot edit these capabilities or enter an arbitrary base URL in V1.
+
+A connection can be selected for a namespace only if its provider definition implements the namespace's complete V1 contract. For example, a provider that supports Chat Completions but not Responses cannot power `/openai/v1`. Langfuse rejects an incompatible configuration before traffic is sent rather than relying on an upstream error for a mismatch it already knows about.
+
+This controlled registry keeps execution, model discovery, credential handling, and security predictable. Additional providers, including Bedrock and Vertex, remain additive registry entries once their native transports pass the same conformance and security gates. Arbitrary origins require a separate secure-fetch boundary and are not part of V1.
 
 ### Model discovery
 
-Model discovery is namespaced and upstream-authoritative:
+Model discovery uses the same organization connection as inference within its namespace:
 
-- `/anthropic/v1/models` forwards to the selected Anthropic connection and returns its native response unchanged.
-- `/openai/v1/models` forwards to the selected OpenAI connection and returns its native response unchanged.
-- Claude Code does not use model discovery for its native Bedrock or Vertex protocols.
+```text
+/openai/v1/models     -> organization's OpenAI namespace connection
+/anthropic/v1/models  -> organization's Anthropic namespace connection
+```
 
-Langfuse does not maintain, merge, normalize, or enforce a gateway model catalog in V1. The selected connection determines which models are available, and the provider remains responsible for accepting or rejecting the request's native model identifier. The discovery path is authenticated and uses the same connection resolution as inference. It is not cached initially; a short response cache may be added later if upstream latency or rate limits require it.
+The gateway forwards the upstream model response unchanged. Langfuse does not maintain, merge, normalize, or cache a gateway model catalog initially. Model discovery is authenticated and does not create a customer generation.
 
 ## Architecture
 
@@ -76,60 +65,72 @@ flowchart LR
     C["Claude Code, Codex, or application"] -->|"native API request"| G["Rust AI Gateway"]
     G -->|"cache miss: resolve"| W["Langfuse Web control plane"]
     W --> P[("Postgres and existing auth/config")]
-    G -->|"native request"| O["OpenAI, Anthropic, Bedrock, or Vertex"]
+    G -->|"native request"| O["Approved upstream provider"]
     O -->|"native response stream"| G
     G -->|"native response"| C
-    G -.->|"batched telemetry and media"| W
+    G -.->|"batched OTLP and media"| W
     W -.-> I["Existing Langfuse ingestion"]
 ```
 
-The gateway is a separate stateless Rust service built with Axum, Tokio, Hyper/Reqwest, Serde, Bytes, Rustls, and OpenTelemetry. It has no direct Postgres, Redis, ClickHouse, S3, or queue credentials. Langfuse Web remains the authority for authentication, project selection, LLM Connections, and ingestion.
+The gateway is a separate stateless Rust service built for long-lived concurrent streams. It has no direct Postgres, Redis, ClickHouse, S3, or queue credentials. Langfuse Web remains the authority for authentication, project selection, connections, and ingestion.
 
 ## Control Plane
 
-### Gateway virtual keys
+### Organization LLM connections
 
-A **Gateway virtual key** is a Langfuse-issued credential accepted only by the gateway. It is named, reveal-once, attributable, expirable, rotatable, revocable, and authorized with an explicit `gateway:invoke` permission preset.
+Gateway connections are new organization-owned resources. They are intentionally separate from today's project-owned LLM Connections:
 
-Only organization administrators create Gateway virtual keys in V1. The implementation extends the authorization and key lifecycle planned in the [granular API permissions RFC](https://linear.app/clickhouse/document/rfc-granular-api-permissions-a-unified-authorization-core-for-langfuse-04e83c1c436b); the gateway must not create a parallel permissions system.
+- Gateway credentials are shared infrastructure administered once for the organization.
+- Project connections remain private to their current project and continue powering existing playground, evaluation, and other product workflows.
+- An optional "import from project connection" flow may copy an existing configuration into a new organization connection, but the two resources are not kept in a live relationship.
 
-Each execution maps to exactly one Langfuse project. Project selection is:
-
-1. A project override fixed when the key is created, if the organization permits it.
-2. Otherwise, the organization's current default gateway project.
-
-Clients cannot submit or override a project ID. Changing the organization default affects executions after their cached configuration expires.
-
-### LLM Connections and destinations
-
-LLM Connections become organization-level resources. For V1, an administrator explicitly selects one default connection for each enabled upstream adapter: OpenAI, Anthropic, Bedrock, and Vertex. The selection contract may later return multiple candidates for routing or fallback, but V1 always resolves exactly one connection.
-
-A request resolves without consulting a model catalog:
+An administrator selects at most one default organization connection for each enabled API namespace:
 
 ```text
-Gateway virtual key + protocol namespace
-  -> organization and project
-  -> one default LLM Connection
-  -> native execution with the request's model unchanged
+openai     -> one compatible organization connection
+anthropic  -> one compatible organization connection
 ```
 
-Official provider origins and custom LLM Connection base URLs are supported. Custom origins require the Rust equivalent of Langfuse's secure LLM fetch boundary: scheme and URL checks when saved and used, DNS/IP validation when connecting, validation of every redirect, and strict credential/header stripping. Cloud blocks private, loopback, link-local, and metadata destinations. Self-hosters may explicitly allow private destination ranges needed for their own inference infrastructure.
+The selection contract can later grow to support routing and fallbacks, but V1 always resolves exactly one connection. Project-level connection overrides are not supported in V1.
+
+As a follow-up, Langfuse projects should be able to choose the organization gateway as an execution source for playgrounds, evaluations, and experiments. This lets those features reuse centrally governed credentials without copying them back into project connections.
+
+### Gateway virtual keys and permissions
+
+A **Gateway virtual key** is a Langfuse-issued, reveal-once credential accepted only by the gateway. It can be named, attributed, expired, rotated, and revoked, and it never reaches the upstream provider.
+
+Gateway keys extend Langfuse's common authorization and API-key lifecycle rather than introducing a separate permission system:
+
+- Organization administrators can create service keys.
+- A user whose role or group grants `gateway:invoke` can create a user-owned key carrying that permission.
+- A key cannot outlive or exceed the creator's effective authorization; removing the permission invalidates future resolutions within the documented cache window.
+
+### Telemetry project selection
+
+Every execution and its telemetry map to exactly one Langfuse project. Clients cannot submit a project ID on inference requests.
+
+Resolution selects the project in this order:
+
+1. Use the key's project override when one was selected at key creation and the organization permits overrides.
+2. Otherwise use the organization's current default gateway project.
+
+The creator must have access to an overridden project when the key is created. Changing the organization default reroutes future non-overridden executions after cached configurations expire. The control plane should warn and audit this change because it moves subsequent telemetry; already-issued ingestion contexts retain their original project.
 
 ### Telemetry policy
 
-An organization chooses one gateway telemetry mode:
+An organization selects one gateway telemetry mode:
 
 | Mode | Customer telemetry |
 | --- | --- |
-| `full` | Input, output, tools, media references, metadata, usage, and cost |
-| `usage` | Model, status, timing, attribution, usage, and cost; no content |
-| `none` | No customer request trace or cost record |
+| `usage` | Model, status, timing, attribution, usage, and cost; no request or response content |
+| `full` | Usage telemetry plus bounded input, output, tools, and media references |
+| `none` | No customer trace or cost record |
 
-`full` is the default. `none` does not disable content-free service health, security, and capacity telemetry. Rate or spend enforcement may later require at least `usage` mode.
+`usage` is the default. Full capture requires explicit organization opt-in because coding-agent traffic can contain source code, tool arguments, and secrets. The selected mode is recorded on each observation. `none` does not disable content-free service health, capacity, or security telemetry.
 
-## Cached Resolution and Gateway-to-Web Authentication
+## Resolution and Service Authentication
 
-The gateway must not call Web for every inference request. It caches a resolved execution configuration in memory by a keyed fingerprint of the Gateway virtual key and protocol namespace.
+The gateway must not call Web for every inference request. It caches resolution in memory by a keyed fingerprint of the Gateway virtual key and API namespace for a hard, non-sliding maximum of 60 seconds.
 
 ```mermaid
 sequenceDiagram
@@ -138,147 +139,91 @@ sequenceDiagram
     participant Web
     participant Provider
 
-    Client->>Gateway: Request and Gateway virtual key
-    alt Valid execution config in memory
-        Gateway->>Gateway: Reuse configuration
-    else Cache miss or hard expiry
-        Gateway->>Web: Resolve service token + virtual key
-        Web-->>Gateway: Destination, telemetry policy, sealed context
-        Gateway->>Gateway: Cache for at most 60 seconds
+    Client->>Gateway: Native request + Gateway virtual key
+    alt Cached resolution is valid
+        Gateway->>Gateway: Reuse execution configuration
+    else Cache miss or expiry
+        Gateway->>Web: Service token + Gateway virtual key + namespace
+        Web-->>Gateway: Connection, project, policy, ingestion context
     end
     Gateway->>Provider: Execute once
-    Provider-->>Gateway: Response stream
+    Provider-->>Gateway: Native response stream
     Gateway-->>Client: Forward stream
-    Gateway-->>Web: Batched telemetry + sealed context
+    Gateway-->>Web: Batched telemetry + ingestion context
 ```
 
-### Service authentication envelope
-
-Gateway-to-Web requests use the standard `Authorization` header so proxies and observability systems are most likely to redact it. The credentials use one deliberately simple, versioned encoding:
+Gateway-to-Web calls use one standard `Authorization` header containing a versioned encoding of both required credentials:
 
 ```http
 Authorization: Langfuse-Gateway <base64url({"v":1,"service":"...","key":"..."})>
 ```
 
-Telemetry and media submissions replace `key` with the sealed context:
+Telemetry and media submissions replace `key` with Web's opaque, signed ingestion context. That context binds the organization, selected project, key attribution, connection, namespace, and telemetry mode. It authorizes only OTLP and media writes for a short bounded retry window; it cannot execute inference or select another project. The regular public OTLP and media endpoints validate it and continue through existing ingestion controls.
 
-```http
-Authorization: Langfuse-Gateway <base64url({"v":1,"service":"...","context":"..."})>
-```
+The shared service token is stored in Secrets Manager on Cloud or a Kubernetes Secret for self-hosting. Rotation uses `current` and `previous`: Web accepts both during rollout, while gateways emit only `current`. HTTPS provides transport protection. Authorization headers, virtual keys, contexts, and provider credentials must be redacted throughout the request path.
 
-The fields have one meaning at every endpoint:
-
-- `service` is the shared Gateway-to-Web service token.
-- `key` is the caller-provided Gateway virtual key used to resolve an execution configuration.
-- `context` is Web's sealed execution and ingestion context, used instead of `key` for telemetry and media.
-
-Web validates the shared gateway service token before authenticating the customer key or opening the context. The header must not be logged and is stripped before upstream execution.
-
-`Langfuse-Gateway` distinguishes this service exchange from ordinary customer `Bearer` authentication. Base64url is encoding, not protection; HTTPS and the two credentials provide the security. Web, Gateway, and the self-hosting guide must suppress the full `Authorization` field from logs.
-
-The shared service token supports current/next rotation and is distributed through Secrets Manager on Cloud or one shared Kubernetes Secret for self-hosting. Resolution, telemetry ingestion, and media upload are public authenticated Langfuse endpoints in V1; no private-network connectivity is required.
-
-### Execution configuration and sealed context
-
-On a cache miss, Web returns:
-
-- Organization, project, key, and attribution identifiers.
-- Ingress and upstream protocols.
-- One connection ID, upstream origin, safe headers, and provider credential.
-- Telemetry mode.
-- A cache hard-expiry timestamp.
-- An opaque sealed execution context.
-
-The provider credential exists only in gateway memory and is held in a secret-safe type. The cache key uses a keyed cryptographic digest of the Gateway virtual key and is never logged. The hard cache TTL is at most 60 seconds and is not sliding. An expired entry is never used; resolution failure without a valid entry fails closed. This makes 60 seconds the explicit maximum propagation window for revocation or configuration changes in V1. The control plane may cache underlying data longer because it has explicit invalidation; the gateway does not.
-
-The sealed context is reusable across all requests using that cached execution configuration. It contains a version, organization ID, project ID, Gateway virtual-key ID and attribution, selected connection ID, ingress/upstream protocols and adapter, telemetry mode, issued time, and expiry. It intentionally does **not** contain a request ID, model, or provider credential. Each inference request generates its own `gateway_request_id`, returned as `x-langfuse-gateway-request-id` and included in telemetry.
-
-Web seals the context with a Web-only authenticated-encryption key. The gateway treats it as opaque. A longer context lifetime, initially 24 hours, authorizes only delayed telemetry/media delivery; it can never authorize a new inference request or extend the 60-second execution-config cache. There is no grant table, Redis record, refresh flow, or JWKS subsystem.
+An expired cached resolution is never served. Resolution failure without a valid entry fails closed. The execution configuration contains one selected connection and provider credential in addition to trusted project, key, namespace, and telemetry-policy data; the credential remains only in secret-safe gateway memory.
 
 ## Data Plane
 
 ### Request lifecycle
 
-1. **Classify and bound:** Select the ingress protocol from the namespace, normalize the client credential, reject an invalid method/content type or declared oversize body, and stream or read the body under a hard byte limit.
-2. **Authenticate and resolve:** Load or refresh the cached execution configuration for the key and protocol namespace. No client-controlled origin, connection, or project is accepted.
-3. **Protect:** Enforce gateway-owned limits, header policy, protocol/connection compatibility, and custom-origin security. The upstream provider validates its native schema, model, media formats, and capabilities.
-4. **Prepare:** Preserve the native body and model identifier unchanged. Apply only the resolved origin, provider authentication, and safe header adjustments. Native Bedrock and Vertex transports place the unchanged model in their provider-required path.
-5. **Execute once:** Replace client authentication with the provider credential and perform one upstream request. Inference POSTs receive zero gateway retries.
-6. **Relay and observe:** Stream native response bytes with backpressure and cancellation. Telemetry observes the same stream and never becomes a second consumer.
-7. **Finalize:** Enqueue bounded telemetry/media work. Failures after provider dispatch fail open and never corrupt an otherwise healthy client response.
+1. **Classify and bound:** Select the namespace from the path and enforce method, content type, header, body-size, and stream-duration boundaries.
+2. **Authenticate and resolve:** Load or refresh the execution configuration. No client-controlled origin, connection, or project is accepted.
+3. **Prepare:** Preserve the native body and model unchanged while replacing client authentication with the selected provider authentication.
+4. **Execute once:** Send one request to the provider's controlled origin. Inference POSTs receive no gateway retries.
+5. **Relay and observe:** Stream native statuses, safe headers, errors, and response bytes with backpressure and cancellation. Telemetry observes the same stream and is never a second consumer.
+6. **Finalize:** Enqueue byte- and count-bounded telemetry and media work. Failures after provider dispatch fail open and do not corrupt an otherwise healthy client response.
 
-Gateway-generated errors use the client's native error envelope. Provider-native statuses, errors, response bodies, and SSE events are preserved.
+The upstream provider validates its native schema, model, media formats, and capabilities. Gateway-generated errors use the client's native error envelope.
 
-### Native protocol handling
+### Telemetry and media
 
-Native calls bypass a universal prompt representation. The gateway parses only what resolution, boundary enforcement, and telemetry require; it does not reconstruct provider requests or response events when the semantic protocol already matches.
+The gateway creates one Langfuse generation per provider execution. It includes project and key attribution, namespace, model and connection, timings and time to first token, provider request ID, terminal outcome, usage/cache usage, and cost inputs. Content inclusion follows the resolved telemetry mode and explicit byte bounds.
 
-Native Anthropic execution preserves the evolving, non-credential `anthropic-*` headers and body fields as an open set. Upstream headers are reconstructed: customer/provider credentials, cookies, forwarding and hop-by-hop headers are always removed, and sensitive headers are never followed across origins. The gateway does not fetch prompt-supplied media URLs. Inline media remains part of the native body, and the provider validates its type and contents.
+Telemetry is accumulated into timeout-or-size bounded OTLP batches and submitted to Langfuse's regular public OTLP ingestion endpoint. Media uses the regular public media endpoint with the same ingestion context. The gateway does not receive storage or queue credentials.
 
-Transport adaptation is distinct from cross-provider protocol translation. The Bedrock and Vertex adapters accept Claude Code's native provider request paths and framing, change authentication and safe transport details as required, and preserve the provider's semantic schema. They do not accept the Anthropic namespace and convert it to another provider protocol.
-
-### Why translation is excluded from V1
-
-Translation is feasible for a constrained subset, but it is a continuously maintained compatibility product rather than gateway plumbing:
-
-- **Stateful continuation:** Responses can refer only to `previous_response_id` or a stored conversation, while Messages expects complete history. Correct support requires gateway-owned state and reconstruction; LiteLLM has failed second tool turns when those identities diverged ([LiteLLM #26167](https://github.com/BerriAI/litellm/issues/26167)).
-- **Agent tool semantics:** Parallel tool calls and results have different grouping, ordering, choice, and terminal rules. Incorrect translation can return a provider `400`, silently enable disabled tools, or end a successful-looking stream before the agent executes its tool ([LiteLLM #23105](https://github.com/BerriAI/litellm/issues/23105), [LiteLLM #32505](https://github.com/BerriAI/litellm/issues/32505), [Bifrost #6123](https://github.com/maximhq/bifrost/issues/6123)).
-- **Provider-owned artifacts:** Encrypted reasoning, thinking signatures, hosted tools, file IDs, prompt-cache controls, background execution, and conversation resources do not have lossless cross-provider representations.
-- **Streaming and multimodal breadth:** Every request field, response item, nested media location, SSE transition, provider/model capability, and client release expands the conformance matrix. OSS gateways with substantial adapter suites still regress on new server tools and heterogeneous stream items ([Bifrost #4780](https://github.com/maximhq/bifrost/issues/4780), [Bifrost #4713](https://github.com/maximhq/bifrost/issues/4713)).
-
-The dangerous failures are not limited to obvious request rejection. A translated stream can appear successful while losing a tool result, changing a stop reason, enabling a disabled tool, or breaking reasoning continuity. Those failures are difficult to detect from gateway health metrics and directly affect agent correctness and safety.
-
-V1 therefore supports each client through its native provider protocol and does not schedule cross-provider translation as a fast follow. Langfuse will reconsider translation only if strong measured user demand justifies the permanent compatibility maintenance and scope expansion. Any translation work requires a separate RFC with an explicit compatibility profile, rejection rules, translator-version telemetry, and real-client multi-turn conformance tests.
-
-## Telemetry and Media
-
-The gateway builds one Langfuse generation per provider execution, including project/key attribution, protocol pair, model and connection, timing and time-to-first-token, provider request ID, terminal outcome, usage/cache usage, and cost inputs. Claude Code session and agent headers may be recorded for grouping but are never treated as user identity. Content inclusion follows the resolved telemetry mode and explicit byte bounds.
-
-Telemetry is accumulated into timeout-or-size bounded OTLP batches and submitted to Langfuse's regular public OTLP ingestion endpoint. That endpoint validates the sealed context, derives the project and attribution, and reuses the existing ingestion path. Media uses the regular public media upload endpoint with the same context. The gateway does not receive storage or queue credentials.
-
-V1 does not add a separate ClickHouse gateway-logs table. Langfuse traces/generations remain the customer-facing request record; Datadog metrics and sanitized service logs cover operational health. A separate durable execution ledger should only be introduced when spend enforcement, settlement, or audit guarantees require semantics that best-effort observability cannot provide.
+V1 does not add a separate ClickHouse gateway-logs table. Langfuse generations remain the customer-facing request record; operational metrics and sanitized service logs cover service health. A durable execution ledger should be introduced only when spend enforcement, settlement, or audit guarantees require semantics that best-effort observability cannot provide.
 
 ## Deployment and Reliability
 
 ### Langfuse Cloud
 
-Deploy `ai-gateway` as an independently scalable Rust ECS/Fargate service in every existing regional environment. Reuse the regional VPC, private subnets, NAT egress, ALB/WAF, Secrets Manager, deployment pipeline, and monitoring foundations while giving the gateway dedicated tasks, target group, security group, IAM roles, and autoscaling.
+Deploy `ai-gateway` as an independently scalable Rust ECS/Fargate service in every existing regional environment. It reuses the regional VPC, private subnets, NAT egress, ALB/WAF, Secrets Manager, deployment pipeline, and monitoring foundations while receiving dedicated tasks, target group, security group, IAM role, and autoscaling.
 
-The public edge uses a gateway hostname and streaming-safe idle/drain settings. Gateway-to-Web resolution, telemetry, and media use public authenticated Web endpoints; private routing may be added later as transparent defense-in-depth. Scale primarily on active streams, with CPU, memory, bytes in flight, connection rate, and telemetry-queue pressure as guardrails. Deployments require readiness, graceful draining, a maximum stream duration, and progressive regional rollout.
+Use a stable gateway hostname from V1. Initially route it through the existing ALB to the gateway target group, while keeping DNS movable if stream behavior, WAF policy, or connection isolation later requires a dedicated load balancer. Scale primarily on active streams with CPU, memory, bytes in flight, connection rate, and telemetry-queue pressure as guardrails.
 
 ### Self-hosted
 
-Ship the same image at V1 launch as an optional first-class Helm component, not a Web sidecar. Enabling the component should automatically create its Deployment and Service, connect it to Web, and share a generated or operator-provided gateway service token.
-
-Operators configure only enablement, public ingress/TLS, and optionally an existing Secret. The chart exposes replicas, resources, probes, PDB, topology, graceful termination, and HPA/KEDA settings without requiring direct database, cache, object-store, or queue configuration for the gateway.
+Ship the same image at V1 launch as an optional first-class Helm component rather than a Web sidecar. Enabling it creates its Deployment and Service, connects it to Web, and shares a generated or operator-provided service token. The chart exposes ingress/TLS, replicas, resources, probes, disruption budget, topology, graceful termination, and autoscaling without giving the gateway direct database, cache, object-store, or queue access.
 
 ## Failure Semantics
 
-- Authentication, expired-cache resolution, destination selection, protocol matching, and boundary validation fail closed before provider dispatch.
-- Inference POSTs are never retried by the gateway.
-- Provider statuses and errors are passed through unchanged.
-- After provider dispatch, telemetry and media failures fail open.
-- Capture, batches, and queues are byte- and count-bounded.
-- Saturation sheds new work or telemetry according to explicit limits; it never permits unbounded memory growth.
+- Authentication, expired-cache resolution, namespace selection, compatibility checks, and boundary validation fail closed before provider dispatch.
+- Inference requests are never retried by the gateway.
+- Provider statuses and errors pass through unchanged.
+- Telemetry and media failures after provider dispatch fail open.
+- Captures, batches, and queues are byte- and count-bounded; saturation never permits unbounded memory growth.
 
 ## Delivery Milestones
 
-1. **Control-plane readiness:** Gateway virtual keys and permissions, project selection, organization-level LLM Connections, one explicit default connection per protocol namespace, the 60-second resolution contract, shared service authentication, and sealed execution contexts.
-2. **Data-plane readiness:** Rust gateway, native OpenAI/Anthropic/Bedrock/Vertex transports, upstream model discovery, secure custom origins, streaming/backpressure/cancellation, bounded OTLP/media publication, and protocol conformance/load tests.
-3. **Cloud readiness:** Regional ECS/Fargate service, public ALB/WAF edge, Secrets Manager wiring, stream-aware autoscaling, graceful draining, observability, SLOs, and progressive rollout.
-4. **Self-hosted readiness:** The same release image, first-class Helm component, service-token wiring, ingress/TLS configuration, custom-origin controls, operational documentation, and the same conformance suite.
+1. **Control plane:** Organization connections and provider registry, namespace defaults, Gateway virtual keys and permissions, project selection, telemetry modes, 60-second resolution, service authentication, and ingestion contexts.
+2. **Data plane:** Native OpenAI and Anthropic transports, upstream model discovery, streaming/backpressure/cancellation, bounded OTLP/media publication, and conformance/load testing.
+3. **Cloud:** Regional service, stable public edge, secrets, stream-aware autoscaling, graceful draining, observability, SLOs, and progressive rollout.
+4. **Self-hosting:** Same release image, first-class Helm component, service-token wiring, ingress/TLS configuration, operations documentation, and the same conformance suite.
 
-These tracks can proceed mostly independently once the resolution response, protocol identifiers, sealed-context contents, terminal outcomes, and telemetry facts are fixed. V1 launches only when all four tracks are ready.
+The tracks can proceed mostly independently once the resolution response, namespace identifiers, ingestion-context claims, terminal outcomes, and telemetry facts are fixed. V1 launches only when all four tracks are ready.
 
 ## Launch Gates
 
-- Real Claude Code and Codex sessions, including tools, media, cancellation, long sessions, and applicable model discovery.
-- OpenAI and Anthropic TypeScript/Python SDK conformance for native paths, plus Claude Code conformance for Anthropic, Bedrock, and Vertex.
-- Golden native request/response/error fixtures and exact SSE pass-through behavior.
-- Strict negative tests for incompatible protocol namespaces and connection combinations.
-- Credential/header leak, tenant isolation, revocation-window, SSRF, redirect, and custom-origin tests.
-- Long-lived stream, slow-client, disconnect, deployment-drain, Web outage, provider failure, and telemetry saturation tests.
-- Measured gateway overhead and capacity on production-like multi-core containers.
+- Real Claude Code and Codex sessions with tools, media, cancellation, long streams, token counting, compaction, and model discovery.
+- OpenAI and Anthropic TypeScript/Python SDK conformance for all exposed native endpoints.
+- OpenRouter conformance for the complete namespace before it can be selected for that namespace.
+- Exact request, response, error, and streaming pass-through fixtures.
+- Credential/header leak, tenant-isolation, permission-revocation, and cache-window tests.
+- Verification that `Authorization`, `x-api-key`, Gateway virtual keys, ingestion contexts, and provider credentials are redacted from WAF, proxy, application, trace, error, and support output and never forwarded to the wrong boundary.
+- Long-lived stream, slow-client, disconnect, deployment-drain, Web outage, provider failure, and telemetry-saturation tests.
+- Measured latency, memory, and stream capacity on production-like multi-core containers.
 
 ## References
 
@@ -293,6 +238,11 @@ These tracks can proceed mostly independently once the resolution response, prot
 - [OpenAI Responses](https://developers.openai.com/api/reference/resources/responses/methods/create)
 - [OpenAI Responses streaming events](https://developers.openai.com/api/reference/resources/responses/streaming-events)
 - [OpenAI Models](https://developers.openai.com/api/reference/resources/models/methods/list)
+
+### Provider registries
+
+- [Vercel AI Gateway BYOK](https://vercel.com/docs/ai-gateway/authentication-and-byok/byok)
+- [OpenRouter BYOK](https://openrouter.ai/docs/guides/overview/auth/byok)
 
 ### Translation decision evidence
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16891 app preview](https://pr-16891.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- define the concise V1 plan for the Langfuse AI Gateway
- use native OpenAI and Anthropic API namespaces with one organization connection per namespace
- introduce a controlled provider registry and upstream-authoritative model discovery
- define Gateway virtual keys, project attribution, cached resolution, telemetry modes, and ingestion contexts
- scope Cloud and self-hosted deployment around the same Rust service
- explicitly defer translation, arbitrary origins, Bedrock/Vertex transports, routing, and policy enforcement

## Impacted packages

- specification only: `specs/llm-gateway-rfc.md`

## Verification

- `git diff --check origin/main...HEAD`
- verified `origin/main...HEAD` contains exactly one Markdown file
