### PR TITLE
fix(evals): classify invalid model output as customer error

### DIFF
--- a/worker/src/features/evaluation/evalExecutionMetrics.test.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.test.ts
@@ -91,6 +91,18 @@ describe("evaluation execution metrics", () => {
       } satisfies EvaluatorLlmErrorClassification,
       expected: "upstream_error",
     },
+    ...["AI_NoObjectGeneratedError", "AI_NoOutputGeneratedError"].map(
+      (name) => ({
+        classification: {
+          kind: "ai-sdk" as const,
+          message: "model output did not match the required format",
+          isRetryable: false,
+          error: Object.assign(new Error("invalid model output"), { name }),
+          blockReason: null,
+        } satisfies EvaluatorLlmErrorClassification,
+        expected: "customer_error",
+      }),
+    ),
   ])(
     "classifies LLM terminal errors as $expected",
     ({ classification, expected }) => {

--- a/worker/src/features/evaluation/evalExecutionMetrics.ts
+++ b/worker/src/features/evaluation/evalExecutionMetrics.ts
@@ -18,6 +18,11 @@ export type EvalExecutionTerminalOutcome =
   | "customer_error"
   | "cancelled";
 
+const LLM_EVAL_CUSTOMER_OUTPUT_ERROR_NAMES: ReadonlySet<string> = new Set([
+  "AI_NoObjectGeneratedError",
+  "AI_NoOutputGeneratedError",
+]);
+
 const CODE_EVAL_CUSTOMER_ERROR_CODES: ReadonlySet<string> = new Set([
   CodeEvalDispatcherErrorCodes.INVALID_RESULT,
   CodeEvalDispatcherErrorCodes.INVALID_SOURCE,
@@ -63,7 +68,9 @@ export function getLlmEvalTerminalErrorOutcome(
   if (
     classification.blockReason !== null ||
     classification.kind === "evaluator-policy" ||
-    classification.kind === "validation"
+    classification.kind === "validation" ||
+    (classification.kind === "ai-sdk" &&
+      isLlmEvalCustomerOutputError(classification.error))
   ) {
     return "customer_error";
   }
@@ -92,6 +99,36 @@ export function getCodeEvalTerminalErrorOutcome(
   return CODE_EVAL_CUSTOMER_ERROR_CODES.has(error.code)
     ? "customer_error"
     : "platform_error";
+}
+
+function isLlmEvalCustomerOutputError(error: unknown): boolean {
+  const visited = new Set<unknown>();
+  const pending = [error];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object" ||
+      visited.has(current)
+    ) {
+      continue;
+    }
+
+    visited.add(current);
+    const value = current as Record<string, unknown>;
+    if (
+      typeof value.name === "string" &&
+      LLM_EVAL_CUSTOMER_OUTPUT_ERROR_NAMES.has(value.name)
+    ) {
+      return true;
+    }
+
+    pending.push(value.cause, value.lastError);
+  }
+
+  return false;
 }
 
 function getEvaluatorTypeTag(


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16900 app preview](https://pr-16900.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- classify `AI_NoObjectGeneratedError` and `AI_NoOutputGeneratedError` as customer errors for LLM-as-a-Judge terminal metrics
- keep other AI SDK errors classified as platform errors
- cover both output-generation error types with focused worker tests

## Verification

- `pnpm run db:generate`
- `pnpm run lint`
- `pnpm --filter worker run typecheck`
- `CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_USER=clickhouse CLICKHOUSE_PASSWORD=clickhouse LANGFUSE_S3_EVENT_UPLOAD_BUCKET=test pnpm --filter worker run test evalExecutionMetrics.test.ts`
- regression check against the previous implementation: 2 expected failures, one for each output-generation error

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates LLM-as-a-judge terminal metrics so invalid structured model output is attributed to customer errors while preserving existing handling for other AI SDK failures.

- Recognizes `AI_NoObjectGeneratedError` and `AI_NoOutputGeneratedError`, including wrapped errors reached through `cause` or `lastError`.
- Uses cycle-safe traversal of nested error objects.
- Adds focused tests for both output-generation error names.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the intended metric reclassification narrowly scoped to the two invalid-output error types.

The traversal handles direct and wrapped target errors without recursion or cycle risk, while all other AI SDK classifications retain the existing platform-error outcome.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): classify invalid model outpu..."](https://github.com/langfuse/langfuse/commit/231f97882568a61b1f52070e552dbb20ab6d05f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59096370)</sub>

<!-- /greptile_comment -->