### PR TITLE
fix(blob-storage): normalize storage regions

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -115,7 +115,7 @@ types:
         docs: Custom endpoint URL (required for S3_COMPATIBLE type)
       region:
         type: string
-        docs: Storage region
+        docs: Storage region. Leading and trailing whitespace is removed; the remaining value must be a valid hostname label (1-63 letters, numbers, or hyphens, and cannot start or end with a hyphen).
       accessKeyId:
         type: optional<string>
         docs: Access key ID for authentication

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -115,7 +115,7 @@ types:
         docs: Custom endpoint URL (required for S3_COMPATIBLE type)
       region:
         type: string
-        docs: Storage region. Leading and trailing whitespace is removed; the remaining value must be a valid hostname label (1-63 letters, numbers, or hyphens, and cannot start or end with a hyphen).
+        docs: "Storage region used by S3-compatible clients (AWS, GCS, Cloudflare R2, MinIO, Azure location IDs such as eastus, OCI). Leading and trailing whitespace is removed. The remaining value must be 1-63 letters, numbers, or hyphens, and cannot start or end with a hyphen. Examples: us-east-1, europe-west1, eastus, auto."
       accessKeyId:
         type: optional<string>
         docs: Access key ID for authentication

--- a/packages/shared/src/server/services/StorageService.test.ts
+++ b/packages/shared/src/server/services/StorageService.test.ts
@@ -9,6 +9,27 @@ import { env } from "../../env";
 import { resolveMediaStorageEndpoints } from "../s3";
 import { StorageServiceFactory } from "./StorageService";
 
+describe("S3StorageService region normalization", () => {
+  it("trims a persisted region before configuring the AWS client", async () => {
+    const service = StorageServiceFactory.getInstance({
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+      bucketName: "test-bucket",
+      endpoint: undefined,
+      region: " us-west-2",
+      forcePathStyle: false,
+      useAzureBlob: false,
+      useGoogleCloudStorage: false,
+      useOCIObjectStorage: false,
+      awsSse: undefined,
+      awsSseKmsKeyId: undefined,
+    });
+    const client = (service as unknown as { client: S3Client }).client;
+
+    await expect(client.config.region()).resolves.toBe("us-west-2");
+  });
+});
+
 describe("resolveMediaStorageEndpoints", () => {
   it("keeps the existing endpoint for both server access and signed URLs by default", () => {
     expect(

--- a/packages/shared/src/server/services/StorageService.test.ts
+++ b/packages/shared/src/server/services/StorageService.test.ts
@@ -28,6 +28,24 @@ describe("S3StorageService region normalization", () => {
 
     await expect(client.config.region()).resolves.toBe("us-west-2");
   });
+
+  it("rejects malformed persisted regions before creating an AWS client", () => {
+    expect(() =>
+      StorageServiceFactory.getInstance({
+        accessKeyId: "test-access-key",
+        secretAccessKey: "test-secret-key",
+        bucketName: "test-bucket",
+        endpoint: undefined,
+        region: "us west-2",
+        forcePathStyle: false,
+        useAzureBlob: false,
+        useGoogleCloudStorage: false,
+        useOCIObjectStorage: false,
+        awsSse: undefined,
+        awsSseKmsKeyId: undefined,
+      }),
+    ).toThrow("Region must be a valid hostname label");
+  });
 });
 
 describe("resolveMediaStorageEndpoints", () => {

--- a/packages/shared/src/server/services/StorageService.test.ts
+++ b/packages/shared/src/server/services/StorageService.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { S3Client } from "@aws-sdk/client-s3";
 
+import { BLOB_STORAGE_REGION_INVALID_MESSAGE } from "../../utils/stringChecks";
 import { env } from "../../env";
 import { resolveMediaStorageEndpoints } from "../s3";
 import { StorageServiceFactory } from "./StorageService";
@@ -44,8 +45,30 @@ describe("S3StorageService region normalization", () => {
         awsSse: undefined,
         awsSseKmsKeyId: undefined,
       }),
-    ).toThrow("Region must be a valid hostname label");
+    ).toThrow(BLOB_STORAGE_REGION_INVALID_MESSAGE);
   });
+
+  it.each(["europe-west1", "eastus", "auto"])(
+    "configures an S3-compatible client with region %s",
+    async (region) => {
+      const service = StorageServiceFactory.getInstance({
+        accessKeyId: "test-access-key",
+        secretAccessKey: "test-secret-key",
+        bucketName: "test-bucket",
+        endpoint: "https://storage.googleapis.com",
+        region,
+        forcePathStyle: true,
+        useAzureBlob: false,
+        useGoogleCloudStorage: false,
+        useOCIObjectStorage: false,
+        awsSse: undefined,
+        awsSseKmsKeyId: undefined,
+      });
+      const client = (service as unknown as { client: S3Client }).client;
+
+      await expect(client.config.region()).resolves.toBe(region);
+    },
+  );
 });
 
 describe("resolveMediaStorageEndpoints", () => {

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -21,6 +21,7 @@ import {
 import { Storage, Bucket, GetSignedUrlConfig } from "@google-cloud/storage";
 import { logger } from "../logger";
 import { env } from "../../env";
+import { normalizeBlobStorageRegion } from "../../utils/stringChecks";
 import { backOff } from "exponential-backoff";
 import { ServiceUnavailableError } from "../../errors";
 import {
@@ -763,7 +764,10 @@ class S3StorageService implements StorageService {
         : undefined;
 
     const requestHandler = createS3RequestHandler(params.connectionValidation);
-    const region = params.region?.trim() || undefined;
+    const region =
+      params.region === undefined
+        ? undefined
+        : normalizeBlobStorageRegion(params.region);
 
     // Create the main client for S3 operations using the internal endpoint
     this.client = new S3Client({

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -763,12 +763,13 @@ class S3StorageService implements StorageService {
         : undefined;
 
     const requestHandler = createS3RequestHandler(params.connectionValidation);
+    const region = params.region?.trim() || undefined;
 
     // Create the main client for S3 operations using the internal endpoint
     this.client = new S3Client({
       credentials,
       endpoint: params.endpoint,
-      region: params.region,
+      region,
       forcePathStyle: params.forcePathStyle,
       // Restore pre-v3.729 default so CompleteMultipartUpload doesn't send a
       // composite CRC32 header, which GCS's S3-compat layer rejects with 412.
@@ -780,7 +781,7 @@ class S3StorageService implements StorageService {
     addS3DiagnosticsMiddleware(this.client, {
       bucketName: params.bucketName,
       endpoint: params.endpoint,
-      region: params.region,
+      region,
       forcePathStyle: params.forcePathStyle,
     });
 
@@ -791,7 +792,7 @@ class S3StorageService implements StorageService {
       ? new S3Client({
           credentials,
           endpoint: params.externalEndpoint,
-          region: params.region,
+          region,
           forcePathStyle: params.forcePathStyle,
           requestChecksumCalculation: "WHEN_REQUIRED",
           responseChecksumValidation: "WHEN_REQUIRED",

--- a/packages/shared/src/utils/stringChecks.test.ts
+++ b/packages/shared/src/utils/stringChecks.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { truncate } from "./stringChecks";
+import {
+  BLOB_STORAGE_REGION_INVALID_MESSAGE,
+  normalizeBlobStorageRegion,
+  truncate,
+} from "./stringChecks";
 
 function hasLoneSurrogate(s: string): boolean {
   for (let i = 0; i < s.length; i++) {
@@ -15,6 +19,38 @@ function hasLoneSurrogate(s: string): boolean {
   }
   return false;
 }
+
+describe("normalizeBlobStorageRegion", () => {
+  it.each([
+    ["us-west-2", "AWS"],
+    ["europe-west1", "GCP"],
+    ["us-central1", "GCP"],
+    ["US", "GCS multi-region"],
+    ["eastus", "Azure"],
+    ["westeurope", "Azure"],
+    ["germanywestcentral", "Azure"],
+    ["auto", "GCS/R2 signing region"],
+    ["wnam", "Cloudflare R2"],
+    ["us-ashburn-1", "OCI"],
+    ["us-west-004", "Backblaze"],
+  ])("accepts %s (%s)", (region) => {
+    expect(normalizeBlobStorageRegion(` ${region} `)).toBe(region);
+  });
+
+  it.each([
+    "us west-2",
+    "East US",
+    "US-CENTRAL1+US-EAST1",
+    "us_west_2",
+    "-us-west-2",
+    "us-west-2-",
+    "a".repeat(64),
+  ])("rejects %s", (region) => {
+    expect(() => normalizeBlobStorageRegion(region)).toThrow(
+      BLOB_STORAGE_REGION_INVALID_MESSAGE,
+    );
+  });
+});
 
 describe("truncate", () => {
   it("returns the string unchanged when at or under the limit", () => {

--- a/packages/shared/src/utils/stringChecks.ts
+++ b/packages/shared/src/utils/stringChecks.ts
@@ -17,6 +17,17 @@ export const MULTILINE_VARIABLE_REGEX = /{{[^{}\n]*\n[^{}]*}}/g;
 // Regex to find unclosed variables
 export const UNCLOSED_VARIABLE_REGEX = /{{(?!{)(?![^{]*}})/g;
 
+// Mirrors the hostname-label validation used by the AWS SDK for S3 regions.
+export const BLOB_STORAGE_REGION_REGEX = /^(?!.*-$)(?!-)[a-zA-Z0-9-]{1,63}$/;
+
+export function normalizeBlobStorageRegion(region: string): string {
+  const normalizedRegion = region.trim();
+  if (!BLOB_STORAGE_REGION_REGEX.test(normalizedRegion)) {
+    throw new Error("Region must be a valid hostname label");
+  }
+  return normalizedRegion;
+}
+
 export function isValidVariableName(variable: string): boolean {
   return VARIABLE_REGEX.test(variable);
 }

--- a/packages/shared/src/utils/stringChecks.ts
+++ b/packages/shared/src/utils/stringChecks.ts
@@ -17,13 +17,19 @@ export const MULTILINE_VARIABLE_REGEX = /{{[^{}\n]*\n[^{}]*}}/g;
 // Regex to find unclosed variables
 export const UNCLOSED_VARIABLE_REGEX = /{{(?!{)(?![^{]*}})/g;
 
-// Mirrors the hostname-label validation used by the AWS SDK for S3 regions.
+// Smithy host-label check used by S3-compatible clients. AWS, GCS XML/S3,
+// Cloudflare R2, MinIO, Azure location IDs (eastus), and OCI region ids all
+// fit this pattern. Spaces, underscores, and GCP dual-region `+` syntax are
+// rejected because they throw inside the AWS SDK and can terminate the process.
 export const BLOB_STORAGE_REGION_REGEX = /^(?!.*-$)(?!-)[a-zA-Z0-9-]{1,63}$/;
+
+export const BLOB_STORAGE_REGION_INVALID_MESSAGE =
+  "Region must be 1-63 letters, numbers, or hyphens, and cannot start or end with a hyphen";
 
 export function normalizeBlobStorageRegion(region: string): string {
   const normalizedRegion = region.trim();
   if (!BLOB_STORAGE_REGION_REGEX.test(normalizedRegion)) {
-    throw new Error("Region must be a valid hostname label");
+    throw new Error(BLOB_STORAGE_REGION_INVALID_MESSAGE);
   }
   return normalizedRegion;
 }

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -9775,9 +9775,11 @@ components:
         region:
           type: string
           description: >-
-            Storage region. Leading and trailing whitespace is removed; the
-            remaining value must be a valid hostname label (1-63 letters,
-            numbers, or hyphens, and cannot start or end with a hyphen).
+            Storage region used by S3-compatible clients (AWS, GCS, Cloudflare
+            R2, MinIO, Azure location IDs such as eastus, OCI). Leading and
+            trailing whitespace is removed. The remaining value must be 1-63
+            letters, numbers, or hyphens, and cannot start or end with a hyphen.
+            Examples: us-east-1, europe-west1, eastus, auto.
         accessKeyId:
           type: string
           nullable: true

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -9774,7 +9774,10 @@ components:
           description: Custom endpoint URL (required for S3_COMPATIBLE type)
         region:
           type: string
-          description: Storage region
+          description: >-
+            Storage region. Leading and trailing whitespace is removed; the
+            remaining value must be a valid hostname label (1-63 letters,
+            numbers, or hyphens, and cannot start or end with a hyphen).
         accessKeyId:
           type: string
           nullable: true

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -258,6 +258,24 @@ describe("Blob Storage Integration tRPC Router", () => {
     vi.clearAllMocks();
   });
 
+  describe("region normalization", () => {
+    it("persists a trimmed region", async () => {
+      const { caller, project } = await prepare();
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        region: " us-west-2",
+      });
+
+      const integration = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: project.id },
+        select: { region: true },
+      });
+      expect(integration?.region).toBe("us-west-2");
+    });
+  });
+
   describe("runNow", () => {
     it("creates a success audit log when a manual run is queued", async () => {
       const add = vi.fn().mockResolvedValue(undefined);

--- a/web/src/features/blobstorage-integration/components/StorageProviderFields.tsx
+++ b/web/src/features/blobstorage-integration/components/StorageProviderFields.tsx
@@ -126,7 +126,7 @@ export const StorageProviderFields = ({
               <FormDescription>
                 {integrationType === "S3"
                   ? "AWS region (e.g., us-east-1)"
-                  : "S3 compatible storage region"}
+                  : "S3 compatible storage region (e.g. europe-west1, auto)"}
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -6,6 +6,7 @@ import {
   type AnalyticsIntegrationExportSource,
   BlobStorageIntegrationFileType,
   type ObservationFieldGroupFull,
+  normalizeBlobStorageRegion,
 } from "@langfuse/shared";
 import { assertPersistedExportSourceAllowed } from "@/src/features/analytics-integrations/server/exportSource";
 import { encrypt } from "@langfuse/shared/encryption";
@@ -70,10 +71,11 @@ export async function upsertBlobStorageIntegration(params: {
 
   const accessKeyId = data.accessKeyId?.trim() || null;
   const secretAccessKey = data.secretAccessKey?.trim() || null;
-  const region = data.region.trim();
-
-  if (!region) {
-    throw new InvalidRequestError("Region is required");
+  let region: string;
+  try {
+    region = normalizeBlobStorageRegion(data.region);
+  } catch {
+    throw new InvalidRequestError("Region must be a valid hostname label");
   }
 
   if (data.endpoint) {

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -6,6 +6,7 @@ import {
   type AnalyticsIntegrationExportSource,
   BlobStorageIntegrationFileType,
   type ObservationFieldGroupFull,
+  BLOB_STORAGE_REGION_INVALID_MESSAGE,
   normalizeBlobStorageRegion,
 } from "@langfuse/shared";
 import { assertPersistedExportSourceAllowed } from "@/src/features/analytics-integrations/server/exportSource";
@@ -75,7 +76,7 @@ export async function upsertBlobStorageIntegration(params: {
   try {
     region = normalizeBlobStorageRegion(data.region);
   } catch {
-    throw new InvalidRequestError("Region must be a valid hostname label");
+    throw new InvalidRequestError(BLOB_STORAGE_REGION_INVALID_MESSAGE);
   }
 
   if (data.endpoint) {

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -70,6 +70,11 @@ export async function upsertBlobStorageIntegration(params: {
 
   const accessKeyId = data.accessKeyId?.trim() || null;
   const secretAccessKey = data.secretAccessKey?.trim() || null;
+  const region = data.region.trim();
+
+  if (!region) {
+    throw new InvalidRequestError("Region is required");
+  }
 
   if (data.endpoint) {
     try {
@@ -96,7 +101,7 @@ export async function upsertBlobStorageIntegration(params: {
     type: data.type,
     bucketName: data.bucketName,
     endpoint: data.endpoint,
-    region: data.region,
+    region,
     accessKeyId,
     prefix: data.prefix,
     exportFrequency: data.exportFrequency,

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -17,7 +17,11 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
   type: z.enum(BlobStorageIntegrationType),
   bucketName: z.string().min(1, { message: "Bucket name is required" }),
   endpoint: z.url().optional().nullable(),
-  region: z.string().default("auto"),
+  region: z
+    .string()
+    .trim()
+    .min(1, { message: "Region is required" })
+    .default("auto"),
   accessKeyId: z.string().optional(),
   secretAccessKey: z.string().nullable().optional(),
   prefix: z

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -5,6 +5,7 @@ import {
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
   OBSERVATION_FIELD_GROUPS_FULL,
+  BLOB_STORAGE_REGION_INVALID_MESSAGE,
   BLOB_STORAGE_REGION_REGEX,
 } from "@langfuse/shared";
 import {
@@ -23,7 +24,7 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
     .trim()
     .min(1, { message: "Region is required" })
     .regex(BLOB_STORAGE_REGION_REGEX, {
-      message: "Region must be a valid hostname label",
+      message: BLOB_STORAGE_REGION_INVALID_MESSAGE,
     })
     .default("auto"),
   accessKeyId: z.string().optional(),

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -5,6 +5,7 @@ import {
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
   OBSERVATION_FIELD_GROUPS_FULL,
+  BLOB_STORAGE_REGION_REGEX,
 } from "@langfuse/shared";
 import {
   validateAzureContainerName,
@@ -21,6 +22,9 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
     .string()
     .trim()
     .min(1, { message: "Region is required" })
+    .regex(BLOB_STORAGE_REGION_REGEX, {
+      message: "Region must be a valid hostname label",
+    })
     .default("auto"),
   accessKeyId: z.string().optional(),
   secretAccessKey: z.string().nullable().optional(),

--- a/web/src/features/blobstorage-integration/validation.clienttest.ts
+++ b/web/src/features/blobstorage-integration/validation.clienttest.ts
@@ -4,7 +4,23 @@ import {
   AZURE_CONTAINER_NAME_REGEX,
   validateAzureContainerName,
 } from "./validation";
+import { blobStorageIntegrationFormSchemaBase } from "./types";
+import { CreateBlobStorageIntegrationRequest } from "@/src/features/public-api/types/blob-storage-integrations";
 import { z } from "zod";
+
+describe("blob storage region normalization", () => {
+  it("trims regions submitted through the settings form", () => {
+    expect(
+      blobStorageIntegrationFormSchemaBase.shape.region.parse(" us-west-2"),
+    ).toBe("us-west-2");
+  });
+
+  it("trims regions submitted through the public API", () => {
+    expect(
+      CreateBlobStorageIntegrationRequest.shape.region.parse(" us-west-2"),
+    ).toBe("us-west-2");
+  });
+});
 
 describe("AZURE_CONTAINER_NAME_REGEX", () => {
   const valid = [

--- a/web/src/features/blobstorage-integration/validation.clienttest.ts
+++ b/web/src/features/blobstorage-integration/validation.clienttest.ts
@@ -20,6 +20,20 @@ describe("blob storage region normalization", () => {
       CreateBlobStorageIntegrationRequest.shape.region.parse(" us-west-2"),
     ).toBe("us-west-2");
   });
+
+  it.each(["us west-2", "-us-west-2", "us-west-2-", "a".repeat(64)])(
+    "rejects a region that the AWS SDK cannot use as a hostname label: %s",
+    (region) => {
+      expect(
+        blobStorageIntegrationFormSchemaBase.shape.region.safeParse(region)
+          .success,
+      ).toBe(false);
+      expect(
+        CreateBlobStorageIntegrationRequest.shape.region.safeParse(region)
+          .success,
+      ).toBe(false);
+    },
+  );
 });
 
 describe("AZURE_CONTAINER_NAME_REGEX", () => {

--- a/web/src/features/blobstorage-integration/validation.clienttest.ts
+++ b/web/src/features/blobstorage-integration/validation.clienttest.ts
@@ -21,19 +21,35 @@ describe("blob storage region normalization", () => {
     ).toBe("us-west-2");
   });
 
-  it.each(["us west-2", "-us-west-2", "us-west-2-", "a".repeat(64)])(
-    "rejects a region that the AWS SDK cannot use as a hostname label: %s",
+  it.each(["europe-west1", "eastus", "auto", "US", "wnam"])(
+    "accepts S3-compatible provider region %s",
     (region) => {
       expect(
-        blobStorageIntegrationFormSchemaBase.shape.region.safeParse(region)
-          .success,
-      ).toBe(false);
+        blobStorageIntegrationFormSchemaBase.shape.region.parse(region),
+      ).toBe(region);
       expect(
-        CreateBlobStorageIntegrationRequest.shape.region.safeParse(region)
-          .success,
-      ).toBe(false);
+        CreateBlobStorageIntegrationRequest.shape.region.parse(region),
+      ).toBe(region);
     },
   );
+
+  it.each([
+    "us west-2",
+    "East US",
+    "US-CENTRAL1+US-EAST1",
+    "-us-west-2",
+    "us-west-2-",
+    "a".repeat(64),
+  ])("rejects a region the S3 client cannot use: %s", (region) => {
+    expect(
+      blobStorageIntegrationFormSchemaBase.shape.region.safeParse(region)
+        .success,
+    ).toBe(false);
+    expect(
+      CreateBlobStorageIntegrationRequest.shape.region.safeParse(region)
+        .success,
+    ).toBe(false);
+  });
 });
 
 describe("AZURE_CONTAINER_NAME_REGEX", () => {

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -100,7 +100,9 @@ export const CreateBlobStorageIntegrationRequest = z
     type: BlobStorageIntegrationType,
     bucketName: z.string().min(1),
     endpoint: z.string().nullable().optional(),
-    region: z.string().trim().min(1).regex(BLOB_STORAGE_REGION_REGEX),
+    region: z.string().trim().min(1).regex(BLOB_STORAGE_REGION_REGEX, {
+      message: "Region must be a valid hostname label",
+    }),
     accessKeyId: z.string().nullable().optional(),
     secretAccessKey: z.string().nullable().optional(),
     prefix: z

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -99,7 +99,7 @@ export const CreateBlobStorageIntegrationRequest = z
     type: BlobStorageIntegrationType,
     bucketName: z.string().min(1),
     endpoint: z.string().nullable().optional(),
-    region: z.string(),
+    region: z.string().trim().min(1),
     accessKeyId: z.string().nullable().optional(),
     secretAccessKey: z.string().nullable().optional(),
     prefix: z

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   AnalyticsIntegrationExportSource,
   OBSERVATION_FIELD_GROUPS_FULL,
+  BLOB_STORAGE_REGION_REGEX,
 } from "@langfuse/shared";
 import {
   validateAzureContainerName,
@@ -99,7 +100,7 @@ export const CreateBlobStorageIntegrationRequest = z
     type: BlobStorageIntegrationType,
     bucketName: z.string().min(1),
     endpoint: z.string().nullable().optional(),
-    region: z.string().trim().min(1),
+    region: z.string().trim().min(1).regex(BLOB_STORAGE_REGION_REGEX),
     accessKeyId: z.string().nullable().optional(),
     secretAccessKey: z.string().nullable().optional(),
     prefix: z

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   AnalyticsIntegrationExportSource,
   OBSERVATION_FIELD_GROUPS_FULL,
+  BLOB_STORAGE_REGION_INVALID_MESSAGE,
   BLOB_STORAGE_REGION_REGEX,
 } from "@langfuse/shared";
 import {
@@ -101,7 +102,7 @@ export const CreateBlobStorageIntegrationRequest = z
     bucketName: z.string().min(1),
     endpoint: z.string().nullable().optional(),
     region: z.string().trim().min(1).regex(BLOB_STORAGE_REGION_REGEX, {
-      message: "Region must be a valid hostname label",
+      message: BLOB_STORAGE_REGION_INVALID_MESSAGE,
     }),
     accessKeyId: z.string().nullable().optional(),
     secretAccessKey: z.string().nullable().optional(),

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -239,6 +239,51 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     });
   });
 
+  describe("invalid persisted region", () => {
+    const originalWriteMode = env.LANGFUSE_MIGRATION_V4_WRITE_MODE;
+
+    afterEach(() => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = originalWriteMode;
+    });
+
+    it("persists the error before any S3 upload starts", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_WRITE_MODE = "events_only";
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: projectId,
+          accessKeyId,
+          secretAccessKey: encrypt(secretAccessKey),
+          region: "us west-2",
+          endpoint: endpoint ?? null,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "daily",
+          exportSource: "EVENTS",
+          lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+        },
+      });
+
+      await expect(
+        handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job),
+      ).rejects.toThrow("Region must be a valid hostname label");
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.lastError).toBe("Region must be a valid hostname label");
+      expect(row.lastErrorAt).not.toBeNull();
+      expect(row.enabled).toBe(true);
+    });
+  });
+
   // A classified customer fault disables the integration on its first
   // occurrence and resolves the job; everything else keeps retrying as before.
   describe("customer-fault disable", () => {

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -66,6 +66,7 @@ import { BLOB_INTEGRATION_DISABLED_METRIC } from "../features/blobstorage/isCust
 import {
   BlobStorageIntegrationType,
   BlobStorageIntegrationFileType,
+  BLOB_STORAGE_REGION_INVALID_MESSAGE,
   LEGACY_BLOB_EXPORTER_CUTOFF,
 } from "@langfuse/shared";
 import { encrypt } from "@langfuse/shared/encryption";
@@ -273,12 +274,12 @@ describe("BlobStorageIntegrationProcessingJob", () => {
         handleBlobStorageIntegrationProjectJob({
           data: { payload: { projectId } },
         } as Job),
-      ).rejects.toThrow("Region must be a valid hostname label");
+      ).rejects.toThrow(BLOB_STORAGE_REGION_INVALID_MESSAGE);
 
       const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
         where: { projectId },
       });
-      expect(row.lastError).toBe("Region must be a valid hostname label");
+      expect(row.lastError).toBe(BLOB_STORAGE_REGION_INVALID_MESSAGE);
       expect(row.lastErrorAt).not.toBeNull();
       expect(row.enabled).toBe(true);
     });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16911 app preview](https://pr-16911.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Normalizes blob-storage regions at every write boundary and rejects values that S3-compatible clients cannot use as a host label. AWS, GCS, Azure location IDs, Cloudflare R2, MinIO, and OCI identifiers all match that pattern (`us-east-1`, `europe-west1`, `eastus`, `auto`). S3 service construction applies the same check synchronously, so already-persisted malformed values fail in job error bookkeeping instead of as an unhandled AWS SDK rejection.

Impacted packages: `web`, `worker`, `@langfuse/shared`. Fern and generated OpenAPI descriptions document the accepted region format with those examples.

## Proof of work

<a href="https://cursor.com/agents/bc-9b4c9af4-e09a-4314-90e5-1ce93334c132/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_blob_storage_region.mp4"><img src="https://cursor.com/artifacts/c/art-d571948c-c12a-4763-84a0-ce845015c88d" alt="preview_blob_storage_region.mp4" /></a>

The settings form saves ` us-west-2`, reloads it as `us-west-2`, and blocks `us west-2`. GCP/Azure location ids such as `europe-west1` and `eastus` are accepted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

- `pnpm --filter @langfuse/shared run test src/utils/stringChecks.test.ts src/server/services/StorageService.test.ts` — `Tests 43 passed (43)`
- `pnpm --filter web run test-client src/features/blobstorage-integration/validation.clienttest.ts` — `Tests 37 passed (37)`
- `pnpm --filter web run test src/__tests__/server/blob-storage-integration-trpc.servertest.ts` — `Tests 49 passed (49)` (earlier on this branch)
- `pnpm --filter worker run test src/__tests__/blobStorageIntegrationProcessing.test.ts -t "persists the error before any S3 upload starts"` — `Tests 1 passed | 36 skipped (37)`
- commit hook `turbo run lint` — `Tasks: 7 successful, 7 total`
- commit hook Prettier check — `All matched files use Prettier code style!`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15874](https://linear.app/clickhouse/issue/LFE-15874/bug-invalid-blob-storage-region-terminates-web-and-worker-tasks-in)

<div><a href="https://cursor.com/agents/bc-9b4c9af4-e09a-4314-90e5-1ce93334c132?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b4c9af4-e09a-4314-90e5-1ce93334c132&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR normalizes blob-storage regions before persistence and S3 client construction, preventing surrounding whitespace from reaching the AWS SDK.
- Trims and validates regions in settings-form and public API schemas.
- Persists the normalized region and rejects blank values at the service boundary.
- Uses the normalized region for internal and external S3 clients and diagnostic metadata.
- Adds focused coverage for schema and S3-client normalization.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with region normalization consistently enforced across write and S3-client boundaries.

The changed schemas, service boundary, and S3 construction path consistently trim regions, current callers satisfy the required string contract, and no reachable regression remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-storage): normalize storage reg..."](https://github.com/langfuse/langfuse/commit/d4aa0898ea74edc77a4b8bff165f1d3cee0e8674) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59168734)</sub>

<!-- /greptile_comment -->