### PR TITLE
fix(ingestion): merge same-timestamp events in arrival order

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -1732,6 +1732,8 @@ class OCIObjectStorageService implements StorageService {
         namespaceName,
         bucketName: this.bucketName,
         prefix,
+        // Object summaries only carry `name` unless asked for more.
+        fields: "name,timeCreated",
       };
       const resp = await client.listObjects(req);
       const objects = ((resp as any).listObjects?.objects ?? []) as Array<{

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -182,6 +182,12 @@ export const ingestionQueueProcessorBuilder = (
         events.push(...(Array.isArray(parsedFile) ? parsedFile : [parsedFile]));
       } else {
         eventFiles = await s3Client.listFiles(s3Prefix);
+        // Listings are ordered by key (client-supplied event ids), not by
+        // upload time. Sort so arrival order is upload order; score merges
+        // rely on that for same-timestamp re-sends.
+        eventFiles.sort(
+          (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+        );
 
         // Process files in batches
         // If a user has 5k events, this will likely take 100 seconds.
@@ -225,11 +231,8 @@ export const ingestionQueueProcessorBuilder = (
         totalS3DownloadSizeBytes,
       );
 
-      const firstS3WriteTime =
-        eventFiles
-          .map((fileRef) => fileRef.createdAt)
-          .sort()
-          .shift() ?? new Date();
+      // eventFiles is sorted by createdAt above.
+      const firstS3WriteTime = eventFiles[0]?.createdAt ?? new Date();
 
       if (events.length === 0) {
         logger.warn(

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -618,8 +618,15 @@ export class IngestionService {
     } = params;
     if (scoreEventList.length === 0) return;
 
-    const timeSortedEvents =
-      IngestionService.toTimeSortedEventList(scoreEventList);
+    // Re-sending a score with the same id and timestamp is the documented way
+    // to overwrite it, so ties must keep arrival order for the later one to
+    // win. Score events are all creates, so no create-first rule is needed.
+    const timeSortedEvents = scoreEventList
+      .slice()
+      .sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      );
 
     const minTimestamp = Math.min(
       ...timeSortedEvents.flatMap((e) =>
@@ -1217,14 +1224,20 @@ export class IngestionService {
   }
 
   private static toTimeSortedEventList<
-    T extends TraceEventType | ScoreEventType | ObservationEvent,
+    T extends TraceEventType | ObservationEvent,
   >(eventList: T[]): T[] {
     return eventList.slice().sort((a, b) => {
       const aTimestamp = new Date(a.timestamp).getTime();
       const bTimestamp = new Date(b.timestamp).getTime();
 
       if (aTimestamp === bTimestamp) {
-        return a.type.includes("create") ? -1 : 1; // create events should come first
+        // Creates sort before updates. For two tied creates this is not a
+        // total order: V8 places the later-arriving one first, so the
+        // first-arriving create wins the merge. OTel relies on that: a root
+        // span's trace-create and a child span's trace update share the span
+        // start time, and the child's explicit fields must beat the root's
+        // derived ones. Score events use their own stable sort instead.
+        return a.type.includes("create") ? -1 : 1;
       }
 
       return aTimestamp - bTimestamp;

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -380,6 +380,17 @@ describe("IngestionService unit tests", () => {
     expect(sortedEventList).not.toBe(records); // Ensure that the original array is not mutated
   });
 
+  it("puts the first-arriving of tied create events last so it wins the merge", () => {
+    // OTel stamps a root span's trace-create and a child span's trace update
+    // with the same start time; the child arrives first and must win.
+    const first = { timestamp: 1, type: "trace-create", id: "first" };
+    const second = { timestamp: 1, type: "trace-create", id: "second" };
+
+    expect(
+      (IngestionService as any).toTimeSortedEventList([first, second]),
+    ).toEqual([second, first]);
+  });
+
   it("correctly convert Date to Clickhouse DateTime", async () => {
     const date = new Date("2024-10-12T12:13:14.123Z");
 
@@ -604,5 +615,72 @@ describe("IngestionService unit tests", () => {
     ).rejects.toThrow("Unexpected error(s) validating score batch");
 
     expect(addToQueue).not.toHaveBeenCalled();
+  });
+
+  it("keeps the last-arriving event when score events share a timestamp", async () => {
+    // Re-sending the full score with the same id, name, and timestamp is the
+    // documented way to overwrite it, so the events tie on timestamp and
+    // arrival order has to decide the winner.
+    const timestamp = "2026-08-31T12:00:00.000Z";
+    const buildEvent = (id: string, value: string): ScoreEventType => ({
+      id,
+      timestamp,
+      type: "score-create",
+      body: {
+        id: "score-id",
+        name: "quality",
+        dataType: "TEXT",
+        source: "API",
+        sessionId: "session-id",
+        environment: "default",
+        value,
+      },
+    });
+    const first = buildEvent("event-first", "first");
+    const second = buildEvent("event-second", "second");
+
+    const mergeAndReadValue = async (events: ScoreEventType[]) => {
+      const addToQueue = vi.fn();
+      const ingestionService = new IngestionService(
+        {} as any,
+        {} as any,
+        { addToQueue } as any,
+        {} as any,
+      );
+      vi.spyOn(
+        ingestionService as any,
+        "getClickhouseRecord",
+      ).mockResolvedValue(null);
+
+      await ingestionService.mergeAndWrite({
+        eventType: "score",
+        projectId: "project-id",
+        entityId: "score-id",
+        createdAtTimestamp: new Date(timestamp),
+        events,
+        forwardToEventsTable: false,
+        attribution: {
+          ingestionApiKey: "pk-lf-unit-test",
+          ingestionSdkName: "langfuse-test",
+          ingestionSdkVersion: "0.0.0",
+        },
+      });
+
+      expect(addToQueue).toHaveBeenCalledWith(
+        TableName.Scores,
+        expect.anything(),
+      );
+      return addToQueue.mock.calls[0]?.[1].string_value;
+    };
+
+    for (const events of [
+      [first, second],
+      [second, first],
+    ]) {
+      await expect(
+        mergeAndReadValue(events),
+        `arrival order ${events.map((e) => e.id).join(", ")}`,
+      ).resolves.toBe(events.at(-1)?.body.value);
+    }
   });
 });


### PR DESCRIPTION
## What does this PR do?

Re-sending a score with the same `id`, `name`, and `timestamp` is the documented way to overwrite it ([FAQ: updating scores](https://langfuse.com/faq/all/tracing-data-updates#updating-scores)), but the new value was lost about half the time.

Two things combined:

- The worker lists the event files for an entity from blob storage (up to `LANGFUSE_S3_LIST_MAX_KEYS`). Listings come back ordered by key, i.e. by client-supplied event id, not by upload time.
- Score events were sorted with `toTimeSortedEventList`, whose tie-break returns -1 for both `cmp(a, b)` and `cmp(b, a)` when both events are creates. V8 reverses a run of such ties, so the file that happened to list first won the merge.

Ties are common in practice: since 3.10.5 the Python SDK uses the user-supplied score `timestamp` as the ingestion event timestamp, so every re-send of a score with a fixed timestamp ties with the original. This cannot be avoided in the SDK: `ScoreBody` has no timestamp field, so the event timestamp is the only way a user-supplied score timestamp reaches ClickHouse. The merged row still gets a fresh `event_ts`, so `updatedAt` advances while the value stays stale.

Changes:

- Sort listed event files by upload time before merging, so arrival order is upload order.
- Sort score events with a plain stable timestamp sort, so a tied re-send keeps arrival order and the later-uploaded one wins. Score events are all creates, so the create-before-update rule does not apply.
- Take the first write time from the first sorted file. The previous `.sort()` on `Date` objects compared their string form, so `"Fri Sep 04 ..."` sorted before `"Tue Sep 01 ..."` and the earliest file could be the wrong one whenever an entity's files spanned different weekdays or months. That time seeds `created_at` for records without a ClickHouse baseline row.
- Request `timeCreated` from OCI object listings, which otherwise only return `name`. Without it every OCI entry had `createdAt = new Date()`, which also seeded `created_at` with "now" on OCI.
- Unit tests: for two tied score events the last-arriving one wins (fails on main), and the existing tie behaviour of `toTimeSortedEventList` for tied creates is pinned.

`toTimeSortedEventList` itself is left unchanged for traces and observations, and now carries a comment saying why. The OTel processor emits a `trace-create` for the root span and another for a child span carrying trace updates, both stamped with the span start time. When they start in the same millisecond, the current reversal makes the child's explicit `update_current_trace()` values win over the root's derived name and input. Keeping arrival order there would flip that. One consequence of sorting files by upload time is that cross-file ties for traces and observations are now deterministic (earliest upload wins, because of that reversal) where they were random before; within one file nothing changes.

Known limits: S3 and Azure report upload time at second granularity, so two re-sends uploaded within the same second can still tie and fall back to key order. The ordering applies to the files visible to the job that merges last; a job that listed before a re-send was uploaded and finishes after the re-send's job can still write the older value. Both are unchanged from main. Re-sends within one request land in one file in batch order.

Verification: `pnpm --filter worker run test IngestionService.unit.test.ts` → `Tests  14 passed (14)` (without the fix the new score test fails: `expected 'first' to be 'second'`), `pnpm run lint` → `Tasks: 7 successful, 7 total`, shared and worker typecheck pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
