### PR TITLE
fix(evals): default observation filters to query mode

### DIFF
--- a/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
+++ b/web/src/features/evals/v2/components/Evaluators/Testing/components/SampleObservationSelectorBase/SampleObservationSelectorBase.tsx
@@ -180,7 +180,7 @@ export function SampleObservationSelectorBase(
   const [filterMode, setFilterMode] =
     useLocalStorage<EvaluatorFilterExperience>(
       EVALUATOR_FILTER_EXPERIENCE_STORAGE_KEY,
-      "builder",
+      "query",
     );
   const datasets = api.datasets.allDatasetMeta.useQuery(
     { projectId },

--- a/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
+++ b/web/src/features/evals/v2/pages/EvaluatorSetupPage.tsx
@@ -169,7 +169,7 @@ export function EvaluatorSetupPage(
   const capture = usePostHogClientCapture();
   const [filterExperience] = useLocalStorage<EvaluatorFilterExperience>(
     EVALUATOR_FILTER_EXPERIENCE_STORAGE_KEY,
-    "builder",
+    "query",
   );
   const canReactivate = useHasProjectAccess({
     projectId,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16962 app preview](https://pr-16962.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## Summary

- default observation filters to the query search bar for evaluator setup and rule configuration
- keep the saved user preference unchanged

## Testing

- `pnpm --filter web run test-client EvaluatorSetupPage ObservationFilterBuilder`
- `pnpm run lint`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the default observation-filter experience from builder mode to query mode while preserving existing locally stored preferences.

- Defaults sample observation selection to the query search bar.
- Aligns evaluator setup analytics with the same query-mode default.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

Existing preferences are preserved by the local-storage read path, and the default observation filter is representable in query mode.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): default observation filters ..."](https://github.com/langfuse/langfuse/commit/e40873058a92808698831fc5bf53ada94b8c1730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59493094)</sub>

<!-- /greptile_comment -->