### PR TITLE
fix(ingestion): pick the earliest event file by time, not by string

### DIFF
--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -228,7 +228,7 @@ export const ingestionQueueProcessorBuilder = (
       const firstS3WriteTime =
         eventFiles
           .map((fileRef) => fileRef.createdAt)
-          .sort()
+          .sort((a, b) => a.getTime() - b.getTime())
           .shift() ?? new Date();
 
       if (events.length === 0) {


### PR DESCRIPTION
## What does this PR do?

The ingestion worker derives the first write time of an entity from the creation times of its event files. That list of `Date` objects was sorted with the default comparator, which compares their string form, so `"Fri Sep 04 2026 ..."` sorts before `"Tue Sep 01 2026 ..."` and the earliest file can be the wrong one whenever an entity's event files span different weekdays or months.

The first write time seeds `created_at` for scores, traces, and observations that have no ClickHouse baseline row, and the partition-aware timestamp for staging writes.

Change: sort by `getTime()`.

```
> [new Date("2026-09-01T22:51:47Z"), new Date("2026-09-04T09:00:00Z")].sort().shift()
2026-09-04T09:00:00.000Z   // default comparator
2026-09-01T22:51:47.000Z   // (a, b) => a.getTime() - b.getTime()
```

Verification: `pnpm run lint` → `Tasks: 7 successful, 7 total`, worker typecheck passes. No test added: the processor has no unit harness and the change is a one-line comparator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes ingestion timestamp selection by sorting event-file creation dates numerically rather than using JavaScript’s default string-based ordering.
- Uses epoch milliseconds to select the actual earliest event file.
- Corrects the seed timestamp used for new score, trace, observation, and staging writes.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the changed comparator correctly orders valid Date values chronologically.

The one-line change fixes the documented default-sort defect without altering queue contracts, downstream write flow, or other ingestion behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): pick the earliest event ..."](https://github.com/langfuse/langfuse/commit/c32257e3e8683bd4d57b89fd88d43873218649eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59309559)</sub>

<!-- /greptile_comment -->