### PR TITLE
feat(billing): send cloud provider, region and cell in CHB project events

### DIFF
--- a/web/src/__tests__/server/unit/chb-project-events.servertest.ts
+++ b/web/src/__tests__/server/unit/chb-project-events.servertest.ts
@@ -6,7 +6,7 @@ const EVENT_BUS_ARN =
 
 const mocks = vi.hoisted(() => ({
   env: {
-    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: "eu" as string | undefined,
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: "EU" as string | undefined,
     CLICKHOUSE_BILLING_EVENT_BUS_ARN:
       "arn:aws:events:eu-central-1:720474339533:event-bus/control-plane-events" as
         | string
@@ -92,6 +92,7 @@ const waitFor = (assertion: () => void) =>
 describe("chbProjectEvents", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "EU";
     mocks.env.CLICKHOUSE_BILLING_EVENT_BUS_ARN = EVENT_BUS_ARN;
     mocks.send.mockResolvedValue({ FailedEntryCount: 0 });
     mocks.findProjects.mockResolvedValue([]);
@@ -117,11 +118,42 @@ describe("chbProjectEvents", () => {
     expect(entry.Source).toBe("langfuse");
     // The event carries CHB's organization id, not ours -- CHB's registry is
     // keyed by its own org id.
-    expect(JSON.parse(entry.Detail)).toMatchObject({
+    const detail = JSON.parse(entry.Detail);
+    expect(detail).toMatchObject({
       type: "LANGFUSE_PROJECT_CREATED",
       organizationId: CHB_ORG_ID,
       projectId: PROJECT_ID,
-      regionId: "eu",
+      // Where this deployment runs: the provider region it lives in plus our
+      // own cell name, lowercased.
+      cloudProvider: "aws",
+      region: "eu-west-1",
+      cell: "eu",
+    });
+    expect(detail).not.toHaveProperty("regionId");
+  });
+
+  // CHB locates a deployment by provider region plus cell, not by our cell
+  // name alone. HIPAA and US share us-west-2, so the cell is what still tells
+  // them apart.
+  it.each([
+    ["US", "us-west-2", "us"],
+    ["EU", "eu-west-1", "eu"],
+    ["HIPAA", "us-west-2", "hipaa"],
+    ["JP", "ap-northeast-1", "jp"],
+    ["STAGING", "eu-west-1", "staging"],
+  ])("locates cell %s in %s", async (cloudRegion, awsRegion, cell) => {
+    mocks.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = cloudRegion;
+
+    await sendChbProjectEvent({
+      type: "LANGFUSE_PROJECT_CREATED",
+      chbOrganizationId: CHB_ORG_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(publishedDetails()[0]).toMatchObject({
+      cloudProvider: "aws",
+      region: awsRegion,
+      cell,
     });
   });
 

--- a/web/src/ee/features/billing/server/chb/chbProjectEvents.ts
+++ b/web/src/ee/features/billing/server/chb/chbProjectEvents.ts
@@ -45,21 +45,46 @@ const EVENT_BUS_REQUEST_TIMEOUT_MS = 5_000;
 // hundred bytes each, so the 256KB per-call limit is never the binding one.
 const EVENT_BUS_MAX_ENTRIES_PER_CALL = 10;
 
-// The envelope (type, CHB organizationId, Langfuse projectId, regionId) still
-// needs a final confirmation from CHB before rollout, so it is isolated here:
-// a contract change stays a one-function edit. `type` is repeated here and in
-// detail-type so a consumer reading either one sees it.
+type CloudCell = NonNullable<typeof env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION>;
+
+// Where each cell runs, mirroring the per-environment AWS region in the
+// infrastructure repo. Exhaustive on purpose: a new cell does not compile until
+// its location is filled in. DEV is a developer machine with no fixed
+// location, so it reports none.
+const CELL_LOCATION: Record<
+  CloudCell,
+  { cloudProvider: "aws"; region: string } | null
+> = {
+  US: { cloudProvider: "aws", region: "us-west-2" },
+  EU: { cloudProvider: "aws", region: "eu-west-1" },
+  HIPAA: { cloudProvider: "aws", region: "us-west-2" },
+  JP: { cloudProvider: "aws", region: "ap-northeast-1" },
+  STAGING: { cloudProvider: "aws", region: "eu-west-1" },
+  DEV: null,
+};
+
+// The envelope is the contract with CHB, so it is isolated here: a contract
+// change stays a one-function edit. `type` is repeated here and in detail-type
+// so a consumer reading either one sees it.
 const buildChbProjectEventPayload = (params: {
   type: ChbProjectEventType;
   chbOrganizationId: string;
   projectId: string;
-}) => ({
-  type: params.type,
-  organizationId: params.chbOrganizationId,
-  projectId: params.projectId,
-  regionId: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-  createdAt: new Date().toISOString(),
-});
+}) => {
+  const cell = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+
+  return {
+    type: params.type,
+    organizationId: params.chbOrganizationId,
+    projectId: params.projectId,
+    // CHB locates a deployment by provider region plus cell, not by our cell
+    // name alone: two cells can share one region (US and HIPAA both run in
+    // us-west-2), so the cell is what still tells them apart.
+    ...(cell ? CELL_LOCATION[cell] : null),
+    cell: cell?.toLowerCase(),
+    createdAt: new Date().toISOString(),
+  };
+};
 
 // One bus per deployment, so one client: the ARN comes from env and cannot
 // change at runtime. Lazy so a web instance that never touches CHB billing


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16941 app preview](https://pr-16941.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

**TL;DR:** The project lifecycle events published to ClickHouse Billing's EventBridge bus now carry `cloudProvider`, `region` and `cell` instead of a single `regionId`.

## Why

CHB locates a deployment by cloud provider region plus cell, not by the Langfuse cell name alone. Two cells can share one region (US and HIPAA both run in us-west-2), so the cell is what still tells them apart.

## What changed

Envelope `Detail` before:

```json
{ "type": "LANGFUSE_PROJECT_CREATED", "organizationId": "…", "projectId": "…", "regionId": "US", "createdAt": "…" }
```

After:

```json
{ "type": "LANGFUSE_PROJECT_CREATED", "organizationId": "…", "projectId": "…", "cloudProvider": "aws", "region": "us-west-2", "cell": "us", "createdAt": "…" }
```

- `cell` is the lowercased `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION`.
- `cloudProvider` and `region` come from an exhaustive per-cell table in `chbProjectEvents.ts` that mirrors the per-environment AWS region in the infrastructure repo (US and HIPAA → us-west-2, EU and STAGING → eu-west-1, JP → ap-northeast-1). Adding a cell to the env enum fails to compile until its location is filled in.
- `DEV` (a developer machine) has no fixed location and reports only `cell`.
- Applies to `LANGFUSE_PROJECT_CREATED` and `LANGFUSE_PROJECT_DELETED` alike, including the checkout-time backfill, since all of them share the one envelope builder.

## Impacted packages

- `web` only.

## Verification

- `pnpm --filter web run test chb-project-events` → `Tests  15 passed (15)` (new `it.each` covers every cell's location; the envelope test asserts `regionId` is gone).
- `pnpm run lint` → `Tasks: 7 successful, 7 total`
- `pnpm --filter web run typecheck` → exit 0
- Not run locally: `projectsRouter-chbProjectEvents.servertest.ts` needs a migrated Postgres, which this worktree lacks. It does not assert on the location fields; CI covers it.

## What to doubt

- Whether CHB wants the `cell` lowercased (`us`) as in the requested example, or the raw enum value (`US`).
- Whether reporting nothing but `cell` for `DEV` is acceptable for local end-to-end tests against CHB's staging bus, or whether it should claim a region.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates ClickHouse Billing project lifecycle events to identify deployments using cloud provider, provider region, and lowercased cell instead of `regionId`.
- Adds an exhaustive deployment-cell location mapping, with DEV intentionally lacking a fixed provider region.
- Applies the new envelope through the shared builder used for create, delete, and checkout backfill events.
- Expands unit coverage across all fixed-location cells and verifies that `regionId` is removed.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defect identified.

The environment schema restricts cells to the exhaustively mapped values, the shared builder consistently applies the intended contract change, and the tests cover every fixed-location cell.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(billing): send cloud provider, regi..."](https://github.com/langfuse/langfuse/commit/847dd773308703c64ee5c41f5857c39fde5625c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59435909)</sub>

<!-- /greptile_comment -->