### PR TITLE
fix(web): show non-default environment values in the filter bar

### DIFF
--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -321,7 +321,7 @@ export default function SessionsTable({
     projectId,
     tableName: sessionsFilterConfig.tableName,
     enabled: sessionsSearchBarEnabled,
-    filterState: queryFilter.explicitFilterState,
+    filterState: queryFilter.searchBarFilterState,
     searchQuery: null,
     searchType: DEFAULT_SEARCH_TYPE,
     observed: observedOptions,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -50,6 +50,10 @@ import { createTagsTableColumn } from "@/src/components/design-system/table/colu
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
+import {
+  buildManagedEnvironmentPolicyConfig,
+  toSearchBarEnvironmentFilters,
+} from "@/src/features/filters/lib/managedEnvironmentPolicy";
 import { cn } from "@/src/utils/tailwind";
 import { getLevelColors } from "@/src/components/level-colors";
 import {
@@ -742,7 +746,7 @@ export default function ObservationsEventsTable({
     projectId,
     tableName: eventsFilterConfig.tableName,
     enabled: searchBarMode,
-    filterState: queryFilter.explicitFilterState,
+    filterState: queryFilter.searchBarFilterState,
     searchQuery,
     searchType,
     observed: observedOptions,
@@ -761,7 +765,16 @@ export default function ObservationsEventsTable({
       if (!searchBarMode) return;
       const { actions } = searchBarStore.getState();
       if (state) {
-        actions.setPreview(filterStateToQueryText(state.filters).text);
+        actions.setPreview(
+          filterStateToQueryText(
+            toSearchBarEnvironmentFilters({
+              explicitFilters: state.filters,
+              config: buildManagedEnvironmentPolicyConfig(
+                DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
+              ),
+            }),
+          ).text,
+        );
       } else {
         actions.clearPreview();
       }

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -50,10 +50,6 @@ import { createTagsTableColumn } from "@/src/components/design-system/table/colu
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
-import {
-  buildManagedEnvironmentPolicyConfig,
-  toSearchBarEnvironmentFilters,
-} from "@/src/features/filters/lib/managedEnvironmentPolicy";
 import { cn } from "@/src/utils/tailwind";
 import { getLevelColors } from "@/src/components/level-colors";
 import {
@@ -675,6 +671,7 @@ export default function ObservationsEventsTable({
       isV4: true,
     },
   );
+  const projectFiltersForSearchBar = queryFilter.projectFiltersForSearchBar;
 
   // Lazy filter-options: load a facet's values when its sidebar section is
   // expanded (also covers active filters, which auto-expand on mount). The
@@ -766,20 +763,14 @@ export default function ObservationsEventsTable({
       const { actions } = searchBarStore.getState();
       if (state) {
         actions.setPreview(
-          filterStateToQueryText(
-            toSearchBarEnvironmentFilters({
-              explicitFilters: state.filters,
-              config: buildManagedEnvironmentPolicyConfig(
-                DEFAULT_SIDEBAR_IMPLICIT_ENVIRONMENT_CONFIG,
-              ),
-            }),
-          ).text,
+          filterStateToQueryText(projectFiltersForSearchBar(state.filters))
+            .text,
         );
       } else {
         actions.clearPreview();
       }
     },
-    [searchBarMode, searchBarStore],
+    [searchBarMode, searchBarStore, projectFiltersForSearchBar],
   );
 
   // Disabled for now because perhaps confusing

--- a/web/src/features/filters/filter-integration.clienttest.ts
+++ b/web/src/features/filters/filter-integration.clienttest.ts
@@ -1317,8 +1317,9 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
   it("strips only the system-shaped implicit default, keeping user-authored selections", () => {
     // The implicit default the sidebar auto-derives — and that the facet
     // re-creates when the user clears back to the default selection — is the
-    // `none of [hidden]` shape. That is the ONLY env filter we strip before
-    // persistence, so returning to default leaves a clean URL.
+    // `none of [hidden]` shape. That default is stripped before persistence,
+    // so returning to default leaves a clean URL. Extra exclusions on top of
+    // that default are kept as `none of [extras]` only.
     const explicitWithExactDefault: FilterState = [
       {
         column: "environment",
@@ -1427,6 +1428,113 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
         type: "stringOptions",
         operator: "any of",
         value: ["langfuse-evaluation"],
+      },
+    ]);
+  });
+
+  it("keeps only non-default environment exclusions in explicit state", () => {
+    // Unchecking a default-included environment (production) from the implicit
+    // `none of [hidden]` default produces `none of [hidden ∪ production]`.
+    // The bar should persist/show only the deviation (`production`), not the
+    // implicit hidden set that every table already applies.
+    expect(
+      strip([
+        {
+          column: "environment",
+          type: "stringOptions",
+          operator: "none of",
+          value: [...hiddenEnvironments, "production"],
+        },
+        {
+          column: "name",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["trace-a"],
+        },
+      ]),
+    ).toEqual([
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: ["production"],
+      },
+      {
+        column: "name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["trace-a"],
+      },
+    ]);
+  });
+
+  it("merges hidden environments back into extras-only none-of effective state", () => {
+    const effective = buildEffectiveEnvironmentFilter({
+      explicitFilters: [
+        {
+          column: "environment",
+          type: "stringOptions",
+          operator: "none of",
+          value: ["production"],
+        },
+      ],
+      config: managedEnvironmentConfig,
+    });
+
+    expect(effective).toEqual([
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: [...hiddenEnvironments, "production"],
+      },
+    ]);
+  });
+
+  it("does not strip a none-of that enables a hidden environment", () => {
+    // Checking one hidden env leaves `none of [hidden − that env]`. That is
+    // not the implicit default and must stay explicit so the enabled env
+    // is not silently re-hidden.
+    const remainingHidden = hiddenEnvironments.filter(
+      (environment) => environment !== "langfuse-evaluation",
+    );
+
+    expect(
+      strip([
+        {
+          column: "environment",
+          type: "stringOptions",
+          operator: "none of",
+          value: remainingHidden,
+        },
+      ]),
+    ).toEqual([
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: remainingHidden,
+      },
+    ]);
+
+    expect(
+      buildEffectiveEnvironmentFilter({
+        explicitFilters: [
+          {
+            column: "environment",
+            type: "stringOptions",
+            operator: "none of",
+            value: remainingHidden,
+          },
+        ],
+        config: managedEnvironmentConfig,
+      }),
+    ).toEqual([
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: remainingHidden,
       },
     ]);
   });

--- a/web/src/features/filters/filter-integration.clienttest.ts
+++ b/web/src/features/filters/filter-integration.clienttest.ts
@@ -39,6 +39,7 @@ import {
   buildImplicitEnvironmentFilter,
   buildEffectiveEnvironmentFilter,
   stripImplicitEnvironmentFilterFromExplicitState,
+  toSearchBarEnvironmentFilters,
 } from "./lib/managedEnvironmentPolicy";
 import { astToFilterState } from "@/src/features/search-bar/lib/adapter";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
@@ -1319,7 +1320,7 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
     // re-creates when the user clears back to the default selection — is the
     // `none of [hidden]` shape. That default is stripped before persistence,
     // so returning to default leaves a clean URL. Extra exclusions on top of
-    // that default are kept as `none of [extras]` only.
+    // that default stay as `none of [hidden ∪ extras]`.
     const explicitWithExactDefault: FilterState = [
       {
         column: "environment",
@@ -1432,26 +1433,76 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
     ]);
   });
 
-  it("keeps only non-default environment exclusions in explicit state", () => {
+  it("keeps the full none-of exclusion set in explicit state", () => {
     // Unchecking a default-included environment (production) from the implicit
     // `none of [hidden]` default produces `none of [hidden ∪ production]`.
-    // The bar should persist/show only the deviation (`production`), not the
-    // implicit hidden set that every table already applies.
+    // Persist the full set so this cannot collapse with "enabled every hidden
+    // env and left production unchecked".
+    const fullExclusion: FilterState = [
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: [...hiddenEnvironments, "production"],
+      },
+      {
+        column: "name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["trace-a"],
+      },
+    ];
+
+    expect(strip(fullExclusion)).toEqual(fullExclusion);
+  });
+
+  it("expands extras-only none-of to the full exclusion set on persist", () => {
+    // A search-bar commit of the displayed chip (`-environment:production`)
+    // lowers to extras-only none-of. Treat that as default-plus-extra-exclusion.
+    const stripped = strip([
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: ["production"],
+      },
+    ]);
+
+    expect(stripped).toEqual([
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: [...hiddenEnvironments, "production"],
+      },
+    ]);
     expect(
-      strip([
-        {
-          column: "environment",
-          type: "stringOptions",
-          operator: "none of",
-          value: [...hiddenEnvironments, "production"],
-        },
-        {
-          column: "name",
-          type: "stringOptions",
-          operator: "any of",
-          value: ["trace-a"],
-        },
-      ]),
+      buildEffectiveEnvironmentFilter({
+        explicitFilters: stripped,
+        config: managedEnvironmentConfig,
+      }),
+    ).toEqual(stripped);
+  });
+
+  it("shows only extras in the search-bar projection of a full none-of", () => {
+    expect(
+      toSearchBarEnvironmentFilters({
+        explicitFilters: [
+          {
+            column: "environment",
+            type: "stringOptions",
+            operator: "none of",
+            value: [...hiddenEnvironments, "production"],
+          },
+          {
+            column: "name",
+            type: "stringOptions",
+            operator: "any of",
+            value: ["trace-a"],
+          },
+        ],
+        config: managedEnvironmentConfig,
+      }),
     ).toEqual([
       {
         column: "environment",
@@ -1468,25 +1519,28 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
     ]);
   });
 
-  it("merges hidden environments back into extras-only none-of effective state", () => {
-    const effective = buildEffectiveEnvironmentFilter({
-      explicitFilters: [
-        {
-          column: "environment",
-          type: "stringOptions",
-          operator: "none of",
-          value: ["production"],
-        },
-      ],
-      config: managedEnvironmentConfig,
-    });
-
-    expect(effective).toEqual([
+  it("does not fold extras-only none-of in effective state", () => {
+    // Effective state uses the persisted form as-is. Extras-only is expanded
+    // on persist/read of explicit state first; callers must strip before
+    // building effective state so hidden envs stay excluded.
+    expect(
+      buildEffectiveEnvironmentFilter({
+        explicitFilters: [
+          {
+            column: "environment",
+            type: "stringOptions",
+            operator: "none of",
+            value: ["production"],
+          },
+        ],
+        config: managedEnvironmentConfig,
+      }),
+    ).toEqual([
       {
         column: "environment",
         type: "stringOptions",
         operator: "none of",
-        value: [...hiddenEnvironments, "production"],
+        value: ["production"],
       },
     ]);
   });

--- a/web/src/features/filters/filter-integration.clienttest.ts
+++ b/web/src/features/filters/filter-integration.clienttest.ts
@@ -38,7 +38,7 @@ import {
   buildManagedEnvironmentPolicyConfig,
   buildImplicitEnvironmentFilter,
   buildEffectiveEnvironmentFilter,
-  stripImplicitEnvironmentFilterFromExplicitState,
+  canonicalizeExplicitEnvironmentFilters,
   toSearchBarEnvironmentFilters,
 } from "./lib/managedEnvironmentPolicy";
 import { astToFilterState } from "@/src/features/search-bar/lib/adapter";
@@ -1272,8 +1272,8 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
     managedEnvironmentColumn: "environment",
     hiddenEnvironments,
   });
-  const strip = (explicitFilters: FilterState) =>
-    stripImplicitEnvironmentFilterFromExplicitState({
+  const canonicalize = (explicitFilters: FilterState) =>
+    canonicalizeExplicitEnvironmentFilters({
       explicitFilters,
       config: managedEnvironmentConfig,
     });
@@ -1336,7 +1336,7 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
       },
     ];
 
-    expect(strip(explicitWithExactDefault)).toEqual([
+    expect(canonicalize(explicitWithExactDefault)).toEqual([
       {
         column: "name",
         type: "stringOptions",
@@ -1357,7 +1357,9 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
         value: ["production", "staging"],
       },
     ];
-    expect(strip(userAuthoredDefaultSet)).toEqual(userAuthoredDefaultSet);
+    expect(canonicalize(userAuthoredDefaultSet)).toEqual(
+      userAuthoredDefaultSet,
+    );
   });
 
   it("keeps explicit overrides that enable hidden environments", () => {
@@ -1376,7 +1378,9 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
       },
     ];
 
-    expect(strip(explicitWithHiddenEnabled)).toEqual(explicitWithHiddenEnabled);
+    expect(canonicalize(explicitWithHiddenEnabled)).toEqual(
+      explicitWithHiddenEnabled,
+    );
 
     const explicitAll: FilterState = [
       {
@@ -1387,12 +1391,12 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
       },
     ];
 
-    expect(strip(explicitAll)).toEqual(explicitAll);
+    expect(canonicalize(explicitAll)).toEqual(explicitAll);
   });
 
   it("keeps hidden-only explicit selection as explicit override", () => {
     expect(
-      strip([
+      canonicalize([
         {
           column: "environment",
           type: "stringOptions",
@@ -1453,13 +1457,13 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
       },
     ];
 
-    expect(strip(fullExclusion)).toEqual(fullExclusion);
+    expect(canonicalize(fullExclusion)).toEqual(fullExclusion);
   });
 
   it("expands extras-only none-of to the full exclusion set on persist", () => {
     // A search-bar commit of the displayed chip (`-environment:production`)
     // lowers to extras-only none-of. Treat that as default-plus-extra-exclusion.
-    const stripped = strip([
+    const stripped = canonicalize([
       {
         column: "environment",
         type: "stringOptions",
@@ -1554,7 +1558,7 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
     );
 
     expect(
-      strip([
+      canonicalize([
         {
           column: "environment",
           type: "stringOptions",

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -688,19 +688,34 @@ export function useSidebarFilterStateCore(
         ? memoryFilterState
         : urlFilterState;
 
+  const managedEnvironmentPolicyConfig = useMemo(
+    () => buildManagedEnvironmentPolicyConfig(implicitDefaultConfig),
+    [implicitDefaultConfig],
+  );
+
   const explicitFilterState = useMemo(() => {
     const defaultFilters = hookOptions.defaultExplicitFilterState ?? [];
-    if (defaultFilters.length === 0) return persistedExplicitFilterState;
+    const merged = (() => {
+      if (defaultFilters.length === 0) return persistedExplicitFilterState;
+      const explicitlyOwnedColumns = new Set(
+        persistedExplicitFilterState.map((filter) => filter.column),
+      );
+      return persistedExplicitFilterState.concat(
+        defaultFilters.filter(
+          (filter) => !explicitlyOwnedColumns.has(filter.column),
+        ),
+      );
+    })();
 
-    const explicitlyOwnedColumns = new Set(
-      persistedExplicitFilterState.map((filter) => filter.column),
-    );
-    return persistedExplicitFilterState.concat(
-      defaultFilters.filter(
-        (filter) => !explicitlyOwnedColumns.has(filter.column),
-      ),
-    );
-  }, [hookOptions.defaultExplicitFilterState, persistedExplicitFilterState]);
+    return stripImplicitEnvironmentFilterFromExplicitState({
+      explicitFilters: merged,
+      config: managedEnvironmentPolicyConfig,
+    });
+  }, [
+    hookOptions.defaultExplicitFilterState,
+    persistedExplicitFilterState,
+    managedEnvironmentPolicyConfig,
+  ]);
 
   // LFE-10164: When arriving via a URL/deep link that already carries applied
   // filters, expand the sidebar sections that have an active filter. Sidebar
@@ -769,11 +784,6 @@ export function useSidebarFilterStateCore(
       return next.length === seeded.length ? current : next.join(",");
     });
   }
-
-  const managedEnvironmentPolicyConfig = useMemo(
-    () => buildManagedEnvironmentPolicyConfig(implicitDefaultConfig),
-    [implicitDefaultConfig],
-  );
 
   const managedEnvironmentColumn =
     managedEnvironmentPolicyConfig.managedEnvironmentColumn;
@@ -1852,11 +1862,12 @@ export function useSidebarFilterPresentation(
         // A user-authored environment filter lives in EXPLICIT state; the
         // implicit hidden-env default (`none of [hidden]`) is added to EFFECTIVE
         // state only and stripped from explicit state by the managed-environment
-        // policy. So "explicit env filter present" is exactly "the user committed
-        // to an environment selection" — including `environment:default` (any-of
-        // the default set), which now persists. Keying the facet's active state
-        // off this keeps it in sync with the search bar, which renders any
-        // explicit env filter as a chip.
+        // policy. Extra exclusions on top of that default persist as
+        // `none of [extras]` only. So "explicit env filter present" is exactly
+        // "the user committed to an environment selection" — including
+        // `environment:default` (any-of the default set), which now persists.
+        // Keying the facet's active state off this keeps it in sync with the
+        // search bar, which renders any explicit env filter as a chip.
         const hasExplicitManagedEnvironmentFilter =
           isManagedEnvironmentFacet &&
           explicitFilterState.some(

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -32,6 +32,7 @@ import {
   buildEffectiveEnvironmentFilter,
   buildManagedEnvironmentPolicyConfig,
   stripImplicitEnvironmentFilterFromExplicitState,
+  toSearchBarEnvironmentFilters,
   type ManagedEnvironmentPolicyInput,
 } from "../lib/managedEnvironmentPolicy";
 import { useKeyedSessionStorageState } from "./useKeyedSessionStorageState";
@@ -809,6 +810,18 @@ export function useSidebarFilterStateCore(
     ],
   );
 
+  // Display projection for the search bar: persist the full
+  // `none of [hidden ∪ extras]` exclusion, but show only extras
+  // (`-environment:production`) so implicit hidden envs stay off the chip.
+  const searchBarFilterState: FilterState = useMemo(
+    () =>
+      toSearchBarEnvironmentFilters({
+        explicitFilters: explicitFilterState,
+        config: managedEnvironmentPolicyConfig,
+      }),
+    [explicitFilterState, managedEnvironmentPolicyConfig],
+  );
+
   // `options.updateType` controls the history semantics of the URL write:
   // user-initiated filter edits keep the default (push — a Back-able step);
   // programmatic writes (e.g. the session default-view auto-apply) pass
@@ -988,6 +1001,7 @@ export function useSidebarFilterStateCore(
     /** Effective applied filters: explicit + defaults + managed-env policy. */
     filterState,
     explicitFilterState,
+    searchBarFilterState,
     setFilterState,
     expandedState,
     onExpandedChange,
@@ -1021,6 +1035,7 @@ export function useSidebarFilterPresentation(
   const {
     filterState,
     explicitFilterState,
+    searchBarFilterState,
     setFilterState,
     expandedState,
     onExpandedChange,
@@ -1040,6 +1055,10 @@ export function useSidebarFilterPresentation(
       managedEnvironmentColumn:
         managedEnvironmentPolicyConfig.hiddenEnvironments.length > 0
           ? managedEnvironmentColumn
+          : undefined,
+      hiddenEnvironments:
+        managedEnvironmentPolicyConfig.hiddenEnvironments.length > 0
+          ? managedEnvironmentPolicyConfig.hiddenEnvironments
           : undefined,
     }),
     [
@@ -1863,7 +1882,8 @@ export function useSidebarFilterPresentation(
         // implicit hidden-env default (`none of [hidden]`) is added to EFFECTIVE
         // state only and stripped from explicit state by the managed-environment
         // policy. Extra exclusions on top of that default persist as
-        // `none of [extras]` only. So "explicit env filter present" is exactly
+        // `none of [hidden ∪ extras]`; the search bar display projection shows
+        // only extras. So "explicit env filter present" is exactly
         // "the user committed to an environment selection" — including
         // `environment:default` (any-of the default set), which now persists.
         // Keying the facet's active state off this keeps it in sync with the
@@ -1990,6 +2010,7 @@ export function useSidebarFilterPresentation(
     filterState,
     effectiveFilterState: filterState,
     explicitFilterState,
+    searchBarFilterState,
     setFilterState,
     updateFilter,
     updateFilterOnly,

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -31,7 +31,7 @@ import { normalizeFilterColumnNames } from "../lib/filter-transform";
 import {
   buildEffectiveEnvironmentFilter,
   buildManagedEnvironmentPolicyConfig,
-  stripImplicitEnvironmentFilterFromExplicitState,
+  canonicalizeExplicitEnvironmentFilters,
   toSearchBarEnvironmentFilters,
   type ManagedEnvironmentPolicyInput,
 } from "../lib/managedEnvironmentPolicy";
@@ -708,7 +708,7 @@ export function useSidebarFilterStateCore(
       );
     })();
 
-    return stripImplicitEnvironmentFilterFromExplicitState({
+    return canonicalizeExplicitEnvironmentFilters({
       explicitFilters: merged,
       config: managedEnvironmentPolicyConfig,
     });
@@ -813,13 +813,18 @@ export function useSidebarFilterStateCore(
   // Display projection for the search bar: persist the full
   // `none of [hidden ∪ extras]` exclusion, but show only extras
   // (`-environment:production`) so implicit hidden envs stay off the chip.
-  const searchBarFilterState: FilterState = useMemo(
-    () =>
+  const projectFiltersForSearchBar = useCallback(
+    (filters: FilterState) =>
       toSearchBarEnvironmentFilters({
-        explicitFilters: explicitFilterState,
+        explicitFilters: filters,
         config: managedEnvironmentPolicyConfig,
       }),
-    [explicitFilterState, managedEnvironmentPolicyConfig],
+    [managedEnvironmentPolicyConfig],
+  );
+
+  const searchBarFilterState: FilterState = useMemo(
+    () => projectFiltersForSearchBar(explicitFilterState),
+    [explicitFilterState, projectFiltersForSearchBar],
   );
 
   // `options.updateType` controls the history semantics of the URL write:
@@ -836,7 +841,7 @@ export function useSidebarFilterStateCore(
       },
     ) => {
       const explicitFilters = stripOmittedColumns(
-        stripImplicitEnvironmentFilterFromExplicitState({
+        canonicalizeExplicitEnvironmentFilters({
           explicitFilters: newFilters,
           config: managedEnvironmentPolicyConfig,
         }),
@@ -1002,6 +1007,7 @@ export function useSidebarFilterStateCore(
     filterState,
     explicitFilterState,
     searchBarFilterState,
+    projectFiltersForSearchBar,
     setFilterState,
     expandedState,
     onExpandedChange,
@@ -1036,6 +1042,7 @@ export function useSidebarFilterPresentation(
     filterState,
     explicitFilterState,
     searchBarFilterState,
+    projectFiltersForSearchBar,
     setFilterState,
     expandedState,
     onExpandedChange,
@@ -2011,6 +2018,7 @@ export function useSidebarFilterPresentation(
     effectiveFilterState: filterState,
     explicitFilterState,
     searchBarFilterState,
+    projectFiltersForSearchBar,
     setFilterState,
     updateFilter,
     updateFilterOnly,

--- a/web/src/features/filters/lib/managedEnvironmentPolicy.ts
+++ b/web/src/features/filters/lib/managedEnvironmentPolicy.ts
@@ -1,5 +1,4 @@
 import type { FilterState } from "@langfuse/shared";
-import { areStringSetsEqual } from "./stringSetUtils";
 
 type EnvironmentFilter = Extract<
   FilterState[number],
@@ -25,6 +24,29 @@ export function buildManagedEnvironmentPolicyConfig(
   };
 }
 
+function partitionNoneOfEnvironmentValues(params: {
+  values: string[];
+  hiddenEnvironments: string[];
+}): {
+  extras: string[];
+  hiddenInValues: string[];
+  excludesAllHidden: boolean;
+} {
+  const { values, hiddenEnvironments } = params;
+  const hiddenSet = new Set(hiddenEnvironments);
+  const extras = values.filter((value) => !hiddenSet.has(value));
+  const hiddenInValues = values.filter((value) => hiddenSet.has(value));
+  const valueSet = new Set(values);
+
+  return {
+    extras,
+    hiddenInValues,
+    excludesAllHidden:
+      hiddenEnvironments.length > 0 &&
+      hiddenEnvironments.every((environment) => valueSet.has(environment)),
+  };
+}
+
 // Only the SYSTEM-shaped implicit default — the `none of [hidden]` filter the
 // sidebar auto-derives, and that the facet re-creates when the user clears back
 // to the default selection — counts as "no real filter" and is stripped before
@@ -33,18 +55,39 @@ export function buildManagedEnvironmentPolicyConfig(
 // happens to select exactly the current default set: if the user committed to a
 // value we keep it explicit and visible. Returning to the default is the user's
 // action (remove the filter / uncheck back to default), not something we infer.
-function isEquivalentToImplicitEnvironmentDefault(params: {
+//
+// A `none of [hidden ∪ extras]` exclusion is the same default plus the user's
+// extra unchecked values (unchecking production from the implicit default).
+// Persist only the extras so the search bar shows the non-default values
+// (`-environment:production`) instead of burying them in the hidden-env list.
+function canonicalizeNoneOfEnvironmentFilter(params: {
   envFilter: EnvironmentFilter;
   hiddenEnvironments: string[];
-}): boolean {
+}): EnvironmentFilter | null {
   const { envFilter, hiddenEnvironments } = params;
 
-  if (hiddenEnvironments.length === 0) return false;
+  if (envFilter.operator !== "none of") {
+    return envFilter;
+  }
 
-  return (
-    envFilter.operator === "none of" &&
-    areStringSetsEqual(envFilter.value, hiddenEnvironments)
-  );
+  if (hiddenEnvironments.length === 0) {
+    return envFilter.value.length === 0 ? null : envFilter;
+  }
+
+  const { extras, excludesAllHidden } = partitionNoneOfEnvironmentValues({
+    values: envFilter.value,
+    hiddenEnvironments,
+  });
+
+  if (!excludesAllHidden) {
+    return envFilter;
+  }
+
+  if (extras.length === 0) {
+    return null;
+  }
+
+  return { ...envFilter, value: extras };
 }
 
 export function stripImplicitEnvironmentFilterFromExplicitState(params: {
@@ -69,17 +112,19 @@ export function stripImplicitEnvironmentFilterFromExplicitState(params: {
   }
 
   const envFilter = managedColumnFilters[0] as EnvironmentFilter;
-  const otherFilters = explicitFilters.filter((filter) => filter !== envFilter);
+  const canonical = canonicalizeNoneOfEnvironmentFilter({
+    envFilter,
+    hiddenEnvironments,
+  });
 
-  if (
-    isEquivalentToImplicitEnvironmentDefault({
-      envFilter,
-      hiddenEnvironments,
-    })
-  ) {
-    return otherFilters;
+  if (canonical === envFilter) {
+    return explicitFilters;
   }
-  return explicitFilters;
+
+  return explicitFilters.flatMap((filter) => {
+    if (filter !== envFilter) return [filter];
+    return canonical === null ? [] : [canonical];
+  });
 }
 
 export function buildImplicitEnvironmentFilter(params: {
@@ -112,7 +157,7 @@ export function buildEffectiveEnvironmentFilter(params: {
   config: ManagedEnvironmentPolicyConfig;
 }): FilterState {
   const { explicitFilters, config } = params;
-  const { managedEnvironmentColumn } = config;
+  const { managedEnvironmentColumn, hiddenEnvironments } = config;
 
   const managedColumnFilters = explicitFilters.filter(
     (filter) => filter.column === managedEnvironmentColumn,
@@ -133,5 +178,24 @@ export function buildEffectiveEnvironmentFilter(params: {
   }
 
   const envFilter = managedColumnFilters[0] as EnvironmentFilter;
+
+  if (envFilter.operator === "none of" && hiddenEnvironments.length > 0) {
+    const { extras, hiddenInValues } = partitionNoneOfEnvironmentValues({
+      values: envFilter.value,
+      hiddenEnvironments,
+    });
+
+    // Extras-only form (`none of [production]`): fold the implicit hidden
+    // exclusions back in so queries still hide internal environments.
+    if (hiddenInValues.length === 0 && extras.length > 0) {
+      return [
+        {
+          ...envFilter,
+          value: [...hiddenEnvironments, ...extras],
+        },
+      ];
+    }
+  }
+
   return [envFilter];
 }

--- a/web/src/features/filters/lib/managedEnvironmentPolicy.ts
+++ b/web/src/features/filters/lib/managedEnvironmentPolicy.ts
@@ -25,8 +25,8 @@ export function buildManagedEnvironmentPolicyConfig(
 }
 
 export function partitionNoneOfEnvironmentValues(params: {
-  values: string[];
-  hiddenEnvironments: string[];
+  values: readonly string[];
+  hiddenEnvironments: readonly string[];
 }): {
   extras: string[];
   hiddenInValues: string[];
@@ -99,7 +99,7 @@ function canonicalizeNoneOfEnvironmentFilter(params: {
   return envFilter;
 }
 
-export function stripImplicitEnvironmentFilterFromExplicitState(params: {
+export function canonicalizeExplicitEnvironmentFilters(params: {
   explicitFilters: FilterState;
   config: ManagedEnvironmentPolicyConfig;
 }): FilterState {

--- a/web/src/features/filters/lib/managedEnvironmentPolicy.ts
+++ b/web/src/features/filters/lib/managedEnvironmentPolicy.ts
@@ -24,7 +24,7 @@ export function buildManagedEnvironmentPolicyConfig(
   };
 }
 
-function partitionNoneOfEnvironmentValues(params: {
+export function partitionNoneOfEnvironmentValues(params: {
   values: string[];
   hiddenEnvironments: string[];
 }): {
@@ -56,10 +56,16 @@ function partitionNoneOfEnvironmentValues(params: {
 // value we keep it explicit and visible. Returning to the default is the user's
 // action (remove the filter / uncheck back to default), not something we infer.
 //
-// A `none of [hidden ∪ extras]` exclusion is the same default plus the user's
-// extra unchecked values (unchecking production from the implicit default).
-// Persist only the extras so the search bar shows the non-default values
-// (`-environment:production`) instead of burying them in the hidden-env list.
+// A `none of [hidden ∪ extras]` exclusion is the same default plus extra
+// unchecked values (unchecking production from the implicit default). Persist
+// the full exclusion set so the two intents that both look like
+// `none of [production]` cannot collapse:
+//   1. default + uncheck production → `none of [hidden ∪ production]`
+//   2. enable every hidden env and leave production unchecked → sidebar stores
+//      `any of [checked]`, never extras-only none-of
+// The search bar still shows only extras (`-environment:production`) via
+// `toSearchBarEnvironmentFilters`. A bar commit of that extras-only chip is
+// expanded back to the full exclusion set on write.
 function canonicalizeNoneOfEnvironmentFilter(params: {
   envFilter: EnvironmentFilter;
   hiddenEnvironments: string[];
@@ -74,20 +80,23 @@ function canonicalizeNoneOfEnvironmentFilter(params: {
     return envFilter.value.length === 0 ? null : envFilter;
   }
 
-  const { extras, excludesAllHidden } = partitionNoneOfEnvironmentValues({
-    values: envFilter.value,
-    hiddenEnvironments,
-  });
+  const { extras, hiddenInValues, excludesAllHidden } =
+    partitionNoneOfEnvironmentValues({
+      values: envFilter.value,
+      hiddenEnvironments,
+    });
 
-  if (!excludesAllHidden) {
-    return envFilter;
-  }
-
-  if (extras.length === 0) {
+  if (excludesAllHidden && extras.length === 0) {
     return null;
   }
 
-  return { ...envFilter, value: extras };
+  // Bar commit of the displayed extras-only chip (`-environment:production`)
+  // means intent (1): keep hidden environments excluded.
+  if (hiddenInValues.length === 0 && extras.length > 0) {
+    return { ...envFilter, value: [...hiddenEnvironments, ...extras] };
+  }
+
+  return envFilter;
 }
 
 export function stripImplicitEnvironmentFilterFromExplicitState(params: {
@@ -127,6 +136,47 @@ export function stripImplicitEnvironmentFilterFromExplicitState(params: {
   });
 }
 
+export function toSearchBarEnvironmentFilters(params: {
+  explicitFilters: FilterState;
+  config: ManagedEnvironmentPolicyConfig;
+}): FilterState {
+  const { explicitFilters, config } = params;
+  const { managedEnvironmentColumn, hiddenEnvironments } = config;
+
+  if (hiddenEnvironments.length === 0) return explicitFilters;
+
+  const managedColumnFilters = explicitFilters.filter(
+    (filter) => filter.column === managedEnvironmentColumn,
+  );
+
+  if (
+    managedColumnFilters.length !== 1 ||
+    managedColumnFilters[0]?.type !== "stringOptions"
+  ) {
+    return explicitFilters;
+  }
+
+  const envFilter = managedColumnFilters[0] as EnvironmentFilter;
+  if (envFilter.operator !== "none of") {
+    return explicitFilters;
+  }
+
+  const { extras, excludesAllHidden } = partitionNoneOfEnvironmentValues({
+    values: envFilter.value,
+    hiddenEnvironments,
+  });
+
+  if (!excludesAllHidden) {
+    return explicitFilters;
+  }
+
+  return explicitFilters.flatMap((filter) => {
+    if (filter !== envFilter) return [filter];
+    if (extras.length === 0) return [];
+    return [{ ...envFilter, value: extras }];
+  });
+}
+
 export function buildImplicitEnvironmentFilter(params: {
   explicitFilters: FilterState;
   config: ManagedEnvironmentPolicyConfig;
@@ -157,7 +207,7 @@ export function buildEffectiveEnvironmentFilter(params: {
   config: ManagedEnvironmentPolicyConfig;
 }): FilterState {
   const { explicitFilters, config } = params;
-  const { managedEnvironmentColumn, hiddenEnvironments } = config;
+  const { managedEnvironmentColumn } = config;
 
   const managedColumnFilters = explicitFilters.filter(
     (filter) => filter.column === managedEnvironmentColumn,
@@ -177,25 +227,5 @@ export function buildEffectiveEnvironmentFilter(params: {
     return managedColumnFilters;
   }
 
-  const envFilter = managedColumnFilters[0] as EnvironmentFilter;
-
-  if (envFilter.operator === "none of" && hiddenEnvironments.length > 0) {
-    const { extras, hiddenInValues } = partitionNoneOfEnvironmentValues({
-      values: envFilter.value,
-      hiddenEnvironments,
-    });
-
-    // Extras-only form (`none of [production]`): fold the implicit hidden
-    // exclusions back in so queries still hide internal environments.
-    if (hiddenInValues.length === 0 && extras.length > 0) {
-      return [
-        {
-          ...envFilter,
-          value: [...hiddenEnvironments, ...extras],
-        },
-      ];
-    }
-  }
-
-  return [envFilter];
+  return [managedColumnFilters[0] as EnvironmentFilter];
 }

--- a/web/src/features/filters/lib/sidebar-filter-actions.clienttest.ts
+++ b/web/src/features/filters/lib/sidebar-filter-actions.clienttest.ts
@@ -187,6 +187,55 @@ describe("applySelection", () => {
     ]);
   });
 
+  it("promotes extras-only none-of from the explicit-operator path to any-of", () => {
+    const hidden = ["langfuse-evaluation", "sdk-experiment"];
+    const managedCtx: SidebarFilterActionContext = {
+      ...ctx,
+      managedEnvironmentColumn: "env",
+      hiddenEnvironments: hidden,
+      options: {
+        ...ctx.options,
+        env: ["production", "staging", ...hidden],
+      },
+    };
+
+    expect(
+      applySelection(managedCtx, [], "env", ["production"], "none of"),
+    ).toEqual([
+      {
+        column: "env",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["production"],
+      },
+    ]);
+  });
+
+  it("keeps an explicit none-of that already excludes every hidden env", () => {
+    const hidden = ["langfuse-evaluation", "sdk-experiment"];
+    const managedCtx: SidebarFilterActionContext = {
+      ...ctx,
+      managedEnvironmentColumn: "env",
+      hiddenEnvironments: hidden,
+      options: {
+        ...ctx.options,
+        env: ["production", "staging", ...hidden],
+      },
+    };
+    const exclusions = ["production", ...hidden];
+
+    expect(
+      applySelection(managedCtx, [], "env", exclusions, "none of"),
+    ).toEqual([
+      {
+        column: "env",
+        type: "stringOptions",
+        operator: "none of",
+        value: exclusions,
+      },
+    ]);
+  });
+
   it("treats an explicit empty none-of as a no-op reset", () => {
     const current: FilterState = [
       {

--- a/web/src/features/filters/lib/sidebar-filter-actions.clienttest.ts
+++ b/web/src/features/filters/lib/sidebar-filter-actions.clienttest.ts
@@ -111,6 +111,82 @@ describe("applySelection", () => {
     ]);
   });
 
+  it("keeps none-of when unchecking a default env while hidden stay excluded", () => {
+    const hidden = ["langfuse-evaluation", "sdk-experiment"];
+    const managedCtx: SidebarFilterActionContext = {
+      ...ctx,
+      managedEnvironmentColumn: "env",
+      hiddenEnvironments: hidden,
+      options: {
+        ...ctx.options,
+        env: ["production", "staging", ...hidden],
+      },
+    };
+
+    expect(applySelection(managedCtx, [], "env", ["staging"])).toEqual([
+      {
+        column: "env",
+        type: "stringOptions",
+        operator: "none of",
+        value: ["production", ...hidden],
+      },
+    ]);
+  });
+
+  it("stores any-of when every hidden env is checked and a default env is not", () => {
+    const hidden = ["langfuse-evaluation", "sdk-experiment"];
+    const managedCtx: SidebarFilterActionContext = {
+      ...ctx,
+      managedEnvironmentColumn: "env",
+      hiddenEnvironments: hidden,
+      options: {
+        ...ctx.options,
+        env: ["production", "staging", ...hidden],
+      },
+    };
+    const existing: FilterState = [
+      {
+        column: "env",
+        type: "stringOptions",
+        operator: "none of",
+        value: ["production", ...hidden],
+      },
+    ];
+    const checked = ["staging", ...hidden];
+
+    expect(applySelection(managedCtx, existing, "env", checked)).toEqual([
+      {
+        column: "env",
+        type: "stringOptions",
+        operator: "any of",
+        value: checked,
+      },
+    ]);
+  });
+
+  it("stores any-of when a hidden environment is enabled from the default", () => {
+    const hidden = ["langfuse-evaluation", "sdk-experiment"];
+    const managedCtx: SidebarFilterActionContext = {
+      ...ctx,
+      managedEnvironmentColumn: "env",
+      hiddenEnvironments: hidden,
+      options: {
+        ...ctx.options,
+        env: ["production", "staging", ...hidden],
+      },
+    };
+    const checked = ["production", "staging", "langfuse-evaluation"];
+
+    expect(applySelection(managedCtx, [], "env", checked)).toEqual([
+      {
+        column: "env",
+        type: "stringOptions",
+        operator: "any of",
+        value: checked,
+      },
+    ]);
+  });
+
   it("treats an explicit empty none-of as a no-op reset", () => {
     const current: FilterState = [
       {

--- a/web/src/features/filters/lib/sidebar-filter-actions.ts
+++ b/web/src/features/filters/lib/sidebar-filter-actions.ts
@@ -4,6 +4,7 @@ import type {
   SingleValueOption,
 } from "@langfuse/shared";
 import type { FilterConfig } from "./filter-config";
+import { partitionNoneOfEnvironmentValues } from "./managedEnvironmentPolicy";
 
 // Pure FilterState transitions behind the sidebar's facet interactions.
 // No React: every function maps (context, current state, user input) to the
@@ -31,6 +32,12 @@ export type SidebarFilterActionContext = {
    * enable-all-environments override in applySelection.
    */
   managedEnvironmentColumn?: string;
+  /**
+   * Hidden environments for the managed-environment policy. Required to
+   * distinguish "default plus extra exclusions" (stay in none-of) from
+   * "user enabled at least one hidden env" (store as any-of [checked]).
+   */
+  hiddenEnvironments?: readonly string[];
 };
 
 // Represents one active filter row in the key-value facet UI
@@ -300,6 +307,26 @@ export function applySelection(
     // "none of" filter.
     if (finalOperator === "none of" && finalValues.length === 0) {
       return other;
+    }
+
+    // Managed environment: a none-of that does not exclude every hidden env
+    // means the user enabled at least one hidden environment. Store that as
+    // a positive any-of of the checked set so it cannot be confused with
+    // "default plus extra exclusions" (`none of [hidden ∪ extras]`).
+    const hiddenEnvironments = ctx.hiddenEnvironments ?? [];
+    if (
+      isManagedEnvironmentColumn &&
+      finalOperator === "none of" &&
+      hiddenEnvironments.length > 0
+    ) {
+      const { excludesAllHidden } = partitionNoneOfEnvironmentValues({
+        values: finalValues,
+        hiddenEnvironments: [...hiddenEnvironments],
+      });
+      if (!excludesAllHidden) {
+        finalOperator = "any of";
+        finalValues = values;
+      }
     }
   }
 

--- a/web/src/features/filters/lib/sidebar-filter-actions.ts
+++ b/web/src/features/filters/lib/sidebar-filter-actions.ts
@@ -308,25 +308,27 @@ export function applySelection(
     if (finalOperator === "none of" && finalValues.length === 0) {
       return other;
     }
+  }
 
-    // Managed environment: a none-of that does not exclude every hidden env
-    // means the user enabled at least one hidden environment. Store that as
-    // a positive any-of of the checked set so it cannot be confused with
-    // "default plus extra exclusions" (`none of [hidden ∪ extras]`).
-    const hiddenEnvironments = ctx.hiddenEnvironments ?? [];
-    if (
-      isManagedEnvironmentColumn &&
-      finalOperator === "none of" &&
-      hiddenEnvironments.length > 0
-    ) {
-      const { excludesAllHidden } = partitionNoneOfEnvironmentValues({
-        values: finalValues,
-        hiddenEnvironments: [...hiddenEnvironments],
-      });
-      if (!excludesAllHidden) {
-        finalOperator = "any of";
-        finalValues = values;
-      }
+  // Managed environment: a none-of that does not exclude every hidden env
+  // means the user enabled at least one hidden environment. Store that as
+  // a positive any-of of the checked set so it cannot be confused with
+  // "default plus extra exclusions" (`none of [hidden ∪ extras]`). Shared
+  // by checkbox writes and the explicit-operator path (Only / operator
+  // toggle) so the sidebar never persists extras-only none-of.
+  const hiddenEnvironments = ctx.hiddenEnvironments ?? [];
+  if (
+    isManagedEnvironmentColumn &&
+    finalOperator === "none of" &&
+    hiddenEnvironments.length > 0
+  ) {
+    const { excludesAllHidden } = partitionNoneOfEnvironmentValues({
+      values: finalValues,
+      hiddenEnvironments,
+    });
+    if (!excludesAllHidden) {
+      finalOperator = "any of";
+      finalValues = values;
     }
   }
 

--- a/web/src/features/filters/lib/stringSetUtils.ts
+++ b/web/src/features/filters/lib/stringSetUtils.ts
@@ -1,6 +1,0 @@
-export function areStringSetsEqual(left: string[], right: string[]): boolean {
-  if (left.length !== right.length) return false;
-  const leftSet = new Set(left);
-  if (leftSet.size !== new Set(right).size) return false;
-  return right.every((value) => leftSet.has(value));
-}

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -17,6 +17,10 @@ import type { FilterConfig } from "./lib/filter-config";
 import { useTableViewManager } from "../../components/table/table-view-presets/hooks/useTableViewManager";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
 import { EVENTS_FIELD_REGISTRY } from "@/src/features/search-bar/lib/fields";
+import {
+  buildManagedEnvironmentPolicyConfig,
+  toSearchBarEnvironmentFilters,
+} from "./lib/managedEnvironmentPolicy";
 
 const mockUseRouter = vi.fn();
 const mockCapture = vi.fn();
@@ -217,6 +221,9 @@ function SavedViewHarness({
       <div data-testid="applied-view-id">{appliedViewId ?? "null"}</div>
       <pre data-testid="explicit-state">
         {JSON.stringify(queryFilter.explicitFilterState)}
+      </pre>
+      <pre data-testid="search-bar-state">
+        {JSON.stringify(queryFilter.searchBarFilterState)}
       </pre>
       <pre data-testid="effective-state">
         {JSON.stringify(queryFilter.filterState)}
@@ -729,6 +736,9 @@ describe("Saved view restore with implicit environment defaults", () => {
     const explicit = JSON.parse(
       screen.getByTestId("explicit-state").textContent ?? "[]",
     ) as FilterState;
+    const searchBar = JSON.parse(
+      screen.getByTestId("search-bar-state").textContent ?? "[]",
+    ) as FilterState;
     const effective = JSON.parse(
       screen.getByTestId("effective-state").textContent ?? "[]",
     ) as FilterState;
@@ -739,7 +749,7 @@ describe("Saved view restore with implicit environment defaults", () => {
           column: "environment",
           type: "stringOptions",
           operator: "none of",
-          value: ["production"],
+          value: [...HIDDEN_ENVIRONMENTS, "production"],
         },
         {
           column: "name",
@@ -751,7 +761,7 @@ describe("Saved view restore with implicit environment defaults", () => {
     );
     expect(
       explicit.find((filter) => filter.column === "environment")?.value,
-    ).toEqual(["production"]);
+    ).toEqual(expect.arrayContaining([...HIDDEN_ENVIRONMENTS, "production"]));
 
     const envEffective = effective.find(
       (filter) => filter.column === "environment",
@@ -768,8 +778,75 @@ describe("Saved view restore with implicit environment defaults", () => {
     ).toEqual(expect.arrayContaining([...HIDDEN_ENVIRONMENTS, "production"]));
 
     expect(
-      filterStateToQueryText(explicit, {}, EVENTS_FIELD_REGISTRY).text,
+      searchBar.find((filter) => filter.column === "environment")?.value,
+    ).toEqual(["production"]);
+    expect(
+      filterStateToQueryText(
+        toSearchBarEnvironmentFilters({
+          explicitFilters: explicit,
+          config: buildManagedEnvironmentPolicyConfig({
+            hiddenEnvironments: HIDDEN_ENVIRONMENTS,
+          }),
+        }),
+        {},
+        EVENTS_FIELD_REGISTRY,
+      ).text,
     ).toContain("-environment:production");
+  });
+
+  it("expands a legacy extras-only saved view to the full exclusion set", async () => {
+    savedViewFilters = [
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: ["production"],
+      },
+    ];
+    mockGetByIdUseQuery.mockReturnValue({
+      data: {
+        id: "view-1",
+        name: "View excluding production",
+        tableName: TableViewPresetTableName.Traces,
+        projectId: "project-1",
+        orderBy: null,
+        filters: savedViewFilters,
+        columnOrder: null,
+        columnVisibility: null,
+        searchQuery: "",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        createdBy: "user-1",
+        createdByUser: null,
+      },
+      error: null,
+    });
+
+    render(<SavedViewHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state").textContent).toBe("ready");
+    });
+
+    const explicit = JSON.parse(
+      screen.getByTestId("explicit-state").textContent ?? "[]",
+    ) as FilterState;
+    const searchBar = JSON.parse(
+      screen.getByTestId("search-bar-state").textContent ?? "[]",
+    ) as FilterState;
+    const effective = JSON.parse(
+      screen.getByTestId("effective-state").textContent ?? "[]",
+    ) as FilterState;
+
+    expect(
+      explicit.find((filter) => filter.column === "environment")?.value,
+    ).toEqual(expect.arrayContaining([...HIDDEN_ENVIRONMENTS, "production"]));
+    expect(
+      effective.find((filter) => filter.column === "environment")?.value,
+    ).toEqual(expect.arrayContaining([...HIDDEN_ENVIRONMENTS, "production"]));
+    expect(
+      searchBar.find((filter) => filter.column === "environment")?.value,
+    ).toEqual(["production"]);
   });
 });
 

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -15,6 +15,8 @@ import { useState } from "react";
 import { useSidebarFilterState } from "./hooks/useSidebarFilterState";
 import type { FilterConfig } from "./lib/filter-config";
 import { useTableViewManager } from "../../components/table/table-view-presets/hooks/useTableViewManager";
+import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
+import { EVENTS_FIELD_REGISTRY } from "@/src/features/search-bar/lib/fields";
 
 const mockUseRouter = vi.fn();
 const mockCapture = vi.fn();
@@ -682,6 +684,92 @@ describe("Saved view restore with implicit environment defaults", () => {
       { projectId: "project-1", viewId: null },
       expect.objectContaining({ enabled: false }),
     );
+  });
+
+  it("surfaces only non-default environment exclusions from a saved view in the search bar", async () => {
+    savedViewFilters = [
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+        value: [...HIDDEN_ENVIRONMENTS, "production"],
+      },
+      {
+        column: "name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["checkout"],
+      },
+    ];
+    mockGetByIdUseQuery.mockReturnValue({
+      data: {
+        id: "view-1",
+        name: "View excluding production",
+        tableName: TableViewPresetTableName.Traces,
+        projectId: "project-1",
+        orderBy: null,
+        filters: savedViewFilters,
+        columnOrder: null,
+        columnVisibility: null,
+        searchQuery: "",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        createdBy: "user-1",
+        createdByUser: null,
+      },
+      error: null,
+    });
+
+    render(<SavedViewHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state").textContent).toBe("ready");
+    });
+
+    const explicit = JSON.parse(
+      screen.getByTestId("explicit-state").textContent ?? "[]",
+    ) as FilterState;
+    const effective = JSON.parse(
+      screen.getByTestId("effective-state").textContent ?? "[]",
+    ) as FilterState;
+
+    expect(explicit).toEqual(
+      expect.arrayContaining([
+        {
+          column: "environment",
+          type: "stringOptions",
+          operator: "none of",
+          value: ["production"],
+        },
+        {
+          column: "name",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["checkout"],
+        },
+      ]),
+    );
+    expect(
+      explicit.find((filter) => filter.column === "environment")?.value,
+    ).toEqual(["production"]);
+
+    const envEffective = effective.find(
+      (filter) => filter.column === "environment",
+    );
+    expect(envEffective).toEqual(
+      expect.objectContaining({
+        column: "environment",
+        type: "stringOptions",
+        operator: "none of",
+      }),
+    );
+    expect(
+      envEffective && "value" in envEffective ? envEffective.value : [],
+    ).toEqual(expect.arrayContaining([...HIDDEN_ENVIRONMENTS, "production"]));
+
+    expect(
+      filterStateToQueryText(explicit, {}, EVENTS_FIELD_REGISTRY).text,
+    ).toContain("-environment:production");
   });
 });
 

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -154,19 +154,21 @@ committedText ──resetTo──▶ store.draft ──(type/pick/remove)──�
   on a `textSearch` field — `-name:=v` — is representable: it lowers to a
   `stringOptions none of`, the exact-inequality form the facet emits when one
   value is unchecked. It is NOT `does not contain`.)
-- **User-authored filters are never auto-removed.** The bar reads the sidebar's
-  **explicit** `FilterState`, so the managed-environment implicit default
-  (`environment none of [hidden internal envs]`, derived into _effective_ state
-  by `features/filters/lib/managedEnvironmentPolicy.ts`) never shows as a token.
+- **User-authored filters are never auto-removed.** The bar reads a display
+  projection of the sidebar's **explicit** `FilterState`, so the
+  managed-environment implicit default (`environment none of [hidden internal
+envs]`, derived into _effective_ state by
+  `features/filters/lib/managedEnvironmentPolicy.ts`) never shows as a token.
   That policy strips the implicit `none of [hidden]` default (which the facet
-  also re-creates on "clear back to default") and canonicalizes
-  `none of [hidden ∪ extras]` down to `none of [extras]` so only the values
-  that differ from the global default appear as chips
-  (`-environment:production`). Queries still exclude the hidden set — effective
-  state folds it back in. A user-authored positive selection
-  (`environment:default`, typed or saved) is kept explicit even when it equals
-  the current default set; the user returns to the default by removing the
-  filter, never by us inferring it.
+  also re-creates on "clear back to default") and keeps
+  `none of [hidden ∪ extras]` in persisted/effective state so queries still
+  exclude the hidden set. The search-bar projection shows only extras
+  (`-environment:production`). A bar commit of that extras-only chip expands
+  back to the full exclusion set. Enabling any hidden environment stores a
+  positive `any of [checked]` instead, so it cannot be remasked as extras-only
+  none-of. A user-authored positive selection (`environment:default`, typed or
+  saved) is kept explicit even when it equals the current default set; the user
+  returns to the default by removing the filter, never by us inferring it.
 
 ## Ownership map
 

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -158,11 +158,15 @@ committedText ──resetTo──▶ store.draft ──(type/pick/remove)──�
   **explicit** `FilterState`, so the managed-environment implicit default
   (`environment none of [hidden internal envs]`, derived into _effective_ state
   by `features/filters/lib/managedEnvironmentPolicy.ts`) never shows as a token.
-  That policy strips exactly one shape from explicit state — that same implicit
-  `none of [hidden]` default (which the facet also re-creates on "clear back to
-  default"). A user-authored positive selection (`environment:default`, typed or
-  saved) is kept explicit even when it equals the current default set; the user
-  returns to the default by removing the filter, never by us inferring it.
+  That policy strips the implicit `none of [hidden]` default (which the facet
+  also re-creates on "clear back to default") and canonicalizes
+  `none of [hidden ∪ extras]` down to `none of [extras]` so only the values
+  that differ from the global default appear as chips
+  (`-environment:production`). Queries still exclude the hidden set — effective
+  state folds it back in. A user-authored positive selection
+  (`environment:default`, typed or saved) is kept explicit even when it equals
+  the current default set; the user returns to the default by removing the
+  filter, never by us inferring it.
 
 ## Ownership map
 

--- a/web/src/features/search-bar/hooks/useEventsSearchBar.ts
+++ b/web/src/features/search-bar/hooks/useEventsSearchBar.ts
@@ -90,7 +90,7 @@ export function useEventsSearchBar({
   /** Table this bar filters — the `tableName` analytics dimension. */
   tableName: string;
   enabled: boolean;
-  /** The user's explicit facet filters (sidebar `explicitFilterState`). */
+  /** Search-bar projection of the user's explicit facet filters. */
   filterState: FilterState;
   searchQuery: string | null;
   searchType: TracingSearchType[];


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16893 app preview](https://pr-16893.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Saved views and sidebar environment edits that only differ from the global default (for example unchecking `production`) used to persist and render as `none of [hidden internal envs ∪ extras]`. That hid the real selection in a long exclusion chip.

Persisted and effective state now keep the full exclusion set (`none of [hidden ∪ extras]`). The search bar shows only the extras (`-environment:production`). A bar commit of that chip expands back to the full set.

Enabling any hidden environment stores a positive `any of [checked]` instead — including from the Only button / explicit-operator path. That keeps those environments in query results; they are no longer remasked as implicit defaults.

Saved-view hover previews use the same search-bar projection as the live bar (`projectFiltersForSearchBar`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format`)
- I have commented the behavior that is not obvious from the code
- I have checked if my PR needs changes to the documentation
- I have checked if my changes generate no new warnings (`pnpm run lint`)
- I have added tests that prove my fix is effective
- I have checked if new and existing unit tests pass locally with my changes

## Impacted packages

- `web` — managed environment policy, sidebar checkbox persist, search-bar display projection, client tests

## Verification

- `pnpm run lint` — `Tasks: 7 successful, 7 total`
- `pnpm --filter web run test-client filter-integration.clienttest.ts savedViewImplicitEnvironmentRegression.clienttest.tsx sidebar-filter-actions.clienttest.ts` — `Tests  107 passed (107)`

## Test this

Preview: https://pr-16893.preview.langfuse.com/project/cmfzimu6801jbad079856b07r/sessions

1. Uncheck `production` in Environment → bar should show `-environment:production`, not a chip listing hidden envs.
2. Recheck `production` → the env chip should disappear.
3. Check every hidden env and leave `production` unchecked → those hidden envs should still appear in results.

Data: demo project is enough if it has `production` plus hidden internal environments. Sandbox: same path on `http://localhost:3000` after the cloud stack is up.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15864](https://linear.app/clickhouse/issue/LFE-15864/show-non-default-values-in-saved-view-filter-bar)

<div><a href="https://cursor.com/agents/bc-9edaec5b-3fc3-48ce-a620-f1d0178485e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edaec5b-3fc3-48ce-a620-f1d0178485e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR canonicalizes managed environment exclusions so implicit hidden environments do not clutter persisted or search-bar state while remaining applied to effective queries.

- Rewrites `none of [hidden ∪ extras]` explicit filters as `none of [extras]`.
- Restores hidden exclusions when building effective query state.
- Applies canonicalization during sidebar and saved-view hydration.
- Adds integration and saved-view regression coverage and documents the updated contract.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until an all-hidden-enabled facet selection is preserved instead of being silently converted back to hidden exclusions.

The new extras-only effective-state branch conflates the intended canonical saved-view form with the reachable checkbox state where every hidden environment was explicitly enabled, causing selected environments to disappear from query results.

**Files Needing Attention:** web/src/features/filters/lib/managedEnvironmentPolicy.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Environment facet selection] --> B[Explicit FilterState]
  B --> C{none of contains hidden values?}
  C -->|All hidden plus extras| D[Canonicalize to extras only]
  C -->|Partial hidden set| E[Preserve literal filter]
  D --> F[Search bar and persistence]
  F --> G[Effective-state builder]
  G --> H[Restore hidden plus extras]
  E --> I[Effective query unchanged]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/filters/lib/managedEnvironmentPolicy.ts:190-197
**Explicit environments become hidden**

When a user checks every hidden environment but leaves a normal environment such as `production` unchecked, the sidebar represents that selection as `none of ["production"]`. This branch unconditionally restores the hidden exclusions, causing environments the user explicitly selected to disappear from the table results.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): show non-default environment v..."](https://github.com/langfuse/langfuse/commit/2406ce1c690ff74580b5777b1cd527ec04b310b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59060664)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->