### PR TITLE
refactor(web): Use `createTextTableColumn` more

### DIFF
--- a/web/src/components/design-system/table/columns/createTextTableColumn.tsx
+++ b/web/src/components/design-system/table/columns/createTextTableColumn.tsx
@@ -15,14 +15,12 @@ type TextValueMapper<TData extends RowData, TValue> = (
 type TextTableColumnOptions<TData extends RowData, TValue> = TableColumnOptions<
   TData,
   TValue
-> & {
-  className?: string;
-} & ([TValue] extends [string]
+> &
+  ([TValue] extends [string]
     ? { mapValue?: TextValueMapper<TData, TValue> }
     : { mapValue: TextValueMapper<TData, TValue> });
 
 export function createTextTableColumn<TData extends RowData, TValue = string>({
-  className,
   mapValue,
   ...options
 }: TextTableColumnOptions<TData, TValue>) {
@@ -37,7 +35,7 @@ export function createTextTableColumn<TData extends RowData, TValue = string>({
       if (text === null || text === undefined) return null;
       if (typeof text !== "string") return loadingCell;
 
-      return className ? <span className={className}>{text}</span> : text;
+      return <span title={text}>{text}</span>;
     },
   });
 }

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -145,6 +145,7 @@ export type ObservationsTableRow = {
   id: string;
   traceName?: string;
   traceId?: string;
+  version: string;
   timestamp?: Date;
   promptId?: string;
   promptVersion?: string;
@@ -1041,9 +1042,8 @@ export default function ObservationsTable({
       enableHiding: true,
       defaultHidden: true,
     },
-    {
+    createTextTableColumn<ObservationsTableRow>({
       accessorKey: "version",
-      id: "version",
       header: "Version",
       size: 100,
       headerTooltip: {
@@ -1053,7 +1053,7 @@ export default function ObservationsTable({
       enableHiding: true,
       enableSorting,
       defaultHidden: true,
-    },
+    }),
     {
       accessorKey: "usage",
       header: "Usage",

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -105,13 +105,12 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
       header: "Name",
       enableHiding: true,
     }),
-    {
+    createTextTableColumn<ScoreConfigTableRow>({
       accessorKey: "dataType",
-      id: "dataType",
       header: "Data Type",
       size: 80,
       enableHiding: true,
-    },
+    }),
     createIOTableColumn<ScoreConfigTableRow, Prisma.JsonValue>({
       id: "range",
       accessorFn: getConfigRange,

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -12,6 +12,7 @@ import { createDateTableColumn } from "@/src/components/design-system/table/colu
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createUserTableColumn } from "@/src/components/design-system/table/columns/createUserTableColumn";
 import { createIOTableColumn } from "@/src/components/design-system/table/columns/createIOTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { ConnectedIOTableCell } from "@/src/components/table/ConnectedIOTableCell";
@@ -593,14 +594,13 @@ export default function ScoresTable({
       enableSorting: true,
       size: 150,
     }),
-    {
+    createTextTableColumn<ScoresTableRow>({
       accessorKey: "name",
       header: "Name",
-      id: "name",
       enableHiding: true,
       enableSorting: true,
       size: 150,
-    },
+    }),
     {
       accessorKey: "value",
       header: "Value",
@@ -609,15 +609,14 @@ export default function ScoresTable({
       enableSorting: true,
       size: 100,
     },
-    {
+    createTextTableColumn<ScoresTableRow>({
       accessorKey: "dataType",
       header: "Data Type",
-      id: "dataType",
       enableHiding: true,
       enableSorting: true,
       defaultHidden: true,
       size: 100,
-    },
+    }),
     {
       accessorKey: "source",
       header: "Source",

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -673,18 +673,13 @@ export default function TracesTable({
       enableHiding: true,
       enableSorting,
     }),
-    {
+    createTextTableColumn<TracesTableRow>({
       accessorKey: "name",
       header: "Name",
-      id: "name",
       size: 150,
       enableHiding: true,
       enableSorting,
-      cell: ({ row }) => {
-        const value: TracesTableRow["name"] = row.getValue("name");
-        return value ?? undefined;
-      },
-    },
+    }),
     {
       accessorKey: "input",
       header: "Input",
@@ -760,20 +755,24 @@ export default function TracesTable({
       },
       enableHiding: true,
     },
-    createTextTableColumn<TracesTableRow, number>({
+    {
       accessorKey: "latency",
+      id: "latency",
       header: "Latency",
       size: 100,
-      className: "text-nowrap",
-      mapValue: (value, { row }) =>
-        isMetricPending(row.original.id)
-          ? { type: "loading" }
-          : value === null || value === undefined
-            ? undefined
-            : formatIntervalSeconds(value),
+      loadingCell: <Skeleton className="h-4 w-1/2" />,
+      cell: ({ row }) => {
+        const value: TracesTableRow["latency"] = row.getValue("latency");
+        if (isMetricPending(row.original.id)) {
+          return <Skeleton className="h-4 w-1/2" />;
+        }
+        return value !== undefined ? (
+          <span className="text-nowrap">{formatIntervalSeconds(value)}</span>
+        ) : undefined;
+      },
       enableHiding: true,
       enableSorting,
-    }),
+    },
 
     createTokenUsageTableColumn<TracesTableRow, TracesTableRow["usage"]>({
       id: "tokens",
@@ -1011,9 +1010,8 @@ export default function TracesTable({
       enableHiding: true,
       enableSorting,
     },
-    {
+    createTextTableColumn<TracesTableRow>({
       accessorKey: "version",
-      id: "version",
       header: "Version",
       size: 100,
       headerTooltip: {
@@ -1037,10 +1035,9 @@ export default function TracesTable({
       defaultHidden: true,
       enableHiding: true,
       enableSorting,
-    },
-    {
+    }),
+    createTextTableColumn<TracesTableRow>({
       accessorKey: "release",
-      id: "release",
       header: "Release",
       size: 100,
       headerTooltip: {
@@ -1065,7 +1062,7 @@ export default function TracesTable({
       defaultHidden: true,
       enableHiding: true,
       enableSorting,
-    },
+    }),
     createIdTableColumn<TracesTableRow>({
       accessorKey: "id",
       header: "Trace ID",

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -14,18 +14,16 @@ export default function BackgroundMigrationsTable() {
   const backgroundMigrations = api.backgroundMigrations.all.useQuery();
 
   const columns = [
-    {
+    createTextTableColumn<BackgroundMigration>({
       accessorKey: "name",
-      id: "name",
       enableColumnFilter: false,
       header: "Name",
-    },
-    {
+    }),
+    createTextTableColumn<BackgroundMigration>({
       accessorKey: "script",
-      id: "script",
       enableColumnFilter: false,
       header: "Script",
-    },
+    }),
     {
       accessorKey: "args",
       id: "args",
@@ -49,12 +47,11 @@ export default function BackgroundMigrationsTable() {
       size: 80,
       enableSorting: false,
     }),
-    {
+    createTextTableColumn<BackgroundMigration>({
       accessorKey: "failedReason",
-      id: "failedReason",
       enableColumnFilter: false,
       header: "Failed Reason",
-    },
+    }),
     createTextTableColumn<BackgroundMigration, BackgroundMigration["state"]>({
       accessorKey: "state",
       enableColumnFilter: false,

--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
@@ -8,6 +8,7 @@ import {
 } from "@langfuse/shared";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createIOTableColumn } from "@/src/components/design-system/table/columns/createIOTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableColumnVisibilityFilter } from "@/src/components/table/data-table-column-visibility-filter";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
@@ -387,30 +388,27 @@ export function SampleObservationSelectorBase(
         size: 170,
         enableHiding: true,
       }),
-      {
+      createTextTableColumn<SampleObservation>({
         accessorKey: "type",
-        id: "type",
         header: "Type",
         size: 110,
         enableHiding: true,
-      },
-      {
+      }),
+      createTextTableColumn<SampleObservation>({
         accessorKey: "name",
-        id: "name",
         header: "Name",
         size: 200,
         enableHiding: true,
-        cell: ({ row }) => row.original.name ?? "—",
-      },
-      {
+        mapValue: (value) => value ?? "—",
+      }),
+      createTextTableColumn<SampleObservation>({
         accessorKey: "traceName",
-        id: "traceName",
         header: "Trace name",
         size: 180,
         enableHiding: true,
         defaultHidden: true,
-        cell: ({ row }) => row.original.traceName ?? "—",
-      },
+        mapValue: (value) => value ?? "—",
+      }),
       createIOTableColumn<SampleObservation>({
         accessorKey: "input",
         header: "Input",
@@ -452,14 +450,13 @@ export function SampleObservationSelectorBase(
         singleLine: rowHeight === "s",
         enableExpandOnHover: rowHeight === "s",
       }),
-      {
+      createTextTableColumn<SampleObservation>({
         accessorKey: "environment",
-        id: "environment",
         header: "Environment",
         size: 130,
         enableHiding: true,
         defaultHidden: true,
-      },
+      }),
     ],
     [observationIOById, observationIOPending, leadingColumns, rowHeight],
   );

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1139,28 +1139,18 @@ export default function ObservationsEventsTable({
       size: 50,
       enableSorting,
     }),
-    {
+    createTextTableColumn<EventsTableRow>({
       accessorKey: "name",
-      id: "name",
       header: getEventsColumnName("name"),
       size: 150,
       enableSorting,
-      cell: ({ row }) => {
-        const value: EventsTableRow["name"] = row.getValue("name");
-        return value ?? undefined;
-      },
-    },
-    {
+    }),
+    createTextTableColumn<EventsTableRow>({
       accessorKey: "traceName",
-      id: "traceName",
       header: getEventsColumnName("traceName"),
       size: 150,
       enableSorting: true,
-      cell: ({ row }) => {
-        const value: string | undefined = row.getValue("traceName");
-        return value ?? undefined;
-      },
-    },
+    }),
     createIOTableColumn<EventsTableRow>({
       accessorKey: "input",
       header: getEventsColumnName("input"),
@@ -1510,9 +1500,8 @@ export default function ObservationsEventsTable({
       enableHiding: true,
       defaultHidden: true,
     },
-    {
+    createTextTableColumn<EventsTableRow>({
       accessorKey: "version",
-      id: "version",
       header: getEventsColumnName("version"),
       size: 100,
       headerTooltip: {
@@ -1522,10 +1511,9 @@ export default function ObservationsEventsTable({
       enableHiding: true,
       enableSorting,
       defaultHidden: true,
-    },
-    {
+    }),
+    createTextTableColumn<EventsTableRow>({
       accessorKey: "release",
-      id: "release",
       header: getEventsColumnName("release"),
       size: 100,
       headerTooltip: {
@@ -1535,7 +1523,7 @@ export default function ObservationsEventsTable({
       enableHiding: true,
       enableSorting,
       defaultHidden: true,
-    },
+    }),
     {
       accessorKey: "userId",
       id: "userId",

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -29,6 +29,7 @@ import { useFolderPagination } from "@/src/features/folders/hooks/useFolderPagin
 import { buildFullPath } from "@/src/features/folders/utils";
 import { FolderBreadcrumb } from "@/src/features/folders/components/FolderBreadcrumb";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
 type PromptTableRow = {
   id: string;
@@ -305,13 +306,12 @@ export function PromptTable() {
         return getValue<number | undefined>();
       },
     },
-    {
+    createTextTableColumn<PromptTableRow>({
       accessorKey: "type",
       header: "Type",
-      id: "type",
       enableSorting: true,
       size: 60,
-    },
+    }),
     createDateTableColumn({
       accessorKey: "createdAt",
       header: "Latest Version Created At",

--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -38,6 +38,7 @@ import { useEffect } from "react";
 import { UserFeaturePreviewsControl } from "@/src/features/feature-flags/components/UserFeaturePreviewsPopover";
 import type { FeaturePreviewFlag } from "@/src/features/feature-flags/available-flags";
 import { env } from "@/src/env.mjs";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { Button } from "@/src/components/ui/button";
 import { Popover, PopoverTrigger } from "@/src/components/ui/popover";
 
@@ -171,23 +172,16 @@ export function MembersTable({
         );
       },
     },
-    {
+    createTextTableColumn<MembersTableRow>({
       accessorKey: "email",
-      id: "email",
       header: "Email",
-    },
-    {
+    }),
+    createTextTableColumn<MembersTableRow, string[]>({
       accessorKey: "providers",
-      id: "providers",
       header: "SSO Provider",
       enableHiding: true,
-      cell: ({ row }) => {
-        const providers = row.getValue("providers") as string[];
-        if (providers.length === 0) return "-";
-
-        return providers.join(", ");
-      },
-    },
+      mapValue: (providers) => (providers?.length ? providers.join(", ") : "-"),
+    }),
     {
       accessorKey: "orgRole",
       id: "orgRole",

--- a/web/src/features/rbac/components/MembershipInvitesPage.tsx
+++ b/web/src/features/rbac/components/MembershipInvitesPage.tsx
@@ -11,6 +11,7 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import Header from "@/src/components/layouts/header";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { createUserTableColumn } from "@/src/components/design-system/table/columns/createUserTableColumn";
+import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
 export type InvitesTableRow = {
   email: string;
@@ -91,16 +92,14 @@ export function MembershipInvitesPage({
   });
 
   const columns: LangfuseColumnDef<InvitesTableRow>[] = [
-    {
+    createTextTableColumn<InvitesTableRow>({
       accessorKey: "email",
-      id: "email",
       header: "Email",
-    },
-    {
+    }),
+    createTextTableColumn<InvitesTableRow>({
       accessorKey: "orgRole",
-      id: "orgRole",
       header: "Organization Role",
-    },
+    }),
     {
       accessorKey: "createdAt",
       id: "createdAt",
@@ -112,11 +111,10 @@ export function MembershipInvitesPage({
     },
     ...(projectId
       ? [
-          {
+          createTextTableColumn<InvitesTableRow>({
             accessorKey: "projectRole",
-            id: "projectRole",
             header: "Project Role",
-          },
+          }),
         ]
       : []),
     createUserTableColumn<InvitesTableRow>({

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -302,22 +302,22 @@ export function DashboardWidgetTable() {
       header: "Description",
       size: 300,
     }),
-    columnHelper.accessor("view", {
+    createTextTableColumn<WidgetTableRow>({
+      accessorKey: "view",
       header: "View Type",
-      id: "view",
       enableSorting: true,
       size: 100,
-      cell: (row) => {
-        return startCase(row.getValue().toLowerCase());
-      },
+      mapValue: (value) => startCase(value?.toLowerCase()),
     }),
-    columnHelper.accessor("chartType", {
+    createTextTableColumn<WidgetTableRow>({
+      accessorKey: "chartType",
       header: "Chart Type",
-      id: "chartType",
       enableSorting: true,
       size: 100,
-      cell: (row) =>
-        getChartTypeDisplayName(row.getValue() as DashboardWidgetChartType),
+      mapValue: (value) =>
+        value
+          ? getChartTypeDisplayName(value as DashboardWidgetChartType)
+          : undefined,
     }),
     createDateTableColumn<WidgetTableRow>({
       accessorKey: "createdAt",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16932 app preview](https://pr-16932.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardizes text-column rendering across product tables by adopting `createTextTableColumn` more broadly and adding native text titles.

- Migrates text fields in trace, observation, score, event, prompt, RBAC, migration, evaluator, and widget tables to the shared column helper.
- Updates the helper to consistently render mapped text inside a titled span.
- Retains custom latency rendering where nowrap styling and loading state are required.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The migrated columns preserve their prior value mappings and table behavior, while current row construction prevents the investigated nullable latency and version cases from causing failures.
</details>

<sub>Reviews (1): Last reviewed commit: ["Migrate text table columns"](https://github.com/langfuse/langfuse/commit/60b471226f9f870f8c3991d7dbfb662e65532a93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59423906)</sub>

<!-- /greptile_comment -->