### PR TITLE
feat(dashboards): rename templates, add Home tool widgets, compact list

### DIFF
--- a/packages/shared/src/domain/dashboard-templates.test.ts
+++ b/packages/shared/src/domain/dashboard-templates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  DASHBOARD_TEMPLATE_IDS,
+  resolveDashboardTemplate,
+} from "./dashboard-templates";
+import { LANGFUSE_HOME_DASHBOARD_ID } from "./home-dashboard";
+
+describe("resolveDashboardTemplate", () => {
+  it("maps known Langfuse template ids and ignores project dashboards", () => {
+    expect(resolveDashboardTemplate(LANGFUSE_HOME_DASHBOARD_ID)).toBe("home");
+    expect(resolveDashboardTemplate(DASHBOARD_TEMPLATE_IDS.cost_tracking)).toBe(
+      "cost_tracking",
+    );
+    expect(
+      resolveDashboardTemplate(DASHBOARD_TEMPLATE_IDS.latency_tracking),
+    ).toBe("latency_tracking");
+    expect(
+      resolveDashboardTemplate(DASHBOARD_TEMPLATE_IDS.usage_management),
+    ).toBe("usage_management");
+    expect(resolveDashboardTemplate(DASHBOARD_TEMPLATE_IDS.tool_usage)).toBe(
+      "tool_usage",
+    );
+    expect(resolveDashboardTemplate("cmprojowneddashboardid0001")).toBe(
+      undefined,
+    );
+  });
+});

--- a/packages/shared/src/domain/dashboard-templates.ts
+++ b/packages/shared/src/domain/dashboard-templates.ts
@@ -1,0 +1,24 @@
+/**
+ * Deterministic ids for Langfuse-owned dashboard templates.
+ * Safe to send to product analytics: these are our templates, not user content.
+ */
+export const DASHBOARD_TEMPLATE_IDS = {
+  home: "langfuse-home-dashboard",
+  cost_tracking: "cmawoi7yd00aqad07f3why08w",
+  latency_tracking: "cmawk4ywj00jmad072jn7s0ru",
+  usage_management: "cmawln8k700xqad07000k1q8b",
+  tool_usage: "cmtdm68000006ad07dzdb73zw",
+} as const;
+
+export type DashboardTemplate = keyof typeof DASHBOARD_TEMPLATE_IDS;
+
+const DASHBOARD_ID_TO_TEMPLATE = Object.fromEntries(
+  Object.entries(DASHBOARD_TEMPLATE_IDS).map(([template, id]) => [
+    id,
+    template,
+  ]),
+) as Record<string, DashboardTemplate>;
+
+export const resolveDashboardTemplate = (
+  dashboardId: string,
+): DashboardTemplate | undefined => DASHBOARD_ID_TO_TEMPLATE[dashboardId];

--- a/packages/shared/src/domain/home-dashboard.test.ts
+++ b/packages/shared/src/domain/home-dashboard.test.ts
@@ -23,6 +23,9 @@ describe("LANGFUSE_HOME_DASHBOARD", () => {
 
     expect(parsed.id).toBe(LANGFUSE_HOME_DASHBOARD_ID);
     expect(parsed.name).toBe("Home");
+    expect(parsed.description).toBe(
+      "Traces, costs, scores, usage, and latency.",
+    );
     expect(parsed.definition.widgets.length).toBeGreaterThan(0);
   });
 

--- a/packages/shared/src/domain/home-dashboard.test.ts
+++ b/packages/shared/src/domain/home-dashboard.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   HOME_DASHBOARD_PRESET_IDS,
+  HOME_DASHBOARD_TOOL_WIDGET_IDS,
   LANGFUSE_HOME_DASHBOARD,
   LANGFUSE_HOME_DASHBOARD_ID,
 } from "./home-dashboard";
 import { DashboardDomainSchema } from "../server/services/DashboardService/types";
+
+const HOME_TOOL_WIDGET_IDS = Object.values(HOME_DASHBOARD_TOOL_WIDGET_IDS);
 
 describe("LANGFUSE_HOME_DASHBOARD", () => {
   it("parses through DashboardDomainSchema the way the worker upsert consumes it", () => {
@@ -19,10 +22,8 @@ describe("LANGFUSE_HOME_DASHBOARD", () => {
     });
 
     expect(parsed.id).toBe(LANGFUSE_HOME_DASHBOARD_ID);
+    expect(parsed.name).toBe("Home");
     expect(parsed.definition.widgets.length).toBeGreaterThan(0);
-    expect(parsed.definition.widgets.every((w) => w.type === "preset")).toBe(
-      true,
-    );
   });
 
   it("places every registered preset exactly once", () => {
@@ -39,6 +40,40 @@ describe("LANGFUSE_HOME_DASHBOARD", () => {
       (w) => w.id,
     );
     expect(new Set(placementIds).size).toBe(placementIds.length);
+  });
+
+  it("places the three tool widgets after the overview row", () => {
+    const toolWidgets = LANGFUSE_HOME_DASHBOARD.definition.widgets.filter(
+      (w) => w.type === "widget",
+    );
+
+    expect(toolWidgets.map((w) => w.widgetId).sort()).toEqual(
+      [...HOME_TOOL_WIDGET_IDS].sort(),
+    );
+    expect(toolWidgets.every((w) => w.y === 5 && w.y_size === 5)).toBe(true);
+    expect(
+      toolWidgets.map((w) => ({
+        widgetId: w.widgetId,
+        x: w.x,
+        x_size: w.x_size,
+      })),
+    ).toEqual([
+      {
+        widgetId: HOME_DASHBOARD_TOOL_WIDGET_IDS.totalToolCalls,
+        x: 0,
+        x_size: 3,
+      },
+      {
+        widgetId: HOME_DASHBOARD_TOOL_WIDGET_IDS.top20CalledTools,
+        x: 3,
+        x_size: 5,
+      },
+      {
+        widgetId: HOME_DASHBOARD_TOOL_WIDGET_IDS.p95ToolLatency,
+        x: 8,
+        x_size: 4,
+      },
+    ]);
   });
 
   it("fits the 12-column grid without overlapping tiles", () => {

--- a/packages/shared/src/domain/home-dashboard.ts
+++ b/packages/shared/src/domain/home-dashboard.ts
@@ -9,9 +9,9 @@ import type { DashboardDefinition } from "../server/services/DashboardService/ty
  * page fetches it by this well-known id and falls back to this constant when
  * the row does not exist yet (e.g. the worker has not run).
  *
- * All placements are "preset" placements: they render the existing Home card
- * components (registered by presetId in the web preset registry) with their
- * existing data fetches — no DashboardWidget rows, no query configuration.
+ * Preset placements render Home card components (registered by presetId in the
+ * web preset registry). Widget placements reuse Langfuse-owned DashboardWidget
+ * rows from the template catalog.
  *
  * When changing the definition, bump `updatedAt` so the worker upsert
  * overwrites the existing row.
@@ -35,6 +35,12 @@ export const HOME_DASHBOARD_PRESET_IDS = [
 
 export type HomeDashboardPresetId = (typeof HOME_DASHBOARD_PRESET_IDS)[number];
 
+export const HOME_DASHBOARD_TOOL_WIDGET_IDS = {
+  totalToolCalls: "cmtdm68000001ad076tqc9kr4",
+  top20CalledTools: "cmtdm68000003ad07afj8ag4o",
+  p95ToolLatency: "cmtdm68000008ad07p95bytl0",
+} as const;
+
 const placement = (
   presetId: HomeDashboardPresetId,
   x: number,
@@ -53,6 +59,22 @@ const placement = (
   y_size,
 });
 
+const widgetPlacement = (
+  widgetId: string,
+  x: number,
+  y: number,
+  x_size: number,
+  y_size: number,
+) => ({
+  type: "widget" as const,
+  id: widgetId,
+  widgetId,
+  x,
+  y,
+  x_size,
+  y_size,
+});
+
 export const LANGFUSE_HOME_DASHBOARD_DEFINITION: DashboardDefinition = {
   widgets: [
     // Grid rows are 16:9-proportional to column width (see DashboardGrid), so
@@ -65,30 +87,40 @@ export const LANGFUSE_HOME_DASHBOARD_DEFINITION: DashboardDefinition = {
     placement("home-traces", 0, 0, 4, 5),
     placement("home-model-costs", 4, 0, 4, 5),
     placement("home-scores-table", 8, 0, 4, 5),
-    // Row 2: traffic + usage time series (tabbed cards with headline metrics
+    // Row 2: tool-call widgets (shared with Tool Usage)
+    widgetPlacement(HOME_DASHBOARD_TOOL_WIDGET_IDS.totalToolCalls, 0, 5, 3, 5),
+    widgetPlacement(
+      HOME_DASHBOARD_TOOL_WIDGET_IDS.top20CalledTools,
+      3,
+      5,
+      5,
+      5,
+    ),
+    widgetPlacement(HOME_DASHBOARD_TOOL_WIDGET_IDS.p95ToolLatency, 8, 5, 4, 5),
+    // Row 3: traffic + usage time series (tabbed cards with headline metrics
     // have the largest intrinsic height)
-    placement("home-traces-obs-time-series", 0, 5, 6, 6),
-    placement("home-model-usage", 6, 5, 6, 6),
-    // Row 3: users + scores over time
-    placement("home-users", 0, 11, 6, 6),
-    placement("home-chart-scores", 6, 11, 6, 6),
-    // Row 4: latency percentile tables
-    placement("home-latency-table-traces", 0, 17, 4, 5),
-    placement("home-latency-table-generations", 4, 17, 4, 5),
-    placement("home-latency-table-observations", 8, 17, 4, 5),
-    // Row 5+: full-width analytics
-    placement("home-generation-latency", 0, 22, 12, 6),
-    placement("home-score-analytics", 0, 28, 12, 6),
+    placement("home-traces-obs-time-series", 0, 10, 6, 6),
+    placement("home-model-usage", 6, 10, 6, 6),
+    // Row 4: users + scores over time
+    placement("home-users", 0, 16, 6, 6),
+    placement("home-chart-scores", 6, 16, 6, 6),
+    // Row 5: latency percentile tables
+    placement("home-latency-table-traces", 0, 22, 4, 5),
+    placement("home-latency-table-generations", 4, 22, 4, 5),
+    placement("home-latency-table-observations", 8, 22, 4, 5),
+    // Row 6+: full-width analytics
+    placement("home-generation-latency", 0, 27, 12, 6),
+    placement("home-score-analytics", 0, 33, 12, 6),
   ],
 };
 
 export const LANGFUSE_HOME_DASHBOARD = {
   id: LANGFUSE_HOME_DASHBOARD_ID,
-  name: "Langfuse Home",
+  name: "Home",
   description:
     "Overview of traces, costs, scores, usage, and latencies in this project. Shown on the project home page.",
   definition: LANGFUSE_HOME_DASHBOARD_DEFINITION,
   filters: [],
   createdAt: "2026-07-06T00:00:00.000Z",
-  updatedAt: "2026-07-09T00:00:00.000Z",
+  updatedAt: "2026-09-02T00:00:00.000Z",
 };

--- a/packages/shared/src/domain/home-dashboard.ts
+++ b/packages/shared/src/domain/home-dashboard.ts
@@ -117,10 +117,9 @@ export const LANGFUSE_HOME_DASHBOARD_DEFINITION: DashboardDefinition = {
 export const LANGFUSE_HOME_DASHBOARD = {
   id: LANGFUSE_HOME_DASHBOARD_ID,
   name: "Home",
-  description:
-    "Overview of traces, costs, scores, usage, and latencies in this project. Shown on the project home page.",
+  description: "Traces, costs, scores, usage, and latency.",
   definition: LANGFUSE_HOME_DASHBOARD_DEFINITION,
   filters: [],
   createdAt: "2026-07-06T00:00:00.000Z",
-  updatedAt: "2026-09-02T00:00:00.000Z",
+  updatedAt: "2026-09-02T00:00:04.000Z",
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from "./domain/dataset-run-items";
 export * from "./domain/dataset-items";
 export * from "./domain/score-configs";
 export * from "./domain/home-dashboard";
+export * from "./domain/dashboard-templates";
 
 // llm api
 export * from "./server/llm/types";

--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -121,9 +121,14 @@ export class DashboardService {
             select: { name: true, email: true },
           },
         },
-        orderBy: orderBy
-          ? [{ [orderBy.column]: orderBy.order.toLowerCase() }]
-          : [{ updatedAt: "desc" }],
+        // Project-owned dashboards stay above Langfuse templates. The
+        // requested column (default updatedAt) still sorts inside each group.
+        orderBy: [
+          { projectId: { sort: "asc", nulls: "last" } },
+          orderBy
+            ? { [orderBy.column]: orderBy.order.toLowerCase() }
+            : { updatedAt: "desc" },
+        ],
         skip,
         take,
       }),

--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -116,6 +116,11 @@ export class DashboardService {
     const [dashboards, totalCount] = await Promise.all([
       prisma.dashboard.findMany({
         where,
+        include: {
+          createdByUser: {
+            select: { name: true, email: true },
+          },
+        },
         orderBy: orderBy
           ? [{ [orderBy.column]: orderBy.order.toLowerCase() }]
           : [{ updatedAt: "desc" }],
@@ -131,6 +136,10 @@ export class DashboardService {
       DashboardDomainSchema.parse({
         ...dashboard,
         owner: dashboard.projectId ? "PROJECT" : "LANGFUSE",
+        createdByName:
+          dashboard.createdByUser?.name ??
+          dashboard.createdByUser?.email ??
+          (dashboard.projectId ? null : "Langfuse"),
       }),
     );
 

--- a/packages/shared/src/server/services/DashboardService/types.ts
+++ b/packages/shared/src/server/services/DashboardService/types.ts
@@ -135,6 +135,7 @@ export const DashboardDomainSchema = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   createdBy: z.string().nullable(),
+  createdByName: z.string().nullable().optional(),
   updatedBy: z.string().nullable(),
   projectId: z.string().nullable(),
   name: z.string(),

--- a/web/src/__tests__/server/dashboard-service-update.servertest.ts
+++ b/web/src/__tests__/server/dashboard-service-update.servertest.ts
@@ -4,6 +4,7 @@ import {
   DashboardService,
 } from "@langfuse/shared/src/server";
 import { LangfuseNotFoundError } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
 
 describe("DashboardService update methods", () => {
   it("throw LangfuseNotFoundError instead of P2025 for a missing dashboard", async () => {
@@ -23,5 +24,43 @@ describe("DashboardService update methods", () => {
     await expect(
       DashboardService.updateDashboardFilters(missingId, projectId, []),
     ).rejects.toThrow(LangfuseNotFoundError);
+  });
+});
+
+describe("DashboardService listDashboards", () => {
+  it("returns the creator name, and Langfuse for curated templates", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const user = await prisma.user.create({
+      data: {
+        id: uuidv4(),
+        email: `dashboard-list-${uuidv4().substring(0, 8)}@test.com`,
+        name: "Ada Lovelace",
+      },
+    });
+
+    const projectDashboard = await DashboardService.createDashboard(
+      projectId,
+      "Project board",
+      "",
+      user.id,
+    );
+    const langfuseDashboard = await prisma.dashboard.create({
+      data: {
+        name: "Curated template",
+        description: "",
+        projectId: null,
+        definition: { widgets: [] },
+      },
+    });
+
+    const { dashboards } = await DashboardService.listDashboards({
+      projectId,
+    });
+    const byId = Object.fromEntries(
+      dashboards.map((dashboard) => [dashboard.id, dashboard]),
+    );
+
+    expect(byId[projectDashboard.id]?.createdByName).toBe("Ada Lovelace");
+    expect(byId[langfuseDashboard.id]?.createdByName).toBe("Langfuse");
   });
 });

--- a/web/src/__tests__/server/dashboard-service-update.servertest.ts
+++ b/web/src/__tests__/server/dashboard-service-update.servertest.ts
@@ -63,4 +63,73 @@ describe("DashboardService listDashboards", () => {
     expect(byId[projectDashboard.id]?.createdByName).toBe("Ada Lovelace");
     expect(byId[langfuseDashboard.id]?.createdByName).toBe("Langfuse");
   });
+
+  it("lists project dashboards first, then templates by updatedAt", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const olderProject = await DashboardService.createDashboard(
+      projectId,
+      "Older project board",
+      "",
+    );
+    const newerProject = await DashboardService.createDashboard(
+      projectId,
+      "Newer project board",
+      "",
+    );
+    const olderTemplate = await prisma.dashboard.create({
+      data: {
+        name: "Older template",
+        description: "",
+        projectId: null,
+        definition: { widgets: [] },
+      },
+    });
+    const newerTemplate = await prisma.dashboard.create({
+      data: {
+        name: "Newer template",
+        description: "",
+        projectId: null,
+        definition: { widgets: [] },
+      },
+    });
+
+    await prisma.dashboard.update({
+      where: { id: olderProject.id },
+      data: { updatedAt: new Date("2020-01-01T00:00:00.000Z") },
+    });
+    await prisma.dashboard.update({
+      where: { id: newerProject.id },
+      data: { updatedAt: new Date("2021-01-01T00:00:00.000Z") },
+    });
+    await prisma.dashboard.update({
+      where: { id: olderTemplate.id },
+      data: { updatedAt: new Date("2026-08-01T00:00:00.000Z") },
+    });
+    await prisma.dashboard.update({
+      where: { id: newerTemplate.id },
+      data: { updatedAt: new Date("2026-09-02T00:00:00.000Z") },
+    });
+
+    const { dashboards } = await DashboardService.listDashboards({
+      projectId,
+      orderBy: { column: "updatedAt", order: "DESC" },
+    });
+    const listedIds = dashboards.map((dashboard) => dashboard.id);
+    const projectIds = new Set([olderProject.id, newerProject.id]);
+    const lastProjectIndex = listedIds.findLastIndex((id) =>
+      projectIds.has(id),
+    );
+    const firstTemplateIndex = listedIds.findIndex(
+      (id) => id === olderTemplate.id || id === newerTemplate.id,
+    );
+
+    expect(listedIds.indexOf(newerProject.id)).toBeLessThan(
+      listedIds.indexOf(olderProject.id),
+    );
+    expect(lastProjectIndex).toBeLessThan(firstTemplateIndex);
+    expect(listedIds.indexOf(newerTemplate.id)).toBeLessThan(
+      listedIds.indexOf(olderTemplate.id),
+    );
+  });
 });

--- a/web/src/features/dashboard/components/CloneFirstDialog.tsx
+++ b/web/src/features/dashboard/components/CloneFirstDialog.tsx
@@ -15,6 +15,7 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { type DashboardPlacement } from "@/src/features/widgets/components/DashboardGrid";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
 
 /**
  * Clone-first flow for Langfuse-managed (read-only) dashboards: any edit
@@ -79,6 +80,7 @@ export function CloneFirstDialog({
         dashboardId,
         // The clone-first flow only exists for locked Langfuse-owned dashboards.
         owner: "LANGFUSE",
+        ...dashboardTemplateProps(dashboardId),
       });
       showSuccessToast({
         title: "Editable copy created",

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -6,14 +6,13 @@ import { api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
 import { DataTable } from "@/src/components/table/data-table";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
-import { createColumnHelper } from "@tanstack/react-table";
 import { createDropdownTableColumn } from "@/src/components/design-system/table/columns/createDropdownTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { Button } from "@/src/components/ui/button";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { Copy, Edit, User as UserIcon } from "lucide-react";
+import { Copy, Edit } from "lucide-react";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
@@ -225,7 +224,6 @@ export function DashboardTable() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dashboards.isSuccess, dashboards.data]);
 
-  const columnHelper = createColumnHelper<DashboardTableRow>();
   const dashboardColumns = [
     createLinkTableColumn<DashboardTableRow>({
       accessorKey: "name",
@@ -250,25 +248,6 @@ export function DashboardTable() {
       accessorKey: "description",
       header: "Description",
       size: 300,
-    }),
-    columnHelper.display({
-      id: "ownerTag",
-      header: "Owner",
-      size: 80,
-      cell: (row) => {
-        return row.row.original.owner === "LANGFUSE" ? (
-          <span className="flex gap-1 px-2 py-0.5 text-xs">
-            <span role="img" aria-label="Langfuse">
-              🪢
-            </span>
-            Langfuse
-          </span>
-        ) : (
-          <span className="flex gap-1 px-2 py-0.5 text-xs">
-            <UserIcon className="h-3 w-3" /> Project
-          </span>
-        );
-      },
     }),
     createUserTableColumn<DashboardTableRow, { name: string }>({
       accessorFn: (row) =>

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -7,7 +7,6 @@ import { safeExtract } from "@/src/utils/map-utils";
 import { DataTable } from "@/src/components/table/data-table";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { createColumnHelper } from "@tanstack/react-table";
-import { createDateTableColumn } from "@/src/components/design-system/table/columns/createDateTableColumn";
 import { createDropdownTableColumn } from "@/src/components/design-system/table/columns/createDropdownTableColumn";
 import { createLinkTableColumn } from "@/src/components/design-system/table/columns/createLinkTableColumn";
 import { createTextTableColumn } from "@/src/components/design-system/table/columns/createTextTableColumn";
@@ -23,6 +22,11 @@ import { DeleteDashboardButton } from "@/src/components/deleteButton";
 import { EditDashboardDialog } from "@/src/features/dashboard/components/EditDashboardDialog";
 import { CloneFirstDialog } from "@/src/features/dashboard/components/CloneFirstDialog";
 import { useRouter } from "next/router";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
+import { formatDashboardModified } from "@/src/features/dashboard/utils/formatDashboardModified";
+import { createUserTableColumn } from "@/src/components/design-system/table/columns/createUserTableColumn";
+import { createTableColumn } from "@/src/components/design-system/table/columns/utils/createTableColumn";
+import { Skeleton } from "@/src/components/ui/skeleton";
 
 type DashboardTableRow = {
   id: string;
@@ -30,6 +34,7 @@ type DashboardTableRow = {
   description: string;
   createdAt: Date;
   updatedAt: Date;
+  createdByName?: string | null;
   owner: "PROJECT" | "LANGFUSE";
 };
 
@@ -56,6 +61,7 @@ function CloneDashboardButton({
         source: "list_clone_button",
         dashboardId,
         owner,
+        ...dashboardTemplateProps(dashboardId),
       });
       showSuccessToast({
         title: "Dashboard cloned",
@@ -264,17 +270,35 @@ export function DashboardTable() {
         );
       },
     }),
-    createDateTableColumn<DashboardTableRow>({
-      accessorKey: "createdAt",
-      header: "Created At",
-      enableSorting: true,
+    createUserTableColumn<DashboardTableRow, { name: string }>({
+      accessorFn: (row) =>
+        row.createdByName ? { name: row.createdByName } : undefined,
+      id: "createdByName",
+      header: "Created by",
       size: 150,
+      variant: "text",
+      emptyValue: "API",
     }),
-    createDateTableColumn<DashboardTableRow>({
+    createTableColumn<DashboardTableRow, Date>({
       accessorKey: "updatedAt",
-      header: "Updated At",
+      header: "Modified",
       enableSorting: true,
-      size: 150,
+      size: 160,
+      loadingCell: <Skeleton className="h-8 w-2/3" />,
+      renderCell: (_value, { row }) => {
+        const { updatedRelative, createdAbsolute } = formatDashboardModified(
+          row.original.updatedAt,
+          row.original.createdAt,
+        );
+        return (
+          <div className="flex flex-col">
+            <span>{updatedRelative}</span>
+            <span className="text-muted-foreground text-xs">
+              {createdAbsolute}
+            </span>
+          </div>
+        );
+      },
     }),
     createDropdownTableColumn<DashboardTableRow, string>({
       id: "actions",

--- a/web/src/features/dashboard/utils/dashboardTemplateProps.clienttest.ts
+++ b/web/src/features/dashboard/utils/dashboardTemplateProps.clienttest.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { DASHBOARD_TEMPLATE_IDS } from "@langfuse/shared";
+import { dashboardTemplateProps } from "./dashboardTemplateProps";
+
+describe("dashboardTemplateProps", () => {
+  it("emits dashboardTemplate only for known Langfuse template ids", () => {
+    expect(
+      dashboardTemplateProps(DASHBOARD_TEMPLATE_IDS.cost_tracking),
+    ).toEqual({ dashboardTemplate: "cost_tracking" });
+    expect(dashboardTemplateProps("cmprojowneddashboardid0001")).toEqual({});
+    expect(dashboardTemplateProps("")).toEqual({});
+  });
+});

--- a/web/src/features/dashboard/utils/dashboardTemplateProps.ts
+++ b/web/src/features/dashboard/utils/dashboardTemplateProps.ts
@@ -1,0 +1,7 @@
+import { resolveDashboardTemplate } from "@langfuse/shared";
+
+/** Metadata-only: emits a known Langfuse template enum, never a user dashboard name. */
+export const dashboardTemplateProps = (dashboardId: string) => {
+  const dashboardTemplate = resolveDashboardTemplate(dashboardId);
+  return dashboardTemplate ? { dashboardTemplate } : {};
+};

--- a/web/src/features/dashboard/utils/formatDashboardModified.clienttest.ts
+++ b/web/src/features/dashboard/utils/formatDashboardModified.clienttest.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatDashboardModified } from "./formatDashboardModified";
+
+describe("formatDashboardModified", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-02T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows relative updated time and an absolute created date", () => {
+    expect(
+      formatDashboardModified(
+        new Date("2026-08-27T12:00:00.000Z"),
+        new Date("2024-10-01T00:00:00.000Z"),
+      ),
+    ).toEqual({
+      updatedRelative: "6 days ago",
+      createdAbsolute: "Created Oct 1, 2024",
+    });
+  });
+});

--- a/web/src/features/dashboard/utils/formatDashboardModified.ts
+++ b/web/src/features/dashboard/utils/formatDashboardModified.ts
@@ -1,0 +1,9 @@
+import { format, formatDistanceToNowStrict } from "date-fns";
+
+export const formatDashboardModified = (
+  updatedAt: Date,
+  createdAt: Date,
+): { updatedRelative: string; createdAbsolute: string } => ({
+  updatedRelative: formatDistanceToNowStrict(updatedAt, { addSuffix: true }),
+  createdAbsolute: `Created ${format(createdAt, "MMM d, yyyy")}`,
+});

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -215,6 +215,7 @@ const events = {
   ],
   dashboard: [
     "view",
+    "created",
     "widget_saved",
     "clone_dashboard",
     "home_dashboard_viewed",

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -66,6 +66,7 @@ import { type ResolvedReadPath } from "@/src/features/events/hooks/useReadPath";
 import { useScheduledDashboardExecuteQuery } from "@/src/hooks/useDashboardQueryScheduler";
 import { CopyWidgetDialog } from "@/src/features/widgets/components/CopyWidgetDialog";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
 import { Badge } from "@/src/components/ui/badge";
 
 export interface WidgetPlacement {
@@ -515,6 +516,7 @@ export function DashboardWidget({
         source_widget_id: placement.widgetId,
         new_widget_id: data.widgetId,
         dashboard_id: dashboardId,
+        ...dashboardTemplateProps(dashboardId),
       });
       utils.dashboard.getDashboard.invalidate().then(() => {
         router.push(

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -32,6 +32,7 @@ import {
 import { useReadPath } from "@/src/features/events/hooks/useReadPath";
 import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
 import { InAppAgentWidgetComposer } from "@/src/features/in-app-agent/components/InAppAgentWidgetComposer";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
 
 export type WidgetItem = {
   id: string;
@@ -116,6 +117,7 @@ export function SelectWidgetDialog({
     if (open && !openCapturedRef.current) {
       capture("dashboard:add_widget_dialog_open", {
         dashboard_id: dashboardId,
+        ...dashboardTemplateProps(dashboardId),
       });
     }
     openCapturedRef.current = open;
@@ -156,10 +158,12 @@ export function SelectWidgetDialog({
   const selectWidget = (widget: WidgetItem) => {
     capture("dashboard:widget_added", {
       kind: "project_widget",
+      widgetOwner: "PROJECT",
       widget_id: widget.id,
       chart_type: widget.chartType,
       view: widget.view,
       dashboard_id: dashboardId,
+      ...dashboardTemplateProps(dashboardId),
     });
     onSelectWidget(widget);
     onOpenChange(false);
@@ -192,6 +196,7 @@ export function SelectWidgetDialog({
                   capture("dashboard:new_widget_form_open", {
                     source: "add_widget_dialog",
                     dashboard_id: dashboardId,
+                    ...dashboardTemplateProps(dashboardId),
                   });
                   router.push(
                     `/project/${projectId}/widgets/new?dashboardId=${dashboardId}`,
@@ -263,8 +268,10 @@ export function SelectWidgetDialog({
                             onClick={() => {
                               capture("dashboard:widget_added", {
                                 kind: "home_preset",
+                                widgetOwner: "LANGFUSE",
                                 preset_id: presetId,
                                 dashboard_id: dashboardId,
+                                ...dashboardTemplateProps(dashboardId),
                               });
                               onSelectPreset(presetId);
                               onOpenChange(false);

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -16,6 +16,7 @@ import {
   LANGFUSE_HOME_DASHBOARD_ID,
   type HomeDashboardPresetId,
 } from "@langfuse/shared";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
 import { Button } from "@/src/components/ui/button";
 import {
   PlusIcon,
@@ -168,7 +169,11 @@ function DashboardDetailView({ readPath }: { readPath: ResolvedReadPath }) {
   useEffect(() => {
     if (!dashboardOwner || viewedDashboardRef.current === dashboardId) return;
     viewedDashboardRef.current = dashboardId;
-    capture("dashboard:view", { dashboardId, owner: dashboardOwner });
+    capture("dashboard:view", {
+      dashboardId,
+      owner: dashboardOwner,
+      ...dashboardTemplateProps(dashboardId),
+    });
   }, [capture, dashboardId, dashboardOwner]);
 
   // Access for cloning (independent of dashboard owner)
@@ -1101,7 +1106,12 @@ function DashboardDetailView({ readPath }: { readPath: ResolvedReadPath }) {
   const mutateCloneDashboard = api.dashboard.cloneDashboard.useMutation({
     onSuccess: (data) => {
       utils.dashboard.invalidate();
-      capture("dashboard:clone_dashboard", { source: "detail_clone_button" });
+      capture("dashboard:clone_dashboard", {
+        source: "detail_clone_button",
+        dashboardId,
+        owner: dashboardOwner,
+        ...dashboardTemplateProps(dashboardId),
+      });
       // Redirect to new dashboard
       if (data?.id) {
         router.replace(
@@ -1293,6 +1303,7 @@ function DashboardDetailView({ readPath }: { readPath: ResolvedReadPath }) {
                         capture("dashboard:home_dashboard_set_default", {
                           dashboard_id: dashboardId,
                           source: "detail_menu",
+                          ...dashboardTemplateProps(dashboardId),
                         });
                         setHomeDashboard.mutate({
                           projectId,

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -201,6 +201,7 @@ function DashboardDetailView({ readPath }: { readPath: ResolvedReadPath }) {
         dashboard_id: dashboardId,
         attempt,
         surface: "detail",
+        ...dashboardTemplateProps(dashboardId),
       });
       setCloneFirstState({
         open: true,

--- a/web/src/pages/project/[projectId]/dashboards/new.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/new.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/src/components/ui/label";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 export default function NewDashboard() {
   const router = useRouter();
@@ -23,17 +24,10 @@ export default function NewDashboard() {
     projectId,
     scope: "dashboards:CUD",
   });
+  const capture = usePostHogClientCapture();
 
   // Mutation for creating a new dashboard
   const createDashboard = api.dashboard.createDashboard.useMutation({
-    onSuccess: (data) => {
-      showSuccessToast({
-        title: "Dashboard created",
-        description: "Your new dashboard has been created successfully",
-      });
-      // Navigate to the newly created dashboard
-      router.push(`/project/${projectId}/dashboards/${data.id}`);
-    },
     onError: (error) => {
       showErrorToast("Error creating dashboard", error.message);
     },
@@ -41,15 +35,32 @@ export default function NewDashboard() {
 
   // Handle form submission
   const handleCreateDashboard = () => {
-    if (dashboardName.trim()) {
-      createDashboard.mutate({
+    if (!dashboardName.trim()) {
+      showErrorToast("Validation error", "Dashboard name is required");
+      return;
+    }
+
+    const hasDescription = Boolean(dashboardDescription.trim());
+    createDashboard.mutate(
+      {
         projectId,
         name: dashboardName,
         description: dashboardDescription,
-      });
-    } else {
-      showErrorToast("Validation error", "Dashboard name is required");
-    }
+      },
+      {
+        onSuccess: (data) => {
+          capture("dashboard:created", {
+            source: "new_form",
+            hasDescription,
+          });
+          showSuccessToast({
+            title: "Dashboard created",
+            description: "Your new dashboard has been created successfully",
+          });
+          router.push(`/project/${projectId}/dashboards/${data.id}`);
+        },
+      },
+    );
   };
 
   return (

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -10,6 +10,7 @@ import {
   type ColumnDefinition,
   type FilterState,
 } from "@langfuse/shared";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
@@ -183,7 +184,7 @@ function HomeDashboard({ readPath }: { readPath: ResolvedReadPath }) {
     : (homeDashboard.data?.dashboard ?? null);
   const dashboardId =
     displayedDashboard?.id ?? peekId ?? LANGFUSE_HOME_DASHBOARD_ID;
-  const dashboardName = displayedDashboard?.name ?? "Langfuse Home";
+  const dashboardName = displayedDashboard?.name ?? "Home";
   const dashboardOwner = displayedDashboard?.owner ?? "LANGFUSE";
   // Show a loading state until the home resolution (or peek fetch) settles —
   // rendering the curated fallback early would flash the wrong layout and
@@ -221,6 +222,7 @@ function HomeDashboard({ readPath }: { readPath: ResolvedReadPath }) {
       dashboard_owner: displayedDashboard.owner,
       is_peek: Boolean(peekId),
       is_curated_default: !peekId && !homeDashboard.data?.homeDashboardId,
+      ...dashboardTemplateProps(displayedDashboard.id),
     });
   }, [
     displayedDashboard,
@@ -319,6 +321,7 @@ function HomeDashboard({ readPath }: { readPath: ResolvedReadPath }) {
                   capture("dashboard:home_dashboard_peeked", {
                     dashboard_id: id,
                     is_default: id === appliedDefaultId,
+                    ...dashboardTemplateProps(id),
                   });
                   setPeekId(id === appliedDefaultId ? null : id);
                 }}
@@ -333,6 +336,7 @@ function HomeDashboard({ readPath }: { readPath: ResolvedReadPath }) {
                     capture("dashboard:home_dashboard_set_default", {
                       dashboard_id: dashboardId,
                       source: "home_selector",
+                      ...dashboardTemplateProps(dashboardId),
                     });
                     setHomeDashboard.mutate({
                       projectId,

--- a/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
@@ -9,6 +9,7 @@ import { type metricAggregations, type views } from "@langfuse/shared/query";
 import { type z } from "zod";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useReadPath } from "@/src/features/events/hooks/useReadPath";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
 
 export default function EditWidget() {
   const router = useRouter();
@@ -49,6 +50,8 @@ export default function EditWidget() {
         measures: variables.metrics.map((m) => `${m.agg}:${m.measure}`),
         dimensionCount: variables.dimensions.length,
         filterCount: variables.filters.length,
+        hasDashboardContext: Boolean(dashboardId),
+        ...dashboardTemplateProps(dashboardId ?? ""),
       });
       showSuccessToast({
         title: "Widget updated successfully",

--- a/web/src/pages/project/[projectId]/widgets/new.tsx
+++ b/web/src/pages/project/[projectId]/widgets/new.tsx
@@ -13,6 +13,7 @@ import { useReadPath } from "@/src/features/events/hooks/useReadPath";
 import { getDefaultView } from "@/src/features/widgets/utils";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { dashboardTemplateProps } from "@/src/features/dashboard/utils/dashboardTemplateProps";
 
 export default function NewWidget() {
   const router = useRouter();
@@ -33,6 +34,8 @@ export default function NewWidget() {
         measures: variables.metrics.map((m) => `${m.agg}:${m.measure}`),
         dimensionCount: variables.dimensions.length,
         filterCount: variables.filters.length,
+        hasDashboardContext: Boolean(dashboardId),
+        ...dashboardTemplateProps(dashboardId ?? ""),
       });
       showSuccessToast({
         title: "Widget created successfully",

--- a/worker/src/constants/langfuse-dashboards.json
+++ b/worker/src/constants/langfuse-dashboards.json
@@ -624,11 +624,11 @@
     {
       "id": "cmawk4ywj00jmad072jn7s0ru",
       "createdAt": "2025-05-20T13:36:15.283Z",
-      "updatedAt": "2025-05-20T15:56:46.000Z",
+      "updatedAt": "2026-09-02T00:00:00.000Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,
-      "name": "Langfuse Latency Dashboard",
+      "name": "Latency Tracking",
       "description": "Monitor latency metrics across traces and generations for performance optimization.",
       "owner": "LANGFUSE",
       "definition": {
@@ -646,11 +646,11 @@
     {
       "id": "cmawln8k700xqad07000k1q8b",
       "createdAt": "2025-05-20T14:18:27.223Z",
-      "updatedAt": "2025-05-20T15:56:46.000Z",
+      "updatedAt": "2026-09-02T00:00:00.000Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,
-      "name": "Langfuse Usage Management",
+      "name": "Usage Management",
       "description": "Track usage metrics across traces, observations, and scores to manage resource allocation.",
       "owner": "LANGFUSE",
       "definition": {
@@ -671,11 +671,11 @@
     {
       "id": "cmawoi7yd00aqad07f3why08w",
       "createdAt": "2025-05-20T15:38:32.005Z",
-      "updatedAt": "2025-05-20T16:09:56.618Z",
+      "updatedAt": "2026-09-02T00:00:00.000Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,
-      "name": "Langfuse Cost Dashboard",
+      "name": "Cost Tracking",
       "description": "Review your LLM costs.",
       "owner": "LANGFUSE",
       "definition": {
@@ -697,11 +697,11 @@
     {
       "id": "cmtdm68000006ad07dzdb73zw",
       "createdAt": "2026-08-26T00:00:00.000Z",
-      "updatedAt": "2026-08-26T13:00:00.000Z",
+      "updatedAt": "2026-09-02T00:00:00.000Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,
-      "name": "Langfuse Agent Dashboard",
+      "name": "Tool Usage",
       "description": "Monitor agent tool usage: total tool calls, most-called tools, tool errors and latency, and observation type breakdowns.",
       "owner": "LANGFUSE",
       "definition": {

--- a/worker/src/constants/langfuse-dashboards.json
+++ b/worker/src/constants/langfuse-dashboards.json
@@ -624,7 +624,7 @@
     {
       "id": "cmawk4ywj00jmad072jn7s0ru",
       "createdAt": "2025-05-20T13:36:15.283Z",
-      "updatedAt": "2026-09-02T00:00:00.000Z",
+      "updatedAt": "2026-09-02T00:00:00.001Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,

--- a/worker/src/constants/langfuse-dashboards.json
+++ b/worker/src/constants/langfuse-dashboards.json
@@ -629,7 +629,7 @@
       "updatedBy": null,
       "projectId": null,
       "name": "Latency Tracking",
-      "description": "Monitor latency metrics across traces and generations for performance optimization.",
+      "description": "Latency across traces and generations.",
       "owner": "LANGFUSE",
       "definition": {
         "widgets": [
@@ -646,12 +646,12 @@
     {
       "id": "cmawln8k700xqad07000k1q8b",
       "createdAt": "2025-05-20T14:18:27.223Z",
-      "updatedAt": "2026-09-02T00:00:00.000Z",
+      "updatedAt": "2026-09-02T00:00:01.000Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,
       "name": "Usage Management",
-      "description": "Track usage metrics across traces, observations, and scores to manage resource allocation.",
+      "description": "Trace, observation, and score volume.",
       "owner": "LANGFUSE",
       "definition": {
         "widgets": [
@@ -671,12 +671,12 @@
     {
       "id": "cmawoi7yd00aqad07f3why08w",
       "createdAt": "2025-05-20T15:38:32.005Z",
-      "updatedAt": "2026-09-02T00:00:00.000Z",
+      "updatedAt": "2026-09-02T00:00:03.000Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,
       "name": "Cost Tracking",
-      "description": "Review your LLM costs.",
+      "description": "LLM costs.",
       "owner": "LANGFUSE",
       "definition": {
         "widgets": [
@@ -697,12 +697,12 @@
     {
       "id": "cmtdm68000006ad07dzdb73zw",
       "createdAt": "2026-08-26T00:00:00.000Z",
-      "updatedAt": "2026-09-02T00:00:00.000Z",
+      "updatedAt": "2026-09-02T00:00:02.000Z",
       "createdBy": null,
       "updatedBy": null,
       "projectId": null,
       "name": "Tool Usage",
-      "description": "Monitor agent tool usage: total tool calls, most-called tools, tool errors and latency, and observation type breakdowns.",
+      "description": "Tool calls, errors, and latency.",
       "owner": "LANGFUSE",
       "definition": {
         "widgets": [

--- a/worker/src/scripts/langfuseDashboards.test.ts
+++ b/worker/src/scripts/langfuseDashboards.test.ts
@@ -14,4 +14,20 @@ describe("langfuse template dashboards", () => {
     });
     expect(widget?.description).not.toMatch(/observations that called/i);
   });
+
+  it("uses the short template dashboard titles", () => {
+    const titles = Object.fromEntries(
+      langfuseDashboards.dashboards.map((dashboard) => [
+        dashboard.id,
+        dashboard.name,
+      ]),
+    );
+
+    expect(titles).toMatchObject({
+      cmawoi7yd00aqad07f3why08w: "Cost Tracking",
+      cmawk4ywj00jmad072jn7s0ru: "Latency Tracking",
+      cmawln8k700xqad07000k1q8b: "Usage Management",
+      cmtdm68000006ad07dzdb73zw: "Tool Usage",
+    });
+  });
 });

--- a/worker/src/scripts/langfuseDashboards.test.ts
+++ b/worker/src/scripts/langfuseDashboards.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { LANGFUSE_HOME_DASHBOARD } from "@langfuse/shared";
 import langfuseDashboards from "../constants/langfuse-dashboards.json";
 
 describe("langfuse template dashboards", () => {
@@ -29,5 +30,43 @@ describe("langfuse template dashboards", () => {
       cmawln8k700xqad07000k1q8b: "Usage Management",
       cmtdm68000006ad07dzdb73zw: "Tool Usage",
     });
+
+    const descriptions = Object.fromEntries(
+      langfuseDashboards.dashboards.map((dashboard) => [
+        dashboard.id,
+        dashboard.description,
+      ]),
+    );
+    expect(descriptions).toMatchObject({
+      cmawoi7yd00aqad07f3why08w: "LLM costs.",
+      cmawk4ywj00jmad072jn7s0ru: "Latency across traces and generations.",
+      cmawln8k700xqad07000k1q8b: "Trace, observation, and score volume.",
+      cmtdm68000006ad07dzdb73zw: "Tool calls, errors, and latency.",
+    });
+    expect(LANGFUSE_HOME_DASHBOARD.description).toBe(
+      "Traces, costs, scores, usage, and latency.",
+    );
+  });
+
+  it("ranks Home, Cost Tracking, then Tool Usage first among templates", () => {
+    const updatedAtById = Object.fromEntries(
+      langfuseDashboards.dashboards.map((dashboard) => [
+        dashboard.id,
+        Date.parse(dashboard.updatedAt),
+      ]),
+    );
+
+    expect(Date.parse(LANGFUSE_HOME_DASHBOARD.updatedAt)).toBeGreaterThan(
+      updatedAtById.cmawoi7yd00aqad07f3why08w,
+    );
+    expect(updatedAtById.cmawoi7yd00aqad07f3why08w).toBeGreaterThan(
+      updatedAtById.cmtdm68000006ad07dzdb73zw,
+    );
+    expect(updatedAtById.cmtdm68000006ad07dzdb73zw).toBeGreaterThan(
+      updatedAtById.cmawln8k700xqad07000k1q8b,
+    );
+    expect(updatedAtById.cmawln8k700xqad07000k1q8b).toBeGreaterThan(
+      updatedAtById.cmawk4ywj00jmad072jn7s0ru,
+    );
   });
 });


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16961 app preview](https://pr-16961.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

| Area | Change |
|---|---|
| Template titles | Home, Cost Tracking, Latency Tracking, Usage Management, Tool Usage |
| Template copy | Short descriptions on all five |
| Home | Adds Total Tool Calls, Top 20 Called Tools, and P 95 Tool Latency by Tool after the overview row |
| Dashboards list | Modified column (relative updated + Created date). Created by shows the signed-in creator, or Langfuse / API. Owner column removed. |
| List order | Default sort stays Modified. Project dashboards always sit above templates. Among templates: Home, Cost Tracking, Tool Usage, then Usage Management, Latency Tracking. |
| Analytics | See tracking table. Metadata only. No dashboard names, widget names, or descriptions. |

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tracking

| Question | Event | Props | Key dimension |
|---|---|---|---|
| Which template is viewed? | `dashboard:view`, `dashboard:home_dashboard_viewed` | `dashboardTemplate` when the id is a known Langfuse template | template enum or absent (custom) |
| Do people clone a template to edit? | `dashboard:clone_dashboard` | `source`, `owner`, `dashboardTemplate` | template vs project |
| Do people create a blank dashboard? | `dashboard:created` | `source: new_form`, `hasDescription` | custom create |
| Do people create a custom widget? | `dashboard:widget_saved` | `isNew`, chart shape counts, `hasDashboardContext`, `dashboardTemplate` if opened from a template | custom create vs edit |
| Do they add an existing widget or Home card? | `dashboard:widget_added` | `kind`, `widgetOwner`, `dashboardTemplate` | project widget vs Langfuse preset |
| Do they copy a Langfuse widget into the project? | `dashboard:widget_copied_to_project` | `dashboardTemplate` | OOTB consume → customize |
| Do they try to edit a locked template? | `dashboard:locked_edit_attempt` | `attempt`, `dashboardTemplate` | which template they tried to change |

`dashboardTemplate` is `home` / `cost_tracking` / `latency_tracking` / `usage_management` / `tool_usage` only. Project dashboards omit it.

## Packages

- `@langfuse/shared`
- `web`
- `worker`

## Verification

- `pnpm run lint` (pre-commit: Tasks: 7 successful, 7 total)
- `pnpm --filter @langfuse/shared run test home-dashboard dashboard-templates` → Tests 5 passed (5)
- `pnpm --filter worker run test langfuseDashboards` → Tests 3 passed (3)
- `pnpm --filter web run test-client dashboardTemplateProps formatDashboardModified` → Tests 2 passed (2)
- `pnpm --filter web run test dashboard-service-update` → Tests 3 passed (3)

## Mandatory Tasks

- [x] Self-reviewed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28c4baab-d5d6-48c1-9541-aa3cb1668785?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28c4baab-d5d6-48c1-9541-aa3cb1668785&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames the managed dashboard templates, expands Home with three Tool Usage widgets, compacts dashboard-list metadata, and attaches known-template enums to dashboard analytics events.

- Adds shared template-ID resolution and analytics metadata.
- Adds tool-call count, ranking, and latency widgets to Home.
- Combines dashboard creation/update information and displays the creator.
- Updates worker-owned template titles and timestamps.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The Home fallback dependency should be fixed before merging because fresh or partially initialized deployments can show three broken widget tiles.

The new fallback layout requests worker-populated widget records precisely when the persisted curated dashboard may be unavailable, so Home no longer provides a self-contained fallback.

**Files Needing Attention:** packages/shared/src/domain/home-dashboard.ts and web/src/pages/project/[projectId]/index.tsx
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  H[Project Home request] --> P{Persisted Home exists?}
  P -->|Yes| D[Persisted dashboard definition]
  P -->|No| F[Built-in Home fallback]
  F --> W[Three fixed widget IDs]
  U[Worker startup] --> C[Upsert widget catalog]
  C --> W
  W -->|Rows available| R[Render tool widgets]
  W -->|Rows unavailable| M[Widget not found tiles]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/domain/home-dashboard.ts:91-99
**Home fallback requires database widgets**

If the web application serves Home before the worker has populated the product-dashboard catalog, the fallback definition requests three widget rows that do not exist, causing the new tool tiles to display “Widget not found” until worker initialization succeeds.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboards): rename templates, add ..."](https://github.com/langfuse/langfuse/commit/caf93ca33a8c66deab914c8f3980f1fe337f4264) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59491925)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Dashboards, metrics, and monitors](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/dashboards-metrics-and-monitors.md)
- Knowledge Base — [Asynchronous processing](https://app.greptile.com/personal-org-4986/-/custom-context/knowledge-base/langfuse/langfuse/-/docs/asynchronous-processing.md)

<!-- /greptile_comment -->