### PR TITLE
refactor(web): Use `createNumberTableColumn` more

### DIFF
--- a/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
@@ -3,6 +3,7 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
+import { usdFormatter } from "@/src/utils/numbers";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
@@ -14,6 +15,7 @@ import { useScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
 import { convertRunItemToItemsByItemUiTableRow } from "@/src/features/datasets/lib/convertRunItemDataToUiTableRow";
@@ -183,18 +185,13 @@ export function DatasetRunItemsByItemTable(props: {
         return <>{!!latency ? formatIntervalSeconds(latency) : null}</>;
       },
     },
-    {
+    createNumberTableColumn<DatasetRunItemByItemRowData>({
       accessorKey: "totalCost",
       header: "Cost",
-      id: "totalCost",
       size: 60,
       enableHiding: true,
-      cell: ({ row }) => {
-        const totalCost: DatasetRunItemByItemRowData["totalCost"] =
-          row.getValue("totalCost");
-        return totalCost ?? undefined;
-      },
-    },
+      formatter: (value) => usdFormatter(value),
+    }),
     {
       accessorKey: "scores",
       header: "Scores",

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -3,6 +3,7 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
+import { usdFormatter } from "@/src/utils/numbers";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
@@ -22,6 +23,7 @@ import { datasetRunItemsTableColsWithOptions } from "@langfuse/shared";
 import { convertRunItemToItemsByRunUiTableRow } from "@/src/features/datasets/lib/convertRunItemDataToUiTableRow";
 import { type DatasetRunItemByRunRowData } from "@/src/features/datasets/lib/types";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useDebounce } from "@/src/hooks/useDebounce";
 
@@ -164,18 +166,13 @@ export function DatasetRunItemsByRunTable(props: {
         return <>{!!latency ? formatIntervalSeconds(latency) : null}</>;
       },
     },
-    {
+    createNumberTableColumn<DatasetRunItemByRunRowData>({
       accessorKey: "totalCost",
       header: "Cost",
-      id: "totalCost",
       size: 60,
       enableHiding: true,
-      cell: ({ row }) => {
-        const totalCost: DatasetRunItemByRunRowData["totalCost"] =
-          row.getValue("totalCost");
-        return totalCost ?? undefined;
-      },
-    },
+      formatter: (value) => usdFormatter(value),
+    }),
     {
       accessorKey: "scores",
       header: "Scores",

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -24,6 +24,7 @@ import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createFolderKeyTableColumn } from "@/src/components/design-system/table/columns/createFolderKeyTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import { useTableViewManager } from "@/src/components/table/table-view-presets/hooks/useTableViewManager";
@@ -348,20 +349,20 @@ export function DatasetsTable(props: { projectId: string }) {
       enableHiding: true,
       size: 200,
     }),
-    {
+    createNumberTableColumn<DatasetTableRow>({
       accessorKey: "countItems",
       header: "Items",
-      id: "countItems",
       enableHiding: true,
       size: 60,
-    },
-    {
+      formatter: (value) => String(value),
+    }),
+    createNumberTableColumn<DatasetTableRow>({
       accessorKey: "countRuns",
       header: "Experiments",
-      id: "countRuns",
       enableHiding: true,
       size: 60,
-    },
+      formatter: (value) => String(value),
+    }),
     createDateTableColumn<DatasetTableRow>({
       accessorKey: "createdAt",
       header: "Created",

--- a/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
+++ b/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
@@ -1,10 +1,22 @@
-import { usdFormatter } from "@/src/utils/numbers";
 import {
   type DatasetRunItemByRunRowData,
   type DatasetRunItemByItemRowData,
 } from "./types";
 import { type EnrichedDatasetRunItem } from "@langfuse/shared/src/server";
 import { isPresent } from "@langfuse/shared";
+
+const getRunItemTotalCost = (
+  item: EnrichedDatasetRunItem,
+): number | undefined => {
+  const observationCost = item.observation?.calculatedTotalCost;
+  if (isPresent(observationCost)) {
+    return observationCost.toNumber();
+  }
+  if (isPresent(item.trace?.totalCost)) {
+    return item.trace.totalCost;
+  }
+  return undefined;
+};
 
 export const convertRunItemToItemsByItemUiTableRow = (
   item: EnrichedDatasetRunItem,
@@ -20,11 +32,7 @@ export const convertRunItemToItemsByItemUiTableRow = (
         }
       : undefined,
     scores: item.scores,
-    totalCost: isPresent(item.observation?.calculatedTotalCost)
-      ? usdFormatter(item.observation.calculatedTotalCost.toNumber())
-      : isPresent(item.trace?.totalCost)
-        ? usdFormatter(item.trace.totalCost)
-        : undefined,
+    totalCost: getRunItemTotalCost(item),
     latency: item.observation?.latency ?? item.trace?.duration ?? undefined,
   };
 };
@@ -44,11 +52,7 @@ export const convertRunItemToItemsByRunUiTableRow = (
         }
       : undefined,
     scores: item.scores,
-    totalCost: isPresent(item.observation?.calculatedTotalCost)
-      ? usdFormatter(item.observation.calculatedTotalCost.toNumber())
-      : isPresent(item.trace?.totalCost)
-        ? usdFormatter(item.trace.totalCost)
-        : undefined,
+    totalCost: getRunItemTotalCost(item),
     latency: item.observation?.latency ?? item.trace?.duration ?? undefined,
   };
 };

--- a/web/src/features/datasets/lib/types.ts
+++ b/web/src/features/datasets/lib/types.ts
@@ -16,7 +16,7 @@ export type DatasetRunItemByItemRowData = {
   // scores holds grouped column with individual scores
   scores: ScoreAggregate;
   latency?: number;
-  totalCost?: string;
+  totalCost?: number;
 };
 
 export type DatasetRunItemByRunRowData = {
@@ -36,5 +36,5 @@ export type DatasetRunItemByRunRowData = {
   // scores holds grouped column with individual scores
   scores: ScoreAggregate;
   latency?: number;
-  totalCost?: string;
+  totalCost?: number;
 };

--- a/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
+++ b/web/src/features/evals/v2/components/Rules/RulesTable/RulesTable.tsx
@@ -354,15 +354,14 @@ export function RulesTable({
             <RuleFilterPills filter={row.original.filter} />
           ),
       },
-      {
+      createNumberTableColumn<RuleTableRow>({
         accessorKey: "sampling",
-        id: "sampling",
         header: "Sampling",
         size: 100,
         enableHiding: true,
         enableSorting: true,
-        cell: ({ row }) => `${Math.round(row.original.sampling * 100)}%`,
-      },
+        formatter: (value) => `${Math.round(value * 100)}%`,
+      }),
       createUserTableColumn<RuleTableRow>({
         accessorKey: "createdByUser",
         header: "Created by",

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -29,6 +29,7 @@ import { useFolderPagination } from "@/src/features/folders/hooks/useFolderPagin
 import { buildFullPath } from "@/src/features/folders/utils";
 import { FolderBreadcrumb } from "@/src/features/folders/components/FolderBreadcrumb";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 
 type PromptTableRow = {
@@ -295,17 +296,17 @@ export function PromptTable() {
         };
       },
     }),
-    {
+    createNumberTableColumn<PromptTableRow>({
       accessorKey: "version",
       header: "Versions",
-      id: "version",
       enableSorting: true,
       size: 70,
-      cell: ({ getValue, row }) => {
-        if (row.original.type === "folder") return null;
-        return getValue<number | undefined>();
+      formatter: (value) => String(value),
+      getValue: (value, { row }) => {
+        if (row.original.type === "folder") return undefined;
+        return value ?? undefined;
       },
-    },
+    }),
     createTextTableColumn<PromptTableRow>({
       accessorKey: "type",
       header: "Type",


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16950 app preview](https://pr-16950.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Migrates the remaining dataset, eval-rule, and prompt table number cells onto `createNumberTableColumn` so they share the same formatting, empty, and loading behavior as other number columns.

- Dataset run-item **Cost** now stores a numeric total and formats with `usdFormatter`
- Datasets **Items** / **Experiments** counts
- Eval rules **Sampling** (`0.25` still sorts as a fraction, displays as `25%`)
- Prompts **Versions** (folders stay empty)

## Type of change

- [x] Refactor (restructures existing code without changing behavior)

## Impacted packages

- `web`

## Verification

- Pre-commit `turbo run lint`: `Tasks: 7 successful, 7 total`
- GitHub CI `all-ci-passed`
- Browser: Datasets Items/Experiments, Prompts Versions, Eval Rules Sampling on `http://localhost:3000`

## Proof

![Datasets table Items and Experiments columns](https://cursor.com/artifacts/c/art-04b9b395-3d17-471b-953d-7b8c43191c02)
![Prompts table Versions column](https://cursor.com/artifacts/c/art-2f083d28-699e-4e3b-8d15-fc1025882407)
![Eval rules Sampling column shows 100 percent](https://cursor.com/artifacts/c/art-f38b0722-93a3-4b1b-bd66-aa20214b5e39)
<a href="https://cursor.com/agents/bc-46d9e0bd-50c7-4c1d-a12b-38f22903474c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnumber_columns_datasets_prompts_rules.mp4"><img src="https://cursor.com/artifacts/c/art-207f3ac3-baef-430e-b3d9-ad77cbec0c12" alt="number_columns_datasets_prompts_rules.mp4" /></a>

## Test this

Preview: [pr-16950 app preview](https://pr-16950.preview.langfuse.com)

1. Open **Datasets** and confirm Items / Experiments still show integer counts; folder rows stay empty.
2. Open a dataset experiment/run that still uses the run-items table (or a dataset item **Runs** tab when experiments beta is off) and confirm **Cost** still shows currency (e.g. `$0.00`).
3. Open **Prompts** and confirm **Versions** is a number; folders stay empty.
4. Open **Evaluators → Rules** and confirm **Sampling** still shows `N%`.

Data: demo project is enough.
Sandbox: same paths on `http://localhost:3000` after `pnpm run db:seed:examples`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15901](https://linear.app/clickhouse/issue/LFE-15901/migrate-more-table-columns-to-createnumbertablecolumn)

<div><a href="https://cursor.com/agents/bc-46d9e0bd-50c7-4c1d-a12b-38f22903474c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46d9e0bd-50c7-4c1d-a12b-38f22903474c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR standardizes dataset, evaluation-rule, and prompt numeric cells on `createNumberTableColumn`.

- Stores dataset run-item costs as numbers and formats them as USD at render time.
- Migrates dataset counts, evaluation sampling percentages, and prompt versions to the shared numeric-column helper.
- Preserves empty folder cells, raw numeric sorting values, and existing column identifiers.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable regressions identified.

The migrated columns preserve their raw numeric values, identifiers, sorting behavior, formatting, and empty folder-row behavior, and the cost row contract is updated consistently across its consumers.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): migrate table columns to ..."](https://github.com/langfuse/langfuse/commit/9e2ec9c02f8afd2a3a99e8f32664030316c7f5c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59455772)</sub>

<!-- /greptile_comment -->