### PR TITLE
perf(query): keep truncation-safe metadata filters on events_core

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
@@ -59,6 +59,16 @@ describe("metadataFilterIsEventsCoreSafe", () => {
     },
   );
 
+  // Fail-safe default: the classifier is an allow-list, so any operator not
+  // explicitly whitelisted must route to events_full. `!=` and `any of` are
+  // ClickhouseOperator members that are not on the allow-list.
+  it.each(["!=", "any of"] as const)(
+    "routes non-allow-listed `%s` to events_full by default",
+    (operator) => {
+      expect(metadataFilterIsEventsCoreSafe(operator, "x")).toBe(false);
+    },
+  );
+
   it("keeps numeric metadata comparisons on events_core", () => {
     expect(metadataFilterIsEventsCoreSafe("=", 42)).toBe(true);
     expect(metadataFilterIsEventsCoreSafe(">", 42)).toBe(true);

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.events-full-routing.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BooleanObjectFilter,
+  FilterList,
+  filtersRequireEventsFull,
+  metadataFilterIsEventsCoreSafe,
+  NullFilter,
+  NumberObjectFilter,
+  StringFilter,
+  StringObjectFilter,
+} from "./clickhouse-filter";
+
+// events_core_mv truncates metadata values to leftUTF8(v, 200), so the safety
+// boundary is 200 Unicode code points.
+const under200 = "a".repeat(199);
+const exactly200 = "a".repeat(200);
+const over200 = "a".repeat(500);
+
+const metadataString = (
+  operator: StringObjectFilter["operator"],
+  value: string,
+) =>
+  new StringObjectFilter({
+    clickhouseTable: "events_core",
+    field: "metadata",
+    key: "some_key",
+    operator,
+    value,
+  });
+
+describe("metadataFilterIsEventsCoreSafe", () => {
+  it("keeps `=` on a sub-200 value on events_core", () => {
+    expect(metadataFilterIsEventsCoreSafe("=", under200)).toBe(true);
+  });
+
+  it("routes `=` at exactly 200 to events_full (a >200 stored value shares the first 200 chars)", () => {
+    expect(metadataFilterIsEventsCoreSafe("=", exactly200)).toBe(false);
+  });
+
+  it("routes `=` above 200 to events_full", () => {
+    expect(metadataFilterIsEventsCoreSafe("=", over200)).toBe(false);
+  });
+
+  it("keeps `starts with` up to and including 200 on events_core", () => {
+    expect(metadataFilterIsEventsCoreSafe("starts with", exactly200)).toBe(
+      true,
+    );
+  });
+
+  it("routes `starts with` above 200 to events_full", () => {
+    expect(metadataFilterIsEventsCoreSafe("starts with", over200)).toBe(false);
+  });
+
+  it.each(["contains", "does not contain", "ends with", "matches"] as const)(
+    "routes truncation-sensitive `%s` to events_full regardless of value",
+    (operator) => {
+      expect(metadataFilterIsEventsCoreSafe(operator, "x")).toBe(false);
+    },
+  );
+
+  it("keeps numeric metadata comparisons on events_core", () => {
+    expect(metadataFilterIsEventsCoreSafe("=", 42)).toBe(true);
+    expect(metadataFilterIsEventsCoreSafe(">", 42)).toBe(true);
+  });
+
+  it("keeps boolean metadata comparisons on events_core", () => {
+    expect(metadataFilterIsEventsCoreSafe("=", true)).toBe(true);
+    expect(metadataFilterIsEventsCoreSafe("<>", false)).toBe(true);
+  });
+
+  it("keeps null / existence checks on events_core", () => {
+    expect(metadataFilterIsEventsCoreSafe("is null", undefined)).toBe(true);
+    expect(metadataFilterIsEventsCoreSafe("is not null", undefined)).toBe(true);
+  });
+
+  it("counts by code point, not UTF-16 unit (astral chars near the boundary)", () => {
+    // 100 astral code points = 200 UTF-16 units but only 100 code points, so an
+    // `=` filter stays on events_core.
+    const astral = "\u{1F600}".repeat(100);
+    expect(astral.length).toBe(200); // UTF-16 units
+    expect(metadataFilterIsEventsCoreSafe("=", astral)).toBe(true);
+  });
+});
+
+describe("filtersRequireEventsFull metadata routing", () => {
+  const requires = (filter: StringObjectFilter | NumberObjectFilter) =>
+    filtersRequireEventsFull(new FilterList([filter]));
+
+  it("keeps a metadata `=` with a sub-200 param on events_core", () => {
+    // Regression: a >200-char stored value truncates to 200 code points and can
+    // never equal this <200 param, so events_core stays correct.
+    expect(requires(metadataString("=", under200))).toBe(false);
+  });
+
+  it("keeps metadata `starts with` (<=200), numeric, and boolean filters on events_core", () => {
+    expect(requires(metadataString("starts with", exactly200))).toBe(false);
+    expect(
+      requires(
+        new NumberObjectFilter({
+          clickhouseTable: "events_core",
+          field: "metadata",
+          key: "n",
+          operator: "=",
+          value: 5,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      filtersRequireEventsFull(
+        new FilterList([
+          new BooleanObjectFilter({
+            clickhouseTable: "events_core",
+            field: "metadata",
+            key: "b",
+            operator: "=",
+            value: true,
+          }),
+        ]),
+      ),
+    ).toBe(false);
+    expect(
+      filtersRequireEventsFull(
+        new FilterList([
+          new NullFilter({
+            clickhouseTable: "events_core",
+            field: "metadata",
+            operator: "is not null",
+          }),
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("routes a metadata `contains` to events_full (match may sit past char 200)", () => {
+    expect(requires(metadataString("contains", "needle"))).toBe(true);
+  });
+
+  it("routes metadata `ends with`, `does not contain`, and `=` >=200 to events_full", () => {
+    expect(requires(metadataString("ends with", "x"))).toBe(true);
+    expect(requires(metadataString("does not contain", "x"))).toBe(true);
+    expect(requires(metadataString("=", exactly200))).toBe(true);
+    expect(requires(metadataString("starts with", over200))).toBe(true);
+  });
+});
+
+describe("filtersRequireEventsFull input/output routing", () => {
+  const ioFilter = (field: "input" | "output") =>
+    new StringFilter({
+      clickhouseTable: "events_core",
+      field,
+      operator: "=",
+      value: "short",
+    });
+
+  it("always forces events_full for input/output filters (truncated + no I/O FTS index)", () => {
+    expect(filtersRequireEventsFull(new FilterList([ioFilter("input")]))).toBe(
+      true,
+    );
+    expect(filtersRequireEventsFull(new FilterList([ioFilter("output")]))).toBe(
+      true,
+    );
+  });
+
+  it("ignores filters on non-events tables", () => {
+    expect(
+      filtersRequireEventsFull(
+        new FilterList([
+          new StringObjectFilter({
+            clickhouseTable: "traces",
+            field: "metadata",
+            key: "k",
+            operator: "contains",
+            value: "x",
+          }),
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("forces events_full if any filter in the list is truncation-sensitive", () => {
+    expect(
+      filtersRequireEventsFull(
+        new FilterList([
+          metadataString("=", under200),
+          metadataString("contains", "needle"),
+        ]),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -745,14 +745,31 @@ export class FilterList {
 // change its result.
 const EVENTS_CORE_TRUNCATION_LIMIT = 200;
 
-// Metadata operators whose match can live past code point 200, so truncation
-// can hide it regardless of the filter value: substring/suffix matching and the
-// FTS `matches` operator (which additionally needs the events_full-only index).
-const TRUNCATION_UNSAFE_METADATA_OPERATORS = new Set<ClickhouseOperator>([
-  "contains",
-  "does not contain",
-  "ends with",
-  FTS_MATCH_OPERATOR,
+// Metadata operators that can be answered correctly against the truncated
+// events_core copy — an allow-list, so any operator not named here defaults to
+// events_full. That default is the safe one: routing a decidable filter to
+// events_full only costs performance, whereas routing a truncation-sensitive
+// filter to events_core silently drops matches past code point 200. When a new
+// ClickhouseOperator is added it must be reviewed and added here explicitly
+// before it can use events_core.
+//   - `=` / `starts with`: string ops, subject to the length guard below.
+//   - `>` `<` `>=` `<=`: numeric comparisons — values are inherently short.
+//   - `<>`: boolean not-equal — value is inherently short.
+//   - `is null` / `is not null`: truncation-invariant (metadata_names is not
+//     truncated; emptiness is unaffected).
+// Deliberately excluded (match can live past code point 200): `contains`,
+// `does not contain`, `ends with`, and the FTS `matches` operator (which also
+// needs the events_full-only index).
+const EVENTS_CORE_SAFE_METADATA_OPERATORS = new Set<ClickhouseOperator>([
+  "=",
+  "starts with",
+  ">",
+  "<",
+  ">=",
+  "<=",
+  "<>",
+  "is null",
+  "is not null",
 ]);
 
 // Count Unicode code points to mirror ClickHouse leftUTF8, which truncates by
@@ -764,18 +781,21 @@ const codePointLength = (value: string): number => Array.from(value).length;
  * correctly against the truncated events_core copy, or must it read events_full?
  *
  * events_core keeps only the first {@link EVENTS_CORE_TRUNCATION_LIMIT} code
- * points of each metadata value (metadata_names is not truncated). A filter is
- * events_core-safe when its operator and value length make anything past that
- * boundary irrelevant:
+ * points of each metadata value (metadata_names is not truncated). This is an
+ * allow-list: an operator is events_core-safe only if it is named in
+ * {@link EVENTS_CORE_SAFE_METADATA_OPERATORS} and, for the two length-sensitive
+ * string operators, its value fits within the retained prefix:
  *   - `starts with`, value length <= 200 — the prefix lives within retained chars.
  *   - `=`, value length < 200 — a stored value longer than 200 truncates to 200
  *     code points and can never equal a sub-200 value. Strict `<` avoids the
  *     exact-200 false positive where a >200 value shares the first 200 chars.
- *   - key existence / `is null` / `is not null` / empty checks — truncation
- *     invariant (metadata_names is untruncated; emptiness is unaffected).
- *   - numeric / boolean / date metadata comparisons — the value is inherently
- *     short, so its truncated copy is complete.
- * Unsafe: `contains`, `does not contain`, `ends with`, `matches`.
+ *   - `is null` / `is not null` — truncation invariant (metadata_names is
+ *     untruncated; emptiness is unaffected).
+ *   - numeric / boolean metadata comparisons — the value is inherently short,
+ *     so its truncated copy is complete.
+ * Anything else (including any newly added operator) is routed to events_full,
+ * because over-routing only costs performance while under-routing silently
+ * drops matches past the truncation boundary.
  *
  * Single source of truth for metadata truncation routing. Do not reuse
  * NGRAM_ACCELERATED_METADATA_OPERATORS or FTS_TEXT_OPERATORS: those classify
@@ -786,7 +806,7 @@ export const metadataFilterIsEventsCoreSafe = (
   operator: ClickhouseOperator,
   value: unknown,
 ): boolean => {
-  if (TRUNCATION_UNSAFE_METADATA_OPERATORS.has(operator)) {
+  if (!EVENTS_CORE_SAFE_METADATA_OPERATORS.has(operator)) {
     return false;
   }
   if (typeof value === "string") {
@@ -797,8 +817,6 @@ export const metadataFilterIsEventsCoreSafe = (
       return codePointLength(value) < EVENTS_CORE_TRUNCATION_LIMIT;
     }
   }
-  // Non-string values (numeric/boolean) and truncation-invariant operators
-  // (key existence, null checks) are always decidable on events_core.
   return true;
 };
 

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -739,12 +739,87 @@ export class FilterList {
   }
 }
 
+// events_core_mv truncates each metadata_values element (and input/output) to
+// the first 200 UTF-8 code points via leftUTF8(v, 200). A metadata filter is
+// only safe to answer against events_core when 200-char truncation cannot
+// change its result.
+const EVENTS_CORE_TRUNCATION_LIMIT = 200;
+
+// Metadata operators whose match can live past code point 200, so truncation
+// can hide it regardless of the filter value: substring/suffix matching and the
+// FTS `matches` operator (which additionally needs the events_full-only index).
+const TRUNCATION_UNSAFE_METADATA_OPERATORS = new Set<ClickhouseOperator>([
+  "contains",
+  "does not contain",
+  "ends with",
+  FTS_MATCH_OPERATOR,
+]);
+
+// Count Unicode code points to mirror ClickHouse leftUTF8, which truncates by
+// code point rather than UTF-16 unit or byte.
+const codePointLength = (value: string): number => Array.from(value).length;
+
+/**
+ * Truncation-safety classifier: can a single metadata filter be answered
+ * correctly against the truncated events_core copy, or must it read events_full?
+ *
+ * events_core keeps only the first {@link EVENTS_CORE_TRUNCATION_LIMIT} code
+ * points of each metadata value (metadata_names is not truncated). A filter is
+ * events_core-safe when its operator and value length make anything past that
+ * boundary irrelevant:
+ *   - `starts with`, value length <= 200 — the prefix lives within retained chars.
+ *   - `=`, value length < 200 — a stored value longer than 200 truncates to 200
+ *     code points and can never equal a sub-200 value. Strict `<` avoids the
+ *     exact-200 false positive where a >200 value shares the first 200 chars.
+ *   - key existence / `is null` / `is not null` / empty checks — truncation
+ *     invariant (metadata_names is untruncated; emptiness is unaffected).
+ *   - numeric / boolean / date metadata comparisons — the value is inherently
+ *     short, so its truncated copy is complete.
+ * Unsafe: `contains`, `does not contain`, `ends with`, `matches`.
+ *
+ * Single source of truth for metadata truncation routing. Do not reuse
+ * NGRAM_ACCELERATED_METADATA_OPERATORS or FTS_TEXT_OPERATORS: those classify
+ * ngram/FTS index eligibility, a different axis (the ngram set includes
+ * truncation-unsafe `contains`/`ends with` and excludes truncation-safe `=`).
+ */
+export const metadataFilterIsEventsCoreSafe = (
+  operator: ClickhouseOperator,
+  value: unknown,
+): boolean => {
+  if (TRUNCATION_UNSAFE_METADATA_OPERATORS.has(operator)) {
+    return false;
+  }
+  if (typeof value === "string") {
+    if (operator === "starts with") {
+      return codePointLength(value) <= EVENTS_CORE_TRUNCATION_LIMIT;
+    }
+    if (operator === "=") {
+      return codePointLength(value) < EVENTS_CORE_TRUNCATION_LIMIT;
+    }
+  }
+  // Non-string values (numeric/boolean) and truncation-invariant operators
+  // (key existence, null checks) are always decidable on events_core.
+  return true;
+};
+
 // events_core stores input/output/metadata_values truncated to 200 chars
-// (events_core_mv); filters on these fields must run against events_full or
-// matches beyond the truncation point are silently dropped.
+// (events_core_mv). A filter must read events_full when truncation could change
+// its result: input/output always (truncated, and events_core lacks the I/O FTS
+// indices); metadata only when the operator/value is truncation-sensitive.
+const filterRequiresEventsFull = (filter: Filter): boolean => {
+  if (!isFtsEventsTable(filter.clickhouseTable)) {
+    return false;
+  }
+  if (isFtsTextField(filter.field)) {
+    return true;
+  }
+  if (isFtsMetadataField(filter.field)) {
+    const value =
+      "value" in filter ? (filter as { value: unknown }).value : undefined;
+    return !metadataFilterIsEventsCoreSafe(filter.operator, value);
+  }
+  return false;
+};
+
 export const filtersRequireEventsFull = (filters: FilterList): boolean =>
-  filters.some(
-    (f) =>
-      isFtsEventsTable(f.clickhouseTable) &&
-      (isFtsTextField(f.field) || isFtsMetadataField(f.field)),
-  );
+  filters.some(filterRequiresEventsFull);

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -20,6 +20,7 @@ export {
   NullFilter,
   encodeBooleanScoreEntry,
   filtersRequireEventsFull,
+  metadataFilterIsEventsCoreSafe,
   type ClickhouseOperator,
 } from "./clickhouse-sql/clickhouse-filter";
 export {

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -241,8 +241,11 @@ describe("buildEventsFilterOptionsForColumnsQuery", () => {
       projectId: "test-project",
       filter: [
         {
+          // `contains` is truncation-unsafe (a match can sit past char 200),
+          // so it must force full-table routing — which is what this test
+          // asserts. A short `=`/`starts with` value stays on events_core.
           column: "metadata",
-          operator: "=",
+          operator: "contains",
           key: "region",
           value: "eu",
           type: "stringObject",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16894 app preview](https://pr-16894.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

`filtersRequireEventsFull` routed a query to the larger `events_full` table whenever it saw **any** metadata filter, ignoring the operator and the filter value length. `events_core` is a cheaper derivative that truncates each metadata value to the first 200 UTF-8 code points (`leftUTF8(v, 200)` in `events_core_mv`). Because the predicate ignored operator and value length — both known at query-build time — it over-routed filters that are provably decidable on `events_core`, making them pay the `events_full` payload/decompression/index tax for no correctness reason.

This extracts a single-source-of-truth classifier, `metadataFilterIsEventsCoreSafe(operator, value)`, and makes `filtersRequireEventsFull` consume it. Truncation only hides matches past character 200, so the operator + value length decide whether that can matter:

- **Stay on `events_core`:** `starts with` (≤200), `=` (<200), key existence / `is null` / `is not null` / empty checks, and numeric/boolean metadata comparisons.
- **Still force `events_full`:** `contains`, `does not contain`, `ends with`, `matches` (FTS), and all `input`/`output` filters (truncated, and `events_core` lacks the I/O full-text indices).

All four routing surfaces (`events.ts`, `event-query-builder.ts` via `forceFullTable`, the dashboard `queryBuilder.ts`, `events-observation-row-selection.ts`) already funnel through `filtersRequireEventsFull`, so they inherit the same decision — which is the guardrail against cross-surface routing drift.

The classifier length check counts Unicode code points to mirror `leftUTF8`; `=` uses a strict `< 200` to avoid the exact-200 false positive where a >200 stored value shares the first 200 chars. Correctness-neutral by construction — it only downshifts provably-safe filters to the cheaper table. No API change.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Added a regression suite (`clickhouse-filter.events-full-routing.test.ts`, 20 cases) covering: a metadata `=` on a <200 param staying on `events_core` (a >200 stored value truncates to 200 code points and can never equal it), the exact-200 `=` edge routing to `events_full`, `contains`/`ends with`/`does not contain`/`matches` forcing `events_full`, numeric/boolean/null staying on `events_core`, all input/output filters forcing `events_full`, and a code-point-vs-UTF-16 boundary case.
- Verified: shared lint + typecheck, web + worker typecheck, and adjacent SQL-string suites (`event-query-builder`, `events-stream-query`, `queryBuilder`) all pass.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR refines ClickHouse event-table routing so metadata predicates that remain correct after 200-code-point truncation can use `events_core`.

- Adds a shared operator-and-value classifier for metadata truncation safety.
- Preserves `events_full` routing for truncation-sensitive metadata and input/output filters.
- Adds boundary, Unicode, operator, and mixed-filter regression coverage.
- Re-exports the classifier through the shared query package.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or maintainability issues identified.

The classifier matches the materialized view’s 200-code-point truncation, recognizes the table identities used by real routing paths, and keeps every constructible truncation-sensitive metadata operator on `events_full`.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  F[Event filters] --> R{Any input/output filter?}
  R -- Yes --> Full[Query events_full]
  R -- No --> M{Metadata filter truncation-sensitive?}
  M -- Yes --> Full
  M -- No --> Core[Query events_core]
  M -. "contains / suffix / negative contains / FTS / long equality or prefix" .-> Full
  M -. "short equality / bounded prefix / numeric / boolean / null" .-> Core
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(query): keep truncation-safe metada..."](https://github.com/langfuse/langfuse/commit/8bcdeb2db9bd8ba94a5bebc86b2268eaace7ca82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59080136)</sub>

<!-- /greptile_comment -->