### PR TITLE
docs(preview): document Mailpit SMTP port-forward

### DIFF
--- a/.agents/skills/langfuse-previews/SKILL.md
+++ b/.agents/skills/langfuse-previews/SKILL.md
@@ -52,6 +52,11 @@ Pushing updates it; closing the PR tears it down.
   (`pr-<N> app preview`, `pr-<N> storybook preview`) — keep that suffix when
   editing either comment, or the shortcut disappears. A bare URL is not
   matched.
+- **Read captured email** — each preview has an in-namespace Mailpit SMTP
+  sink (invites, password reset, batch-export, spend alerts, mentions). It
+  does not send real mail. The UI is not public; port-forward it:
+  `kubectl -n langfuse-pr-<N> port-forward svc/preview-mailpit 8025:8025`
+  then open `http://localhost:8025`.
 - **Know where you are** — every preview page shows a top strip linking back
   to the PR, with the author and when the preview content last changed.
 - **Update** — push to the PR; it rebuilds and rolls to the new image (~5 min,

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -328,6 +328,7 @@ jobs:
             ```sh
             kubectl -n ${{ needs.meta.outputs.namespace }} logs -f deploy/${{ needs.meta.outputs.namespace }}-web      # web
             kubectl -n ${{ needs.meta.outputs.namespace }} logs -f deploy/${{ needs.meta.outputs.namespace }}-worker   # worker
+            kubectl -n ${{ needs.meta.outputs.namespace }} port-forward svc/preview-mailpit 8025:8025                  # captured email UI → http://localhost:8025
             ```
             Add `--previous` for a crashed container, `--tail=200` to limit, or
             `kubectl -n ${{ needs.meta.outputs.namespace }} get pods` to inspect status.


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16908 app preview](https://pr-16908.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- Document how to read captured preview email via Mailpit (`kubectl port-forward svc/preview-mailpit 8025:8025`).
- Add the same command to the preview-build bot comment.

Depends on the infrastructure chart change: https://github.com/langfuse/infrastructure/pull/1318 (in-namespace Mailpit; no public hostname).

## Test plan
- [ ] After infrastructure #1318 is on `main` and a preview has synced, run the documented port-forward and confirm http://localhost:8025 shows Mailpit.
- [ ] Confirm a new preview-build comment includes the Mailpit port-forward line.


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents access to each preview environment’s Mailpit UI and adds the same port-forward command to successful preview-build comments.
- Adds Mailpit access instructions to the preview skill.
- Adds the namespace-specific Mailpit command to the preview bot’s troubleshooting block.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed documentation or workflow comment.

The documented namespace matches the workflow’s deterministic preview namespace, and the comment action preserves the command as inert text while only posting it after a successful build.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(preview): document Mailpit SMTP por..."](https://github.com/langfuse/langfuse/commit/c702c834d28589716e141945ecc9b3cc5ec086ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59125831)</sub>

<!-- /greptile_comment -->