### PR TITLE
fix(experiments): the bugs found while rebuilding the experiments UI

### DIFF
--- a/web/src/components/table/data-table-column-visibility-filter.clienttest.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.clienttest.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { StrictMode, useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { type VisibilityState } from "@tanstack/react-table";
 import { DataTableColumnVisibilityFilter } from "@/src/components/table/data-table-column-visibility-filter";
@@ -161,6 +161,28 @@ describe("DataTableColumnVisibilityFilter", () => {
       tableName: "experiments",
       isV4: true,
     });
+  });
+
+  // The capture used to sit inside the setColumnVisibility updater. An updater
+  // has to be pure, and React re-invokes it under StrictMode — which the app
+  // enables — so every toggle was counted twice. Rendering the harness in
+  // StrictMode is what makes this a guard rather than a restatement of the
+  // test above. (LFE-15720)
+  it("counts one toggle once under StrictMode", () => {
+    render(
+      <StrictMode>
+        <ColumnVisibilityFilterHarness />
+      </StrictMode>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /columns/i }));
+    fireEvent.click(screen.getByText("Input"));
+
+    const events = h.capture.mock.calls.filter(
+      ([name]) => name === "table:column_visibility_changed",
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0][1].selectedColumns).not.toContain("input");
   });
 
   it("notifies onColumnGroupToggle with the group id, not score names", () => {

--- a/web/src/components/table/data-table-column-visibility-filter.clienttest.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.clienttest.tsx
@@ -167,7 +167,7 @@ describe("DataTableColumnVisibilityFilter", () => {
   // has to be pure, and React re-invokes it under StrictMode — which the app
   // enables — so every toggle was counted twice. Rendering the harness in
   // StrictMode is what makes this a guard rather than a restatement of the
-  // test above. (LFE-15720)
+  // test above.
   it("counts one toggle once under StrictMode", () => {
     render(
       <StrictMode>

--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -335,7 +335,7 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
       const targetValue = !currentValue;
       // The event belongs to the click, not to the state updater: an updater
       // must be pure, and React invokes it twice under StrictMode — which
-      // double-counted every toggle. Same payload, emitted once. (LFE-15720)
+      // double-counted every toggle. Same payload, emitted once.
       const nextVisibility = { ...columnVisibility, [columnId]: targetValue };
       capture("table:column_visibility_changed", {
         selectedColumns: Object.keys(nextVisibility).filter(

--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -333,21 +333,21 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
       // calculate target state outside of setState to make it idempotent
       const currentValue = columnVisibility[columnId];
       const targetValue = !currentValue;
-      setColumnVisibility((old: any) => {
-        const newColumnVisibility = {
-          ...old,
-          [columnId]: targetValue,
-        };
-        const selectedColumns = Object.keys(newColumnVisibility).filter(
-          (key) => newColumnVisibility[key],
-        );
-        capture("table:column_visibility_changed", {
-          selectedColumns: selectedColumns,
-          tableName,
-          isV4,
-        });
-        return newColumnVisibility;
+      // The event belongs to the click, not to the state updater: an updater
+      // must be pure, and React invokes it twice under StrictMode — which
+      // double-counted every toggle. Same payload, emitted once. (LFE-15720)
+      const nextVisibility = { ...columnVisibility, [columnId]: targetValue };
+      capture("table:column_visibility_changed", {
+        selectedColumns: Object.keys(nextVisibility).filter(
+          (key) => nextVisibility[key],
+        ),
+        tableName,
+        isV4,
       });
+      setColumnVisibility((old: any) => ({
+        ...old,
+        [columnId]: targetValue,
+      }));
     },
     // eslint disable is because we don't want the posthog capture as deps
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/components/table/table-view-presets/hooks/useViewData.ts
+++ b/web/src/components/table/table-view-presets/hooks/useViewData.ts
@@ -9,10 +9,16 @@ export const useViewData = ({
   projectId: string;
 }) => {
   const { data: TableViewPresets } =
-    api.TableViewPresets.getByTableName.useQuery({
-      tableName,
-      projectId,
-    });
+    api.TableViewPresets.getByTableName.useQuery(
+      {
+        tableName,
+        projectId,
+      },
+      // `projectId` comes from `router.query`, which Next.js populates only
+      // after hydration; unguarded the query fires with `undefined` and the
+      // rejected zod input surfaces as a "Bad Request" toast.
+      { enabled: Boolean(projectId) },
+    );
 
   return {
     TableViewPresetsList: TableViewPresets,

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -349,7 +349,7 @@ export default function ExperimentItemsTable({
     {
       stateLocation: "url",
       loading: isFilterOptionsLoading,
-      // v4-only surface — drives `isV4` on filters:* analytics (LFE-10781).
+      // v4-only surface — drives `isV4` on filters:* analytics.
       isV4: true,
     },
   );

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -346,7 +346,12 @@ export default function ExperimentItemsTable({
   const queryFilter = useSidebarFilterState(
     experimentItemsFilterConfig,
     scoreFilterOptions,
-    { stateLocation: "url", loading: isFilterOptionsLoading, isV4: true },
+    {
+      stateLocation: "url",
+      loading: isFilterOptionsLoading,
+      // v4-only surface — drives `isV4` on filters:* analytics (LFE-10781).
+      isV4: true,
+    },
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -361,6 +361,7 @@ export default function ExperimentsTable({
     loading: isFilterOptionsPending,
     stateLocation: "urlAndSessionStorage",
     sessionFilterContextId,
+    // v4-only surface — drives `isV4` on filters:* analytics (LFE-10781).
     isV4: true,
   });
 

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -361,7 +361,7 @@ export default function ExperimentsTable({
     loading: isFilterOptionsPending,
     stateLocation: "urlAndSessionStorage",
     sessionFilterContextId,
-    // v4-only surface — drives `isV4` on filters:* analytics (LFE-10781).
+    // v4-only surface — drives `isV4` on filters:* analytics.
     isV4: true,
   });
 

--- a/web/src/features/experiments/hooks/useExperimentFilterOptions.ts
+++ b/web/src/features/experiments/hooks/useExperimentFilterOptions.ts
@@ -21,10 +21,18 @@ export function useExperimentFilterOptions({
   projectId: string;
   oldFilterState: FilterState;
 }) {
+  // `projectId` comes from `router.query`, which Next.js populates only after
+  // hydration; unguarded queries fire with `undefined` and the rejected zod
+  // input surfaces as a "Bad Request" toast.
+  const isProjectReady = Boolean(projectId);
+
   // Fetch datasets to get ID -> name mapping
-  const datasets = api.datasets.allDatasetMeta.useQuery({
-    projectId,
-  });
+  const datasets = api.datasets.allDatasetMeta.useQuery(
+    {
+      projectId,
+    },
+    { enabled: isProjectReady },
+  );
 
   // Extract start time filters for filter options query
   const startTimeFilters = useMemo(() => {
@@ -36,10 +44,14 @@ export function useExperimentFilterOptions({
   }, [oldFilterState]);
 
   // Fetch experiment-specific filter options (scores scoped to experiment events)
-  const filterOptions = api.experiments.filterOptions.useQuery({
-    projectId,
-    startTimeFilter: startTimeFilters.length > 0 ? startTimeFilters : undefined,
-  });
+  const filterOptions = api.experiments.filterOptions.useQuery(
+    {
+      projectId,
+      startTimeFilter:
+        startTimeFilters.length > 0 ? startTimeFilters : undefined,
+    },
+    { enabled: isProjectReady },
+  );
 
   const usedDatasets = useMemo(
     () =>

--- a/web/src/features/experiments/hooks/useExperimentItemsFilterOptions.ts
+++ b/web/src/features/experiments/hooks/useExperimentItemsFilterOptions.ts
@@ -34,7 +34,9 @@ export const useExperimentItemsFilterOptions = ({
   const filterOptions = api.experiments.itemsFilterOptions.useQuery(
     { projectId, experimentIds },
     {
-      enabled: experimentIds.length > 0,
+      // `projectId` arrives with `router.query` after hydration; without it in
+      // the guard the query can fire with `undefined` and zod rejects it.
+      enabled: Boolean(projectId) && experimentIds.length > 0,
       staleTime: Infinity,
       refetchOnMount: false,
       refetchOnWindowFocus: false,

--- a/web/src/features/experiments/hooks/useExperimentNames.ts
+++ b/web/src/features/experiments/hooks/useExperimentNames.ts
@@ -24,7 +24,9 @@ export function useExperimentNames({
     {
       projectId,
     },
-    { enabled: hasExperimentsReadAccess },
+    // `projectId` arrives with `router.query` after hydration; without it in
+    // the guard the query can fire with `undefined` and zod rejects it.
+    { enabled: Boolean(projectId) && hasExperimentsReadAccess },
   );
 
   const sortedExperimentNames = data?.experimentNames.sort((a, b) =>

--- a/web/src/features/experiments/hooks/useExperimentsTableData.ts
+++ b/web/src/features/experiments/hooks/useExperimentsTableData.ts
@@ -67,8 +67,14 @@ export function useExperimentsTableData({
     ],
   );
 
+  // `projectId` is read from `router.query`, which Next.js populates only after
+  // hydration. Without this guard both queries fire with `projectId: undefined`
+  // on a cold load and the rejected zod input surfaces as a "Bad Request" toast.
+  const isProjectReady = Boolean(projectId);
+
   // Fetch experiments
   const experimentsQuery = api.experiments.all.useQuery(getAllPayload, {
+    enabled: isProjectReady,
     refetchOnWindowFocus: true,
   });
 
@@ -88,13 +94,15 @@ export function useExperimentsTableData({
 
   // Fetch metrics
   const metricsQuery = api.experiments.metrics.useQuery(metricsPayload!, {
-    enabled: experimentsQuery.isSuccess && metricsPayload !== null,
+    enabled:
+      isProjectReady && experimentsQuery.isSuccess && metricsPayload !== null,
     refetchOnWindowFocus: false,
     staleTime: 0,
   });
 
   // Fetch total count
   const totalCountQuery = api.experiments.countAll.useQuery(getCountPayload, {
+    enabled: isProjectReady,
     refetchOnWindowFocus: true,
   });
 
@@ -103,7 +111,9 @@ export function useExperimentsTableData({
   // Memoize joined data to prevent infinite re-renders
   // Handle loading, error, and success states
   const joinedData = useMemo(() => {
-    if (experimentsQuery.isLoading) {
+    // A disabled query is neither loading nor errored, so keep the table in its
+    // loading state until the project id arrives instead of flashing "no rows".
+    if (!isProjectReady || experimentsQuery.isLoading) {
       return { status: "loading" as const, rows: undefined };
     }
 
@@ -117,6 +127,7 @@ export function useExperimentsTableData({
       metricsQuery.data,
     );
   }, [
+    isProjectReady,
     experimentsQuery.isLoading,
     experimentsQuery.isError,
     experimentsQuery.data?.data,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16912 app preview](https://pr-16912.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

**TL;DR** — Three bugs found while rebuilding the experiments UI, split out so they can land on their own. A cold experiments-list load shows **five error toasts**; a column toggle is counted **twice** in PostHog on **every table in the app**.

**1 of 8** in the LFE-15711 experiments-UI stack. Base: `main`.

## Why

- **Five error toasts on a cold list load.** `projectId` comes from `router.query`, which Next.js populates only after hydration. Eight queries across the two experiments surfaces fired with `projectId: undefined`, and each rejected zod input surfaced as its own "Bad Request" toast. Console errors on the same load: 11.
- **Every column toggle is counted twice.** `table:column_visibility_changed` was captured from inside the `setColumnVisibility` updater. An updater has to be pure, and React re-invokes it under StrictMode — which this app enables. **This is live on `main` today and inflates column-picker usage on every table in the app**, which matters because that event is what we read to decide which columns should be visible by default.

## What

Gate the eight queries on the id being present, and keep the table in its loading state while it is missing so a disabled query does not read as "no rows". Move the analytics capture out of the state updater and onto the click, with a test that renders the picker inside `StrictMode`.

## Result

Cold list load: **5 user-visible error toasts → 0**, console errors **11 → 2** (both a 404 for one asset, unrelated). One `column_visibility_changed` per toggle instead of two.

<details>
<summary>Mechanism, files and verification</summary>

**The projectId guard.** `useExperimentsTableData` (three queries: `all`, `metrics`, `countAll`), `useViewData` (the saved-view lookup, shared by every table with view presets), `useExperimentFilterOptions` (two), `useExperimentItemsFilterOptions`, `useExperimentNames`. A disabled query is neither loading nor errored, so `useExperimentsTableData` also treats "project id not yet known" as loading rather than falling through to the empty state.

**The double count.** `data-table-column-visibility-filter.tsx` — the next visibility state is computed before `setColumnVisibility`, captured once, and the updater is reduced to the pure spread it should always have been. The new test is a guard rather than a restatement of the existing one because it renders the harness inside `StrictMode`; without the fix it sees two events.

**Also here:** a comment recording why both experiments tables pass `isV4: true` into their filter state. Upstream landed the dimension itself while this work was in flight, so only the explanation is left.

**Verification:** `pnpm --filter=web run typecheck` clean, `turbo lint` clean across 7 packages, client suite green. Reviewed against the reconciled reference branch: [`lfe-15711-experiments-ui-rebuild`](https://github.com/langfuse/langfuse/tree/lfe-15711-experiments-ui-rebuild).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents experiment-related queries from firing before the Next.js router supplies a project ID and moves column-visibility analytics out of a React state updater.

- Adds project-readiness guards to experiment, filter-option, name, item, count, metrics, and saved-view queries.
- Keeps the experiments table loading until project identity becomes available.
- Emits one column-visibility analytics event per click and adds a StrictMode regression test.
- Documents the experiments tables' v4 analytics classification.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The new query guards prevent invalid pre-hydration requests, and the analytics change removes the StrictMode side effect without altering table visibility state.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(experiments): say why the experimen..."](https://github.com/langfuse/langfuse/commit/4a09aba706db339c7c8d71911a9d56e3c67a9128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59174860)</sub>

**Context used:**

- Knowledge Base — [Product web application](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/product-web-application.md)
- Knowledge Base — [Datasets and experiments](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/datasets-and-experiments.md)

<!-- /greptile_comment -->