### PR TITLE
fix(evals): resolve media previews in variable mapper

### DIFF
--- a/web/src/components/MediaTag/MediaTag.clienttest.tsx
+++ b/web/src/components/MediaTag/MediaTag.clienttest.tsx
@@ -32,6 +32,25 @@ describe("MediaTag", () => {
     );
   });
 
+  it("stops portaled preview actions from triggering parent clicks", () => {
+    const onParentClick = vi.fn();
+
+    render(
+      <div onClick={onParentClick}>
+        <MediaTag
+          contentType="image/png"
+          status="ready"
+          url="data:image/png;base64,"
+          open
+        />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Open in new tab" }));
+
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
   it("opens the preview on click", async () => {
     const onOpenChange = vi.fn();
 

--- a/web/src/components/MediaTag/MediaTag.tsx
+++ b/web/src/components/MediaTag/MediaTag.tsx
@@ -290,6 +290,7 @@ export const MediaTag = React.forwardRef<HTMLButtonElement, MediaTagProps>(
         <HoverCardContent
           align="start"
           className="ph-no-capture flex w-auto max-w-sm flex-col gap-2 p-2"
+          onClick={(event) => event.stopPropagation()}
         >
           <div className="flex items-center justify-between gap-4">
             <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs">

--- a/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.clienttest.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.clienttest.tsx
@@ -2,37 +2,55 @@ import { render, screen } from "@testing-library/react";
 
 import { EditableVariableMapping } from "./EditableVariableMapping";
 
-vi.mock("@/src/components/MediaTag/MediaTag", () => ({
-  MediaTag: ({ contentType }: { contentType: string }) => (
-    <span data-testid="media-tag">{contentType}</span>
+vi.mock("@/src/components/ui/media/MediaReferenceTag", () => ({
+  MediaReferenceTag: ({
+    descriptor,
+  }: {
+    descriptor: { kind: string; mediaId?: string; contentType: string };
+  }) => (
+    <span data-testid="resolved-media-tag">
+      {descriptor.kind}:{descriptor.mediaId}:{descriptor.contentType}
+    </span>
   ),
 }));
 
+const reference = "@@@langfuseMedia:type=image/png|id=media-1|source=bytes@@@";
+
+const renderMapping = (state: "preview" | "editing") =>
+  render(
+    <EditableVariableMapping
+      mappings={[
+        {
+          variable: "input",
+          fieldState: { selectedColumnId: "input", jsonSelector: null },
+        },
+      ]}
+      activeMapping={{ variable: "input", state }}
+      onActiveMappingChange={vi.fn()}
+      onChangeField={vi.fn()}
+      sourceObject={{ input: reference }}
+      hasMatchingObservations
+    />,
+  );
+
 describe("EditableVariableMapping", () => {
-  it("renders a mapped Langfuse media reference as an aligned media tag", () => {
-    const reference =
-      "@@@langfuseMedia:type=image/png|id=media-1|source=bytes@@@";
+  it("resolves a mapped Langfuse media reference in the value preview", () => {
+    renderMapping("preview");
 
-    render(
-      <EditableVariableMapping
-        mappings={[
-          {
-            variable: "input",
-            fieldState: { selectedColumnId: "input", jsonSelector: null },
-          },
-        ]}
-        activeMapping={{ variable: "input", state: "preview" }}
-        onActiveMappingChange={vi.fn()}
-        onChangeField={vi.fn()}
-        sourceObject={{ input: reference }}
-        hasMatchingObservations
-      />,
+    expect(screen.getByTestId("resolved-media-tag")).toHaveTextContent(
+      "langfuseRef:media-1:image/png",
     );
-
-    expect(screen.getByTestId("media-tag")).toHaveTextContent("image/png");
     expect(screen.queryByText(reference)).not.toBeInTheDocument();
     expect(screen.getByTestId("mapped-media-preview")).toHaveClass(
       "items-center",
+    );
+  });
+
+  it("resolves a Langfuse media reference in the sample data tree", () => {
+    renderMapping("editing");
+
+    expect(screen.getByTestId("resolved-media-tag")).toHaveTextContent(
+      "langfuseRef:media-1:image/png",
     );
   });
 });

--- a/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.clienttest.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.clienttest.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import { EditableVariableMapping } from "./EditableVariableMapping";
 
@@ -8,15 +8,18 @@ vi.mock("@/src/components/ui/media/MediaReferenceTag", () => ({
   }: {
     descriptor: { kind: string; mediaId?: string; contentType: string };
   }) => (
-    <span data-testid="resolved-media-tag">
+    <button type="button" data-media-tag="" data-testid="resolved-media-tag">
       {descriptor.kind}:{descriptor.mediaId}:{descriptor.contentType}
-    </span>
+    </button>
   ),
 }));
 
 const reference = "@@@langfuseMedia:type=image/png|id=media-1|source=bytes@@@";
 
-const renderMapping = (state: "preview" | "editing") =>
+const renderMapping = (
+  state: "preview" | "editing",
+  onActiveMappingChange = vi.fn(),
+) =>
   render(
     <EditableVariableMapping
       mappings={[
@@ -26,7 +29,7 @@ const renderMapping = (state: "preview" | "editing") =>
         },
       ]}
       activeMapping={{ variable: "input", state }}
-      onActiveMappingChange={vi.fn()}
+      onActiveMappingChange={onActiveMappingChange}
       onChangeField={vi.fn()}
       sourceObject={{ input: reference }}
       hasMatchingObservations
@@ -46,11 +49,25 @@ describe("EditableVariableMapping", () => {
     );
   });
 
+  it("does not enter editing when the mapped media trigger is used", () => {
+    const onActiveMappingChange = vi.fn();
+    renderMapping("preview", onActiveMappingChange);
+
+    const mediaTag = screen.getByTestId("resolved-media-tag");
+    fireEvent.click(mediaTag);
+    fireEvent.keyDown(mediaTag, { key: "Enter" });
+
+    expect(onActiveMappingChange).not.toHaveBeenCalled();
+  });
+
   it("resolves a Langfuse media reference in the sample data tree", () => {
     renderMapping("editing");
 
-    expect(screen.getByTestId("resolved-media-tag")).toHaveTextContent(
-      "langfuseRef:media-1:image/png",
-    );
+    const mediaTag = screen.getByTestId("resolved-media-tag");
+    expect(mediaTag).toHaveTextContent("langfuseRef:media-1:image/png");
+    expect(mediaTag.closest("[title]")).toBeNull();
+    expect(
+      mediaTag.closest("div")?.querySelector("button"),
+    ).not.toHaveAttribute("title");
   });
 });

--- a/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.stories.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.stories.tsx
@@ -43,7 +43,7 @@ export const MappedMediaValue = meta.story({
         attachments: [
           {
             media:
-              "@@@langfuseMedia:type=image/png|id=cc48838a-3da8-4ca4-a007-2cf8df930e69|source=bytes@@@",
+              "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",
           },
         ],
       },

--- a/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { TriangleAlert } from "lucide-react";
 
-import { MediaTag } from "@/src/components/MediaTag/MediaTag";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import { MediaReferenceTag } from "@/src/components/ui/media/MediaReferenceTag";
 import {
   classifyMediaValue,
   splitStringByMediaReferences,
@@ -72,10 +72,7 @@ function MappedValuePreview({ value }: { value: string }) {
         >
           {mediaSegments.map((segment, index) =>
             segment.type === "media" ? (
-              <MediaTag
-                key={index}
-                contentType={segment.descriptor.contentType}
-              />
+              <MediaReferenceTag key={index} descriptor={segment.descriptor} />
             ) : (
               <span key={index} className="break-words whitespace-pre-wrap">
                 {segment.value}

--- a/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/EditableVariableMapping/EditableVariableMapping.tsx
@@ -105,8 +105,22 @@ function MappingPreviewSurface({
       aria-label={`Change mapping for {{${variable}}}`}
       title={`Change mapping for {{${variable}}}`}
       className="hover:bg-muted/50 focus-visible:ring-ring cursor-pointer rounded-b-md transition-colors focus-visible:ring-2 focus-visible:outline-hidden focus-visible:ring-inset"
-      onClick={onEdit}
+      onClick={(event) => {
+        if (
+          event.target instanceof Element &&
+          event.target.closest("[data-media-tag]")
+        ) {
+          return;
+        }
+        onEdit();
+      }}
       onKeyDown={(event) => {
+        if (
+          event.target instanceof Element &&
+          event.target.closest("[data-media-tag]")
+        ) {
+          return;
+        }
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           onEdit();

--- a/web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.stories.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.stories.tsx
@@ -58,7 +58,7 @@ export const MediaReference = meta.story({
               filename: "cache-hit-ratio.png",
               content_type: "image/png",
               media:
-                "@@@langfuseMedia:type=image/png|id=cc48838a-3da8-4ca4-a007-2cf8df930e69|source=bytes@@@",
+                "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==",
             },
           ],
         },

--- a/web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.tsx
@@ -11,7 +11,7 @@ import {
   WILDCARD,
   type PathSegment,
 } from "@/src/features/evals/v2/fns/variableMapping/segmentsToJsonPath";
-import { MediaTag } from "@/src/components/MediaTag/MediaTag";
+import { MediaReferenceTag } from "@/src/components/ui/media/MediaReferenceTag";
 import {
   classifyMediaValue,
   splitStringByMediaReferences,
@@ -68,7 +68,7 @@ function MediaAwarePreview({
             data-tree-row-action=""
             className="inline-flex shrink-0 self-center"
           >
-            <MediaTag contentType={segment.descriptor.contentType} />
+            <MediaReferenceTag descriptor={segment.descriptor} />
           </span>
         ) : (
           <span

--- a/web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.tsx
+++ b/web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.tsx
@@ -59,7 +59,6 @@ function MediaAwarePreview({
         "text-muted-foreground flex min-w-0 flex-1 items-baseline gap-0.5 overflow-hidden text-xs leading-4",
         directDescriptor && "self-center",
       )}
-      title={preview}
     >
       {segments.map((segment, index) =>
         segment.type === "media" ? (
@@ -182,7 +181,13 @@ function TreeRow({
             "flex min-w-0 cursor-pointer items-baseline gap-2 text-left",
             hasMedia ? "shrink-0" : "flex-1",
           )}
-          title={expandable ? preview : `Pull {{${variable}}} from here`}
+          title={
+            hasMedia
+              ? undefined
+              : expandable
+                ? preview
+                : `Pull {{${variable}}} from here`
+          }
         >
           {expandable ? (
             <ChevronDown


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16944 app preview](https://pr-16944.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Fixes blank media previews in the evaluator variable mapper.

The mapper rendered the display-only `MediaTag`, so Langfuse media references never requested their signed preview URL. Both the sample data tree and mapped-value preview now use `MediaReferenceTag`, which resolves the reference when the preview opens.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code

## Verification

- Client tests: `Tests  19 passed (19)`
- Storybook tests: `Tests  6 passed (6)`
- Lint: `Tasks: 7 successful, 7 total`
- CI: `all-ci-passed`

Browser proof: open the [mapped media Storybook preview](https://pr-16944-storybook.langfuse.vercel.app/?path=/story/features-evaluations-variablemapping-editablevariablemapping--mapped-media-value), then click **GIF media**. The preview opens with the MIME type and **Open in new tab** action, while the mapping stays in preview mode.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces display-only media tags in evaluator variable mapping with reference-resolving previews and adds regression coverage for both affected paths.

- Resolves mapped-value media references when their preview opens.
- Resolves media references displayed in the sample-data tree.
- Adds client tests for preview and editing states.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking sample-tree tooltip overlap that should be corrected.

Reference resolution is correctly introduced in both mapper paths, but the sample-data tree does not apply the existing title-suppression contract required by interactive media previews.

**Files Needing Attention:** web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/evals/v2/components/VariableMapping/components/SampleDataTreeSelector/SampleDataTreeSelector.tsx:71
**Titled ancestors overlap media previews**

The new interactive `MediaReferenceTag` remains inside ancestors with native `title` attributes. When its peek opens, the browser tooltip can cover the resolved preview and its open-in-new-tab action; suppress these ancestor titles while the media trigger is active, as other media containers do.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): resolve media previews in va..."](https://github.com/langfuse/langfuse/commit/96919fe84bb2f9246a5d72cc3c14ec38b3fe6d75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59440035)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->