### PR TITLE
feat(experiments): a worse-than-comparison filter and a score-by-run matrix

### DIFF
--- a/web/src/features/experiments/components/ExperimentDisplaySettings.tsx
+++ b/web/src/features/experiments/components/ExperimentDisplaySettings.tsx
@@ -86,6 +86,12 @@ export function ExperimentDisplaySettings({
         >
           Side by side — a column per experiment
         </OptionItem>
+        <OptionItem
+          selected={layout === "matrix"}
+          onSelect={() => onLayoutChange("matrix")}
+        >
+          Score matrix — scores as rows, runs as columns
+        </OptionItem>
 
         <DropdownMenuSeparator />
 

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -93,6 +93,20 @@ import {
   type ScoreColumnSummary,
 } from "@/src/features/experiments/fns/summariseScoreColumn";
 import { ScoreColumnHeaderSummary } from "./ScoreColumnHeaderSummary";
+import { ScoreColumnFilterMenu } from "./ScoreColumnFilterMenu";
+import { ScoreComparisonFilterPills } from "./ScoreComparisonFilterPills";
+import {
+  ExperimentScoreMatrix,
+  type ScoreMatrixRow,
+} from "./ExperimentScoreMatrix";
+import { useScoreComparisonFilters } from "@/src/features/experiments/hooks/useScoreComparisonFilters";
+import {
+  describeEmptyScoreComparison,
+  rowPassesScoreComparisonFilters,
+  scoreFieldForLevel,
+  type ScoreComparisonFilter,
+  type ScoreLevel,
+} from "@/src/features/experiments/fns/scoreComparisonFilter";
 import { resetStaleDefaultColumnOrder } from "@/src/features/experiments/fns/experimentItemsColumnOrder";
 const renderExperimentSpecificHeader = (label: string) => (
   <span className="text-muted-foreground">{label}</span>
@@ -810,6 +824,47 @@ export default function ExperimentItemsTable({
     scoreColumnDefs.traceScoreColumns,
   ]);
 
+  const scoreNamesByKey = useMemo(() => {
+    const build = (columns: ScoreColumnDef[]) =>
+      new Map(toScoreColumnInput(columns).map(({ key, name }) => [key, name]));
+    return {
+      observationScores: build(scoreColumnDefs.observationScoreColumns),
+      traceScores: build(scoreColumnDefs.traceScoreColumns),
+    };
+  }, [
+    scoreColumnDefs.observationScoreColumns,
+    scoreColumnDefs.traceScoreColumns,
+  ]);
+
+  const {
+    filters: scoreComparisonFilters,
+    setFilter: setScoreComparisonFilter,
+    removeFilter: removeScoreComparisonFilter,
+  } = useScoreComparisonFilters();
+
+  // The runs a score can be read against, the auto-selected comparison first so
+  // the menu's default is the one the column header already reports.
+  const comparisonTargets = useMemo(() => {
+    const others = selectedExperimentNames.filter(
+      (exp) => exp.experimentId !== primaryExperimentId,
+    );
+    return [
+      ...others.filter((exp) => exp.experimentId === primaryComparisonId),
+      ...others.filter((exp) => exp.experimentId !== primaryComparisonId),
+    ].map(({ experimentId, experimentName }) => ({
+      experimentId,
+      experimentName,
+    }));
+  }, [selectedExperimentNames, primaryExperimentId, primaryComparisonId]);
+
+  const scoreDataTypeFor = useCallback(
+    (filter: ScoreComparisonFilter) =>
+      scoreDataTypesByKey[scoreFieldForLevel(filter.level)].get(
+        filter.scoreKey,
+      ),
+    [scoreDataTypesByKey],
+  );
+
   const scoreColumnSummaries = useMemo(() => {
     const rowsInView = items.rows ?? [];
     return {
@@ -852,6 +907,13 @@ export default function ExperimentItemsTable({
           typeof scoreCol.header === "string"
             ? scoreCol.header
             : (scoreCol.accessorKey ?? "");
+        const level: ScoreLevel =
+          scoreField === "traceScores" ? "trace" : "observation";
+        const activeComparisonFilter = key
+          ? scoreComparisonFilters.find(
+              (filter) => filter.level === level && filter.scoreKey === key,
+            )
+          : undefined;
 
         return {
           ...scoreCol,
@@ -868,6 +930,27 @@ export default function ExperimentItemsTable({
                     dataType={dataType}
                     summary={summary}
                     comparisonName={primaryComparisonName}
+                    filterMenu={
+                      <ScoreColumnFilterMenu
+                        targets={comparisonTargets}
+                        hasOrder={dataType !== "CATEGORICAL"}
+                        active={activeComparisonFilter}
+                        onSelect={(operator, comparisonExperimentId) => {
+                          if (!key) return;
+                          const nextFilter = {
+                            level,
+                            scoreKey: key,
+                            operator,
+                            comparisonExperimentId,
+                          };
+                          setScoreComparisonFilter(nextFilter);
+                        }}
+                        onClear={() =>
+                          activeComparisonFilter &&
+                          removeScoreComparisonFilter(activeComparisonFilter)
+                        }
+                      />
+                    }
                   />
                 ),
               }
@@ -971,6 +1054,10 @@ export default function ExperimentItemsTable({
       scoreColumnSummaries,
       scoreDataTypesByKey,
       showComparisonDiff,
+      comparisonTargets,
+      scoreComparisonFilters,
+      setScoreComparisonFilter,
+      removeScoreComparisonFilter,
       runNameOf,
     ],
   );
@@ -1428,8 +1515,20 @@ export default function ExperimentItemsTable({
   const rows: ExperimentItemsTableRow[] = useMemo(() => {
     if (items.status !== "success" || !items.rows) return [];
     // Add 'id' field for DataTable row identification (peek view requires it)
-    return items.rows.map((row) => ({ ...row, id: row.itemId }));
-  }, [items]);
+    const withIds = items.rows.map((row) => ({ ...row, id: row.itemId }));
+    // The score comparison filters narrow the page here rather than in the
+    // query — see `useScoreComparisonFilters` for why. The header aggregates
+    // deliberately keep describing the whole fetched page, so the movement the
+    // filter was built from stays readable while it is applied.
+    return withIds.filter((row) =>
+      rowPassesScoreComparisonFilters({
+        filters: scoreComparisonFilters,
+        experiments: row.experiments,
+        baselineExperimentId: primaryExperimentId,
+        dataTypeFor: scoreDataTypeFor,
+      }),
+    );
+  }, [items, scoreComparisonFilters, primaryExperimentId, scoreDataTypeFor]);
 
   useEffect(() => {
     if (items.status === "success") {
@@ -1470,6 +1569,38 @@ export default function ExperimentItemsTable({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items.status, rows, baselineId]);
+
+  // Plain English for the active comparisons, and for the table when they leave
+  // nothing: "no regressions on this score" is an answer, not a broken table.
+  const scoreComparisonPills = useMemo(
+    () =>
+      scoreComparisonFilters.map((filter) => ({
+        filter,
+        scoreName:
+          scoreNamesByKey[scoreFieldForLevel(filter.level)].get(
+            filter.scoreKey,
+          ) ?? filter.scoreKey,
+        comparisonName:
+          selectedExperimentNames.find(
+            (exp) => exp.experimentId === filter.comparisonExperimentId,
+          )?.experimentName ?? filter.comparisonExperimentId,
+      })),
+    [scoreComparisonFilters, scoreNamesByKey, selectedExperimentNames],
+  );
+
+  const scoreComparisonEmptyMessage = useMemo(() => {
+    if (rows.length > 0 || (items.rows ?? []).length === 0) return undefined;
+    if (scoreComparisonPills.length !== 1)
+      return scoreComparisonPills.length > 1
+        ? "No item on this page matches every score comparison."
+        : undefined;
+    const [pill] = scoreComparisonPills;
+    return describeEmptyScoreComparison({
+      operator: pill.filter.operator,
+      scoreName: pill.scoreName,
+      comparisonName: pill.comparisonName,
+    });
+  }, [rows.length, items.rows, scoreComparisonPills]);
 
   const pagination = useMemo(
     () => ({
@@ -1640,6 +1771,13 @@ export default function ExperimentItemsTable({
           />
         )}
 
+        {/* Score comparison filters — evaluated over the loaded page */}
+        <ScoreComparisonFilterPills
+          pills={scoreComparisonPills}
+          onRemove={removeScoreComparisonFilter}
+          className="border-b"
+        />
+
         {/* Filter Pills with Experiment Targeting */}
         {filtersByExperiment.length > 0 && (
           <ExperimentFilterPills
@@ -1719,6 +1857,10 @@ export default function ExperimentItemsTable({
                   !hasSelectedRuns ? (
                     <span className="text-muted-foreground text-sm">
                       Please select a baseline experiment.
+                    </span>
+                  ) : scoreComparisonEmptyMessage ? (
+                    <span className="text-muted-foreground text-sm">
+                      {scoreComparisonEmptyMessage}
                     </span>
                   ) : undefined
                 }

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -711,6 +711,16 @@ export default function ExperimentItemsTable({
     () => allExperimentIds.join(","),
     [allExperimentIds],
   );
+  // The selection arrives as a fresh array on every render, so anything that
+  // reaches a hook dependency has to come off the key, which is stable by
+  // value. `rows` below is one of those: it feeds the effect that publishes the
+  // peek navigation list, and publishing re-renders every consumer of that
+  // provider — this table included. Depending on the array identity there
+  // leaves the two re-triggering each other for as long as the page is open.
+  const comparableExperimentIds = useMemo(
+    () => (experimentSelectionKey ? experimentSelectionKey.split(",") : []),
+    [experimentSelectionKey],
+  );
   const [expectedOutputSeenFor, setExpectedOutputSeenFor] = useState<
     string | null
   >(null);
@@ -1600,7 +1610,7 @@ export default function ExperimentItemsTable({
           filters: scoreComparisonFilters,
           experiments: row.experiments,
           baselineExperimentId: primaryExperimentId,
-          comparableExperimentIds: allExperimentIds,
+          comparableExperimentIds,
           dataTypeFor: scoreDataTypeFor,
         }),
       ),
@@ -1608,7 +1618,7 @@ export default function ExperimentItemsTable({
       unfilteredRows,
       scoreComparisonFilters,
       primaryExperimentId,
-      allExperimentIds,
+      comparableExperimentIds,
       scoreDataTypeFor,
     ],
   );

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -1453,6 +1453,59 @@ export default function ExperimentItemsTable({
     columnOrderMigrations,
   );
 
+  // The transposed layout's axes (LFE-15711 C8): score columns as rows —
+  // respecting what the column picker hid — and the selected runs as columns,
+  // baseline first. Both are a re-read of what the grid already has, so the
+  // layout needs no query of its own.
+  const matrixScoreRows = useMemo<ScoreMatrixRow[]>(() => {
+    const build = (
+      scoreCols: LangfuseColumnDef<ExperimentItemData>[],
+      level: ScoreLevel,
+    ): ScoreMatrixRow[] =>
+      scoreCols.flatMap((scoreCol) => {
+        const accessorKey = scoreCol.accessorKey;
+        if (!accessorKey || columnVisibility[accessorKey] === false) return [];
+        const scoreKey = accessorKey.replace(/^Trace-/, "");
+        const dataType =
+          scoreDataTypesByKey[scoreFieldForLevel(level)].get(scoreKey);
+        if (!dataType) return [];
+        return [
+          {
+            scoreKey,
+            level,
+            dataType,
+            label:
+              typeof scoreCol.header === "string" ? scoreCol.header : scoreKey,
+          },
+        ];
+      });
+    return [
+      ...build(observationScoreColumns, "observation"),
+      ...build(traceScoreColumns, "trace"),
+    ];
+  }, [
+    observationScoreColumns,
+    traceScoreColumns,
+    scoreDataTypesByKey,
+    columnVisibility,
+  ]);
+
+  const matrixExperiments = useMemo(
+    () =>
+      [
+        ...(primaryExperimentId ? [primaryExperimentId] : []),
+        ...allExperimentIds.filter((id) => id !== primaryExperimentId),
+      ].map((experimentId) => ({
+        experimentId,
+        experimentName:
+          selectedExperimentNames.find(
+            (exp) => exp.experimentId === experimentId,
+          )?.experimentName ?? experimentId.slice(0, 8),
+        isBaseline: experimentId === primaryExperimentId,
+      })),
+    [allExperimentIds, primaryExperimentId, selectedExperimentNames],
+  );
+
   const peekNavigationProps = usePeekNavigation({
     queryParams: [
       "observation",
@@ -1800,7 +1853,22 @@ export default function ExperimentItemsTable({
           )}
 
           <div className="flex flex-1 flex-col overflow-hidden">
-            {layout === "grid" ? (
+            {layout === "matrix" ? (
+              hasSelectedRuns ? (
+                <ExperimentScoreMatrix
+                  rows={rows}
+                  scoreRows={matrixScoreRows}
+                  experiments={matrixExperiments}
+                  isLoading={items.status === "loading" || isViewLoading}
+                />
+              ) : (
+                <div className="flex flex-1 items-center justify-center">
+                  <span className="text-muted-foreground text-sm">
+                    Please select a baseline experiment.
+                  </span>
+                </div>
+              )
+            ) : layout === "grid" ? (
               hasSelectedRuns ? (
                 <ExperimentGridView
                   projectId={projectId}

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -1889,6 +1889,7 @@ export default function ExperimentItemsTable({
                   scoreRows={matrixScoreRows}
                   experiments={matrixExperiments}
                   isLoading={items.status === "loading" || isViewLoading}
+                  pagination={pagination}
                 />
               ) : (
                 <div className="flex flex-1 items-center justify-center">

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -1453,7 +1453,7 @@ export default function ExperimentItemsTable({
     columnOrderMigrations,
   );
 
-  // The transposed layout's axes (LFE-15711 C8): score columns as rows —
+  // The transposed layout's axes: score columns as rows —
   // respecting what the column picker hid — and the selected runs as columns,
   // baseline first. Both are a re-read of what the grid already has, so the
   // layout needs no query of its own.
@@ -1565,23 +1565,37 @@ export default function ExperimentItemsTable({
     };
   }, [peekNavigationProps, canUsePeek]);
 
-  const rows: ExperimentItemsTableRow[] = useMemo(() => {
+  // The page as fetched. The score column header aggregates — and the score
+  // matrix, which reads the same ones — deliberately describe this whole page,
+  // so the movement a comparison filter was built from stays readable while
+  // that filter is applied.
+  const unfilteredRows: ExperimentItemsTableRow[] = useMemo(() => {
     if (items.status !== "success" || !items.rows) return [];
     // Add 'id' field for DataTable row identification (peek view requires it)
-    const withIds = items.rows.map((row) => ({ ...row, id: row.itemId }));
-    // The score comparison filters narrow the page here rather than in the
-    // query — see `useScoreComparisonFilters` for why. The header aggregates
-    // deliberately keep describing the whole fetched page, so the movement the
-    // filter was built from stays readable while it is applied.
-    return withIds.filter((row) =>
-      rowPassesScoreComparisonFilters({
-        filters: scoreComparisonFilters,
-        experiments: row.experiments,
-        baselineExperimentId: primaryExperimentId,
-        dataTypeFor: scoreDataTypeFor,
-      }),
-    );
-  }, [items, scoreComparisonFilters, primaryExperimentId, scoreDataTypeFor]);
+    return items.rows.map((row) => ({ ...row, id: row.itemId }));
+  }, [items]);
+
+  // The score comparison filters narrow the page here rather than in the
+  // query — see `useScoreComparisonFilters` for why.
+  const rows: ExperimentItemsTableRow[] = useMemo(
+    () =>
+      unfilteredRows.filter((row) =>
+        rowPassesScoreComparisonFilters({
+          filters: scoreComparisonFilters,
+          experiments: row.experiments,
+          baselineExperimentId: primaryExperimentId,
+          comparableExperimentIds: allExperimentIds,
+          dataTypeFor: scoreDataTypeFor,
+        }),
+      ),
+    [
+      unfilteredRows,
+      scoreComparisonFilters,
+      primaryExperimentId,
+      allExperimentIds,
+      scoreDataTypeFor,
+    ],
+  );
 
   useEffect(() => {
     if (items.status === "success") {
@@ -1856,7 +1870,7 @@ export default function ExperimentItemsTable({
             {layout === "matrix" ? (
               hasSelectedRuns ? (
                 <ExperimentScoreMatrix
-                  rows={rows}
+                  rows={unfilteredRows}
                   scoreRows={matrixScoreRows}
                   experiments={matrixExperiments}
                   isLoading={items.status === "loading" || isViewLoading}
@@ -1895,6 +1909,13 @@ export default function ExperimentItemsTable({
                   rowSelection={selectedRows}
                   setRowSelection={setSelectedRows}
                   highlightAllRows={selectAll}
+                  noResultsMessage={
+                    scoreComparisonEmptyMessage ? (
+                      <span className="text-muted-foreground text-sm">
+                        {scoreComparisonEmptyMessage}
+                      </span>
+                    ) : undefined
+                  }
                 />
               ) : (
                 <div className="flex flex-1 items-center justify-center">

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -93,7 +93,10 @@ import {
   type ScoreColumnSummary,
 } from "@/src/features/experiments/fns/summariseScoreColumn";
 import { ScoreColumnHeaderSummary } from "./ScoreColumnHeaderSummary";
-import { ScoreColumnFilterMenu } from "./ScoreColumnFilterMenu";
+import {
+  ScoreColumnFilterMenu,
+  ScoreColumnFilterMenuTrigger,
+} from "./ScoreColumnFilterMenu";
 import { ScoreComparisonFilterPills } from "./ScoreComparisonFilterPills";
 import {
   ExperimentScoreMatrix,
@@ -949,7 +952,20 @@ export default function ExperimentItemsTable({
                           activeComparisonFilter &&
                           removeScoreComparisonFilter(activeComparisonFilter)
                         }
-                      />
+                      >
+                        {({ Trigger }) => (
+                          // The header cell sorts on click, so opening the menu
+                          // must not also reorder the table.
+                          <Trigger
+                            asChild
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            <ScoreColumnFilterMenuTrigger
+                              isActive={Boolean(activeComparisonFilter)}
+                            />
+                          </Trigger>
+                        )}
+                      </ScoreColumnFilterMenu>
                     }
                   />
                 ),
@@ -1842,7 +1858,6 @@ export default function ExperimentItemsTable({
         <ScoreComparisonFilterPills
           pills={scoreComparisonPills}
           onRemove={removeScoreComparisonFilter}
-          className="border-b"
         />
 
         {/* Filter Pills with Experiment Targeting */}

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -944,38 +944,40 @@ export default function ExperimentItemsTable({
                     summary={summary}
                     comparisonName={primaryComparisonName}
                     filterMenu={
-                      <ScoreColumnFilterMenu
-                        targets={comparisonTargets}
-                        hasOrder={dataType !== "CATEGORICAL"}
-                        active={activeComparisonFilter}
-                        onSelect={(operator, comparisonExperimentId) => {
-                          if (!key) return;
-                          const nextFilter = {
-                            level,
-                            scoreKey: key,
-                            operator,
-                            comparisonExperimentId,
-                          };
-                          setScoreComparisonFilter(nextFilter);
-                        }}
-                        onClear={() =>
-                          activeComparisonFilter &&
-                          removeScoreComparisonFilter(activeComparisonFilter)
-                        }
-                      >
-                        {({ Trigger }) => (
-                          // The header cell sorts on click, so opening the menu
-                          // must not also reorder the table.
-                          <Trigger
-                            asChild
-                            onClick={(event) => event.stopPropagation()}
-                          >
-                            <ScoreColumnFilterMenuTrigger
-                              isActive={Boolean(activeComparisonFilter)}
-                            />
-                          </Trigger>
-                        )}
-                      </ScoreColumnFilterMenu>
+                      comparisonTargets.length === 0 ? undefined : (
+                        <ScoreColumnFilterMenu
+                          targets={comparisonTargets}
+                          hasOrder={dataType !== "CATEGORICAL"}
+                          active={activeComparisonFilter}
+                          onSelect={(operator, comparisonExperimentId) => {
+                            if (!key) return;
+                            const nextFilter = {
+                              level,
+                              scoreKey: key,
+                              operator,
+                              comparisonExperimentId,
+                            };
+                            setScoreComparisonFilter(nextFilter);
+                          }}
+                          onClear={() =>
+                            activeComparisonFilter &&
+                            removeScoreComparisonFilter(activeComparisonFilter)
+                          }
+                        >
+                          {({ Trigger }) => (
+                            // The header cell sorts on click, so opening the menu
+                            // must not also reorder the table.
+                            <Trigger
+                              asChild
+                              onClick={(event) => event.stopPropagation()}
+                            >
+                              <ScoreColumnFilterMenuTrigger
+                                isActive={Boolean(activeComparisonFilter)}
+                              />
+                            </Trigger>
+                          )}
+                        </ScoreColumnFilterMenu>
+                      )
                     }
                   />
                 ),
@@ -1865,10 +1867,12 @@ export default function ExperimentItemsTable({
         )}
 
         {/* Score comparison filters — evaluated over the loaded page */}
-        <ScoreComparisonFilterPills
-          pills={scoreComparisonPills}
-          onRemove={removeScoreComparisonFilter}
-        />
+        {scoreComparisonPills.length > 0 && (
+          <ScoreComparisonFilterPills
+            pills={scoreComparisonPills}
+            onRemove={removeScoreComparisonFilter}
+          />
+        )}
 
         {/* Filter Pills with Experiment Targeting */}
         {filtersByExperiment.length > 0 && (

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.clienttest.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.clienttest.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { PaginationState } from "@tanstack/react-table";
+import { TooltipProvider } from "@/src/components/ui/tooltip";
+import {
+  ExperimentScoreMatrix,
+  type ScoreMatrixColumn,
+  type ScoreMatrixRow,
+} from "./ExperimentScoreMatrix";
+import type { ExperimentItemsTableRow } from "./types";
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+const scoreKey = "groundedness-EVAL-NUMERIC";
+
+const scoreRows: ScoreMatrixRow[] = [
+  { scoreKey, level: "trace", dataType: "NUMERIC", label: "# groundedness" },
+];
+
+const experiments: ScoreMatrixColumn[] = [
+  { experimentId: "base", experimentName: "baseline-run", isBaseline: true },
+  { experimentId: "cand", experimentName: "candidate-run", isBaseline: false },
+];
+
+const itemRow = (id: string, value: number): ExperimentItemsTableRow =>
+  ({
+    id,
+    experiments: experiments.map((experiment) => ({
+      experimentId: experiment.experimentId,
+      traceScores: { [scoreKey]: { type: "NUMERIC", average: value } },
+    })),
+  }) as unknown as ExperimentItemsTableRow;
+
+const renderMatrix = ({
+  rows,
+  state,
+  onChange,
+  totalCount,
+}: {
+  rows: ExperimentItemsTableRow[];
+  state: PaginationState;
+  onChange: (next: unknown) => void;
+  totalCount: number | null;
+}) =>
+  render(
+    <TooltipProvider>
+      <ExperimentScoreMatrix
+        rows={rows}
+        scoreRows={scoreRows}
+        experiments={experiments}
+        isLoading={false}
+        pagination={{ totalCount, onChange, state }}
+      />
+    </TooltipProvider>,
+  );
+
+describe("ExperimentScoreMatrix pagination", () => {
+  it("offers page controls and reports the window it aggregated", () => {
+    const onChange = vi.fn();
+    renderMatrix({
+      rows: [itemRow("a", 0.5), itemRow("b", 0.7)],
+      state: { pageIndex: 0, pageSize: 2 },
+      onChange,
+      totalCount: 6,
+    });
+
+    // The footnote has to name the window, since the cells above it are an
+    // aggregate over exactly these rows and not over the whole run.
+    expect(
+      screen.getByText(/aggregated over the 2 items on this page/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /go to next page/i }));
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("keeps the page controls when no score has a value on this page", () => {
+    render(
+      <TooltipProvider>
+        <ExperimentScoreMatrix
+          rows={[itemRow("a", 0.5)]}
+          scoreRows={[]}
+          experiments={experiments}
+          isLoading={false}
+          pagination={{
+            totalCount: 6,
+            onChange: vi.fn(),
+            state: { pageIndex: 1, pageSize: 1 },
+          }}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(
+      screen.getByText(/No score columns are visible for the items in view/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /go to next page/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
@@ -192,6 +192,10 @@ export const ExperimentScoreMatrix = ({
         ? -1
         : Math.ceil(Number(pagination.totalCount) / pagination.state.pageSize),
     onPaginationChange: pagination.onChange,
+    // The page lives in the URL and the rows arrive per page, so TanStack's
+    // default reset-on-data-change would write page 1 back on every fetch and
+    // re-fetch from it. The data tables opt out for the same reason.
+    autoResetPageIndex: false,
     state: { pagination: pagination.state },
   });
 

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
@@ -1,0 +1,285 @@
+import { useMemo } from "react";
+import { Badge } from "@/src/components/ui/badge";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+import { DiffLabel } from "@/src/features/datasets/components/DiffLabel";
+import {
+  getScoreDataTypeExplanation,
+  splitScoreDataTypeIcon,
+} from "@/src/features/scores/lib/scoreColumns";
+import {
+  formatScoreColumnAggregate,
+  formatScoreValue,
+} from "@/src/features/experiments/fns/formatScoreColumnAggregate";
+import {
+  summariseScoreColumn,
+  type ScoreColumnDataType,
+  type ScoreColumnSummary,
+} from "@/src/features/experiments/fns/summariseScoreColumn";
+import {
+  scoreFieldForLevel,
+  type ScoreLevel,
+} from "@/src/features/experiments/fns/scoreComparisonFilter";
+import {
+  getExperimentColorStyles,
+  type ExperimentItemsTableRow,
+} from "./types";
+import { cn } from "@/src/utils/tailwind";
+
+/** One row of the matrix: a score column, read at its own level. */
+export type ScoreMatrixRow = {
+  scoreKey: string;
+  level: ScoreLevel;
+  dataType: ScoreColumnDataType;
+  /** The column header, e.g. `Trace: # groundedness (eval)`. */
+  label: string;
+};
+
+/** One column of the matrix: a selected experiment, the baseline first. */
+export type ScoreMatrixColumn = {
+  experimentId: string;
+  experimentName: string;
+  isBaseline: boolean;
+};
+
+const MatrixCell = ({
+  summary,
+  hasBaselineColumn,
+}: {
+  summary: ScoreColumnSummary;
+  /** False for the baseline's own column, which has nothing to move against. */
+  hasBaselineColumn: boolean;
+}) => {
+  const { baseline, delta, movement } = summary;
+  const notComparable = movement?.notComparable ?? 0;
+
+  if (!baseline)
+    return <span className="text-muted-foreground">not scored</span>;
+
+  return (
+    <span className="flex flex-wrap items-center gap-x-1 gap-y-0.5 tabular-nums">
+      <span className="font-bold">{formatScoreColumnAggregate(baseline)}</span>
+      {hasBaselineColumn && delta !== null && delta !== 0 && (
+        <DiffLabel
+          diff={{
+            type: "NUMERIC",
+            absoluteDifference: Math.abs(delta),
+            direction: delta > 0 ? "+" : "-",
+          }}
+          formatValue={formatScoreValue}
+        />
+      )}
+      {hasBaselineColumn && movement && movement.changed > 0 && (
+        <span className="text-muted-foreground">↻{movement.changed}</span>
+      )}
+      {/* Items only one of the two runs scored: never folded into the delta. */}
+      {hasBaselineColumn && notComparable > 0 && (
+        <span className="text-muted-foreground opacity-70">
+          {notComparable} n/a
+        </span>
+      )}
+    </span>
+  );
+};
+
+/**
+ * The transpose of the grid: **scores as rows, experiments as columns**, every
+ * cell the run's aggregate plus its move against the baseline column. Answers
+ * "how did all my runs move on all my metrics" in one screen — what the deleted
+ * Analytics tab was going to be. (LFE-15711 C8)
+ *
+ * It needs no query of its own: the aggregates are the same ones the score
+ * column headers compute, over the items already loaded for this page.
+ */
+export const ExperimentScoreMatrix = ({
+  rows,
+  scoreRows,
+  experiments,
+  isLoading,
+}: {
+  rows: ExperimentItemsTableRow[];
+  scoreRows: ScoreMatrixRow[];
+  experiments: ScoreMatrixColumn[];
+  isLoading: boolean;
+}) => {
+  const baselineExperimentId = experiments.find(
+    (exp) => exp.isBaseline,
+  )?.experimentId;
+
+  const summaries = useMemo(() => {
+    const scoresOf = (
+      row: ExperimentItemsTableRow,
+      experimentId: string,
+      level: ScoreLevel,
+    ) =>
+      row.experiments.find((exp) => exp.experimentId === experimentId)?.[
+        scoreFieldForLevel(level)
+      ];
+
+    // Cell (score, experiment) reads the experiment as the thing the delta
+    // describes and the baseline column as what it moved against — the same
+    // frame as a score column header.
+    const byScore = new Map<string, Map<string, ScoreColumnSummary>>();
+    for (const scoreRow of scoreRows) {
+      const byExperiment = new Map<string, ScoreColumnSummary>();
+      for (const experiment of experiments) {
+        byExperiment.set(
+          experiment.experimentId,
+          summariseScoreColumn({
+            pairs: rows.map((row) => ({
+              baseline:
+                scoresOf(row, experiment.experimentId, scoreRow.level)?.[
+                  scoreRow.scoreKey
+                ] ?? null,
+              comparison:
+                baselineExperimentId === undefined
+                  ? null
+                  : (scoresOf(row, baselineExperimentId, scoreRow.level)?.[
+                      scoreRow.scoreKey
+                    ] ?? null),
+            })),
+            dataType: scoreRow.dataType,
+            hasComparison:
+              baselineExperimentId !== undefined &&
+              experiment.experimentId !== baselineExperimentId,
+          }),
+        );
+      }
+      byScore.set(`${scoreRow.level}-${scoreRow.scoreKey}`, byExperiment);
+    }
+    return byScore;
+  }, [rows, scoreRows, experiments, baselineExperimentId]);
+
+  if (isLoading)
+    return (
+      <div className="flex flex-col gap-2 p-4">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Skeleton key={index} className="h-6 w-full" />
+        ))}
+      </div>
+    );
+
+  if (scoreRows.length === 0)
+    return (
+      <div className="flex flex-1 items-center justify-center p-4">
+        <span className="text-muted-foreground text-sm">
+          No score columns are visible for the items in view.
+        </span>
+      </div>
+    );
+
+  const allExperimentIds = experiments.map((exp) => exp.experimentId);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="w-full min-w-max border-separate border-spacing-0 text-xs">
+          <thead>
+            <tr>
+              <th className="bg-background text-muted-foreground sticky top-0 left-0 z-20 min-w-[220px] border-b p-2 text-left font-normal">
+                Score
+              </th>
+              {experiments.map((experiment) => {
+                const colorStyles = getExperimentColorStyles(
+                  experiment.experimentId,
+                  allExperimentIds,
+                );
+                return (
+                  <th
+                    key={experiment.experimentId}
+                    className="bg-background sticky top-0 z-10 min-w-[150px] border-b p-2 text-left font-normal"
+                  >
+                    <span className="flex min-w-0 items-center gap-1">
+                      <span
+                        className={cn(
+                          "block h-3 w-0.5 shrink-0 rounded-full",
+                          colorStyles.markerClass,
+                        )}
+                      />
+                      <span
+                        className="truncate font-bold"
+                        title={experiment.experimentName}
+                      >
+                        {experiment.experimentName}
+                      </span>
+                      {experiment.isBaseline && (
+                        <Badge
+                          size="sm"
+                          variant="secondary"
+                          className="shrink-0"
+                        >
+                          baseline
+                        </Badge>
+                      )}
+                    </span>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {scoreRows.map((scoreRow) => {
+              const { icon, label } = splitScoreDataTypeIcon(scoreRow.label);
+              const byExperiment = summaries.get(
+                `${scoreRow.level}-${scoreRow.scoreKey}`,
+              );
+              return (
+                <tr key={`${scoreRow.level}-${scoreRow.scoreKey}`}>
+                  <th
+                    scope="row"
+                    className="bg-background sticky left-0 z-10 min-w-[220px] border-b p-2 text-left font-normal"
+                  >
+                    <span className="flex min-w-0 items-baseline gap-1">
+                      {icon && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="text-muted-foreground shrink-0 cursor-default">
+                              {icon}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-[280px]">
+                            {getScoreDataTypeExplanation(scoreRow.dataType)}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                      <span className="truncate" title={scoreRow.label}>
+                        {label}
+                      </span>
+                    </span>
+                  </th>
+                  {experiments.map((experiment) => {
+                    const summary = byExperiment?.get(experiment.experimentId);
+                    return (
+                      <td
+                        key={experiment.experimentId}
+                        className="min-w-[150px] border-b p-2 align-top"
+                      >
+                        {summary ? (
+                          <MatrixCell
+                            summary={summary}
+                            hasBaselineColumn={!experiment.isBaseline}
+                          />
+                        ) : null}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className="text-muted-foreground border-t px-2 py-1.5 text-[10px]">
+        {scoreRows.length} score{scoreRows.length === 1 ? "" : "s"} ×{" "}
+        {experiments.length} run{experiments.length === 1 ? "" : "s"},
+        aggregated over the {rows.length} item
+        {rows.length === 1 ? "" : "s"} loaded on this page. Deltas are measured
+        against the baseline column.
+      </div>
+    </div>
+  );
+};

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
@@ -90,7 +90,7 @@ const MatrixCell = ({
  * The transpose of the grid: **scores as rows, experiments as columns**, every
  * cell the run's aggregate plus its move against the baseline column. Answers
  * "how did all my runs move on all my metrics" in one screen — what the deleted
- * Analytics tab was going to be. (LFE-15711 C8)
+ * Analytics tab was going to be.
  *
  * It needs no query of its own: the aggregates are the same ones the score
  * column headers compute, over the items already loaded for this page.

--- a/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
+++ b/web/src/features/experiments/components/table/ExperimentScoreMatrix.tsx
@@ -1,6 +1,15 @@
 import { useMemo } from "react";
+import {
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+  type OnChangeFn,
+  type PaginationState,
+  type Table as TanStackTable,
+} from "@tanstack/react-table";
 import { Badge } from "@/src/components/ui/badge";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { DataTablePagination } from "@/src/components/table/data-table-pagination";
 import {
   Tooltip,
   TooltipContent,
@@ -29,6 +38,12 @@ import {
   type ExperimentItemsTableRow,
 } from "./types";
 import { cn } from "@/src/utils/tailwind";
+
+/**
+ * The pagination instance never renders cells, only counts rows, so it needs
+ * no column defs. Module-level so the reference stays stable across renders.
+ */
+const NO_COLUMNS: ColumnDef<ExperimentItemsTableRow>[] = [];
 
 /** One row of the matrix: a score column, read at its own level. */
 export type ScoreMatrixRow = {
@@ -93,18 +108,26 @@ const MatrixCell = ({
  * Analytics tab was going to be.
  *
  * It needs no query of its own: the aggregates are the same ones the score
- * column headers compute, over the items already loaded for this page.
+ * column headers compute, over the items already loaded for this page. Which
+ * page that is stays the user's choice — see `paginationTable`.
  */
 export const ExperimentScoreMatrix = ({
   rows,
   scoreRows,
   experiments,
   isLoading,
+  pagination,
 }: {
   rows: ExperimentItemsTableRow[];
   scoreRows: ScoreMatrixRow[];
   experiments: ScoreMatrixColumn[];
   isLoading: boolean;
+  pagination: {
+    totalCount: number | null;
+    onChange: OnChangeFn<PaginationState>;
+    state: PaginationState;
+    options?: number[];
+  };
 }) => {
   const baselineExperimentId = experiments.find(
     (exp) => exp.isBaseline,
@@ -154,6 +177,24 @@ export const ExperimentScoreMatrix = ({
     return byScore;
   }, [rows, scoreRows, experiments, baselineExperimentId]);
 
+  // The matrix aggregates the items on the page instead of listing them, so it
+  // has no table of its own to drive the pagination bar. A headless instance
+  // over the same rows and the same URL-held state does, which keeps the
+  // aggregate's window under the user's control rather than pinning it to
+  // whichever page was open first.
+  const paginationTable = useReactTable({
+    data: rows,
+    columns: NO_COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    pageCount:
+      pagination.totalCount === null
+        ? -1
+        : Math.ceil(Number(pagination.totalCount) / pagination.state.pageSize),
+    onPaginationChange: pagination.onChange,
+    state: { pagination: pagination.state },
+  });
+
   if (isLoading)
     return (
       <div className="flex flex-col gap-2 p-4">
@@ -163,16 +204,28 @@ export const ExperimentScoreMatrix = ({
       </div>
     );
 
+  const allExperimentIds = experiments.map((exp) => exp.experimentId);
+
+  // The empty state shares the footer, so the page controls stay reachable
+  // when the items on this page happen to carry none of the visible scores.
   if (scoreRows.length === 0)
     return (
-      <div className="flex flex-1 items-center justify-center p-4">
-        <span className="text-muted-foreground text-sm">
-          No score columns are visible for the items in view.
-        </span>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex flex-1 items-center justify-center p-4">
+          <span className="text-muted-foreground text-sm">
+            No score columns are visible for the items in view.
+          </span>
+        </div>
+        <MatrixFooter
+          scoreCount={0}
+          experimentCount={experiments.length}
+          itemCount={rows.length}
+          paginationTable={paginationTable}
+          paginationOptions={pagination.options}
+          isLoading={isLoading}
+        />
       </div>
     );
-
-  const allExperimentIds = experiments.map((exp) => exp.experimentId);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -273,13 +326,50 @@ export const ExperimentScoreMatrix = ({
           </tbody>
         </table>
       </div>
-      <div className="text-muted-foreground border-t px-2 py-1.5 text-[10px]">
-        {scoreRows.length} score{scoreRows.length === 1 ? "" : "s"} ×{" "}
-        {experiments.length} run{experiments.length === 1 ? "" : "s"},
-        aggregated over the {rows.length} item
-        {rows.length === 1 ? "" : "s"} loaded on this page. Deltas are measured
-        against the baseline column.
-      </div>
+      <MatrixFooter
+        scoreCount={scoreRows.length}
+        experimentCount={experiments.length}
+        itemCount={rows.length}
+        paginationTable={paginationTable}
+        paginationOptions={pagination.options}
+        isLoading={isLoading}
+      />
     </div>
   );
 };
+
+/**
+ * What the numbers above cover, and the control that changes it. The scope
+ * sentence and the page controls sit on one line deliberately: the aggregate
+ * is a window over the run, so reading it without seeing which window is
+ * selected invites the wrong conclusion.
+ */
+const MatrixFooter = ({
+  scoreCount,
+  experimentCount,
+  itemCount,
+  paginationTable,
+  paginationOptions,
+  isLoading,
+}: {
+  scoreCount: number;
+  experimentCount: number;
+  itemCount: number;
+  paginationTable: TanStackTable<ExperimentItemsTableRow>;
+  paginationOptions?: number[];
+  isLoading: boolean;
+}) => (
+  <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t px-2 py-1.5">
+    <span className="text-muted-foreground text-[10px]">
+      {scoreCount} score{scoreCount === 1 ? "" : "s"} × {experimentCount} run
+      {experimentCount === 1 ? "" : "s"}, aggregated over the {itemCount} item
+      {itemCount === 1 ? "" : "s"} on this page. Deltas are measured against the
+      baseline column.
+    </span>
+    <DataTablePagination
+      table={paginationTable}
+      isLoading={isLoading}
+      paginationOptions={paginationOptions}
+    />
+  </div>
+);

--- a/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
@@ -1,7 +1,10 @@
-/* eslint-disable @repo/no-abstracted-overlay-trigger */
 import {
-  DropdownMenu,
-  DropdownMenuContent,
+  forwardRef,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+} from "react";
+import {
+  DropdownMenuController,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuPortal,
@@ -9,7 +12,6 @@ import {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { Check, ListFilter } from "lucide-react";
 import { type ScoreComparisonOperator } from "@/src/features/experiments/fns/scoreComparisonFilter";
@@ -33,6 +35,38 @@ const ORDERED_OPERATORS: ScoreComparisonOperator[] = [
 ];
 
 /**
+ * The score header's filter affordance. Spreads and forwards so a
+ * `<Trigger asChild>` at the call site can hand it Radix's open state and
+ * handlers, and takes its look from an explicit variant rather than a style
+ * prop.
+ */
+export const ScoreColumnFilterMenuTrigger = forwardRef<
+  HTMLButtonElement,
+  Omit<
+    ComponentPropsWithoutRef<"button">,
+    "className" | "style" | "children" | "aria-label"
+  > & {
+    /** A filter is set on this score, so the control stops hiding itself. */
+    isActive: boolean;
+  }
+>(({ isActive, ...triggerProps }, ref) => (
+  <button
+    ref={ref}
+    aria-label="Filter items by this score"
+    className={cn(
+      "hover:bg-muted mt-0.5 shrink-0 rounded-sm p-0.5",
+      isActive
+        ? "text-primary-accent"
+        : "text-muted-foreground opacity-0 group-hover:opacity-100",
+    )}
+    {...triggerProps}
+  >
+    <ListFilter className="h-3 w-3" />
+  </button>
+));
+ScoreColumnFilterMenuTrigger.displayName = "ScoreColumnFilterMenuTrigger";
+
+/**
  * The score column's own way into the comparison filter: "show
  * only the items worse than <comparison> on this score", from the header of the
  * score in question, with the comparison to read against picked here rather than
@@ -44,6 +78,7 @@ export const ScoreColumnFilterMenu = ({
   hasOrder,
   onSelect,
   onClear,
+  children,
 }: {
   /** The experiments this score can be read against, default first. */
   targets: ScoreComparisonTarget[];
@@ -58,6 +93,8 @@ export const ScoreColumnFilterMenu = ({
     comparisonExperimentId: string,
   ) => void;
   onClear: () => void;
+  /** Renders the trigger, so its presentation stays with the caller. */
+  children: ComponentProps<typeof DropdownMenuController>["children"];
 }) => {
   if (targets.length === 0) return null;
 
@@ -67,87 +104,78 @@ export const ScoreColumnFilterMenu = ({
     active?.comparisonExperimentId === experimentId;
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          aria-label="Filter items by this score"
-          onClick={(event) => event.stopPropagation()}
-          className={cn(
-            "hover:bg-muted mt-0.5 shrink-0 rounded-sm p-0.5",
-            active
-              ? "text-primary-accent"
-              : "text-muted-foreground opacity-0 group-hover:opacity-100",
-          )}
-        >
-          <ListFilter className="h-3 w-3" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        className="w-64"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <DropdownMenuLabel>Show only items</DropdownMenuLabel>
-        {operators.map((operator) =>
-          targets.length === 1 ? (
-            <DropdownMenuItem
-              key={operator}
-              onClick={() => onSelect(operator, targets[0].experimentId)}
-            >
-              {isActive(operator, targets[0].experimentId) ? (
-                <Check className="mr-2 h-4 w-4 shrink-0" />
-              ) : (
-                <span className="mr-2 h-4 w-4 shrink-0" />
-              )}
-              <span
-                className="truncate"
-                title={`${OPERATOR_LABELS[operator]} ${targets[0].experimentName}`}
+    <DropdownMenuController
+      align="end"
+      maxWidth="16rem"
+      renderMenu={() => (
+        <>
+          <DropdownMenuLabel>Show only items</DropdownMenuLabel>
+          {operators.map((operator) =>
+            targets.length === 1 ? (
+              <DropdownMenuItem
+                key={operator}
+                onClick={() => onSelect(operator, targets[0].experimentId)}
               >
-                {OPERATOR_LABELS[operator]} {targets[0].experimentName}
-              </span>
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuSub key={operator}>
-              <DropdownMenuSubTrigger>
-                {OPERATOR_LABELS[operator]}…
-              </DropdownMenuSubTrigger>
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent className="w-56">
-                  {targets.map((target) => (
-                    <DropdownMenuItem
-                      key={target.experimentId}
-                      onClick={() => onSelect(operator, target.experimentId)}
-                    >
-                      {isActive(operator, target.experimentId) ? (
-                        <Check className="mr-2 h-4 w-4 shrink-0" />
-                      ) : (
-                        <span className="mr-2 h-4 w-4 shrink-0" />
-                      )}
-                      <span className="truncate" title={target.experimentName}>
-                        {target.experimentName}
-                      </span>
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
-          ),
-        )}
-        {active && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onClear}>
-              <span className="mr-2 h-4 w-4 shrink-0" />
-              Remove this score&apos;s filter
-            </DropdownMenuItem>
-          </>
-        )}
-        <DropdownMenuSeparator />
-        <span className="text-muted-foreground block px-2 py-1.5 text-[10px]">
-          Compares the items loaded on this page — page through to check the
-          rest of the run.
-        </span>
-      </DropdownMenuContent>
-    </DropdownMenu>
+                {isActive(operator, targets[0].experimentId) ? (
+                  <Check className="mr-2 h-4 w-4 shrink-0" />
+                ) : (
+                  <span className="mr-2 h-4 w-4 shrink-0" />
+                )}
+                <span
+                  className="truncate"
+                  title={`${OPERATOR_LABELS[operator]} ${targets[0].experimentName}`}
+                >
+                  {OPERATOR_LABELS[operator]} {targets[0].experimentName}
+                </span>
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuSub key={operator}>
+                <DropdownMenuSubTrigger>
+                  {OPERATOR_LABELS[operator]}…
+                </DropdownMenuSubTrigger>
+                <DropdownMenuPortal>
+                  <DropdownMenuSubContent className="w-56">
+                    {targets.map((target) => (
+                      <DropdownMenuItem
+                        key={target.experimentId}
+                        onClick={() => onSelect(operator, target.experimentId)}
+                      >
+                        {isActive(operator, target.experimentId) ? (
+                          <Check className="mr-2 h-4 w-4 shrink-0" />
+                        ) : (
+                          <span className="mr-2 h-4 w-4 shrink-0" />
+                        )}
+                        <span
+                          className="truncate"
+                          title={target.experimentName}
+                        >
+                          {target.experimentName}
+                        </span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuPortal>
+              </DropdownMenuSub>
+            ),
+          )}
+          {active && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={onClear}>
+                <span className="mr-2 h-4 w-4 shrink-0" />
+                Remove this score&apos;s filter
+              </DropdownMenuItem>
+            </>
+          )}
+          <DropdownMenuSeparator />
+          <span className="text-muted-foreground block px-2 py-1.5 text-[10px]">
+            Compares the items loaded on this page — page through to check the
+            rest of the run.
+          </span>
+        </>
+      )}
+    >
+      {children}
+    </DropdownMenuController>
   );
 };

--- a/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
@@ -1,0 +1,153 @@
+/* eslint-disable @repo/no-abstracted-overlay-trigger */
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { Check, ListFilter } from "lucide-react";
+import { type ScoreComparisonOperator } from "@/src/features/experiments/fns/scoreComparisonFilter";
+import { cn } from "@/src/utils/tailwind";
+
+export type ScoreComparisonTarget = {
+  experimentId: string;
+  experimentName: string;
+};
+
+const OPERATOR_LABELS: Record<ScoreComparisonOperator, string> = {
+  lower: "Worse than",
+  higher: "Better than",
+  differs: "Different from",
+};
+
+const ORDERED_OPERATORS: ScoreComparisonOperator[] = [
+  "lower",
+  "higher",
+  "differs",
+];
+
+/**
+ * The score column's own way into the comparison filter (LFE-15711 C7): "show
+ * only the items worse than <comparison> on this score", from the header of the
+ * score in question, with the comparison to read against picked here rather than
+ * assumed.
+ */
+export const ScoreColumnFilterMenu = ({
+  targets,
+  active,
+  hasOrder,
+  onSelect,
+  onClear,
+}: {
+  /** The experiments this score can be read against, default first. */
+  targets: ScoreComparisonTarget[];
+  active?: {
+    operator: ScoreComparisonOperator;
+    comparisonExperimentId: string;
+  };
+  /** Categorical scores have no order, so only "different from" applies. */
+  hasOrder: boolean;
+  onSelect: (
+    operator: ScoreComparisonOperator,
+    comparisonExperimentId: string,
+  ) => void;
+  onClear: () => void;
+}) => {
+  if (targets.length === 0) return null;
+
+  const operators = hasOrder ? ORDERED_OPERATORS : (["differs"] as const);
+  const isActive = (operator: ScoreComparisonOperator, experimentId: string) =>
+    active?.operator === operator &&
+    active?.comparisonExperimentId === experimentId;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label="Filter items by this score"
+          onClick={(event) => event.stopPropagation()}
+          className={cn(
+            "hover:bg-muted mt-0.5 shrink-0 rounded-sm p-0.5",
+            active
+              ? "text-primary-accent"
+              : "text-muted-foreground opacity-0 group-hover:opacity-100",
+          )}
+        >
+          <ListFilter className="h-3 w-3" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-64"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <DropdownMenuLabel>Show only items</DropdownMenuLabel>
+        {operators.map((operator) =>
+          targets.length === 1 ? (
+            <DropdownMenuItem
+              key={operator}
+              onClick={() => onSelect(operator, targets[0].experimentId)}
+            >
+              {isActive(operator, targets[0].experimentId) ? (
+                <Check className="mr-2 h-4 w-4 shrink-0" />
+              ) : (
+                <span className="mr-2 h-4 w-4 shrink-0" />
+              )}
+              <span
+                className="truncate"
+                title={`${OPERATOR_LABELS[operator]} ${targets[0].experimentName}`}
+              >
+                {OPERATOR_LABELS[operator]} {targets[0].experimentName}
+              </span>
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuSub key={operator}>
+              <DropdownMenuSubTrigger>
+                {OPERATOR_LABELS[operator]}…
+              </DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent className="w-56">
+                  {targets.map((target) => (
+                    <DropdownMenuItem
+                      key={target.experimentId}
+                      onClick={() => onSelect(operator, target.experimentId)}
+                    >
+                      {isActive(operator, target.experimentId) ? (
+                        <Check className="mr-2 h-4 w-4 shrink-0" />
+                      ) : (
+                        <span className="mr-2 h-4 w-4 shrink-0" />
+                      )}
+                      <span className="truncate" title={target.experimentName}>
+                        {target.experimentName}
+                      </span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+          ),
+        )}
+        {active && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onClear}>
+              <span className="mr-2 h-4 w-4 shrink-0" />
+              Remove this score&apos;s filter
+            </DropdownMenuItem>
+          </>
+        )}
+        <DropdownMenuSeparator />
+        <span className="text-muted-foreground block px-2 py-1.5 text-[10px]">
+          Compares the items loaded on this page — page through to check the
+          rest of the run.
+        </span>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
@@ -33,7 +33,7 @@ const ORDERED_OPERATORS: ScoreComparisonOperator[] = [
 ];
 
 /**
- * The score column's own way into the comparison filter (LFE-15711 C7): "show
+ * The score column's own way into the comparison filter: "show
  * only the items worse than <comparison> on this score", from the header of the
  * score in question, with the comparison to read against picked here rather than
  * assumed.

--- a/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
+++ b/web/src/features/experiments/components/table/ScoreColumnFilterMenu.tsx
@@ -96,8 +96,6 @@ export const ScoreColumnFilterMenu = ({
   /** Renders the trigger, so its presentation stays with the caller. */
   children: ComponentProps<typeof DropdownMenuController>["children"];
 }) => {
-  if (targets.length === 0) return null;
-
   const operators = hasOrder ? ORDERED_OPERATORS : (["differs"] as const);
   const isActive = (operator: ScoreComparisonOperator, experimentId: string) =>
     active?.operator === operator &&

--- a/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
+++ b/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
@@ -22,7 +22,7 @@ export type ScoreComparisonPill = {
 /**
  * The active score comparisons, in plain English ("Worse groundedness than
  * judge-haiku-baseline") and removable — the same affordance the score filters
- * get, for the one predicate that is evaluated in the client. (LFE-15711 C7)
+ * get, for the one predicate that is evaluated in the client.
  */
 export const ScoreComparisonFilterPills = ({
   pills,

--- a/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
+++ b/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @repo/no-style-props */
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -7,7 +6,6 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import { GitCompareArrows, X } from "lucide-react";
-import { cn } from "@/src/utils/tailwind";
 import {
   describeScoreComparisonFilter,
   type ScoreComparisonFilter,
@@ -27,18 +25,14 @@ export type ScoreComparisonPill = {
 export const ScoreComparisonFilterPills = ({
   pills,
   onRemove,
-  className,
 }: {
   pills: ScoreComparisonPill[];
   onRemove: (filter: ScoreComparisonFilter) => void;
-  className?: string;
 }) => {
   if (pills.length === 0) return null;
 
   return (
-    <div
-      className={cn("flex flex-wrap items-center gap-1.5 px-2 py-2", className)}
-    >
+    <div className="flex flex-wrap items-center gap-1.5 border-b px-2 py-2">
       {pills.map(({ filter, scoreName, comparisonName }) => {
         const label = describeScoreComparisonFilter({
           operator: filter.operator,

--- a/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
+++ b/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable @repo/no-style-props */
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+import { GitCompareArrows, X } from "lucide-react";
+import { cn } from "@/src/utils/tailwind";
+import {
+  describeScoreComparisonFilter,
+  type ScoreComparisonFilter,
+} from "@/src/features/experiments/fns/scoreComparisonFilter";
+
+export type ScoreComparisonPill = {
+  filter: ScoreComparisonFilter;
+  scoreName: string;
+  comparisonName: string;
+};
+
+/**
+ * The active score comparisons, in plain English ("Worse groundedness than
+ * judge-haiku-baseline") and removable — the same affordance the score filters
+ * get, for the one predicate that is evaluated in the client. (LFE-15711 C7)
+ */
+export const ScoreComparisonFilterPills = ({
+  pills,
+  onRemove,
+  className,
+}: {
+  pills: ScoreComparisonPill[];
+  onRemove: (filter: ScoreComparisonFilter) => void;
+  className?: string;
+}) => {
+  if (pills.length === 0) return null;
+
+  return (
+    <div
+      className={cn("flex flex-wrap items-center gap-1.5 px-2 py-2", className)}
+    >
+      {pills.map(({ filter, scoreName, comparisonName }) => {
+        const label = describeScoreComparisonFilter({
+          operator: filter.operator,
+          scoreName,
+          comparisonName,
+        });
+        return (
+          <Badge
+            key={`${filter.level}-${filter.scoreKey}`}
+            variant="secondary"
+            className="flex max-w-full items-center gap-1 px-2 py-1 text-xs"
+          >
+            <GitCompareArrows className="h-3 w-3 shrink-0" />
+            <span className="truncate" title={label}>
+              {label}
+            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-muted-foreground shrink-0 cursor-default underline decoration-dotted">
+                  this page
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[280px]">
+                Comparing one experiment&apos;s score against another&apos;s is
+                not something the items query can express, so this narrows the
+                items loaded on the current page. Page through to check the rest
+                of the run.
+              </TooltipContent>
+            </Tooltip>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-4 w-4 shrink-0 p-0 hover:bg-transparent"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRemove(filter);
+              }}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </Badge>
+        );
+      })}
+    </div>
+  );
+};

--- a/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
+++ b/web/src/features/experiments/components/table/ScoreComparisonFilterPills.tsx
@@ -29,8 +29,6 @@ export const ScoreComparisonFilterPills = ({
   pills: ScoreComparisonPill[];
   onRemove: (filter: ScoreComparisonFilter) => void;
 }) => {
-  if (pills.length === 0) return null;
-
   return (
     <div className="flex flex-wrap items-center gap-1.5 border-b px-2 py-2">
       {pills.map(({ filter, scoreName, comparisonName }) => {

--- a/web/src/features/experiments/fns/scoreComparisonFilter.clienttest.ts
+++ b/web/src/features/experiments/fns/scoreComparisonFilter.clienttest.ts
@@ -1,0 +1,105 @@
+import { type AggregatedScoreData } from "@langfuse/shared";
+import {
+  decodeScoreComparisonFilter,
+  encodeScoreComparisonFilter,
+  matchesScoreComparisonFilter,
+} from "./scoreComparisonFilter";
+
+const numeric = (value: number): AggregatedScoreData => ({
+  type: "NUMERIC",
+  values: [value],
+  average: value,
+});
+
+const categorical = (value: string): AggregatedScoreData => ({
+  type: "CATEGORICAL",
+  values: [value],
+  valueCounts: [{ value, count: 1 }],
+});
+
+describe("matchesScoreComparisonFilter", () => {
+  it("keeps only the items the experiment you opened scored lower on", () => {
+    const lower = (baseline: number, comparison: number) =>
+      matchesScoreComparisonFilter({
+        operator: "lower",
+        dataType: "NUMERIC",
+        baseline: numeric(baseline),
+        comparison: numeric(comparison),
+      });
+
+    expect(lower(0.2, 0.9)).toBe(true);
+    expect(lower(0.9, 0.2)).toBe(false);
+    expect(lower(0.5, 0.5)).toBe(false);
+  });
+
+  it("never keeps an item only one of the two experiments scored", () => {
+    for (const operator of ["lower", "higher", "differs"] as const) {
+      expect(
+        matchesScoreComparisonFilter({
+          operator,
+          dataType: "NUMERIC",
+          baseline: numeric(0.2),
+          comparison: null,
+        }),
+      ).toBe(false);
+      expect(
+        matchesScoreComparisonFilter({
+          operator,
+          dataType: "NUMERIC",
+          baseline: undefined,
+          comparison: numeric(0.2),
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("reads a boolean as false < true", () => {
+    expect(
+      matchesScoreComparisonFilter({
+        operator: "lower",
+        dataType: "BOOLEAN",
+        baseline: categorical("false"),
+        comparison: categorical("true"),
+      }),
+    ).toBe(true);
+  });
+
+  it("only answers 'differs' for a categorical score, which has no order", () => {
+    const args = {
+      dataType: "CATEGORICAL" as const,
+      baseline: categorical("weak"),
+      comparison: categorical("grounded"),
+    };
+    expect(matchesScoreComparisonFilter({ ...args, operator: "lower" })).toBe(
+      false,
+    );
+    expect(matchesScoreComparisonFilter({ ...args, operator: "differs" })).toBe(
+      true,
+    );
+    expect(
+      matchesScoreComparisonFilter({
+        ...args,
+        operator: "differs",
+        comparison: categorical("weak"),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("score comparison filter URL state", () => {
+  it("round-trips through the URL and rejects anything malformed", () => {
+    const filter = {
+      level: "trace" as const,
+      scoreKey: "groundedness-EVAL-NUMERIC",
+      operator: "lower" as const,
+      comparisonExperimentId: "1b0a2c3d-4e5f",
+    };
+
+    expect(
+      decodeScoreComparisonFilter(encodeScoreComparisonFilter(filter)),
+    ).toEqual(filter);
+    expect(decodeScoreComparisonFilter("trace:key:sideways:id")).toBeNull();
+    expect(decodeScoreComparisonFilter("session:key:lower:id")).toBeNull();
+    expect(decodeScoreComparisonFilter("")).toBeNull();
+  });
+});

--- a/web/src/features/experiments/fns/scoreComparisonFilter.clienttest.ts
+++ b/web/src/features/experiments/fns/scoreComparisonFilter.clienttest.ts
@@ -102,4 +102,30 @@ describe("score comparison filter URL state", () => {
     expect(decodeScoreComparisonFilter("session:key:lower:id")).toBeNull();
     expect(decodeScoreComparisonFilter("")).toBeNull();
   });
+
+  // The score key carries the score's name, which is user-supplied: a name
+  // holding the field separator or the one between several filters used to
+  // land in the wrong slot and drop the filter without a word.
+  it("round-trips a score name holding the separators", () => {
+    for (const scoreKey of [
+      "ratio:accuracy-EVAL-NUMERIC",
+      "either|or-EVAL-NUMERIC",
+      "a:b|c-EVAL-NUMERIC",
+    ]) {
+      const filter = {
+        level: "observation" as const,
+        scoreKey,
+        operator: "differs" as const,
+        comparisonExperimentId: "1b0a2c3d-4e5f",
+      };
+      const encoded = encodeScoreComparisonFilter(filter);
+      expect(encoded).not.toContain("|");
+      expect(encoded.split(":")).toHaveLength(4);
+      expect(decodeScoreComparisonFilter(encoded)).toEqual(filter);
+    }
+  });
+
+  it("rejects a malformed escape instead of throwing", () => {
+    expect(decodeScoreComparisonFilter("trace:%zz:lower:id")).toBeNull();
+  });
 });

--- a/web/src/features/experiments/fns/scoreComparisonFilter.ts
+++ b/web/src/features/experiments/fns/scoreComparisonFilter.ts
@@ -12,7 +12,7 @@ export type ScoreComparisonOperator = "lower" | "higher" | "differs";
 /**
  * "Keep the items whose score is lower than the comparison experiment's" — the
  * one predicate the item filters could not express, because it is about a pair
- * of experiments rather than a column against a literal. (LFE-15711 C7)
+ * of experiments rather than a column against a literal.
  */
 export type ScoreComparisonFilter = {
   level: ScoreLevel;
@@ -26,8 +26,10 @@ export type ScoreComparisonFilter = {
 const OPERATORS: ScoreComparisonOperator[] = ["lower", "higher", "differs"];
 
 /**
- * `level:scoreKey:operator:experimentId`. Score keys are normalised to hold no
- * colon and experiment ids are uuids, so the separator is unambiguous.
+ * `level:scoreKey:operator:experimentId`, each field percent-encoded. A score
+ * key carries the score's name, which is user-supplied and may hold a colon or
+ * the pipe that separates several of these in the URL — an unescaped field
+ * would land in the wrong slot and the filter would silently vanish.
  */
 export const encodeScoreComparisonFilter = (
   filter: ScoreComparisonFilter,
@@ -37,14 +39,27 @@ export const encodeScoreComparisonFilter = (
     filter.scoreKey,
     filter.operator,
     filter.comparisonExperimentId,
-  ].join(":");
+  ]
+    .map(encodeURIComponent)
+    .join(":");
 
 export const decodeScoreComparisonFilter = (
   encoded: string | null | undefined,
 ): ScoreComparisonFilter | null => {
   if (!encoded) return null;
-  const [level, scoreKey, operator, comparisonExperimentId] =
-    encoded.split(":");
+  const parts = encoded.split(":");
+  if (parts.length !== 4) return null;
+  let level: string;
+  let scoreKey: string;
+  let operator: string;
+  let comparisonExperimentId: string;
+  try {
+    [level, scoreKey, operator, comparisonExperimentId] =
+      parts.map(decodeURIComponent);
+  } catch {
+    // A hand-edited or truncated URL can hold a malformed escape.
+    return null;
+  }
   if (level !== "observation" && level !== "trace") return null;
   if (!scoreKey || !comparisonExperimentId) return null;
   if (!OPERATORS.includes(operator as ScoreComparisonOperator)) return null;
@@ -126,14 +141,17 @@ export const scoreFieldForLevel = (level: ScoreLevel) =>
   level === "trace" ? ("traceScores" as const) : ("observationScores" as const);
 
 /**
- * Whether one item survives every active score comparison. A filter whose score
- * type is not known yet (the column definitions still loading) does not hide
- * rows.
+ * Whether one item survives every active score comparison. A filter that cannot
+ * be evaluated does not hide rows: its score type is not known yet (the column
+ * definitions are still loading), or its target is no longer one of the runs on
+ * screen. Reading either as "nothing matches" would empty the table, which
+ * looks like a broken page rather than a filter with nothing to point at.
  */
 export const rowPassesScoreComparisonFilters = ({
   filters,
   experiments,
   baselineExperimentId,
+  comparableExperimentIds,
   dataTypeFor,
 }: {
   filters: ScoreComparisonFilter[];
@@ -143,6 +161,8 @@ export const rowPassesScoreComparisonFilters = ({
     traceScores: Record<string, AggregatedScoreData>;
   }>;
   baselineExperimentId?: string;
+  /** The runs currently being compared, if the caller knows them. */
+  comparableExperimentIds?: readonly string[];
   dataTypeFor: (
     filter: ScoreComparisonFilter,
   ) => ScoreColumnDataType | undefined;
@@ -158,6 +178,14 @@ export const rowPassesScoreComparisonFilters = ({
   return filters.every((filter) => {
     const dataType = dataTypeFor(filter);
     if (!dataType) return true;
+    // The target was deselected, or is now the baseline it would be read
+    // against — either way there is no second run left to compare with.
+    if (filter.comparisonExperimentId === baselineExperimentId) return true;
+    if (
+      comparableExperimentIds &&
+      !comparableExperimentIds.includes(filter.comparisonExperimentId)
+    )
+      return true;
     return matchesScoreComparisonFilter({
       operator: filter.operator,
       dataType,

--- a/web/src/features/experiments/fns/scoreComparisonFilter.ts
+++ b/web/src/features/experiments/fns/scoreComparisonFilter.ts
@@ -1,0 +1,187 @@
+import { type AggregatedScoreData } from "@langfuse/shared";
+import {
+  readOrderedScoreValue,
+  type ScoreColumnDataType,
+} from "./summariseScoreColumn";
+
+/** Which score family a filtered column belongs to. */
+export type ScoreLevel = "observation" | "trace";
+
+export type ScoreComparisonOperator = "lower" | "higher" | "differs";
+
+/**
+ * "Keep the items whose score is lower than the comparison experiment's" — the
+ * one predicate the item filters could not express, because it is about a pair
+ * of experiments rather than a column against a literal. (LFE-15711 C7)
+ */
+export type ScoreComparisonFilter = {
+  level: ScoreLevel;
+  /** Aggregate score key, e.g. `groundedness-EVAL-NUMERIC`. */
+  scoreKey: string;
+  operator: ScoreComparisonOperator;
+  /** The experiment the score is read against. */
+  comparisonExperimentId: string;
+};
+
+const OPERATORS: ScoreComparisonOperator[] = ["lower", "higher", "differs"];
+
+/**
+ * `level:scoreKey:operator:experimentId`. Score keys are normalised to hold no
+ * colon and experiment ids are uuids, so the separator is unambiguous.
+ */
+export const encodeScoreComparisonFilter = (
+  filter: ScoreComparisonFilter,
+): string =>
+  [
+    filter.level,
+    filter.scoreKey,
+    filter.operator,
+    filter.comparisonExperimentId,
+  ].join(":");
+
+export const decodeScoreComparisonFilter = (
+  encoded: string | null | undefined,
+): ScoreComparisonFilter | null => {
+  if (!encoded) return null;
+  const [level, scoreKey, operator, comparisonExperimentId] =
+    encoded.split(":");
+  if (level !== "observation" && level !== "trace") return null;
+  if (!scoreKey || !comparisonExperimentId) return null;
+  if (!OPERATORS.includes(operator as ScoreComparisonOperator)) return null;
+  return {
+    level,
+    scoreKey,
+    operator: operator as ScoreComparisonOperator,
+    comparisonExperimentId,
+  };
+};
+
+export const isSameScoreComparisonTarget = (
+  a: ScoreComparisonFilter,
+  b: ScoreComparisonFilter,
+) => a.level === b.level && a.scoreKey === b.scoreKey;
+
+/**
+ * Whether one item passes the filter, read the same way the column header reads
+ * it: an item only one of the two experiments scored is not comparable, so it is
+ * never a regression and never kept. A categorical score has no order, so only
+ * `differs` can match it.
+ */
+export const matchesScoreComparisonFilter = ({
+  operator,
+  dataType,
+  baseline,
+  comparison,
+}: {
+  operator: ScoreComparisonOperator;
+  dataType: ScoreColumnDataType;
+  baseline: AggregatedScoreData | null | undefined;
+  comparison: AggregatedScoreData | null | undefined;
+}): boolean => {
+  if (!baseline || !comparison) return false;
+
+  if (dataType === "CATEGORICAL") {
+    // No order, so only "differs" means anything on a categorical score.
+    if (operator !== "differs") return false;
+    if (baseline.type !== "CATEGORICAL" || comparison.type !== "CATEGORICAL")
+      return false;
+    return (
+      [...baseline.values].sort().join("|") !==
+      [...comparison.values].sort().join("|")
+    );
+  }
+
+  const baselineValue = readOrderedScoreValue(baseline, dataType);
+  const comparisonValue = readOrderedScoreValue(comparison, dataType);
+  if (baselineValue === null || comparisonValue === null) return false;
+
+  if (operator === "differs") return baselineValue !== comparisonValue;
+  return operator === "lower"
+    ? baselineValue < comparisonValue
+    : baselineValue > comparisonValue;
+};
+
+const OPERATOR_WORDS: Record<ScoreComparisonOperator, string> = {
+  lower: "Worse",
+  higher: "Better",
+  differs: "Different",
+};
+
+/** The chip's plain English: "Worse groundedness than judge-haiku-baseline". */
+export const describeScoreComparisonFilter = ({
+  operator,
+  scoreName,
+  comparisonName,
+}: {
+  operator: ScoreComparisonOperator;
+  scoreName: string;
+  comparisonName: string;
+}): string =>
+  `${OPERATOR_WORDS[operator]} ${scoreName} ${
+    operator === "differs" ? "vs" : "than"
+  } ${comparisonName}`;
+
+/** Which of a row's two score maps a level's scores live in. */
+export const scoreFieldForLevel = (level: ScoreLevel) =>
+  level === "trace" ? ("traceScores" as const) : ("observationScores" as const);
+
+/**
+ * Whether one item survives every active score comparison. A filter whose score
+ * type is not known yet (the column definitions still loading) does not hide
+ * rows.
+ */
+export const rowPassesScoreComparisonFilters = ({
+  filters,
+  experiments,
+  baselineExperimentId,
+  dataTypeFor,
+}: {
+  filters: ScoreComparisonFilter[];
+  experiments: Array<{
+    experimentId: string;
+    observationScores: Record<string, AggregatedScoreData>;
+    traceScores: Record<string, AggregatedScoreData>;
+  }>;
+  baselineExperimentId?: string;
+  dataTypeFor: (
+    filter: ScoreComparisonFilter,
+  ) => ScoreColumnDataType | undefined;
+}): boolean => {
+  if (filters.length === 0) return true;
+  if (!baselineExperimentId) return true;
+
+  const scoresOf = (experimentId: string, level: ScoreLevel) =>
+    experiments.find(
+      (experiment) => experiment.experimentId === experimentId,
+    )?.[scoreFieldForLevel(level)];
+
+  return filters.every((filter) => {
+    const dataType = dataTypeFor(filter);
+    if (!dataType) return true;
+    return matchesScoreComparisonFilter({
+      operator: filter.operator,
+      dataType,
+      baseline: scoresOf(baselineExperimentId, filter.level)?.[filter.scoreKey],
+      comparison: scoresOf(filter.comparisonExperimentId, filter.level)?.[
+        filter.scoreKey
+      ],
+    });
+  });
+};
+
+/** What an emptied table says, so it reads as an answer and not as a failure. */
+export const describeEmptyScoreComparison = ({
+  operator,
+  scoreName,
+  comparisonName,
+}: {
+  operator: ScoreComparisonOperator;
+  scoreName: string;
+  comparisonName: string;
+}): string => {
+  if (operator === "differs")
+    return `No item on this page scored ${scoreName} differently from ${comparisonName}.`;
+  if (operator === "lower")
+    return `No regressions on this score — no item on this page scored lower on ${scoreName} than ${comparisonName}.`;
+  return `No item on this page scored higher on ${scoreName} than ${comparisonName}.`;
+};

--- a/web/src/features/experiments/fns/summariseScoreColumn.ts
+++ b/web/src/features/experiments/fns/summariseScoreColumn.ts
@@ -54,7 +54,7 @@ const countValues = (aggregate: AggregatedScoreData) =>
  * The score read as a number, so two items can be ordered. A boolean's ordered
  * reading is its true-rate (false < true); a categorical has none.
  */
-const readOrderedScoreValue = (
+export const readOrderedScoreValue = (
   aggregate: AggregatedScoreData | null,
   dataType: ScoreColumnDataType,
 ): number | null => {

--- a/web/src/features/experiments/hooks/useExperimentResultsState.ts
+++ b/web/src/features/experiments/hooks/useExperimentResultsState.ts
@@ -10,15 +10,18 @@ import useLocalStorage from "@/src/components/useLocalStorage";
 
 /**
  * How the selected experiments are laid out against each other: one row per item
- * ("list") or one column per experiment ("grid").
+ * ("list"), one column per experiment ("grid"), or the transpose — scores as
+ * rows and experiments as columns ("matrix").
  */
-export type ExperimentResultsLayout = "grid" | "list";
+export type ExperimentResultsLayout = "grid" | "list" | "matrix";
 
 /** What a diff cell's extra line is measured against. */
 export type ExperimentDiffMode = "comparison" | "expected" | "off";
 
 const asLayout = (value: unknown): ExperimentResultsLayout | undefined =>
-  value === "grid" || value === "list" ? value : undefined;
+  value === "grid" || value === "list" || value === "matrix"
+    ? value
+    : undefined;
 
 const asDiffMode = (value: unknown): ExperimentDiffMode | undefined =>
   value === "comparison" || value === "expected" || value === "off"

--- a/web/src/features/experiments/hooks/useScoreComparisonFilters.ts
+++ b/web/src/features/experiments/hooks/useScoreComparisonFilters.ts
@@ -1,0 +1,86 @@
+import { useCallback, useMemo } from "react";
+import { ArrayParam, useQueryParams, withDefault } from "use-query-params";
+import {
+  decodeScoreComparisonFilter,
+  encodeScoreComparisonFilter,
+  isSameScoreComparisonTarget,
+  type ScoreComparisonFilter,
+} from "@/src/features/experiments/fns/scoreComparisonFilter";
+
+/**
+ * "Show only the items this run scored worse on than <comparison>" — Annabell's
+ * top ask, as a filter rather than a report. (LFE-15711 C7)
+ *
+ * The predicate is about a *pair* of experiments, which the items query cannot
+ * express: `compileExperimentFilter` translates each condition into a
+ * `column op literal` WHERE clause on a single experiment's rows, so comparing
+ * one experiment's score against another's for the same item would need a new
+ * HAVING path over the `experiment_item_id` group — new query machinery we are
+ * explicitly not building. So the comparison is evaluated in the client over the
+ * items already fetched for the current page, and the UI says so. Everything
+ * else about it behaves like a filter: it lives in the URL, it is shareable, it
+ * survives a reload, and it shows as a removable chip.
+ *
+ * One filter per score column: picking an operator on a column replaces that
+ * column's filter instead of stacking a second one.
+ */
+const NO_FILTERS: string[] = [];
+
+export const useScoreComparisonFilters = () => {
+  const [state, setState] = useQueryParams({
+    scoreCompare: withDefault(ArrayParam, NO_FILTERS),
+  });
+
+  // Keyed on the encoded filters rather than the array `use-query-params` hands
+  // back, whose identity changes on every render and would make every consumer
+  // of `filters` — the filtered rows above all — churn with it.
+  const encoded = (
+    (state.scoreCompare as (string | null)[] | undefined) ?? NO_FILTERS
+  )
+    .filter(Boolean)
+    .join("|");
+
+  const filters = useMemo(
+    () =>
+      encoded
+        .split("|")
+        .map(decodeScoreComparisonFilter)
+        .filter(Boolean) as ScoreComparisonFilter[],
+    [encoded],
+  );
+
+  const write = useCallback(
+    (next: ScoreComparisonFilter[]) =>
+      setState({
+        scoreCompare: next.length
+          ? next.map(encodeScoreComparisonFilter)
+          : undefined,
+      }),
+    [setState],
+  );
+
+  const setFilter = useCallback(
+    (filter: ScoreComparisonFilter) =>
+      write([
+        ...filters.filter(
+          (existing) => !isSameScoreComparisonTarget(existing, filter),
+        ),
+        filter,
+      ]),
+    [filters, write],
+  );
+
+  const removeFilter = useCallback(
+    (filter: ScoreComparisonFilter) =>
+      write(
+        filters.filter(
+          (existing) => !isSameScoreComparisonTarget(existing, filter),
+        ),
+      ),
+    [filters, write],
+  );
+
+  const clearFilters = useCallback(() => write([]), [write]);
+
+  return { filters, setFilter, removeFilter, clearFilters };
+};

--- a/web/src/features/experiments/hooks/useScoreComparisonFilters.ts
+++ b/web/src/features/experiments/hooks/useScoreComparisonFilters.ts
@@ -9,7 +9,7 @@ import {
 
 /**
  * "Show only the items this run scored worse on than <comparison>" — Annabell's
- * top ask, as a filter rather than a report. (LFE-15711 C7)
+ * top ask, as a filter rather than a report.
  *
  * The predicate is about a *pair* of experiments, which the items query cannot
  * express: `compileExperimentFilter` translates each condition into a


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16918 app preview](https://pr-16918.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

**TL;DR** — Two things the score column headers made possible and nothing yet exposed: a filter for "worse than this comparison run", and a transposed layout that puts **11 scores × 5 runs on one screen**.

**7 of 8** in the LFE-15711 experiments-UI stack. Base: #16917.

## Why

PR #16917 put an improved/regressed count in every score column header. Reading *which* items regressed still meant scrolling the page looking for red — and the existing item filters cannot express it at all, because they compare a score to a constant, not to another run's score for the same item.

Separately, both existing layouts are item-first: a row or a column per dataset item, with the scores inside. "Which of these five runs is best on each score" therefore has no shape on the page — the answer is spread across every row's headers. On `main`, four run columns at 400px each leave **1 of 4 visible** at 1512px, the second clipped mid-word.

## What

Each score column's menu offers "lower than", "higher than" or "different from" a chosen comparison run, with the auto-selected comparison first so the default matches what the header already reports; a categorical score gets only "different from", because it has no order. Plus a third layout that transposes the grid: scores as rows, runs as columns, one aggregate per cell with its move against the baseline.

## Result

"Which items regressed on this score" is **2 clicks**, and the state is in the URL so the answer is shareable. The score matrix shows **11 of 11 scores × 4–5 runs on one screen** at 34px rows.

## Heads-up for whoever merges second

Two upstream PRs interact with this one:

- **#16788** (score filters in the search bar) overlaps in intent with the header filter menu here. Worth deciding which is the front door before both ship.
- **#16786** (an item's scores become its whole run's scores) is the dangerous one. `summariseScoreColumn`'s improved/regressed counts, the page-scoped comparison filter added here, and score coverage collection all read per-item score maps and compare them **across runs**. If every item in a run reports the run's scores, those maps become identical per run — so the counts would be zero, the filter would match nothing, and coverage would flatten. **They would go silent rather than visibly wrong**, which is the failure mode nobody notices. If #16786 lands first, these three call sites need re-reading against the new semantics before this merges; if this lands first, the same review belongs on #16786.

<details>
<summary>Mechanism, files and verification</summary>

**The filter** is evaluated over the loaded page rather than in the query, because the predicate is per-item across runs and there is no server-side shape for it yet. The header aggregates deliberately keep describing the whole fetched page, so the movement the filter was built from stays readable while the filter is applied — and the UI says so. When the filter leaves nothing, the table says "no regressions on this score" in plain English rather than looking broken (`describeEmptyScoreComparison`). Active filters live in the URL (`&scoreCompare=trace:<key>:lower:<id>`).

Files: `fns/scoreComparisonFilter.ts` (+ tests), `hooks/useScoreComparisonFilters.ts`, `components/table/ScoreColumnFilterMenu.tsx`, `components/table/ScoreComparisonFilterPills.tsx`.

**The matrix** re-reads what the grid already fetched — no query of its own — and respects what the column picker hid. `components/table/ExperimentScoreMatrix.tsx`, reachable from `Display → Score matrix` and from `&layout=matrix`.

**Scope, stated plainly:** the matrix transposes one dataset's items on one page. It is not a project-wide summary table.

**Verification:** typecheck clean, `turbo lint` clean across 7 packages, 194 client tests green across the experiments and table suites, including a new suite for the comparison-filter predicate. Reference branch: [`lfe-15711-experiments-ui-rebuild`](https://github.com/langfuse/langfuse/tree/lfe-15711-experiments-ui-rebuild).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds URL-backed, page-scoped score comparison filters and a transposed score-by-run matrix layout.

- Adds lower-than, higher-than, and differs-from score predicates with removable filter pills.
- Adds score-matrix rendering over the currently loaded experiment-item page.
- Extends experiment result layout state with the matrix option.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until matrix pagination, stale comparison targets, and lossless filter serialization are addressed.

Matrix mode cannot navigate beyond the currently fetched page, removed comparison runs can leave filters that hide every item, and valid score names containing serialization delimiters cannot round-trip through shared URLs.

**Files Needing Attention:** web/src/features/experiments/components/table/ExperimentItemsTable.tsx, web/src/features/experiments/fns/scoreComparisonFilter.ts, web/src/features/experiments/hooks/useScoreComparisonFilters.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Selected experiment runs] --> B[Paginated experiment-item query]
  B --> C[Loaded page rows]
  D[scoreCompare URL filters] --> E[Per-item cross-run predicate]
  C --> E
  E --> F[Filtered rows]
  F --> G[List layout]
  F --> H[Grid layout]
  F --> I[Score matrix]
  I --> J[Per-score, per-run page aggregates]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/experiments/components/table/ExperimentItemsTable.tsx:1821-1827
**Matrix layout loses pagination**

When a comparison contains more items than the page size, this branch renders only the current page in `ExperimentScoreMatrix` without the pagination controller used by the other layouts, so users cannot inspect or aggregate another page without manually editing the URL.

### Issue 2
web/src/features/experiments/fns/scoreComparisonFilter.ts:164-167
**Stale targets hide every row**

When the referenced comparison run is removed or absent from a shared URL's selected runs, `scoresOf` returns no comparison score and every row fails the retained filter, causing an empty results page until the user clears the stale pill.

### Issue 3
web/src/features/experiments/fns/scoreComparisonFilter.ts:32-57
**Delimiters break filter URLs**

When a valid score name contains `:` or `|`, the aggregate key retains that character but this format uses it as an unescaped field or filter delimiter, so decoding drops the comparison filter and the shared URL does not preserve the selected state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(experiments): add a transposed scor..."](https://github.com/langfuse/langfuse/commit/100ac7eb834ee85d681ecce5c05f9c3b76f34cda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59176021)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->