### PR TITLE
fix(ingestion): map OpenAI cache_write_tokens to input_cache_creation

### DIFF
--- a/packages/shared/src/server/ingestion/types.test.ts
+++ b/packages/shared/src/server/ingestion/types.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { UsageDetails } from "./types";
+
+describe("UsageDetails", () => {
+  describe("OpenAI cache write tokens", () => {
+    it("stores Responses API input_tokens_details.cache_write_tokens as input_cache_creation", () => {
+      const usageDetails = UsageDetails.parse({
+        input_tokens: 100_000,
+        output_tokens: 1_000,
+        total_tokens: 101_000,
+        input_tokens_details: { cached_tokens: 0, cache_write_tokens: 80_000 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      });
+
+      expect(usageDetails).toEqual({
+        input: 20_000,
+        output: 1_000,
+        total: 101_000,
+        input_cached_tokens: 0,
+        input_cache_creation: 80_000,
+        output_reasoning_tokens: 0,
+      });
+    });
+
+    it("stores Chat Completions prompt_tokens_details.cache_write_tokens as input_cache_creation", () => {
+      const usageDetails = UsageDetails.parse({
+        prompt_tokens: 100_000,
+        completion_tokens: 1_000,
+        total_tokens: 101_000,
+        prompt_tokens_details: { cached_tokens: 0, cache_write_tokens: 80_000 },
+        completion_tokens_details: { reasoning_tokens: 0 },
+      });
+
+      expect(usageDetails).toEqual({
+        input: 20_000,
+        output: 1_000,
+        total: 101_000,
+        input_cached_tokens: 0,
+        input_cache_creation: 80_000,
+        output_reasoning_tokens: 0,
+      });
+    });
+  });
+});

--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -105,6 +105,18 @@ const RawUsageDetails = z.record(z.string(), z.unknown()).transform((val) => {
   return Object.keys(result).length > 0 ? result : undefined;
 });
 
+// OpenAI reports prompt-cache writes as `cache_write_tokens` inside
+// `prompt_tokens_details` / `input_tokens_details`. They are stored under
+// `input_cache_creation`, the usage type the OTel usage normalization emits for
+// cache writes and the one model prices carry, instead of the generic
+// `input_`-prefixed key.
+const OPENAI_INPUT_TOKENS_DETAILS_KEY_MAP: Record<string, string> = {
+  cache_write_tokens: "input_cache_creation",
+};
+
+const openAIInputTokensDetailsKey = (key: string): string =>
+  OPENAI_INPUT_TOKENS_DETAILS_KEY_MAP[key] ?? `input_${key}`;
+
 const OpenAICompletionUsageSchema = z
   .object({
     prompt_tokens: z.number().int().nonnegative(),
@@ -141,7 +153,7 @@ const OpenAICompletionUsageSchema = z
     if (prompt_tokens_details) {
       for (const [key, value] of Object.entries(prompt_tokens_details)) {
         if (value !== null && value !== undefined) {
-          result[`input_${key}`] = value;
+          result[openAIInputTokensDetailsKey(key)] = value;
           result.input = Math.max(result.input - (value ?? 0), 0);
         }
       }
@@ -196,7 +208,7 @@ const OpenAIResponseUsageSchema = z
     if (input_tokens_details) {
       for (const [key, value] of Object.entries(input_tokens_details)) {
         if (value !== null && value !== undefined) {
-          result[`input_${key}`] = value;
+          result[openAIInputTokensDetailsKey(key)] = value;
           result.input = Math.max(result.input - (value ?? 0), 0);
         }
       }

--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -28,14 +28,18 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   };
 });
 
+import Decimal from "decimal.js";
+
 import { IngestionService } from "../../IngestionService";
 import {
   convertDateToClickhouseDateTime,
   createTraceScore,
   type ObservationEvent,
   type ScoreEventType,
+  UsageDetails,
 } from "@langfuse/shared/src/server";
 import { TableName } from "../../ClickhouseWriter";
+import defaultModelPrices from "../../../constants/default-model-prices.json";
 
 describe("IngestionService unit tests", () => {
   beforeEach(() => {
@@ -478,6 +482,36 @@ describe("IngestionService unit tests", () => {
         metadata: { large: metadataValue },
       });
     }
+  });
+
+  it("prices OpenAI cache write tokens with the default gpt-5.6 model prices", () => {
+    const defaultTier = defaultModelPrices
+      .find((model) => model.modelName === "gpt-5.6-sol")
+      ?.pricingTiers.find((tier) => tier.isDefault);
+    const modelPrices = Object.entries(defaultTier?.prices ?? {}).map(
+      ([usageType, price]) => ({ usageType, price: new Decimal(price) }),
+    );
+
+    const usageUnits = UsageDetails.parse({
+      input_tokens: 100_000,
+      output_tokens: 1_000,
+      total_tokens: 101_000,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 80_000 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    });
+
+    const costs = (IngestionService as any).calculateUsageCosts(
+      modelPrices,
+      { provided_cost_details: {} },
+      usageUnits,
+    );
+
+    // 20,000 input tokens at $4/1M, 80,000 cache write tokens at $5/1M,
+    // 1,000 output tokens at $20/1M
+    expect(costs.cost_details.input).toBeCloseTo(0.08, 6);
+    expect(costs.cost_details.input_cache_creation).toBeCloseTo(0.4, 6);
+    expect(costs.cost_details.output).toBeCloseTo(0.02, 6);
+    expect(costs.total_cost).toBeCloseTo(0.5, 6);
   });
 
   it("correctly sorts events in ascending order by timestamp", async () => {


### PR DESCRIPTION
## What does this PR do?

OpenAI reports prompt-cache writes as `cache_write_tokens` inside `prompt_tokens_details` (Chat Completions) and `input_tokens_details` (Responses API). The two OpenAI usage schemas in `packages/shared/src/server/ingestion/types.ts` flatten every `*_tokens_details` entry to `input_<key>`, so cache writes were stored as `input_cache_write_tokens`.

No model price uses that usage type. The gpt-5.6 entries in `worker/src/constants/default-model-prices.json` carry the cache-write price under `input_cache_creation` (and `cache_write_tokens`), and the OTel usage normalization in `OtelIngestionProcessor.ts` already maps `cache_write_tokens` to `input_cache_creation`. `IngestionService.calculateUsageCosts` only prices usage keys that have a matching price and skips the rest, so on the `usage_details` path (Python OpenAI integration, `@langfuse/openai`, any caller forwarding the OpenAI usage object) cache-write tokens were counted correctly but priced at $0.

This change maps the `cache_write_tokens` detail key to `input_cache_creation` in both OpenAI usage schemas, so the SDK path emits the same usage type as the OTel path and the shipped prices apply. All other detail keys keep the generic `input_` prefix.

### Worked example

`gpt-5.6-sol`, Standard tier, Responses API usage object as returned by OpenAI:

```json
{
  "input_tokens": 100000,
  "output_tokens": 1000,
  "total_tokens": 101000,
  "input_tokens_details": { "cached_tokens": 0, "cache_write_tokens": 80000 },
  "output_tokens_details": { "reasoning_tokens": 0 }
}
```

OpenAI pricing page (https://developers.openai.com/api/docs/pricing, "Prices per 1M tokens", Standard, short context): `gpt-5.6-sol` Input $4.00, Cached input $0.40, Cache writes $5.00, Output $20.00. OpenAI prompt caching guide (https://developers.openai.com/api/docs/guides/prompt-caching): "For GPT-5.6 and later, cache writes cost 1.25× the standard, uncached input-token rate." and `ordinary_input_tokens = input_tokens - cached_tokens - cache_write_tokens`.

| Bucket         | Tokens | Rate per 1M | Cost       |
| -------------- | ------ | ----------- | ---------- |
| Ordinary input | 20,000 | $4.00       | $0.080     |
| Cache writes   | 80,000 | $5.00       | $0.400     |
| Output         | 1,000  | $20.00      | $0.020     |
| **Total**      |        |             | **$0.500** |

Before this change, with the default `gpt-5.6-sol` prices:

```
usage_details: { input: 20000, output: 1000, total: 101000, input_cached_tokens: 0, input_cache_write_tokens: 80000, output_reasoning_tokens: 0 }
cost_details:  { input: 0.08, output: 0.02, input_cached_tokens: 0, output_reasoning_tokens: 0, total: 0.1 }
total_cost:    0.1
```

After:

```
usage_details: { input: 20000, output: 1000, total: 101000, input_cached_tokens: 0, input_cache_creation: 80000, output_reasoning_tokens: 0 }
cost_details:  { input: 0.08, output: 0.02, input_cached_tokens: 0, input_cache_creation: 0.4, output_reasoning_tokens: 0, total: 0.5 }
total_cost:    0.5
```

Token counts were already correct in both cases; only the cost changes. The Chat Completions shape (`prompt_tokens_details.cache_write_tokens`) behaves the same way.

### Not addressed here

Anthropic's nested `usage.cache_creation` object (`ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`) is dropped by `RawUsageDetails`, so on the `usage_details` path 1-hour cache writes are priced at the 5-minute rate even though `input_cache_creation_5m` / `input_cache_creation_1h` prices exist. That is a separate issue with a different fix and is not part of this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## How this was tested

- `packages/shared/src/server/ingestion/types.test.ts` (new): parses the Responses API and Chat Completions usage shapes with `cache_write_tokens` and asserts the exact resulting usage details. Without the fix both cases fail (`input_cache_write_tokens: 80000` received, `input_cache_creation: 80000` expected); with it they pass.
  `pnpm --filter @langfuse/shared run test src/server/ingestion/types.test.ts`
- `worker/src/services/IngestionService/tests/IngestionService.unit.test.ts` (new case): runs the parsed Responses API usage through `IngestionService.calculateUsageCosts` with the default `gpt-5.6-sol` prices. Without the fix it fails (`cost_details.input_cache_creation` is `undefined`, `total_cost` is `0.1`); with it the file passes 18/18 with `input_cache_creation: 0.4` and `total_cost: 0.5`.
  `pnpm --filter worker run test IngestionService.unit.test.ts`
- ESLint and Prettier pass on the changed files.

Both test files run without Postgres or ClickHouse.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns OpenAI cache-write usage normalization with the existing `input_cache_creation` pricing bucket.

- Maps `cache_write_tokens` from both Chat Completions and Responses API detail objects.
- Preserves subtraction of cache-write tokens from ordinary input tokens.
- Adds schema-level tests for both OpenAI usage shapes and an ingestion-service pricing test using the default GPT-5.6 pricing.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new mapping consistent across both OpenAI schemas and the existing pricing contract.

The changed key now matches the established cache-creation usage category while retaining the existing input-token adjustment, and the added tests cover normalization and downstream cost calculation.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): map OpenAI cache\_write\_t..."](https://github.com/langfuse/langfuse/commit/2af7772ebdcc5a6d6eb5dd32dd31e4738143a09f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59481617)</sub>

<!-- /greptile_comment -->