### PR TITLE
fix(evals): classify code evaluator OOM as customer error

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -23,6 +23,7 @@
 - Repository layer: `src/server/repositories/*`
 - Queue payload schemas: `src/server/queues.ts`
 - Queue helpers: `src/server/redis/*`
+- Code evaluator dispatcher/error contract: `src/server/evals/codeEvalDispatcherTypes.ts`. Keep provider mappings, user-visible messages, and worker terminal-outcome classification aligned when adding an error code.
 - Dashboard/monitor query feature (data model + server-only builder/executor): `src/features/query/*`
 - Query-builder AST (server half, WIP): `src/server/query-ast/*` — golden-SQL
   recording/diff harness that captures the current SQL at the

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
     instrumentAsync: vi.fn(async (_ctx, callback) => callback(span)),
     recordDistribution: vi.fn(),
     traceException: vi.fn(),
+    loggerWarn: vi.fn(),
   };
 });
 
@@ -25,7 +26,7 @@ vi.mock("../instrumentation", () => ({
 
 vi.mock("../logger", () => ({
   logger: {
-    warn: vi.fn(),
+    warn: mocks.loggerWarn,
   },
 }));
 
@@ -192,6 +193,46 @@ describe("AwsLambdaCodeEvalDispatcher observability", () => {
       "langfuse.code_eval.error.retryable": false,
     });
   });
+
+  it.each([
+    {
+      errorType: "Runtime.OutOfMemory",
+      errorMessage: "Runtime exited with error: signal: killed",
+    },
+    {
+      errorType: "Runtime.ExitError",
+      errorMessage: "Runtime exited with error: signal: killed",
+    },
+  ])(
+    "classifies Lambda $errorType failures as evaluator memory errors",
+    async ({ errorType, errorMessage }) => {
+      const dispatcher = new AwsLambdaCodeEvalDispatcher({
+        lambdaClient: {
+          send: vi.fn().mockResolvedValue({
+            StatusCode: 200,
+            FunctionError: "Unhandled",
+            Payload: Buffer.from(JSON.stringify({ errorMessage, errorType })),
+            $metadata: {
+              requestId: "request-oom",
+              httpStatusCode: 200,
+              attempts: 1,
+              totalRetryDelay: 0,
+            },
+          }),
+        } as any,
+      });
+
+      await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+        code: "OUT_OF_MEMORY",
+        retryable: false,
+      });
+      expectSpanAttributes({
+        "langfuse.code_eval.error.code": "OUT_OF_MEMORY",
+        "langfuse.code_eval.error.retryable": false,
+      });
+      expect(mocks.loggerWarn).not.toHaveBeenCalled();
+    },
+  );
 
   it("records the original Lambda FunctionError before throwing the derived user-facing error", async () => {
     const dispatcher = new AwsLambdaCodeEvalDispatcher({

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -54,6 +54,7 @@ const USER_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
   CodeEvalDispatcherErrorCodes.PAYLOAD_TOO_LARGE,
   CodeEvalDispatcherErrorCodes.RESULT_TOO_LARGE,
   CodeEvalDispatcherErrorCodes.SOURCE_TOO_LARGE,
+  CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY,
   CodeEvalDispatcherErrorCodes.USER_CODE_ERROR,
 ]);
 
@@ -429,7 +430,20 @@ function classifyLambdaFunctionError(params: {
     );
   }
 
-  // Abnormal runtime exit (OOM kill, segfault, process.exit, SIGKILL).
+  const isOutOfMemoryError =
+    errorType === "Runtime.OutOfMemory" ||
+    (errorType === "Runtime.ExitError" &&
+      errorMessage !== null &&
+      /signal:\s*killed/i.test(errorMessage));
+
+  if (isOutOfMemoryError) {
+    return new CodeEvalDispatcherError(
+      composedMessage || "Evaluator exceeded the available memory",
+      { code: CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY, retryable: false },
+    );
+  }
+
+  // Other abnormal runtime exits (segfault, process.exit, SIGKILL).
   // Retrying never recovers from these.
   if (errorType === "Runtime.ExitError") {
     return new CodeEvalDispatcherError(

--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -148,6 +148,7 @@ export const CodeEvalDispatcherErrorCode = z.enum([
   "RESULT_TOO_LARGE",
   "SOURCE_TOO_LARGE",
   "TIMEOUT",
+  "OUT_OF_MEMORY",
   "UNSUPPORTED_RUNTIME",
   "USER_CODE_ERROR",
   "LAMBDA_CONCURRENCY_LIMIT",

--- a/packages/shared/src/server/evals/codeEvalExecution.ts
+++ b/packages/shared/src/server/evals/codeEvalExecution.ts
@@ -45,6 +45,9 @@ const USER_VISIBLE_CODE_EVAL_ERROR_MESSAGE_BY_CODE: Partial<
   [CodeEvalDispatcherErrorCodes.TIMEOUT]: withCodeEvalDocs(
     "Evaluator timed out. Code-based evaluators must complete within the configured runtime limit. Long executions can be caused by network calls, which are forbidden and may never complete. Remove network calls, optimize your evaluator code, and try again.",
   ),
+  [CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY]: withCodeEvalDocs(
+    "Evaluator exceeded the available memory limit. Reduce memory usage in your evaluator code to stay within the limit, then try again.",
+  ),
   [CodeEvalDispatcherErrorCodes.SOURCE_TOO_LARGE]: withCodeEvalDocs(
     `Evaluator source code is too large. Code-based evaluator source code is limited to ${formatCodeEvalByteLimit(CODE_EVAL_SOURCE_MAX_BYTES)}. Shorten the evaluator code and try again.`,
   ),

--- a/worker/AGENTS.md
+++ b/worker/AGENTS.md
@@ -16,6 +16,7 @@
 - Worker registration/lifecycle: `src/queues/workerManager.ts`
 - Queue processors: `src/queues/*`
 - Feature processors: `src/features/*`
+- Evaluation terminal-outcome classification: `src/features/evaluation/evalExecutionMetrics.ts`. Keep it aligned with shared code evaluator dispatcher error codes and user-visible error mapping.
 - Service layer: `src/services/*`
 - Tests: `src/__tests__/*`, `src/queues/__tests__/*`
 

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
@@ -255,9 +255,8 @@ describe("AwsLambdaCodeEvalDispatcher", () => {
     } satisfies Partial<CodeEvalDispatcherError>);
   });
 
-  it("classifies Runtime.ExitError as non-retryable LAMBDA_CONFIGURATION_ERROR", async () => {
-    // Documented Lambda RIC errorType for abnormal runtime termination
-    // (OOM kill, segfault, process.exit). Retrying never recovers.
+  it("classifies Runtime.ExitError with signal killed as non-retryable OUT_OF_MEMORY", async () => {
+    // Lambda reports some OOM kills as Runtime.ExitError with signal: killed.
     const send = vi.fn().mockResolvedValue({
       FunctionError: "Unhandled",
       Payload: Buffer.from(
@@ -273,7 +272,7 @@ describe("AwsLambdaCodeEvalDispatcher", () => {
     });
 
     await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
-      code: "LAMBDA_CONFIGURATION_ERROR",
+      code: "OUT_OF_MEMORY",
       retryable: false,
     } satisfies Partial<CodeEvalDispatcherError>);
   });

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -641,6 +641,56 @@ describe("executeCodeBasedEvaluation", () => {
     expect(trace).not.toContain(rawTimeoutMessage);
   });
 
+  it("shows a user-visible error when evaluator code exceeds available memory", async () => {
+    const error = new CodeEvalDispatcherError(
+      "Runtime.OutOfMemory: Runtime exited with error: signal: killed",
+      {
+        code: CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY,
+        retryable: false,
+      },
+    );
+    mocks.dispatcher.dispatch.mockRejectedValue(error);
+
+    const promise = executeCodeBasedEvaluation({
+      projectId: "project-1",
+      organizationId: "org-1",
+      job: {
+        id: "job-1",
+        jobConfigurationId: "config-1",
+        jobInputTraceId: "trace-1",
+        jobInputObservationId: "obs-1",
+        jobInputDatasetItemId: null,
+      } as any,
+      config: { id: "config-1", scoreName: "default-score" } as any,
+      template: {
+        id: "template-1",
+        name: "Code evaluator",
+        type: EvalTemplateType.CODE,
+        version: 1,
+        sourceCode: "function evaluate() {}",
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        prompt: null,
+        outputDefinition: null,
+      } as any,
+      extractedVariables: [{ var: "input", value: "prompt" }],
+      executionMetadata: { job_execution_id: "job-1" },
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      code: "OUT_OF_MEMORY",
+      retryable: false,
+    });
+    await expect(promise).rejects.toThrow(
+      "Evaluator exceeded the available memory limit. Reduce memory usage in your evaluator code to stay within the limit, then try again.",
+    );
+
+    const trace = JSON.stringify(mocks.writeInternalTrace.mock.calls[0]?.[0]);
+    expect(trace).toContain(
+      "Evaluator exceeded the available memory limit. Reduce memory usage in your evaluator code to stay within the limit, then try again.",
+    );
+    expect(trace).not.toContain("Runtime.OutOfMemory");
+  });
+
   it("masks internal dispatcher errors in the internal trace", async () => {
     const error = new CodeEvalDispatcherError(
       "Failed to invoke code eval Lambda code-based-eval-executor-node: ResourceNotFoundException: Function not found",

--- a/worker/src/features/evaluation/evalExecutionMetrics.test.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.test.ts
@@ -108,6 +108,10 @@ describe("evaluation execution metrics", () => {
       expected: "customer_error",
     },
     {
+      code: CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY,
+      expected: "customer_error",
+    },
+    {
       code: CodeEvalDispatcherErrorCodes.LAMBDA_CONCURRENCY_LIMIT,
       expected: "platform_error",
     },

--- a/worker/src/features/evaluation/evalExecutionMetrics.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.ts
@@ -25,6 +25,7 @@ const CODE_EVAL_CUSTOMER_ERROR_CODES: ReadonlySet<string> = new Set([
   CodeEvalDispatcherErrorCodes.RESULT_TOO_LARGE,
   CodeEvalDispatcherErrorCodes.SOURCE_TOO_LARGE,
   CodeEvalDispatcherErrorCodes.TIMEOUT,
+  CodeEvalDispatcherErrorCodes.OUT_OF_MEMORY,
   CodeEvalDispatcherErrorCodes.USER_CODE_ERROR,
 ]);
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16897 app preview](https://pr-16897.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

Treat evaluator out-of-memory failures as customer errors instead of platform errors.

Reasoning:
- HIPAA recorded terminal platform errors caused by Node Lambda OOM failures.
- Memory use comes from evaluator code, similar to evaluator timeouts, and should not burn the platform reliability SLO.
- Retrying with the same code and memory limit is unlikely to help.
- A dedicated `OUT_OF_MEMORY` code keeps real Lambda invocation and configuration failures classified as platform errors.

## Changes

- Detect `Runtime.OutOfMemory` responses from AWS Lambda.
- Mark them as non-retryable customer errors.
- Show: `Evaluator exceeded the available memory limit. Reduce memory usage in your evaluator code to stay within the limit, then try again.`
- Exclude these failures from the code evaluator platform-error SLO.

## Verification

- `pnpm --filter @langfuse/shared run test awsLambdaCodeEvalDispatcher.test.ts` - 5 tests passed
- `pnpm --filter worker run test evalExecutionMetrics.test.ts executeCodeBasedEvaluation.test.ts` - 23 tests passed
- `pnpm run lint` - 7/7 tasks passed
- `pnpm --filter web run typecheck` - passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR recognizes AWS Lambda evaluator out-of-memory responses as terminal customer errors rather than retryable platform failures.
- Adds the OUT_OF_MEMORY dispatcher error code and AWS response classification.
- Provides a sanitized user-facing remediation message.
- Excludes evaluator OOM failures from code-evaluator platform-error metrics.
- Adds dispatcher, execution, and metrics coverage for the new classification.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking observability issue where customer-triggered OOM failures continue to generate warning logs.

The OOM code is propagated consistently through user messaging, terminal queue handling, and metric classification, but the dispatcher logging filter was not updated alongside the new customer-error classification.

**Files Needing Attention:** packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts:432-437
**OOM warnings bypass filtering**

`OUT_OF_MEMORY` is classified as a routine customer error but is absent from `USER_ERROR_CODES`, so every evaluator OOM still emits a warning and adds customer-caused noise to infrastructure-focused logs and alerts.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): classify code evaluator OOM ..."](https://github.com/langfuse/langfuse/commit/f589848f6ad4a641b80e61e67ffefe5d9bc70f42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59089372)</sub>

<!-- /greptile_comment -->