### PR TITLE
chore(eslint): widen root margin rule to all components

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -190,13 +190,6 @@ export default [
     },
     rules: {
       ...reactYouMightNotNeedAnEffect.configs.recommended.rules,
-      // Margin makes components harder to compose and should therefore be applied by the parent.
-      // See: https://mxstbr.com/thoughts/margin for a discussion of this pattern.
-      // TODO: Consider expanding this rule beyond design-system components
-      "@repo/no-margin-on-root-elements": [
-        "warn",
-        { classNameFunctions: ["cn", "clsx"] },
-      ],
       "boundaries/dependencies": [
         "error",
         {
@@ -223,6 +216,20 @@ export default [
 
       // TODO: Expand to more of the codebase
       "no-nested-ternary": "error",
+    },
+  },
+
+  {
+    name: "langfuse/web/component-margin-rules",
+    files: ["src/components/**/*.{ts,tsx}"],
+    ignores: ["src/components/**/*.stories.{ts,tsx}"],
+    rules: {
+      // Margin makes components harder to compose and should therefore be applied by the parent.
+      // See: https://mxstbr.com/thoughts/margin for a discussion of this pattern.
+      "@repo/no-margin-on-root-elements": [
+        "warn",
+        { classNameFunctions: ["cn", "clsx"] },
+      ],
     },
   },
 

--- a/web/src/components/ChatMessages/ToolCallCard.tsx
+++ b/web/src/components/ChatMessages/ToolCallCard.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-margin-on-root-elements */
 import { type LLMToolCall } from "@langfuse/shared";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 

--- a/web/src/components/ScoreBadge/ScoreBadge.tsx
+++ b/web/src/components/ScoreBadge/ScoreBadge.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-margin-on-root-elements */
 import { type LastUserScore, type ScoreDomain } from "@langfuse/shared";
 import {
   BracesIcon,

--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger */
+/* eslint-disable @repo/no-style-props, @repo/no-abstracted-overlay-trigger, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/layouts/header.tsx
+++ b/web/src/components/layouts/header.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 import Link from "next/link";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { Badge } from "@/src/components/ui/badge";

--- a/web/src/components/layouts/page-tabs.tsx
+++ b/web/src/components/layouts/page-tabs.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 import { cn } from "@/src/utils/tailwind";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/web/src/components/layouts/settings-table-card.tsx
+++ b/web/src/components/layouts/settings-table-card.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 import { Card } from "@/src/components/ui/card";
 import { cn } from "@/src/utils/tailwind";
 

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-margin-on-root-elements */
 "use client";
 import { type LucideIcon } from "lucide-react";
 import {

--- a/web/src/components/session/ModernSessionSidebar.tsx
+++ b/web/src/components/session/ModernSessionSidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-margin-on-root-elements */
 import React, { useCallback, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 import {
   type default as React,
   createContext,

--- a/web/src/components/table/data-table-multi-select-actions/data-table-select-all-banner.tsx
+++ b/web/src/components/table/data-table-multi-select-actions/data-table-select-all-banner.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-margin-on-root-elements */
 import { type MultiSelect } from "@/src/components/table/data-table-toolbar";
 import { Button } from "@/src/components/ui/button";
 import { numberFormatter } from "@/src/utils/numbers";

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/input-command.tsx
+++ b/web/src/components/ui/input-command.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 // Adapted command to be used as a form field with suggestions

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/splash-screen.tsx
+++ b/web/src/components/ui/splash-screen.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @repo/no-margin-on-root-elements */
 import React, { useState } from "react";
 import { cn } from "@/src/utils/tailwind";
 import Image from "next/image";

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 import * as React from "react";
 
 import { Button } from "@/src/components/ui/button";

--- a/web/src/components/ui/tabs-bar.tsx
+++ b/web/src/components/ui/tabs-bar.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @repo/no-style-props */
+/* eslint-disable @repo/no-style-props, @repo/no-margin-on-root-elements */
 "use client";
 
 import * as React from "react";


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16931 app preview](https://pr-16931.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Widen `@repo/no-margin-on-root-elements` from design-system components to all components under `web/src/components`. Existing root-margin usages are explicitly documented with file-level ESLint suppressions, extending existing directives where present.

The branch has been rebased onto the latest `main`; the obsolete `web/src/components/ui/alert.tsx` deletion from `main` was preserved during conflict resolution.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Verification

- Focused component ESLint passed with zero warnings/errors.
- Margin rule tests passed: `Tests 99 passed (99)`.
- Pre-commit checks passed: `Tasks: 7 successful, 7 total`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15885](https://linear.app/clickhouse/issue/LFE-15885/widen-eslint-repono-margin-on-root-elements-to-all-components)

<div><a href="https://cursor.com/agents/bc-41c35f91-e48a-49cc-9412-da49fda21d1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41c35f91-e48a-49cc-9412-da49fda21d1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR widens the root-element margin lint rule from design-system components to all components under `web/src/components`, excluding stories.

- Adds a component-wide ESLint configuration block for the rule.
- Adds or extends suppressions in components containing existing root margins.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking concern that broad file-level suppressions weaken enforcement for compliant sibling components.

The widened ESLint scope is correctly configured, but several multi-component modules disable the rule globally to exempt a single existing root margin, allowing future violations in unrelated exports to escape linting.

**Files Needing Attention:** web/src/components/ui/tabs.tsx and similarly suppressed multi-component UI modules
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/ui/tabs.tsx:1
**File-wide suppression weakens enforcement**

The file-level directive exempts every component in this module even though only `TabsContent` currently has a root margin. A new root margin on a compliant sibling such as `TabsList` will therefore pass lint, weakening the composability rule this change is intended to extend; the same pattern occurs in `alert.tsx`, `dialog.tsx`, and `table.tsx`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(eslint): widen root margin rule to..."](https://github.com/langfuse/langfuse/commit/4907e83c2394db5bc28f4b0461d7630a7395d6ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59423171)</sub>

<!-- /greptile_comment -->