### PR TITLE
feat: rename providedModelName to model in observation APIs

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -313,7 +313,7 @@ types:
         docs: Additional metadata of the observation
 
       # Model fields (field group: model)
-      providedModelName:
+      model:
         type: optional<nullable<string>>
         docs: The model name as provided by the user
       internalModelId:

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -21,7 +21,7 @@ service:
         - `time` - completionStartTime, createdAt, updatedAt
         - `io` - input, output
         - `metadata` - metadata (truncated to 200 chars by default, use `expandMetadata` to get full values)
-        - `model` - providedModelName, internalModelId, modelParameters
+        - `model` - model, internalModelId, modelParameters
         - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
         - `prompt` - promptId, promptName, promptVersion
         - `metrics` - latency, timeToFirstToken

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -37,7 +37,7 @@ export const OBSERVATION_FIELD_GROUPS_PUBLIC_API = [
   "time", // completionStartTime, createdAt, updatedAt
   "io", // input, output
   "metadata", // metadata
-  "model", // providedModelName, internalModelId, modelParameters
+  "model", // model (from providedModelName), internalModelId, modelParameters
   "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
   "prompt", // promptId, promptName, promptVersion
   "metrics", // latency, timeToFirstToken

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -4285,7 +4285,7 @@ paths:
         - `metadata` - metadata (truncated to 200 chars by default, use
         `expandMetadata` to get full values)
 
-        - `model` - providedModelName, internalModelId, modelParameters
+        - `model` - model, internalModelId, modelParameters
 
         - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
 
@@ -10619,7 +10619,7 @@ components:
         metadata:
           nullable: true
           description: Additional metadata of the observation
-        providedModelName:
+        model:
           type: string
           nullable: true
           description: The model name as provided by the user

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -386,7 +386,7 @@ const APIObservationV2 = z
     metadata: z.any().optional(),
 
     // Model fields (field group: model)
-    providedModelName: z.string().nullable().optional(),
+    model: z.string().nullable().optional(),
     internalModelId: z.string().nullable().optional(),
     modelParameters: z.any().optional(),
 


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16946 app preview](https://pr-16946.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Rename the public observation field `providedModelName` to `model` to match the reality.
- Update field-group documentation, API definitions, OpenAPI output, and runtime validation.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR renames the public v2 observation response field `providedModelName` to `model` while preserving the internal storage mapping.
- Aligns the Fern contract, generated OpenAPI schema, and runtime Zod validation.
- Updates observation field-group documentation to use the public `model` name.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the renamed public field is consistent across the API definition, generated contract, runtime schema, and response mapping.

The observation converter already maps the internal `provided_model_name` value to `model`, and current HTTP and MCP consumers are aligned with that output.
</details>

<sub>Reviews (1): Last reviewed commit: ["Rename observation model field in public..."](https://github.com/langfuse/langfuse/commit/2ce315d59496b49ffbada36420b17505bbbbfc61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59447355)</sub>

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->