### PR TITLE
feat: disambiguate evaluator names in filters

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -34,6 +34,34 @@ beforeAll(() => {
 });
 
 describe("CategoricalFacet", () => {
+  it("uses a custom option hover title", () => {
+    render(
+      <Accordion type="multiple" value={["evaluatorId"]}>
+        <CategoricalFacet
+          label="Evaluator"
+          filterKey="evaluatorId"
+          expanded
+          loading={false}
+          options={["evaluator-1"]}
+          displayByValue={new Map([["evaluator-1", "Answer quality"]])}
+          counts={new Map()}
+          value={[]}
+          onChange={() => {}}
+          getOptionTitle={(value, label) => `${label} (${value})`}
+          isActive={false}
+          isDisabled={false}
+          onReset={() => {}}
+        />
+      </Accordion>,
+      { wrapper: TooltipProvider },
+    );
+
+    expect(screen.getByText("Answer quality")).toHaveAttribute(
+      "title",
+      "Answer quality (evaluator-1)",
+    );
+  });
+
   it("renders an option suffix after its label", () => {
     render(
       <Accordion type="multiple" value={["model"]}>

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -544,6 +544,7 @@ export function DataTableControls({
           onOnlyChange={filter.onOnlyChange}
           renderIcon={filter.renderIcon}
           renderOptionSuffix={filter.renderOptionSuffix}
+          getOptionTitle={filter.getOptionTitle}
           isActive={filter.isActive}
           onReset={filter.onReset}
           operator={filter.operator}
@@ -1291,6 +1292,7 @@ interface CategoricalFacetProps extends BaseFacetProps {
   onOnlyChange?: (value: string) => void;
   renderIcon?: (value: string) => React.ReactNode;
   renderOptionSuffix?: (value: string) => React.ReactNode;
+  getOptionTitle?: (value: string, displayLabel: string) => string;
   operator?: "any of" | "all of" | "none of";
   onOperatorChange?: (operator: "any of" | "all of" | "none of") => void;
   textFilters?: TextFilterEntry[];
@@ -1592,6 +1594,7 @@ export function CategoricalFacet({
   onOnlyChange,
   renderIcon,
   renderOptionSuffix,
+  getOptionTitle,
   isActive,
   isDisabled,
   disabledReason,
@@ -1672,6 +1675,7 @@ export function CategoricalFacet({
             onOnlyChange={onOnlyChange}
             renderIcon={renderIcon}
             renderOptionSuffix={renderOptionSuffix}
+            getOptionTitle={getOptionTitle}
             operator={operator}
             onOperatorChange={onOperatorChange}
           />
@@ -1713,6 +1717,7 @@ function CategoricalSelectContent({
   onOnlyChange,
   renderIcon,
   renderOptionSuffix,
+  getOptionTitle,
   operator,
   onOperatorChange,
 }: Pick<
@@ -1727,6 +1732,7 @@ function CategoricalSelectContent({
   | "onOnlyChange"
   | "renderIcon"
   | "renderOptionSuffix"
+  | "getOptionTitle"
   | "operator"
   | "onOperatorChange"
 >) {
@@ -1809,6 +1815,7 @@ function CategoricalSelectContent({
         key={option}
         id={`${filterKey}-${option}`}
         label={displayLabel}
+        title={getOptionTitle?.(option, displayLabel)}
         icon={renderIcon?.(option)}
         suffix={renderOptionSuffix?.(option)}
         count={counts.get(option) || 0}
@@ -2630,6 +2637,7 @@ function TextFilterSection({
 interface FilterValueCheckboxProps {
   id: string;
   label: string;
+  title?: string;
   icon?: React.ReactNode;
   suffix?: React.ReactNode;
   count: number;
@@ -2643,6 +2651,7 @@ interface FilterValueCheckboxProps {
 function FilterValueCheckbox({
   id,
   label,
+  title,
   icon,
   suffix,
   count,
@@ -2657,7 +2666,7 @@ function FilterValueCheckbox({
 
   // Display placeholder for empty strings to ensure clickable area
   const displayLabel = label === "" ? "(empty)" : label;
-  const displayTitle = label === "" ? "(empty)" : label;
+  const displayTitle = title ?? (label === "" ? "(empty)" : label);
 
   return (
     <div

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -959,6 +959,7 @@ function FilterBuilderForm({
         onValueChange={(value) => handleFilterChange({ ...filter, value }, i)}
         disabled={disabled}
         isCustomSelectEnabled
+        showOptionValue={column?.id === "evaluatorId"}
       />
     ) : filter.type === "string" || filter.type === "stringObject" ? (
       <Input

--- a/web/src/features/filters/components/single-select.clienttest.tsx
+++ b/web/src/features/filters/components/single-select.clienttest.tsx
@@ -73,4 +73,39 @@ describe("SingleSelect", () => {
 
     expect(onValueChange).toHaveBeenCalledWith("evaluator-1");
   });
+
+  it("shows stable option values only for duplicate display labels", () => {
+    render(
+      <SingleSelect
+        title="Evaluator"
+        value="evaluator-1"
+        options={[
+          { value: "evaluator-1", displayValue: "Answer quality" },
+          { value: "evaluator-2", displayValue: "Answer quality" },
+          { value: "evaluator-3", displayValue: "Hallucination" },
+        ]}
+        onValueChange={() => {}}
+        showOptionValue
+      />,
+    );
+
+    expect(screen.getByText("Answer quality")).toHaveClass("shrink-0");
+    expect(screen.getByText("(evaluator-1)")).toHaveClass(
+      "text-muted-foreground",
+      "font-normal",
+      "truncate",
+    );
+
+    open();
+    expect(screen.getAllByText("(evaluator-1)")).toHaveLength(2);
+    expect(screen.getByText("(evaluator-2)")).toBeInTheDocument();
+    expect(screen.queryByText("(evaluator-3)")).not.toBeInTheDocument();
+    expect(screen.getByText("Hallucination")).toHaveAttribute(
+      "title",
+      "Hallucination (evaluator-3)",
+    );
+    expect(screen.getByText("Hallucination").parentElement).toHaveClass(
+      "flex-1",
+    );
+  });
 });

--- a/web/src/features/filters/components/single-select.clienttest.tsx
+++ b/web/src/features/filters/components/single-select.clienttest.tsx
@@ -74,6 +74,27 @@ describe("SingleSelect", () => {
     expect(onValueChange).toHaveBeenCalledWith("evaluator-1");
   });
 
+  it("finds duplicate display labels by their visible stable value", () => {
+    render(
+      <SingleSelect
+        title="Evaluator"
+        options={[
+          { value: "evaluator-1", displayValue: "Answer quality" },
+          { value: "evaluator-2", displayValue: "Answer quality" },
+        ]}
+        onValueChange={() => {}}
+        showOptionValue
+      />,
+    );
+
+    open();
+    fireEvent.change(screen.getByPlaceholderText("Evaluator"), {
+      target: { value: "evaluator-2" },
+    });
+
+    expect(screen.getByText("(evaluator-2)")).toBeInTheDocument();
+  });
+
   it("shows stable option values only for duplicate display labels", () => {
     render(
       <SingleSelect

--- a/web/src/features/filters/components/single-select.tsx
+++ b/web/src/features/filters/components/single-select.tsx
@@ -30,6 +30,7 @@ export function SingleSelect({
   className,
   disabled,
   isCustomSelectEnabled = false,
+  showOptionValue = false,
 }: {
   /** title labels the search box and stands in as the empty-state placeholder. */
   title?: string;
@@ -40,6 +41,8 @@ export function SingleSelect({
   disabled?: boolean;
   /** isCustomSelectEnabled offers the typed search text as a custom value. */
   isCustomSelectEnabled?: boolean;
+  /** Shows the stable option value in muted brackets after its display label. */
+  showOptionValue?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -48,9 +51,35 @@ export function SingleSelect({
     () => options.find((option) => option.value === value),
     [options, value],
   );
+  const duplicateDisplayValues = useMemo(() => {
+    const counts = new Map<string, number>();
+    options.forEach((option) => {
+      if (option.displayValue) {
+        counts.set(
+          option.displayValue,
+          (counts.get(option.displayValue) ?? 0) + 1,
+        );
+      }
+    });
+    return new Set(
+      [...counts.entries()]
+        .filter(([, count]) => count > 1)
+        .map(([displayValue]) => displayValue),
+    );
+  }, [options]);
+  const shouldShowOptionValue = (option: FilterOption | undefined) =>
+    Boolean(
+      showOptionValue &&
+      option?.displayValue &&
+      duplicateDisplayValues.has(option.displayValue),
+    );
   const hasValue = value !== undefined && value !== "";
   const isCustomValue = hasValue && selectedOption === undefined;
   const label = hasValue ? (selectedOption?.displayValue ?? value) : undefined;
+  const selectedTitle =
+    showOptionValue && selectedOption?.displayValue
+      ? `${selectedOption.displayValue} (${selectedOption.value})`
+      : (label ?? title);
 
   // Hoist the selected option to the top so it reads as current.
   const displayOptions = useMemo<FilterOption[]>(() => {
@@ -109,15 +138,41 @@ export function SingleSelect({
           )}
         >
           <span
-            className={cn("truncate", !hasValue && "text-muted-foreground")}
-            title={label ?? title}
+            className={cn(
+              "flex min-w-0 items-center gap-1",
+              !hasValue && "text-muted-foreground",
+            )}
+            title={selectedTitle}
           >
-            {label ?? title ?? "Select"}
+            <span
+              className={cn(
+                shouldShowOptionValue(selectedOption)
+                  ? "max-w-[calc(100%-3rem)] shrink-0 truncate"
+                  : "truncate",
+              )}
+              title={selectedTitle}
+            >
+              {label ?? title ?? "Select"}
+            </span>
+            {shouldShowOptionValue(selectedOption) ? (
+              <span
+                className="text-muted-foreground min-w-0 truncate font-normal"
+                title={selectedOption.value}
+              >
+                ({selectedOption.value})
+              </span>
+            ) : null}
           </span>
           <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0" align="start">
+      <PopoverContent
+        className={cn(
+          "max-w-[calc(100vw-2rem)] p-0",
+          showOptionValue ? "w-[400px]" : "w-[200px]",
+        )}
+        align="start"
+      >
         <InputCommand shouldFilter={false}>
           <InputCommandInput
             placeholder={title}
@@ -137,6 +192,11 @@ export function SingleSelect({
               {filteredOptions.map((option) => {
                 const isSelected = option.value === value;
                 const displayValue = option.displayValue ?? option.value;
+                const showValue = shouldShowOptionValue(option);
+                const optionTitle =
+                  showOptionValue && option.displayValue
+                    ? `${displayValue} (${option.value})`
+                    : displayValue;
 
                 const commandItem = (
                   <InputCommandItem
@@ -160,10 +220,27 @@ export function SingleSelect({
                       )}
                     />
                     <div
-                      className="overflow-x-hidden text-ellipsis whitespace-nowrap"
-                      title={displayValue}
+                      className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
+                      title={optionTitle}
                     >
-                      {displayValue}
+                      <span
+                        className={cn(
+                          showValue
+                            ? "max-w-[calc(100%-3rem)] shrink-0 truncate"
+                            : "truncate",
+                        )}
+                        title={optionTitle}
+                      >
+                        {displayValue}
+                      </span>
+                      {showValue ? (
+                        <span
+                          className="text-muted-foreground min-w-0 truncate font-normal"
+                          title={option.value}
+                        >
+                          ({option.value})
+                        </span>
+                      ) : null}
                     </div>
                     {option.count !== undefined ? (
                       <span className="ml-auto flex h-4 w-4 items-center justify-center pl-1 font-mono text-xs">

--- a/web/src/features/filters/components/single-select.tsx
+++ b/web/src/features/filters/components/single-select.tsx
@@ -97,9 +97,10 @@ export function SingleSelect({
       displayOptions.filter((option) => {
         if (option.value.length === 0) return false;
         if (!query) return true;
-        return (option.displayValue ?? option.value)
-          .toLowerCase()
-          .includes(query);
+        return (
+          option.value.toLowerCase().includes(query) ||
+          (option.displayValue ?? "").toLowerCase().includes(query)
+        );
       }),
     [displayOptions, query],
   );
@@ -154,7 +155,7 @@ export function SingleSelect({
             >
               {label ?? title ?? "Select"}
             </span>
-            {shouldShowOptionValue(selectedOption) ? (
+            {shouldShowOptionValue(selectedOption) && selectedOption ? (
               <span
                 className="text-muted-foreground min-w-0 truncate font-normal"
                 title={selectedOption.value}

--- a/web/src/features/filters/config/monitors-config.ts
+++ b/web/src/features/filters/config/monitors-config.ts
@@ -38,6 +38,8 @@ export const getMonitorFilterConfig = (
             column: "evaluatorId",
             label: "Evaluator",
             disableTextFilter: true,
+            getOptionTitle: (value, displayLabel) =>
+              `${displayLabel} (${value})`,
           },
           baseFacets[1],
         ],

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -184,6 +184,8 @@ export interface CategoricalUIFilter extends BaseUIFilter {
   renderIcon?: (value: string) => React.ReactNode;
   /** Optional content rendered after a filter option label */
   renderOptionSuffix?: (value: string) => React.ReactNode;
+  /** Optional browser hover title for a filter option. */
+  getOptionTitle?: (value: string, displayLabel: string) => string;
   /**
    * Current operator of the facet's checkbox filter (arrayOptions AND
    * stringOptions columns; undefined when no filter is applied):
@@ -1905,6 +1907,8 @@ export function useSidebarFilterPresentation(
             facet.type === "categorical" ? facet.renderIcon : undefined,
           renderOptionSuffix:
             facet.type === "categorical" ? facet.renderOptionSuffix : undefined,
+          getOptionTitle:
+            facet.type === "categorical" ? facet.getOptionTitle : undefined,
           onChange: (values: string[]) => updateFilter(facet.column, values),
           onOnlyChange: (value: string) => {
             if (selectedValues.length === 1 && selectedValues.includes(value)) {

--- a/web/src/features/filters/lib/filter-config.ts
+++ b/web/src/features/filters/lib/filter-config.ts
@@ -19,6 +19,8 @@ interface CategoricalFacet extends BaseFacet {
   renderIcon?: (value: string) => React.ReactNode;
   /** Optional content rendered after a filter option label */
   renderOptionSuffix?: (value: string) => React.ReactNode;
+  /** Optional browser hover title for a filter option. */
+  getOptionTitle?: (value: string, displayLabel: string) => string;
   /** When true, the sidebar hides the contains/does-not-contain text filter mode for this facet. */
   disableTextFilter?: boolean;
 }

--- a/web/src/features/monitors/components/MonitorsTable.clienttest.ts
+++ b/web/src/features/monitors/components/MonitorsTable.clienttest.ts
@@ -57,6 +57,18 @@ describe("getMonitorFilterConfig", () => {
       ),
     ).toBe(true);
   });
+
+  it("includes the evaluator ID in the option hover title", () => {
+    const evaluatorFacet = getMonitorFilterConfig(true).facets.find(
+      (facet) => facet.column === "evaluatorId" && facet.type === "categorical",
+    );
+
+    expect(
+      evaluatorFacet?.type === "categorical"
+        ? evaluatorFacet.getOptionTitle?.("evaluator-1", "Answer quality")
+        : undefined,
+    ).toBe("Answer quality (evaluator-1)");
+  });
 });
 
 describe("filterStateToListMonitorFilter", () => {


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16960 app preview](https://pr-16960.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- Show evaluator IDs next to names only when multiple evaluators share the same name
- Keep evaluator IDs available in hover titles for every evaluator
- Align dropdown rows and make the evaluator picker wider

## Tests

- `pnpm --filter web run test-client src/features/filters/components/single-select.clienttest.tsx`
- `pnpm --filter web run test-client src/components/table/data-table-controls.clienttest.tsx`
- `pnpm --filter web run test-client src/features/monitors/components/MonitorsTable.clienttest.ts`
- `pnpm run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds evaluator-ID hover titles and duplicate-name disambiguation to filter controls, while widening and aligning the custom evaluator picker.
- Computes duplicate evaluator display names and shows IDs beside those options in SingleSelect.
- Propagates custom option titles through categorical table facets.
- Adds evaluator hover titles to monitor filters and updates focused component tests.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until duplicate evaluator names are visibly disambiguated in the monitor sidebar, where identical rows can cause users to select the wrong filter.

The custom evaluator picker correctly exposes IDs for duplicate names, but the monitor facet carries IDs only in hover titles even though distinct evaluators can share the same visible label.

**Files Needing Attention:** web/src/features/filters/config/monitors-config.ts
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/features/filters/config/monitors-config.ts:41-42
**Monitor options remain ambiguous**

If a project has multiple evaluators with the same name, this facet places their IDs only in hover titles while rendering identical checkbox labels, causing users to select the wrong evaluator and apply an unintended monitor filter.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: disambiguate evaluator names in fi..."](https://github.com/langfuse/langfuse/commit/c1584f37e18c306dcf68363c182bb5a08eb24307) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59491322)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)

<!-- /greptile_comment -->