### PR TITLE
feat(public-api): add ?fromTimestamp / ?toTimestamp filters to GET /api/public/models

### DIFF
--- a/fern/apis/server/definition/models.yml
+++ b/fern/apis/server/definition/models.yml
@@ -33,6 +33,18 @@ service:
           limit:
             type: optional<integer>
             docs: limit of items per page
+          fromTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 lower bound on the model row's `createdAt`.
+              Omit for an open-ended start. Pattern matches
+              `GET /api/public/comments`.
+          toTimestamp:
+            type: optional<datetime>
+            docs: |
+              Optional ISO-8601 upper bound on the model row's `createdAt`.
+              Omit for an open-ended end. Pattern matches
+              `GET /api/public/comments`.
       response: PaginatedModels
     get:
       method: GET

--- a/web/src/__tests__/server/model-definitions.servertest.ts
+++ b/web/src/__tests__/server/model-definitions.servertest.ts
@@ -666,3 +666,162 @@ describe("/models API Endpoints", () => {
     expect(modelsAfterDelete.status).toBe(200);
   });
 });
+
+describe("GET /api/public/models timestamp window", () => {
+  it("returns only models with createdAt >= fromTimestamp", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+
+    const early = await makeZodVerifiedAPICall(
+      PostModelsV1Response,
+      "POST",
+      "/api/public/models",
+      {
+        modelName: `early-${v4()}`,
+        matchPattern: "(.*)early(.*)",
+        startDate: "2026-01-01",
+        inputPrice: 0.001,
+        outputPrice: 0.002,
+        unit: "TOKENS",
+      },
+      auth,
+    );
+    expect(early.status).toBe(200);
+
+    const late = await makeZodVerifiedAPICall(
+      PostModelsV1Response,
+      "POST",
+      "/api/public/models",
+      {
+        modelName: `late-${v4()}`,
+        matchPattern: "(.*)late(.*)",
+        startDate: "2026-12-31",
+        inputPrice: 0.003,
+        outputPrice: 0.004,
+        unit: "TOKENS",
+      },
+      auth,
+    );
+    expect(late.status).toBe(200);
+
+    // Force the "late" model's createdAt to a known timestamp in the future
+    // so the fromTimestamp filter is deterministic.
+    const future = new Date("2027-06-15T12:00:00Z");
+    await prisma.model.update({
+      where: { id: late.body.id },
+      data: { createdAt: future },
+    });
+    // Push the "early" model's createdAt into the past so it falls below
+    // the fromTimestamp cutoff.
+    const past = new Date("2026-06-15T12:00:00Z");
+    await prisma.model.update({
+      where: { id: early.body.id },
+      data: { createdAt: past },
+    });
+
+    const res = await makeZodVerifiedAPICall(
+      GetModelsV1Response,
+      "GET",
+      `/api/public/models?fromTimestamp=${encodeURIComponent("2027-01-01T00:00:00Z")}`,
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((m) => m.id);
+    expect(ids).toContain(late.body.id);
+    expect(ids).not.toContain(early.body.id);
+
+    // Cleanup
+    await prisma.model.deleteMany({
+      where: { projectId, id: { in: [early.body.id, late.body.id] } },
+    });
+  });
+
+  it("returns only models with createdAt <= toTimestamp", async () => {
+    const { auth, projectId } = await createOrgProjectAndApiKey();
+
+    const early = await makeZodVerifiedAPICall(
+      PostModelsV1Response,
+      "POST",
+      "/api/public/models",
+      {
+        modelName: `early-${v4()}`,
+        matchPattern: "(.*)early(.*)",
+        startDate: "2026-01-01",
+        inputPrice: 0.001,
+        outputPrice: 0.002,
+        unit: "TOKENS",
+      },
+      auth,
+    );
+    expect(early.status).toBe(200);
+
+    const late = await makeZodVerifiedAPICall(
+      PostModelsV1Response,
+      "POST",
+      "/api/public/models",
+      {
+        modelName: `late-${v4()}`,
+        matchPattern: "(.*)late(.*)",
+        startDate: "2026-12-31",
+        inputPrice: 0.003,
+        outputPrice: 0.004,
+        unit: "TOKENS",
+      },
+      auth,
+    );
+    expect(late.status).toBe(200);
+
+    // early.createdAt = 2026-06-15; late.createdAt = 2027-06-15.
+    await prisma.model.update({
+      where: { id: early.body.id },
+      data: { createdAt: new Date("2026-06-15T12:00:00Z") },
+    });
+    await prisma.model.update({
+      where: { id: late.body.id },
+      data: { createdAt: new Date("2027-06-15T12:00:00Z") },
+    });
+
+    const res = await makeZodVerifiedAPICall(
+      GetModelsV1Response,
+      "GET",
+      `/api/public/models?toTimestamp=${encodeURIComponent("2026-12-31T23:59:59Z")}`,
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((m) => m.id);
+    expect(ids).toContain(early.body.id);
+    expect(ids).not.toContain(late.body.id);
+
+    await prisma.model.deleteMany({
+      where: { projectId, id: { in: [early.body.id, late.body.id] } },
+    });
+  });
+
+  it("rejects an invalid timestamp with 400", async () => {
+    const { auth } = await createOrgProjectAndApiKey();
+
+    const res = await makeAPICall(
+      "GET",
+      "/api/public/models?fromTimestamp=not-a-date",
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("omitting both params preserves the existing unfiltered behavior", async () => {
+    const { auth } = await createOrgProjectAndApiKey();
+
+    // No filter, just exercise the route to make sure it still returns 200.
+    const res = await makeZodVerifiedAPICall(
+      GetModelsV1Response,
+      "GET",
+      "/api/public/models",
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+});

--- a/web/src/features/models/server/publicApiModelService.ts
+++ b/web/src/features/models/server/publicApiModelService.ts
@@ -39,6 +39,8 @@ type ModelAuditScope = {
 
 type ListModelsInput = z.infer<typeof GetModelsV1Query> & {
   projectId: string;
+  fromTimestamp?: Date | null;
+  toTimestamp?: Date | null;
 };
 
 type GetModelInput = z.infer<typeof GetModelV1Query> & {
@@ -142,8 +144,22 @@ export const listModelsForApi = async ({
   projectId,
   page,
   limit,
+  fromTimestamp,
+  toTimestamp,
 }: ListModelsInput) => {
-  const where = visibleModelsWhere(projectId);
+  const where = {
+    ...visibleModelsWhere(projectId),
+    // Optional half-open time window on createdAt. The two params are
+    // independent, so omitting both preserves the existing behavior.
+    ...(fromTimestamp || toTimestamp
+      ? {
+          createdAt: {
+            ...(fromTimestamp ? { gte: fromTimestamp } : {}),
+            ...(toTimestamp ? { lte: toTimestamp } : {}),
+          },
+        }
+      : {}),
+  };
 
   const [models, totalItems] = await Promise.all([
     prisma.model.findMany({

--- a/web/src/features/public-api/types/models.ts
+++ b/web/src/features/public-api/types/models.ts
@@ -131,6 +131,11 @@ export function prismaToApiModelDefinition({
 // GET /models
 export const GetModelsV1Query = z.object({
   ...publicApiPaginationZod,
+  // Optional half-open time window on the model row's `createdAt` column.
+  // Both params are independent; an invalid ISO-8601 timestamp returns 400
+  // via the Zod coerce. Pattern matches GET /api/public/comments.
+  fromTimestamp: z.coerce.date().nullish(),
+  toTimestamp: z.coerce.date().nullish(),
 });
 export const GetModelsV1Response = z
   .object({

--- a/web/src/pages/api/public/models/index.ts
+++ b/web/src/pages/api/public/models/index.ts
@@ -22,6 +22,8 @@ export default withMiddlewares({
         projectId: auth.scope.projectId,
         page: query.page,
         limit: query.limit,
+        fromTimestamp: query.fromTimestamp,
+        toTimestamp: query.toTimestamp,
       });
     },
   }),


### PR DESCRIPTION
Fixes #16948.

## Problem

`GET /api/public/models` previously supported only pagination (`?page`, `?limit`). Customers with a large model catalog (hundreds of project-owned model definitions accumulated over time) could not scope the list to a recent time window — every page scan returned the full history.

The companion `GET /api/public/comments` endpoint already accepts `?fromTimestamp` / `?toTimestamp` (PR #15692) on `createdAt`. The same pattern fits naturally on `/models` since models are project-owned rows with a `createdAt` column.

Concretely:
- A customer integrating the public API for a CI-side model audit needs "models added since $DATE" — currently they must paginate through the full list and filter client-side.
- A bulk-rotation job that needs to know "what did I change this week" has no way to ask the API.

## Proposed solution

Extend `GetModelsV1Query` to accept two optional ISO-8601 timestamp query params and pipe them through to `listModelsForApi` as a Prisma `createdAt` range filter.

- `?fromTimestamp=2026-08-01T00:00:00Z` → `createdAt >= fromTimestamp`
- `?toTimestamp=2026-08-31T23:59:59Z` → `createdAt <= toTimestamp`
- Either param can be omitted (open-ended range). Both together form a half-open window.
- Filter composes with the existing `visibleModelsWhere` clause (project-owned + langfuse-managed). Models that are not visible to the project are still filtered out.
- The `isAdminApiKeyAuthAllowed: true` flag is preserved.

## Files

- `web/src/features/public-api/types/models.ts` — add the two optional Zod fields on `GetModelsV1Query` with `z.coerce.date().nullish()`.
- `web/src/features/models/server/publicApiModelService.ts` — pipe the two params through to the Prisma `where.createdAt` as a half-open window (`gte: fromTimestamp`, `lte: toTimestamp`), composed with the existing `visibleModelsWhere` clause.
- `web/src/pages/api/public/models/index.ts` — pass the new params from the route handler to the service.
- `web/src/__tests__/server/model-definitions.servertest.ts` — four new servertest cases: fromTimestamp only, toTimestamp only, invalid format returns 400, and omitting both (existing behavior). The two filter cases force `createdAt` via `prisma.model.update` so the time window is deterministic.
- `fern/apis/server/definition/models.yml` — document the two new query params on the `list` endpoint.

## Compatibility

- Both params are optional. Existing API consumers see no change.
- `GetModelsV1Query` is widened (more allowed keys), not narrowed, so no client breaks.

## Verification

- `pnpm exec prettier --check` on the 4 source files: clean.
- `pnpm exec tsc --noEmit` from `web/`: clean on the changed file (pre-existing tsc errors in `scores.ts`, `auth.ts`, `otelRequestBody.ts` are unrelated).
- 8/8 standalone smoke tests pass: the URL-parse + where-clause assembly behaves as designed (no filter, from-only, to-only, both, valid parse, invalid parse).
- `pnpm exec vitest run` is blocked locally by a pre-existing storybook dep mismatch (`@typescript/typescript6` package-name issue in `.storybook/main.ts`); CI is expected to exercise the new cases on the standard test infrastructure.

## Risk

Minimal. The change adds a filter that narrows the result set; it cannot widen it. A malformed timestamp is caught by the Zod coerce and returns 400, not 500.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds optional creation-time bounds to the public models listing and documents them in Fern.
- Extends the public query schema and route-to-service parameter flow.
- Applies the bounds to both model retrieval and pagination counts.
- Adds server coverage for one-sided filters, invalid input, and omitted parameters.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until timestamp handling is made consistent across REST and MCP, strict wire-format validation is enforced, and the upper-bound semantics match the declared half-open interval.

The shared schema causes MCP filters to be silently ignored, accepts timestamp formats outside the public contract, and includes records exactly at an upper boundary that the changed code describes as exclusive.

**Files Needing Attention:** web/src/features/public-api/types/models.ts, web/src/features/models/server/publicApiModelService.ts, web/src/features/mcp/server/models/tools/listModels.ts
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[REST or MCP caller] --> Q[GetModelsV1Query]
  Q --> R[Public REST route]
  Q --> M[MCP listModels handler]
  R --> S[listModelsForApi]
  M -. timestamps omitted .-> S
  S --> W[Visible model scope plus createdAt range]
  W --> D[(PostgreSQL models)]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/public-api/types/models.ts:137-138
When an MCP `listModels` caller supplies either timestamp, the shared input schema accepts it, but the MCP handler forwards only `page` and `limit` to `listModelsForApi`, causing the tool to return models outside the requested time range.

### Issue 2
web/src/features/public-api/types/models.ts:137-138
When a caller supplies a non-ISO string that JavaScript can parse as a date, `z.coerce.date()` accepts and applies it even though the public contract requires ISO-8601, causing malformed wire values to return filtered results instead of a 400 response.

### Issue 3
web/src/features/models/server/publicApiModelService.ts:158
When a model's `createdAt` equals `toTimestamp`, `lte` includes it despite the newly declared half-open interval, causing that model to appear in both adjacent audit windows.

```suggestion
            ...(toTimestamp ? { lt: toTimestamp } : {}),
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add ?fromTimestamp / ?..."](https://github.com/langfuse/langfuse/commit/b79bc4aebf4c931cd791a1a5a462d831be20bd26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59456670)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [API and SDK contracts](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/api-and-sdk-contracts.md)

<!-- /greptile_comment -->