### PR TITLE
refactor(web): Use `createStatusTableColumn` more

### DIFF
--- a/web/src/components/design-system/table/columns/createStatusTableColumn.stories.tsx
+++ b/web/src/components/design-system/table/columns/createStatusTableColumn.stories.tsx
@@ -1,5 +1,3 @@
-import { type ReactNode } from "react";
-
 import preview from "../../../../../.storybook/preview";
 
 import {
@@ -10,26 +8,27 @@ import { createStatusTableColumn } from "./createStatusTableColumn";
 
 type Row = {
   status: string | null;
+  isStatusLoading?: boolean;
 };
 
 function StatusTableColumnStory({
   data,
   isLive = true,
-  isLoading,
   emptyValue,
 }: {
   data: AsyncTableData<Row[]>;
   isLive?: boolean;
-  isLoading?: (status: string | null | undefined) => boolean;
-  emptyValue?: ReactNode;
+  emptyValue?: string;
 }) {
   const columns = [
     createStatusTableColumn<Row, string>({
       accessorKey: "status",
       header: "Status",
-      getStatus: (status) => status ?? undefined,
+      getStatus: (status, { row }) =>
+        row.original.isStatusLoading
+          ? { type: "loading" }
+          : (status ?? undefined),
       isLive,
-      isLoading,
       emptyValue,
     }),
   ];
@@ -106,13 +105,16 @@ export const Loading = meta.story({
   },
 });
 
-export const RowLoading = meta.story({
+export const MappedValueLoading = meta.story({
+  name: "Mapped Value Loading",
   args: {
     data: {
       isLoading: false,
       isError: false,
-      data: [{ status: "pending-metrics" }, { status: "error" }],
+      data: [
+        { status: "pending-metrics", isStatusLoading: true },
+        { status: "error" },
+      ],
     },
-    isLoading: (status) => status === "pending-metrics",
   },
 });

--- a/web/src/components/design-system/table/columns/createStatusTableColumn.stories.tsx
+++ b/web/src/components/design-system/table/columns/createStatusTableColumn.stories.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode } from "react";
+
 import preview from "../../../../../.storybook/preview";
 
 import {
@@ -14,10 +16,12 @@ function StatusTableColumnStory({
   data,
   isLive = true,
   isLoading,
+  emptyValue,
 }: {
   data: AsyncTableData<Row[]>;
   isLive?: boolean;
   isLoading?: (status: string | null | undefined) => boolean;
+  emptyValue?: ReactNode;
 }) {
   const columns = [
     createStatusTableColumn<Row, string>({
@@ -26,6 +30,7 @@ function StatusTableColumnStory({
       getStatus: (status) => status ?? undefined,
       isLive,
       isLoading,
+      emptyValue,
     }),
   ];
 
@@ -77,6 +82,7 @@ export const EmptyValue = meta.story({
       isError: false,
       data: [{ status: null }],
     },
+    emptyValue: "-",
   },
 });
 

--- a/web/src/components/design-system/table/columns/createStatusTableColumn.stories.tsx
+++ b/web/src/components/design-system/table/columns/createStatusTableColumn.stories.tsx
@@ -13,9 +13,11 @@ type Row = {
 function StatusTableColumnStory({
   data,
   isLive = true,
+  isLoading,
 }: {
   data: AsyncTableData<Row[]>;
   isLive?: boolean;
+  isLoading?: (status: string | null | undefined) => boolean;
 }) {
   const columns = [
     createStatusTableColumn<Row, string>({
@@ -23,6 +25,7 @@ function StatusTableColumnStory({
       header: "Status",
       getStatus: (status) => status ?? undefined,
       isLive,
+      isLoading,
     }),
   ];
 
@@ -94,5 +97,16 @@ export const Loading = meta.story({
       isLoading: true,
       isError: false,
     },
+  },
+});
+
+export const RowLoading = meta.story({
+  args: {
+    data: {
+      isLoading: false,
+      isError: false,
+      data: [{ status: "pending-metrics" }, { status: "error" }],
+    },
+    isLoading: (status) => status === "pending-metrics",
   },
 });

--- a/web/src/components/design-system/table/columns/createStatusTableColumn.tsx
+++ b/web/src/components/design-system/table/columns/createStatusTableColumn.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable boundaries/dependencies */
 import { type CellContext, type RowData } from "@tanstack/react-table";
+import { type ReactNode } from "react";
 
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
@@ -18,6 +19,7 @@ export function createStatusTableColumn<
   getStatus,
   isLive,
   isLoading,
+  emptyValue,
   ...options
 }: TableColumnOptions<TData, TValue> & {
   getStatus: (
@@ -29,6 +31,7 @@ export function createStatusTableColumn<
     value: TValue | null | undefined,
     context: CellContext<TData, TValue | null | undefined>,
   ) => boolean;
+  emptyValue?: ReactNode;
 }) {
   const loadingCell = <Skeleton className="h-5 w-16 shrink-0 rounded-sm" />;
 
@@ -41,7 +44,11 @@ export function createStatusTableColumn<
       }
 
       const status = getStatus(value, context);
-      return status ? <StatusBadge type={status} isLive={isLive} /> : null;
+      return status ? (
+        <StatusBadge type={status} isLive={isLive} />
+      ) : (
+        (emptyValue ?? null)
+      );
     },
   });
 }

--- a/web/src/components/design-system/table/columns/createStatusTableColumn.tsx
+++ b/web/src/components/design-system/table/columns/createStatusTableColumn.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable boundaries/dependencies */
 import { type CellContext, type RowData } from "@tanstack/react-table";
-import { type ReactNode } from "react";
 
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
@@ -12,26 +11,23 @@ import {
   type TableColumnOptions,
 } from "./utils/createTableColumn";
 
+type StatusCell = Status | (string & {}) | { type: "loading" } | undefined;
+
 export function createStatusTableColumn<
   TData extends RowData,
   TValue = Status,
 >({
   getStatus,
   isLive,
-  isLoading,
   emptyValue,
   ...options
 }: TableColumnOptions<TData, TValue> & {
   getStatus: (
     value: TValue | null | undefined,
     context: CellContext<TData, TValue | null | undefined>,
-  ) => Status | (string & {}) | undefined;
+  ) => StatusCell;
   isLive?: boolean;
-  isLoading?: (
-    value: TValue | null | undefined,
-    context: CellContext<TData, TValue | null | undefined>,
-  ) => boolean;
-  emptyValue?: ReactNode;
+  emptyValue?: string;
 }) {
   const loadingCell = <Skeleton className="h-5 w-16 shrink-0 rounded-sm" />;
 
@@ -39,16 +35,12 @@ export function createStatusTableColumn<
     ...options,
     loadingCell,
     renderCell: (value, context) => {
-      if (isLoading?.(value, context)) {
-        return loadingCell;
-      }
-
       const status = getStatus(value, context);
-      return status ? (
-        <StatusBadge type={status} isLive={isLive} />
-      ) : (
-        (emptyValue ?? null)
-      );
+
+      if (status === undefined) return emptyValue ?? null;
+      if (typeof status !== "string") return loadingCell;
+
+      return <StatusBadge type={status} isLive={isLive} />;
     },
   });
 }

--- a/web/src/components/design-system/table/columns/createStatusTableColumn.tsx
+++ b/web/src/components/design-system/table/columns/createStatusTableColumn.tsx
@@ -17,6 +17,7 @@ export function createStatusTableColumn<
 >({
   getStatus,
   isLive,
+  isLoading,
   ...options
 }: TableColumnOptions<TData, TValue> & {
   getStatus: (
@@ -24,11 +25,21 @@ export function createStatusTableColumn<
     context: CellContext<TData, TValue | null | undefined>,
   ) => Status | (string & {}) | undefined;
   isLive?: boolean;
+  isLoading?: (
+    value: TValue | null | undefined,
+    context: CellContext<TData, TValue | null | undefined>,
+  ) => boolean;
 }) {
+  const loadingCell = <Skeleton className="h-5 w-16 shrink-0 rounded-sm" />;
+
   return createTableColumn<TData, TValue>({
     ...options,
-    loadingCell: <Skeleton className="h-5 w-16 shrink-0 rounded-sm" />,
+    loadingCell,
     renderCell: (value, context) => {
+      if (isLoading?.(value, context)) {
+        return loadingCell;
+      }
+
       const status = getStatus(value, context);
       return status ? <StatusBadge type={status} isLive={isLive} /> : null;
     },

--- a/web/src/components/level-colors.clienttest.ts
+++ b/web/src/components/level-colors.clienttest.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 
-import { getLevelColors, LevelColors } from "@/src/components/level-colors";
+import {
+  getLevelColors,
+  getObservationLevelStatus,
+  LevelColors,
+  observationLevelToStatus,
+} from "@/src/components/level-colors";
 
 describe("getLevelColors", () => {
   it("returns the correct style for each known level", () => {
@@ -48,5 +53,19 @@ describe("getLevelColors", () => {
       expect(typeof colors.bg).toBe("string");
       expect(typeof colors.text).toBe("string");
     }
+  });
+});
+
+describe("observationLevelToStatus", () => {
+  it("maps every known observation level to a status token", () => {
+    expect(observationLevelToStatus.DEFAULT).toBe("default");
+    expect(observationLevelToStatus.DEBUG).toBe("debug");
+    expect(observationLevelToStatus.WARNING).toBe("warning");
+    expect(observationLevelToStatus.ERROR).toBe("error");
+  });
+
+  it("passes through unknown levels so StatusBadge can render them", () => {
+    expect(getObservationLevelStatus("ERROR")).toBe("error");
+    expect(getObservationLevelStatus("INFO")).toBe("INFO");
   });
 });

--- a/web/src/components/level-colors.clienttest.ts
+++ b/web/src/components/level-colors.clienttest.ts
@@ -1,11 +1,6 @@
 // @vitest-environment node
 
-import {
-  getLevelColors,
-  getObservationLevelStatus,
-  LevelColors,
-  observationLevelToStatus,
-} from "@/src/components/level-colors";
+import { getLevelColors, LevelColors } from "@/src/components/level-colors";
 
 describe("getLevelColors", () => {
   it("returns the correct style for each known level", () => {
@@ -53,19 +48,5 @@ describe("getLevelColors", () => {
       expect(typeof colors.bg).toBe("string");
       expect(typeof colors.text).toBe("string");
     }
-  });
-});
-
-describe("observationLevelToStatus", () => {
-  it("maps every known observation level to a status token", () => {
-    expect(observationLevelToStatus.DEFAULT).toBe("default");
-    expect(observationLevelToStatus.DEBUG).toBe("debug");
-    expect(observationLevelToStatus.WARNING).toBe("warning");
-    expect(observationLevelToStatus.ERROR).toBe("error");
-  });
-
-  it("passes through unknown levels so StatusBadge can render them", () => {
-    expect(getObservationLevelStatus("ERROR")).toBe("error");
-    expect(getObservationLevelStatus("INFO")).toBe("INFO");
   });
 });

--- a/web/src/components/level-colors.tsx
+++ b/web/src/components/level-colors.tsx
@@ -2,7 +2,7 @@ import type React from "react";
 import { type ObservationLevelType } from "@langfuse/shared";
 import { cn } from "@/src/utils/tailwind";
 
-export const observationLevelToStatus = {
+const observationLevelToStatus = {
   ERROR: "error",
   WARNING: "warning",
   DEBUG: "debug",

--- a/web/src/components/level-colors.tsx
+++ b/web/src/components/level-colors.tsx
@@ -2,6 +2,19 @@ import type React from "react";
 import { type ObservationLevelType } from "@langfuse/shared";
 import { cn } from "@/src/utils/tailwind";
 
+export const observationLevelToStatus = {
+  ERROR: "error",
+  WARNING: "warning",
+  DEBUG: "debug",
+  DEFAULT: "default",
+} as const satisfies Record<ObservationLevelType, string>;
+
+export function getObservationLevelStatus(level: string): string {
+  return Object.hasOwn(observationLevelToStatus, level)
+    ? observationLevelToStatus[level as ObservationLevelType]
+    : level;
+}
+
 export const LevelColors = {
   DEFAULT: { text: "", bg: "" },
   DEBUG: { text: "text-muted-foreground", bg: "bg-tertiary" },

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -49,8 +49,7 @@ import { formatIntervalSeconds } from "@/src/utils/dates";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
-import { cn } from "@/src/utils/tailwind";
-import { getLevelColors } from "@/src/components/level-colors";
+import { getObservationLevelStatus } from "@/src/components/level-colors";
 import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import {
   formatObservationCost,
@@ -80,6 +79,7 @@ import { createNumberTableColumn } from "@/src/components/design-system/table/co
 import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
 import { createDurationTableColumn } from "@/src/components/design-system/table/columns/createDurationTableColumn";
 import { createItemBadgeTableColumn } from "@/src/components/design-system/table/columns/createItemBadgeTableColumn";
+import { createStatusTableColumn } from "@/src/components/design-system/table/columns/createStatusTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { createTagsTableColumn } from "@/src/components/design-system/table/columns/createTagsTableColumn";
 import { createTokenUsageTableColumn } from "@/src/components/design-system/table/columns/createTokenUsageTableColumn";
@@ -773,9 +773,8 @@ export default function ObservationsTable({
       },
       enableHiding: true,
     },
-    {
+    createStatusTableColumn<ObservationsTableRow, ObservationLevelType>({
       accessorKey: "level",
-      id: "level",
       header: "Status",
       size: 100,
       headerTooltip: {
@@ -784,22 +783,11 @@ export default function ObservationsTable({
         href: "https://langfuse.com/docs/observability/features/log-levels",
       },
       enableHiding: true,
-      cell({ row }) {
-        const value: ObservationLevelType | undefined = row.getValue("level");
-        return value ? (
-          <span
-            className={cn(
-              "rounded-sm p-0.5 text-xs",
-              getLevelColors(value).bg,
-              getLevelColors(value).text,
-            )}
-          >
-            {value}
-          </span>
-        ) : undefined;
-      },
       enableSorting,
-    },
+      isLive: false,
+      getStatus: (level) =>
+        level ? getObservationLevelStatus(level) : undefined,
+    }),
     createTextTableColumn<ObservationsTableRow>({
       accessorKey: "statusMessage",
       header: "Status Message",

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/src/components/ui/button";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
+import { createStatusTableColumn } from "@/src/components/design-system/table/columns/createStatusTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -141,17 +142,14 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
       enableHiding: true,
       defaultHidden: true,
     }),
-    {
+    createStatusTableColumn<ScoreConfigTableRow, boolean>({
       accessorKey: "isArchived",
-      id: "isArchived",
       header: "Status",
       size: 80,
       enableHiding: true,
-      cell: ({ row }) => {
-        const { isArchived } = row.original;
-        return isArchived ? "Archived" : "Active";
-      },
-    },
+      isLive: false,
+      getStatus: (isArchived) => (isArchived ? "archived" : "active"),
+    }),
     {
       accessorKey: "action",
       header: "Action",

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -22,7 +22,6 @@ import { Button } from "@/src/components/ui/button";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { SettingsTableCard } from "@/src/components/layouts/settings-table-card";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
-import { createStatusTableColumn } from "@/src/components/design-system/table/columns/createStatusTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -142,13 +141,12 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
       enableHiding: true,
       defaultHidden: true,
     }),
-    createStatusTableColumn<ScoreConfigTableRow, boolean>({
+    createTextTableColumn<ScoreConfigTableRow, boolean>({
       accessorKey: "isArchived",
       header: "Status",
       size: 80,
       enableHiding: true,
-      isLive: false,
-      getStatus: (isArchived) => (isArchived ? "archived" : "active"),
+      mapValue: (isArchived) => (isArchived ? "Archived" : "Active"),
     }),
     {
       accessorKey: "action",

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -990,9 +990,12 @@ export default function TracesTable({
       enableSorting,
       isLive: false,
       emptyValue: "-",
-      isLoading: (_value, { row }) => isMetricPending(row.original.id),
-      getStatus: (level) =>
-        level ? getObservationLevelStatus(level) : undefined,
+      getStatus: (level, { row }) =>
+        isMetricPending(row.original.id)
+          ? { type: "loading" }
+          : level
+            ? getObservationLevelStatus(level)
+            : undefined,
     }),
     createTextTableColumn<TracesTableRow>({
       accessorKey: "version",

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -10,6 +10,7 @@ import { createDateTableColumn } from "@/src/components/design-system/table/colu
 import { createDropdownTableColumn } from "@/src/components/design-system/table/columns/createDropdownTableColumn";
 import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
+import { createStatusTableColumn } from "@/src/components/design-system/table/columns/createStatusTableColumn";
 import { createTagsTableColumn } from "@/src/components/design-system/table/columns/createTagsTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { createTokenUsageTableColumn } from "@/src/components/design-system/table/columns/createTokenUsageTableColumn";
@@ -37,10 +38,9 @@ import {
 import { DeleteTraceButton } from "@/src/components/deleteButton";
 import {
   formatAsLabel,
-  getLevelColors,
   LevelSymbols,
+  getObservationLevelStatus,
 } from "@/src/components/level-colors";
-import { cn } from "@/src/utils/tailwind";
 import {
   detailPageListKeys,
   useDetailPageLists,
@@ -981,35 +981,18 @@ export default function TracesTable({
       getValue: (value, { row }) =>
         isMetricPending(row.original.id) ? { type: "loading" } : (value ?? 0n),
     }),
-    {
+    createStatusTableColumn<TracesTableRow, ObservationLevelType>({
       accessorKey: "level",
-      id: "level",
       header: "Status",
       size: 75,
-      loadingCell: <Skeleton className="h-4 w-1/2" />,
-      cell: ({ row }) => {
-        const value: TracesTableRow["level"] = row.getValue("level");
-        if (isMetricPending(row.original.id)) {
-          return <Skeleton className="h-4 w-1/2" />;
-        }
-        return value ? (
-          <span
-            className={cn(
-              "rounded-sm p-0.5 text-xs",
-              getLevelColors(value).bg,
-              getLevelColors(value).text,
-            )}
-          >
-            {value}
-          </span>
-        ) : (
-          <span>-</span>
-        );
-      },
       defaultHidden: true,
       enableHiding: true,
       enableSorting,
-    },
+      isLive: false,
+      isLoading: (_value, { row }) => isMetricPending(row.original.id),
+      getStatus: (level) =>
+        level ? getObservationLevelStatus(level) : undefined,
+    }),
     createTextTableColumn<TracesTableRow>({
       accessorKey: "version",
       header: "Version",

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -989,6 +989,7 @@ export default function TracesTable({
       enableHiding: true,
       enableSorting,
       isLive: false,
+      emptyValue: "-",
       isLoading: (_value, { row }) => isMetricPending(row.original.id),
       getStatus: (level) =>
         level ? getObservationLevelStatus(level) : undefined,

--- a/web/src/components/ui/StatusBadge/StatusBadge.tsx
+++ b/web/src/components/ui/StatusBadge/StatusBadge.tsx
@@ -21,11 +21,11 @@ const statusCategories = {
   active: ["production", "live", "active", "public"],
   pending: ["pending", "waiting", "queued", "running", "processing"],
   delayed: ["delayed"],
-  inactive: ["disabled", "inactive", "archived", "cancelled"],
+  inactive: ["disabled", "inactive", "archived", "cancelled", "debug"],
   paused: ["paused"],
   completed: ["completed", "done", "finished"],
-  error: ["error", "failed"],
-  partial: ["partial"],
+  error: ["error", "failed", "triggered"],
+  partial: ["partial", "warning"],
 } as const;
 
 export type Status =

--- a/web/src/ee/features/billing/components/SpendAlerts/SpendAlertsTable.tsx
+++ b/web/src/ee/features/billing/components/SpendAlerts/SpendAlertsTable.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { Badge } from "@/src/components/ui/badge";
 import { DropdownMenuItem } from "@/src/components/ui/dropdown-menu";
 import { Edit, Trash2 } from "lucide-react";
 import { api } from "@/src/utils/api";
@@ -12,6 +11,7 @@ import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { createDropdownTableColumn } from "@/src/components/design-system/table/columns/createDropdownTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
+import { createStatusTableColumn } from "@/src/components/design-system/table/columns/createStatusTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { costFormatter } from "@/src/utils/numbers";
 
@@ -80,17 +80,13 @@ export function SpendAlertsTable({ orgId }: SpendAlertsTableProps) {
       size: 140,
       formatter: costFormatter,
     }),
-    {
-      accessorKey: "status",
+    createStatusTableColumn<AlertRow, Date>({
       id: "status",
+      accessorFn: (row) => row.triggeredAt,
       header: "Status",
       size: 110,
-      cell: ({ row }) => (
-        <Badge variant={row.original.triggeredAt ? "destructive" : "secondary"}>
-          {row.original.triggeredAt ? "Triggered" : "Active"}
-        </Badge>
-      ),
-    },
+      getStatus: (triggeredAt) => (triggeredAt ? "triggered" : "active"),
+    }),
     {
       accessorKey: "lastTriggered",
       id: "lastTriggered",

--- a/web/src/ee/features/billing/components/SpendAlerts/SpendAlertsTable.tsx
+++ b/web/src/ee/features/billing/components/SpendAlerts/SpendAlertsTable.tsx
@@ -85,6 +85,7 @@ export function SpendAlertsTable({ orgId }: SpendAlertsTableProps) {
       accessorFn: (row) => row.triggeredAt,
       header: "Status",
       size: 110,
+      isLive: false,
       getStatus: (triggeredAt) => (triggeredAt ? "triggered" : "active"),
     }),
     {

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -1,4 +1,3 @@
-import { StatusBadge } from "@/src/components/ui/StatusBadge/StatusBadge";
 import { encodeFiltersGeneric } from "@langfuse/shared";
 import { LevelCountsDisplay } from "@/src/components/level-counts-display";
 import { DataTable } from "@/src/components/table/data-table";
@@ -49,6 +48,7 @@ import { usdFormatter } from "@/src/utils/numbers";
 import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createIdTableColumn } from "@/src/components/design-system/table/columns/createIdTableColumn";
+import { createStatusTableColumn } from "@/src/components/design-system/table/columns/createStatusTableColumn";
 import {
   type EvaluatorDataRow,
   useEvaluatorTableData,
@@ -209,20 +209,12 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
         );
       },
     }),
-    columnHelper.accessor("status", {
+    createStatusTableColumn<EvaluatorDataRow, string>({
+      accessorKey: "status",
       header: "Status",
-      id: "status",
       enableSorting: true,
       size: 80,
-      loadingCell: <Skeleton className="h-5 w-16 shrink-0 rounded-sm" />,
-      cell: (row) => {
-        const status = row.getValue();
-        return (
-          <div className={status === "FINISHED" ? "pl-3" : undefined}>
-            <StatusBadge type={status.toLowerCase()} />
-          </div>
-        );
-      },
+      getStatus: (status) => status?.toLowerCase(),
     }),
     createNumberTableColumn<EvaluatorDataRow>({
       accessorKey: "totalCost",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -46,12 +46,13 @@ import { createIdTableColumn } from "@/src/components/design-system/table/column
 import { createItemBadgeTableColumn } from "@/src/components/design-system/table/columns/createItemBadgeTableColumn";
 import { createNumberTableColumn } from "@/src/components/design-system/table/columns/createNumberTableColumn";
 import { createIOTableColumn } from "@/src/components/design-system/table/columns/createIOTableColumn";
+import { createStatusTableColumn } from "@/src/components/design-system/table/columns/createStatusTableColumn";
 import { createTagsTableColumn } from "@/src/components/design-system/table/columns/createTagsTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { filterStateToQueryText } from "@/src/features/search-bar/lib/filter-state-to-query";
 import { cn } from "@/src/utils/tailwind";
-import { getLevelColors } from "@/src/components/level-colors";
+import { getObservationLevelStatus } from "@/src/components/level-colors";
 import {
   compactNumberFormatter,
   numberFormatter,
@@ -1183,9 +1184,8 @@ export default function ObservationsEventsTable({
       singleLine: rowHeight === "s",
       enableHiding: true,
     }),
-    {
+    createStatusTableColumn<EventsTableRow, ObservationLevelType>({
       accessorKey: "level",
-      id: "level",
       header: getEventsColumnName("level"),
       size: 100,
       headerTooltip: {
@@ -1194,22 +1194,11 @@ export default function ObservationsEventsTable({
         href: "https://langfuse.com/docs/observability/features/log-levels",
       },
       enableHiding: true,
-      cell: ({ row }) => {
-        const value: ObservationLevelType | undefined = row.getValue("level");
-        return value ? (
-          <span
-            className={cn(
-              "rounded-sm p-0.5 text-xs",
-              getLevelColors(value).bg,
-              getLevelColors(value).text,
-            )}
-          >
-            {value}
-          </span>
-        ) : undefined;
-      },
       enableSorting,
-    },
+      isLive: false,
+      getStatus: (level) =>
+        level ? getObservationLevelStatus(level) : undefined,
+    }),
     createIOTableColumn<EventsTableRow>({
       accessorKey: "statusMessage",
       header: getEventsColumnName("statusMessage"),


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16951 app preview](https://pr-16951.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Migrates the remaining badge-based Status table columns onto `createStatusTableColumn` so observations, traces, events, evaluators, and spend alerts share the same `StatusBadge` cell and loading skeleton. Score config status remains text and now uses `createTextTableColumn`.

Status tokens now include `warning`, `debug`, and `triggered`. Per-row loading uses the same `{ type: "loading" }` mapper return as the other column creators. Empty cells take an optional `emptyValue: string` (traces keep `"-"`).

Impacted packages: `web`

Verification:
- `pnpm --filter web exec eslint` on the requested files (0 errors)
- `pnpm --filter web run test-client src/components/level-colors.clienttest.ts` — `Tests 12 passed (12)`
- pre-commit `turbo run lint` — `Tasks: 7 successful, 7 total`
- Skipped a clean full `web` typecheck because this environment reports unrelated pre-existing generated-type and implicit-`any` errors

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Code follows the project formatting rules
- Targeted lint and existing client tests pass locally

Proof of work

![Observations Status column with Default, Debug, and Warning badges](https://cursor.com/artifacts/c/art-9bd777ab-d0a5-430d-9c54-ed24c92af893)
![Traces Status column with Error, Default, and Warning badges](https://cursor.com/artifacts/c/art-82d0aa03-ce1a-4b25-91ac-35adb34d180d)
![Evaluators Status column with Active StatusBadge](https://cursor.com/artifacts/c/art-9ee9556b-6a65-4dee-be2d-5734e637254c)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LFE-15900](https://linear.app/clickhouse/issue/LFE-15900/migrate-more-table-columns-to-createstatustablecolumn)

<div><a href="https://cursor.com/agents/bc-eedc4935-203d-4158-a04c-60f6d13b004c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eedc4935-203d-4158-a04c-60f6d13b004c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates the remaining status-oriented table columns to the shared `createStatusTableColumn` renderer and extends its status/loading support.

- Adds per-row loading support to the shared status-column creator.
- Maps observation levels and spend-alert states onto shared status tokens.
- Migrates observation, trace, event, score-config, evaluator, and spend-alert status cells.
- Extends tests and stories for level mapping and row-loading presentation.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking empty-state regression in the trace Status column.

The shared migration preserves status and loading behavior overall, but traces with no aggregated level now render a blank status cell instead of the prior `-` placeholder.

**Files Needing Attention:** web/src/components/table/use-cases/traces.tsx
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/components/table/use-cases/traces.tsx:993-994
**Trace status loses placeholder**

For a loaded trace without an aggregated level, `getStatus` returns `undefined` and the shared column renders a blank cell instead of the previous `-` placeholder, making the loaded empty state indistinguishable from missing content.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): migrate status table colu..."](https://github.com/langfuse/langfuse/commit/374a62956e49f30e453a799a7e4e54a5ddea9a2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59456624)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->