### PR TITLE
fix: align alert button caret spacing

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorAlertButton/EvaluatorAlertButton.clienttest.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorAlertButton/EvaluatorAlertButton.clienttest.tsx
@@ -47,6 +47,7 @@ describe("EvaluatorAlertButton", () => {
       screen.getByRole("button", { name: "Add evaluator alert" }),
     ).toHaveTextContent("Add alert");
     expect(container.querySelector(".lucide-plus")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-chevron-down")).toHaveClass("ml-1");
     expect(container.querySelector(".lucide-bell")).not.toBeInTheDocument();
   });
 

--- a/web/src/features/evals/v2/components/Evaluators/EvaluatorAlertButton/EvaluatorAlertButton.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/EvaluatorAlertButton/EvaluatorAlertButton.tsx
@@ -330,7 +330,7 @@ export function EvaluatorAlertButton(props: EvaluatorAlertButtonProps) {
                 {alertCount}
               </Badge>
             ) : null}
-            <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+            <ChevronDown className="ml-1 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </Trigger>
       )}


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16953 app preview](https://pr-16953.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary
- match the right caret spacing with the left icon spacing
- cover the spacing with a component test

## Checks
- `pnpm --filter web run test-client EvaluatorAlertButton.clienttest.tsx`
- `pnpm run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns the evaluator alert button’s right caret spacing with its left icon spacing and adds a focused component assertion.
- Adds the `ml-1` utility to the alert button’s dropdown caret.
- Extends the client test to verify the caret spacing class.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The change is limited to a presentation utility class and a corresponding assertion, with no behavioral, security, or contract changes.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix alert button caret spacing"](https://github.com/langfuse/langfuse/commit/34b9c6e02824b597edceafb5af2221271d4fb116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59461508)</sub>

<!-- /greptile_comment -->