### PR TITLE
chore(telemetry): reduce AI feature telemetry to assistantRuns

### DIFF
--- a/web/src/features/telemetry/index.ts
+++ b/web/src/features/telemetry/index.ts
@@ -10,10 +10,6 @@ import {
   logger,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
-import {
-  getInAppAgentModelConfig,
-  isInAppAgentInstanceEnabled,
-} from "@langfuse/shared/in-app-agent/server/modelProvider";
 
 // Interval between jobs in minutes
 const JOB_INTERVAL_MINUTES = Prisma.raw("720"); // 12 hours
@@ -241,14 +237,8 @@ async function posthogTelemetry({
       0,
     );
 
-    // AI features. Organizations opt in individually, so the enabled count
-    // needs the total as its denominator. Runs are counted unconditionally:
-    // zero on an instance that never enabled the Assistant is itself the
-    // answer we are looking for.
-    const totalOrganizations = await prisma.organization.count();
-    const aiFeaturesEnabledOrganizations = await prisma.organization.count({
-      where: { aiFeaturesEnabled: true },
-    });
+    // Count Langfuse Assistant runs. Counted unconditionally: zero on an
+    // instance that never enabled the Assistant is itself the answer.
     const countAssistantRuns = await prisma.inAppAgentRun.count({
       where: {
         createdAt: {
@@ -257,9 +247,6 @@ async function posthogTelemetry({
         },
       },
     });
-    // Resolve through the product config, not env vars, so telemetry cannot
-    // claim an instance is configured when the Assistant refuses to run.
-    const modelConfig = getInAppAgentModelConfig();
 
     // Domains (no PII)
     const domains = await prisma.$queryRaw<Array<{ domain: string }>>`
@@ -287,16 +274,11 @@ async function posthogTelemetry({
         datasetItems: countDatasetItems,
         datasetRuns: countDatasetRuns,
         datasetRunItems: countDatasetRunItems,
+        assistantRuns: countAssistantRuns,
         startTimeframe: startTimeframe?.toISOString(),
         endTimeframe: endTimeframe.toISOString(),
         eeLicenseKey: env.LANGFUSE_EE_LICENSE_KEY,
         langfuseCloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-        totalOrganizations: totalOrganizations,
-        aiFeaturesEnabledOrganizations: aiFeaturesEnabledOrganizations,
-        assistantRuns: countAssistantRuns,
-        assistantInstanceEnabled: isInAppAgentInstanceEnabled(),
-        langfuseAiModelConfigured: modelConfig !== undefined,
-        langfuseAiProvider: modelConfig?.provider ?? null,
         $set: {
           environment: process.env.NODE_ENV,
           userDomains: domains,


### PR DESCRIPTION
<!-- aws-preview-pin:start -->
🟡 **Live preview: [pr-16963 app preview](https://pr-16963.preview.langfuse.com)**
<!-- aws-preview-pin:end -->

## What does this PR do?

Reduces the AI feature telemetry added in #16587 to a single data point: `assistantRuns`.

Telemetry answers a high-level adoption question, not a debugging one, and a per-feature laundry list is not something we can keep growing. `assistantRuns` alone already tells us whether the Assistant is used and how much. The five fields being dropped only described how an instance was configured, which nothing acts on:

- `totalOrganizations`
- `aiFeaturesEnabledOrganizations`
- `assistantInstanceEnabled`
- `langfuseAiModelConfigured`
- `langfuseAiProvider`

`assistantRuns` moves up next to the other reporting-window counts so it reads the same way as `datasetRuns` — a bare plural noun for a count over the window, as opposed to the `total`-prefixed all-time snapshots.

The now-unused `modelProvider` import and the `modelConfig` local go away with it.

Docs are updated in the corresponding docs PR (langfuse/langfuse-docs#3619), which trims the field table on the self-hosted telemetry page.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR simplifies self-hosted telemetry to retain only the reporting-window `assistantRuns` count for Assistant adoption.
- Removes organization and Assistant-configuration telemetry fields.
- Removes the corresponding database counts, model configuration lookup, and unused imports.
- Places `assistantRuns` alongside the other reporting-window counters.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking issues identified.

The retained Assistant run count remains unchanged, the removed properties are not required by an in-repository schema or consumer, and the deleted lookups have no required runtime side effects.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(telemetry): reduce AI feature tele..."](https://github.com/langfuse/langfuse/commit/d7d78706565c7b40c7247887c68aa5b9a13d7d6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59496201)</sub>

<!-- /greptile_comment -->