### PR TITLE
fix(web): Resolve redirect paths with the URL constructor

### DIFF
--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -123,24 +123,25 @@ describe("getSafeRedirectPath", () => {
         // since router.query.targetPath is already decoded by Next.js
       });
 
-      it("should block backslash protocol-relative URLs", () => {
-        // WHATWG URL parsing treats `\` as `/` for special schemes, so
-        // `/\evil.com` resolves as `https://evil.com/`.
+      it("should block inputs the WHATWG parser would resolve off-origin", () => {
+        // `new URL(path, origin)` — the same parse as location.assign.
         expect(getSafeRedirectPath("/\\evil.com")).toBe("/");
         expect(getSafeRedirectPath("/\\evil.com/path")).toBe("/");
         expect(getSafeRedirectPath("/\\\\evil.com")).toBe("/");
-        // Two leading backslashes are `//evil.com` after normalize.
         expect(getSafeRedirectPath("\\\\evil.com")).toBe("/");
-        // Next.js already decodes query params; this is `%2F%5Cevil.com`.
         expect(getSafeRedirectPath(decodeURIComponent("%2F%5Cevil.com"))).toBe(
           "/",
         );
+        // Tab between the slashes is dropped by the URL parser, leaving `//`.
+        expect(getSafeRedirectPath("/\t/evil.com")).toBe("/");
+        expect(getSafeRedirectPath("/\t\\evil.com")).toBe("/");
       });
 
-      it("should keep the backslash guard working after control-char strip", () => {
-        // Tab between slash and backslash: `/\t\evil.com` → strip →
-        // `/\evil.com` → normalize → `//evil.com` → safe default.
-        expect(getSafeRedirectPath("/\t\\evil.com")).toBe("/");
+      it("should reject absolute URLs that match the dummy parse origin", () => {
+        expect(getSafeRedirectPath("https://langfuse.invalid/phishing")).toBe(
+          "/",
+        );
+        expect(getSafeRedirectPath("https:/evil.com")).toBe("/");
       });
     });
   });
@@ -231,8 +232,9 @@ describe("getSafeRedirectPath", () => {
     });
 
     it("should handle paths with special characters", () => {
+      // The URL serializer percent-encodes spaces in the pathname.
       expect(getSafeRedirectPath("/path/with spaces")).toBe(
-        "/path/with spaces",
+        "/path/with%20spaces",
       );
       expect(getSafeRedirectPath("/path/with-dashes")).toBe(
         "/path/with-dashes",
@@ -242,15 +244,13 @@ describe("getSafeRedirectPath", () => {
       );
     });
 
-    it("should normalize backslashes in otherwise-safe paths", () => {
-      // The value handed to router.replace / callbackUrl must be the
-      // same string the guard validated. Browsers treat `\` as `/`.
+    it("should return the WHATWG-resolved path for otherwise-safe inputs", () => {
       expect(getSafeRedirectPath("/project\\123")).toBe("/project/123");
       expect(getSafeRedirectPath("/dashboard\\tab?view=traces")).toBe(
         "/dashboard/tab?view=traces",
       );
-      // A single leading backslash is a same-origin path after normalize.
       expect(getSafeRedirectPath("\\dashboard")).toBe("/dashboard");
+      expect(getSafeRedirectPath("/foo/../bar")).toBe("/bar");
     });
 
     it("should handle paths with encoded characters", () => {
@@ -286,69 +286,41 @@ describe("getSafeRedirectPath", () => {
       expect(getSafeRedirectPath("/a\n\n\nb")).toBe("/ab");
     });
 
-    it("should strip null bytes from paths", () => {
-      // Null-byte injection (path-extension confusion) is sanitized
+    it("should percent-encode null bytes and DEL in paths", () => {
       expect(getSafeRedirectPath("/dashboard\u0000.png")).toBe(
-        "/dashboard.png",
+        "/dashboard%00.png",
       );
-      expect(getSafeRedirectPath("/abc\u0000evil")).toBe("/abcevil");
+      expect(getSafeRedirectPath("/abc\u0000evil")).toBe("/abc%00evil");
+      expect(getSafeRedirectPath("/abc\u007Fdef")).toBe("/abc%7Fdef");
+      expect(getSafeRedirectPath("/abc\u001Fdef")).toBe("/abc%1Fdef");
     });
 
-    it("should strip DEL and other control characters from the C0 range", () => {
-      // DEL (U+007F) is the boundary control char; stripped.
-      expect(getSafeRedirectPath("/abc\u007Fdef")).toBe("/abcdef");
-      // Tab (U+0009) is in the C0 range; stripped.
+    it("should strip tabs that the URL parser treats as ignorable", () => {
       expect(getSafeRedirectPath("/abc\tdef")).toBe("/abcdef");
-      // Unit-separator (U+001F) is the upper edge of the C0 range;
-      // stripped.
-      expect(getSafeRedirectPath("/abc\u001Fdef")).toBe("/abcdef");
     });
 
-    it("should NOT strip Unicode bidi-formatting characters outside the C0 range", () => {
-      // The C0 control-char strip is intentionally scoped to 0x00-0x1F
-      // and 0x7F (ASCII control characters per RFC 3986). Unicode bidi
-      // chars like RTL-override (U+202E) are out of scope for THIS fix;
-      // they require a separate, larger change. This test pins the
-      // current scope so future regressions are visible.
-      // Note: when this PR is merged, file a follow-up issue for
-      // bidi-formatting-character handling.
-      const pathWithRtl = "/abc\u202eevil";
-      const result = getSafeRedirectPath(pathWithRtl);
-      // The current implementation does not strip U+202E, so the
-      // character passes through.
-      expect(result).toContain("\u202e");
+    it("should percent-encode Unicode bidi-formatting characters", () => {
+      expect(getSafeRedirectPath("/abc\u202eevil")).toBe("/abc%E2%80%AEevil");
     });
 
     it("should fall back to safe default when path is only control characters", () => {
-      // A path that is nothing but ASCII control characters is fully
-      // stripped to empty, so the safe default is returned.
       expect(getSafeRedirectPath("\n")).toBe("/");
       expect(getSafeRedirectPath("\u0000\u0000")).toBe("/");
     });
 
-    it("should fall back to safe default for path with no leading slash after stripping", () => {
-      // U+202E (RTL-override) is not stripped by this fix, but it
-      // also doesn't start with "/" so the safe default is returned.
-      // This case is documented separately from the control-character
-      // case above because the rejection happens at the startWith("/")
-      // guard, not in the strip step.
+    it("should fall back to safe default for path with no leading slash", () => {
+      // U+202E is not path-absolute, so it is rejected even though
+      // the URL parser would resolve it same-origin as /%E2%80%AE.
       expect(getSafeRedirectPath("\u202e")).toBe("/");
     });
 
-    it("should preserve internal whitespace", () => {
-      // Tabs, spaces, etc. that are NOT control chars (i.e. U+0020
-      // SPACE) are preserved. This is a regression test for the strip
-      // being scoped to control characters only.
-      expect(getSafeRedirectPath("/abc def")).toBe("/abc def");
-      expect(getSafeRedirectPath("/a b c")).toBe("/a b c");
+    it("should percent-encode internal spaces", () => {
+      expect(getSafeRedirectPath("/abc def")).toBe("/abc%20def");
+      expect(getSafeRedirectPath("/a b c")).toBe("/a%20b%20c");
     });
 
     it("should keep protocol-relative and absolute-URL guards working with control characters", () => {
-      // Regression: the existing // guard still wins after the strip.
-      // "//\nevil.com" → strip newline → "//evil.com" → still matches
-      // startsWith("//") → safe default.
       expect(getSafeRedirectPath("//\nevil.com")).toBe("/");
-      // "http:\n//evil.com" → "http://evil.com" → safe default.
       expect(getSafeRedirectPath("http:\n//evil.com")).toBe("/");
     });
   });

--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -122,6 +122,26 @@ describe("getSafeRedirectPath", () => {
         // Note: The function receives already-decoded input in real usage
         // since router.query.targetPath is already decoded by Next.js
       });
+
+      it("should block backslash protocol-relative URLs", () => {
+        // WHATWG URL parsing treats `\` as `/` for special schemes, so
+        // `/\evil.com` resolves as `https://evil.com/`.
+        expect(getSafeRedirectPath("/\\evil.com")).toBe("/");
+        expect(getSafeRedirectPath("/\\evil.com/path")).toBe("/");
+        expect(getSafeRedirectPath("/\\\\evil.com")).toBe("/");
+        // Two leading backslashes are `//evil.com` after normalize.
+        expect(getSafeRedirectPath("\\\\evil.com")).toBe("/");
+        // Next.js already decodes query params; this is `%2F%5Cevil.com`.
+        expect(getSafeRedirectPath(decodeURIComponent("%2F%5Cevil.com"))).toBe(
+          "/",
+        );
+      });
+
+      it("should keep the backslash guard working after control-char strip", () => {
+        // Tab between slash and backslash: `/\t\evil.com` → strip →
+        // `/\evil.com` → normalize → `//evil.com` → safe default.
+        expect(getSafeRedirectPath("/\t\\evil.com")).toBe("/");
+      });
     });
   });
 
@@ -170,6 +190,7 @@ describe("getSafeRedirectPath", () => {
       expect(getSafeRedirectPath("//evil.com")).toBe("/my-app/");
       expect(getSafeRedirectPath("http://evil.com")).toBe("/my-app/");
       expect(getSafeRedirectPath("javascript:alert(1)")).toBe("/my-app/");
+      expect(getSafeRedirectPath("/\\evil.com")).toBe("/my-app/");
     });
 
     it("should not double-prepend basePath when path already includes it", () => {
@@ -219,6 +240,17 @@ describe("getSafeRedirectPath", () => {
       expect(getSafeRedirectPath("/path/with_underscores")).toBe(
         "/path/with_underscores",
       );
+    });
+
+    it("should normalize backslashes in otherwise-safe paths", () => {
+      // The value handed to router.replace / callbackUrl must be the
+      // same string the guard validated. Browsers treat `\` as `/`.
+      expect(getSafeRedirectPath("/project\\123")).toBe("/project/123");
+      expect(getSafeRedirectPath("/dashboard\\tab?view=traces")).toBe(
+        "/dashboard/tab?view=traces",
+      );
+      // A single leading backslash is a same-origin path after normalize.
+      expect(getSafeRedirectPath("\\dashboard")).toBe("/dashboard");
     });
 
     it("should handle paths with encoded characters", () => {

--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -143,6 +143,14 @@ describe("getSafeRedirectPath", () => {
         );
         expect(getSafeRedirectPath("https:/evil.com")).toBe("/");
       });
+
+      it("should reject paths that normalize to protocol-relative", () => {
+        // `/x/..//evil.com` stays on the dummy origin, but pathname is
+        // `//evil.com`. Returning that would reopen the redirect.
+        expect(getSafeRedirectPath("/x/..//evil.com")).toBe("/");
+        expect(getSafeRedirectPath("/..//evil.com")).toBe("/");
+        expect(getSafeRedirectPath("/x/..//evil.com/path")).toBe("/");
+      });
     });
   });
 
@@ -192,6 +200,7 @@ describe("getSafeRedirectPath", () => {
       expect(getSafeRedirectPath("http://evil.com")).toBe("/my-app/");
       expect(getSafeRedirectPath("javascript:alert(1)")).toBe("/my-app/");
       expect(getSafeRedirectPath("/\\evil.com")).toBe("/my-app/");
+      expect(getSafeRedirectPath("/x/..//evil.com")).toBe("/my-app/");
     });
 
     it("should not double-prepend basePath when path already includes it", () => {

--- a/web/src/__tests__/redirect.clienttest.ts
+++ b/web/src/__tests__/redirect.clienttest.ts
@@ -112,6 +112,7 @@ describe("getSafeRedirectPath", () => {
         expect(getSafeRedirectPath("./dashboard")).toBe("/");
         expect(getSafeRedirectPath("../dashboard")).toBe("/");
         expect(getSafeRedirectPath("evil.com")).toBe("/");
+        expect(getSafeRedirectPath("\\dashboard")).toBe("/");
       });
 
       it("should handle URL-encoded attack attempts", () => {
@@ -150,6 +151,7 @@ describe("getSafeRedirectPath", () => {
         expect(getSafeRedirectPath("/x/..//evil.com")).toBe("/");
         expect(getSafeRedirectPath("/..//evil.com")).toBe("/");
         expect(getSafeRedirectPath("/x/..//evil.com/path")).toBe("/");
+        expect(getSafeRedirectPath("/x/%2e%2e//evil.com")).toBe("/");
       });
     });
   });
@@ -228,6 +230,12 @@ describe("getSafeRedirectPath", () => {
         "/my-app/some/my-app/path",
       );
     });
+
+    it("should only skip prepending when the path is a basePath segment", () => {
+      expect(getSafeRedirectPath("/my-application")).toBe(
+        "/my-app/my-application",
+      );
+    });
   });
 
   describe("edge cases", () => {
@@ -258,7 +266,6 @@ describe("getSafeRedirectPath", () => {
       expect(getSafeRedirectPath("/dashboard\\tab?view=traces")).toBe(
         "/dashboard/tab?view=traces",
       );
-      expect(getSafeRedirectPath("\\dashboard")).toBe("/dashboard");
       expect(getSafeRedirectPath("/foo/../bar")).toBe("/bar");
     });
 

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -86,6 +86,13 @@ export function getSafeRedirectPath(
 
   const path = `${parsed.pathname}${parsed.search}${parsed.hash}`;
 
+  // Dot-segment resolution can produce a protocol-relative path while
+  // staying on the dummy origin (`/x/..//evil.com` → `//evil.com`).
+  // Callers such as window.open and res.redirect treat that as off-site.
+  if (path.startsWith("//")) {
+    return safeDefault;
+  }
+
   // If basePath is configured, check if the path already starts with it
   // This prevents double-prepending when the path already includes the base path
   if (basePath && path.startsWith(basePath)) {

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -1,13 +1,28 @@
 import { env } from "@/src/env.mjs";
 
 /**
+ * Dummy https origin used only so the WHATWG URL parser can resolve the
+ * input the same way a browser would. Never returned to callers.
+ */
+const SAME_ORIGIN_BASE = "https://langfuse.invalid";
+const SAME_ORIGIN = new URL(SAME_ORIGIN_BASE).origin;
+
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Validates and sanitizes a redirect path to prevent open redirect attacks.
  *
  * Security Requirements:
- * - Only allows relative paths starting with "/" (e.g., "/dashboard", "/project/123")
- * - Blocks protocol-relative URLs (e.g., "//evil.com", "/\\evil.com")
- * - Blocks absolute URLs (e.g., "http://evil.com", "https://evil.com")
- * - Blocks javascript: and data: URIs
+ * - Only allows path-absolute relative paths (e.g., "/dashboard", "/project/123")
+ * - Blocks any input the WHATWG parser would resolve off the dummy origin
+ *   (protocol-relative, backslash-normalized, absolute http(s), other schemes)
  * - Automatically prepends NEXT_PUBLIC_BASE_PATH if configured
  *
  * @param targetPath - The path to validate (typically from query params or user input)
@@ -35,49 +50,49 @@ export function getSafeRedirectPath(
     return safeDefault;
   }
 
-  // Trim whitespace
   const trimmed = targetPath.trim();
 
   if (!trimmed) {
     return safeDefault;
   }
 
-  // Strip ASCII control characters (0x00-0x1F, 0x7F) to defend against
-  // newline injection (HTTP header / log forging) and null-byte injection
-  // (path-extension confusion). These characters are not valid in URL
-  // paths per RFC 3986. Unicode bidi-formatting characters (e.g.
-  // U+202E RTL-override) are intentionally out of scope for this fix.
-  const sanitized = trimmed.replace(/[\x00-\x1F\x7F]/g, "");
-
-  if (!sanitized) {
+  // Absolute URLs parse without a base. Reject them so a value such as
+  // `https://langfuse.invalid/...` cannot pass the origin check below,
+  // and so javascript:/data:/file: schemes never reach the relative parse.
+  if (isAbsoluteUrl(trimmed)) {
     return safeDefault;
   }
 
-  // WHATWG URL parsing treats `\` as `/` for special schemes (http, https),
-  // so `/\evil.com` is equivalent to `//evil.com` (protocol-relative).
-  // Normalize before the textual same-origin check so the guard sees what
-  // the browser will see, and return this value to callers.
-  const normalized = sanitized.replace(/\\/g, "/");
-
-  // Only allow paths starting with "/" but not "//" (protocol-relative URLs)
-  // This blocks:
-  // - Protocol-relative: "//evil.com", "/\evil.com"
-  // - Absolute URLs: "http://evil.com", "https://evil.com"
-  // - JavaScript URIs: "javascript:alert(1)"
-  // - Data URIs: "data:text/html,..."
-  // - Other schemes: "file://", "ftp://", etc.
-  if (!normalized.startsWith("/") || normalized.startsWith("//")) {
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, SAME_ORIGIN_BASE);
+  } catch {
     return safeDefault;
   }
+
+  // Protocol-relative (`//evil.com`), backslash forms (`/\evil.com`),
+  // and any other host change fail this check. The parser is the same
+  // one the browser uses for `location.assign(path)` / `new URL(path, origin)`.
+  if (parsed.origin !== SAME_ORIGIN) {
+    return safeDefault;
+  }
+
+  // Path-absolute only (`/` or `\`). `dashboard`, `./x`, and `../x`
+  // resolve same-origin against the dummy base but are not accepted
+  // in-app paths.
+  if (!trimmed.startsWith("/") && !trimmed.startsWith("\\")) {
+    return safeDefault;
+  }
+
+  const path = `${parsed.pathname}${parsed.search}${parsed.hash}`;
 
   // If basePath is configured, check if the path already starts with it
   // This prevents double-prepending when the path already includes the base path
-  if (basePath && normalized.startsWith(basePath)) {
-    return normalized;
+  if (basePath && path.startsWith(basePath)) {
+    return path;
   }
 
-  // Prepend basePath if configured
-  return basePath + normalized;
+  return basePath + path;
 }
 
 /**
@@ -98,8 +113,8 @@ export function stripBasePath(path: string): string {
     return path;
   }
 
-  // Strip ASCII control characters (0x00-0x1F, 0x7F) before further
-  // processing. See getSafeRedirectPath for the rationale.
+  // Strip ASCII control characters (0x00-0x1F, 0x7F) so a newline or
+  // null byte cannot split the basePath prefix from the remainder.
   const cleaned = path.replace(/[\x00-\x1F\x7F]/g, "");
 
   const stripped = cleaned.slice(basePath.length) || "/";

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -5,7 +5,7 @@ import { env } from "@/src/env.mjs";
  *
  * Security Requirements:
  * - Only allows relative paths starting with "/" (e.g., "/dashboard", "/project/123")
- * - Blocks protocol-relative URLs (e.g., "//evil.com")
+ * - Blocks protocol-relative URLs (e.g., "//evil.com", "/\\evil.com")
  * - Blocks absolute URLs (e.g., "http://evil.com", "https://evil.com")
  * - Blocks javascript: and data: URIs
  * - Automatically prepends NEXT_PUBLIC_BASE_PATH if configured
@@ -53,25 +53,31 @@ export function getSafeRedirectPath(
     return safeDefault;
   }
 
+  // WHATWG URL parsing treats `\` as `/` for special schemes (http, https),
+  // so `/\evil.com` is equivalent to `//evil.com` (protocol-relative).
+  // Normalize before the textual same-origin check so the guard sees what
+  // the browser will see, and return this value to callers.
+  const normalized = sanitized.replace(/\\/g, "/");
+
   // Only allow paths starting with "/" but not "//" (protocol-relative URLs)
   // This blocks:
-  // - Protocol-relative: "//evil.com"
+  // - Protocol-relative: "//evil.com", "/\evil.com"
   // - Absolute URLs: "http://evil.com", "https://evil.com"
   // - JavaScript URIs: "javascript:alert(1)"
   // - Data URIs: "data:text/html,..."
   // - Other schemes: "file://", "ftp://", etc.
-  if (!sanitized.startsWith("/") || sanitized.startsWith("//")) {
+  if (!normalized.startsWith("/") || normalized.startsWith("//")) {
     return safeDefault;
   }
 
   // If basePath is configured, check if the path already starts with it
   // This prevents double-prepending when the path already includes the base path
-  if (basePath && sanitized.startsWith(basePath)) {
-    return sanitized;
+  if (basePath && normalized.startsWith(basePath)) {
+    return normalized;
   }
 
   // Prepend basePath if configured
-  return basePath + sanitized;
+  return basePath + normalized;
 }
 
 /**

--- a/web/src/utils/redirect.ts
+++ b/web/src/utils/redirect.ts
@@ -4,26 +4,20 @@ import { env } from "@/src/env.mjs";
  * Dummy https origin used only so the WHATWG URL parser can resolve the
  * input the same way a browser would. Never returned to callers.
  */
-const SAME_ORIGIN_BASE = "https://langfuse.invalid";
-const SAME_ORIGIN = new URL(SAME_ORIGIN_BASE).origin;
-
-function isAbsoluteUrl(value: string): boolean {
-  try {
-    new URL(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
+const REDIRECT_ORIGIN = "https://langfuse.invalid";
 
 /**
  * Validates and sanitizes a redirect path to prevent open redirect attacks.
  *
  * Security Requirements:
- * - Only allows path-absolute relative paths (e.g., "/dashboard", "/project/123")
- * - Blocks any input the WHATWG parser would resolve off the dummy origin
+ * - Only allows path-absolute relative paths that start with "/"
+ * - Parses with the WHATWG URL constructor and rejects off-origin results
  *   (protocol-relative, backslash-normalized, absolute http(s), other schemes)
+ * - Rejects serialized output that starts with "//" after dot-segment resolution
  * - Automatically prepends NEXT_PUBLIC_BASE_PATH if configured
+ *
+ * Returned paths are URL-serialized: spaces and control characters are
+ * percent-encoded, and dot segments are resolved.
  *
  * @param targetPath - The path to validate (typically from query params or user input)
  * @returns A safe redirect path with basePath prepended, or "/" (with basePath) if invalid
@@ -45,61 +39,36 @@ export function getSafeRedirectPath(
   const basePath = env.NEXT_PUBLIC_BASE_PATH ?? "";
   const safeDefault = basePath ? `${basePath}/` : "/";
 
-  // Handle empty/null/undefined
-  if (!targetPath || typeof targetPath !== "string") {
+  if (typeof targetPath !== "string") {
     return safeDefault;
   }
 
-  const trimmed = targetPath.trim();
+  const input = targetPath.trim();
 
-  if (!trimmed) {
+  if (!input.startsWith("/")) {
     return safeDefault;
   }
 
-  // Absolute URLs parse without a base. Reject them so a value such as
-  // `https://langfuse.invalid/...` cannot pass the origin check below,
-  // and so javascript:/data:/file: schemes never reach the relative parse.
-  if (isAbsoluteUrl(trimmed)) {
-    return safeDefault;
-  }
-
-  let parsed: URL;
+  let url: URL;
   try {
-    parsed = new URL(trimmed, SAME_ORIGIN_BASE);
+    url = new URL(input, REDIRECT_ORIGIN);
   } catch {
     return safeDefault;
   }
 
-  // Protocol-relative (`//evil.com`), backslash forms (`/\evil.com`),
-  // and any other host change fail this check. The parser is the same
-  // one the browser uses for `location.assign(path)` / `new URL(path, origin)`.
-  if (parsed.origin !== SAME_ORIGIN) {
+  const path = `${url.pathname}${url.search}${url.hash}`;
+
+  // Origin rejects `/\evil.com` (HTTPS parser resolves it off-site).
+  // Leading `//` after serialization rejects `/x/..//evil.com`.
+  if (url.origin !== REDIRECT_ORIGIN || path.startsWith("//")) {
     return safeDefault;
   }
 
-  // Path-absolute only (`/` or `\`). `dashboard`, `./x`, and `../x`
-  // resolve same-origin against the dummy base but are not accepted
-  // in-app paths.
-  if (!trimmed.startsWith("/") && !trimmed.startsWith("\\")) {
-    return safeDefault;
-  }
+  const includesBasePath =
+    basePath &&
+    (url.pathname === basePath || url.pathname.startsWith(`${basePath}/`));
 
-  const path = `${parsed.pathname}${parsed.search}${parsed.hash}`;
-
-  // Dot-segment resolution can produce a protocol-relative path while
-  // staying on the dummy origin (`/x/..//evil.com` → `//evil.com`).
-  // Callers such as window.open and res.redirect treat that as off-site.
-  if (path.startsWith("//")) {
-    return safeDefault;
-  }
-
-  // If basePath is configured, check if the path already starts with it
-  // This prevents double-prepending when the path already includes the base path
-  if (basePath && path.startsWith(basePath)) {
-    return path;
-  }
-
-  return basePath + path;
+  return includesBasePath ? path : basePath + path;
 }
 
 /**


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16928 app preview](https://pr-16928.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

`getSafeRedirectPath` no longer decides "is this same-origin?" with a textual `startsWith("//")` check. It requires a real leading `/`, parses the input with the WHATWG `URL` constructor against a dummy `https://` origin, and accepts the path only when that parse stays on the dummy origin **and** the serialized output does not start with `//`.

That is the same parser a browser uses for `new URL(path, origin)` / `location.assign(path)`, so backslash forms (`/\evil.com`), control characters between slashes, and percent-encoded dot segments (`/x/%2e%2e//evil.com`) are handled without extra character-specific normalization.

Absolute URLs (`javascript:`, `https://…`) never start with `/`, so they are rejected before parse. Inputs that are not path-absolute (`dashboard`, `./x`, `\dashboard`) are rejected the same way.

The value returned to `router.replace` / `callbackUrl` is `pathname + search + hash` from that parse. Base-path matching uses a segment boundary, so `/my-application` is not treated as already under `/my-app`.

## Intentional contract changes

Returned paths are URL-serialized:

- Spaces and some control characters are percent-encoded (`/path/with spaces` → `/path/with%20spaces`)
- Dot segments are resolved (`/foo/../bar` → `/bar`)
- A leading backslash is no longer accepted (`\dashboard` → `/`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `web` — `getSafeRedirectPath` and its client tests

## Verification

- `pnpm --filter web run test-client src/__tests__/redirect.clienttest.ts` — `Tests  52 passed (52)`
- `pnpm --filter web exec eslint src/utils/redirect.ts src/__tests__/redirect.clienttest.ts --max-warnings 0` — clean
- Preview production build (signed-in + sign-in callback): `targetPath=%2F%5Cexample.com` stayed on `pr-16928.preview.langfuse.com`. `targetPath=/setup` landed on `/setup`.

![Signed-in malicious targetPath stays on preview origin](https://cursor.com/artifacts/c/art-5dcd6aa3-2635-41e5-9c6d-dbd128e1cdb2)
![Legitimate /setup targetPath lands on setup](https://cursor.com/artifacts/c/art-229d9534-da3c-4990-b4ff-dd9fbe9441ad)
<a href="https://cursor.com/agents/bc-00e7c231-25d5-4118-ac4f-382b12f3607d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_backslash_targetpath_stays_on_origin.mp4"><img src="https://cursor.com/artifacts/c/art-35455d57-b377-462e-9aa5-f7436c3ccc34" alt="preview_backslash_targetpath_stays_on_origin.mp4" /></a>

## Test this

Preview: https://pr-16928.preview.langfuse.com/auth/sign-in?targetPath=%2F%5Cexample.com

1. Open that URL while signed in (or sign in on it).
2. Confirm the browser stays on the Langfuse origin.
3. Repeat unauthenticated: `/auth/sign-in?autoSignIn=false&targetPath=%2F%5Cexample.com`, then sign in.
4. Repeat with `?targetPath=/setup` and confirm that still lands on `/setup`.

Data: demo project is enough.
Sandbox: same paths on `http://localhost:3000`.

## Why this was hard to reproduce

`new URL("/\\evil.com", "https://cloud.langfuse.com/")` is `https://evil.com/`.
String-concatenating the same value onto the origin (`https://cloud.langfuse.com` + `/\\evil.com`) stays on-site as `https://cloud.langfuse.com//evil.com`. NextAuth's `redirect` callback concatenates; Next `router.replace` may abort via `parseRelativeUrl`. The helper now follows the relative-resolve parser so both sinks get a path that cannot leave the origin.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Code follows the style guidelines of this project
- No documentation update required
- Added tests for off-origin WHATWG resolutions, encoded dot segments, and the basePath segment boundary
- New and existing unit tests in `redirect.clienttest.ts` pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15869](https://linear.app/clickhouse/issue/LFE-15869/security-p4-open-redirect-via-targetpath-on-authsign-in-control-char)

<div><a href="https://cursor.com/agents/bc-00e7c231-25d5-4118-ac4f-382b12f3607d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00e7c231-25d5-4118-ac4f-382b12f3607d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens redirect validation by normalizing backslashes before checking for protocol-relative URLs and returning the same normalized path that was validated.
- Rejects backslash-based protocol-relative redirect payloads.
- Preserves configured safe defaults and base-path handling.
- Adds client tests for malicious, control-character, and valid normalized paths.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and closes the backslash-based open-redirect path while preserving same-origin redirects.

The validator now checks and returns the same slash-normalized representation browsers use, and the added tests cover the reported exploit variants and valid redirect behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): reject backslash protocol-rela..."](https://github.com/langfuse/langfuse/commit/755acdc4fb14a0e83eef4c4f8e0a9531477bcbc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59397405)</sub>

<!-- /greptile_comment -->