### PR TITLE
refactor(web): Use `createIdTableColumn` more

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -145,6 +145,7 @@ export type ObservationsTableRow = {
   id: string;
   traceName?: string;
   traceId?: string;
+  modelId?: string;
   version: string;
   timestamp?: Date;
   promptId?: string;

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1034,14 +1034,13 @@ export default function ObservationsTable({
       enableHiding: true,
       defaultHidden: true,
     }),
-    {
+    createIdTableColumn<ObservationsTableRow>({
       accessorKey: "modelId",
-      id: "modelId",
       header: "Model ID",
       size: 100,
       enableHiding: true,
       defaultHidden: true,
-    },
+    }),
     createTextTableColumn<ObservationsTableRow>({
       accessorKey: "version",
       header: "Version",

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/src/components/ui/button";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -128,13 +129,12 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
       getCell: (value) => value || undefined,
       singleLine: rowHeight === "s",
     }),
-    {
+    createIdTableColumn<ScoreConfigTableRow>({
       accessorKey: "id",
-      id: "id",
       header: "Config ID",
       enableHiding: true,
       defaultHidden: true,
-    },
+    }),
     createDateTableColumn<ScoreConfigTableRow>({
       accessorKey: "createdAt",
       header: "Created At",

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -12,6 +12,7 @@ import {
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createIOTableColumn } from "@/src/components/design-system/table/columns/createIOTableColumn";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
@@ -104,9 +105,9 @@ export default function EvalLogTable({
       header: "End Time",
       enableHiding: true,
     }),
-    columnHelper.accessor("scoreName", {
+    createIdTableColumn<JobExecutionRow>({
+      accessorKey: "scoreName",
       header: "Score Name",
-      id: "scoreName",
       enableHiding: true,
     }),
     columnHelper.accessor("scoreValue", {

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1492,14 +1492,13 @@ export default function ObservationsEventsTable({
       enableHiding: true,
       defaultHidden: true,
     }),
-    {
+    createIdTableColumn<EventsTableRow>({
       accessorKey: "modelId",
-      id: "modelId",
       header: getEventsColumnName("modelId"),
       size: 100,
       enableHiding: true,
       defaultHidden: true,
-    },
+    }),
     createTextTableColumn<EventsTableRow>({
       accessorKey: "version",
       header: getEventsColumnName("version"),
@@ -1524,22 +1523,20 @@ export default function ObservationsEventsTable({
       enableSorting,
       defaultHidden: true,
     }),
-    {
+    createIdTableColumn<EventsTableRow>({
       accessorKey: "userId",
-      id: "userId",
       header: getEventsColumnName("userId"),
       size: 150,
       enableHiding: true,
       defaultHidden: true,
-    },
-    {
+    }),
+    createIdTableColumn<EventsTableRow>({
       accessorKey: "sessionId",
-      id: "sessionId",
       header: getEventsColumnName("sessionId"),
       size: 150,
       enableHiding: true,
       defaultHidden: true,
-    },
+    }),
   ];
 
   const [columnVisibility, setColumnVisibilityState] =


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16949 app preview](https://pr-16949.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Migrates remaining identifier table columns onto `createIdTableColumn` so they share the same `IdTableCell` presentation as other ID columns (truncated, nowrap, tooltip).

Columns updated:

- Observations: Model ID
- Score configs: Config ID
- Eval logs: Score Name
- Events: Model ID, User ID, Session ID

The observations row type now includes `modelId`, which the table already populated at runtime.

## Type of change

- [x] Refactor (restructures existing code without changing behavior)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Code follows the style guidelines of this project (`pnpm run format` via pre-commit)
- No new warnings (`pnpm run lint` via pre-commit: `Tasks: 7 successful, 7 total`)
- `pnpm --filter web run typecheck` passed after adding `modelId` to `ObservationsTableRow`
- No new automated tests: presentation-only column factory swap; `createIdTableColumn` already has Storybook coverage
- Impacted package: `web`

## Test this

Preview: [pr-16949 app preview](https://pr-16949.preview.langfuse.com)

1. Open **Observations**, show **Model ID** / **User ID** / **Session ID**, confirm compact ID cells.
2. Open **Settings → Scores**, show **Config ID**, confirm the same style.
3. Open a legacy evaluator (`/evals/legacy/<id>`), confirm **Score Name** uses the ID cell.

Data: demo project is enough.

Sandbox: same paths on `http://localhost:3000` after the cloud stack is up.

## Proof of work

![Score configs Config ID column uses compact ID cells](https://cursor.com/artifacts/c/art-81dbf720-9c3a-4726-9ce3-a07672a4b1c7)
![Events table headers for Model ID, User ID, and Session ID](https://cursor.com/artifacts/c/art-9ef62450-6386-49d2-94f3-27bfc4090e2c)
![Eval logs Score Name column with ID cell styling](https://cursor.com/artifacts/c/art-e739d791-8f28-4dd0-b265-d93aa69f4591)
<a href="https://cursor.com/agents/bc-a949c326-b13f-4e33-b843-5a9ccb208db3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fid_table_columns_events_and_eval_logs.mp4"><img src="https://cursor.com/artifacts/c/art-a07517e2-b111-49db-bbd9-5d1d677d3a22" alt="id_table_columns_events_and_eval_logs.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15902](https://linear.app/clickhouse/issue/LFE-15902/migrate-more-table-columns-to-createidtablecolumn)

<div><a href="https://cursor.com/agents/bc-a949c326-b13f-4e33-b843-5a9ccb208db3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a949c326-b13f-4e33-b843-5a9ccb208db3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardizes several identifier-oriented table columns on `createIdTableColumn`, giving them consistent truncation, nowrap styling, and tooltips.

- Migrates Model ID columns in the observations and events tables.
- Migrates Config ID in the score configurations table.
- Applies the shared ID-cell presentation to Score Name in evaluation logs.
- Migrates User ID and Session ID in the events table.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The shared factory preserves the existing accessor-derived column identities and safely handles the changed string and optional-string values; the observable presentation changes match the stated intent.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): migrate more table column..."](https://github.com/langfuse/langfuse/commit/337298cb3a23419477b78c63dba1d71e5a51232f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59455395)</sub>

<!-- /greptile_comment -->