### PR TITLE
refactor(web): Use `createDateTableColumn` more

### DIFF
--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -21,6 +21,7 @@ import { Archive, Edit, MoreVertical, PlusIcon } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
+import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -36,8 +37,8 @@ type ScoreConfigTableRow = {
   id: string;
   name: string;
   dataType: ScoreConfigDataType;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date;
+  updatedAt: Date;
   range: {
     maxValue?: number | null;
     minValue?: number | null;
@@ -134,13 +135,12 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
       enableHiding: true,
       defaultHidden: true,
     },
-    {
+    createDateTableColumn<ScoreConfigTableRow>({
       accessorKey: "createdAt",
-      id: "createdAt",
       header: "Created At",
       enableHiding: true,
       defaultHidden: true,
-    },
+    }),
     {
       accessorKey: "isArchived",
       id: "isArchived",
@@ -293,8 +293,8 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
                       name: config.name,
                       dataType: config.dataType,
                       description: config.description,
-                      createdAt: config.createdAt.toLocaleString(),
-                      updatedAt: config.updatedAt.toLocaleString(),
+                      createdAt: config.createdAt,
+                      updatedAt: config.updatedAt,
                       range: {
                         maxValue: config.maxValue,
                         minValue: config.minValue,

--- a/web/src/features/batch-actions/components/BatchActionsTable.tsx
+++ b/web/src/features/batch-actions/components/BatchActionsTable.tsx
@@ -11,7 +11,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { buildLocalIsoDatePresentation } from "@/src/utils/dates";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createUserTableColumn } from "@/src/components/design-system/table/columns/createUserTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
@@ -114,24 +113,11 @@ export function BatchActionsTable(props: { projectId: string }) {
       header: "Created",
       size: 150,
     }),
-    {
+    createDateTableColumn<BatchActionRow>({
       accessorKey: "finishedAt",
-      id: "finishedAt",
       header: "Finished",
       size: 150,
-      cell: ({ row }) => {
-        const finishedAt = row.getValue("finishedAt") as Date | null;
-        const preparedDate = buildLocalIsoDatePresentation({
-          date: finishedAt,
-        });
-
-        return preparedDate ? (
-          <span title={preparedDate.title}>{preparedDate.display}</span>
-        ) : (
-          <span className="text-muted-foreground">-</span>
-        );
-      },
-    },
+    }),
     createUserTableColumn<BatchActionRow>({
       accessorKey: "user",
       header: "Created By",

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/src/components/table/data-table-controls";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createIOTableColumn } from "@/src/components/design-system/table/columns/createIOTableColumn";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
@@ -38,8 +39,8 @@ export type JobExecutionRow = {
   scoreValue?: number | string;
   scoreComment?: string;
   scoreMetadata?: Prisma.JsonValue;
-  startTime?: string;
-  endTime?: string;
+  startTime?: Date;
+  endTime?: Date;
   traceId?: string;
   executionTraceId?: string;
   templateId: string;
@@ -93,13 +94,13 @@ export default function EvalLogTable({
       getStatus: (status) =>
         status ? jobExecutionStatusToStatus[status] : undefined,
     }),
-    columnHelper.accessor("startTime", {
-      id: "startTime",
+    createDateTableColumn<JobExecutionRow>({
+      accessorKey: "startTime",
       header: "Start Time",
       enableHiding: true,
     }),
-    columnHelper.accessor("endTime", {
-      id: "endTime",
+    createDateTableColumn<JobExecutionRow>({
+      accessorKey: "endTime",
       header: "End Time",
       enableHiding: true,
     }),
@@ -233,8 +234,8 @@ export default function EvalLogTable({
         jobConfig.score?.stringValue ?? jobConfig.score?.value ?? undefined,
       scoreComment: jobConfig.score?.comment ?? undefined,
       scoreMetadata: jobConfig.score?.metadata ?? undefined,
-      startTime: jobConfig.startTime?.toLocaleString() ?? undefined,
-      endTime: jobConfig.endTime?.toLocaleString() ?? undefined,
+      startTime: jobConfig.startTime ?? undefined,
+      endTime: jobConfig.endTime ?? undefined,
       traceId: jobConfig.jobInputTraceId ?? undefined,
       executionTraceId: jobConfig.executionTraceId ?? undefined,
       templateId: jobConfig.jobTemplateId ?? "",

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -54,6 +54,7 @@ import {
   shouldShowEvalTemplate,
 } from "@/src/features/evals/utils/code-eval-template-utils";
 import { SiPython, SiTypescript } from "react-icons/si";
+import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
 
@@ -375,13 +376,10 @@ export default function EvalsTemplateTable({
         );
       },
     }),
-    columnHelper.accessor("latestCreatedAt", {
+    createDateTableColumn<EvalsTemplateRow>({
+      accessorKey: "latestCreatedAt",
       header: "Last Edited",
-      id: "latestCreatedAt",
-      size: 80,
-      cell: (row) => {
-        return row.getValue()?.toLocaleDateString();
-      },
+      size: 150,
     }),
     createNumberTableColumn<EvalsTemplateRow>({
       accessorKey: "usageCount",

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -46,6 +46,7 @@ import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-to
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { usdFormatter } from "@/src/utils/numbers";
+import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
 import {
@@ -302,14 +303,14 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
         );
       },
     }),
-    columnHelper.accessor("createdAt", {
-      id: "createdAt",
+    createDateTableColumn<EvaluatorDataRow>({
+      accessorKey: "createdAt",
       header: "Created At",
       enableSorting: true,
       size: 150,
     }),
-    columnHelper.accessor("updatedAt", {
-      id: "updatedAt",
+    createDateTableColumn<EvaluatorDataRow>({
+      accessorKey: "updatedAt",
       header: "Updated At",
       enableSorting: true,
       size: 150,

--- a/web/src/features/evals/hooks/useEvaluatorTableData.ts
+++ b/web/src/features/evals/hooks/useEvaluatorTableData.ts
@@ -18,8 +18,8 @@ import { RAGAS_TEMPLATE_PREFIX } from "@/src/features/evals/types";
 export type EvaluatorDataRow = {
   id: string;
   status: string;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date;
+  updatedAt: Date;
   maintainer: string;
   rawStatus: string;
   template?: {
@@ -109,8 +109,8 @@ export const useEvaluatorTableData = ({
           id: jobConfig.id,
           status,
           rawStatus: jobConfig.status,
-          createdAt: jobConfig.createdAt.toLocaleString(),
-          updatedAt: jobConfig.updatedAt.toLocaleString(),
+          createdAt: jobConfig.createdAt,
+          updatedAt: jobConfig.updatedAt,
           template: jobConfig.evalTemplate
             ? {
                 id: jobConfig.evalTemplate.id,

--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/src/components/ui/hover-card";
 import Link from "next/link";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { useQueryParam, withDefault, StringParam } from "use-query-params";
@@ -318,17 +319,12 @@ export function MembersTable({
           },
         ] satisfies LangfuseColumnDef<MembersTableRow>[])
       : []),
-    {
+    createDateTableColumn<MembersTableRow>({
       accessorKey: "createdAt",
-      id: "createdAt",
       header: "Member Since",
       enableHiding: true,
       defaultHidden: true,
-      cell: ({ row }) => {
-        const value = row.getValue("createdAt") as MembersTableRow["createdAt"];
-        return value ? new Date(value).toLocaleString() : undefined;
-      },
-    },
+    }),
     {
       accessorKey: "meta",
       id: "meta",

--- a/web/src/features/rbac/components/MembershipInvitesPage.tsx
+++ b/web/src/features/rbac/components/MembershipInvitesPage.tsx
@@ -10,6 +10,7 @@ import { type Role } from "@langfuse/shared";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import Header from "@/src/components/layouts/header";
 import useSessionStorage from "@/src/components/useSessionStorage";
+import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createUserTableColumn } from "@/src/components/design-system/table/columns/createUserTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
@@ -100,15 +101,10 @@ export function MembershipInvitesPage({
       accessorKey: "orgRole",
       header: "Organization Role",
     }),
-    {
+    createDateTableColumn<InvitesTableRow>({
       accessorKey: "createdAt",
-      id: "createdAt",
       header: "Invited On",
-      cell: ({ row }) => {
-        const value = row.getValue("createdAt") as InvitesTableRow["createdAt"];
-        return value ? new Date(value).toLocaleString() : undefined;
-      },
-    },
+    }),
     ...(projectId
       ? [
           createTextTableColumn<InvitesTableRow>({


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16938 app preview](https://pr-16938.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Migrates remaining handwritten date cells onto the shared `createDateTableColumn` helper so those tables use the same local ISO presentation and UTC tooltip as traces, datasets, and other already-migrated lists.

Row data now keeps `Date` objects instead of preformatted `toLocaleString()` / `toLocaleDateString()` strings. Unset timestamps render as an empty cell, matching the shared column (batch-action "Finished" no longer shows a `-` placeholder).

Tables:
- Score configs — Created At
- Batch actions — Finished
- Eval logs — Start Time, End Time
- Eval templates — Last Edited
- Evaluators — Created At, Updated At
- Org/project members — Member Since
- Membership invites — Invited On

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Impacted packages: `web`
- Verification: `pnpm run lint` (pre-commit: `Tasks: 7 successful, 7 total`); `pnpm --filter web run typecheck` (tsc exited 0)
- Browser: members, invites, and score configs on the local Cloud stack (`http://localhost:3000`) render `YYYY-MM-DD HH:MM:SS` with `UTC:` tooltips
- I have not added standalone tests; this reuses `createDateTableColumn`, which already has Storybook coverage
- The eval templates "Last Edited" column width is 150 so the full datetime fits

## Test this

Preview: [pr-16938 app preview](https://pr-16938.preview.langfuse.com)

1. Open Settings → Members. Enable the **Member Since** column. Expect `YYYY-MM-DD HH:MM:SS` and a `UTC:` hover tooltip.
2. On the same page, check **Invited On** (invite someone if the list is empty).
3. Open Settings → Scores Configs. Enable **Created At**. Same format and tooltip.
4. Open Evaluators → library and confirm **Last Edited** uses the same datetime format on user-owned templates (managed templates can be blank).
5. If you have legacy evaluators or batch actions, check Created At / Updated At / Finished the same way.

Data: demo project is enough for members. Create a score config or invite if those tables are empty.

Sandbox: same paths on `http://localhost:3000` after the Cloud stack is up (`/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/settings/members` and `/settings/scores`).

## Proof

![Members table Member Since column uses local ISO datetime](https://cursor.com/artifacts/c/art-cd878183-2fba-4d3c-9e1d-e1b7d9ff3056)
![Invited On cell shows UTC tooltip](https://cursor.com/artifacts/c/art-a6573443-5ca0-4fc8-87d4-fd61d99a6642)
![Score config Created At uses local ISO datetime with UTC tooltip](https://cursor.com/artifacts/c/art-49c181aa-fe0b-4a7c-80b5-20cad866c99b)
<a href="https://cursor.com/agents/bc-4b812b30-2acb-497a-8151-15ed728159ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdate_columns_iso_format_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-db0573e1-e3dc-42e8-aea1-585426a3b454" alt="date_columns_iso_format_walkthrough.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15888](https://linear.app/clickhouse/issue/LFE-15888/migrate-more-table-columns-to-createdatetablecolumn)

<div><a href="https://cursor.com/agents/bc-4b812b30-2acb-497a-8151-15ed728159ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b812b30-2acb-497a-8151-15ed728159ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardizes date rendering across several web tables by replacing handwritten date cells with the shared date-column helper and retaining timestamps as `Date` values.
- Migrates score configuration, batch action, evaluation, member, and invitation date columns.
- Preserves evaluator sorting and stored column identifiers.
- Uses consistent local ISO display with UTC tooltip behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or compatibility issues identified.

The shared helper accepts nullable dates, the API transport preserves `Date` instances through SuperJSON, and migrated sortable columns retain their prior IDs and accessor keys.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): migrate more table date c..."](https://github.com/langfuse/langfuse/commit/fb2bce86cccebab93b8fe1c8ae4ea379fc2cc357) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59426591)</sub>

<!-- /greptile_comment -->